### PR TITLE
Handle long text/mtext on DXF import

### DIFF
--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2412,23 +2412,26 @@ bool CDxfRead::ReadText()
                 break;
             case 3:
                 // Additional text that goes before the type 1 text
+                // Note that if breaking the text into type-3 records splits a UFT-8 encoding we do the decoding
+                // after splicing the lines together. I'm not sure if this actually occurs, but handling the text
+                // this way will treat this condition properly.
                 get_line();
                 textPrefix.append(m_str);
                 break;
             case 1:
-                // text
+                // final text
                 // Note that we treat this as the end of the TEXT or MTEXT entity but this may cause us to miss
                 // other properties. Officially the entity ends at the start of the next entity, the BLKEND record
                 // that ends the containing BLOCK, or the ENDSEC record that ends the ENTITIES section. These are
                 // all code 0 records. Changing this would require either some sort of peek/pushback ability or the understanding
                 // that ReadText() and all the other Read... methods return having already read a code 0.
                 get_line();
+                textPrefix.append(m_str);
                 ResolveColorIndex();
                 {
-                    const char* utfStr = (this->*stringToUTF8)(m_str);
+                    const char* utfStr = (this->*stringToUTF8)(textPrefix.c_str());
                     OnReadText(c, height * 25.4 / 72.0, utfStr);
-                    if (utfStr != m_str)
-                        delete utfStr;
+                    delete utfStr;
                 }
                 return(true);
 


### PR DESCRIPTION
This had previously been corrected using similar code but merging another fix lost part of the original change for this issue.
This fixes #8968.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
