### PR TITLE
Sketcher: Fix bug angle via point visualisation

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -143,17 +143,25 @@ Restart:
         auto geom = geolistfacade.getGeometryFromGeoId(geoid);
         auto curve = dynamic_cast<const Part::GeomCurve*>(geom);
 
-        Base::Vector3d normal;
-        try {
-            if (!(curve && curve->normalAt(pointoncurve, normal))) {
+        auto line = dynamic_cast<const Part::GeomLineSegment*>(curve);
+
+        if (line) {
+            Base::Vector3d linedir = line->getEndPoint() - line->getStartPoint();
+            return Base::Vector3d(-linedir.y, linedir.x, 0);
+        }
+        else {
+            Base::Vector3d normal;
+            try {
+                if (!(curve && curve->normalAt(pointoncurve, normal))) {
+                    normal = Base::Vector3d(1, 0, 0);
+                }
+            }
+            catch (const Base::CADKernelError&) {
                 normal = Base::Vector3d(1, 0, 0);
             }
-        }
-        catch (const Base::CADKernelError&) {
-            normal = Base::Vector3d(1, 0, 0);
-        }
 
-        return normal;
+            return normal;
+        }
     };
 
     // go through the constraints and update the position


### PR DESCRIPTION
===============================================

Issue description:
https://forum.freecad.org/viewtopic.php?f=3&t=70325 https://github.com/FreeCAD/FreeCAD/issues/7520

The general algorithm to calculate normals miserably fails when the curve is a line segment and the point through which the normal to a curve is to be drawn is colinear with the line segment.

The solution is to provide specific code for this corner case.

fixes #7520