### PR TITLE
PartDesign: UpToFace check isnull

### DIFF
--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -453,6 +453,7 @@ void ProfileBased::getUpToFace(TopoDS_Face& upToFace,
                               const std::string& method,
                               const gp_Dir& dir)
 {
+
     if ((method == "UpToLast") || (method == "UpToFirst")) {
         // Check for valid support object
         if (support.IsNull())
@@ -522,6 +523,8 @@ void ProfileBased::getUpToFace(TopoDS_Face& upToFace,
 
     // Check that the upToFace is either not parallel to the extrusion direction
     // and that upToFace is not too near
+    if (upToFace.IsNull())
+        throw Base::ValueError("SketchBased: The UpTo-Face is null!");
     BRepAdaptor_Surface upToFaceSurface(TopoDS::Face(upToFace));
     BRepExtrema_DistShapeShape distSS(sketchshape, upToFace);
     if (upToFaceSurface.GetType() == GeomAbs_Plane) {


### PR DESCRIPTION
The next line crash if upToFace is null.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
