### PR TITLE
Rest Machining for Path and Path3D Operations

### DIFF
--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -496,6 +496,79 @@ void Area::add(const TopoDS_Shape& shape, short op) {
     myShapes.emplace_back(op, shape);
 }
 
+std::shared_ptr<Area> Area::getClearedArea(double tipDiameter, double diameter) {
+    build();
+#define AREA_MY(_param) myParams.PARAM_FNAME(_param)
+    PARAM_ENUM_CONVERT(AREA_MY, PARAM_FNAME, PARAM_ENUM_EXCEPT, AREA_PARAMS_OFFSET_CONF);
+    PARAM_ENUM_CONVERT(AREA_MY, PARAM_FNAME, PARAM_ENUM_EXCEPT, AREA_PARAMS_CLIPPER_FILL);
+
+    // Do not fit arcs after these offsets; it introduces unnecessary approximation error, and all off
+    // those arcs will be converted back to segments again for clipper differencing in getRestArea anyway
+    CAreaConfig conf(myParams, /*no_fit_arcs*/ true);
+
+    const double roundPrecision = myParams.Accuracy;
+    const double buffer = 2 * roundPrecision;
+
+    // A = myArea
+    // prevCenters = offset(A, -rTip)
+    const double rTip = tipDiameter / 2.;
+    CArea prevCenter(*myArea);
+    prevCenter.OffsetWithClipper(-rTip, JoinType, EndType, myParams.MiterLimit, roundPrecision);
+
+    // prevCleared = offset(prevCenter, r).
+    CArea prevCleared(prevCenter);
+    prevCleared.OffsetWithClipper(diameter / 2. + buffer, JoinType, EndType, myParams.MiterLimit, roundPrecision);
+
+    std::shared_ptr<Area> clearedArea = make_shared<Area>(*this);
+    clearedArea->myArea.reset(new CArea(prevCleared));
+
+    return clearedArea;
+}
+
+std::shared_ptr<Area> Area::getRestArea(std::vector<std::shared_ptr<Area>> clearedAreas, double diameter) {
+    build();
+    PARAM_ENUM_CONVERT(AREA_MY, PARAM_FNAME, PARAM_ENUM_EXCEPT, AREA_PARAMS_OFFSET_CONF);
+    PARAM_ENUM_CONVERT(AREA_MY, PARAM_FNAME, PARAM_ENUM_EXCEPT, AREA_PARAMS_CLIPPER_FILL);
+
+    const double roundPrecision = myParams.Accuracy;
+    const double buffer = 2 * roundPrecision;
+
+    // transform all clearedAreas into our workplane
+    Area clearedAreasInPlane(&myParams);
+    clearedAreasInPlane.myArea.reset(new CArea());
+    for (std::shared_ptr<Area> clearedArea : clearedAreas) {
+      gp_Trsf trsf = clearedArea->myTrsf;
+      trsf.Invert();
+      trsf.SetTranslationPart(gp_Vec{trsf.TranslationPart().X(), trsf.TranslationPart().Y(), -myTrsf.TranslationPart().Z()}); // discard z-height of cleared workplane, set to myWorkPlane's height
+      TopoDS_Shape clearedShape = Area::toShape(*clearedArea->myArea, false, &trsf);
+      Area::addShape(*(clearedAreasInPlane.myArea), clearedShape, &myTrsf, .01 /*default value*/,
+          &myWorkPlane);
+    }
+
+    // remaining = A - prevCleared
+    CArea remaining(*myArea);
+    remaining.Clip(toClipperOp(Area::OperationDifference), &*(clearedAreasInPlane.myArea), SubjectFill, ClipFill);
+
+    // rest = intersect(A, offset(remaining, dTool))
+    CArea restCArea(remaining);
+    restCArea.OffsetWithClipper(diameter + buffer, JoinType, EndType, myParams.MiterLimit, roundPrecision);
+    restCArea.Clip(toClipperOp(Area::OperationIntersection), &*myArea, SubjectFill, ClipFill);
+
+    gp_Trsf trsf(myTrsf.Inverted());
+    TopoDS_Shape restShape = Area::toShape(restCArea, false, &trsf);
+    std::shared_ptr<Area> restArea = make_shared<Area>(&myParams);
+    restArea->add(restShape, OperationCompound);
+
+    return restArea;
+}
+
+TopoDS_Shape Area::toTopoShape()
+{
+    build();
+    gp_Trsf trsf = myTrsf.Inverted();
+    return toShape(*myArea, false, &trsf);
+}
+
 
 void Area::setParams(const AreaParams& params) {
 #define AREA_SRC(_param) params.PARAM_FNAME(_param)
@@ -1624,7 +1697,6 @@ void Area::build() {
     if (myShapes.empty())
         throw Base::ValueError("no shape added");
 
-#define AREA_MY(_param) myParams.PARAM_FNAME(_param)
     PARAM_ENUM_CONVERT(AREA_MY, PARAM_FNAME, PARAM_ENUM_EXCEPT, AREA_PARAMS_CLIPPER_FILL);
 
     if (myHaveSolid && myParams.SectionCount) {

--- a/src/Mod/Path/App/Area.h
+++ b/src/Mod/Path/App/Area.h
@@ -242,6 +242,10 @@ public:
         const std::vector<double>& heights = std::vector<double>(),
         const TopoDS_Shape& plane = TopoDS_Shape());
 
+    std::shared_ptr<Area> getClearedArea(double tipDiameter, double diameter);
+    std::shared_ptr<Area> getRestArea(std::vector<std::shared_ptr<Area>> clearedAreas, double diameter);
+    TopoDS_Shape toTopoShape();
+
     /** Config this Area object */
     void setParams(const AreaParams& params);
 

--- a/src/Mod/Path/App/AreaPy.xml
+++ b/src/Mod/Path/App/AreaPy.xml
@@ -55,6 +55,21 @@ same algorithm</UserDocu>
           <UserDocu></UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="getClearedArea" Keyword="true">
+      <Documentation>
+          <UserDocu></UserDocu>
+      </Documentation>
+    </Methode>
+    <Methode Name="getRestArea" Keyword="true">
+      <Documentation>
+          <UserDocu></UserDocu>
+      </Documentation>
+    </Methode>
+    <Methode Name="toTopoShape" Keyword="true">
+      <Documentation>
+          <UserDocu></UserDocu>
+      </Documentation>
+    </Methode>
     <Methode Name="setParams" Keyword="true">
       <Documentation>
           <UserDocu></UserDocu>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpPocketFullEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpPocketFullEdit.ui
@@ -245,14 +245,24 @@ The latter can be used to face of the entire stock area to ensure uniform height
         </property>
        </widget>
       </item>
-     <item row="2" column="1">
+      <item row="2" column="1">
        <widget class="QCheckBox" name="minTravel">
         <property name="text">
          <string>Min Travel</string>
         </property>
        </widget>
       </item>
-      </layout>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="useRestMachining">
+        <property name="toolTip">
+         <string>Check to skip machining regions that have already been cleared by previous operations</string>
+        </property>
+        <property name="text">
+         <string>Use Rest Machining</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="4" column="0">

--- a/src/Mod/Path/Path/Op/Area.py
+++ b/src/Mod/Path/Path/Op/Area.py
@@ -38,7 +38,7 @@ __title__ = "Base class for PathArea based operations."
 __author__ = "sliptonic (Brad Collette)"
 __url__ = "https://www.freecad.org"
 __doc__ = "Base class and properties for Path.Area based operations."
-__contributors__ = "russ4262 (Russell Johnson)"
+__contributors__ = "russ4262 (Russell Johnson) davidgilkaufman (David Kaufman)"
 
 
 if False:
@@ -236,6 +236,47 @@ class ObjectOp(PathOp.ObjectOp):
             mode=0, project=self.areaOpUseProjection(obj), heights=heights
         )
         Path.Log.debug("sections = %s" % sections)
+
+        # Rest machining
+        self.sectionShapes = self.sectionShapes + [section.toTopoShape() for section in sections]
+        if hasattr(obj, "UseRestMachining") and obj.UseRestMachining:
+            # Loop through prior operations
+            clearedAreas = []
+            foundSelf = False
+            for op in self.job.Operations.Group:
+                if foundSelf:
+                    break
+                oplist = [op] + op.OutListRecursive
+                oplist = list(filter(lambda op: hasattr(op, "Active"), oplist))
+                for op in oplist:
+                    if op.Proxy == self:
+                        # Ignore self, and all later operations
+                        foundSelf = True
+                        break
+                    if hasattr(op, "RestMachiningRegions") and op.Active:
+                        if hasattr(op, "RestMachiningRegionsNeedRecompute") and op.RestMachiningRegionsNeedRecompute:
+                            Path.Log.warning(
+                                translate("PathAreaOp", "Previous operation %s is required for rest machining, but it has no stored rest machining metadata. Recomputing to generate this metadata...") % op.Label
+                            )
+                            op.recompute()
+
+                        tool = op.Proxy.tool if hasattr(op.Proxy, "tool") else op.ToolController.Proxy.getTool(op.ToolController)
+                        diameter = tool.Diameter.getValueAs("mm")
+                        def shapeToArea(shape):
+                            area = Path.Area()
+                            area.setPlane(PathUtils.makeWorkplane(shape))
+                            area.add(shape)
+                            return area
+                        opClearedAreas = [shapeToArea(pa).getClearedArea(diameter, diameter) for pa in op.RestMachiningRegions.SubShapes]
+                        clearedAreas.extend(opClearedAreas)
+            restSections = []
+            for section in sections:
+                z = section.getShape().BoundBox.ZMin
+                sectionClearedAreas = [a for a in clearedAreas if a.getShape().BoundBox.ZMax <= z]
+                restSection = section.getRestArea(sectionClearedAreas, self.tool.Diameter.getValueAs("mm"))
+                restSections.append(restSection)
+            sections = restSections
+
         shapelist = [sec.getShape() for sec in sections]
         Path.Log.debug("shapelist = %s" % shapelist)
 
@@ -385,6 +426,7 @@ class ObjectOp(PathOp.ObjectOp):
             shapes = [j["shape"] for j in locations]
 
         sims = []
+        self.sectionShapes = []
         for shape, isHole, sub in shapes:
             profileEdgesIsOpen = False
 
@@ -432,6 +474,10 @@ class ObjectOp(PathOp.ObjectOp):
                     )
                 )
 
+        if hasattr(obj, "RestMachiningRegions"):
+            obj.RestMachiningRegions = Part.makeCompound(self.sectionShapes)
+        if hasattr(obj, "RestMachiningRegionsNeedRecompute"):
+            obj.RestMachiningRegionsNeedRecompute = False
         Path.Log.debug("obj.Name: " + str(obj.Name) + "\n\n")
         return sims
 

--- a/src/Mod/Path/Path/Op/Gui/Pocket.py
+++ b/src/Mod/Path/Path/Op/Gui/Pocket.py
@@ -46,7 +46,7 @@ class TaskPanelOpPage(PathPocketBaseGui.TaskPanelOpPage):
 
     def pocketFeatures(self):
         """pocketFeatures() ... return FeaturePocket (see PathPocketBaseGui)"""
-        return PathPocketBaseGui.FeaturePocket
+        return PathPocketBaseGui.FeaturePocket | PathPocketBaseGui.FeatureRestMachining
 
 
 Command = PathOpGui.SetupOperation(

--- a/src/Mod/Path/Path/Op/Gui/PocketBase.py
+++ b/src/Mod/Path/Path/Op/Gui/PocketBase.py
@@ -44,6 +44,7 @@ translate = FreeCAD.Qt.translate
 FeaturePocket = 0x01
 FeatureFacing = 0x02
 FeatureOutline = 0x04
+FeatureRestMachining = 0x08
 
 
 class TaskPanelOpPage(PathOpGui.TaskPanelPage):
@@ -89,6 +90,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if not (FeatureOutline & self.pocketFeatures()):
             form.useOutline.hide()
 
+        if not (FeatureRestMachining & self.pocketFeatures()):
+            form.useRestMachining.hide()
+
         # if True:
         #     # currently doesn't have an effect or is experimental
         #     form.minTravel.hide()
@@ -131,6 +135,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if obj.UseStartPoint != self.form.useStartPoint.isChecked():
             obj.UseStartPoint = self.form.useStartPoint.isChecked()
 
+        if obj.UseRestMachining != self.form.useRestMachining.isChecked():
+            obj.UseRestMachining = self.form.useRestMachining.isChecked()
+
         if FeatureOutline & self.pocketFeatures():
             if obj.UseOutline != self.form.useOutline.isChecked():
                 obj.UseOutline = self.form.useOutline.isChecked()
@@ -155,6 +162,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             ).UserString
         )
         self.form.useStartPoint.setChecked(obj.UseStartPoint)
+        self.form.useRestMachining.setChecked(obj.UseRestMachining)
         if FeatureOutline & self.pocketFeatures():
             self.form.useOutline.setChecked(obj.UseOutline)
 
@@ -186,6 +194,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.extraOffset.editingFinished)
         signals.append(self.form.useStartPoint.clicked)
+        signals.append(self.form.useRestMachining.clicked)
         signals.append(self.form.useOutline.clicked)
         signals.append(self.form.minTravel.clicked)
         signals.append(self.form.coolantController.currentIndexChanged)

--- a/src/Mod/Path/Path/Op/Gui/PocketShape.py
+++ b/src/Mod/Path/Path/Op/Gui/PocketShape.py
@@ -52,7 +52,7 @@ class TaskPanelOpPage(PathPocketBaseGui.TaskPanelOpPage):
 
     def pocketFeatures(self):
         """pocketFeatures() ... return FeaturePocket (see PathPocketBaseGui)"""
-        return PathPocketBaseGui.FeaturePocket | PathPocketBaseGui.FeatureOutline
+        return PathPocketBaseGui.FeaturePocket | PathPocketBaseGui.FeatureOutline | PathPocketBaseGui.FeatureRestMachining
 
     def taskPanelBaseLocationPage(self, obj, features):
         if not hasattr(self, "extensionsPanel"):

--- a/src/Mod/Path/Path/Op/Pocket.py
+++ b/src/Mod/Path/Path/Op/Pocket.py
@@ -135,6 +135,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
 
     def opOnDocumentRestored(self, obj):
         """opOnDocumentRestored(obj) ... adds the properties if they doesn't exist."""
+        super().opOnDocumentRestored(obj)
         self.initPocketOp(obj)
 
     def pocketInvertExtraOffset(self):

--- a/src/Mod/Path/Path/Op/PocketBase.py
+++ b/src/Mod/Path/Path/Op/PocketBase.py
@@ -185,6 +185,25 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                 "Last Stepover Radius.  If 0, 50% of cutter is used. Tuning this can be used to improve stepover for some shapes",
             ),
         )
+        obj.addProperty(
+            "App::PropertyBool",
+            "UseRestMachining",
+            "Pocket",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Skips machining regions that have already been cleared by previous operations.",
+            ),
+        )
+        obj.addProperty(
+            "Part::PropertyPartShape",
+            "RestMachiningRegions",
+            "Pocket",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "The areas cleared by this operation, one area per height, stored as a compound part. Used internally for rest machining.",
+            ),
+        )
+        obj.setEditorMode("RestMachiningRegions", 2)  # hide
 
         for n in self.pocketPropertyEnumerations():
             setattr(obj, n[0], n[1])
@@ -246,6 +265,42 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                 ),
             )
             obj.PocketLastStepOver = 0
+
+        if not hasattr(obj, "UseRestMachining"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "UseRestMachining",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Skips machining regions that have already been cleared by previous operations.",
+                ),
+            )
+
+        if not hasattr(obj, "RestMachiningRegions"):
+            obj.addProperty(
+                "Part::PropertyPartShape",
+                "RestMachiningRegions",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                "The areas cleared by this operation, one area per height, stored as a compound part. Used internally for rest machining.",
+                ),
+            )
+            obj.setEditorMode("RestMachiningRegions", 2)  # hide
+
+            obj.addProperty(
+                "App::PropertyBool",
+                "RestMachiningRegionsNeedRecompute",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Flag to indicate that the rest machining regions have never been computed, and must be recomputed before being used.",
+                ),
+            )
+            obj.setEditorMode("RestMachiningRegionsNeedRecompute", 2)  # hide
+            obj.RestMachiningRegionsNeedRecompute = True
+
         Path.Log.track()
 
     def areaOpPathParams(self, obj, isHole):


### PR DESCRIPTION
WIP, but mostly done. Still TODO:

- [x] make rest machining work with saving (currently it only works using operations that have generated paths since opening the file)
- [x] disable setting debug log level in Path/Op/Area.py
- [x] change UI for enable rest machining instead of multiple modes?
- [x] squash commits
- [x] Bug: path dressups mask the clearedArea property -- look into how those are implemented, and loop through sub operations

Forum thread: https://forum.freecad.org/viewtopic.php?t=78773
Issue: https://github.com/FreeCAD/FreeCAD/issues/9756



Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
