### PR TITLE
[TD]warn on skewed ComplexSection profile

### DIFF
--- a/src/Mod/TechDraw/App/DrawComplexSection.h
+++ b/src/Mod/TechDraw/App/DrawComplexSection.h
@@ -100,6 +100,8 @@ public Q_SLOTS:
 
 private:
     gp_Dir getFaceNormal(TopoDS_Face& face);
+    bool validateOffsetProfile(TopoDS_Wire profile, Base::Vector3d direction, double angleThresholdDeg) const;
+    std::pair<Base::Vector3d, Base::Vector3d> getSegmentEnds(TopoDS_Edge segment) const;
 
     TopoDS_Shape m_toolFaceShape;
     TopoDS_Shape m_alignResult;

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -723,7 +723,9 @@ TopoDS_Compound DrawViewSection::mapToPage(TopoDS_Shape& shapeToAlign)
         }
 
         if (goodWires.empty()) {
-            Base::Console().Warning("DVS::mapToPage - %s - section face has no valid wires.\n",
+            // this may or may not be significant.  In the offset or noparallel strategies,
+            // a profile segment that is parallel to the SectionNormal will not generate a face.
+            Base::Console().Log("DVS::mapToPage - %s - section face has no valid wires.\n",
                                     getNameInDocument());
             continue;
         }


### PR DESCRIPTION
This PR addresses an issue where the section normal is slightly off from the expected direction as reported here: https://forum.freecad.org/viewtopic.php?t=79017

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
