### PR TITLE
Avoid dagerous move without tool height compensation while it is supposed to be active

### DIFF
--- a/src/Mod/Path/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/Path/Path/Post/scripts/fanuc_post.py
@@ -118,7 +118,7 @@ PRECISION = 3
 tapSpeed = 0
 
 # Preamble text will appear at the beginning of the GCODE output file.
-PREAMBLE = """G17 G54 G40 G49 G80 G90
+PREAMBLE = """G17 G54 G40 G80 G90
 """
 
 # Postamble text will appear following the last operation.
@@ -611,8 +611,11 @@ def parse(pathobj):
 
                 # add height offset
                 if USE_TLO:
+                    outstring.append("G49")
                     tool_height = "\nG43 H" + str(int(c.Parameters["T"]))
                     outstring.append(tool_height)
+                else:
+                    outstring.append("G49")
 
             if command == "message":
                 if OUTPUT_COMMENTS is False:

--- a/src/Mod/Path/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/Path/Path/Post/scripts/linuxcnc_post.py
@@ -110,7 +110,7 @@ CORNER_MAX = {"x": 500, "y": 300, "z": 300}
 PRECISION = 3
 
 # Preamble text will appear at the beginning of the GCODE output file.
-PREAMBLE = """G17 G54 G40 G49 G80 G90
+PREAMBLE = """G17 G54 G40 G80 G90
 """
 
 # Postamble text will appear following the last operation.
@@ -432,8 +432,11 @@ def parse(pathobj):
 
                 # add height offset
                 if USE_TLO:
+                    outstring.append("G49")
                     tool_height = "\nG43 H" + str(int(c.Parameters["T"]))
                     outstring.append(tool_height)
+                else:
+                    outstring.append("G49")
 
             if command == "message":
                 if OUTPUT_COMMENTS is False:

--- a/src/Mod/Path/Path/Post/scripts/mach3_mach4_post.py
+++ b/src/Mod/Path/Path/Post/scripts/mach3_mach4_post.py
@@ -110,7 +110,7 @@ CORNER_MAX = {"x": 500, "y": 300, "z": 300}
 PRECISION = 3
 
 # Preamble text will appear at the beginning of the GCODE output file.
-PREAMBLE = """G17 G54 G40 G49 G80 G90
+PREAMBLE = """G17 G54 G40 G80 G90
 """
 
 # Postamble text will appear following the last operation.
@@ -490,8 +490,11 @@ def parse(pathobj):
 
                 # add height offset
                 if USE_TLO:
+                    outstring.append("G49")
                     tool_height = "\nG43 H" + str(int(c.Parameters["T"]))
                     outstring.append(tool_height)
+                else:
+                    outstring.append("G49")
 
             if command == "message":
                 if OUTPUT_COMMENTS is False:

--- a/src/Mod/Path/Path/Post/scripts/uccnc_post.py
+++ b/src/Mod/Path/Path/Post/scripts/uccnc_post.py
@@ -65,7 +65,6 @@ Other (Stepcraft) machines using UC-CNC and UC* controllers should be easy to ad
 PREAMBLE_DEFAULT = """G17 (Default: XY-plane)
 G54 (Default: First coordinate system)
 G40 (Default: Cutter radius compensation none)
-G49 (Default: Tool Length Offsets: cancel tool length)
 G90 (Default: Absolute distance mode selection)
 G80 (Cancel canned cycle)
 """
@@ -73,7 +72,6 @@ G80 (Cancel canned cycle)
 PREAMBLE_DEFAULT_NO_COMMENT = """G17
 G54
 G40
-G49
 G90
 G80
 """
@@ -673,8 +671,11 @@ def parse(pathobj):
 
                 # add height offset
                 if USE_TLO:
+                    commandlist.append("G49")
                     tool_height = "\nG43 H" + str(int(c.Parameters["T"]))
                     commandlist.append(tool_height)
+                else:
+                    commnadlist.append("G49")
 
             if command == "message":
                 if OUTPUT_COMMENTS is False:


### PR DESCRIPTION
Changed all postprocessor using G43 to set tool height compensation after tool change to not set G49 before doing the first move to "safe" height after G54, as this would take an unexpected dive if the already active tool height was significant.

Fixes #9866.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR