### PR TITLE
Change Start page to no longer dial home by default.

### DIFF
--- a/src/Mod/Start/StartPage/StartPage.html
+++ b/src/Mod/Start/StartPage/StartPage.html
@@ -21,7 +21,8 @@
                 <li><a id="htab1" class="active" onClick="toggle('tab1')" href="#">T_DOCUMENTS</a></li>
                 <li><a id="htab2" onClick="toggle('tab2')" href="#">T_HELP</a></li>
                 <li><a id="htab3" onClick="toggle('tab3')" href="#">T_ACTIVITY</a></li>
-                <li><a id="htab4" onClick="toggle('tab4')" href="#">BLOG</a></li>
+                <li><a href="https://blog.freecad.org/" title="Link to the
+FreeCAD blog">BLOG</a></li>
             </ul>
             <div id="tab1" class="panel">
                 
@@ -157,11 +158,6 @@
                 </div>
 
             </div>
-
-            <div id="tab4" class="panel hidden iframecontainer">
-                <iframe src="https://blog.freecad.org/" title="Freecad Blog" class="iframe" ></iframe> 
-            </div>
-
         </div>
     </body>
 </html>


### PR DESCRIPTION
When starting FreeCAD for the first time, it load the HTML content of src/Mod/Start/StartPage/StartPage.html and show it as a friendly startup page. Unfortunately, one of the tabs in the startup page is an iframe loading the content of https://blog.freecadorg/.  The effect is that every time one start FreeCAD, it dial home over the Internet with a HTTP request to the mentioned URL.  This is a privacy problem.  At the moment the blog page in turn will connect to https//i0.wp.com/ and https//s0.wp.com/, in effect also reporting the startup to Wordpress.  Please do not dial out without the expressed approval and on request of the user of the program.

This patch change the startup page to instead of putting the blog posts in a tab, it will link to the blog and the connection is only established when the user click on 'BLOG' in the start page.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR.