### PR TITLE
Draft: fix getcoords in gui_snapper.py

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1100,19 +1100,18 @@ class DraftToolBar:
                     print("debug: DraftGui.validatePoint: AttributeError")
                 else:
                     num_vec = FreeCAD.Vector(numx, numy, numz)
-                    ref_vec = FreeCAD.Vector(0,0,0)
                     if self.pointcallback:
-                        self.pointcallback(num_vec, self.relativeMode)
+                        self.pointcallback(num_vec, self.globalMode, self.relativeMode)
                     else:
+                        ref_vec = FreeCAD.Vector(0, 0, 0)
                         if FreeCAD.DraftWorkingPlane and not self.globalMode:
                             num_vec = FreeCAD.DraftWorkingPlane.getGlobalRot(num_vec)
                             ref_vec = FreeCAD.DraftWorkingPlane.getGlobalCoords(ref_vec)
-                        if self.relativeMode:
-                            if self.sourceCmd.node:
-                                ref_vec = self.sourceCmd.node[-1]
+                        if self.relativeMode and self.sourceCmd.node:
+                            ref_vec = self.sourceCmd.node[-1]
 
                         numx, numy, numz = num_vec + ref_vec
-                        self.sourceCmd.numericInput(numx,numy,numz)
+                        self.sourceCmd.numericInput(numx, numy, numz)
 
             elif self.textValue.isVisible():
                 return False

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -1414,12 +1414,16 @@ class Snapper:
             if movecallback:
                 movecallback(self.pt, self.snapInfo)
 
-        def getcoords(point, relative=False):
+        def getcoords(point, global_mode=True, relative_mode=False):
             """Get the global coordinates from a point."""
-            self.pt = point
-            if relative and last and hasattr(App, "DraftWorkingPlane"):
-                v = App.DraftWorkingPlane.getGlobalCoords(point)
-                self.pt = last.add(v)
+            # Same algorithm as in validatePoint in DraftGui.py.
+            ref = App.Vector(0, 0, 0)
+            if global_mode is False and hasattr(App, "DraftWorkingPlane"):
+                point = App.DraftWorkingPlane.getGlobalRot(point)
+                ref = App.DraftWorkingPlane.getGlobalCoords(ref)
+            if relative_mode is True and last is not None:
+                ref = last
+            self.pt = point + ref
             accept()
 
         def click(event_cb):


### PR DESCRIPTION
The function did not handle global and relative mode properly.

It was not updated when global mode was introduced. This primarily affected Arch commands. As a consequence it was impossible to place a column at the origin of a custom Draft working plane through keyboard input.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=78538

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
