### PR TITLE
[TD]remove html escape sequences from tooltips

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>444</width>
+    <width>474</width>
     <height>416</height>
    </rect>
   </property>
@@ -571,7 +571,7 @@ can be a performance penalty in complex models.</string>
         <item row="7" column="2">
          <widget class="Gui::PrefSpinBox" name="sbScrubCount">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of times FreeCAD should try to remove overlapping edges returned by the Hidden Line Removal algorithm.  A value of 0 indicates no scrubbing, 1 indicates a single pass and 2 indicates a second pass should be performed.  Values above 2 are generally not productive.   Each pass adds to the time required to produce the drawing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>The number of times FreeCAD should try to remove overlapping edges returned by the Hidden Line Removal algorithm. A value of 0 indicates no scrubbing, 1 indicates a single pass and 2 indicates a second pass should be performed. Values above 2 are generally not productive. Each pass adds to the time required to produce the drawing.</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>440</width>
-    <height>400</height>
+    <height>448</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -177,7 +177,7 @@
         <item row="9" column="0">
          <widget class="Gui::PrefCheckBox" name="pcbLightOnDark">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check this to use light text and lines on dark backgrounds.  Set Page Color to a dark color. Transparent or light color faces are recommended with this option.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>Check this to use light text and lines on dark backgrounds. Set Page Color to a dark color. Transparent or light color faces are recommended with this option.</string>
           </property>
           <property name="text">
            <string>Light on dark</string>
@@ -617,7 +617,9 @@
         <item row="10" column="0">
          <widget class="Gui::PrefCheckBox" name="pcbMonochrome">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked FreeCAD will use a single colour for all text and lines.  If unchecked FreeCAD will attempt to use lighter versions of preferred colours.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>If checked FreeCAD will use a single colour for all text and lines. If unchecked FreeCAD will attempt to use lighter versions of preferred colours.
+
+</string>
           </property>
           <property name="text">
            <string>Monochrome</string>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>440</width>
-    <height>498</height>
+    <height>508</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -493,7 +493,7 @@ Multiplier of 'Font Size'</string>
         <item row="3" column="2">
          <widget class="Gui::PrefLineEdit" name="leFormatSpec">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Leave blank for automatic dimension format.  Use %f, %g or %w specifiers to override.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>Leave blank for automatic dimension format. Use %f, %g or %w specifiers to override.</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -524,7 +524,9 @@ Multiplier of 'Font Size'</string>
         <item row="9" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="pdsbGapISO">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls the size of gap between dimension point and start of extension line for ISO dimensions. Value * linewidth is the gap.  Normally, no gap is used.  If using a gap, the recommended value 8.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>Controls the size of gap between dimension point and start of extension line for ISO dimensions. 
+Value * linewidth is the gap. 
+Normally, no gap is used. If using a gap, the recommended value 8.</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -543,7 +545,8 @@ Multiplier of 'Font Size'</string>
         <item row="10" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="pdsbGapASME">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls the size of gap between dimension point and start of extension line for ASME dimensions. Value * linewidth is the gap.  Normally, no gap is used.  If a gap is used, the recommended value is 6.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>Controls the size of gap between dimension point and start of extension line for ASME dimensions. Value * linewidth is the gap. 
+Normally, no gap is used. If a gap is used, the recommended value is 6.</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -577,13 +580,14 @@ Multiplier of 'Font Size'</string>
         <item row="11" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="pdsbLineSpacingFactorISO">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls the size of spacing between dimension line and dimension text. Value * linewidth is the line spacing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>Controls the size of spacing between dimension line and dimension text.
+ Value * linewidth is the line spacing.</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
           <property name="value">
-           <double></double>
+           <double>0.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>LineSpacingFactorISO</cstring>

--- a/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.ui
+++ b/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.ui
@@ -31,7 +31,7 @@
      <item row="1" column="1">
       <widget class="QPushButton" name="pbIcon05">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Material removal prohibited, whole part&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Material removal prohibited, whole part</string>
        </property>
        <property name="text">
         <string/>
@@ -41,7 +41,7 @@
      <item row="1" column="0">
       <widget class="QPushButton" name="pbIcon04">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Any method allowed, whole part&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Any method allowed, whole part</string>
        </property>
        <property name="text">
         <string/>
@@ -51,7 +51,7 @@
      <item row="1" column="2">
       <widget class="QPushButton" name="pbIcon06">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Material removal required, whole part&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Material removal required, whole part</string>
        </property>
        <property name="text">
         <string/>
@@ -61,7 +61,7 @@
      <item row="0" column="2">
       <widget class="QPushButton" name="pbIcon03">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Material removal required&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Material removal required</string>
        </property>
        <property name="text">
         <string/>
@@ -71,7 +71,7 @@
      <item row="0" column="1">
       <widget class="QPushButton" name="pbIcon02">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Material removal prohibited&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Material removal prohibited</string>
        </property>
        <property name="text">
         <string/>
@@ -81,7 +81,7 @@
      <item row="0" column="0">
       <widget class="QPushButton" name="pbIcon01">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Any method allowed&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Any method allowed</string>
        </property>
        <property name="text">
         <string/>
@@ -102,7 +102,7 @@
      <item row="0" column="1">
       <widget class="QLineEdit" name="leAngle">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rotation angle&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Rotation angle</string>
        </property>
        <property name="text">
         <string notr="true">0</string>
@@ -112,7 +112,7 @@
      <item row="1" column="0">
       <widget class="QRadioButton" name="rbISO">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use ISO standard&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Use ISO standard</string>
        </property>
        <property name="text">
         <string>ISO</string>
@@ -125,7 +125,7 @@
      <item row="1" column="1">
       <widget class="QRadioButton" name="rbASME">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use ASME standard&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Use ASME standard</string>
        </property>
        <property name="text">
         <string>ASME</string>


### PR DESCRIPTION
This PR addresses an issue involving html escape codes embedded in text to be translated reported here: https://forum.freecad.org/viewtopic.php?p=684625#p684625

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
