### PR TITLE
Fix build of "tests" on macOS

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 add_executable(Tests_run)
 add_subdirectory(lib)
 add_subdirectory(src)
-target_include_directories(Tests_run PUBLIC ${Python3_INCLUDE_DIRS})
+target_include_directories(Tests_run PUBLIC ${Python3_INCLUDE_DIRS} ${XercesC_INCLUDE_DIRS})
 target_link_libraries(Tests_run gtest_main ${Google_Tests_LIBS} FreeCADApp)
 
 add_executable(Sketcher_tests_run)


### PR DESCRIPTION
Building the C++ unit tests failed for `tests/src/App/Metadata.cpp` and `tests/src/Base/Reader.cpp` because some XML headers were not found. This was because the XercesC include dir was not in the search list for headers. I cannot say why only macOS seems to be affected, but it's not the first time, see e.g https://github.com/FreeCAD/FreeCAD/commit/a1776d3e744075e54cf95c68a9264fa0d937cc2d

---

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
