### PR TITLE
Arch remove undefined type

### DIFF
--- a/src/Mod/Arch/ArchEquipment.py
+++ b/src/Mod/Arch/ArchEquipment.py
@@ -285,7 +285,7 @@ class _Equipment(ArchComponent.Component):
             # IFC2x3 does know a IfcFurnishingElement
             obj.IfcType = "Furnishing Element"
         else:
-            obj.IfcType = "Undefined"
+            obj.IfcType = "Building Element Proxy"
         # Add features in the SketchArch External Add-on, if present
         self.addSketchArchFeatures(obj)
 

--- a/src/Mod/Arch/ArchPipe.py
+++ b/src/Mod/Arch/ArchPipe.py
@@ -190,7 +190,7 @@ class _ArchPipe(ArchComponent.Component):
             obj.IfcType = "Pipe Segment"
         else:
             # IFC2x3 does not know a Pipe Segment
-            obj.IfcType = "Undefined"
+            obj.IfcType = "Building Element Proxy"
 
     def setProperties(self,obj):
 

--- a/src/Mod/Arch/ArchProfile.py
+++ b/src/Mod/Arch/ArchProfile.py
@@ -516,7 +516,7 @@ class ProfileTaskPanel:
         elif isinstance(self.obj.Proxy,_ProfileT):
             self.type = "T"
         else:
-            self.type = "Undefined"
+            self.type = "Building Element Proxy"
         self.form = QtGui.QWidget()
         layout = QtGui.QVBoxLayout(self.form)
         self.comboCategory = QtGui.QComboBox(self.form)

--- a/src/Mod/Arch/ArchStructure.py
+++ b/src/Mod/Arch/ArchStructure.py
@@ -117,7 +117,7 @@ def makeStructure(baseobj=None,length=None,width=None,height=None,name=None):
                 obj.Length = h
 
     if not height and not length:
-        obj.IfcType = "Undefined"
+        obj.IfcType = "Building Element Proxy"
         obj.Label = name if name else translate("Arch","Structure")
     elif obj.Length > obj.Height:
         obj.IfcType = "Beam"

--- a/src/Mod/Arch/Presets/ifc_products_IFC2X3.json
+++ b/src/Mod/Arch/Presets/ifc_products_IFC2X3.json
@@ -4007,11 +4007,5 @@
             }
         ],
         "complex_attributes": []
-    },
-    "IfcUndefined": {
-        "is_abstract": false,
-        "parent": "IfcObject",
-        "attributes": [],
-        "complex_attributes": []
     }
 }

--- a/src/Mod/Arch/Presets/ifc_products_IFC4.json
+++ b/src/Mod/Arch/Presets/ifc_products_IFC4.json
@@ -13265,11 +13265,5 @@
                 "type": "IfcProductRepresentation"
             }
         ]
-    },
-    "IfcUndefined": {
-        "is_abstract": false,
-        "parent": "IfcObject",
-        "attributes": [],
-        "complex_attributes": []
     }
 }

--- a/src/Mod/Arch/TestArch.py
+++ b/src/Mod/Arch/TestArch.py
@@ -678,7 +678,7 @@ class ArchTest(unittest.TestCase):
     def testRemove(self):
         App.Console.PrintLog ('Checking Arch Remove...\n')
         l=Draft.makeLine(App.Vector(0,0,0),App.Vector(2,0,0))
-        w = Arch.makeWall(l,width=0.2,height=2)
+        w = Arch.makeWall(l,width=0.2,height=2,align="Right")
         sb = Part.makeBox(1,1,1)
         b = App.ActiveDocument.addObject('Part::Feature','Box')
         b.Shape = sb


### PR DESCRIPTION
Removes the "Undefined" IFC type and uses "IfcBuildingElementProxy" as default instead, which is the de-facto "undefined" type of the IFC standard.

Fixes #8774 

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
