### PR TITLE
[Core] Fix ordering confusion in backups (retry)

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1928,7 +1928,7 @@ bool Document::saveToFile(const char* filename) const
             count_bak = -1;
         }
         bool useFCBakExtension = App::GetApplication().GetParameterGroupByPath
-            ("User parameter:BaseApp/Preferences/Document")->GetBool("UseFCBakExtension",false);
+            ("User parameter:BaseApp/Preferences/Document")->GetBool("UseFCBakExtension",true);
         std::string saveBackupDateFormat = App::GetApplication().GetParameterGroupByPath
             ("User parameter:BaseApp/Preferences/Document")->GetASCII("SaveBackupDateFormat","%Y%m%d-%H%M%S");
 

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2518,6 +2518,17 @@ void Application::setStyleSheet(const QString& qssFile, bool tiledBackground)
     }
 }
 
+void Application::checkForDeprecatedSettings()
+{
+    // From 0.21, `FCBak` will be the intended default backup format
+    // TODO: Check for `FCStd#` and warn user.
+    bool useFCBakExtension = App::GetApplication().GetParameterGroupByPath
+        ("User parameter:BaseApp/Preferences/Document")->GetBool("UseFCBakExtension", true);
+    if (!useFCBakExtension) {
+        Base::Console().Warning("`.FCStd#` backup format is deprecated from 0.21 and may be removed in future versions. Please use `.FCBak` instead.\n");
+    }
+}
+
 void Application::checkForPreviousCrashes()
 {
     try {

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -192,6 +192,8 @@ public:
 
     /// true when the application shutting down
     bool isClosing();
+
+    void checkForDeprecatedSettings();
     void checkForPreviousCrashes();
 
     /** @name workbench handling */

--- a/src/Gui/DlgSettingsDocument.ui
+++ b/src/Gui/DlgSettingsDocument.ui
@@ -511,6 +511,9 @@ Common sizes are 128, 256 and 512</string>
            <string>Backup files will get extension '.FCbak' and file names
 get date suffix according to the specified format</string>
           </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
           <property name="text">
            <string>Use date and FCBak extension</string>
           </property>

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1447,6 +1447,9 @@ void MainWindow::delayedStartup()
         return;
     }
 
+    // TODO: Check for deprecated settings
+    Application::Instance->checkForDeprecatedSettings();
+
     // Create new document?
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("Document");
     if (hGrp->GetBool("CreateNewDoc", false)) {


### PR DESCRIPTION
Fixes #9635.

Retry of #9668 just in case failures there are because of problems in CI.
