### PR TITLE
Navicube OffsetX and OffsetY fix

### DIFF
--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -455,6 +455,7 @@ void NaviCubeSettings::applySettings()
     parameterChanged("EmphaseColor");
     parameterChanged("HiliteColor");
     parameterChanged("CornerNaviCube");
+    parameterChanged("OffsetX"); // Updates OffsetY too
     parameterChanged("CubeSize");
     parameterChanged("ChamferSize");
     parameterChanged("NaviRotateToNearest");


### PR DESCRIPTION
The navigation cube didn't load parameters OffsetX and OffsetY on creation of a new 3D view. See https://forum.freecad.org/viewtopic.php?p=686678#p686678

- [X]  Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
