### PR TITLE
[TD]fix missing section svg hatch in pdf

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -288,7 +288,9 @@ void MDIViewPage::printPdf()
 
     Gui::WaitCursor wc;
     std::string utf8Content = fn.toUtf8().constData();
+    m_scene->setExporting(true);
     printPdf(utf8Content);
+    m_scene->setExporting(false);
 }
 
 void MDIViewPage::printPdf(std::string file)


### PR DESCRIPTION
This PR addresses a problem with SVG hatch of section face when exported to PDF as reported here: https://forum.freecad.org/viewtopic.php?t=79331&sid=3d4bcb889a053b48ef4da21f69518214

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
