### PR TITLE
Use python3 as the interpreter instead of python (ie v2)

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # SPDX-License-Identifier: LGPL-2.1-or-later
 # ***************************************************************************

--- a/src/Mod/Spreadsheet/importXLSX.py
+++ b/src/Mod/Spreadsheet/importXLSX.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #***************************************************************************
 #*   Copyright (c) 2016 Ulrich Brammer <ulrich1a@users.sourceforge.net>    *

--- a/src/Mod/TechDraw/TDTest/DLeaderRText.py
+++ b/src/Mod/TechDraw/TDTest/DLeaderRText.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # test script for TechDraw module

--- a/src/Mod/TechDraw/TDTest/DrawHatchTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawHatchTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 

--- a/src/Mod/TechDraw/TDTest/DrawViewDetailTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawViewDetailTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # test script for DrawViewDetail

--- a/src/Mod/TechDraw/TDTest/DrawViewPartTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawViewPartTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # basic test script for TechDraw module

--- a/src/Mod/TechDraw/TDTest/TDPyTest.py
+++ b/src/Mod/TechDraw/TDTest/TDPyTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # basic test script for TechDraw Py functions migrated from Drawing

--- a/src/Mod/Test/testmakeWireString.py
+++ b/src/Mod/Test/testmakeWireString.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2013 WandererFan <wandererfan@gmail.com>                *

--- a/src/Mod/Test/unittestgui.py
+++ b/src/Mod/Test/unittestgui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 GUI framework and application for use with Python unit testing framework.
 Execute tests written using the framework provided by the 'unittest' module.


### PR DESCRIPTION
This fixes lintian warning "unusual-interpreter".

Part of the Debian edition of FreeCAD since 2023.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR