### PR TITLE
Missing dependencies qwebengine5-dev and qtwayland5 in Ubuntu Docker install script

### DIFF
--- a/tools/build/Docker/ubuntu.sh
+++ b/tools/build/Docker/ubuntu.sh
@@ -12,4 +12,5 @@ apt-get install --no-install-recommends --yes build-essential cmake doxygen git 
     libvtk-dicom-dev libx11-dev libxerces-c-dev libxmu-dev libxmuu-dev \
     libzipios++-dev netgen netgen-headers pyside2-tools python3-dev \
     python3-matplotlib python3-pivy python3-ply python3-pyside2.qtsvg \
-    python3-pyside2.qtuitools qtchooser qttools5-dev shiboken2 swig
+    python3-pyside2.qtuitools qtchooser qttools5-dev shiboken2 swig \
+    qtwebengine5-dev qtwayland5


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

Missing dependencies qwebengine5-dev and qtwayland5 in Ubuntu Docker install script

Add missing dependencies qwebengine5-dev and qtwayland5 to Ubuntu Docker install script. Details are provided in the  issue #9869 

FreeCAD-forum user name: M4x

fixes #9869 
