### PR TITLE
[Base/Gui/Sketcher] Console improvement and application to Sketcher WB

### DIFF
--- a/src/Base/Builder3D.cpp
+++ b/src/Base/Builder3D.cpp
@@ -987,7 +987,7 @@ void Builder3D::saveToLog()
 {
     ILogger* obs = Base::Console().Get("StatusBar");
     if (obs){
-        obs->SendLog("Builder3D",result.str().c_str(), Base::LogStyle::Log);
+        obs->SendLog("Builder3D",result.str().c_str(), Base::LogStyle::Log, Base::IntendedRecipient::Developer, Base::ContentType::Untranslatable);
     }
 }
 

--- a/src/Base/Console.cpp
+++ b/src/Base/Console.cpp
@@ -97,9 +97,6 @@ public:
                 case ConsoleSingleton::MsgType_Notification:
                     Console().notifyPrivate(LogStyle::Notification, ce->recipient, ce->content, ce->notifier, ce->msg);
                     break;
-                case ConsoleSingleton::MsgType_TranslatedNotification:
-                    Console().notifyPrivate(LogStyle::TranslatedNotification, ce->recipient, ce->content, ce->notifier, ce->msg);
-                    break;
             }
         }
     }
@@ -212,11 +209,6 @@ ConsoleMsgFlags ConsoleSingleton::SetEnabledMsgType(const char* sObs, ConsoleMsg
                 flags |= MsgType_Notification;
             pObs->bNotification = b;
         }
-        if ( type&MsgType_TranslatedNotification ){
-            if ( pObs->bTranslatedNotification != b )
-                flags |= MsgType_TranslatedNotification;
-            pObs->bTranslatedNotification = b;
-        }
 
         return flags;
     }
@@ -242,8 +234,6 @@ bool ConsoleSingleton::IsMsgTypeEnabled(const char* sObs, FreeCAD_ConsoleMsgType
             return pObs->bCritical;
         case MsgType_Notification:
             return pObs->bNotification;
-        case MsgType_TranslatedNotification:
-            return pObs->bTranslatedNotification;
         default:
             return false;
         }
@@ -628,10 +618,8 @@ PyObject *ConsoleSingleton::sPyGetStatus(PyObject * /*self*/, PyObject *args)
             b = pObs->bCritical;
         else if (strcmp(pstr2,"Notification") == 0)
             b = pObs->bNotification;
-        else if (strcmp(pstr2,"TranslatedNotification") == 0)
-            b = pObs->bTranslatedNotification;
         else
-            Py_Error(Base::PyExc_FC_GeneralError,"Unknown message type (use 'Log', 'Err', 'Wrn', 'Msg', 'Critical', 'Notification' or 'TranslatedNotification')");
+            Py_Error(Base::PyExc_FC_GeneralError,"Unknown message type (use 'Log', 'Err', 'Wrn', 'Msg', 'Critical' or 'Notification')");
 
         return PyBool_FromLong(b ? 1 : 0);
     }
@@ -662,10 +650,8 @@ PyObject *ConsoleSingleton::sPySetStatus(PyObject * /*self*/, PyObject *args)
                 pObs->bCritical = status;
             else if (strcmp(pstr2,"Notification") == 0)
                 pObs->bNotification = status;
-            else if (strcmp(pstr2,"TranslatedNotification") == 0)
-                pObs->bTranslatedNotification = status;
             else
-                Py_Error(Base::PyExc_FC_GeneralError,"Unknown message type (use 'Log', 'Err', 'Wrn', 'Msg', 'Critical', 'Notification' or 'TranslatedNotification')");
+                Py_Error(Base::PyExc_FC_GeneralError,"Unknown message type (use 'Log', 'Err', 'Wrn', 'Msg', 'Critical' or 'Notification')");
 
             Py_Return;
         }

--- a/src/Base/Console.cpp
+++ b/src/Base/Console.cpp
@@ -364,21 +364,45 @@ ConsoleSingleton & ConsoleSingleton::Instance()
 
 // ConsoleSingleton Methods structure
 PyMethodDef ConsoleSingleton::Methods[] = {
-    {"PrintMessage",         ConsoleSingleton::sPyMessage, METH_VARARGS,
+    {"PrintMessage",                ConsoleSingleton::sPyMessage, METH_VARARGS,
      "PrintMessage(obj) -> None\n\n"
      "Print a message to the output.\n\n"
      "obj : object\n    The string representation is printed."},
-    {"PrintLog",             ConsoleSingleton::sPyLog, METH_VARARGS,
+    {"PrintLog",                    ConsoleSingleton::sPyLog, METH_VARARGS,
      "PrintLog(obj) -> None\n\n"
      "Print a log message to the output.\n\n"
      "obj : object\n    The string representation is printed."},
-    {"PrintError",           ConsoleSingleton::sPyError, METH_VARARGS,
+    {"PrintError",                  ConsoleSingleton::sPyError, METH_VARARGS,
      "PrintError(obj) -> None\n\n"
      "Print an error message to the output.\n\n"
+     "obj : object\n    The string representation is printed."},
+    {"PrintDeveloperError",         ConsoleSingleton::sPyDeveloperError, METH_VARARGS,
+     "PrintDeveloperError(obj) -> None\n\n"
+     "Print an error message intended only for Developers to the output.\n\n"
+     "obj : object\n    The string representation is printed."},
+    {"PrintUserError",              ConsoleSingleton::sPyUserError, METH_VARARGS,
+     "PrintUserError(obj) -> None\n\n"
+     "Print an error message intended only for the User to the output.\n\n"
+     "obj : object\n    The string representation is printed."},
+    {"PrintTranslatedUserError",    ConsoleSingleton::sPyTranslatedUserError, METH_VARARGS,
+     "PrintTranslatedUserError(obj) -> None\n\n"
+     "Print an already translated error message intended only for the User to the output.\n\n"
      "obj : object\n    The string representation is printed."},
     {"PrintWarning",         ConsoleSingleton::sPyWarning, METH_VARARGS,
      "PrintWarning(obj) -> None\n\n"
      "Print a warning message to the output.\n\n"
+     "obj : object\n    The string representation is printed."},
+    {"PrintDeveloperWarning",         ConsoleSingleton::sPyDeveloperWarning, METH_VARARGS,
+     "PrintDeveloperWarning(obj) -> None\n\n"
+     "Print an warning message intended only for Developers to the output.\n\n"
+     "obj : object\n    The string representation is printed."},
+    {"PrintUserWarning",              ConsoleSingleton::sPyUserWarning, METH_VARARGS,
+     "PrintUserWarning(obj) -> None\n\n"
+     "Print a warning message intended only for the User to the output.\n\n"
+     "obj : object\n    The string representation is printed."},
+    {"PrintTranslatedUserWarning",    ConsoleSingleton::sPyTranslatedUserWarning, METH_VARARGS,
+     "PrintTranslatedUserWarning(obj) -> None\n\n"
+     "Print an already translated warning message intended only for the User to the output.\n\n"
      "obj : object\n    The string representation is printed."},
      {"PrintCritical",ConsoleSingleton::sPyCritical, METH_VARARGS,
      "PrintCritical(obj) -> None\n\n"
@@ -467,7 +491,9 @@ PyObject* FC_PYCONSOLE_MSG(std::function<void(const char*, const char *)> func, 
 PyObject *ConsoleSingleton::sPyMessage(PyObject * /*self*/, PyObject *args)
 {
     return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
-        Instance().Message(notifier, "%s", msg);
+        Instance().Send<Base::LogStyle::Message,
+                        Base::IntendedRecipient::Developer,
+                        Base::ContentType::Untranslatable>(notifier, "%s", msg);
     }, args);
 }
 
@@ -478,38 +504,102 @@ PyObject *ConsoleSingleton::sPyWarning(PyObject * /*self*/, PyObject *args)
     }, args);
 }
 
+PyObject *ConsoleSingleton::sPyDeveloperWarning(PyObject * /*self*/, PyObject *args)
+{
+    return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
+        Instance().Send<Base::LogStyle::Warning,
+                        Base::IntendedRecipient::Developer,
+                        Base::ContentType::Untranslatable>(notifier, "%s", msg);
+    }, args);
+}
+
+PyObject *ConsoleSingleton::sPyUserWarning(PyObject * /*self*/, PyObject *args)
+{
+    return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
+        Instance().Send<Base::LogStyle::Warning,
+                        Base::IntendedRecipient::User,
+                        Base::ContentType::Untranslated>(notifier, "%s", msg);
+    }, args);
+}
+
+PyObject *ConsoleSingleton::sPyTranslatedUserWarning(PyObject * /*self*/, PyObject *args)
+{
+    return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
+        Instance().Send<Base::LogStyle::Warning,
+                        Base::IntendedRecipient::User,
+                        Base::ContentType::Translated>(notifier, "%s", msg);
+    }, args);
+}
+
 PyObject *ConsoleSingleton::sPyError(PyObject * /*self*/, PyObject *args)
 {
     return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
-        Instance().Error(notifier, "%s", msg);
+        Instance().Send<Base::LogStyle::Error,
+                        Base::IntendedRecipient::All,
+                        Base::ContentType::Untranslated>(notifier, "%s", msg);
+    }, args);
+}
+
+PyObject *ConsoleSingleton::sPyDeveloperError(PyObject * /*self*/, PyObject *args)
+{
+    return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
+        Instance().Send<Base::LogStyle::Error,
+                        Base::IntendedRecipient::Developer,
+                        Base::ContentType::Untranslatable>(notifier, "%s", msg);
+    }, args);
+}
+
+PyObject *ConsoleSingleton::sPyUserError(PyObject * /*self*/, PyObject *args)
+{
+    return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
+        Instance().Send<Base::LogStyle::Error,
+                        Base::IntendedRecipient::User,
+                        Base::ContentType::Untranslated>(notifier, "%s", msg);
+    }, args);
+}
+
+PyObject *ConsoleSingleton::sPyTranslatedUserError(PyObject * /*self*/, PyObject *args)
+{
+    return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
+        Instance().Send<Base::LogStyle::Error,
+                        Base::IntendedRecipient::User,
+                        Base::ContentType::Translated>(notifier, "%s", msg);
     }, args);
 }
 
 PyObject *ConsoleSingleton::sPyLog(PyObject * /*self*/, PyObject *args)
 {
     return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
-        Instance().Log(notifier, "%s", msg);
+        Instance().Send<Base::LogStyle::Log,
+                        Base::IntendedRecipient::Developer,
+                        Base::ContentType::Untranslatable>(notifier, "%s", msg);
     }, args);
 }
 
 PyObject *ConsoleSingleton::sPyCritical(PyObject * /*self*/, PyObject *args)
 {
     return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
-        Instance().Critical(notifier, "%s", msg);
+        Instance().Send<Base::LogStyle::Critical,
+                        Base::IntendedRecipient::All,
+                        Base::ContentType::Untranslated>(notifier, "%s", msg);
     }, args);
 }
 
 PyObject *ConsoleSingleton::sPyNotification(PyObject * /*self*/, PyObject *args)
 {
     return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
-        Instance().UserNotification(notifier, "%s", msg);
+        Instance().Send<Base::LogStyle::Notification,
+                        Base::IntendedRecipient::User,
+                        Base::ContentType::Untranslated>(notifier, "%s", msg);
     }, args);
 }
 
 PyObject *ConsoleSingleton::sPyTranslatedNotification(PyObject * /*self*/, PyObject *args)
 {
     return FC_PYCONSOLE_MSG([](const std::string & notifier, const char* msg) {
-        Instance().UserTranslatedNotification(notifier, "%s", msg);
+        Instance().Send<Base::LogStyle::Notification,
+                        Base::IntendedRecipient::User,
+                        Base::ContentType::Translated>(notifier, "%s", msg);
     }, args);
 }
 

--- a/src/Base/Console.h
+++ b/src/Base/Console.h
@@ -501,6 +501,16 @@ public:
     virtual ~ILogger() = 0;
 
     /** Used to send a Log message at the given level.
+     * @param notifiername A string identifying the entity generating the notification.
+     * It may be the Label of the App::Document or the full label of the App::DocumentObject.
+     * @param msg The message to be notified.
+     * @param level A valid level (Log, Message, Error, Notification, CriticalNotification, ...)
+     * @param recipient A valid intended recipient (All, Developer, User).
+     * Observers may decide to process only notifications when a certain recipient is intended.
+     * @param content A valid content property (Untranslated, Translatable, Untranslatable).
+     * Observers may decide not to process notifications if they are not translated or cannot be
+     * translated (are untranslatable). Or conversely, may decide not to process already translated
+     * notifications. It is up to the intended behaviour of the observer.
      */
     virtual void SendLog(const std::string& notifiername, const std::string& msg, LogStyle level,
                          IntendedRecipient recipient, ContentType content) = 0;
@@ -607,9 +617,21 @@ public:
     /// Prints a warning Message with source indication
     template <typename... Args>
     inline void Warning (const std::string & notifier, const char * pMsg, Args&&... args);
+    template <typename... Args>
+    inline void DeveloperWarning (const std::string & notifier, const char * pMsg, Args&&... args);
+    template <typename... Args>
+    inline void UserWarning (const std::string & notifier, const char * pMsg, Args&&... args);
+    template <typename... Args>
+    inline void TranslatedUserWarning (const std::string & notifier, const char * pMsg, Args&&... args);
     /// Prints a error Message with source indication
     template <typename... Args>
     inline void Error   (const std::string & notifier, const char * pMsg, Args&&... args);
+    template <typename... Args>
+    inline void DeveloperError (const std::string & notifier, const char * pMsg, Args&&... args);
+    template <typename... Args>
+    inline void UserError (const std::string & notifier, const char * pMsg, Args&&... args);
+    template <typename... Args>
+    inline void TranslatedUserError (const std::string & notifier, const char * pMsg, Args&&... args);
     /// Prints a log Message with source indication
     template <typename... Args>
     inline void Log     (const std::string & notifier, const char * pMsg, Args&&... args);
@@ -834,6 +856,30 @@ inline void Base::ConsoleSingleton::Warning( const std::string & notifier, const
 }
 
 template <typename... Args>
+inline void Base::ConsoleSingleton::DeveloperWarning( const std::string & notifier, const char * pMsg, Args&&... args )
+{
+    Send<Base::LogStyle::Warning,
+         Base::IntendedRecipient::Developer,
+         Base::ContentType::Untranslatable>(notifier, pMsg, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+inline void Base::ConsoleSingleton::UserWarning( const std::string & notifier, const char * pMsg, Args&&... args )
+{
+    Send<Base::LogStyle::Warning,
+         Base::IntendedRecipient::User,
+         Base::ContentType::Untranslated>(notifier, pMsg, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+inline void Base::ConsoleSingleton::TranslatedUserWarning( const std::string & notifier, const char * pMsg, Args&&... args )
+{
+    Send<Base::LogStyle::Warning,
+         Base::IntendedRecipient::User,
+         Base::ContentType::Translated>(notifier, pMsg, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
 inline void Base::ConsoleSingleton::Error( const char * pMsg, Args&&... args )
 {
     Error(std::string(""), pMsg, std::forward<Args>(args)...);
@@ -843,6 +889,30 @@ template <typename... Args>
 inline void Base::ConsoleSingleton::Error( const std::string & notifier, const char * pMsg, Args&&... args )
 {
     Send<Base::LogStyle::Error>(notifier, pMsg, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+inline void Base::ConsoleSingleton::DeveloperError( const std::string & notifier, const char * pMsg, Args&&... args )
+{
+    Send<Base::LogStyle::Error,
+         Base::IntendedRecipient::Developer,
+         Base::ContentType::Untranslatable>(notifier, pMsg, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+inline void Base::ConsoleSingleton::UserError( const std::string & notifier, const char * pMsg, Args&&... args )
+{
+    Send<Base::LogStyle::Error,
+         Base::IntendedRecipient::User,
+         Base::ContentType::Untranslated>(notifier, pMsg, std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+inline void Base::ConsoleSingleton::TranslatedUserError( const std::string & notifier, const char * pMsg, Args&&... args )
+{
+    Send<Base::LogStyle::Error,
+         Base::IntendedRecipient::User,
+         Base::ContentType::Translated>(notifier, pMsg, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
@@ -866,7 +936,9 @@ inline void Base::ConsoleSingleton::UserNotification( const char * pMsg, Args&&.
 template <typename... Args>
 inline void Base::ConsoleSingleton::UserNotification( const std::string & notifier, const char * pMsg, Args&&... args )
 {
-    Send<Base::LogStyle::Notification>(notifier, pMsg, std::forward<Args>(args)...);
+    Send<Base::LogStyle::Notification,
+         Base::IntendedRecipient::User,
+         Base::ContentType::Untranslated>(notifier, pMsg, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
@@ -878,7 +950,9 @@ inline void Base::ConsoleSingleton::UserTranslatedNotification( const char * pMs
 template <typename... Args>
 inline void Base::ConsoleSingleton::UserTranslatedNotification( const std::string & notifier, const char * pMsg, Args&&... args )
 {
-    Send<Base::LogStyle::TranslatedNotification>(notifier, pMsg, std::forward<Args>(args)...);
+    Send<Base::LogStyle::Notification,
+         Base::IntendedRecipient::User,
+         Base::ContentType::Translated>(notifier, pMsg, std::forward<Args>(args)...);
 }
 
 template <typename... Args>

--- a/src/Base/Console.h
+++ b/src/Base/Console.h
@@ -714,7 +714,13 @@ protected:
     static PyObject *sPyLog                     (PyObject *self,PyObject *args);
     static PyObject *sPyMessage                 (PyObject *self,PyObject *args);
     static PyObject *sPyWarning                 (PyObject *self,PyObject *args);
+    static PyObject *sPyDeveloperWarning        (PyObject *self,PyObject *args);
+    static PyObject *sPyUserWarning             (PyObject *self,PyObject *args);
+    static PyObject *sPyTranslatedUserWarning   (PyObject *self,PyObject *args);
     static PyObject *sPyError                   (PyObject *self,PyObject *args);
+    static PyObject *sPyDeveloperError          (PyObject *self,PyObject *args);
+    static PyObject *sPyUserError               (PyObject *self,PyObject *args);
+    static PyObject *sPyTranslatedUserError     (PyObject *self,PyObject *args);
     static PyObject *sPyCritical                (PyObject *self,PyObject *args);
     static PyObject *sPyNotification            (PyObject *self,PyObject *args);
     static PyObject *sPyTranslatedNotification  (PyObject *self,PyObject *args);

--- a/src/Base/Console.h
+++ b/src/Base/Console.h
@@ -471,7 +471,6 @@ enum class LogStyle{
     Log,
     Critical,               // Special message to mark critical notifications
     Notification,           // Special message for notifications to the user (e.g. educational)
-    TranslatedNotification, // Special message for already translated notifications to the user (e.g. educational)
 };
 
 enum class IntendedRecipient {
@@ -497,7 +496,7 @@ class BaseExport ILogger
 {
 public:
     ILogger()
-    :bErr(true), bMsg(true), bLog(true), bWrn(true), bCritical(true), bNotification(false), bTranslatedNotification(false){}
+    :bErr(true), bMsg(true), bLog(true), bWrn(true), bCritical(true), bNotification(false){}
     virtual ~ILogger() = 0;
 
     /** Used to send a Log message at the given level.
@@ -542,23 +541,20 @@ public:
         if(category == Base::LogStyle::Notification) {
             return bNotification;
         }
-        else
-        if(category == Base::LogStyle::TranslatedNotification) {
-            return bTranslatedNotification;
-        }
+
         return false;
     }
 
     virtual const char *Name(){return nullptr;}
-    bool bErr, bMsg, bLog, bWrn, bCritical, bNotification, bTranslatedNotification;
+    bool bErr, bMsg, bLog, bWrn, bCritical, bNotification;
 };
 
 
 /** The console class
  *  This class manage all the stdio stuff. This includes
- *  Messages, Warnings, Log entries, Errors, Criticals, Notifications and
- *  TranslatedNotifications. The incoming Messages are distributed with the
- *  FCConsoleObserver. The FCConsole class itself makes no IO, it's more like a manager.
+ *  Messages, Warnings, Log entries, Errors, Criticals, Notifications. The incoming Messages are
+ *  distributed with the FCConsoleObserver. The FCConsole class itself makes no IO, it's more like
+ *  a manager.
  *  \par
  *  ConsoleSingleton is a singleton! That means you can access the only
  *  instance of the class from every where in c++ by simply using:
@@ -576,9 +572,9 @@ class BaseExport ConsoleSingleton
 public:
     // exported functions goes here +++++++++++++++++++++++++++++++++++++++
 
-    /** Sends a message of type LogStyle (Message, Warning, Error, Log, Critical, Notification or TranslatedNotification).
-        This function is used by all specific convenience functions (Send(), Message(), Warning(), Error(), Log(), Critical
-        UserNotification and UserTranslatedNotification, without or without notifier id).
+    /** Sends a message of type LogStyle (Message, Warning, Error, Log, Critical or Notification).
+        This function is used by all specific convenience functions (Send(), Message(), Warning(), Error(), Log(), Critical and
+        UserNotification, without or without notifier id).
 
         Notification can be direct or via queue.
     */
@@ -672,7 +668,6 @@ public:
         MsgType_Err                     = 8,
         MsgType_Critical                = 16,  // Special message to notify critical information
         MsgType_Notification            = 32, // Special message to for notifications to the user
-        MsgType_TranslatedNotification  = 64, // Special message for already translated notifications to the user
     };
 
     /// Change mode
@@ -771,8 +766,7 @@ inline constexpr ConsoleSingleton::FreeCAD_ConsoleMsgType ConsoleSingleton::getC
         FreeCAD_ConsoleMsgType::MsgType_Err,
         FreeCAD_ConsoleMsgType::MsgType_Log,
         FreeCAD_ConsoleMsgType::MsgType_Critical,
-        FreeCAD_ConsoleMsgType::MsgType_Notification,
-        FreeCAD_ConsoleMsgType::MsgType_TranslatedNotification
+        FreeCAD_ConsoleMsgType::MsgType_Notification
     };
 
     return msgTypes.at(static_cast<std::size_t>(style));

--- a/src/Base/ConsoleObserver.cpp
+++ b/src/Base/ConsoleObserver.cpp
@@ -58,9 +58,12 @@ ConsoleObserverFile::~ConsoleObserverFile()
     cFileStream.close();
 }
 
-void ConsoleObserverFile::SendLog(const std::string& notifiername, const std::string& msg, LogStyle level)
+void ConsoleObserverFile::SendLog(const std::string& notifiername, const std::string& msg, LogStyle level,
+                                  IntendedRecipient recipient, ContentType content)
 {
     (void) notifiername;
+    (void) recipient;
+    (void) content;
     
     std::string prefix;
     switch(level){
@@ -101,9 +104,12 @@ ConsoleObserverStd::ConsoleObserverStd() :
 
 ConsoleObserverStd::~ConsoleObserverStd() = default;
 
-void ConsoleObserverStd::SendLog(const std::string& notifiername, const std::string& msg, LogStyle level)
+void ConsoleObserverStd::SendLog(const std::string& notifiername, const std::string& msg, LogStyle level,
+                                 IntendedRecipient recipient, ContentType content)
 {
     (void) notifiername;
+    (void) recipient;
+    (void) content;
     
     switch(level){
         case LogStyle::Warning:

--- a/src/Base/ConsoleObserver.cpp
+++ b/src/Base/ConsoleObserver.cpp
@@ -62,8 +62,10 @@ void ConsoleObserverFile::SendLog(const std::string& notifiername, const std::st
                                   IntendedRecipient recipient, ContentType content)
 {
     (void) notifiername;
-    (void) recipient;
-    (void) content;
+
+    // Do not log translated messages, or messages intended only to the user to log file
+    if(recipient == IntendedRecipient::User || content == ContentType::Translated)
+        return;
     
     std::string prefix;
     switch(level){
@@ -108,8 +110,10 @@ void ConsoleObserverStd::SendLog(const std::string& notifiername, const std::str
                                  IntendedRecipient recipient, ContentType content)
 {
     (void) notifiername;
-    (void) recipient;
-    (void) content;
+
+    // Do not log translated messages, or messages intended only to the user to std log
+    if(recipient == IntendedRecipient::User || content == ContentType::Translated)
+        return;
     
     switch(level){
         case LogStyle::Warning:

--- a/src/Base/ConsoleObserver.h
+++ b/src/Base/ConsoleObserver.h
@@ -81,7 +81,7 @@ public:
     // Constructor that will block message types passed as parameter. By default, all types are blocked.
     inline explicit ILoggerBlocker(const char* co, ConsoleMsgFlags msgTypes =
         ConsoleSingleton::MsgType_Txt | ConsoleSingleton::MsgType_Log | ConsoleSingleton::MsgType_Wrn | ConsoleSingleton::MsgType_Err |
-        ConsoleSingleton::MsgType_Critical | ConsoleSingleton::MsgType_Notification | ConsoleSingleton::MsgType_TranslatedNotification);
+        ConsoleSingleton::MsgType_Critical | ConsoleSingleton::MsgType_Notification);
     // Disable copy & move constructors
     ILoggerBlocker(ILoggerBlocker const&) = delete;
     ILoggerBlocker(ILoggerBlocker const &&) = delete;

--- a/src/Base/ConsoleObserver.h
+++ b/src/Base/ConsoleObserver.h
@@ -42,7 +42,8 @@ public:
     explicit ConsoleObserverFile(const char *sFileName);
     ~ConsoleObserverFile() override;
 
-    void SendLog(const std::string& notifiername, const std::string& message, LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& msg, LogStyle level,
+                 IntendedRecipient recipient, ContentType content) override;
     const char* Name() override {return "File";}
 
 protected:
@@ -57,7 +58,8 @@ class BaseExport ConsoleObserverStd: public ILogger
 public:
     ConsoleObserverStd();
     ~ConsoleObserverStd() override;
-    void SendLog(const std::string& notifiername, const std::string& message, LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& msg, LogStyle level,
+                 IntendedRecipient recipient, ContentType content) override;
     const char* Name() override {return "Console";}
 protected:
     bool useColorStderr;

--- a/src/Base/Interpreter.cpp
+++ b/src/Base/Interpreter.cpp
@@ -131,7 +131,7 @@ void PyException::ReportException () const
 {
     if (!_isReported) {
         _isReported = true;
-        Base::Console().Error("%s%s: %s\n",
+        Base::Console().DeveloperError("%s%s: %s\n",
             _stackTrace.c_str(), _errorType.c_str(), what());
     }
 }

--- a/src/Gui/CommandTest.cpp
+++ b/src/Gui/CommandTest.cpp
@@ -728,9 +728,12 @@ public:
     TestConsoleObserver() : matchMsg(0), matchWrn(0), matchErr(0), matchLog(0), matchCritical(0)
     {
     }
-    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override{
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                 Base::IntendedRecipient recipient, Base::ContentType content) override{
 
         (void) notifiername;
+        (void) recipient;
+        (void) content;
 
         QMutexLocker ml(&mutex);
 

--- a/src/Gui/DlgSettingsNotificationArea.cpp
+++ b/src/Gui/DlgSettingsNotificationArea.cpp
@@ -51,8 +51,8 @@ DlgSettingsNotificationArea::DlgSettingsNotificationArea(QWidget* parent)
             ui->autoRemoveUserNotifications->setEnabled(true);
             ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->setEnabled(true);
             ui->preventNonIntrusiveNotificationsWhenWindowNotActive->setEnabled(true);
-            ui->errorSubscriptionEnabled->setEnabled(true);
-            ui->warningSubscriptionEnabled->setEnabled(true);
+            ui->developerErrorSubscriptionEnabled->setEnabled(true);
+            ui->developerWarningSubscriptionEnabled->setEnabled(true);
             QMessageBox::information(this,
                                      tr("Notification Area"),
                                      tr("Activation of the Notification Area only takes effect "
@@ -68,8 +68,8 @@ DlgSettingsNotificationArea::DlgSettingsNotificationArea(QWidget* parent)
             ui->autoRemoveUserNotifications->setEnabled(false);
             ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->setEnabled(false);
             ui->preventNonIntrusiveNotificationsWhenWindowNotActive->setEnabled(false);
-            ui->errorSubscriptionEnabled->setEnabled(false);
-            ui->warningSubscriptionEnabled->setEnabled(false);
+            ui->developerErrorSubscriptionEnabled->setEnabled(false);
+            ui->developerWarningSubscriptionEnabled->setEnabled(false);
             // N.B: Deactivation is handled by the Notification Area itself, as it listens to all
             // its configuration parameters.
         }
@@ -91,8 +91,8 @@ void DlgSettingsNotificationArea::saveSettings()
     ui->notificationWidth->onSave();
     ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->onSave();
     ui->preventNonIntrusiveNotificationsWhenWindowNotActive->onSave();
-    ui->errorSubscriptionEnabled->onSave();
-    ui->warningSubscriptionEnabled->onSave();
+    ui->developerErrorSubscriptionEnabled->onSave();
+    ui->developerWarningSubscriptionEnabled->onSave();
 }
 
 void DlgSettingsNotificationArea::loadSettings()
@@ -107,8 +107,8 @@ void DlgSettingsNotificationArea::loadSettings()
     ui->notificationWidth->onRestore();
     ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->onRestore();
     ui->preventNonIntrusiveNotificationsWhenWindowNotActive->onRestore();
-    ui->errorSubscriptionEnabled->onRestore();
-    ui->warningSubscriptionEnabled->onRestore();
+    ui->developerErrorSubscriptionEnabled->onRestore();
+    ui->developerWarningSubscriptionEnabled->onRestore();
 }
 
 void DlgSettingsNotificationArea::changeEvent(QEvent* e)

--- a/src/Gui/DlgSettingsNotificationArea.ui
+++ b/src/Gui/DlgSettingsNotificationArea.ui
@@ -64,22 +64,22 @@
    <item row="1" column="0">
     <widget class="QGroupBox" name="GroupBoxSubscriptions">
      <property name="title">
-      <string>Additional data Sources</string>
+      <string>Additional data sources</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
+     <layout class="QGridLayout" name="gridLayout_1">
       <item row="0" column="0">
-       <widget class="Gui::PrefCheckBox" name="errorSubscriptionEnabled">
+       <widget class="Gui::PrefCheckBox" name="developerErrorSubscriptionEnabled">
         <property name="toolTip">
-         <string>Errors will appear in the notification area</string>
+         <string>Errors intended for developers will appear in the notification area</string>
         </property>
         <property name="text">
-         <string>Errors</string>
+         <string>Debug errors</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="prefEntry" stdset="0">
-         <cstring>ErrorSubscriptionEnabled</cstring>
+         <cstring>DeveloperErrorSubscriptionEnabled</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>NotificationArea</cstring>
@@ -87,18 +87,18 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="Gui::PrefCheckBox" name="warningSubscriptionEnabled">
+       <widget class="Gui::PrefCheckBox" name="developerWarningSubscriptionEnabled">
         <property name="toolTip">
-         <string>Warnings will appear in the notification area</string>
+         <string>Warnings intended for developers will appear in the notification area</string>
         </property>
         <property name="text">
-         <string>Warnings</string>
+         <string>Debug warnings</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="prefEntry" stdset="0">
-         <cstring>WarningSubscriptionEnabled</cstring>
+         <cstring>DeveloperWarningSubscriptionEnabled</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>NotificationArea</cstring>

--- a/src/Gui/GuiConsole.cpp
+++ b/src/Gui/GuiConsole.cpp
@@ -81,9 +81,14 @@ GUIConsole::~GUIConsole (void)
       FreeConsole();
 }
 
-void GUIConsole::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
+void GUIConsole::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                         Base::IntendedRecipient recipient, Base::ContentType content)
 {
     (void) notifiername;
+
+    // Do not log translated messages, or messages intended only to the user to std log
+    if(recipient == Base::IntendedRecipient::User || content == Base::ContentType::Translated)
+        return;
 
     int color = -1;
     switch(level){
@@ -116,9 +121,12 @@ void GUIConsole::SendLog(const std::string& notifiername, const std::string& msg
 // safely ignore GUIConsole::s_nMaxLines and  GUIConsole::s_nRefCount
 GUIConsole::GUIConsole () {}
 GUIConsole::~GUIConsole () {}
-void GUIConsole::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
+void GUIConsole::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                         Base::IntendedRecipient recipient, Base::ContentType content)
 {
     (void) notifiername;
+    (void) recipient;
+    (void) content;
 
     switch(level){
         case Base::LogStyle::Warning:

--- a/src/Gui/GuiConsole.cpp
+++ b/src/Gui/GuiConsole.cpp
@@ -125,8 +125,10 @@ void GUIConsole::SendLog(const std::string& notifiername, const std::string& msg
                          Base::IntendedRecipient recipient, Base::ContentType content)
 {
     (void) notifiername;
-    (void) recipient;
-    (void) content;
+
+    // Do not log translated messages, or messages intended only to the user to std log
+    if(recipient == Base::IntendedRecipient::User || content == Base::ContentType::Translated)
+        return;
 
     switch(level){
         case Base::LogStyle::Warning:

--- a/src/Gui/GuiConsole.h
+++ b/src/Gui/GuiConsole.h
@@ -47,7 +47,8 @@ public:
   GUIConsole();
   /// Destructor
   ~GUIConsole() override;
-  void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override;
+  void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                 Base::IntendedRecipient recipient, Base::ContentType content) override;
   const char* Name() override {return "GUIConsole";}
 
 protected:

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2252,9 +2252,12 @@ void StatusBarObserver::OnChange(Base::Subject<const char*> &rCaller, const char
     }
 }
 
-void StatusBarObserver::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
+void StatusBarObserver::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                                Base::IntendedRecipient recipient, Base::ContentType content)
 {
     (void) notifiername;
+    (void) recipient;
+    (void) content;
 
     int messageType = -1;
     switch(level){

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2256,8 +2256,12 @@ void StatusBarObserver::SendLog(const std::string& notifiername, const std::stri
                                 Base::IntendedRecipient recipient, Base::ContentType content)
 {
     (void) notifiername;
-    (void) recipient;
-    (void) content;
+
+    // Do not log untranslated messages, or messages intended only to a developer to status bar
+    if( recipient == Base::IntendedRecipient::Developer ||
+        content == Base::ContentType::Untranslated ||
+        content == Base::ContentType::Untranslatable )
+        return;
 
     int messageType = -1;
     switch(level){

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -370,7 +370,8 @@ public:
     /** Observes its parameter group. */
     void OnChange(Base::Subject<const char*> &rCaller, const char * sReason) override;
 
-    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                 Base::IntendedRecipient recipient, Base::ContentType content) override;
 
     /// name of the observer
     const char *Name() override {return "StatusBar";}

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -214,8 +214,8 @@ public:
 
     /// Function that is called by the console interface for this observer with the message
     /// information
-    void SendLog(const std::string& notifiername, const std::string& msg,
-                 Base::LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                 Base::IntendedRecipient recipient, Base::ContentType content) override;
 
     /// Name of the observer
     const char* Name() override
@@ -242,8 +242,8 @@ NotificationAreaObserver::~NotificationAreaObserver()
     Base::Console().DetachObserver(this);
 }
 
-void NotificationAreaObserver::SendLog(const std::string& notifiername, const std::string& msg,
-                                       Base::LogStyle level)
+void NotificationAreaObserver::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                                       Base::IntendedRecipient recipient, Base::ContentType content)
 {
     // 1. As notification system is shared with report view and others, the expectation is that any
     // individual error and warning message will end in "\n". This means the string must be stripped
@@ -252,6 +252,9 @@ void NotificationAreaObserver::SendLog(const std::string& notifiername, const st
     // context, shall not include
     // "\n", as this generates problems with the translation system. Then the string must be
     // stripped of "\n" before translation.
+
+    (void) recipient;
+    (void) content;
 
     auto simplifiedstring =
         QString::fromStdString(msg)

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -234,7 +234,6 @@ NotificationAreaObserver::NotificationAreaObserver(NotificationArea* notificatio
     bLog = false;                  // ignore log messages
     bMsg = false;                  // ignore messages
     bNotification = true;          // activate user notifications
-    bTranslatedNotification = true;// activate translated user notifications
 }
 
 NotificationAreaObserver::~NotificationAreaObserver()
@@ -377,16 +376,14 @@ public:
         if (tableWidget) {
             for (int i = tableWidget->topLevelItemCount() - 1; i >= 0; i--) {
                 auto* item = static_cast<NotificationItem*>(tableWidget->topLevelItem(i));
-                if (item->notificationType == Base::LogStyle::Notification
-                    || item->notificationType == Base::LogStyle::TranslatedNotification) {
+                if (item->notificationType == Base::LogStyle::Notification) {
                     delete item;
                 }
             }
         }
         for (int i = pushedItems.size() - 1; i >= 0; i--) {
             auto* item = static_cast<NotificationItem*>(pushedItems.at(i));
-            if (item->notificationType == Base::LogStyle::Notification
-                || item->notificationType == Base::LogStyle::TranslatedNotification) {
+            if (item->notificationType == Base::LogStyle::Notification) {
                 delete pushedItems.takeAt(i);
             }
         }
@@ -1057,9 +1054,7 @@ void NotificationArea::showInNotificationArea()
                             item->notifying = false;
 
                             if (pImp->autoRemoveUserNotifications) {
-                                if (item->notificationType == Base::LogStyle::Notification
-                                    || item->notificationType
-                                        == Base::LogStyle::TranslatedNotification) {
+                                if (item->notificationType == Base::LogStyle::Notification) {
 
                                     static_cast<NotificationsAction*>(pImp->notificationaction)
                                         ->deleteItem(item);

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -253,8 +253,10 @@ void NotificationAreaObserver::SendLog(const std::string& notifiername, const st
     // "\n", as this generates problems with the translation system. Then the string must be
     // stripped of "\n" before translation.
 
-    (void) recipient;
-    (void) content;
+    if( recipient == Base::IntendedRecipient::Developer ||
+        content == Base::ContentType::Untranslatable) {
+        return;
+    }
 
     auto simplifiedstring =
         QString::fromStdString(msg)
@@ -264,7 +266,7 @@ void NotificationAreaObserver::SendLog(const std::string& notifiername, const st
     if (simplifiedstring.isEmpty())
         return;
 
-    if (level == Base::LogStyle::TranslatedNotification) {
+    if (content == Base::ContentType::Translated) {
         notificationArea->pushNotification(
             QString::fromStdString(notifiername), simplifiedstring, level);
     }
@@ -369,7 +371,7 @@ public:
     }
 
 public:
-    /// deletes only notifications (messages of type Notification and TranslatedNotification)
+    /// deletes only notifications (messages of type Notification)
     void deleteNotifications()
     {
         if (tableWidget) {

--- a/src/Gui/NotificationArea.h
+++ b/src/Gui/NotificationArea.h
@@ -66,6 +66,9 @@ public:
     void pushNotification(const QString& notifiername, const QString& message,
                           Base::LogStyle level);
 
+    bool areDeveloperWarningsActive () const;
+    bool areDeveloperErrorsActive () const;
+
 private:
     void showInNotificationArea();
     bool confirmationRequired(Base::LogStyle level);

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -472,9 +472,12 @@ void ReportOutput::restoreFont()
     setFont(serifFont);
 }
 
-void ReportOutput::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level)
+void ReportOutput::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                           Base::IntendedRecipient recipient, Base::ContentType content)
 {
     (void) notifiername;
+    (void) recipient;
+    (void) content;
 
     ReportHighlighter::Paragraph style = ReportHighlighter::LogText;
     switch (level) {

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -476,8 +476,11 @@ void ReportOutput::SendLog(const std::string& notifiername, const std::string& m
                            Base::IntendedRecipient recipient, Base::ContentType content)
 {
     (void) notifiername;
-    (void) recipient;
-    (void) content;
+
+    // Do not log translated messages, or messages intended only to the user to the Report View
+    if( recipient == Base::IntendedRecipient::User ||
+        content == Base::ContentType::Translated)
+        return;
 
     ReportHighlighter::Paragraph style = ReportHighlighter::LogText;
     switch (level) {

--- a/src/Gui/ReportView.h
+++ b/src/Gui/ReportView.h
@@ -141,7 +141,8 @@ public:
     /** Observes its parameter group. */
     void OnChange(Base::Subject<const char*> &rCaller, const char * sReason) override;
 
-    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override;
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                 Base::IntendedRecipient recipient, Base::ContentType content) override;
 
     /// returns the name for observer handling
     const char* Name() override {return "ReportOutput";}

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -176,9 +176,12 @@ public:
     {
         return "SplashObserver";
     }
-    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                 Base::IntendedRecipient recipient, Base::ContentType content) override
     {
         Q_UNUSED(notifiername)
+        Q_UNUSED(recipient)
+        Q_UNUSED(content)
         
 #ifdef FC_DEBUG
         Log(msg.c_str());

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -182,7 +182,7 @@ public:
         Q_UNUSED(notifiername)
         Q_UNUSED(recipient)
         Q_UNUSED(content)
-        
+
 #ifdef FC_DEBUG
         Log(msg.c_str());
         Q_UNUSED(level)

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -377,7 +377,11 @@ PyObject* SketchObjectPy::addConstraint(PyObject* args)
 
         for (std::vector<Constraint*>::iterator it = values.begin(); it != values.end(); ++it) {
             if (!this->getSketchObjectPtr()->evaluateConstraint(*it)) {
-                PyErr_SetString(PyExc_IndexError, "Constraint has invalid indexes");
+                PyErr_SetString(
+                    PyExc_IndexError,
+                    QT_TRANSLATE_NOOP(
+                        "Notifications",
+                        "The constraint has invalid index information and is malformed."));
                 return nullptr;
             }
         }

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -145,14 +145,14 @@ void finishDatumConstraint (Gui::Command* cmd, Sketcher::SketchObject* sketch, b
 
 void showNoConstraintBetweenExternal(const App::DocumentObject * obj)
 {
-    Gui::TranslatedNotification(obj,
+    Gui::TranslatedUserWarning(obj,
                   QObject::tr("Wrong selection"),
                   QObject::tr("Cannot add a constraint between two external geometries."));
 }
 
 void showNoConstraintBetweenFixedGeometry(const App::DocumentObject * obj)
 {
-    Gui::TranslatedNotification(obj,
+    Gui::TranslatedUserWarning(obj,
                   QObject::tr("Wrong selection"),
                   QObject::tr("Cannot add a constraint between two fixed geometries. "
                                                      "Fixed geometries include external geometry, "
@@ -913,7 +913,7 @@ void CmdSketcherConstrainHorizontal::activated(int iMsg)
                     new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select an edge from the sketch."));
         }
         return;
@@ -939,7 +939,7 @@ void CmdSketcherConstrainHorizontal::activated(int iMsg)
         if (isEdge(GeoId,PosId)) {// it is an edge
             const Part::Geometry *geo = Obj->getGeometry(GeoId);
             if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-                Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge is not a line segment."));
+                Gui::TranslatedUserWarning(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge is not a line segment."));
                 return;
             }
 
@@ -947,16 +947,16 @@ void CmdSketcherConstrainHorizontal::activated(int iMsg)
             for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                  it != vals.end(); ++it) {
                 if ((*it)->Type == Sketcher::Horizontal && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none){
-                    Gui::TranslatedNotification(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a horizontal constraint!"));
+                    Gui::TranslatedUserWarning(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a horizontal constraint!"));
                     return;
                 }
                 if ((*it)->Type == Sketcher::Vertical && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a vertical constraint!"));
+                    Gui::TranslatedUserWarning(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a vertical constraint!"));
                     return;
                 }
                 // check if the edge already has a Block constraint
                 if ((*it)->Type == Sketcher::Block && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a Block constraint!"));
+                    Gui::TranslatedUserWarning(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a Block constraint!"));
                     return;
                 }
             }
@@ -974,7 +974,7 @@ void CmdSketcherConstrainHorizontal::activated(int iMsg)
     }
 
     if (edgegeoids.empty() && pointgeoids.empty()) {
-        Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected item(s) can't accept a horizontal constraint!"));
+        Gui::TranslatedUserWarning(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected item(s) can't accept a horizontal constraint!"));
         return;
     }
 
@@ -1001,7 +1001,7 @@ void CmdSketcherConstrainHorizontal::activated(int iMsg)
         }
     }
     else { // vertex mode, fixedpoints > 1
-        Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("There are more than one fixed points selected. Select a maximum of one fixed point!"));
+        Gui::TranslatedUserWarning(Obj, QObject::tr("Impossible constraint"), QObject::tr("There are more than one fixed points selected. Select a maximum of one fixed point!"));
         return;
     }
     // finish the transaction and update
@@ -1028,7 +1028,7 @@ void CmdSketcherConstrainHorizontal::applyConstraint(std::vector<SelIdPair> &sel
             if (CrvId != -1) {
                 const Part::Geometry *geo = Obj->getGeometry(CrvId);
                 if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-                    Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge is not a line segment."));
+                    Gui::TranslatedUserWarning(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge is not a line segment."));
                     return;
                 }
 
@@ -1036,16 +1036,16 @@ void CmdSketcherConstrainHorizontal::applyConstraint(std::vector<SelIdPair> &sel
                 for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                     it != vals.end(); ++it) {
                     if ((*it)->Type == Sketcher::Horizontal && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none){
-                        Gui::TranslatedNotification(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a horizontal constraint!"));
+                        Gui::TranslatedUserWarning(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a horizontal constraint!"));
                         return;
                     }
                     if ((*it)->Type == Sketcher::Vertical && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                        Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a vertical constraint!"));
+                        Gui::TranslatedUserWarning(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a vertical constraint!"));
                         return;
                     }
                     // check if the edge already has a Block constraint
                     if ((*it)->Type == Sketcher::Block && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                        Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a Block constraint!"));
+                        Gui::TranslatedUserWarning(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a Block constraint!"));
                         return;
                     }
                 }
@@ -1141,7 +1141,7 @@ void CmdSketcherConstrainVertical::activated(int iMsg)
                 new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select an edge from the sketch."));
         }
         return;
@@ -1167,7 +1167,7 @@ void CmdSketcherConstrainVertical::activated(int iMsg)
         if (isEdge(GeoId,PosId)) {// it is an edge
             const Part::Geometry *geo = Obj->getGeometry(GeoId);
             if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Impossible constraint"),
                               QObject::tr("The selected edge is not a line segment."));
                 return;
@@ -1177,20 +1177,20 @@ void CmdSketcherConstrainVertical::activated(int iMsg)
             for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                  it != vals.end(); ++it) {
                 if ((*it)->Type == Sketcher::Vertical && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none){
-                    Gui::TranslatedNotification(Obj,
+                    Gui::TranslatedUserWarning(Obj,
                                   QObject::tr("Double constraint"),
                                   QObject::tr("The selected edge already has a horizontal constraint!"));
                     return;
                 }
                 if ((*it)->Type == Sketcher::Horizontal && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    Gui::TranslatedNotification(Obj,
+                    Gui::TranslatedUserWarning(Obj,
                                   QObject::tr("Impossible constraint"),
                                   QObject::tr("The selected edge already has a horizontal constraint!"));
                     return;
                 }
                 // check if the edge already has a Block constraint
                 if ((*it)->Type == Sketcher::Block && (*it)->First == GeoId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    Gui::TranslatedNotification(Obj,
+                    Gui::TranslatedUserWarning(Obj,
                                   QObject::tr("Impossible constraint"),
                                   QObject::tr("The selected edge already has a Block constraint!"));
                     return;
@@ -1209,7 +1209,7 @@ void CmdSketcherConstrainVertical::activated(int iMsg)
     }
 
     if (edgegeoids.empty() && pointgeoids.empty()) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Impossible constraint"),
                       QObject::tr("The selected item(s) can't accept a vertical constraint!"));
         return;
@@ -1236,7 +1236,7 @@ void CmdSketcherConstrainVertical::activated(int iMsg)
         }
     }
     else { // vertex mode, fixedpoints > 1
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Impossible constraint"),
                       QObject::tr("There are more than one fixed points selected. Select a maximum of one fixed point!"));
         return;
@@ -1266,7 +1266,7 @@ void CmdSketcherConstrainVertical::applyConstraint(std::vector<SelIdPair> &selSe
         if (CrvId != -1) {
             const Part::Geometry *geo = Obj->getGeometry(CrvId);
             if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-                Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge is not a line segment."));
+                Gui::TranslatedUserWarning(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge is not a line segment."));
                 return;
             }
 
@@ -1274,16 +1274,16 @@ void CmdSketcherConstrainVertical::applyConstraint(std::vector<SelIdPair> &selSe
             for (std::vector< Sketcher::Constraint * >::const_iterator it= vals.begin();
                  it != vals.end(); ++it) {
                 if ((*it)->Type == Sketcher::Horizontal && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none){
-                    Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a horizontal constraint!"));
+                    Gui::TranslatedUserWarning(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a horizontal constraint!"));
                     return;
                 }
                 if ((*it)->Type == Sketcher::Vertical && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    Gui::TranslatedNotification(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a vertical constraint!"));
+                    Gui::TranslatedUserWarning(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a vertical constraint!"));
                     return;
                 }
                 // check if the edge already has a Block constraint
                 if ((*it)->Type == Sketcher::Block && (*it)->First == CrvId && (*it)->FirstPos == Sketcher::PointPos::none) {
-                    Gui::TranslatedNotification(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a Block constraint!"));
+                    Gui::TranslatedUserWarning(Obj, QObject::tr("Impossible constraint"), QObject::tr("The selected edge already has a Block constraint!"));
                     return;
                 }
             }
@@ -1379,7 +1379,7 @@ void CmdSketcherConstrainLock::activated(int iMsg)
                 new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select vertices from the sketch."));
         }
         return;
@@ -1402,12 +1402,12 @@ void CmdSketcherConstrainLock::activated(int iMsg)
         if ((it != std::prev(SubNames.end()) && (isEdge(GeoIdt,PosIdt) || (GeoIdt < 0 && GeoIdt >= Sketcher::GeoEnum::VAxis))) ||
             (it == std::prev(SubNames.end()) && isEdge(GeoIdt,PosIdt)) ) {
             if(selection.size() == 1) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select one vertex from the sketch other than the origin."));
             }
             else {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select only vertices from the sketch. The last selected vertex may be the origin."));
             }
@@ -1604,7 +1604,7 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
                             new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                     QObject::tr("Select vertices from the sketch."));
         }
         return;
@@ -1616,7 +1616,7 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
 
     // Check that the solver does not report redundant/conflicting constraints
     if(Obj->getLastSolverStatus()!=GCS::Success || Obj->getLastHasConflicts() || Obj->getLastHasRedundancies()) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong solver status"),
                       QObject::tr("A Block constraint cannot be added "
                                                          "if the sketch is unsolved "
@@ -1635,12 +1635,12 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
 
         if ( isVertex(GeoIdt,PosIdt) || GeoIdt < 0 ) {
             if(selection.size() == 1) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select one edge from the sketch."));
             }
             else {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select only edges from the sketch."));
             }
@@ -1651,7 +1651,7 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
 
         // check if the edge already has a Block constraint
         if ( checkConstraint(vals, Sketcher::Block, GeoIdt, Sketcher::PointPos::none)) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Double constraint"),
                           QObject::tr("The selected edge already has a Block constraint!"));
             return;
@@ -1669,6 +1669,8 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
             Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('Block',%d))", (*itg));
 
         } catch (const Base::Exception& e) {
+            // Exceptions originating in Python have already been reported by the Interpreter as
+            // Untranslated developer intended messages (i.e. to the Report View)
             Gui::NotifyError(Obj,
                         QT_TRANSLATE_NOOP("Notifications", "Error"),
                         e.what());
@@ -1701,7 +1703,7 @@ void CmdSketcherConstrainBlock::applyConstraint(std::vector<SelIdPair> &selSeq, 
             const std::vector< Sketcher::Constraint * > &vals = Obj->Constraints.getValues();
 
             if ( checkConstraint(vals, Sketcher::Block, selSeq.front().GeoId, Sketcher::PointPos::none)) {
-                Gui::TranslatedNotification(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a Block constraint!"));
+                Gui::TranslatedUserWarning(Obj, QObject::tr("Double constraint"), QObject::tr("The selected edge already has a Block constraint!"));
                 return;
             }
 
@@ -1984,7 +1986,7 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select two or more points from the sketch."));
         }
         return;
@@ -1995,7 +1997,7 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.size() < 2) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select two or more vertices from the sketch."));
         return;
@@ -2016,7 +2018,7 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
             allConicsEdges = false; //at least one point is selected, so concentric can't be applied.
 
         if (atLeastOneEdge && !allConicsEdges) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select two or more vertices from the sketch for a coincident constraint, or two or more circles, ellipses, arcs or arcs of ellipse for a concentric constraint."));
             return;
@@ -2092,7 +2094,7 @@ void CmdSketcherConstrainCoincident::applyConstraint(std::vector<SelIdPair> &sel
     case 4: // {SelExternalEdge, SelEdge}
         //Concentric for circles, ellipse, arc, arcofEllipse only.
         if (!isGeoConcentricCompatible(Obj->getGeometry(GeoId1)) || !isGeoConcentricCompatible(Obj->getGeometry(GeoId2))) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select two vertices from the sketch for a coincident constraint, or two circles, ellipses, arcs or arcs of ellipse for a concentric constraint."));
             return;
@@ -2180,7 +2182,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
             getSelection().clearSelection();
         }
         else {
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select vertices from the sketch."));
         }
         return;
@@ -2191,7 +2193,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty() || SubNames.size() > 2) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select exactly one line or one point and one line or two points from the sketch."));
         return;
@@ -2376,7 +2378,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
     }
     else if (isEdge(GeoId1,PosId1)) { // line length
         if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Cannot add a length constraint on an axis!"));
             return;
@@ -2410,7 +2412,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
         }
     }
 
-    Gui::TranslatedNotification(Obj,
+    Gui::TranslatedUserWarning(Obj,
                   QObject::tr("Wrong selection"),
                   QObject::tr("Select exactly one line or one point and one line or two points or two circles from the sketch."));
     return;
@@ -2505,7 +2507,7 @@ void CmdSketcherConstrainDistance::applyConstraint(std::vector<SelIdPair> &selSe
             // allow this selection but do nothing as it needs 2 circles or 1 circle and 1 line
         }
         else {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("This constraint does not make sense for non-linear curves."));
         }
@@ -2597,7 +2599,7 @@ void CmdSketcherConstrainDistance::applyConstraint(std::vector<SelIdPair> &selSe
 
             return;
         } else {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                 QObject::tr("Wrong selection"),
                 QObject::tr("Select exactly one line or one point and one line or two points or two circles from the sketch."));
 
@@ -2706,7 +2708,7 @@ void CmdSketcherConstrainPointOnObject::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -2745,7 +2747,7 @@ void CmdSketcherConstrainPointOnObject::activated(int iMsg)
                 const Part::Geometry *geom = Obj->getGeometry(curves[iCrv].GeoId);
 
                 if( geom && isBsplinePole(geom)) {
-                    Gui::TranslatedNotification(Obj,
+                    Gui::TranslatedUserWarning(Obj,
                                   QObject::tr("Wrong selection"),
                                   QObject::tr("Select an edge that is not a B-spline weight."));
                     abortCommand();
@@ -2768,7 +2770,7 @@ void CmdSketcherConstrainPointOnObject::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             abortCommand();
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("None of the selected points were constrained "
                                                              "onto the respective curves, "
@@ -2780,7 +2782,7 @@ void CmdSketcherConstrainPointOnObject::activated(int iMsg)
         return;
     }
 
-    Gui::TranslatedNotification(Obj,
+    Gui::TranslatedUserWarning(Obj,
                   QObject::tr("Wrong selection"),
                   QObject::tr("Select either one point and several curves, "
                                                      "or one curve and several points."));
@@ -2827,7 +2829,7 @@ void CmdSketcherConstrainPointOnObject::applyConstraint(std::vector<SelIdPair> &
     const Part::Geometry *geom = Obj->getGeometry(GeoIdCrv);
 
     if( geom && isBsplinePole(geom)) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select an edge that is not a B-spline weight."));
         abortCommand();
@@ -2845,7 +2847,7 @@ void CmdSketcherConstrainPointOnObject::applyConstraint(std::vector<SelIdPair> &
     }
     else {
         abortCommand();
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("None of the selected points "
                                                          "were constrained onto the respective curves, "
@@ -2907,7 +2909,7 @@ void CmdSketcherConstrainDistanceX::activated(int iMsg)
         }
         else {
             // TODO: Get the exact message from git history and put it here
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -2918,7 +2920,7 @@ void CmdSketcherConstrainDistanceX::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty() || SubNames.size() > 2) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select exactly one line or up to two points from the sketch."));
         return;
@@ -2948,7 +2950,7 @@ void CmdSketcherConstrainDistanceX::activated(int iMsg)
     if (isEdge(GeoId1,PosId1) && GeoId2 == GeoEnum::GeoUndef)  {
         // horizontal length of a line
         if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Cannot add a horizontal length constraint on an axis!"));
             return;
@@ -2999,7 +3001,7 @@ void CmdSketcherConstrainDistanceX::activated(int iMsg)
         // point on fixed x-coordinate
 
         if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Cannot add a fixed x-coordinate constraint on the origin point!"));
             return;
@@ -3029,7 +3031,7 @@ void CmdSketcherConstrainDistanceX::activated(int iMsg)
         return;
     }
 
-    Gui::TranslatedNotification(Obj,
+    Gui::TranslatedUserWarning(Obj,
                   QObject::tr("Wrong selection"),
                   QObject::tr("Select exactly one line or up to two points from the sketch."));
 
@@ -3060,7 +3062,7 @@ void CmdSketcherConstrainDistanceX::applyConstraint(std::vector<SelIdPair> &selS
 
         const Part::Geometry *geom = Obj->getGeometry(GeoId1);
         if (geom->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("This constraint only makes sense on a line segment or a pair of points."));
             return;
@@ -3165,7 +3167,7 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -3176,7 +3178,7 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty() || SubNames.size() > 2) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select exactly one line or up to two points from the sketch."));
         return;
@@ -3202,7 +3204,7 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
 
     if (isEdge(GeoId1,PosId1) && GeoId2 == GeoEnum::GeoUndef)  { // vertical length of a line
         if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Cannot add a vertical length constraint on an axis!"));
             return;
@@ -3253,7 +3255,7 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
     else if (isVertex(GeoId1,PosId1) && GeoId2 == GeoEnum::GeoUndef) {
         // point on fixed y-coordinate
         if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Cannot add a fixed y-coordinate constraint on the origin point!"));
             return;
@@ -3283,7 +3285,7 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
         return;
     }
 
-    Gui::TranslatedNotification(Obj,
+    Gui::TranslatedUserWarning(Obj,
                   QObject::tr("Wrong selection"),
                   QObject::tr("Select exactly one line or up to two points from the sketch."));
 
@@ -3314,7 +3316,7 @@ void CmdSketcherConstrainDistanceY::applyConstraint(std::vector<SelIdPair> &selS
 
         const Part::Geometry *geom = Obj->getGeometry(GeoId1);
         if (geom->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("This constraint only makes sense on a line segment or a pair of points."));
             return;
@@ -3416,7 +3418,7 @@ void CmdSketcherConstrainParallel::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select two or more lines from the sketch."));
         }
         return;
@@ -3429,7 +3431,7 @@ void CmdSketcherConstrainParallel::activated(int iMsg)
     // go through the selected subelements
 
     if (SubNames.size() < 2) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select at least two lines from the sketch."));
         return;
@@ -3444,7 +3446,7 @@ void CmdSketcherConstrainParallel::activated(int iMsg)
         getIdsFromName(*it, Obj, GeoId, PosId);
 
         if (!isEdge(GeoId,PosId)) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select a valid line."));
             return;
@@ -3461,7 +3463,7 @@ void CmdSketcherConstrainParallel::activated(int iMsg)
         // Check that the curve is a line segment
         const Part::Geometry *geo = Obj->getGeometry(GeoId);
         if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("The selected edge is not a valid line."));
 
@@ -3501,7 +3503,7 @@ void CmdSketcherConstrainParallel::applyConstraint(std::vector<SelIdPair> &selSe
         // Check that the curves are line segments
         if (    Obj->getGeometry(GeoId1)->getTypeId() != Part::GeomLineSegment::getClassTypeId() ||
                 Obj->getGeometry(GeoId2)->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("The selected edge is not a valid line."));
             return;
@@ -3589,7 +3591,7 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
             QString strError = QObject::tr("Select some geometry from the sketch.", "perpendicular constraint");
             strError.append(QString::fromLatin1("\n\n"));
             strError.append(strBasicHelp);
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  std::move(strError));
         }
         return;
@@ -3600,7 +3602,7 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
     Sketcher::SketchObject* Obj = dynamic_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (!Obj || (SubNames.size() != 2 && SubNames.size() != 3)) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Wrong number of selected objects!"));
         return;
@@ -3631,7 +3633,7 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
         if (isEdge(GeoId1, PosId1) && isEdge(GeoId2, PosId2) && isVertex(GeoId3, PosId3)) {
 
             if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select an edge that is not a B-spline weight."));
                 return;
@@ -3678,7 +3680,7 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
 
         };
 
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("With 3 objects, there must be 2 curves and 1 point."));
 
@@ -3689,7 +3691,7 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
 
             if (isSimpleVertex(Obj, GeoId1, PosId1) ||
                 isSimpleVertex(Obj, GeoId2, PosId2)) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Cannot add a perpendicularity constraint at an unconnected point!"));
                 return;
@@ -3727,7 +3729,7 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
             }
 
             if (isSimpleVertex(Obj, GeoId1, PosId1)) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Cannot add a perpendicularity constraint at an unconnected point!"));
                 return;
@@ -3737,14 +3739,14 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
 
             if( geom2 && geom2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() ){
                 // unsupported until normal to B-spline at any point implemented.
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Perpendicular to B-spline edge currently unsupported."));
                 return;
             }
 
             if(isBsplinePole(geom2)) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select an edge that is not a B-spline weight."));
                 return;
@@ -3769,7 +3771,7 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
 
             if (geo1->getTypeId() != Part::GeomLineSegment::getClassTypeId() &&
                 geo2->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("One of the selected edges should be a line."));
                 return;
@@ -3779,7 +3781,7 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
                 geo2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()){
 
                 // unsupported until tangent to B-spline at any point implemented.
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Perpendicular to B-spline edge currently unsupported."));
                 return;
@@ -3789,7 +3791,7 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
                 std::swap(GeoId1,GeoId2);
 
             if(isBsplinePole(Obj, GeoId1)) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select an edge that is not a B-spline weight."));
                 return;
@@ -3950,7 +3952,7 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair> &
 
         if (geo1->getTypeId() != Part::GeomLineSegment::getClassTypeId() &&
             geo2->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("One of the selected edges should be a line."));
             return;
@@ -3960,7 +3962,7 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair> &
             geo2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()){
 
             // unsupported until tangent to B-spline at any point implemented.
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Perpendicular to B-spline edge currently unsupported."));
 
@@ -3971,7 +3973,7 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair> &
             std::swap(GeoId1,GeoId2);
 
         if(isBsplinePole(Obj, GeoId1)) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select an edge that is not a B-spline weight."));
             return;
@@ -4129,7 +4131,7 @@ void CmdSketcherConstrainPerpendicular::applyConstraint(std::vector<SelIdPair> &
         }
 
         if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select an edge that is not a B-spline weight."));
 
@@ -4301,7 +4303,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
             QString strError = QObject::tr("Select some geometry from the sketch.", "tangent constraint");
             strError.append(QString::fromLatin1("\n\n"));
             strError.append(strBasicHelp);
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  std::move(strError));
         }
         return;
@@ -4312,7 +4314,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.size() != 2 && SubNames.size() != 3){
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Wrong number of selected objects!"));
 
@@ -4344,7 +4346,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
         if (isEdge(GeoId1, PosId1) && isEdge(GeoId2, PosId2) && isVertex(GeoId3, PosId3)) {
 
             if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select an edge that is not a B-spline weight."));
 
@@ -4390,7 +4392,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
 
         };
 
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("With 3 objects, there must be 2 curves and 1 point."));
 
@@ -4410,7 +4412,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
                 if (isBsplineKnot(Obj, GeoId1)) {
                     const Part::Geometry *geom2 = Obj->getGeometry(GeoId2);
                     if (!geom2 || geom2->getTypeId() !=Part::GeomLineSegment::getClassTypeId()) {
-                        Gui::TranslatedNotification(Obj,
+                        Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Tangent constraint at B-spline knot is only supported with lines!"));
 
@@ -4418,7 +4420,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
                     }
                 }
                 else {
-                    Gui::TranslatedNotification(Obj,
+                    Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Cannot add a tangency constraint at an unconnected point!"));
 
@@ -4445,14 +4447,14 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
                 if (isBsplineKnot(Obj, GeoId1)) {
                     const Part::Geometry *geom2 = Obj->getGeometry(GeoId2);
                     if (!geom2 || geom2->getTypeId() !=Part::GeomLineSegment::getClassTypeId()) {
-                        Gui::TranslatedNotification(Obj,
+                        Gui::TranslatedUserWarning(Obj,
                                       QObject::tr("Wrong selection"),
                                       QObject::tr("Tangent constraint at B-spline knot is only supported with lines!"));
                         return;
                     }
                 }
                 else {
-                    Gui::TranslatedNotification(Obj,
+                    Gui::TranslatedUserWarning(Obj,
                                   QObject::tr("Wrong selection"),
                                   QObject::tr("Cannot add a tangency constraint at an unconnected point!"));
 
@@ -4464,7 +4466,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
 
             if( geom2 && geom2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() ){
                 // unsupported until tangent to B-spline at any point implemented.
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Tangency to B-spline edge currently unsupported."));
 
@@ -4472,7 +4474,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
             }
 
             if(isBsplinePole(geom2)) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select an edge that is not a B-spline weight."));
 
@@ -4498,7 +4500,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
                 geom2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() )){
 
                 // unsupported until tangent to B-spline at any point implemented.
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Tangency to B-spline edge currently unsupported."));
 
@@ -4506,7 +4508,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
             }
 
             if(isBsplinePole(geom1) || isBsplinePole(geom2)) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select an edge that is not a B-spline weight."));
 
@@ -4696,7 +4698,7 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair> &selSeq
             geom2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() )){
 
             // unsupported until tangent to B-spline at any point implemented.
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Tangency to B-spline edge currently unsupported."));
 
@@ -4704,7 +4706,7 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair> &selSeq
         }
 
         if(isBsplinePole(geom1) || isBsplinePole(geom2)) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select an edge that is not a B-spline weight."));
 
@@ -4857,7 +4859,7 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair> &selSeq
 
         if (isSimpleVertex(Obj, GeoId1, PosId1) ||
             isSimpleVertex(Obj, GeoId2, PosId2)) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Cannot add a tangency constraint at an unconnected point!"));
 
@@ -4901,7 +4903,7 @@ void CmdSketcherConstrainTangent::applyConstraint(std::vector<SelIdPair> &selSeq
         }
 
         if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select an edge that is not a B-spline weight."));
 
@@ -4997,7 +4999,7 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -5008,7 +5010,7 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty()) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select one or more arcs or circles from the sketch."));
         return;
@@ -5070,7 +5072,7 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
     }
 
     if (geoIdRadiusMap.empty() && externalGeoIdRadiusMap.empty()) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select one or more arcs or circles from the sketch."));
 
@@ -5078,7 +5080,7 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
     }
 
     if(poles && nonpoles) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select either only one or more B-Spline poles or only one or more arcs or circles from the sketch, but not mixed."));
 
@@ -5199,7 +5201,7 @@ void CmdSketcherConstrainRadius::applyConstraint(std::vector<SelIdPair> &selSeq,
             radius = circle->getRadius();
         }
         else {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Constraint only applies to arcs or circles."));
 
@@ -5304,7 +5306,7 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -5315,7 +5317,7 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty()) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select one or more arcs or circles from the sketch."));
 
@@ -5359,7 +5361,7 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
             double radius = circle->getRadius();
 
             if(isBsplinePole(geom)) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select an edge that is not a B-spline weight."));
 
@@ -5376,7 +5378,7 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
     }
 
     if (geoIdDiameterMap.empty() && externalGeoIdDiameterMap.empty()) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select one or more arcs or circles from the sketch."));
 
@@ -5484,7 +5486,7 @@ void CmdSketcherConstrainDiameter::applyConstraint(std::vector<SelIdPair> &selSe
                 diameter = 2*circle->getRadius();
             }
             else {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Constraint only applies to arcs or circles."));
 
@@ -5492,7 +5494,7 @@ void CmdSketcherConstrainDiameter::applyConstraint(std::vector<SelIdPair> &selSe
             }
 
             if(isBsplinePole(geom)) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select an edge that is not a B-spline weight."));
 
@@ -5588,7 +5590,7 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -5599,7 +5601,7 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty()) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select one or more arcs or circles from the sketch."));
 
@@ -5656,7 +5658,7 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
     }
 
     if (geoIdRadiamMap.empty() && externalGeoIdRadiamMap.empty()) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select one or more arcs or circles from the sketch."));
 
@@ -5664,7 +5666,7 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
     }
 
     if(poles && nonpoles) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select either only one or more B-Spline poles or only one or more arcs or circles from the sketch, but not mixed."));
 
@@ -5805,7 +5807,7 @@ void CmdSketcherConstrainRadiam::applyConstraint(std::vector<SelIdPair> &selSeq,
                     isPole = true;
             }
             else {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Constraint only applies to arcs or circles."));
 
@@ -6055,7 +6057,7 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
             getSelection().clearSelection();
         } else {
             // TODO: Get the exact message from git history and put it here
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select the right things from the sketch."));
         }
         return;
@@ -6066,7 +6068,7 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty() || SubNames.size() > 3) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select one or two lines from the sketch. Or select two edges and a point."));
 
@@ -6099,7 +6101,7 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
         if (isEdge(GeoId1, PosId1) && isEdge(GeoId2, PosId2) && isVertex(GeoId3, PosId3)) {
 
             if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Select an edge that is not a B-spline weight."));
                 return;
@@ -6162,7 +6164,7 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
         }
 
         if(isBsplinePole(Obj, GeoId1) || (GeoId2 != GeoEnum::GeoUndef && isBsplinePole(Obj, GeoId2))) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select an edge that is not a B-spline weight."));
 
@@ -6228,7 +6230,7 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
                 if (dir3.Length() < Precision::Intersection()) {
                     Base::Vector3d dist = (p1[0] - p2[0]) % dir1;
                     if (dist.Sqr() > Precision::Intersection()) {
-                        Gui::TranslatedNotification(Obj,
+                        Gui::TranslatedUserWarning(Obj,
                                       QObject::tr("Parallel lines"),
                                       QObject::tr("An angle constraint cannot be set for two parallel lines."));
 
@@ -6262,7 +6264,7 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
             }
         } else if (isEdge(GeoId1,PosId1)) { // line angle
             if (GeoId1 < 0 && GeoId1 >= Sketcher::GeoEnum::VAxis) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Cannot add an angle constraint on an axis!"));
 
@@ -6320,7 +6322,7 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
         }
     };
 
-    Gui::TranslatedNotification(Obj,
+    Gui::TranslatedUserWarning(Obj,
                   QObject::tr("Wrong selection"),
                   QObject::tr("Select one or two lines from the sketch. Or select two edges and a point."));
 
@@ -6401,7 +6403,7 @@ void CmdSketcherConstrainAngle::applyConstraint(std::vector<SelIdPair> &selSeq, 
             if (dir3.Length() < Precision::Intersection()) {
                 Base::Vector3d dist = (p1[0] - p2[0]) % dir1;
                 if (dist.Sqr() > Precision::Intersection()) {
-                    Gui::TranslatedNotification(Obj,
+                    Gui::TranslatedUserWarning(Obj,
                                   QObject::tr("Parallel lines"),
                                   QObject::tr("An angle constraint cannot be set for two parallel lines."));
 
@@ -6464,7 +6466,7 @@ void CmdSketcherConstrainAngle::applyConstraint(std::vector<SelIdPair> &selSeq, 
     if (isEdge(GeoId1, PosId1) && isEdge(GeoId2, PosId2) && isVertex(GeoId3, PosId3)) {
 
         if(isBsplinePole(Obj, GeoId1) || isBsplinePole(Obj, GeoId2)) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select an edge that is not a B-spline weight."));
 
@@ -6583,7 +6585,7 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
                             new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select two edges from the sketch."));
         }
         return;
@@ -6596,7 +6598,7 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
     // go through the selected subelements
 
     if (SubNames.size() < 2) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select at least two lines from the sketch."));
 
@@ -6614,14 +6616,14 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
         getIdsFromName(*it, Obj, GeoId, PosId);
 
         if (!isEdge(GeoId,PosId)) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select two or more compatible edges."));
 
             return;
         }
         else if (GeoId == Sketcher::GeoEnum::HAxis || GeoId == Sketcher::GeoEnum::VAxis) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Sketch axes cannot be used in equality constraints."));
 
@@ -6642,7 +6644,7 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
 
         if(geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
             // unsupported as they are generally hereogeneus shapes
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Equality for B-spline edge currently unsupported."));
 
@@ -6674,7 +6676,7 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
             parabSel = true;
         }
         else {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select two or more edges of similar type."));
 
@@ -6691,7 +6693,7 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
          ( hyperbSel && (parabSel || weightSel)) ||
          ( parabSel && weightSel)) {
 
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select two or more edges of similar type."));
 
@@ -6744,7 +6746,7 @@ void CmdSketcherConstrainEqual::applyConstraint(std::vector<SelIdPair> &selSeq, 
              ( (geo1->getTypeId() == Part::GeomEllipse::getClassTypeId() || geo1->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()) &&
                !(geo2->getTypeId() == Part::GeomEllipse::getClassTypeId() || geo2->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId())) ){
 
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select two or more edges of similar type."));
 
@@ -6828,7 +6830,7 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
                             new DrawSketchHandlerGenConstraint(this));
             getSelection().clearSelection();
         } else {
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                  QObject::tr("Select two points and a symmetry line, "
                                              "two points and a symmetry point "
                                              "or a line and a symmetry point from the sketch."));
@@ -6841,7 +6843,7 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
     Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.size() != 3 && SubNames.size() != 2) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select two points and a symmetry line, "
                                                          "two points and a symmetry point "
@@ -6868,7 +6870,7 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
             const Part::Geometry *geom = Obj->getGeometry(GeoId1);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
                 if (GeoId1 == GeoId2) {
-                    Gui::TranslatedNotification(Obj,
+                    Gui::TranslatedUserWarning(Obj,
                                   QObject::tr("Wrong selection"),
                                   QObject::tr("Cannot add a symmetry constraint "
                                                                      "between a line and its end points."));
@@ -6892,7 +6894,7 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
             }
         }
 
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                       QObject::tr("Wrong selection"),
                       QObject::tr("Select two points and a symmetry line, "
                                                          "two points and a symmetry point "
@@ -6924,7 +6926,7 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
             const Part::Geometry *geom = Obj->getGeometry(GeoId3);
             if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
                 if (GeoId1 == GeoId2 && GeoId2 == GeoId3) {
-                    Gui::TranslatedNotification(Obj,
+                    Gui::TranslatedUserWarning(Obj,
                                   QObject::tr("Wrong selection"),
                                   QObject::tr("Cannot add a symmetry constraint "
                                                                      "between a line and its end points!"));
@@ -6964,7 +6966,7 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
         }
     }
 
-    Gui::TranslatedNotification(Obj,
+    Gui::TranslatedUserWarning(Obj,
                   QObject::tr("Wrong selection"),
                   QObject::tr("Select two points and a symmetry line, "
                                                      "two points and a symmetry point "
@@ -6988,7 +6990,7 @@ void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair> &selS
         PosId1 = Sketcher::PointPos::start; PosId2 = Sketcher::PointPos::end; PosId3 = selSeq.at(1).PosId;
 
         if (GeoId1 == GeoId3) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Cannot add a symmetry constraint between a line and its end points!"));
 
@@ -7032,7 +7034,7 @@ void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair> &selS
         const Part::Geometry *geom = Obj->getGeometry(GeoId3);
         if (geom->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
             if (GeoId1 == GeoId2 && GeoId2 == GeoId3) {
-                Gui::TranslatedNotification(Obj,
+                Gui::TranslatedUserWarning(Obj,
                               QObject::tr("Wrong selection"),
                               QObject::tr("Cannot add a symmetry constraint "
                                                                  "between a line and its end points."));
@@ -7050,7 +7052,7 @@ void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair> &selS
             tryAutoRecompute(Obj);
         }
         else {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select two points and a symmetry line, "
                                                              "two points and a symmetry point "
@@ -7135,7 +7137,7 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
                                 "from one sketch.", dmbg);
 
         strError.append(strHelp);
-        Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+        Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                                 std::move(strError));
     }
 
@@ -7144,7 +7146,7 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
     const std::vector<std::string> &SubNames = selection[0].getSubNames();
 
     if (SubNames.size() != 3) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                         QObject::tr("Wrong selection"),
                         QObject::tr("Number of selected objects is not 3"));
 
@@ -7169,7 +7171,7 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
 
     //a bunch of validity checks
     if (areAllPointsOrSegmentsFixed(Obj, GeoId1, GeoId2, GeoId3) ) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                         QObject::tr("Wrong selection"),
                         QObject::tr("Cannot create constraint with external geometry only."));
 
@@ -7180,7 +7182,7 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
             isVertex(GeoId2,PosId2) && !isSimpleVertex(Obj, GeoId2, PosId2) &&
             isEdge(GeoId3,PosId3)   )) {
 
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                         QObject::tr("Wrong selection"),
                         QObject::tr("Incompatible geometry is selected."));
 
@@ -7191,7 +7193,7 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
 
     if( geo && geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId() ){
         // unsupported until normal to B-spline at any point implemented.
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                         QObject::tr("Wrong selection"),
                         QObject::tr("SnellsLaw on B-spline edge is currently unsupported."));
 
@@ -7199,7 +7201,7 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
     }
 
     if(isBsplinePole(geo)) {
-        Gui::TranslatedNotification(Obj,
+        Gui::TranslatedUserWarning(Obj,
                         QObject::tr("Wrong selection"),
                         QObject::tr("Select an edge that is not a B-spline weight."));
 
@@ -7326,7 +7328,7 @@ void CmdSketcherToggleDrivingConstraint::activated(int iMsg)
 
         // only one sketch with its subelements are allowed to be selected
         if (selection.size() != 1 || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
-            Gui::TranslatedNotification("Sketcher", QObject::tr("Wrong selection"),
+            Gui::TranslatedUserWarning("Sketcher", QObject::tr("Wrong selection"),
                 QObject::tr("Select constraints from the sketch."));
             return;
         }
@@ -7336,7 +7338,7 @@ void CmdSketcherToggleDrivingConstraint::activated(int iMsg)
         // get the needed lists and objects
         const std::vector<std::string> &SubNames = selection[0].getSubNames();
         if (SubNames.empty()) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select constraints from the sketch."));
 
@@ -7370,7 +7372,7 @@ void CmdSketcherToggleDrivingConstraint::activated(int iMsg)
         // get the needed lists and objects
         const std::vector<std::string> &SubNames = selection[0].getSubNames();
         if (SubNames.empty()) {
-            Gui::TranslatedNotification(Obj,
+            Gui::TranslatedUserWarning(Obj,
                           QObject::tr("Wrong selection"),
                           QObject::tr("Select constraints from the sketch."));
 
@@ -7444,7 +7446,7 @@ void CmdSketcherToggleActiveConstraint::activated(int iMsg)
 
         // only one sketch with its subelements are allowed to be selected
         if (selection.size() != 1 || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
-            Gui::TranslatedNotification("Sketcher",
+            Gui::TranslatedUserWarning("Sketcher",
                                  QObject::tr("Wrong selection"),
                                  QObject::tr("Select constraints from the sketch."));
             return;
@@ -7455,7 +7457,7 @@ void CmdSketcherToggleActiveConstraint::activated(int iMsg)
         // get the needed lists and objects
         const std::vector<std::string> &SubNames = selection[0].getSubNames();
         if (SubNames.empty()) {
-            Gui::TranslatedNotification( Obj,
+            Gui::TranslatedUserWarning( Obj,
                                     QObject::tr("Wrong selection"),
                                     QObject::tr("Select constraints from the sketch."));
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -469,7 +469,7 @@ void ElementView::changeLayer(int layer)
                 }
             }
             else {
-                Gui::TranslatedNotification(sketchobject,
+                Gui::TranslatedUserWarning(sketchobject,
                                             QObject::tr("Unsupported visual layer operation"),
                                             QObject::tr("It is currently unsupported to move external geometry to another visual layer. External geometry will be omitted"));
             }

--- a/src/Mod/Test/Gui/AppTestGui.cpp
+++ b/src/Mod/Test/Gui/AppTestGui.cpp
@@ -40,9 +40,13 @@ public:
 
     void flush() {buffer.str("");buffer.clear();}
 
-    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level) override{
+    void SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
+                 Base::IntendedRecipient recipient, Base::ContentType content) override{
         (void) notifiername;
         (void) msg;
+        (void) recipient;
+        (void) content;
+
         switch(level){
             case Base::LogStyle::Warning:
                 buffer << "WRN";


### PR DESCRIPTION

This PR proposes an extension of the console interface intended to fix the limitations identified here:
https://github.com/FreeCAD/FreeCAD-translations/issues/223
https://forum.freecad.org/viewtopic.php?t=77673

In essence:
1. The console framework is extended to include additional information, the intended recipient and the translation status of the message. The TranslatedNotification message is removed, as it is covered by a notification where the translation status is "translated".
2. The notifications framework is adapted to the new console framework.
3. Base interpreter is adapted to report the exception with intended recipients being only Developers
4. The Notification Area is adapted. It won't show a message that is intended for developers or that is untranslatable (such a stack), unless in preferences the user has opted-in to receive developer messages.
5. The Notification Area preferences are adapted. While it is possible to opt-in developer warnings and errors, they are not show by default. User intended warnings and errors are an integral part part of the notification area and it is no longer possible to opt-out. Of course, it is always possible to disable the notification area as before.
6. The Report view will show errors and warnings intended for developers and not translated, i.e. in English. It won't show errors intended exclusively to users or messages that are translated.
7. The Sketcher Constraint Commands is adapted to the new framework and may serve as a reference for other portions of the code.

Is there any breaking change?

No. The API is the same as before, except that it is extended to have more options.

Is there code that should be adapted?

Errors and Warning messages should be curated. This means identifying the recipient, curating the text and using the extended API if appropriate.

What is the main goal?

I. To be able to differentiate between messages that are curated and translated and intended to be shown to the end user and messages which may be very useful for a power user (e.g. to debug macros or console statements) or for developers.

II. To stop showing stack traces in the Notification Area, which is a major reason of complaint.

Should this be merged for 0.21?

I think it would be advantageous to do so, if only because of the traces being reported in the Notification Area. However, I do not have a strong opinion.