### PR TITLE
[TD]fix lost parent on undo

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -76,7 +76,6 @@
 #include "Rez.h"
 #include "ViewProviderPage.h"
 
-
 using namespace TechDrawGui;
 using namespace TechDraw;
 namespace bp = boost::placeholders;
@@ -194,6 +193,7 @@ bool MDIViewPage::onMsg(const char* pMsg, const char**)
     else if (strcmp("Undo", pMsg) == 0) {
         doc->undo(1);
         Gui::Command::updateActive();
+        fixSceneDependencies();    // check QGraphicsScene item parenting
         return true;
     }
     else if (strcmp("Redo", pMsg) == 0) {
@@ -243,6 +243,14 @@ void MDIViewPage::setTabText(std::string tabText)
     if (!isPassive() && !tabText.empty()) {
         QString cap = QString::fromLatin1("%1 [*]").arg(QString::fromUtf8(tabText.c_str()));
         setWindowTitle(cap);
+    }
+}
+
+// advise the page to check QGraphicsScene parent/child relationships after undo
+void MDIViewPage::fixSceneDependencies()
+{
+    if (getViewProviderPage()) {
+        getViewProviderPage()->fixSceneDependencies();
     }
 }
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -116,6 +116,7 @@ public:
     void contextMenuEvent(QContextMenuEvent *event) override;
 
     void setScene(QGSPage* scene, QGVPage* view);
+    void fixSceneDependencies();
 
 public Q_SLOTS:
     void viewAll() override;

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -60,6 +60,7 @@
 #include "QGVPage.h"
 #include "ViewProviderPageExtension.h"
 #include "ViewProviderTemplate.h"
+#include "ViewProviderViewPart.h"
 
 
 using namespace TechDrawGui;
@@ -557,3 +558,23 @@ ViewProviderPageExtension* ViewProviderPage::getVPPExtension() const
 }
 
 const char* ViewProviderPage::whoAmI() const { return m_pageName.c_str(); }
+
+
+void ViewProviderPage::fixSceneDependencies()
+{
+    App::Document* doc = getDrawPage()->getDocument();
+    std::vector<App::DocumentObject*> docObjs =
+        doc->getObjectsOfType(TechDraw::DrawViewPart::getClassTypeId());
+    for (auto& obj : docObjs) {
+        Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(obj);
+        if (!vp) {
+            continue;// can't fix this one
+        }
+        TechDrawGui::ViewProviderViewPart* vpvp = dynamic_cast<TechDrawGui::ViewProviderViewPart*>(vp);
+        if (!vpvp) {
+            continue;// can't fix this one
+        }
+        vpvp->fixSceneDependencies();
+    }
+
+}

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.h
@@ -126,6 +126,9 @@ public:
 
     const char* whoAmI() const;
 
+    void fixSceneDependencies();
+
+
 protected:
     bool setEdit(int ModNum) override;
     void createMDIViewPage();

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -52,6 +52,10 @@
 #include "QGIView.h"
 #include "TaskDetail.h"
 #include "ViewProviderViewPart.h"
+#include "ViewProviderPage.h"
+#include "QGIViewDimension.h"
+#include "QGIViewBalloon.h"
+#include "QGSPage.h"
 
 using namespace TechDrawGui;
 using namespace TechDraw;
@@ -167,6 +171,7 @@ void ViewProviderViewPart::onChanged(const App::Property* prop)
 
 void ViewProviderViewPart::attach(App::DocumentObject *pcFeat)
 {
+//    Base::Console().Message("VPVP::attach(%s)\n", pcFeat->getNameInDocument());
     TechDraw::DrawViewMulti* dvm = dynamic_cast<TechDraw::DrawViewMulti*>(pcFeat);
     TechDraw::DrawViewDetail* dvd = dynamic_cast<TechDraw::DrawViewDetail*>(pcFeat);
     if (dvm) {
@@ -222,6 +227,7 @@ std::vector<App::DocumentObject*> ViewProviderViewPart::claimChildren() const
         return std::vector<App::DocumentObject*>();
     }
 }
+
 bool ViewProviderViewPart::setEdit(int ModNum)
 {
     if (ModNum != ViewProvider::Default ) {
@@ -309,26 +315,16 @@ bool ViewProviderViewPart::onDelete(const std::vector<std::string> &)
     auto viewSection = getViewObject()->getSectionRefs();
     auto viewDetail = getViewObject()->getDetailRefs();
     auto viewLeader = getViewObject()->getLeaders();
+    auto viewDimension = getViewObject()->getDimensions();
+    auto viewBalloon = getViewObject()->getBalloons();
 
-    if (!viewSection.empty()) {
+    if (!viewDimension.empty() ||
+             !viewBalloon.empty() ||
+             !viewSection.empty() ||
+             !viewDetail.empty() ||
+             !viewLeader.empty()) {
         bodyMessageStream << qApp->translate("Std_Delete",
-            "You cannot delete this view because it has a section view that would become broken.");
-        QMessageBox::warning(Gui::getMainWindow(),
-            qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,
-            QMessageBox::Ok);
-        return false;
-    }
-    else if (!viewDetail.empty()) {
-        bodyMessageStream << qApp->translate("Std_Delete",
-            "You cannot delete this view because it has a detail view that would become broken.");
-        QMessageBox::warning(Gui::getMainWindow(),
-            qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,
-            QMessageBox::Ok);
-        return false;
-    }
-    else if (!viewLeader.empty()) {
-        bodyMessageStream << qApp->translate("Std_Delete",
-            "You cannot delete this view because it has a leader line that would become broken.");
+            "You cannot delete this view because it has one or more dependent objects that would become broken.");
         QMessageBox::warning(Gui::getMainWindow(),
             qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,
             QMessageBox::Ok);
@@ -364,4 +360,31 @@ int ViewProviderViewPart::prefHighlightStyle()
     return Preferences::getPreferenceGroup("Decorations")->GetInt("HighlightStyle", 2);
 }
 
+// it can happen that Dimensions/Balloons/etc can lose their parent item if the
+// the parent is deleted, then undo is invoked.  The linkages on the App side are
+// handled by the undo mechanism, but the QGraphicsScene parentage is not reset.
+// TODO: does this need to be implemented for Leaderlines and ???? others?
+void ViewProviderViewPart::fixSceneDependencies()
+{
+//    Base::Console().Message("VPVP::fixSceneDependencies()\n");
+    auto scene = getViewProviderPage()->getQGSPage();
+    auto partQView = getQView();
 
+    auto dimensions =  getViewPart()->getDimensions();
+    for (auto& dim : dimensions) {
+        auto dimQView = dynamic_cast<QGIViewDimension *>(scene->findQViewForDocObj(dim));
+        if (dimQView && dimQView->parentItem() != partQView) {
+            // need to add the dim QView to this QGIViewPart
+            scene->addDimToParent(dimQView, partQView);
+        }
+    }
+
+    auto balloons = getViewPart()->getBalloons();
+    for (auto& bal : balloons) {
+        auto balQView = dynamic_cast<QGIViewBalloon*>(scene->findQViewForDocObj(bal));
+        if (balQView && balQView->parentItem() != partQView) {
+            // need to add the balloon QView to this QGIViewPart
+            scene->addBalloonToParent(balQView, partQView);
+        }
+    }
+}

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
@@ -69,16 +69,14 @@ public:
     bool canDelete(App::DocumentObject* obj) const override;
     bool setEdit(int ModNum) override;
     bool doubleClicked(void) override;
-
-public:
     void onChanged(const App::Property *prop) override;
     void handleChangedPropertyType(Base::XMLReader &reader, const char *TypeName, App::Property * prop) override;
     App::Color prefSectionColor(void);
     App::Color prefHighlightColor(void);
     int prefHighlightStyle(void);
 
-
     std::vector<App::DocumentObject*> claimChildren(void) const override;
+    void fixSceneDependencies();
 
     TechDraw::DrawViewPart* getViewObject() const override;
     TechDraw::DrawViewPart* getViewPart() const;


### PR DESCRIPTION
This PR addresses an issue where QGraphicsItems are not reparented correctly following an undo as reported here: https://forum.freecad.org/viewtopic.php?p=688817#p688817

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
