### PR TITLE
Surface: fix BlendCurve relative size

### DIFF
--- a/src/Mod/Surface/App/Blending/BlendCurve.cpp
+++ b/src/Mod/Surface/App/Blending/BlendCurve.cpp
@@ -131,9 +131,8 @@ void BlendCurve::setSize(int i, double f, bool relative)
     double size = f;
     try {
         if (relative) {
-            double nb_poles = blendPoints.front().nbVectors() + blendPoints[1].nbVectors();
             Base::Vector3d diff = blendPoints[1].vectors[0] - blendPoints[0].vectors[0];
-            size = size * diff.Length() / nb_poles;
+            size = size * diff.Length();
         }
         blendPoints[i].setSize(size);
     }


### PR DESCRIPTION
A size value independent of the number of control points is more intuitive.
And the curve shape will be more stable upon continuity changes.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
