### PR TITLE
Sketch dumper and fixes to PythonConverter

### DIFF
--- a/src/Mod/Sketcher/App/PreCompiled.h
+++ b/src/Mod/Sketcher/App/PreCompiled.h
@@ -39,6 +39,7 @@
 #include <QDateTime>
 
 // Boost
+#include <boost/algorithm/string/regex.hpp>
 #include <boost/format.hpp>
 #include <boost/uuid/uuid_io.hpp>
 

--- a/src/Mod/Sketcher/App/PythonConverter.h
+++ b/src/Mod/Sketcher/App/PythonConverter.h
@@ -24,6 +24,8 @@
 #ifndef SKETCHER_PythonConverter_H
 #define SKETCHER_PythonConverter_H
 
+#include <Mod/Sketcher/SketcherGlobal.h>
+
 namespace Part
 {
 class Geometry;
@@ -63,6 +65,8 @@ public:
 
     static std::string convert(const std::string& doc,
                                const std::vector<Sketcher::Constraint*>& constraints);
+
+    static std::vector<std::string> multiLine(std::string&& singlestring);
 
 private:
     static SingleGeometry process(const Part::Geometry* geo);

--- a/src/Mod/Sketcher/App/SketchObjectPy.xml
+++ b/src/Mod/Sketcher/App/SketchObjectPy.xml
@@ -419,7 +419,13 @@ If there is no such constraint an exception is raised.
             </UserDocu>
         </Documentation>
     </Methode>
-
+    <Methode Name="toPythonCommands">
+        <Documentation>
+            <UserDocu>
+                Prints the commands that should be executed to recreate the Geometry and Constraints of the present sketch (excluding any External Geometry).
+            </UserDocu>
+        </Documentation>
+    </Methode>
     <Attribute Name="MissingPointOnPointConstraints" ReadOnly="false">
         <Documentation>
             <UserDocu>


### PR DESCRIPTION

Bug fix:
- PythonConverter did not respect the creation order when normal and construction geometries were interleaved.

Sketch dumper:
- small new feature to help produce functional unit tests.

Often we have very nice sketches showing problems, for example bugs. Some of them would be invaluable as functional tests (for example those involving the solver, such as the popularity contest algorithm). Yet, there is an important barrier in turning already made sketches into the Python statements necessary to build them.

Sketch dumper is a small, fully-detached, Python-only utility to easily get that Python code (see commit description). My expectation is that this would help reduce that barrier.
