### PR TITLE
FEM: let gmsh infer format from file name

### DIFF
--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -869,7 +869,6 @@ class GmshTools():
 
         # save mesh
         geo.write("// save\n")
-        geo.write("Mesh.Format = 2;\n")  # unv
         if self.group_elements and self.group_nodes_export:
             geo.write("// For each group save not only the elements but the nodes too.;\n")
             geo.write("Mesh.SaveGroupsOfNodes = 1;\n")

--- a/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
+++ b/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
@@ -41,7 +41,6 @@ Mesh  3;
 Coherence Mesh; // Remove duplicate vertices
 
 // save
-Mesh.Format = 2;
 // Ignore Physical definitions and save all elements;
 Mesh.SaveAll = 1;
 Save "/tmp/tmpjVhNNb.unv";


### PR DESCRIPTION
I sometimes use the FEM workbench to create meshes for a problem that I'll solve with an external FE solver that doesn't yet have workbench integration, or to prepare a Gmsh file for tweaks from directly running Gmsh. The `.unv` format is pretty limited on technical grounds so I rename the file to `.msh` (can express everything Gmsh can) or a parallel-friendly format. Explicitly setting `Mesh.Format = 2` is confusing because this line also needs to be fixed (or deleted) when renaming the output file name.

## Alternative
I would consider going further and also removing the `Save "Shape_Mesh.unv"` line from the file, then invoking as `gmsh -3 path/to/shape2mesh.geo -o path/to/Shape_Mesh.unv`. The reason is that it's ready for a person/script to invoke `gmsh` directly or to load the `shape2mesh.geo` for interactive graphical work without forcing a save on each refresh.

---
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
