### PR TITLE
Improved font handling on Navigation cube

### DIFF
--- a/src/Gui/DlgSettingsNavigation.cpp
+++ b/src/Gui/DlgSettingsNavigation.cpp
@@ -108,10 +108,13 @@ void DlgSettingsNavigation::saveSettings()
         hCustom->SetFloat("Q2", q2);
         hCustom->SetFloat("Q3", q3);
     }
-
     hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/NaviCube");
-    hGrp->SetASCII("FontString", ui->naviCubeFontName->currentText().toLatin1());
+    if (ui->naviCubeFontName->currentIndex()) {
+        hGrp->SetASCII("FontString", ui->naviCubeFontName->currentText().toLatin1());        
+    } else {
+        hGrp->RemoveASCII("FontString");
+    }
 }
 
 void DlgSettingsNavigation::loadSettings()
@@ -171,9 +174,6 @@ void DlgSettingsNavigation::loadSettings()
         this, &DlgSettingsNavigation::onMouseButtonClicked);
 
     // fill up font styles
-    hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/NaviCube");
-    std::string defaultSansserifFont = NaviCubeSettings::getDefaultSansserifFont().toStdString();
 
     // we purposely allow all available fonts on the system
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -182,12 +182,12 @@ void DlgSettingsNavigation::loadSettings()
     QStringList familyNames = QFontDatabase::families(QFontDatabase::Any);
 #endif
     ui->naviCubeFontName->addItems(familyNames);
-
+    
+    hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/NaviCube");
     int indexFamilyNames = familyNames.indexOf(
-        QString::fromStdString(hGrp->GetASCII("FontString", defaultSansserifFont.c_str())));
-    if (indexFamilyNames < 0)
-        indexFamilyNames = 0;
-    ui->naviCubeFontName->setCurrentIndex(indexFamilyNames);
+        QString::fromStdString(hGrp->GetASCII("FontString")));
+    ui->naviCubeFontName->setCurrentIndex(indexFamilyNames + 1);
 
 }
 

--- a/src/Gui/DlgSettingsNavigation.ui
+++ b/src/Gui/DlgSettingsNavigation.ui
@@ -157,6 +157,11 @@
         <property name="prefPath" stdset="0">
          <cstring>NaviCube</cstring>
         </property>
+        <item>
+         <property name="text">
+          <string>Default</string>
+         </property>
+        </item>
        </widget>
       </item>
       <item row="2" column="0">

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -446,16 +446,6 @@ MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
     // accept drops on the window, get handled in dropEvent, dragEnterEvent
     setAcceptDrops(true);
 
-    // setup font substitutions for NaviCube
-    // Helvetica usually gives good enough results on mac & linux
-    // in rare cases Helvetica matches a bad font on linux
-    // Nimbus Sans Narrow and Open Sans Condensed added as fallback
-    // Bahnschrift is a condensed font available on windows versions since 2017
-    // Arial added as fallback for older version
-    auto substitutions = QStringLiteral("Bahnschrift,Helvetica,Nimbus Sans Narrow,Open Sans Condensed,Arial,Sans");
-    auto family = QStringLiteral("FreeCAD NaviCube");
-    QFont::insertSubstitutions(family, substitutions.split(QLatin1Char(',')));
-
     statusBar()->showMessage(tr("Ready"), 2001);
 }
 

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -401,12 +401,10 @@ int imageVerticalBalance(QImage p, int sizeHint) {
 
 void NaviCubeImplementation::createCubeFaceTextures() {
     int texSize = 192; // Works well for the max cube size 1024
-    // find font sizes
     QFont font;
-    if (!m_TextFont.empty()) {
-        QString fontString = QString::fromStdString(m_TextFont);
-        font.fromString(fontString);
-    }
+    if (m_TextFont.empty()) font.fromString(QStringLiteral("Arial"));
+    else font.fromString(QString::fromStdString(m_TextFont));
+    font.setStyleHint(QFont::SansSerif);
     if (m_FontWeight > 0) {
         font.setWeight(convertWeights(m_FontWeight));
     }
@@ -454,9 +452,10 @@ void NaviCubeImplementation::createCubeFaceTextures() {
             delete m_LabelTextures[pickId].texture;
         }
         m_LabelTextures[pickId].texture = new QOpenGLTexture(image.mirrored());
-        m_LabelTextures[pickId].texture->generateMipMaps();
+        m_LabelTextures[pickId].texture->setMaximumAnisotropy(4.0);
         m_LabelTextures[pickId].texture->setMinificationFilter(QOpenGLTexture::LinearMipMapLinear);
         m_LabelTextures[pickId].texture->setMagnificationFilter(QOpenGLTexture::Linear);
+        m_LabelTextures[pickId].texture->generateMipMaps();
     }
 }
 

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -442,22 +442,11 @@ NaviCubeSettings::NaviCubeSettings(ParameterGrp::handle hGrp,
         [this](ParameterGrp*, ParameterGrp::ParamType, const char *Name, const char *) {
             parameterChanged(Name);
     });
-
 }
 
 NaviCubeSettings::~NaviCubeSettings()
 {
     connectParameterChanged.disconnect();
-}
-
-QString NaviCubeSettings::getDefaultSansserifFont()
-{
-    // "FreeCAD NaviCube" family susbtitutions are set in MainWindow::MainWindow
-    QFont font(QStringLiteral("FreeCAD NaviCube"));
-    font.setStyleHint(QFont::SansSerif);
-    // QFontInfo is required to get the actually matched font family
-    return QFontInfo(font).family();
-    // return QStringLiteral("FreeCAD NaviCube");
 }
 
 void NaviCubeSettings::applySettings()
@@ -506,9 +495,7 @@ void NaviCubeSettings::parameterChanged(const char* Name)
         nc->setFontZoom(hGrp->GetFloat("FontZoom", 0.3));
     }
     else if (strcmp(Name, "FontString") == 0) {
-        std::string font =
-            hGrp->GetASCII("FontString", getDefaultSansserifFont().toStdString().c_str());
-        nc->setFont(font);
+        nc->setFont(hGrp->GetASCII("FontString"));
     }
     else if (strcmp(Name, "FontWeight") == 0) {
         nc->setFontWeight(hGrp->GetInt("FontWeight", 0));

--- a/src/Gui/View3DSettings.h
+++ b/src/Gui/View3DSettings.h
@@ -60,7 +60,6 @@ public:
     ~NaviCubeSettings();
 
     void applySettings();
-    static QString getDefaultSansserifFont();
 private:
     void parameterChanged(ParameterGrp::MessageType pName);
     ParameterGrp::handle hGrp;


### PR DESCRIPTION
Adding anisotropy texture mapping for better readability on steep angles. Tip from aapo in this post https://forum.freecad.org/viewtopic.php?p=657880#p657880
Before:
![Skärmavbild 2023-06-04 kl  10 20 38](https://github.com/FreeCAD/FreeCAD/assets/39026960/99b025d2-ee8c-453d-ad04-eef4a0b8ede2)
After:
![Skärmavbild 2023-06-04 kl  10 23 33](https://github.com/FreeCAD/FreeCAD/assets/39026960/2ec58e17-7494-48fe-9589-dd0862cc0b37)

Don't save a font name to parameters if none is chosen in preferences
![Skärmavbild 2023-06-04 kl  10 51 12](https://github.com/FreeCAD/FreeCAD/assets/39026960/750b0027-9db3-455d-b96a-5bb2eedf115c)

Fix #9672 because the "FreeCAD NaviCube" is no longer created.

- [X]  The Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
