### PR TITLE
Skip open_de9b3fb438 s390x to avoid OOM.

### DIFF
--- a/src/Mod/Fem/femtest/app/test_open.py
+++ b/src/Mod/Fem/femtest/app/test_open.py
@@ -25,6 +25,7 @@ __title__ = "Open files FEM App unit tests"
 __author__ = "Bernd Hahnebach"
 __url__ = "https://www.freecad.org"
 
+import platform
 import tempfile
 import unittest
 from os.path import join
@@ -128,6 +129,12 @@ class TestObjectOpen(unittest.TestCase):
     def test_femobjects_open_de9b3fb438(
         self
     ):
+        # migration modules fail on s390x (big endian) and trigger OOMs,
+        # https://bugs.debian.org/984952 and
+        # https://bugs.launchpad.net/ubuntu/+source/freecad/+bug/1918474.
+        if platform.machine() == "s390x":
+            return
+
         # the number in method name is the FreeCAD commit the document was created with
         # https://github.com/FreeCAD/FreeCAD/commit/de9b3fb438
         # the document was created by running the object create unit test


### PR DESCRIPTION
The load of the current file in test_open_head is fine, but open_de9b3fb438 goes into an OOM even in huge (e.g. 10GB) systemd. This probably needs a proper fix by upstream in regard to the migration modules that load the old code, but until then (since the rest works on s390x) this unblocks the package self-test in Debian & Ubuntu.

Patch by Christian Ehrhardt <christian.ehrhardt@canonical.com>.

This is Debian bug https://bugs.debian.org/984952 and Ubuntu bug https://bugs.launchpad.net/ubuntu/+source/freecad/+bug/1918474.

Been part of the Debian edition of FreeCAD since 2021.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR