### PR TITLE
Arch: Improve performance of WebGL importer

### DIFF
--- a/src/Mod/Arch/importWebGL.py
+++ b/src/Mod/Arch/importWebGL.py
@@ -810,11 +810,10 @@ def export( exportList, filename, colors = None, camera = None ):
 
         vIndex = {}
         verts = []
-        for p in range( len(mesh.Points) ):
-            vIndex[ mesh.Points[p].Index ] = p
-            verts.append( '{:.5f}'.format(mesh.Points[p].Vector.x) )
-            verts.append( '{:.5f}'.format(mesh.Points[p].Vector.y) )
-            verts.append( '{:.5f}'.format(mesh.Points[p].Vector.z) )
+        for p in mesh.Points:
+            vIndex[p.Index] = p.Index
+            pVec = p.Vector
+            verts.extend(["{:.5f}".format(pVec.x), "{:.5f}".format(pVec.y), "{:.5f}".format(pVec.z)])
 
         # create floats list to compress verts and wires being written into the JS
         if not disableCompression:


### PR DESCRIPTION
Get the Points attribute of MeshObject at each step of the loop,  drastically penalizes the importer's performance (depending on the object, it could take several minutes in the loop). With these changes, this loop takes only a fraction of a second.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
