### PR TITLE
PartDesign: clean redundant/incorrect length validation for pad & pocket

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -69,13 +69,8 @@ Pad::Pad()
 
 App::DocumentObjectExecReturn *Pad::execute()
 {
-    // Validate parameters
     double L = Length.getValue();
-    if ((std::string(Type.getValueAsString()) == "Length") && (L < Precision::Confusion()))
-        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Length of pad too small"));
     double L2 = Length2.getValue();
-    if ((std::string(Type.getValueAsString()) == "TwoLengths") && (L < Precision::Confusion()))
-        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Second length of pad too small"));
 
     // if midplane is true, disable reversed and vice versa
     bool hasMidplane = Midplane.getValue();

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -76,14 +76,8 @@ App::DocumentObjectExecReturn *Pocket::execute()
         (!UpToFace.getValue() && Length.getValue() > Precision::Confusion()))
         Type.setValue("Length");
 
-    // Validate parameters
     double L = Length.getValue();
-    if ((std::string(Type.getValueAsString()) == "Length") && (L < Precision::Confusion()))
-        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Length of pocket too small"));
-
     double L2 = Length2.getValue();
-    if ((std::string(Type.getValueAsString()) == "TwoLengths") && (L < Precision::Confusion()))
-        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Pocket: Second length of pocket too small"));
 
     TopoDS_Shape profileshape;
     try {


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
 replaces #9740
better validation is  already done for both at FeatureExtrude::generatePrism instead:
https://github.com/FreeCAD/FreeCAD/blob/bf8c59ba2ab4a2e6bd2060544130a0a4693ba4d8/src/Mod/PartDesign/App/FeatureExtrude.cpp#LL168C1-L174C1