### PR TITLE
Arch: Arch_Reference: task panel layout was added incorrectly

### DIFF
--- a/src/Mod/Arch/ArchReference.py
+++ b/src/Mod/Arch/ArchReference.py
@@ -664,7 +664,7 @@ class ArchReferenceTaskPanel:
         self.openButton.setText("Open")
         if not self.obj.File:
             self.openButton.setEnabled(False)
-        l2 = QtGui.QHBoxLayout(self.form)
+        l2 = QtGui.QHBoxLayout()
         layout.addLayout(l2)
         l2.addWidget(self.fileButton)
         l2.addWidget(self.openButton)


### PR DESCRIPTION
The 2nd layout was wrongly added to the form which already has a layout.

This resulted in a warning:
QLayout: Attempting to add QLayout "" to QWidget "", which already has a layout

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
