### PR TITLE
Sketcher: Expose constraint redundancy information to Python

### DIFF
--- a/src/Mod/Sketcher/App/SketchObjectPy.xml
+++ b/src/Mod/Sketcher/App/SketchObjectPy.xml
@@ -494,6 +494,46 @@ If there is no such constraint an exception is raised.
       </Documentation>
       <Parameter Name="GeometryFacadeList" Type="List"/>
     </Attribute>
+    <Attribute Name="DoF" ReadOnly="true">
+      <Documentation>
+        <UserDocu>
+          Return the DoFs of the current solved sketch
+        </UserDocu>
+      </Documentation>
+      <Parameter Name="DoF" Type="Long"/>
+    </Attribute>
+    <Attribute Name="ConflictingConstraints" ReadOnly="true">
+      <Documentation>
+        <UserDocu>
+          Return a list of integers indicating the constraints detected as conflicting
+        </UserDocu>
+      </Documentation>
+      <Parameter Name="ConflictingConstraints" Type="List"/>
+    </Attribute>
+    <Attribute Name="RedundantConstraints" ReadOnly="true">
+      <Documentation>
+        <UserDocu>
+          Return a list of integers indicating the constraints detected as redundant
+        </UserDocu>
+      </Documentation>
+      <Parameter Name="RedundantConstraints" Type="List"/>
+    </Attribute>
+    <Attribute Name="PartiallyRedundantConstraints" ReadOnly="true">
+      <Documentation>
+        <UserDocu>
+          Return a list of integers indicating the constraints detected as partially redundant
+        </UserDocu>
+      </Documentation>
+      <Parameter Name="PartiallyRedundantConstraints" Type="List"/>
+    </Attribute>
+    <Attribute Name="MalformedConstraints" ReadOnly="true">
+      <Documentation>
+        <UserDocu>
+          Return a list of integers indicating the constraints detected as malformed
+        </UserDocu>
+      </Documentation>
+      <Parameter Name="MalformedConstraints" Type="List"/>
+    </Attribute>
     <Methode Name="setGeometryId">
       <Documentation>
         <UserDocu>sets the GeometryId of the SketchGeometryExtension of the geometry with the provided GeoId</UserDocu>

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -2152,6 +2152,64 @@ PyObject* SketchObjectPy::setGeometryId(PyObject* args)
     Py_Return;
 }
 
+Py::Long SketchObjectPy::getDoF() const
+{
+    auto dofs = this->getSketchObjectPtr()->getLastDoF();
+
+    return Py::Long(dofs);
+}
+
+Py::List SketchObjectPy::getConflictingConstraints() const
+{
+    auto conflictinglist = this->getSketchObjectPtr()->getLastConflicting();
+
+    Py::List conflicting;
+
+    for (auto cid : conflictinglist) {
+        conflicting.append(Py::Int(cid));
+    }
+
+    return conflicting;
+}
+
+Py::List SketchObjectPy::getRedundantConstraints() const
+{
+    auto redundantlist = this->getSketchObjectPtr()->getLastRedundant();
+
+    Py::List redundant;
+
+    for (auto cid : redundantlist) {
+        redundant.append(Py::Int(cid));
+    }
+
+    return redundant;
+}
+
+Py::List SketchObjectPy::getPartiallyRedundantConstraints() const
+{
+    auto redundantlist = this->getSketchObjectPtr()->getLastPartiallyRedundant();
+
+    Py::List redundant;
+
+    for (auto cid : redundantlist) {
+        redundant.append(Py::Int(cid));
+    }
+
+    return redundant;
+}
+
+Py::List SketchObjectPy::getMalformedConstraints() const
+{
+    auto malformedlist = this->getSketchObjectPtr()->getLastMalformedConstraints();
+
+    Py::List malformed;
+
+    for (auto cid : malformedlist) {
+        malformed.append(Py::Int(cid));
+    }
+
+    return malformed;
+}
 
 PyObject* SketchObjectPy::getCustomAttributes(const char* /*attr*/) const
 {


### PR DESCRIPTION
Expose redundancy/conflicting/dofs/malformed information to the solver.

DoFs: returns a long with the current amount of DoFs.
The others: return a list with the constraints that are detected as redundant, partially redundant, conflicting or malformed.

Example:
```
>>> ActiveSketch.RedundantConstraints
[7]
```
This should enable functional unit tests of popularity contest:
https://forum.freecad.org/viewtopic.php?p=686535#p686535