### PR TITLE
Path: Minor translation fixes

### DIFF
--- a/src/Mod/Path/Gui/DlgSettingsPathColor.ui
+++ b/src/Mod/Path/Gui/DlgSettingsPathColor.ui
@@ -23,6 +23,41 @@
       <string>Default Path colors</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="1">
+       <widget class="Gui::PrefSpinBox" name="DefaultPathLineWidth">
+        <property name="toolTip">
+         <string>The default line thickness for new shapes</string>
+        </property>
+        <property name="suffix">
+         <string>px</string>
+        </property>
+        <property name="maximum">
+         <number>9</number>
+        </property>
+        <property name="value">
+         <number>1</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultPathLineWidth</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Path</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_11">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Path highlight color</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_6">
         <property name="minimumSize">
@@ -33,6 +68,39 @@
         </property>
         <property name="text">
          <string>Default normal path color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="Gui::PrefColorButton" name="DefaultBBoxNormalColor">
+        <property name="toolTip">
+         <string>The default line color for new shapes</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>255</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultBBoxNormalColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Path</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_13">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Bounding box normal color</string>
         </property>
        </widget>
       </item>
@@ -56,8 +124,28 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_9">
+      <item row="3" column="1">
+       <widget class="Gui::PrefColorButton" name="DefaultRapidPathColor">
+        <property name="toolTip">
+         <string>The default line color for new shapes</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>170</red>
+          <green>0</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultRapidPathColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Path</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_8">
         <property name="minimumSize">
          <size>
           <width>182</width>
@@ -65,29 +153,53 @@
          </size>
         </property>
         <property name="text">
-         <string>Default pathline width</string>
+         <string>Probe path color</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="Gui::PrefSpinBox" name="DefaultPathLineWidth">
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Rapid path color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="Gui::PrefColorButton" name="DefaultHighlightPathColor">
         <property name="toolTip">
-         <string>The default line thickness for new shapes</string>
+         <string>The default line color for new shapes</string>
         </property>
-        <property name="suffix">
-         <string>px</string>
-        </property>
-        <property name="maximum">
-         <number>9</number>
-        </property>
-        <property name="value">
-         <number>1</number>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>125</green>
+          <blue>0</blue>
+         </color>
         </property>
         <property name="prefEntry" stdset="0">
-         <cstring>DefaultPathLineWidth</cstring>
+         <cstring>DefaultHighlightPathColor</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Path</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_14">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Bounding box selection color</string>
         </property>
        </widget>
       </item>
@@ -124,8 +236,8 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_7">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_9">
         <property name="minimumSize">
          <size>
           <width>182</width>
@@ -133,40 +245,7 @@
          </size>
         </property>
         <property name="text">
-         <string>Rapid path color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="Gui::PrefColorButton" name="DefaultRapidPathColor">
-        <property name="toolTip">
-         <string>The default line color for new shapes</string>
-        </property>
-        <property name="color" stdset="0">
-         <color>
-          <red>170</red>
-          <green>0</green>
-          <blue>0</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>DefaultRapidPathColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Path</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_8">
-        <property name="minimumSize">
-         <size>
-          <width>182</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Probe Path color</string>
+         <string>Default pathline width</string>
         </property>
        </widget>
       </item>
@@ -190,103 +269,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Machine extents color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="Gui::PrefColorButton" name="DefaultExtentsColor">
-        <property name="prefEntry" stdset="0">
-         <cstring>DefaultExtentsColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Path</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_11">
-        <property name="minimumSize">
-         <size>
-          <width>182</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Path Highlight Color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="Gui::PrefColorButton" name="DefaultHighlightPathColor">
-        <property name="toolTip">
-         <string>The default line color for new shapes</string>
-        </property>
-        <property name="color" stdset="0">
-         <color>
-          <red>255</red>
-          <green>125</green>
-          <blue>0</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>DefaultHighlightPathColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Path</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="label_13">
-        <property name="minimumSize">
-         <size>
-          <width>182</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Bounding Box Normal Color</string>
-        </property>
-       </widget>
-      </item>
       <item row="7" column="1">
-       <widget class="Gui::PrefColorButton" name="DefaultBBoxNormalColor">
-        <property name="toolTip">
-         <string>The default line color for new shapes</string>
-        </property>
-        <property name="color" stdset="0">
-         <color>
-          <red>255</red>
-          <green>255</green>
-          <blue>255</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>DefaultBBoxNormalColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Path</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="label_14">
-        <property name="minimumSize">
-         <size>
-          <width>182</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Bounding Box Selection Color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1">
        <widget class="Gui::PrefColorButton" name="DefaultBBoxSelectionColor">
         <property name="toolTip">
          <string>The default line color for new shapes</string>
@@ -307,38 +290,7 @@
        </widget>
       </item>
      </layout>
-     <zorder>label_6</zorder>
-     <zorder>DefaultNormalPathColor</zorder>
-     <zorder>label_9</zorder>
-     <zorder>DefaultPathLineWidth</zorder>
-     <zorder>label_10</zorder>
-     <zorder>DefaultPathMarkerColor</zorder>
-     <zorder>label_7</zorder>
-     <zorder>DefaultRapidPathColor</zorder>
-     <zorder>label</zorder>
-     <zorder>DefaultExtentsColor</zorder>
-     <zorder>label_8</zorder>
-     <zorder>DefaultProbePathColor</zorder>
-     <zorder>label_11</zorder>
-     <zorder>DefaultHighlightPathColor</zorder>
-     <zorder>label_13</zorder>
-     <zorder>DefaultBBoxNormalColor</zorder>
-     <zorder>label_14</zorder>
-     <zorder>DefaultBBoxSelectionColor</zorder>
     </widget>
-   </item>
-   <item row="0" column="1">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>7</width>
-       <height>220</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox_3">
@@ -445,6 +397,19 @@
       <size>
        <width>20</width>
        <height>217</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>7</width>
+       <height>220</height>
       </size>
      </property>
     </spacer>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpPocketExtEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpPocketExtEdit.ui
@@ -62,7 +62,7 @@
         <item row="2" column="1">
           <widget class="QCheckBox" name="extendCorners">
            <property name="toolTip">
-            <string>Extend the corner between two edges of a pocket. If selected adjacent edges are combined</string>
+            <string>Extend the corner between two edges of a pocket. Selected adjacent edges are combined.</string>
            </property>
            <property name="text">
             <string>Extend Corners</string>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -139,7 +139,7 @@
      <widget class="QLineEdit" name="postProcessorOutputFile">
       <property name="toolTip">
        <string>Enter a path and optionally file name (see below) to be used as the default for the post processor export.
-The following substitutions are performed before the name is resolved at the time of the post-processing:
+The following substitutions are performed before the name is resolved at the time of the post processing:
 Substitution allows the following:
 %D ... directory of the active document
 %d ... name of the active document (with extension)
@@ -397,7 +397,7 @@ FreeCAD has no knowledge of where a particular coordinate system exists within t
           <string>If multiple coordinate systems are in use, setting this to TRUE will cause the gcode to be written to multiple output files as controlled by the 'order by' property.  For example, if ordering by Fixture, the first output file will be for the first fixture and separate file for the second.</string>
          </property>
          <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If True, post-processing will create multiple output files based on the &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; setting.
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If True, post processing will create multiple output files based on the &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; setting.
 
 
 For example, if &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; is set to Tool, the first output file will contain the first tool change and all operations, in all coordinate systems, that can be done with that tool before the next tool change is called.

--- a/src/Mod/Path/Gui/Resources/preferences/Advanced.ui
+++ b/src/Mod/Path/Gui/Resources/preferences/Advanced.ui
@@ -64,7 +64,7 @@
          <string>Suppress warning whenever a Path selection mode is activated</string>
         </property>
         <property name="text">
-         <string>Suppress Velocity warning</string>
+         <string>Suppress feed rate warning</string>
         </property>
         <property name="checked">
          <bool>false</bool>

--- a/src/Mod/Path/Gui/Resources/preferences/Advanced.ui
+++ b/src/Mod/Path/Gui/Resources/preferences/Advanced.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>512</width>
+    <width>487</width>
     <height>691</height>
    </rect>
   </property>
@@ -102,42 +102,22 @@
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="title">
-      <string>Open CAMlib</string>
+      <string>OpenCAMLib</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QTextEdit" name="textEdit">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>If OpenCAMLib is installed with Python bindings it can be used by some additional 3D operations. NOTE: Enabling OpenCAMLib here requires a restart of FreeCAD to take effect.</string>
         </property>
-        <property name="verticalScrollBarPolicy">
-         <enum>Qt::ScrollBarAlwaysOff</enum>
-        </property>
-        <property name="horizontalScrollBarPolicy">
-         <enum>Qt::ScrollBarAlwaysOff</enum>
-        </property>
-        <property name="sizeAdjustPolicy">
-         <enum>QAbstractScrollArea::AdjustToContents</enum>
-        </property>
-        <property name="readOnly">
+        <property name="wordWrap">
          <bool>true</bool>
-        </property>
-        <property name="html">
-         <string>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd"&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name="qrichtext" content="1" /&gt;&lt;style type="text/css"&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=" font-family:'DejaVu Sans'; font-size:12pt; font-weight:400; font-style:normal;"&gt;
-&lt;p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;span style=" font-family:'Sans'; font-size:16pt;"&gt;If openCAMlib is installed with its python interface it can be used by some additional 3d operations.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=" margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"&gt;&lt;span style=" font-family:'Sans'; font-size:16pt;"&gt;Changing this value requires a restart of FreeCAD to take effect.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
+++ b/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
@@ -185,8 +185,8 @@ If left empty no template will be preselected.</string>
             <item>
              <widget class="QLineEdit" name="leOutputFile">
               <property name="toolTip">
-               <string>Enter a path and optionally file name (see below) to be used as the default for the post-processor export.
-The following substitutions are performed before the name is resolved at the time of the post-processing:
+               <string>Enter a path and optionally file name (see below) to be used as the default for the post processor export.
+The following substitutions are performed before the name is resolved at the time of the post processing:
 Substitution allows the following:
 %D ... directory of the active document
 %d ... name of the active document (with extension)

--- a/src/Mod/Path/Path/Main/Gui/Inspect.py
+++ b/src/Mod/Path/Path/Main/Gui/Inspect.py
@@ -140,7 +140,7 @@ class GCodeEditorDialog(QtGui.QDialog):
         lab.setText(
             translate(
                 "Path_Inspect",
-                "<b>Note</b>: This dialog shows Path Commands in FreeCAD base units (mm/s). \n Values will be converted to the desired unit during post-processing.",
+                "<b>Note</b>: This dialog shows Path Commands in FreeCAD base units (mm/s). \n Values will be converted to the desired unit during post processing.",
             )
         )
         lab.setWordWrap(True)

--- a/src/Mod/Path/Path/Main/Job.py
+++ b/src/Mod/Path/Path/Main/Job.py
@@ -133,14 +133,14 @@ class ObjectJob:
             "App::PropertyString",
             "LastPostProcessDate",
             "Output",
-            QT_TRANSLATE_NOOP("App::Property", "Last Time the Job was post-processed"),
+            QT_TRANSLATE_NOOP("App::Property", "Last Time the Job was post processed"),
         )
         obj.setEditorMode("LastPostProcessDate", 2)  # Hide
         obj.addProperty(
             "App::PropertyString",
             "LastPostProcessOutput",
             "Output",
-            QT_TRANSLATE_NOOP("App::Property", "Last Time the Job was post-processed"),
+            QT_TRANSLATE_NOOP("App::Property", "Last Time the Job was post processed"),
         )
         obj.setEditorMode("LastPostProcessOutput", 2)  # Hide
 


### PR DESCRIPTION
As discussed on CrowdIn (and Telegram), this PR:
* Standardizes on "post processor" (with a space, and no hyphen)
* Tweaks the wording of a confusing tooltip
* Removes the deprecated "machine extents color" preference
* Removes the HTML in the description of the OpenCAMlib preference, and changes it to a `QLabel`.
* Standardizes the capitalization in DlgSettingsPathColor.ui

All other changes are just Qt Designer rearranging things: I did not normalize the file.

---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR