### PR TITLE
Arch: Fix ArchReference (broken after #9316)

### DIFF
--- a/src/Mod/Arch/ArchReference.py
+++ b/src/Mod/Arch/ArchReference.py
@@ -159,6 +159,7 @@ class ArchReference:
                             f = zdoc.open(self.parts[obj.Part][1])
                             shapedata = f.read()
                             f.close()
+                            shapedata = shapedata.decode("utf8")
                             shape = self.cleanShape(shapedata,obj,self.parts[obj.Part][2])
                             obj.Shape = shape
                             if not pl.isIdentity():
@@ -260,6 +261,7 @@ class ArchReference:
             materials = {}
             writemode = False
             for line in docf:
+                line = line.decode("utf8")
                 if "<Object name=" in line:
                     n = re.findall('name=\"(.*?)\"',line)
                     if n:
@@ -315,6 +317,7 @@ class ArchReference:
             writemode1 = False
             writemode2 = False
             for line in docf:
+                line = line.decode("utf8")
                 if ("<ViewProvider name=" in line) and (part in line):
                     writemode1 = True
                 elif writemode1 and ("<Property name=\"DiffuseColor\"" in line):
@@ -619,6 +622,7 @@ class ViewProviderArchReference:
             writemode1 = False
             writemode2 = False
             for line in docf:
+                line = line.decode("utf8")
                 if ("<Object name=" in line) and (part in line):
                     writemode1 = True
                 elif writemode1 and ("<Property name=\"SavedInventor\"" in line):
@@ -635,6 +639,7 @@ class ViewProviderArchReference:
             return None
         f = zdoc.open(ivfile)
         buf = f.read()
+        buf = buf.decode("utf8")
         f.close()
         buf = buf.replace("lineWidth 2","lineWidth "+str(int(obj.ViewObject.LineWidth)))
         return buf


### PR DESCRIPTION
In #9316 I wrongly removed all decode code from ArchReference.py. But for bytes objects this code is still required.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
