### PR TITLE
Improve VSCode integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ install_manifest.txt
 /conda/environment.yml
 OpenSCAD_rc.py
 tags
+Testing
 
 # crowdin file
 src/Tools/freecad.zip

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,12 +1,27 @@
 {
-  "configurations": [
-    {
-      "name": "FreeCAD",
-      "includePath": ["${workspaceFolder}/**"],
-      "cStandard": "c17",
-      "cppStandard": "c++17",
-      "configurationProvider": "ms-vscode.cmake-tools"
-    }
-  ],
-  "version": 4
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "configurationProvider": "ms-vscode.cmake-tools"
+        },
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "configurationProvider": "ms-vscode.cmake-tools"
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "/usr/include/**"
+            ],
+            "configurationProvider": "ms-vscode.cmake-tools"
+        }
+    ],
+    "version": 4
 }

--- a/.vscode/cmake-kits.json
+++ b/.vscode/cmake-kits.json
@@ -1,18 +1,29 @@
 [
-  {
-    "name": "FreeCAD Linux",
-    "compilers": {
-      "C": "${workspaceFolder}/.conda/freecad/bin/cc",
-      "CXX": "${workspaceFolder}/.conda/freecad/bin/c++"
+    {
+      "name": "Conda Unix",
+      "environmentSetupScript": "${workspaceFolder}/.conda/freecad/bin/activate",
+      "cmakeSettings": {
+        "BUILD_WITH_CONDA:BOOL": "ON",
+        "BUILD_FEM_NETGEN:BOOL": "ON",
+        "FREECAD_USE_PYBIND11:BOOL": "ON",
+        "FREECAD_USE_EXTERNAL_SMESH:BOOL": "ON",
+        "FREECAD_USE_EXTERNAL_FMT:BOOL": "OFF"
+      }
     },
-    "environmentSetupScript": "${workspaceFolder}/.vscode/env.sh"
-  },
-  {
-    "name": "FreeCAD macOS",
-    "compilers": {
-      "C": "${workspaceFolder}/.conda/freecad/bin/clang",
-      "CXX": "${workspaceFolder}/.conda/freecad/bin/clang++"
-    },
-    "environmentSetupScript": "${workspaceFolder}/.vscode/env.sh"
-  }
-]
+    {
+      "name": "Conda Windows",
+      "environmentSetupScript": "${workspaceFolder}/.conda/freecad/condabin/activate.bat",
+      "cmakeSettings": {
+        "BUILD_WITH_CONDA:BOOL": "ON",
+        "BUILD_FEM_NETGEN:BOOL": "ON",
+        "FREECAD_USE_PYBIND11:BOOL": "ON",
+        "FREECAD_USE_EXTERNAL_SMESH:BOOL": "ON",
+        "FREECAD_USE_EXTERNAL_FMT:BOOL": "OFF",
+        "FREECAD_LIBPACK_USE:BOOL": "OFF",
+        "FREECAD_USE_CCACHE": "OFF",
+        "FREECAD_USE_PCH": "OFF",
+        "BUILD_TEST": "OFF",
+        "Boost_NO_BOOST_CMAKE": "OFF"
+      }
+    }
+  ]

--- a/.vscode/env.sh
+++ b/.vscode/env.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-source activate freecad

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,35 +2,65 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "C/C++: Linux: build and debug FreeCAD",
+      "name": "Debug C++ Tests",
       "type": "cppdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/build/bin/FreeCAD",
-      "args": [],
-      "stopAtEntry": false,
       "cwd": "${workspaceFolder}",
-      "environment": [],
+      "program": "${command:cmake.buildDirectory}/tests/Tests_run", 
+      "args": [],
+      "linux": {
+        "MIMode": "gdb",
+        "miDebuggerPath": "/usr/bin/gdb"
+      },
+      "osx": {
+        "MIMode": "lldb"
+      },
+      "windows": {
+        "MIMode": "gdb",
+        "miDebuggerPath": "C:\\MinGw\\bin\\gdb.exe"
+      },
+      "stopAtEntry": false,
       "externalConsole": false,
-      "preLaunchTask": "CMake: build"
+      "preLaunchTask": "CMake: build",
+      "sourceFileMap": {
+        "${workspaceFolder}": "${workspaceFolder}"
+      }
     },
     {
-      "name": "C/C++: macOS: build and debug FreeCAD",
+      "name": "C/C++ debugger",
       "type": "cppdbg",
       "request": "launch",
-      "program": "${workspaceFolder}/build/bin/FreeCAD",
-      "args": [],
-      "stopAtEntry": false,
       "cwd": "${workspaceFolder}",
-      "environment": [],
+      "program": "${command:cmake.buildDirectory}/bin/FreeCAD", 
+      "args": ["${workspaceFolder}/.vscode/scripts/VSCodeAutostartDebug.FCMacro"],
+      "environment": [
+        {
+          "name": "PYDEVD_DISABLE_FILE_VALIDATION",
+          "value": "1"
+        }
+      ],
+      "linux": {
+        "MIMode": "gdb",
+        "miDebuggerPath": "/usr/bin/gdb"
+      },
+      "osx": {
+        "MIMode": "lldb"
+      },
+      "windows": {
+        "MIMode": "gdb",
+        "miDebuggerPath": "C:\\MinGw\\bin\\gdb.exe"
+      },
+      "stopAtEntry": false,
       "externalConsole": false,
-      "MIMode": "lldb",
-      "preLaunchTask": "CMake: build"
+      "presentation": {
+        "hidden": true,
+      }
     },
     {
-      "name": "Python: Remote Attach",
+      "name": "Python debugger",
       "type": "python",
       "request": "attach",
-      "preLaunchTask": "conda: activate environment",
+      "preLaunchTask": "WaitForDebugpy",
       "redirectOutput": true,
       "connect": {
         "host": "localhost",
@@ -38,11 +68,25 @@
       },
       "pathMappings": [
         {
-          "localRoot": "${workspaceFolder}",
-          "remoteRoot": "${workspaceFolder}"
+          "localRoot": "${workspaceFolder}/src",
+          "remoteRoot": "${workspaceFolder}/build"
         }
       ],
-      "justMyCode": false
+      "justMyCode": false,
+      "presentation": {
+        "hidden": true,
+      }
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug FreeCAD",
+      "configurations": ["C/C++ debugger", "Python debugger"],
+      "preLaunchTask": "CMake: build",
+      "stopAll": true,
+      "presentation": {
+        "order": 1
+      }
     }
   ]
 }

--- a/.vscode/scripts/VSCodeAutostartDebug.FCMacro
+++ b/.vscode/scripts/VSCodeAutostartDebug.FCMacro
@@ -1,0 +1,18 @@
+import debugpy
+from multiprocessing.connection import Listener
+from freecad.utils import get_python_exe
+
+# get_python_exe is needed because debugpy needs a python interpreter to work.
+# It does not have to be FC embedded interpreter.
+# By default it attempts to use Freecad's PID mistaking it for python.
+# https://github.com/microsoft/debugpy/issues/262
+debugpy.configure(python=get_python_exe())
+debugpy.listen(('localhost', 5678))
+
+# Turns out you cannot probe debugpy to see if it is up:
+# https://github.com/microsoft/debugpy/issues/974
+# Open another port that the script WaitForDebugpy can probe to see if 
+# debugpy is running
+listener = Listener(('localhost', 6000), backlog=10)
+
+debugpy.wait_for_client()

--- a/.vscode/scripts/WaitForDebugpy.py
+++ b/.vscode/scripts/WaitForDebugpy.py
@@ -1,0 +1,29 @@
+import socket
+from contextlib import closing
+import time
+   
+TIMEOUT_TIME_S = 30
+RETRY_DELAY_S = 0.1
+
+MAX_ATTEMPTS = TIMEOUT_TIME_S / RETRY_DELAY_S
+
+def check_socket(host, port):
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.settimeout(RETRY_DELAY_S)
+        return sock.connect_ex((host, port)) == 0
+
+def main():
+    # DO NOT CHECK 5678 or debugpy will break
+    # Check other port manually opened instead
+    attempt_counter = 0
+    while (not check_socket('localhost', 6000)) and attempt_counter < MAX_ATTEMPTS:
+        time.sleep(RETRY_DELAY_S)
+        attempt_counter += 1
+
+    if attempt_counter >= MAX_ATTEMPTS:
+        exit(1)
+    else:
+        exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,36 @@
-{
+{  
+  // This disables vscode from adding lines to files.associations, 
+  // some files might not be recognized though.
+  // This is a vscode issue.
+  "C_Cpp.autoAddFileAssociations": false, 
   "files.associations": {
-    "__config": "cpp",
-    "iosfwd": "cpp",
-    "vector": "cpp",
-    "tuple": "cpp"
-  },
+    "*.c": "c",
+    "*.h": "cpp",
+    "*.cpp": "cpp",
+    "*.hpp": "cpp",
+    "*.cxx": "cpp",
+    "*.hxx": "cpp",
+    "*.py": "python",
+    "*.FCMacro": "python"
+  }, 
+
   "editor.formatOnType": true,
+  "files.autoSave": "afterDelay",
+  "debug.onTaskErrors": "abort", //to not launch the python debugger when waitforport.py fails
+
+  // Does not quick launch the debugger, forces to select debugger config every time
+  // Use the debug panel on the left instead
+  "debug.showInStatusBar": "never", 
+  
   "cmake.preferredGenerators": ["Ninja", "NMake Makefiles"],
-  "cmake.cmakePath": "${workspaceFolder}/.conda/freecad/bin/cmake",
-  "cmake.configureSettings": {
-    "BUILD_WITH_CONDA:BOOL": "ON",
-    "BUILD_FEM_NETGEN:BOOL": "ON",
-    "FREECAD_USE_PYBIND11:BOOL": "ON",
-    "FREECAD_USE_EXTERNAL_SMESH:BOOL": "ON"
+  "cmake.useProjectStatusView": false, // to enable settings below
+  "cmake.statusbar.advanced": {
+    "build": {"visibility": "default"},         // "default" labels the button and makes it larger   
+    "buildTarget": {"visibility": "hidden"},    // build ALL targets (default)
+    "debug": {"visibility": "hidden"},          // does not launch the proper debugger. Use vscode debugger with configurations from launch.json instead
+    "launch": {"visibility": "hidden"},         // launch using the debug configuration instead
+    "launchTarget": { "visibility": "hidden" }, // not used. If in doubt select [FreeCADMain]
+    "ctest": {"visibility": "hidden"}           // does not seem to work. use the test panel on the left instead
   }
+
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,20 +1,18 @@
 {
   "tasks": [
     {
+      "label": "WaitForDebugpy",
       "type": "shell",
-      "label": "conda: activate environment",
-      "command": "activate freecad",
+      "command": "python ${workspaceFolder}/.vscode/scripts/WaitForDebugpy.py",
+      "group": "none",
       "problemMatcher": [],
-      "detail": "Activate conda environment",
-      "group": "build"
-    },
-    {
-      "type": "cmake",
-      "label": "CMake: configure",
-      "command": "configure",
-      "problemMatcher": [],
-      "detail": "CMake template configure task",
-      "group": "build"
+      "presentation": {
+        "reveal": "never", //silently fail and don't launch the debugger
+        "panel": "dedicated",
+        "close": true,
+        "revealProblems": "never"
+      },
+      "hide": true
     },
     {
       "type": "cmake",
@@ -26,32 +24,31 @@
         "isDefault": true
       },
       "problemMatcher": [],
-      "detail": "CMake template build task"
+      "detail": "Build all targets"
     },
     {
-      "type": "cmake",
-      "label": "CMake: test",
-      "command": "test",
-      "problemMatcher": [],
-      "detail": "CMake template test task",
-      "group": "build"
+      "label": "Tests: run c++ tests",
+      "detail": "Run googletest",
+      "type": "shell",
+      "command": "${command:cmake.buildDirectory}/tests/Tests_run",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "dependsOn": ["CMake: build"],
+      "problemMatcher": []
     },
     {
-      "type": "cmake",
-      "label": "CMake: clean",
-      "command": "clean",
-      "problemMatcher": [],
-      "detail": "CMake template clean task",
-      "group": "build"
-    },
-    {
-      "type": "cmake",
-      "label": "CMake: clean rebuild",
-      "command": "cleanRebuild",
-      "targets": ["all"],
-      "problemMatcher": [],
-      "detail": "CMake template clean rebuild task",
-      "group": "build"
+      "label": "Tests: run python tests",
+      "detail": "Run FreeCAD integrated tests",
+      "type": "shell",
+      "command": "${command:cmake.buildDirectory}/bin/FreeCAD",
+      "args": ["-t", "0"],
+      "group": {
+        "kind": "test"
+      },
+      "dependsOn": ["CMake: build"],
+      "problemMatcher": []
     }
   ],
   "version": "2.0.0"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,8 @@ if(MSVC AND FREECAD_LIBPACK_USE AND LIBPACK_FOUND)
 endif()
 
 if (ENABLE_DEVELOPER_TESTS)
+    include(CTest)
+    enable_testing()
     add_subdirectory(tests)
 endif()
 

--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -94,5 +94,4 @@ dependencies:
 - vtk
 - xerces-c
 - zlib
-- pip:
-  - ptvsd
+- debugpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ opencamlib==2023.1.11
 packaging==23.0
 Pivy==0.6.8
 ply==3.11
-ptvsd==4.3.2
+debugpy==1.6.7
 pyNastran==1.3.4
 pyshp==2.3.1
 PySide2==5.15.2.1

--- a/src/Ext/freecad/CMakeLists.txt
+++ b/src/Ext/freecad/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 configure_file(__init__.py.template ${NAMESPACE_INIT})
 configure_file(project_utility.py ${NAMESPACE_DIR}/project_utility.py)
 configure_file(UiTools.py ${NAMESPACE_DIR}/UiTools.py)
+configure_file(utils.py ${NAMESPACE_DIR}/utils.py)
 
 if (INSTALL_TO_SITEPACKAGES)
     SET(SITE_PACKAGE_DIR ${PYTHON_MAIN_DIR}/freecad)
@@ -29,6 +30,7 @@ INSTALL(
         ${NAMESPACE_INIT}
         project_utility.py
         UiTools.py
+        utils.py
     DESTINATION
         ${SITE_PACKAGE_DIR}
 )

--- a/src/Ext/freecad/utils.py
+++ b/src/Ext/freecad/utils.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2022-2023 FreeCAD Project Association                   *
+# *   Copyright (c) 2018 Gaël Écorchard <galou_breizh@yahoo.fr>             *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+import os
+import platform
+import shutil
+
+import FreeCAD
+
+
+def get_python_exe() -> str:
+    """Find Python. In preference order
+    A) The value of the PythonExecutableForPip user preference
+    B) The executable located in the same bin directory as FreeCAD and called "python3"
+    C) The executable located in the same bin directory as FreeCAD and called "python"
+    D) The result of a shutil search for your system's "python3" executable
+    E) The result of a shutil search for your system's "python" executable"""
+    prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/PythonConsole")
+    python_exe = prefs.GetString("ExternalPythonExecutable", "Not set")
+    fc_dir = FreeCAD.getHomePath()
+    if not python_exe or python_exe == "Not set" or not os.path.exists(python_exe):
+        python_exe = os.path.join(fc_dir, "bin", "python3")
+        if "Windows" in platform.system():
+            python_exe += ".exe"
+
+    if not python_exe or not os.path.exists(python_exe):
+        python_exe = os.path.join(fc_dir, "bin", "python")
+        if "Windows" in platform.system():
+            python_exe += ".exe"
+
+    if not python_exe or not os.path.exists(python_exe):
+        python_exe = shutil.which("python3")
+
+    if not python_exe or not os.path.exists(python_exe):
+        python_exe = shutil.which("python")
+
+    if not python_exe or not os.path.exists(python_exe):
+        return ""
+
+    python_exe = python_exe.replace("/", os.path.sep)
+    prefs.SetString("ExternalPythonExecutable", python_exe)
+    return python_exe

--- a/src/Gui/PreferencePages/DlgSettingsPythonConsole.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsPythonConsole.cpp
@@ -46,6 +46,7 @@ void DlgSettingsPythonConsole::saveSettings()
     ui->PythonWordWrap->onSave();
     ui->PythonBlockCursor->onSave();
     ui->PythonSaveHistory->onSave();
+    ui->ExternalPythonExecutable->onSave();
 }
 
 void DlgSettingsPythonConsole::loadSettings()
@@ -53,6 +54,7 @@ void DlgSettingsPythonConsole::loadSettings()
     ui->PythonWordWrap->onRestore();
     ui->PythonBlockCursor->onRestore();
     ui->PythonSaveHistory->onRestore();
+    ui->ExternalPythonExecutable->onRestore();
 }
 
 void DlgSettingsPythonConsole::changeEvent(QEvent *e)

--- a/src/Gui/PreferencePages/DlgSettingsPythonConsole.ui
+++ b/src/Gui/PreferencePages/DlgSettingsPythonConsole.ui
@@ -11,13 +11,13 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Python console</string>
+   <string>General</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
     <widget class="QGroupBox" name="GroupBox11">
      <property name="title">
-      <string>Settings</string>
+      <string>Console</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
@@ -82,6 +82,47 @@ horizontal space in Python console</string>
     </widget>
    </item>
    <item row="1" column="0">
+   <widget class="QGroupBox" name="GroupBox11">
+     <property name="title">
+      <string>Other</string>
+     </property>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="fclabel">
+       <property name="text">
+        <string>Path to external Python executable (optional):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="Gui::PrefFileChooser" name="ExternalPythonExecutable" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>300</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Used for package installation with pip and debugging with debugpy. Autodetected if needed and not specified.</string>
+       </property>
+       <property name="prefEntry" stdset="0">
+        <cstring>ExternalPythonExecutable</cstring>
+       </property>
+       <property name="prefPath" stdset="0">
+        <cstring>PythonConsole</cstring>
+       </property>
+      </widget>
+     </item>
+    </layout>
+    </widget>
+   </item>
+      <item row="2" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -100,6 +141,11 @@ horizontal space in Python console</string>
   <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+    <customwidget>
+   <class>Gui::PrefFileChooser</class>
+   <extends>QWidget</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Gui/RemoteDebugger.ui
+++ b/src/Gui/RemoteDebugger.ui
@@ -89,16 +89,6 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0" colspan="2">
-        <widget class="QCheckBox" name="checkRedirectOutput">
-         <property name="text">
-          <string>Redirect output</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
        <item row="3" column="1">
         <spacer name="verticalSpacer_2">
          <property name="orientation">

--- a/src/Mod/AddonManager/AddonManagerOptions.ui
+++ b/src/Mod/AddonManager/AddonManagerOptions.ui
@@ -270,38 +270,6 @@ installed addons will be checked for available updates
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="fclabel">
-       <property name="text">
-        <string>Path to Python executable (optional):</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="Gui::PrefFileChooser" name="gui::preffilechooser" native="true">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>300</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>The path to the Python executable for package installation with pip. Autodetected if needed and not specified.</string>
-       </property>
-       <property name="prefEntry" stdset="0">
-        <cstring>PythonExecutableForPip</cstring>
-       </property>
-       <property name="prefPath" stdset="0">
-        <cstring>Addons</cstring>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">

--- a/src/Mod/AddonManager/addonmanager_dependency_installer.py
+++ b/src/Mod/AddonManager/addonmanager_dependency_installer.py
@@ -27,6 +27,8 @@ import os
 import subprocess
 from typing import List
 
+from freecad.utils import get_python_exe
+
 import addonmanager_freecad_interface as fci
 from addonmanager_pyside_interface import QObject, Signal, is_interruption_requested
 
@@ -151,9 +153,7 @@ class DependencyInstaller(QObject):
                 fci.Console.PrintMessage(proc.stdout + "\n")
             except subprocess.CalledProcessError as e:
                 fci.Console.PrintError(
-                    translate(
-                        "AddonsInstaller", "Installation of optional package failed"
-                    )
+                    translate("AddonsInstaller", "Installation of optional package failed")
                     + ":\n"
                     + str(e)
                     + "\n"
@@ -172,7 +172,7 @@ class DependencyInstaller(QObject):
 
     def _get_python(self) -> str:
         """Wrap Python access so test code can mock it."""
-        python_exe = utils.get_python_exe()
+        python_exe = get_python_exe()
         if not python_exe:
             self.no_python_exe.emit()
         return python_exe
@@ -182,23 +182,19 @@ class DependencyInstaller(QObject):
             if is_interruption_requested():
                 return
             fci.Console.PrintMessage(
-                translate(
-                    "AddonsInstaller", "Installing required dependency {}"
-                ).format(addon.name)
+                translate("AddonsInstaller", "Installing required dependency {}").format(addon.name)
                 + "\n"
             )
             if addon.macro is None:
                 installer = AddonInstaller(addon)
             else:
                 installer = MacroInstaller(addon)
-            result = (
-                installer.run()
-            )  # Run in this thread, which should be off the GUI thread
+            result = installer.run()  # Run in this thread, which should be off the GUI thread
             if not result:
                 self.failure.emit(
-                    translate(
-                        "AddonsInstaller", "Installation of Addon {} failed"
-                    ).format(addon.name),
+                    translate("AddonsInstaller", "Installation of Addon {} failed").format(
+                        addon.name
+                    ),
                     "",
                 )
                 return

--- a/src/Mod/AddonManager/addonmanager_devmode.py
+++ b/src/Mod/AddonManager/addonmanager_devmode.py
@@ -29,6 +29,7 @@ import subprocess
 
 import FreeCAD
 import FreeCADGui
+from freecad.utils import get_python_exe
 
 from PySide.QtWidgets import (
     QFileDialog,
@@ -70,9 +71,7 @@ class AddonGitInterface:
             try:
                 AddonGitInterface.git_manager = GitManager()
             except NoGitFound:
-                FreeCAD.Console.PrintLog(
-                    "No git found, Addon Manager Developer Mode disabled."
-                )
+                FreeCAD.Console.PrintLog("No git found, Addon Manager Developer Mode disabled.")
                 return
 
         self.path = path
@@ -127,12 +126,8 @@ class DeveloperMode:
         small_size_policy.setHorizontalStretch(1)
         self.people_table.widget.setSizePolicy(large_size_policy)
         self.licenses_table.widget.setSizePolicy(small_size_policy)
-        self.dialog.peopleAndLicenseshorizontalLayout.addWidget(
-            self.people_table.widget
-        )
-        self.dialog.peopleAndLicenseshorizontalLayout.addWidget(
-            self.licenses_table.widget
-        )
+        self.dialog.peopleAndLicenseshorizontalLayout.addWidget(self.people_table.widget)
+        self.dialog.peopleAndLicenseshorizontalLayout.addWidget(self.licenses_table.widget)
         self.pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
         self.current_mod: str = ""
         self.git_interface = None
@@ -267,27 +262,17 @@ class DeveloperMode:
                 if item.Name:
                     info.append(translate("AddonsInstaller", "Name") + ": " + item.Name)
                 if item.Classname:
-                    info.append(
-                        translate("AddonsInstaller", "Class") + ": " + item.Classname
-                    )
+                    info.append(translate("AddonsInstaller", "Class") + ": " + item.Classname)
                 if item.Description:
                     info.append(
-                        translate("AddonsInstaller", "Description")
-                        + ": "
-                        + item.Description
+                        translate("AddonsInstaller", "Description") + ": " + item.Description
                     )
                 if item.Subdirectory:
                     info.append(
-                        translate("AddonsInstaller", "Subdirectory")
-                        + ": "
-                        + item.Subdirectory
+                        translate("AddonsInstaller", "Subdirectory") + ": " + item.Subdirectory
                     )
                 if item.File:
-                    info.append(
-                        translate("AddonsInstaller", "Files")
-                        + ": "
-                        + ", ".join(item.File)
-                    )
+                    info.append(translate("AddonsInstaller", "Files") + ": " + ", ".join(item.File))
                 contents_string += ", ".join(info)
 
                 item = QListWidgetItem(contents_string)
@@ -357,24 +342,14 @@ class DeveloperMode:
     def _setup_dialog_signals(self):
         """Set up the signal and slot connections for the main dialog."""
 
-        self.dialog.addonPathBrowseButton.clicked.connect(
-            self._addon_browse_button_clicked
-        )
-        self.dialog.pathToAddonComboBox.editTextChanged.connect(
-            self._addon_combo_text_changed
-        )
-        self.dialog.detectMinPythonButton.clicked.connect(
-            self._detect_min_python_clicked
-        )
+        self.dialog.addonPathBrowseButton.clicked.connect(self._addon_browse_button_clicked)
+        self.dialog.pathToAddonComboBox.editTextChanged.connect(self._addon_combo_text_changed)
+        self.dialog.detectMinPythonButton.clicked.connect(self._detect_min_python_clicked)
         self.dialog.iconBrowseButton.clicked.connect(self._browse_for_icon_clicked)
 
         self.dialog.addContentItemToolButton.clicked.connect(self._add_content_clicked)
-        self.dialog.removeContentItemToolButton.clicked.connect(
-            self._remove_content_clicked
-        )
-        self.dialog.contentsListWidget.itemSelectionChanged.connect(
-            self._content_selection_changed
-        )
+        self.dialog.removeContentItemToolButton.clicked.connect(self._remove_content_clicked)
+        self.dialog.contentsListWidget.itemSelectionChanged.connect(self._content_selection_changed)
         self.dialog.contentsListWidget.itemDoubleClicked.connect(self._edit_content)
 
         self.dialog.versionToTodayButton.clicked.connect(self._set_to_today_clicked)
@@ -393,17 +368,13 @@ class DeveloperMode:
             self.metadata = FreeCAD.Metadata()
 
         self.metadata.Name = self.dialog.displayNameLineEdit.text()
-        self.metadata.Description = (
-            self.dialog.descriptionTextEdit.document().toPlainText()
-        )
+        self.metadata.Description = self.dialog.descriptionTextEdit.document().toPlainText()
         self.metadata.Version = self.dialog.versionLineEdit.text()
         self.metadata.Icon = self.dialog.iconPathLineEdit.text()
 
         urls = []
         if self.dialog.websiteURLLineEdit.text():
-            urls.append(
-                {"location": self.dialog.websiteURLLineEdit.text(), "type": "website"}
-            )
+            urls.append({"location": self.dialog.websiteURLLineEdit.text(), "type": "website"})
         if self.dialog.repositoryURLLineEdit.text():
             urls.append(
                 {
@@ -420,9 +391,7 @@ class DeveloperMode:
                 }
             )
         if self.dialog.readmeURLLineEdit.text():
-            urls.append(
-                {"location": self.dialog.readmeURLLineEdit.text(), "type": "readme"}
-            )
+            urls.append({"location": self.dialog.readmeURLLineEdit.text(), "type": "readme"})
         if self.dialog.documentationURLLineEdit.text():
             urls.append(
                 {
@@ -594,9 +563,7 @@ class DeveloperMode:
             )
             return
         FreeCAD.Console.PrintMessage(
-            translate(
-                "AddonsInstaller", "Scanning Addon for Python version compatibility"
-            )
+            translate("AddonsInstaller", "Scanning Addon for Python version compatibility")
             + "...\n"
         )
         # pylint: disable=import-outside-toplevel
@@ -608,9 +575,7 @@ class DeveloperMode:
                 if filename.endswith(".py"):
                     with open(os.path.join(dir_path, filename), encoding="utf-8") as f:
                         contents = f.read()
-                        version_strings = vermin.version_strings(
-                            vermin.detect(contents)
-                        )
+                        version_strings = vermin.version_strings(vermin.detect(contents))
                         version = version_strings.split(",")
                         if len(version) >= 2:
                             # Only care about Py3, and only if there is a dot in the version:
@@ -622,9 +587,7 @@ class DeveloperMode:
                                     FreeCAD.Console.PrintLog(
                                         f"Detected Python 3.{minor} required by {filename}\n"
                                     )
-                                    required_minor_version = max(
-                                        required_minor_version, minor
-                                    )
+                                    required_minor_version = max(required_minor_version, minor)
         self.dialog.minPythonLineEdit.setText(f"3.{required_minor_version}")
         QMessageBox.information(
             self.dialog,
@@ -654,13 +617,10 @@ class DeveloperMode:
             if response == QMessageBox.Cancel:
                 return False
             FreeCAD.Console.PrintMessage(
-                translate("AddonsInstaller", "Attempting to install Vermin from PyPi")
-                + "...\n"
+                translate("AddonsInstaller", "Attempting to install Vermin from PyPi") + "...\n"
             )
-            python_exe = utils.get_python_exe()
-            vendor_path = os.path.join(
-                FreeCAD.getUserAppDataDir(), "AdditionalPythonPackages"
-            )
+            python_exe = get_python_exe()
+            vendor_path = os.path.join(FreeCAD.getUserAppDataDir(), "AdditionalPythonPackages")
             if not os.path.exists(vendor_path):
                 os.makedirs(vendor_path)
 

--- a/src/Mod/AddonManager/addonmanager_preferences_defaults.json
+++ b/src/Mod/AddonManager/addonmanager_preferences_defaults.json
@@ -25,7 +25,6 @@
     "PrimaryAddonsSubmoduleURL":
         "https://raw.githubusercontent.com/FreeCAD/FreeCAD-addons/master/.gitmodules",
     "ProxyUrl": "",
-    "PythonExecutableForPip": "Not set",
     "RemoteIconCacheURL": "https://addons.freecad.org/icon_cache.zip",
     "SelectedAddon": "",
     "ShowBranchSwitcher": false,

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -342,40 +342,6 @@ def is_float(element: Any) -> bool:
         return False
 
 
-def get_python_exe() -> str:
-    """Find Python. In preference order
-    A) The value of the PythonExecutableForPip user preference
-    B) The executable located in the same bin directory as FreeCAD and called "python3"
-    C) The executable located in the same bin directory as FreeCAD and called "python"
-    D) The result of a shutil search for your system's "python3" executable
-    E) The result of a shutil search for your system's "python" executable"""
-    prefs = fci.ParamGet("User parameter:BaseApp/Preferences/Addons")
-    python_exe = prefs.GetString("PythonExecutableForPip", "Not set")
-    fc_dir = fci.DataPaths().home_dir
-    if not python_exe or python_exe == "Not set" or not os.path.exists(python_exe):
-        python_exe = os.path.join(fc_dir, "bin", "python3")
-        if "Windows" in platform.system():
-            python_exe += ".exe"
-
-    if not python_exe or not os.path.exists(python_exe):
-        python_exe = os.path.join(fc_dir, "bin", "python")
-        if "Windows" in platform.system():
-            python_exe += ".exe"
-
-    if not python_exe or not os.path.exists(python_exe):
-        python_exe = shutil.which("python3")
-
-    if not python_exe or not os.path.exists(python_exe):
-        python_exe = shutil.which("python")
-
-    if not python_exe or not os.path.exists(python_exe):
-        return ""
-
-    python_exe = python_exe.replace("/", os.path.sep)
-    prefs.SetString("PythonExecutableForPip", python_exe)
-    return python_exe
-
-
 def get_pip_target_directory():
     # Get the default location to install new pip packages
     major, minor, _ = platform.python_version_tuple()

--- a/src/Mod/AddonManager/manage_python_dependencies.py
+++ b/src/Mod/AddonManager/manage_python_dependencies.py
@@ -36,6 +36,7 @@ from typing import Dict, List, Tuple
 
 import FreeCAD
 import FreeCADGui
+from freecad.utils import get_python_exe
 from PySide import QtCore, QtGui, QtWidgets
 
 import addonmanager_utilities as utils
@@ -89,7 +90,7 @@ def call_pip(args) -> List[str]:
     """Tries to locate the appropriate Python executable and run pip with version checking
     disabled. Fails if Python can't be found or if pip is not installed."""
 
-    python_exe = utils.get_python_exe()
+    python_exe = get_python_exe()
     pip_failed = False
     if python_exe:
         call_args = [python_exe, "-m", "pip", "--disable-pip-version-check"]
@@ -134,12 +135,8 @@ class PythonPackageManager:
         def process(self):
             """Execute this object."""
             try:
-                self.all_packages_stdout = call_pip(
-                    ["list", "--path", self.vendor_path]
-                )
-                self.outdated_packages_stdout = call_pip(
-                    ["list", "-o", "--path", self.vendor_path]
-                )
+                self.all_packages_stdout = call_pip(["list", "--path", self.vendor_path])
+                self.outdated_packages_stdout = call_pip(["list", "-o", "--path", self.vendor_path])
             except PipFailed as e:
                 FreeCAD.Console.PrintError(str(e) + "\n")
                 self.error.emit(str(e))
@@ -197,9 +194,7 @@ class PythonPackageManager:
         self.dlg.tableWidget.setItem(
             0,
             0,
-            QtWidgets.QTableWidgetItem(
-                translate("AddonsInstaller", "Processing, please wait...")
-            ),
+            QtWidgets.QTableWidgetItem(translate("AddonsInstaller", "Processing, please wait...")),
         )
         self.dlg.tableWidget.horizontalHeader().setSectionResizeMode(
             0, QtWidgets.QHeaderView.ResizeToContents
@@ -230,9 +225,7 @@ class PythonPackageManager:
                     dependencies.append(addon["name"] + "*")
                 else:
                     dependencies.append(addon["name"])
-            self.dlg.tableWidget.setItem(
-                counter, 0, QtWidgets.QTableWidgetItem(package_name)
-            )
+            self.dlg.tableWidget.setItem(counter, 0, QtWidgets.QTableWidgetItem(package_name))
             self.dlg.tableWidget.setItem(
                 counter,
                 1,
@@ -249,13 +242,9 @@ class PythonPackageManager:
                 QtWidgets.QTableWidgetItem(", ".join(dependencies)),
             )
             if len(package_details["available_version"]) > 0:
-                updateButtons.append(
-                    QtWidgets.QPushButton(translate("AddonsInstaller", "Update"))
-                )
+                updateButtons.append(QtWidgets.QPushButton(translate("AddonsInstaller", "Update")))
                 updateButtons[-1].setIcon(QtGui.QIcon(":/icons/button_up.svg"))
-                updateButtons[-1].clicked.connect(
-                    partial(self._update_package, package_name)
-                )
+                updateButtons[-1].clicked.connect(partial(self._update_package, package_name))
                 self.dlg.tableWidget.setCellWidget(counter, 4, updateButtons[-1])
                 update_counter += 1
             else:
@@ -292,9 +281,7 @@ class PythonPackageManager:
                 dependent_addons.append({"name": addon.name, "optional": True})
         return dependent_addons
 
-    def _parse_pip_list_output(
-        self, all_packages, outdated_packages
-    ) -> Dict[str, Dict[str, str]]:
+    def _parse_pip_list_output(self, all_packages, outdated_packages) -> Dict[str, Dict[str, str]]:
         """Parses the output from pip into a dictionary with update information in it. The pip
         output should be an array of lines of text."""
 
@@ -350,17 +337,13 @@ class PythonPackageManager:
                 self.dlg.tableWidget.setItem(
                     line,
                     2,
-                    QtWidgets.QTableWidgetItem(
-                        translate("AddonsInstaller", "Updating...")
-                    ),
+                    QtWidgets.QTableWidgetItem(translate("AddonsInstaller", "Updating...")),
                 )
                 break
         QtCore.QCoreApplication.processEvents(QtCore.QEventLoop.AllEvents, 50)
 
         try:
-            call_pip(
-                ["install", "--upgrade", package_name, "--target", self.vendor_path]
-            )
+            call_pip(["install", "--upgrade", package_name, "--target", self.vendor_path])
             self._create_list_from_pip()
         except PipFailed as e:
             FreeCAD.Console.PrintError(str(e) + "\n")
@@ -373,8 +356,7 @@ class PythonPackageManager:
         for package_name, package_details in package_list.items():
             if (
                 len(package_details["available_version"]) > 0
-                and package_details["available_version"]
-                != package_details["installed_version"]
+                and package_details["available_version"] != package_details["installed_version"]
             ):
                 updates.append(package_name)
 
@@ -389,9 +371,7 @@ class PythonPackageManager:
 
         migrated = False
 
-        old_directory = os.path.join(
-            FreeCAD.getUserAppDataDir(), "AdditionalPythonPackages"
-        )
+        old_directory = os.path.join(FreeCAD.getUserAppDataDir(), "AdditionalPythonPackages")
 
         new_directory = utils.get_pip_target_directory()
         new_directory_name = new_directory.rsplit(os.path.sep, 1)[1]
@@ -420,12 +400,8 @@ class PythonPackageManager:
         sys.path.append(new_directory)
         cls._add_current_python_version()
 
-        with open(
-            os.path.join(old_directory, "MIGRATION_COMPLETE"), "w", encoding="utf-8"
-        ) as f:
-            f.write(
-                "Files originally installed in this directory have been migrated to:\n"
-            )
+        with open(os.path.join(old_directory, "MIGRATION_COMPLETE"), "w", encoding="utf-8") as f:
+            f.write("Files originally installed in this directory have been migrated to:\n")
             f.write(new_directory)
             f.write(
                 "\nThe existence of this file prevents the Addon Manager from "

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,3 +44,9 @@ add_executable(Sketcher_tests_run)
 add_subdirectory(src/Mod/Sketcher)
 target_include_directories(Sketcher_tests_run PUBLIC ${EIGEN3_INCLUDE_DIR} ${OCC_INCLUDE_DIR} ${Python3_INCLUDE_DIRS})
 target_link_libraries(Sketcher_tests_run gtest_main ${Google_Tests_LIBS} Sketcher)
+
+include(GoogleTest)
+# discovers tests by asking the compiled test executable to enumerate its tests
+set(CMAKE_GTEST_DISCOVER_TESTS_DISCOVERY_MODE PRE_TEST)
+gtest_discover_tests(Tests_run) 
+gtest_discover_tests(Sketcher_tests_run) 


### PR DESCRIPTION
This PR:

- Improves includepath configuration, can now be customized per-OS
- Makes configuration general, not tied to conda. 
- C++ and python debugging should now work automatically within VSCode. Tested only on linux: can someone test on windows and mac please?
- Tests (googletest) are automatically discovered and presented in VSCode. It is not recommended to use this feature, it's way faster to run the gtest executable directly. Python tests are run using freecad, so they cant be easily integrated in vscode, there's just a simple task for those.
- Upgrade integrated python debugger from ptvsd (deprecated) to debugpy. 

When all the things are fixed/approved I'll create a followup pr on the developers handbook on how to use all these features and get started coding in vscode.  