### PR TITLE
Start: Remove frameborder attribute from iframe

### DIFF
--- a/src/Mod/Start/StartPage/StartPage.html
+++ b/src/Mod/Start/StartPage/StartPage.html
@@ -159,7 +159,7 @@
             </div>
 
             <div id="tab4" class="panel hidden iframecontainer">
-                <iframe src="https://blog.freecad.org/" title="Freecad Blog" frameborder="0" class="iframe" ></iframe> 
+                <iframe src="https://blog.freecad.org/" title="Freecad Blog" class="iframe" ></iframe> 
             </div>
 
         </div>


### PR DESCRIPTION
Fixes the CI failure introduced by #9777. This attribute is obsolete. CSS should be used instead to achieve the effect. This is causing the GUI tests to fail because the HTML valuation fails.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR