### PR TITLE
Arch: more consistent object naming and labelling

### DIFF
--- a/src/Mod/Arch/ArchAxis.py
+++ b/src/Mod/Arch/ArchAxis.py
@@ -55,16 +55,16 @@ __url__    = "https://www.freecad.org"
 #  An axis is a collection of planar axes with a number/tag
 
 
-def makeAxis(num=5,size=1000,name="Axes"):
+def makeAxis(num=5,size=1000,name=None):
 
-    '''makeAxis(num,size): makes an Axis set
+    '''makeAxis([num],[size],[name]): makes an Axis set
     based on the given number of axes and interval distances'''
 
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Axis")
-    obj.Label = translate("Arch",name)
+    obj.Label = name if name else translate("Arch","Axes")
     _Axis(obj)
     if FreeCAD.GuiUp:
         _ViewProviderAxis(obj.ViewObject)

--- a/src/Mod/Arch/ArchAxisSystem.py
+++ b/src/Mod/Arch/ArchAxisSystem.py
@@ -48,14 +48,14 @@ __url__    = "https://www.freecad.org"
 #  An axis system is a collection of multiple axes
 
 
-def makeAxisSystem(axes,name="Axis System"):
+def makeAxisSystem(axes,name=None):
 
-    '''makeAxisSystem(axes): makes a system from the given list of axes'''
+    '''makeAxisSystem(axes,[name]): makes a system from the given list of axes'''
 
     if not isinstance(axes,list):
         axes = [axes]
     obj = FreeCAD.ActiveDocument.addObject("App::FeaturePython","AxisSystem")
-    obj.Label = translate("Arch",name)
+    obj.Label = name if name else translate("Arch","Axis System")
     _AxisSystem(obj)
     obj.Axes = axes
     if FreeCAD.GuiUp:

--- a/src/Mod/Arch/ArchBuilding.py
+++ b/src/Mod/Arch/ArchBuilding.py
@@ -190,21 +190,22 @@ BuildingTypes = ['Undefined',
 ]
 
 
-def makeBuilding(objectslist=None,baseobj=None,name="Building"):
+def makeBuilding(objectslist=None,name=None):
+    '''Obsolete, superseded by ArchBuildingPart.makeBuilding.
 
-    '''makeBuilding(objectslist): creates a building including the
+    makeBuilding([objectslist],[name]): creates a building including the
     objects from the given list.'''
 
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroupPython","Building")
+    obj.Label = name if name else translate("Arch","Building")
     _Building(obj)
     if FreeCAD.GuiUp:
         _ViewProviderBuilding(obj.ViewObject)
     if objectslist:
         obj.Group = objectslist
-    obj.Label = translate("Arch",name)
     return obj
 
 

--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -195,14 +195,14 @@ BuildingTypes = ['Undefined',
 ]
 
 
-def makeBuildingPart(objectslist=None,baseobj=None,name="BuildingPart"):
+def makeBuildingPart(objectslist=None,baseobj=None,name=None):
 
-    '''makeBuildingPart(objectslist): creates a buildingPart including the
+    '''makeBuildingPart([objectslist],[name]): creates a buildingPart including the
     objects from the given list.'''
 
     obj = FreeCAD.ActiveDocument.addObject("App::GeometryPython","BuildingPart")
     #obj = FreeCAD.ActiveDocument.addObject("App::FeaturePython","BuildingPart")
-    obj.Label = translate("Arch","BuildingPart")
+    obj.Label = name if name else translate("Arch","BuildingPart")
     BuildingPart(obj)
     obj.IfcType = "Building Element Part"
     if FreeCAD.GuiUp:
@@ -212,22 +212,22 @@ def makeBuildingPart(objectslist=None,baseobj=None,name="BuildingPart"):
     return obj
 
 
-def makeFloor(objectslist=None,baseobj=None,name="Floor"):
+def makeFloor(objectslist=None,baseobj=None,name=None):
 
     """overwrites ArchFloor.makeFloor"""
 
     obj = makeBuildingPart(objectslist)
-    obj.Label = name
+    obj.Label = name if name else translate("Arch","Floor")
     obj.IfcType = "Building Storey"
     return obj
 
 
-def makeBuilding(objectslist=None,baseobj=None,name="Building"):
+def makeBuilding(objectslist=None,baseobj=None,name=None):
 
     """overwrites ArchBuilding.makeBuilding"""
 
     obj = makeBuildingPart(objectslist)
-    obj.Label = name
+    obj.Label = name if name else translate("Arch","Building")
     obj.IfcType = "Building"
     obj.addProperty("App::PropertyEnumeration","BuildingType","Building",QT_TRANSLATE_NOOP("App::Property","The type of this building"))
     obj.BuildingType = BuildingTypes

--- a/src/Mod/Arch/ArchCommands.py
+++ b/src/Mod/Arch/ArchCommands.py
@@ -205,14 +205,14 @@ def removeComponents(objectsList,host=None):
                         a.remove(o)
                         h.Objects = a
 
-def makeComponent(baseobj=None,name="Component",delete=False):
-    '''makeComponent([baseobj]): creates an undefined, non-parametric Arch
+def makeComponent(baseobj=None,name=None,delete=False):
+    '''makeComponent([baseobj],[name],[delete]): creates an undefined, non-parametric Arch
     component from the given base object'''
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Component")
-    obj.Label = translate("Arch",name)
+    obj.Label = name if name else translate("Arch","Component")
     ArchComponent.Component(obj)
     if FreeCAD.GuiUp:
         ArchComponent.ViewProviderComponent(obj.ViewObject)

--- a/src/Mod/Arch/ArchCurtainWall.py
+++ b/src/Mod/Arch/ArchCurtainWall.py
@@ -69,17 +69,17 @@ the facet is triangulated and receives a third mullion
 """
 
 
-def makeCurtainWall(baseobj=None,name="Curtain Wall"):
+def makeCurtainWall(baseobj=None,name=None):
 
     """
-    makeCurtainWall([baseobj]): Creates a curtain wall in the active document
+    makeCurtainWall([baseobj],[name]): Creates a curtain wall in the active document
     """
 
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","CurtainWall")
-    obj.Label = translate("Arch","Curtain Wall")
+    obj.Label = name if name else translate("Arch","Curtain Wall")
     CurtainWall(obj)
     if FreeCAD.GuiUp:
         ViewProviderCurtainWall(obj.ViewObject)

--- a/src/Mod/Arch/ArchEquipment.py
+++ b/src/Mod/Arch/ArchEquipment.py
@@ -49,20 +49,20 @@ else:
 #  or hydraulic appliances in a building
 
 
-def makeEquipment(baseobj=None,placement=None,name="Equipment"):
+def makeEquipment(baseobj=None,placement=None,name=None):
 
-    "makeEquipment([baseobj,placement,name]): creates an equipment object from the given base object."
+    "makeEquipment([baseobj],[placement],[name]): creates an equipment object from the given base object."
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Equipment")
+    obj.Label = name if name else translate("Arch","Equipment")
     _Equipment(obj)
     if baseobj:
         if baseobj.isDerivedFrom("Mesh::Feature"):
             obj.Mesh = baseobj
         else:
             obj.Base = baseobj
-    obj.Label = translate("Arch",name)
     if placement:
         obj.Placement = placement
     if FreeCAD.GuiUp:

--- a/src/Mod/Arch/ArchFloor.py
+++ b/src/Mod/Arch/ArchFloor.py
@@ -57,7 +57,7 @@ __title__  = "FreeCAD Arch Floor"
 __author__ = "Yorik van Havre"
 __url__    = "https://www.freecad.org"
 
-def makeFloor(objectslist=None,baseobj=None,name="Floor"):
+def makeFloor(objectslist=None,baseobj=None,name=None):
     """Obsolete, superseded by ArchBuildingPart.makeFloor.
 
     Create a floor.
@@ -84,8 +84,8 @@ def makeFloor(objectslist=None,baseobj=None,name="Floor"):
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
-    obj = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroupPython",name)
-    obj.Label = translate("Arch",name)
+    obj = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroupPython","Floor")
+    obj.Label = name if name else translate("Arch","Floor")
     _Floor(obj)
     if FreeCAD.GuiUp:
         _ViewProviderFloor(obj.ViewObject)

--- a/src/Mod/Arch/ArchFrame.py
+++ b/src/Mod/Arch/ArchFrame.py
@@ -48,7 +48,7 @@ __author__ = "Yorik van Havre"
 __url__    = "https://www.freecad.org"
 
 
-def makeFrame(baseobj,profile,name=translate("Arch","Frame")):
+def makeFrame(baseobj,profile,name=None):
 
     """makeFrame(baseobj,profile,[name]): creates a frame object from a base sketch (or any other object
     containing wires) and a profile object (an extrudable 2D object containing faces or closed wires)"""
@@ -57,7 +57,7 @@ def makeFrame(baseobj,profile,name=translate("Arch","Frame")):
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Frame")
-    obj.Label = translate("Arch",name)
+    obj.Label = name if name else translate("Arch","Frame")
     _Frame(obj)
     if FreeCAD.GuiUp:
         _ViewProviderFrame(obj.ViewObject)

--- a/src/Mod/Arch/ArchGrid.py
+++ b/src/Mod/Arch/ArchGrid.py
@@ -47,12 +47,12 @@ __url__    = "https://www.freecad.org"
 #  This module provides tools to build grid systems
 
 
-def makeGrid(name="Grid"):
+def makeGrid(name=None):
 
-    '''makeGrid(): makes a grid object'''
+    '''makeGrid([name]): makes a grid object'''
 
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Grid")
-    obj.Label = translate("Arch",name)
+    obj.Label = name if name else translate("Arch","Grid")
     ArchGrid(obj)
     if FreeCAD.GuiUp:
         ViewProviderArchGrid(obj.ViewObject)

--- a/src/Mod/Arch/ArchMaterial.py
+++ b/src/Mod/Arch/ArchMaterial.py
@@ -45,14 +45,14 @@ __url__ = "http://www.freecad.org"
 #  This module provides tools to add materials to
 #  Arch objects
 
-def makeMaterial(name="Material",color=None,transparency=None):
+def makeMaterial(name=None,color=None,transparency=None):
 
-    '''makeMaterial(name): makes an Material object'''
+    '''makeMaterial([name],[color],[transparency]): makes an Material object'''
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("App::MaterialObjectPython","Material")
-    obj.Label = name
+    obj.Label = name if name else translate("Arch","Material")
     _ArchMaterial(obj)
     if FreeCAD.GuiUp:
         _ViewProviderArchMaterial(obj.ViewObject)
@@ -80,11 +80,11 @@ def getMaterialContainer():
     return obj
 
 
-def makeMultiMaterial(name="MultiMaterial"):
+def makeMultiMaterial(name=None):
 
-    '''makeMultiMaterial(name): makes an Material object'''
+    '''makeMultiMaterial([name]): makes an MultiMaterial object'''
     obj = FreeCAD.ActiveDocument.addObject("App::FeaturePython","MultiMaterial")
-    obj.Label = name
+    obj.Label = name if name else translate("Arch","MultiMaterial")
     _ArchMultiMaterial(obj)
     if FreeCAD.GuiUp:
         _ViewProviderArchMultiMaterial(obj.ViewObject)

--- a/src/Mod/Arch/ArchPanel.py
+++ b/src/Mod/Arch/ArchPanel.py
@@ -68,9 +68,9 @@ Presets = [None,
 
 
 
-def makePanel(baseobj=None,length=0,width=0,thickness=0,placement=None,name="Panel"):
+def makePanel(baseobj=None,length=0,width=0,thickness=0,placement=None,name=None):
 
-    '''makePanel([obj],[length],[width],[thickness],[placement]): creates a
+    '''makePanel([baseobj],[length],[width],[thickness],[placement],[name]): creates a
     panel element based on the given profile object and the given
     extrusion thickness. If no base object is given, you can also specify
     length and width for a simple cubic object.'''
@@ -79,7 +79,7 @@ def makePanel(baseobj=None,length=0,width=0,thickness=0,placement=None,name="Pan
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Panel")
-    obj.Label = translate("Arch",name)
+    obj.Label = name if name else translate("Arch","Panel")
     _Panel(obj)
     if FreeCAD.GuiUp:
         _ViewProviderPanel(obj.ViewObject)
@@ -96,26 +96,27 @@ def makePanel(baseobj=None,length=0,width=0,thickness=0,placement=None,name="Pan
     return obj
 
 
-def makePanelCut(panel,name="PanelCut"):
+def makePanelCut(panel,name=None):
 
-    """makePanelCut(panel) : Creates a 2D view of the given panel
+    """makePanelCut(panel,[name]) : Creates a 2D view of the given panel
     in the 3D space, positioned at the origin."""
 
-    view = FreeCAD.ActiveDocument.addObject("Part::FeaturePython",name)
+    view = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","PanelCut")
+    view.Label = name if name else translate("Arch","View of")+" "+panel.Label
     PanelCut(view)
     view.Source = panel
-    view.Label = translate("Arch","View of")+" "+panel.Label
     if FreeCAD.GuiUp:
         ViewProviderPanelCut(view.ViewObject)
     return view
 
 
-def makePanelSheet(panels=[],name="PanelSheet"):
+def makePanelSheet(panels=[],name=None):
 
-    """makePanelSheet([panels]) : Creates a sheet with the given panel cuts
+    """makePanelSheet([panels],[name]) : Creates a sheet with the given panel cuts
     in the 3D space, positioned at the origin."""
 
-    sheet = FreeCAD.ActiveDocument.addObject("Part::FeaturePython",name)
+    sheet = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","PanelSheet")
+    sheet.Label = name if name else translate("Arch","PanelSheet")
     PanelSheet(sheet)
     if panels:
         sheet.Group = panels

--- a/src/Mod/Arch/ArchPipe.py
+++ b/src/Mod/Arch/ArchPipe.py
@@ -47,15 +47,15 @@ __author__ = "Yorik van Havre"
 __url__    = "https://www.freecad.org"
 
 
-def makePipe(baseobj=None,diameter=0,length=0,placement=None,name="Pipe"):
+def makePipe(baseobj=None,diameter=0,length=0,placement=None,name=None):
 
-    "makePipe([baseobj,diamerter,length,placement,name]): creates an pipe object from the given base object"
+    "makePipe([baseobj],[diameter],[length],[placement],[name]): creates an pipe object from the given base object"
 
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
-    obj= FreeCAD.ActiveDocument.addObject("Part::FeaturePython",name)
-    obj.Label = name
+    obj= FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Pipe")
+    obj.Label = name if name else translate("Arch","Pipe")
     _ArchPipe(obj)
     if FreeCAD.GuiUp:
         _ViewProviderPipe(obj.ViewObject)
@@ -78,15 +78,15 @@ def makePipe(baseobj=None,diameter=0,length=0,placement=None,name="Pipe"):
     return obj
 
 
-def makePipeConnector(pipes,radius=0,name="Connector"):
+def makePipeConnector(pipes,radius=0,name=None):
 
-    "makePipeConnector(pipes,[radius,name]): creates a connector between the given pipes"
+    "makePipeConnector(pipes,[radius],[name]): creates a connector between the given pipes"
 
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
-    obj= FreeCAD.ActiveDocument.addObject("Part::FeaturePython",name)
-    obj.Label = name
+    obj= FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Connector")
+    obj.Label = name if name else translate("Arch","Connector")
     _ArchPipeConnector(obj)
     obj.Pipes = pipes
     if not radius:

--- a/src/Mod/Arch/ArchProject.py
+++ b/src/Mod/Arch/ArchProject.py
@@ -48,7 +48,7 @@ __title__  = "FreeCAD Project"
 __author__ = "Yorik van Havre"
 __url__    = "https://www.freecad.org"
 
-def makeProject(sites=None, name="Project"):
+def makeProject(sites=None, name=None):
     """Create an Arch project.
 
     If sites are provided, add them as children of the new project.
@@ -72,7 +72,7 @@ def makeProject(sites=None, name="Project"):
 
     import Part
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", "Project")
-    obj.Label = translate("Arch", name)
+    obj.Label = name if name else translate("Arch", "Project")
     _Project(obj)
     if FreeCAD.GuiUp:
         _ViewProviderProject(obj.ViewObject)

--- a/src/Mod/Arch/ArchRebar.py
+++ b/src/Mod/Arch/ArchRebar.py
@@ -50,9 +50,9 @@ __author__ = "Yorik van Havre"
 __url__    = "https://www.freecad.org"
 
 
-def makeRebar(baseobj=None,sketch=None,diameter=None,amount=1,offset=None,name="Rebar"):
+def makeRebar(baseobj=None,sketch=None,diameter=None,amount=1,offset=None,name=None):
 
-    """makeRebar([baseobj,sketch,diameter,amount,offset,name]): adds a Reinforcement Bar object
+    """makeRebar([baseobj],[sketch],[diameter],[amount],[offset],[name]): adds a Reinforcement Bar object
     to the given structural object, using the given sketch as profile."""
 
     if not FreeCAD.ActiveDocument:
@@ -60,7 +60,7 @@ def makeRebar(baseobj=None,sketch=None,diameter=None,amount=1,offset=None,name="
         return
     p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch")
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Rebar")
-    obj.Label = translate("Arch",name)
+    obj.Label = name if name else translate("Arch","Rebar")
     _Rebar(obj)
     if FreeCAD.GuiUp:
         _ViewProviderRebar(obj.ViewObject)

--- a/src/Mod/Arch/ArchReference.py
+++ b/src/Mod/Arch/ArchReference.py
@@ -51,16 +51,16 @@ else:
 
 
 
-def makeReference(filepath=None,partname=None,name="External Reference"):
+def makeReference(filepath=None,partname=None,name=None):
 
 
-    "makeReference([filepath,partname]): Creates an Arch Reference object"
+    "makeReference([filepath],[partname],[name]): Creates an Arch Reference object"
 
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","ArchReference")
-    obj.Label = name
+    obj.Label = name if name else translate("Arch","External Reference")
     ArchReference(obj)
     if FreeCAD.GuiUp:
         ViewProviderArchReference(obj.ViewObject)

--- a/src/Mod/Arch/ArchRoof.py
+++ b/src/Mod/Arch/ArchRoof.py
@@ -147,7 +147,7 @@ def face_from_points(ptLst):
 def makeRoof(baseobj=None,
              facenr=0,
              angles=[45.0], run=[250.0], idrel=[-1], thickness=[50.0], overhang=[100.0],
-             name="Roof"):
+             name=None):
     '''makeRoof(baseobj, [facenr], [angle], [name]): Makes a roof based on
     a closed wire or an object.
 
@@ -161,8 +161,8 @@ def makeRoof(baseobj=None,
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
-    obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", name)
-    obj.Label = translate("Arch", name)
+    obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", "Roof")
+    obj.Label = name if name else translate("Arch", "Roof")
     baseWire = None
     _Roof(obj)
     if FreeCAD.GuiUp:

--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -55,16 +55,16 @@ else:
 
 ISRENDERING = False # flag to prevent concurrent runs of the coin renderer
 
-def makeSectionPlane(objectslist=None,name="Section"):
+def makeSectionPlane(objectslist=None,name=None):
 
-    """makeSectionPlane([objectslist]) : Creates a Section plane objects including the
+    """makeSectionPlane([objectslist],[name]) : Creates a Section plane objects including the
     given objects. If no object is given, the whole document will be considered."""
 
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
-    obj = FreeCAD.ActiveDocument.addObject("App::FeaturePython",name)
-    obj.Label = translate("Arch",name)
+    obj = FreeCAD.ActiveDocument.addObject("App::FeaturePython","Section")
+    obj.Label = name if name else translate("Arch","Section")
     _SectionPlane(obj)
     if FreeCAD.GuiUp:
         _ViewProviderSectionPlane(obj.ViewObject)

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -60,9 +60,9 @@ __author__ = "Yorik van Havre"
 __url__ = "https://www.freecad.org"
 
 
-def makeSite(objectslist=None,baseobj=None,name="Site"):
+def makeSite(objectslist=None,baseobj=None,name=None):
 
-    '''makeBuilding(objectslist): creates a site including the
+    '''makeBuilding([objectslist],[baseobj],[name]): creates a site including the
     objects from the given list.'''
 
     if not FreeCAD.ActiveDocument:
@@ -70,7 +70,7 @@ def makeSite(objectslist=None,baseobj=None,name="Site"):
         return
     import Part
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Site")
-    obj.Label = translate("Arch",name)
+    obj.Label = name if name else translate("Arch","Site")
     _Site(obj)
     if FreeCAD.GuiUp:
         _ViewProviderSite(obj.ViewObject)

--- a/src/Mod/Arch/ArchSpace.py
+++ b/src/Mod/Arch/ArchSpace.py
@@ -171,17 +171,18 @@ else:
 #  Spaces define an open volume inside or outside a
 #  building, ie. a room.
 
-def makeSpace(objects=None,baseobj=None,name="Space"):
+def makeSpace(objects=None,baseobj=None,name=None):
 
-    """makeSpace([objects]): Creates a space object from the given objects. Objects can be one
-    document object, in which case it becomes the base shape of the space object, or a list of
-    selection objects as got from getSelectionEx(), or a list of tuples (object, subobjectname)"""
+    """makeSpace([objects],[baseobj],[name]): Creates a space object from the given objects.
+    Objects can be one document object, in which case it becomes the base shape of the space
+    object, or a list of selection objects as got from getSelectionEx(), or a list of tuples
+    (object, subobjectname)"""
 
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Space")
-    obj.Label = translate("Arch",name)
+    obj.Label = name if name else translate("Arch","Space")
     _Space(obj)
     if FreeCAD.GuiUp:
         _ViewProviderSpace(obj.ViewObject)

--- a/src/Mod/Arch/ArchStairs.py
+++ b/src/Mod/Arch/ArchStairs.py
@@ -50,9 +50,9 @@ else:
 zeroMM = FreeCAD.Units.Quantity('0mm')
 
 
-def makeStairs(baseobj=None,length=None,width=None,height=None,steps=None,name="Stairs"):
+def makeStairs(baseobj=None,length=None,width=None,height=None,steps=None,name=None):
 
-    """makeStairs([baseobj,length,width,height,steps]): creates a Stairs
+    """makeStairs([baseobj],[length],[width],[height],[steps],[name]): creates a Stairs
     objects with given attributes."""
 
     if not FreeCAD.ActiveDocument:
@@ -62,8 +62,9 @@ def makeStairs(baseobj=None,length=None,width=None,height=None,steps=None,name="
 
     stairs = []
     additions = []
+    label = name if name else translate("Arch","Stairs")
 
-    def setProperty(obj,length,width,height,steps,name):
+    def setProperty(obj,length,width,height,steps):
         if length:
             obj.Length = length
         else:
@@ -94,19 +95,19 @@ def makeStairs(baseobj=None,length=None,width=None,height=None,steps=None,name="
         lenSelection = len(baseobj)
         if lenSelection > 1:
             stair = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Stairs")
-            stair.Label = translate("Arch",name)
+            stair.Label = label
             _Stairs(stair)
             stairs.append(stair)
-            stairs[0].Label = translate("Arch",name)
+            stairs[0].Label = label
             i = 1
         else:
             i = 0
         for baseobjI in baseobj:
             stair = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Stairs")
-            stair.Label = translate("Arch",name)
+            stair.Label = label
             _Stairs(stair)
             stairs.append(stair)
-            stairs[i].Label = translate("Arch",name)
+            stairs[i].Label = label
             stairs[i].Base = baseobjI
 
             if len(baseobjI.Shape.Edges) > 1:
@@ -115,7 +116,7 @@ def makeStairs(baseobj=None,length=None,width=None,height=None,steps=None,name="
                 stepsI = steps
             else:
                 stepsI = 20
-            setProperty(stairs[i],None,width,height,stepsI,name)
+            setProperty(stairs[i],None,width,height,stepsI)
 
             if i > 1:
                 additions.append(stairs[i])
@@ -129,9 +130,9 @@ def makeStairs(baseobj=None,length=None,width=None,height=None,steps=None,name="
 
     else:
         obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Stairs")
-        obj.Label = translate("Arch",name)
+        obj.Label = label
         _Stairs(obj)
-        setProperty(obj,length,width,height,steps,name)
+        setProperty(obj,length,width,height,steps)
         stairs.append(obj)
 
     if FreeCAD.GuiUp:
@@ -167,7 +168,7 @@ def makeRailing(stairs):
                 outlineLRAll = stair.OutlineRightAll
                 stairRailingLR = "RailingRight"
             if outlineLR or outlineLRAll:
-                lrRail = ArchPipe.makePipe(baseobj=None,diameter=0,length=0,placement=None,name="Rail")
+                lrRail = ArchPipe.makePipe(baseobj=None,diameter=0,length=0,placement=None,name=translate("Arch","Railing"))
                 if outlineLRAll:
                     setattr(stair, stairRailingLR, lrRail)
                     break

--- a/src/Mod/Arch/ArchStructure.py
+++ b/src/Mod/Arch/ArchStructure.py
@@ -61,9 +61,9 @@ for pre in Presets:
         Categories.append(pre[1])
 
 
-def makeStructure(baseobj=None,length=None,width=None,height=None,name="Structure"):
+def makeStructure(baseobj=None,length=None,width=None,height=None,name=None):
 
-    '''makeStructure([obj],[length],[width],[height],[swap]): creates a
+    '''makeStructure([baseobj],[length],[width],[height],[name]): creates a
     structure element based on the given profile object and the given
     extrusion height. If no base object is given, you can also specify
     length and width for a cubic object.'''
@@ -73,7 +73,6 @@ def makeStructure(baseobj=None,length=None,width=None,height=None,name="Structur
         return
     p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch")
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Structure")
-    obj.Label = translate("Arch","Structure")
     _Structure(obj)
     if FreeCAD.GuiUp:
         _ViewProviderStructure(obj.ViewObject)
@@ -119,17 +118,18 @@ def makeStructure(baseobj=None,length=None,width=None,height=None,name="Structur
 
     if not height and not length:
         obj.IfcType = "Undefined"
+        obj.Label = name if name else translate("Arch","Structure")
     elif obj.Length > obj.Height:
         obj.IfcType = "Beam"
-        obj.Label = translate("Arch","Beam")
+        obj.Label = name if name else translate("Arch","Beam")
     elif obj.Height > obj.Length:
         obj.IfcType = "Column"
-        obj.Label = translate("Arch","Column")
+        obj.Label = name if name else translate("Arch","Column")
     return obj
 
-def makeStructuralSystem(objects=[],axes=[],name="StructuralSystem"):
+def makeStructuralSystem(objects=[],axes=[],name=None):
 
-    '''makeStructuralSystem(objects,axes): makes a structural system
+    '''makeStructuralSystem([objects],[axes],[name]): makes a structural system
     based on the given objects and axes'''
 
     if not FreeCAD.ActiveDocument:
@@ -145,8 +145,8 @@ def makeStructuralSystem(objects=[],axes=[],name="StructuralSystem"):
     else:
         objects = [None]
     for o in objects:
-        obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython",name)
-        obj.Label = translate("Arch",name)
+        obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","StructuralSystem")
+        obj.Label = name if name else translate("Arch","StructuralSystem")
         _StructuralSystem(obj)
         if FreeCAD.GuiUp:
             _ViewProviderStructuralSystem(obj.ViewObject)

--- a/src/Mod/Arch/ArchTruss.py
+++ b/src/Mod/Arch/ArchTruss.py
@@ -51,17 +51,17 @@ rodmodes = ("/|/|/|",
             "/|\\|/|\\",
            )
 
-def makeTruss(baseobj=None,name="Truss"):
+def makeTruss(baseobj=None,name=None):
 
     """
-    makeTruss([baseobj]): Creates a space object from the given object (a line)
+    makeTruss([baseobj],[name]): Creates a space object from the given object (a line)
     """
 
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Truss")
-    obj.Label = translate("Arch","Truss")
+    obj.Label = name if name else translate("Arch","Truss")
     Truss(obj)
     if FreeCAD.GuiUp:
         ViewProviderTruss(obj.ViewObject)


### PR DESCRIPTION
Following the example of Arch_Wall:
- Fixed object name.
- Default label is translatable.
- Name argument should only be used for the label and not be translated.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
