### PR TITLE
Sketcher console error split

### DIFF
--- a/src/Base/Console.h
+++ b/src/Base/Console.h
@@ -371,17 +371,17 @@ using PyMethodDef = struct PyMethodDef;
 
 #define _FC_PRINT(_instance,_l,_func,_msg) __FC_PRINT(_instance,_l,_func,_msg,__FILE__,__LINE__)
 
-#define FC_MSG(_msg) _FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_MSG,Notify<Base::LogStyle::Message>,_msg)
-#define FC_WARN(_msg) _FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_WARN,Notify<Base::LogStyle::Warning>,_msg)
-#define FC_ERR(_msg) _FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_ERR,Notify<Base::LogStyle::Error>,_msg)
-#define FC_LOG(_msg) _FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_LOG,Notify<Base::LogStyle::Log>,_msg)
-#define FC_TRACE(_msg) _FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_TRACE,Notify<Base::LogStyle::Log>,_msg)
+#define FC_MSG(_msg) _FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_MSG,Message,_msg)
+#define FC_WARN(_msg) _FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_WARN,DeveloperWarning,_msg)
+#define FC_ERR(_msg) _FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_ERR,DeveloperError,_msg)
+#define FC_LOG(_msg) _FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_LOG,Log,_msg)
+#define FC_TRACE(_msg) _FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_TRACE,Log,_msg)
 
-#define _FC_MSG(_file,_line,_msg) __FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_MSG,Notify<Base::LogStyle::Message>,_msg,_file,_line)
-#define _FC_WARN(_file,_line,_msg) __FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_WARN,Notify<Base::LogStyle::Warning>,_msg,_file,_line)
-#define _FC_ERR(_file,_line,_msg) __FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_ERR,Notify<Base::LogStyle::Error>,_msg,_file,_line)
-#define _FC_LOG(_file,_line,_msg) __FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_LOG,Notify<Base::LogStyle::Log>,_msg,_file,_line)
-#define _FC_TRACE(_file,_line,_msg) __FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_TRACE,Notify<Base::LogStyle::Log>,_msg,_file,_line)
+#define _FC_MSG(_file,_line,_msg) __FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_MSG,Message,_msg,_file,_line)
+#define _FC_WARN(_file,_line,_msg) __FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_WARN,DeveloperWarning,_msg,_file,_line)
+#define _FC_ERR(_file,_line,_msg) __FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_ERR,DeveloperError,_msg,_file,_line)
+#define _FC_LOG(_file,_line,_msg) __FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_LOG,Log,_msg,_file,_line)
+#define _FC_TRACE(_file,_line,_msg) __FC_PRINT(FC_LOG_INSTANCE,FC_LOGLEVEL_TRACE,Log,_msg,_file,_line)
 
 #define FC_XYZ(_pt) '('<<(_pt).X()<<", " << (_pt).Y()<<", " << (_pt).Z()<<')'
 #define FC_xy(_pt) '('<<(_pt).x<<", " << (_pt).y<<')'

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -129,7 +129,7 @@ CurveConverter::CurveConverter()
         hGrp->Attach(this);
     }
     catch(const Base::ValueError & e) { // ensure that if parameter strings are not well-formed, the exception is not propagated
-        Base::Console().Error("CurveConverter: Malformed parameter string: %s\n", e.what());
+        Base::Console().DeveloperError("CurveConverter", "Malformed parameter string: %s\n", e.what());
     }
 
     updateCurvedEdgeCountSegmentsParameter();
@@ -142,7 +142,7 @@ CurveConverter::~CurveConverter()
         hGrp->Detach(this);
     }
     catch(const Base::ValueError & e) {// ensure that if parameter strings are not well-formed, the program is not terminated when calling the noexcept destructor.
-        Base::Console().Error("CurveConverter: Malformed parameter string: %s\n", e.what());
+        Base::Console().DeveloperError("CurveConverter", "Malformed parameter string: %s\n", e.what());
     }
 }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -23,6 +23,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerArc_H
 #define SKETCHERGUI_DrawSketchHandlerArc_H
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -184,7 +186,9 @@ public:
                 Gui::Command::commitCommand();
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to add arc: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Failed to add arc"));
                 Gui::Command::abortCommand();
             }
 
@@ -433,7 +437,9 @@ public:
                 Gui::Command::commitCommand();
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to add arc: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Failed to add arc"));
                 Gui::Command::abortCommand();
             }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -23,8 +23,9 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerArcOfEllipse_H
 #define SKETCHERGUI_DrawSketchHandlerArcOfEllipse_H
 
-#include "GeometryCreationMode.h"
+#include <Gui/Notifications.h>
 
+#include "GeometryCreationMode.h"
 
 namespace SketcherGui {
 
@@ -276,7 +277,9 @@ public:
                 Gui::cmdAppObjectArgs(sketchgui->getObject(), "exposeInternalGeometry(%d)", currentgeoid);
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Failed to add arc of ellipse"));
                 Gui::Command::abortCommand();
 
                 tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -25,6 +25,8 @@
 
 #include <boost/math/special_functions/fpclassify.hpp>
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -224,7 +226,9 @@ public:
 
             if (boost::math::isnan(startAngle) || boost::math::isnan(endAngle)) {
                 sketchgui->purgeHandler();
-                Base::Console().Error("Cannot create arc of hyperbola from invalid angles, try again!\n");
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Cannot create arc of hyperbola from invalid angles, try again!"));
                 return false;
             }
 
@@ -287,7 +291,9 @@ public:
                 Gui::cmdAppObjectArgs(sketchgui->getObject(), "exposeInternalGeometry(%d)", currentgeoid);
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Cannot create arc of hyperbola"));
                 Gui::Command::abortCommand();
 
                 tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -25,6 +25,7 @@
 
 #include "GeometryCreationMode.h"
 
+#include <Gui/Notifications.h>
 
 namespace SketcherGui {
 
@@ -241,7 +242,9 @@ public:
                 Gui::cmdAppObjectArgs(sketchgui->getObject(), "exposeInternalGeometry(%d)", currentgeoid);
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Cannot create arc of parabola"));
                 Gui::Command::abortCommand();
 
                 tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -26,6 +26,8 @@
 #include <QInputDialog>
 #include <Inventor/events/SoKeyboardEvent.h>
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -114,7 +116,10 @@ public:
                                       poleGeoIds.back(), 1.0 ); // First pole defaults to 1.0 weight
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Error adding B-Spline pole"));
+
                 Gui::Command::abortCommand();
 
                 static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->solve();
@@ -183,7 +188,9 @@ public:
 
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Error creating BSpline pole"));
                 Gui::Command::abortCommand();
 
                 static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->solve();
@@ -277,7 +284,9 @@ public:
                 drawCursorToPosition(prevCursorPosition);
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Error deleting last pole"));
                 // some commands might have already deleted some constraints/geometries but not others
                 Gui::Command::abortCommand();
 
@@ -463,7 +472,9 @@ private:
                 Gui::cmdAppObjectArgs(sketchgui->getObject(), "exposeInternalGeometry(%d)", currentgeoid);
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Error creating B-Spline"));
                 Gui::Command::abortCommand();
 
                 tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSplineByInterpolation.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSplineByInterpolation.h
@@ -26,6 +26,8 @@
 #include <Inventor/events/SoKeyboardEvent.h>
 #include <QInputDialog>
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -117,7 +119,9 @@ public:
                 knotGeoIds.push_back(getHighestCurveIndex());
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Cannot add knot point"));
                 Gui::Command::abortCommand();
 
                 static_cast<Sketcher::SketchObject*>(sketchgui->getObject())->solve();
@@ -185,7 +189,9 @@ public:
                 knotGeoIds.push_back(getHighestCurveIndex());
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Cannot add internal alignment points"));
                 Gui::Command::abortCommand();
 
                 static_cast<Sketcher::SketchObject*>(sketchgui->getObject())->solve();
@@ -292,7 +298,9 @@ public:
                 drawCursorToPosition(prevCursorPosition);
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Error removing knot"));
                 // some commands might have already deleted some constraints/geometries but not
                 // others
                 Gui::Command::abortCommand();
@@ -600,7 +608,9 @@ private:
                     sketchgui->getObject(), "exposeInternalGeometry(%d)", currentgeoid);
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Error creating B-Spline"));
                 Gui::Command::abortCommand();
 
                 tryAutoRecomputeIfNotSolve(

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -23,6 +23,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerCarbonCopy_H
 #define SKETCHERGUI_DrawSketchHandlerCarbonCopy_H
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -143,7 +145,9 @@ public:
                         * right button of the mouse */
                 }
                 catch (const Base::Exception& e) {
-                    Base::Console().Error("Failed to add carbon copy: %s\n", e.what());
+                    Gui::NotifyError(sketchgui,
+                                     QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                     QT_TRANSLATE_NOOP("Notifications", "Failed to add carbon copy"));
                     Gui::Command::abortCommand();
                 }
                 return true;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -114,7 +114,9 @@ public:
                 Gui::Command::commitCommand();
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to add circle: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                 QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                 QT_TRANSLATE_NOOP("Notifications", "Failed to add circle"));
                 Gui::Command::abortCommand();
             }
 
@@ -287,7 +289,9 @@ public:
                 Gui::Command::commitCommand();
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to add circle: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Failed to add circle"));
                 Gui::Command::abortCommand();
             }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -27,6 +27,8 @@
 #include <QDebug>
 #include <GC_MakeEllipse.hxx>
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -746,7 +748,9 @@ private:
             Gui::cmdAppObjectArgs(sketchgui->getObject(), "exposeInternalGeometry(%d)", currentgeoid);
         }
         catch (const Base::Exception& e) {
-            Base::Console().Error("%s\n", e.what());
+            Gui::NotifyError(sketchgui,
+                                QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                QT_TRANSLATE_NOOP("Notifications", "Failed to add an ellipse"));
             Gui::Command::abortCommand();
 
             tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
@@ -23,6 +23,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerExtend_H
 #define SKETCHERGUI_DrawSketchHandlerExtend_H
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -274,7 +276,9 @@ public:
                 }
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to extend edge: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Failed to extend edge"));
                 Gui::Command::abortCommand();
             }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -23,6 +23,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerExternal_H
 #define SKETCHERGUI_DrawSketchHandlerExternal_H
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -152,7 +154,9 @@ public:
                 * right button of the mouse */
                 }
                 catch (const Base::Exception& e) {
-                    Base::Console().Error("Failed to add external geometry: %s\n", e.what());
+                    Gui::NotifyError(sketchgui,
+                                QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                QT_TRANSLATE_NOOP("Notifications", "Failed to add external geometry"));
                     Gui::Selection().clearSelection();
                     Gui::Command::abortCommand();
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -22,6 +22,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerLine_H
 #define SKETCHERGUI_DrawSketchHandlerLine_H
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -104,7 +106,10 @@ public:
                 Gui::Command::commitCommand();
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to add line: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                                    QT_TRANSLATE_NOOP("Notifications", "Failed to add line"));
+
                 Gui::Command::abortCommand();
             }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -26,6 +26,8 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <Inventor/events/SoKeyboardEvent.h>
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -405,7 +407,9 @@ public:
                 }
                 catch (const Base::Exception& e) {
                     addedGeometry = false;
-                    Base::Console().Error("Failed to add line: %s\n", e.what());
+                    Gui::NotifyError(sketchgui,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        QT_TRANSLATE_NOOP("Notifications", "Failed to add line"));
                     Gui::Command::abortCommand();
                 }
 
@@ -427,7 +431,10 @@ public:
                 }
                 catch (const Base::Exception& e) {
                     addedGeometry = false;
-                    Base::Console().Error("Failed to add arc: %s\n", e.what());
+                    Gui::NotifyError(sketchgui,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        QT_TRANSLATE_NOOP("Notifications", "Failed to add arc"));
+
                     Gui::Command::abortCommand();
                 }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -23,6 +23,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerPoint_H
 #define SKETCHERGUI_DrawSketchHandlerPoint_H
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -68,7 +70,10 @@ public:
                 Gui::Command::commitCommand();
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to add point: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        QT_TRANSLATE_NOOP("Notifications", "Failed to add point"));
+
                 Gui::Command::abortCommand();
             }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -23,6 +23,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerPolygon_H
 #define SKETCHERGUI_DrawSketchHandlerPolygon_H
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 #include "SketcherRegularPolygonDialog.h"
 
@@ -142,7 +144,10 @@ public:
                 tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to add hexagon: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        QT_TRANSLATE_NOOP("Notifications", "Failed to add polygon"));
+
                 Gui::Command::abortCommand();
 
                 tryAutoRecompute(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -23,6 +23,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerRectangle_H
 #define SKETCHERGUI_DrawSketchHandlerRectangle_H
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -232,7 +234,10 @@ public:
                 }
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to add box: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        QT_TRANSLATE_NOOP("Notifications", "Failed to add box"));
+
                 Gui::Command::abortCommand();
             }
 
@@ -563,7 +568,10 @@ public:
                 tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to add rounded rectangle: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        QT_TRANSLATE_NOOP("Notifications", "Failed to add rounded rectangle"));
+
                 Gui::Command::abortCommand();
 
                 tryAutoRecompute(static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -23,6 +23,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerSlot_H
 #define SKETCHERGUI_DrawSketchHandlerSlot_H
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -258,7 +260,10 @@ public:
                 tryAutoRecomputeIfNotSolve(static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to add slot: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        QT_TRANSLATE_NOOP("Notifications", "Failed to add slot"));
+
                 Gui::Command::abortCommand();
 
                 tryAutoRecompute(static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -23,6 +23,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerSplitting_H
 #define SKETCHERGUI_DrawSketchHandlerSplitting_H
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -137,7 +139,10 @@ public:
                 tryAutoRecompute(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("Failed to split edge: %s\n", e.what());
+                Gui::NotifyError(sketchgui,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        QT_TRANSLATE_NOOP("Notifications", "Failed to add edge"));
+
                 Gui::Command::abortCommand();
             }
         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -23,6 +23,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerTrimming_H
 #define SKETCHERGUI_DrawSketchHandlerTrimming_H
 
+#include <Gui/Notifications.h>
+
 #include "GeometryCreationMode.h"
 
 
@@ -134,7 +136,10 @@ public:
                     tryAutoRecompute(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));
                 }
                 catch (const Base::Exception& e) {
-                    Base::Console().Error("Failed to trim edge: %s\n", e.what());
+                    Gui::NotifyError(sketchgui,
+                        QT_TRANSLATE_NOOP("Notifications", "Error"),
+                        QT_TRANSLATE_NOOP("Notifications", "Failed to trim edge"));
+
                     Gui::Command::abortCommand();
                 }
             }

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -303,7 +303,7 @@ void EditModeCoinManager::ParameterObserver::subscribeToParameters()
         hGrpu->Attach(this);
     }
     catch(const Base::ValueError & e) { // ensure that if parameter strings are not well-formed, the exception is not propagated
-        Base::Console().Error("EditModeCoinManager: Malformed parameter string: %s\n", e.what());
+        Base::Console().DeveloperError("EditModeCoinManager", "Malformed parameter string: %s\n", e.what());
     }
 }
 
@@ -323,7 +323,7 @@ void EditModeCoinManager::ParameterObserver::unsubscribeToParameters()
         hGrpu->Detach(this);
     }
     catch(const Base::ValueError & e) {// ensure that if parameter strings are not well-formed, the program is not terminated when calling the noexcept destructor.
-        Base::Console().Error("EditModeCoinManager: Malformed parameter string: %s\n", e.what());
+        Base::Console().DeveloperError("EditModeCoinManager", "Malformed parameter string: %s\n", e.what());
     }
 }
 

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -1173,10 +1173,10 @@ Restart:
             }
 
         } catch (Base::Exception &e) {
-            Base::Console().Error("Exception during draw: %s\n", e.what());
+            Base::Console().DeveloperError("EditModeConstraintCoinManager","Exception during draw: %s\n", e.what());
             e.ReportException();
         } catch (...){
-            Base::Console().Error("Exception during draw: unknown\n");
+            Base::Console().DeveloperError("EditModeConstraintCoinManager","Exception during draw: unknown\n");
         }
 
     }
@@ -1546,7 +1546,7 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(const GeoListFacade &
                     const Part::Geometry *geo1 = geolistfacade.getGeometryFromGeoId((*it)->First);
                     const Part::Geometry *geo2 = geolistfacade.getGeometryFromGeoId((*it)->Second);
                     if (!geo1 || !geo2) {
-                        Base::Console().Warning("Tangent constraint references non-existing geometry\n");
+                        Base::Console().DeveloperWarning("EditModeConstraintCoinManager","Tangent constraint references non-existing geometry\n");
                     }
                     else if (geo1->getTypeId() == Part::GeomLineSegment::getClassTypeId() &&
                              geo2->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
@@ -1919,7 +1919,7 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade & ge
 
         // Double-check that we can safely access the Inventor nodes
         if (constrId >= editModeScenegraphNodes.constrGroup->getNumChildren()) {
-            Base::Console().Warning("Can't update constraint icons because view is not in sync with sketch\n");
+            Base::Console().DeveloperWarning("EditModeConstraintManager", "Can't update constraint icons because view is not in sync with sketch\n");
             break;
         }
 

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
@@ -347,7 +347,7 @@ void EditModeGeometryCoinConverter::convert(const Sketcher::GeometryFacade * geo
                     // terminating here would mean that the other shapes would not be drawn.
                     // Solution: Report the issue and set dummy curvature to 0
                     e.ReportException();
-                    Base::Console().Error("Curvature graph for B-Spline with GeoId=%d could not be calculated.\n", geoid); // TODO: Fix identification of curve.
+                    Base::Console().DeveloperError("EditModeGeometryCoinConverter","Curvature graph for B-Spline with GeoId=%d could not be calculated.\n", geoid); // TODO: Fix identification of curve.
                     curvaturelist[i] = 0;
                 }
 

--- a/src/Mod/Sketcher/Gui/EditModeInformationOverlayCoinConverter.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeInformationOverlayCoinConverter.cpp
@@ -197,7 +197,7 @@ void EditModeInformationOverlayCoinConverter::calculate(const Part::Geometry * g
                         // terminating here would mean that the other shapes would not be drawn.
                         // Solution: Report the issue and set dummy curvature to 0
                         e.ReportException();
-                        Base::Console().Error("Curvature graph for B-Spline with GeoId=%d could not be calculated.\n", geoid);
+                        Base::Console().DeveloperError("EditModeInformationOverlayCoinConverter","Curvature graph for B-Spline with GeoId=%d could not be calculated.\n", geoid);
                         curvaturelist.emplace_back(0);
                     }
 

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -281,7 +281,7 @@ void SketcherSettingsDisplay::onBtnTVApplyClicked(bool)
             this->ui->checkBoxTVForceOrtho->isChecked()    ? "True": "False",
             this->ui->checkBoxTVSectionView->isChecked()   ? "True": "False");
     } catch (Base::PyException &e){
-        Base::Console().Error("SketcherSettings::onBtnTVApplyClicked:\n");
+        Base::Console().DeveloperError("SketcherSettings", "error in onBtnTVApplyClicked:\n");
         e.ReportException();
         errMsg = QString::fromLatin1(e.what());
     } catch (...) {

--- a/src/Mod/Sketcher/Gui/SnapManager.cpp
+++ b/src/Mod/Sketcher/Gui/SnapManager.cpp
@@ -123,7 +123,7 @@ void SnapManager::ParameterObserver::subscribeToParameters()
         hGrp->Attach(this);
     }
     catch (const Base::ValueError& e) { // ensure that if parameter strings are not well-formed, the exception is not propagated
-        Base::Console().Error("SnapManager: Malformed parameter string: %s\n", e.what());
+        Base::Console().DeveloperError("SnapManager", "Malformed parameter string: %s\n", e.what());
     }
 }
 
@@ -134,7 +134,7 @@ void SnapManager::ParameterObserver::unsubscribeToParameters()
         hGrp->Detach(this);
     }
     catch (const Base::ValueError& e) {// ensure that if parameter strings are not well-formed, the program is not terminated when calling the noexcept destructor.
-        Base::Console().Error("SnapManager: Malformed parameter string: %s\n", e.what());
+        Base::Console().DeveloperError("SnapManager", "Malformed parameter string: %s\n", e.what());
     }
 }
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -176,7 +176,7 @@ void ViewProviderSketch::ParameterObserver::subscribeToParameters()
         hGrpv->Attach(this);
     }
     catch(const Base::ValueError & e) { // ensure that if parameter strings are not well-formed, the exception is not propagated
-        Base::Console().Error("ViewProviderSketch: Malformed parameter string: %s\n", e.what());
+        Base::Console().DeveloperError("ViewProviderSketch", "Malformed parameter string: %s\n", e.what());
     }
 }
 
@@ -193,7 +193,7 @@ void ViewProviderSketch::ParameterObserver::unsubscribeToParameters()
         hGrpv->Detach(this);
     }
     catch(const Base::ValueError & e) { // ensure that if parameter strings are not well-formed, the exception is not propagated
-        Base::Console().Error("ViewProviderSketch: Malformed parameter string: %s\n", e.what());
+        Base::Console().DeveloperError("ViewProviderSketch", "Malformed parameter string: %s\n", e.what());
     }
 }
 
@@ -811,7 +811,7 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                             }
                             catch (const Base::Exception& e) {
                                 getDocument()->abortCommand();
-                                Base::Console().Error("Drag point: %s\n", e.what());
+                                Base::Console().DeveloperError("ViewProviderSketch", "Drag point: %s\n", e.what());
                             }
                         }
                         setPreselectPoint(drag.DragPoint);
@@ -872,7 +872,7 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                             }
                             catch (const Base::Exception& e) {
                                 getDocument()->abortCommand();
-                                Base::Console().Error("Drag curve: %s\n", e.what());
+                                Base::Console().DeveloperError("ViewProviderSketch", "Drag curve: %s\n", e.what());
                             }
                         }
                         preselection.PreselectCurve = drag.DragCurve;
@@ -2881,11 +2881,11 @@ bool ViewProviderSketch::setEdit(int ModNum)
             QByteArray cmdstr_bytearray = cmdstr.toLatin1();
             Gui::Command::runCommand(Gui::Command::Gui, cmdstr_bytearray);
         } catch (Base::PyException &e){
-            Base::Console().Error("ViewProviderSketch::setEdit: visibility automation failed with an error: \n");
+            Base::Console().DeveloperError("ViewProviderSketch","setEdit: visibility automation failed with an error: \n");
             e.ReportException();
         }
     } catch (Base::PyException &){
-        Base::Console().Warning("ViewProviderSketch::setEdit: could not import Show module. Visibility automation will not work.\n");
+        Base::Console().DeveloperWarning("ViewProviderSketch", "setEdit: could not import Show module. Visibility automation will not work.\n");
     }
 
     // start the edit dialog
@@ -3102,7 +3102,7 @@ void ViewProviderSketch::unsetEdit(int ModNum)
     // when pressing ESC make sure to close the dialog
     Gui::Control().closeDialog();
 
-    //visibility autoation
+    //visibility automation
     try{
         QString cmdstr = QString::fromLatin1(
                     "ActiveSketch = App.getDocument('%1').getObject('%2')\n"
@@ -3117,8 +3117,7 @@ void ViewProviderSketch::unsetEdit(int ModNum)
         QByteArray cmdstr_bytearray = cmdstr.toLatin1();
         Gui::Command::runCommand(Gui::Command::Gui, cmdstr_bytearray);
     } catch (Base::PyException &e){
-        Base::Console().Error("ViewProviderSketch::unsetEdit: visibility automation failed with an error: \n");
-        e.ReportException();
+        Base::Console().DeveloperError("ViewProviderSketch","unsetEdit: visibility automation failed with an error: %s \n", e.what());
     }
 }
 
@@ -3139,8 +3138,7 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
             QByteArray cmdstr_bytearray = cmdstr.toLatin1();
             Gui::Command::runCommand(Gui::Command::Gui, cmdstr_bytearray);
         } catch (Base::PyException &e){
-            Base::Console().Error("ViewProviderSketch::setEdit: visibility automation failed with an error: \n");
-            e.ReportException();
+            Base::Console().DeveloperError("ViewProviderSketch", "setEdit: visibility automation failed with an error: %s \n", e.what());
         }
     }
 
@@ -3291,7 +3289,7 @@ void ViewProviderSketch::deleteSelected()
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1) {
-        Base::Console().Warning("Delete: Selection not restricted to one sketch and its subelements\n");
+        Base::Console().DeveloperWarning("ViewProviderSketch", "Delete: Selection not restricted to one sketch and its subelements\n");
         return;
     }
 
@@ -3362,7 +3360,7 @@ bool ViewProviderSketch::onDelete(const std::vector<std::string> &subList)
                 Gui::cmdAppObjectArgs(getObject(), "delConstraint(%d)", *rit);
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Base::Console().DeveloperError("ViewProviderSketch", "%s\n", e.what());
             }
         }
 
@@ -3386,7 +3384,7 @@ bool ViewProviderSketch::onDelete(const std::vector<std::string> &subList)
                             Gui::cmdAppObjectArgs(getObject(), "delConstraintOnPoint(%d,%d)", GeoId, (int)PosId);
                         }
                         catch (const Base::Exception& e) {
-                            Base::Console().Error("%s\n", e.what());
+                            Base::Console().DeveloperError("ViewProviderSketch", "%s\n", e.what());
                         }
                         break;
                     }
@@ -3410,7 +3408,7 @@ bool ViewProviderSketch::onDelete(const std::vector<std::string> &subList)
                 Gui::cmdAppObjectArgs(getObject(), "delGeometries([%s])", stream.str().c_str());
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Base::Console().DeveloperError("ViewProviderSketch", "%s\n", e.what());
             }
 
             stream.str(std::string());
@@ -3421,7 +3419,7 @@ bool ViewProviderSketch::onDelete(const std::vector<std::string> &subList)
                 Gui::cmdAppObjectArgs(getObject(), "delExternal(%d)", *rit);
             }
             catch (const Base::Exception& e) {
-                Base::Console().Error("%s\n", e.what());
+                Base::Console().DeveloperError("ViewProviderSketch", "%s\n", e.what());
             }
         }
 


### PR DESCRIPTION

Revisiting all console calls:
- Using the Notification Framework when the user needs to be notified
- Turning them into DeveloperError/DeveloperWarnings when messages are intended only for developers
