### PR TITLE
Adjusted Appstream metadata component type and added launchable tag

### DIFF
--- a/src/XDGData/org.freecadweb.FreeCAD.appdata.xml.in
+++ b/src/XDGData/org.freecadweb.FreeCAD.appdata.xml.in
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
   <id>org.freecadweb.FreeCAD</id>
   <project_license>LGPL-2.1</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <developer_name>The FreeCAD Team</developer_name>
+  <launchable type="desktop-id">org.freecadweb.FreeCAD.desktop</launchable>
   <name>FreeCAD</name>
   <summary>An open source parametric 3D CAD modeler</summary>
   <description>


### PR DESCRIPTION
This fixes the following appstream warning and make program show up in the appstream data set:

asv-desktop-app-launchable-missing

This `desktop-application` component is missing a `desktop-id` launchable tag. This means that this application can not be launched and has no association with its desktop-entry file. It also means no icon data or category information from the desktop-entry file will be available, which will result in this application being ignored entirely.

Part of Debian FreeCAD edition since 2023.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR