### PR TITLE
FEM: fix gmsh relative paths

### DIFF
--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -720,6 +720,7 @@ class GmshTools():
         self.part_obj.Shape.exportBrep(self.temp_file_geometry)
 
     def write_geo(self):
+        temp_dir = os.path.dirname(self.temp_file_geo)
         geo = open(self.temp_file_geo, "w")
         geo.write("// geo file for meshing with Gmsh meshing software created by FreeCAD\n")
         geo.write("\n")
@@ -732,7 +733,7 @@ class GmshTools():
 
         geo.write("// open brep geometry\n")
         # explicit use double quotes in geo file
-        geo.write('Merge "{}";\n'.format(self.temp_file_geometry))
+        geo.write('Merge "{}";\n'.format(os.path.relpath(self.temp_file_geometry, temp_dir)))
         geo.write("\n")
 
         # groups
@@ -879,7 +880,7 @@ class GmshTools():
         geo.write("// Ignore Physical definitions and save all elements;\n")
         geo.write("Mesh.SaveAll = 1;\n")
         # explicit use double quotes in geo file
-        geo.write('Save "{}";\n'.format(self.temp_file_mesh))
+        geo.write('Save "{}";\n'.format(os.path.relpath(self.temp_file_mesh, temp_dir)))
         geo.write("\n\n")
 
         # some useful information

--- a/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
+++ b/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
@@ -4,7 +4,7 @@
 General.NumThreads = X;
 
 // open brep geometry
-Merge "/tmp/tmp0TVZbM.brep";
+Merge "tmp0TVZbM.brep";
 
 // group data
 Physical Surface("Face1") = {1};
@@ -43,7 +43,7 @@ Coherence Mesh; // Remove duplicate vertices
 // save
 // Ignore Physical definitions and save all elements;
 Mesh.SaveAll = 1;
-Save "/tmp/tmpjVhNNb.unv";
+Save "tmpjVhNNb.unv";
 
 
 // **********************************************************************


### PR DESCRIPTION
Relative paths appearing in Gmsh .geo files are relative to the .geo file, not relative to the cwd when the gmsh executable was invoked. This is okay when using absolute paths with the default "Temporary directories" mode, but if one selects (in Preferences -> FEM) "Beside .FCStd file", then relative paths are written to the .geo file. This causes a (suppressed in FreeCAD output) warning from Gmsh that the brep file is missing as well as the error:

```
Unexpected error when creating mesh: File to load not existing or not readable: partname/FEMMeshGmsh/BaseFeature_Mesh.unv
```
In this commit we just use relative paths, which is also convenient if users move these files elsewhere (e.g., to work directly with advanced features in Gmsh).

---
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
