### PR TITLE
Bug: Loaded Reinforcement WB translations along with Arch WB

### DIFF
--- a/src/Mod/Arch/InitGui.py
+++ b/src/Mod/Arch/InitGui.py
@@ -54,6 +54,13 @@ class ArchWorkbench(FreeCADGui.Workbench):
         import Arch_rc
         import Arch
 
+        # Load Reinforcement WB translations
+        try:
+            import RebarTools
+            RebarTools.load_translations()
+        except Exception:
+            pass
+
         from ArchStructure import _ArchStructureGroupCommand
         from ArchAxis import _ArchAxisGroupCommand
         from ArchPanel import CommandPanelGroup


### PR DESCRIPTION
Ticket:  https://github.com/FreeCAD/FreeCAD-translations/issues/224

### Output

Reinforcement workbench translations automatically loaded along with Arch Workbench 

<img width="931" alt="image" src="https://github.com/FreeCAD/FreeCAD/assets/10414959/3d75176b-e7b4-44e4-b01d-4c92799f93cb">


**Reference commit to Reinforcement WB**: https://github.com/amrit3701/FreeCAD-Reinforcement/commit/ade0085b3b1dac99afc353d246b903d814240315


---

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---