### PR TITLE
Disable memory-check in SMDS because sysinfo.h is not working on BSD.

### DIFF
--- a/src/3rdParty/salomesmesh/src/SMDS/SMDS_Mesh.cpp
+++ b/src/3rdParty/salomesmesh/src/SMDS/SMDS_Mesh.cpp
@@ -61,13 +61,6 @@
 #include <iterator>
 using namespace std;
 
-#ifndef WIN32
-#if !(defined(__MACH__) && defined(__APPLE__))
-#include <sys/sysinfo.h>
-#endif
-#include <sys/wait.h>
-#endif
-
 // number of added entities to check memory after
 #define CHECKMEMORY_INTERVAL 100000
 
@@ -85,56 +78,7 @@ int SMDS_Mesh::chunkSize = 1024;
 
 int SMDS_Mesh::CheckMemory(const bool doNotRaise)
 {
-#if 0
-#if (defined(__MACH__) && defined(__APPLE__))
-        return 1000;
-#else
-#ifndef WIN32
-  struct sysinfo si;
-  int err = sysinfo( &si );
-  if ( err )
-    return -1;
-
-  const unsigned long Mbyte = 1024 * 1024;
-
-  static int limit = -1;
-  if ( limit < 0 ) {
-    int status = system("SMDS_MemoryLimit"); // it returns lower limit of free RAM
-    if (status >= 0 ) {
-      limit = WEXITSTATUS(status);
-    }
-    else {
-      double factor = ( si.totalswap == 0 ) ? 0.1 : 0.2;
-      limit = int(( factor * si.totalram * si.mem_unit ) / Mbyte );
-    }
-    if ( limit < 20 )
-      limit = 20;
-    else
-      limit = int ( limit * 1.5 );
-    MESSAGE ( "SMDS_Mesh::CheckMemory() memory limit = " << limit << " MB" );
-  }
-
-  // compute separately to avoid overflow
-  int freeMb =
-    ( si.freeram  * si.mem_unit ) / Mbyte +
-    ( si.freeswap * si.mem_unit ) / Mbyte;
-  //cout << "freeMb = " << freeMb << " limit = " << limit << endl;
-
-  if ( freeMb > limit )
-    return freeMb - limit;
-
-  if ( doNotRaise )
-    return 0;
-
-  MESSAGE ("SMDS_Mesh::CheckMemory() throws as free memory too low: " << freeMb <<" MB" );
-  throw std::bad_alloc();
-#else
-  return -1;
-#endif
-#endif
-#else
-  return 1000;
-#endif
+    return 1000;
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The SMDS memory check cause the build to fail on on BSD-systems. It would be better to disable it only on BSD-platforms, or use http://code.google.com/p/sysinfo-bsd/source/browse/sysinfo.c for them.

This fixes Debian bug https://bugs.debian.org/623560 .

Patch by Anton Gladky <gladk@debian.org>.

Been part of the Debian edition of FreeCAD since 2011.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR