### PR TITLE
Use python3 as the interpreter instead of python (ie v2) more places.

### DIFF
--- a/src/Mod/Mesh/App/MeshTestsApp.py
+++ b/src/Mod/Mesh/App/MeshTestsApp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #  Copyright (c) 2007 Jürgen Riegel <juergen.riegel@web.de>

--- a/src/Mod/Robot/KukaExporter.py
+++ b/src/Mod/Robot/KukaExporter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Kuka export lib (c) Jürgen Riegel 2009 LGPL 2.1 or higher

--- a/src/Mod/Robot/MovieTool.py
+++ b/src/Mod/Robot/MovieTool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import os,sys,string
 import FreeCAD,FreeCADGui,Robot,RobotGui
 


### PR DESCRIPTION
This fixes lintian warning "unusual-interpreter".

Part of the Debian edition of FreeCAD since 2023.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR.