### PR TITLE
Core: fix navigation cube BaseColor pref tooltip

### DIFF
--- a/src/Gui/DlgSettingsNavigation.ui
+++ b/src/Gui/DlgSettingsNavigation.ui
@@ -209,8 +209,7 @@
       <item row="3" column="1">
        <widget class="Gui::PrefColorButton" name="naviCubeBaseColor">
         <property name="toolTip">
-         <string>color for all elements
-around the cube</string>
+         <string>Base color for all elements</string>
         </property>
         <property name="color">
          <color alpha="128">


### PR DESCRIPTION
BaseColor tooltip was not updated in #9356.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
