### PR TITLE
[Everywhere] FileInfo::hasExtension for multiple values

### DIFF
--- a/src/Base/FileInfo.cpp
+++ b/src/Base/FileInfo.cpp
@@ -316,6 +316,16 @@ bool FileInfo::hasExtension(const char* Ext) const
 #endif
 }
 
+bool FileInfo::hasExtension(std::initializer_list<const char*> Exts) const
+{
+    for (const char* Ext : Exts) {
+        if (hasExtension(Ext)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool FileInfo::exists() const
 {
 #if defined (FC_OS_WIN32)

--- a/src/Base/FileInfo.h
+++ b/src/Base/FileInfo.h
@@ -90,6 +90,8 @@ public:
     std::string completeExtension () const;
     /// Checks for a special extension, NOT case sensitive
     bool hasExtension (const char* Ext) const;
+    /// Checks for any of the special extensions, NOT case sensitive 
+    bool hasExtension (std::initializer_list<const char*> Exts) const; 
     //@}
 
     /** @name methods to test the status of the file or dir */

--- a/src/Gui/SoFCDB.cpp
+++ b/src/Gui/SoFCDB.cpp
@@ -659,14 +659,14 @@ bool Gui::SoFCDB::writeToFile(SoNode* node, const char* filename, bool binary)
     Base::FileInfo fi(filename);
 
     // Write VRML V2.0
-    if (fi.hasExtension("wrl") || fi.hasExtension("vrml") || fi.hasExtension("wrz")) {
+    if (fi.hasExtension({"wrl", "vrml", "wrz"})) {
         // If 'wrz' is set then force compression
         if (fi.hasExtension("wrz"))
             binary = true;
 
         ret = SoFCDB::writeToVRML(node, filename, binary);
     }
-    else if (fi.hasExtension("x3d") || fi.hasExtension("x3dz")) {
+    else if (fi.hasExtension({"x3d", "x3dz"})) {
         // If 'x3dz' is set then force compression
         if (fi.hasExtension("x3dz"))
             binary = true;

--- a/src/Gui/SoFCOffscreenRenderer.cpp
+++ b/src/Gui/SoFCOffscreenRenderer.cpp
@@ -107,7 +107,7 @@ void SoFCOffscreenRenderer::writeToImageFile(const char* filename, const char* c
     }
 
     Base::FileInfo file(filename);
-    if (file.hasExtension("JPG") || file.hasExtension("JPEG")) {
+    if (file.hasExtension({"JPG", "JPEG"})) {
         // writing comment in case of jpeg (Qt ignores setText() in case of jpeg)
         std::string com;
         if (strcmp(comment,"")==0)
@@ -194,7 +194,7 @@ void SoFCOffscreenRenderer::writeToImageFile(const char* filename, const char* c
             if (!writeToFile(filename, file.extension().c_str()))
                 throw Base::FileException("Error writing image file", filename);
         }
-        else if (file.hasExtension("EPS") || file.hasExtension("PS")) {
+        else if (file.hasExtension({"EPS", "PS"})) {
             // Any format which is supported by Coin only
 #ifdef FC_OS_WIN32
             FILE* fd = _wfopen(file.toStdWString().c_str(), L"w");
@@ -206,7 +206,7 @@ void SoFCOffscreenRenderer::writeToImageFile(const char* filename, const char* c
             if (!ok)
                 throw Base::FileException("Error writing image file", filename);
         }
-        else if (file.hasExtension("RGB") || file.hasExtension("SGI")) {
+        else if (file.hasExtension({"RGB", "SGI"})) {
             // Any format which is supported by Coin only
 #ifdef FC_OS_WIN32
             FILE* fd = _wfopen(file.toStdWString().c_str(), L"w");

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1656,7 +1656,7 @@ bool View3DInventorViewer::dumpToFile(SoNode* node, const char* filename, bool b
     bool ret = false;
     Base::FileInfo fi(filename);
 
-    if (fi.hasExtension("idtf") || fi.hasExtension("svg")) {
+    if (fi.hasExtension({"idtf", "svg"})) {
         int ps=4;
         QColor c = Qt::white;
         std::unique_ptr<SoVectorizeAction> vo;
@@ -1667,7 +1667,7 @@ bool View3DInventorViewer::dumpToFile(SoNode* node, const char* filename, bool b
         else if (fi.hasExtension("idtf")) {
             vo = std::unique_ptr<SoVectorizeAction>(new SoFCVectorizeU3DAction());
         }
-        else if (fi.hasExtension("ps") || fi.hasExtension("eps")) {
+        else if (fi.hasExtension({"ps", "eps"})) {
             vo = std::unique_ptr<SoVectorizeAction>(new SoVectorizePSAction());
         }
         else {

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -942,7 +942,7 @@ Py::Object View3DInventorPy::saveVectorGraphic(const Py::Tuple& args)
 
     std::unique_ptr<SoVectorizeAction> vo;
     Base::FileInfo fi(filename);
-    if (fi.hasExtension("ps") || fi.hasExtension("eps")) {
+    if (fi.hasExtension({"ps", "eps"})) {
         vo = std::unique_ptr<SoVectorizeAction>(new SoVectorizePSAction());
         //vo->setGouraudThreshold(0.0f);
     }

--- a/src/Mod/Drawing/Gui/AppDrawingGuiPy.cpp
+++ b/src/Mod/Drawing/Gui/AppDrawingGuiPy.cpp
@@ -82,7 +82,7 @@ private:
         PyMem_Free(Name);
 
         Base::FileInfo file(EncodedName.c_str());
-        if (file.hasExtension("svg") || file.hasExtension("svgz")) {
+        if (file.hasExtension({"svg", "svgz"})) {
             QString fileName = QString::fromUtf8(EncodedName.c_str());
             // Displaying the image in a view
             DrawingView* view = new DrawingView(nullptr, Gui::getMainWindow());
@@ -110,7 +110,7 @@ private:
         PyMem_Free(Name);
 
         Base::FileInfo file(EncodedName.c_str());
-        if (file.hasExtension("svg") || file.hasExtension("svgz")) {
+        if (file.hasExtension({"svg", "svgz"}) {
             QString fileName = QString::fromUtf8(EncodedName.c_str());
             // Displaying the image in a view
             DrawingView* view = new DrawingView(nullptr, Gui::getMainWindow());

--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -1911,7 +1911,7 @@ void FemMesh::read(const char *FileName)
         readNastran(File.filePath());
     }
 #ifdef FC_USE_VTK
-    else if (File.hasExtension("vtk") || File.hasExtension("vtu") || File.hasExtension("pvtu")) {
+    else if (File.hasExtension({"vtk", "vtu", "pvtu"})) {
         // read *.vtk legacy format or *.vtu XML unstructure Mesh
         FemVTKTools::readVTKMesh(File.filePath().c_str(), this);
     }
@@ -2406,7 +2406,7 @@ void FemMesh::write(const char *FileName) const
         writeABAQUS(File.filePath(), elemParam, groupParam);
     }
 #ifdef FC_USE_VTK
-    else if (File.hasExtension("vtk") || File.hasExtension("vtu") ) {
+    else if (File.hasExtension({"vtk", "vtu"})) {
         Base::Console().Log("FEM mesh object will be exported to either vtk or vtu format.\n");
         // write unstructure mesh to VTK format *.vtk and *.vtu
         FemVTKTools::writeVTKMesh(File.filePath().c_str(), this);

--- a/src/Mod/Fem/App/FemPostPipeline.cpp
+++ b/src/Mod/Fem/App/FemPostPipeline.cpp
@@ -121,17 +121,8 @@ DocumentObjectExecReturn* FemPostPipeline::execute() {
 
 bool FemPostPipeline::canRead(Base::FileInfo File) {
 
-    if (File.hasExtension("vtk") ||
-        // from FemResult only unstructural mesh is supported in femvtktoools.cpp
-        File.hasExtension("vtp") ||
-        File.hasExtension("vts") ||
-        File.hasExtension("vtr") ||
-        File.hasExtension("vti") ||
-        File.hasExtension("vtu") ||
-        File.hasExtension("pvtu"))
-        return true;
-
-    return false;
+    // from FemResult only unstructural mesh is supported in femvtktoools.cpp
+    return File.hasExtension({"vtk", "vtp", "vts", "vtr", "vti", "vtu", "pvtu"});
 }
 
 void FemPostPipeline::read(Base::FileInfo File) {

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -155,7 +155,7 @@ private:
             Handle(TDocStd_Document) hDoc;
             hApp->NewDocument(TCollection_ExtendedString("MDTV-CAF"), hDoc);
 
-            if (file.hasExtension("stp") || file.hasExtension("step")) {
+            if (file.hasExtension({"stp", "step"})) {
                 try {
                     STEPCAFControl_Reader aReader;
                     aReader.SetColorMode(true);
@@ -184,7 +184,7 @@ private:
                     pcDoc->recompute();
                 }
             }
-            else if (file.hasExtension("igs") || file.hasExtension("iges")) {
+            else if (file.hasExtension({"igs", "iges"})) {
                 Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
                     .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part")->GetGroup("IGES");
 
@@ -332,7 +332,7 @@ private:
             }
 
             Base::FileInfo file(Utf8Name.c_str());
-            if (file.hasExtension("stp") || file.hasExtension("step")) {
+            if (file.hasExtension({"stp", "step"})) {
                 STEPCAFControl_Writer writer;
                 Part::Interface::writeStepAssembly(Part::Interface::Assembly::On);
                 writer.Transfer(hDoc, STEPControl_AsIs);
@@ -353,7 +353,7 @@ private:
                     throw Py::Exception();
                 }
             }
-            else if (file.hasExtension("igs") || file.hasExtension("iges")) {
+            else if (file.hasExtension({"igs", "iges"})) {
                 IGESControl_Controller::Init();
                 IGESCAFControl_Writer writer;
                 IGESData_GlobalSection header = writer.Model()->GlobalSection();
@@ -368,7 +368,7 @@ private:
                     throw Py::Exception();
                 }
             }
-            else if (file.hasExtension("glb") || file.hasExtension("gltf")) {
+            else if (file.hasExtension({"glb", "gltf"})) {
 #if OCC_VERSION_HEX >= 0x070500
                 TColStd_IndexedDataMapOfStringString aMetadata;
                 RWGltf_CafWriter aWriter (name8bit.c_str(), file.hasExtension("glb"));

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -412,7 +412,7 @@ private:
             FC_TIME_INIT(t);
             FC_DURATION_DECL_INIT2(d1,d2);
 
-            if (file.hasExtension("stp") || file.hasExtension("step")) {
+            if (file.hasExtension({"stp", "step"})) {
 
                 if(mode<0)
                     mode = ocaf.getMode();
@@ -451,7 +451,7 @@ private:
                     pcDoc->recompute();
                 }
             }
-            else if (file.hasExtension("igs") || file.hasExtension("iges")) {
+            else if (file.hasExtension({"igs", "iges"})) {
                 Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
                     .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part")->GetGroup("IGES");
 
@@ -550,7 +550,7 @@ private:
         Py::Dict options;
         Base::FileInfo file(name8bit.c_str());
 
-        if (file.hasExtension("stp") || file.hasExtension("step")) {
+        if (file.hasExtension({"stp", "step"})) {
             PartGui::TaskExportStep dlg(Gui::getMainWindow());
             if (!dlg.showDialog() || dlg.exec()) {
                 auto stepSettings = dlg.getSettings();
@@ -652,7 +652,7 @@ private:
             }
 
             Base::FileInfo file(Utf8Name.c_str());
-            if (file.hasExtension("stp") || file.hasExtension("step")) {
+            if (file.hasExtension({"stp", "step"})) {
                 ParameterGrp::handle hGrp_stp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Part/STEP");
                 std::string scheme = hGrp_stp->GetASCII("Scheme", Part::Interface::writeStepScheme());
                 std::list<std::string> supported = Part::supportedSTEPSchemes();
@@ -681,7 +681,7 @@ private:
                     throw Py::Exception();
                 }
             }
-            else if (file.hasExtension("igs") || file.hasExtension("iges")) {
+            else if (file.hasExtension({"igs", "iges"})) {
                 IGESControl_Controller::Init();
                 IGESCAFControl_Writer writer;
                 IGESData_GlobalSection header = writer.Model()->GlobalSection();
@@ -696,7 +696,7 @@ private:
                     throw Py::Exception();
                 }
             }
-            else if (file.hasExtension("glb") || file.hasExtension("gltf")) {
+            else if (file.hasExtension({"glb", "gltf"})) {
 #if OCC_VERSION_HEX >= 0x070500
                 TColStd_IndexedDataMapOfStringString aMetadata;
                 RWGltf_CafWriter aWriter (name8bit.c_str(), file.hasExtension("glb"));
@@ -742,7 +742,7 @@ private:
             Handle(TDocStd_Document) hDoc;
             hApp->NewDocument(TCollection_ExtendedString("MDTV-CAF"), hDoc);
 
-            if (file.hasExtension("stp") || file.hasExtension("step")) {
+            if (file.hasExtension({"stp", "step"})) {
                 STEPCAFControl_Reader aReader;
                 aReader.SetColorMode(true);
                 aReader.SetNameMode(true);
@@ -763,7 +763,7 @@ private:
                 pi->EndScope();
 #endif
             }
-            else if (file.hasExtension("igs") || file.hasExtension("iges")) {
+            else if (file.hasExtension({"igs", "iges"})) {
                 Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
                     .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part")->GetGroup("IGES");
                 IGESControl_Controller::Init();

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -188,7 +188,7 @@ bool MeshInput::LoadAny(const char* FileName)
     else {
         // read file
         bool ok = false;
-        if (fi.hasExtension("stl") || fi.hasExtension("ast")) {
+        if (fi.hasExtension({"stl", "ast"})) {
             ok = LoadSTL(str);
         }
         else if (fi.hasExtension("iv")) {
@@ -196,7 +196,7 @@ bool MeshInput::LoadAny(const char* FileName)
             if (ok && _rclMesh.CountFacets() == 0)
                 Base::Console().Warning("No usable mesh found in file '%s'", FileName);
         }
-        else if (fi.hasExtension("nas") || fi.hasExtension("bdf")) {
+        else if (fi.hasExtension({"nas", "bdf"})) {
             ok = LoadNastran( str );
         }
         else if (fi.hasExtension("obj")) {
@@ -1711,13 +1711,13 @@ MeshIO::Format MeshOutput::GetFormat(const char* FileName)
     else if (file.hasExtension("py")) {
         return MeshIO::PY;
     }
-    else if (file.hasExtension("wrl") || file.hasExtension("vrml")) {
+    else if (file.hasExtension({"wrl", "vrml"})) {
         return MeshIO::VRML;
     }
     else if (file.hasExtension("wrz")) {
         return MeshIO::WRZ;
     }
-    else if (file.hasExtension("nas") || file.hasExtension("bdf")) {
+    else if (file.hasExtension({"nas", "bdf"})) {
         return MeshIO::NAS;
     }
     else if (file.hasExtension("amf")) {

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -733,14 +733,14 @@ private:
         if (file.extension().empty())
             throw Py::RuntimeError("No file extension");
 
-        if (file.hasExtension("stp") || file.hasExtension("step")) {
+        if (file.hasExtension({"stp", "step"})) {
             // create new document and add Import feature
             App::Document *pcDoc = App::GetApplication().newDocument();
             ImportStepParts(pcDoc,EncodedName.c_str());
 
             pcDoc->recompute();
         }
-        else if (file.hasExtension("igs") || file.hasExtension("iges")) {
+        else if (file.hasExtension({"igs", "iges"})) {
             App::Document *pcDoc = App::GetApplication().newDocument();
             ImportIgesParts(pcDoc,EncodedName.c_str());
             pcDoc->recompute();
@@ -781,12 +781,12 @@ private:
             pcDoc = App::GetApplication().newDocument(DocName);
         }
 
-        if (file.hasExtension("stp") || file.hasExtension("step")) {
+        if (file.hasExtension({"stp", "step"})) {
             ImportStepParts(pcDoc,EncodedName.c_str());
 
             pcDoc->recompute();
         }
-        else if (file.hasExtension("igs") || file.hasExtension("iges")) {
+        else if (file.hasExtension({"igs", "iges"})) {
             ImportIgesParts(pcDoc,EncodedName.c_str());
             pcDoc->recompute();
         }

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -692,14 +692,14 @@ void TopoShape::read(const char *FileName)
     if (!File.isReadable())
         throw Base::FileException("File to load not existing or not readable", FileName);
 
-    if (File.hasExtension("igs") || File.hasExtension("iges")) {
+    if (File.hasExtension({"igs", "iges"})) {
         // read iges file
         importIges(File.filePath().c_str());
     }
-    else if (File.hasExtension("stp") || File.hasExtension("step")) {
+    else if (File.hasExtension({"stp", "step"})) {
         importStep(File.filePath().c_str());
     }
-    else if (File.hasExtension("brp") || File.hasExtension("brep")) {
+    else if (File.hasExtension({"brp", "brep"})) {
         // read brep-file
         importBrep(File.filePath().c_str());
     }
@@ -882,14 +882,14 @@ void TopoShape::write(const char *FileName) const
 {
     Base::FileInfo File(FileName);
 
-    if (File.hasExtension("igs") || File.hasExtension("iges")) {
+    if (File.hasExtension({"igs", "iges"})) {
         // write iges file
         exportIges(File.filePath().c_str());
     }
-    else if (File.hasExtension("stp") || File.hasExtension("step")) {
+    else if (File.hasExtension({"stp", "step"})) {
         exportStep(File.filePath().c_str());
     }
-    else if (File.hasExtension("brp") || File.hasExtension("brep")) {
+    else if (File.hasExtension({"brp", "brep"})) {
         // read brep-file
         exportBrep(File.filePath().c_str());
     }

--- a/src/Mod/TechDraw/App/DrawHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawHatch.cpp
@@ -192,27 +192,13 @@ void DrawHatch::unsetupObject(void)
 bool DrawHatch::isSvgHatch(void) const
 {
     Base::FileInfo fi(HatchPattern.getValue());
-    if (fi.extension() == "svg" ||
-        fi.extension() == "SVG") {
-        return true;
-    }
-    return false;
+    return fi.hasExtension("svg");
 }
 
 bool DrawHatch::isBitmapHatch(void) const
 {
     Base::FileInfo fi(HatchPattern.getValue());
-    if (fi.extension() == "bmp" ||
-        fi.extension() == "BMP" ||
-        fi.extension() == "png" ||
-        fi.extension() == "PNG" ||
-        fi.extension() == "jpg" ||
-        fi.extension() == "JPG" ||
-        fi.extension() == "jpeg" ||
-        fi.extension() == "JPEG" ) {
-        return true;
-    }
-    return false;
+    return fi.hasExtension({"bmp", "png", "jpg", "jpeg"});
 }
 
 //standard preference getters

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -1122,14 +1122,13 @@ void DrawViewSection::makeLineSets(void)
 
     std::string fileSpec = PatIncluded.getValue();
     Base::FileInfo fi(fileSpec);
-    std::string ext = fi.extension();
     if (!fi.isReadable()) {
         Base::Console().Message("%s can not read hatch file: %s\n", getNameInDocument(),
                                 fileSpec.c_str());
         return;
     }
 
-    if (ext == "pat" || ext == "PAT") {
+    if (fi.hasExtension("pat")) {
         if (!fileSpec.empty() && !NameGeomPattern.isEmpty()) {
             m_lineSets.clear();
             m_lineSets = DrawGeomHatch::makeLineSets(fileSpec, NameGeomPattern.getValue());


### PR DESCRIPTION
So far, FileInfo::hasExtension could only check for one extension. This PR can introduce a function overload taking multiple values to check at one call.

So instead of
```
bool DrawHatch::isBitmapHatch(void) const 
{ 
    Base::FileInfo fi(HatchPattern.getValue()); 
    if (fi.extension() == "bmp" || 
        fi.extension() == "BMP" || 
        fi.extension() == "png" || 
        fi.extension() == "PNG" || 
        fi.extension() == "jpg" || 
        fi.extension() == "JPG" || 
        fi.extension() == "jpeg" || 
        fi.extension() == "JPEG" ) { 
        return true; 
    } 
    return false; 
} 
```

This PR introduces the possibility for

```
bool DrawHatch::isBitmapHatch(void) const 
{ 
    Base::FileInfo fi(HatchPattern.getValue()); 
    return fi.hasExtension({"bmp", "png", "jpg", "jpeg"}); 
}
```

There were only 2 locations in the whole FreeCAD codebase that had more than 2 file extensions to check at a time. One of them in TechDraw that I did the change for, and then I could just as well expand it to the rest of the code. But just as I had to test it, I realized that the function (example) in TechDraw wasn't even used, it was just a ghost.

So I really am not interested in merging this personally anymore. But let me know if anyone should have an interest in getting it merged. It hasn't been discussed in the forum nor tested.