### PR TITLE
Core: Tree : Remove useless root item and hide description by default.

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -520,6 +520,7 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
         documentPartialPixmap.reset(new QPixmap(icon.pixmap(documentPixmap->size(), QIcon::Disabled)));
     }
     setColumnHidden(1, TreeParams::getHideColumn());
+    header()->setVisible(!TreeParams::getHideColumn());
 }
 
 TreeWidget::~TreeWidget()

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -901,6 +901,27 @@ void TreeWidget::contextMenuEvent(QContextMenuEvent* e)
         subMenu.addActions(subMenuGroup.actions());
     }
 
+    // add a submenu to present the settings of the tree.
+    QMenu settingsMenu;
+    settingsMenu.setTitle(tr("Tree settings"));
+    contextMenu.addSeparator();
+    contextMenu.addMenu(&settingsMenu);
+
+    QAction* action = new QAction(tr("Show description column"), this);
+    action->setStatusTip(tr("Show an extra tree view column for item description. The item's description can be set by pressing F2 (or your OS's edit button) or by editing the 'label2' property."));
+    action->setCheckable(true);
+
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/TreeView");
+    action->setChecked(!hGrp->GetBool("HideColumn", true));
+
+    settingsMenu.addAction(action);
+    QObject::connect(action, &QAction::triggered, this, [this, action, hGrp]() {
+        bool show = action->isChecked();
+        hGrp->SetBool("HideColumn", !show);
+        setColumnHidden(1, !show);
+        header()->setVisible(show);
+    });
+
     if (contextMenu.actions().count() > 0) {
         try {
             contextMenu.exec(QCursor::pos());

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -400,7 +400,6 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
     this->setAcceptDrops(true);
     this->setDropIndicatorShown(false);
     this->setDragDropMode(QTreeWidget::InternalMove);
-    this->setRootIsDecorated(false);
     this->setColumnCount(2);
     this->setItemDelegate(new TreeWidgetEditDelegate(this));
 
@@ -487,8 +486,7 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
     });
 
     // Add the first main label
-    this->rootItem = new QTreeWidgetItem(this);
-    this->rootItem->setFlags(Qt::ItemIsEnabled);
+    this->rootItem = invisibleRootItem();
     this->expandItem(this->rootItem);
     this->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
@@ -2769,7 +2767,6 @@ void TreeWidget::setupText()
 {
     this->headerItem()->setText(0, tr("Labels & Attributes"));
     this->headerItem()->setText(1, tr("Description"));
-    this->rootItem->setText(0, tr("Application"));
 
     this->showHiddenAction->setText(tr("Show items hidden in tree view"));
     this->showHiddenAction->setStatusTip(tr("Show items that are marked as 'hidden' in the tree view"));

--- a/src/Gui/TreeParams.cpp
+++ b/src/Gui/TreeParams.cpp
@@ -142,7 +142,7 @@ public:
         funcs["ItemBackground"] = &TreeParamsP::updateItemBackground;
         ItemBackgroundPadding = handle->GetInt("ItemBackgroundPadding", 10);
         funcs["ItemBackgroundPadding"] = &TreeParamsP::updateItemBackgroundPadding;
-        HideColumn = handle->GetBool("HideColumn", false);
+        HideColumn = handle->GetBool("HideColumn", true);
         funcs["HideColumn"] = &TreeParamsP::updateHideColumn;
         HideScrollBar = handle->GetBool("HideScrollBar", true);
         funcs["HideScrollBar"] = &TreeParamsP::updateHideScrollBar;
@@ -356,7 +356,7 @@ public:
     }
     // Auto generated code (Tools/params_utils.py:244)
     static void updateHideColumn(TreeParamsP *self) {
-        auto v = self->handle->GetBool("HideColumn", false);
+        auto v = self->handle->GetBool("HideColumn", true);
         if (self->HideColumn != v) {
             self->HideColumn = v;
             TreeParams::onHideColumnChanged();
@@ -1203,7 +1203,7 @@ const bool & TreeParams::getHideColumn() {
 
 // Auto generated code (Tools/params_utils.py:300)
 const bool & TreeParams::defaultHideColumn() {
-    const static bool def = false;
+    const static bool def = true;
     return def;
 }
 

--- a/src/Gui/TreeParams.py
+++ b/src/Gui/TreeParams.py
@@ -69,7 +69,7 @@ Params = [
         doc = "Tree view item background. Only effecitve in overlay."),
     ParamInt('ItemBackgroundPadding', 10, on_change=True, title="Item background padding", proxy=ParamSpinBox(0, 100, 1),
         doc = "Tree view item background padding."),
-    ParamBool('HideColumn', False, on_change=True, title="Hide extra column",
+    ParamBool('HideColumn', True, on_change=True, title="Hide extra column",
         doc = "Hide extra tree view column for item description."),
     ParamBool('HideScrollBar', True, title="Hide scroll bar",
         doc = "Hide tree view scroll bar in dock overlay."),


### PR DESCRIPTION
This PR solve this : https://forum.freecad.org/viewtopic.php?t=78555&sid=6c1c30d9b4ae46d34c3b0d929d6ab34e&start=10

It does 2 things : 
A - Remove the useless "Application" root item.
B - Hide by default the seldomly used "Description" column. Also when it is hidden, the labels are now hidden too.
Below a comparaison picture : on the left after this PR, on the right before.
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/9e0c18ca-4756-45e2-8355-4506e5ce434a)



Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
