### PR TITLE
fix wrong filesystem encoding in GUI with Python 3.11 on Linux

### DIFF
--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -97,6 +97,7 @@ private:
 
 int main( int argc, char ** argv )
 {
+    setlocale(LC_ALL, ""); // use native environment settings
 #if defined (FC_OS_LINUX) || defined(FC_OS_BSD)
     // Make sure to setup the Qt locale system before setting LANG and LC_ALL to C.
     // which is needed to use the system locale settings.


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

The added initialization of the locales will prevent the wrong ascii-only filesystem encoding.

Further description of the problem, tracking down the cause and the solution can be seen at my topic in the forum:
https://forum.freecad.org/viewtopic.php?t=79192

I don't see a reason for the added line to break something. The same line I added has been in the main function of src/Main/MainCmd.cpp for more than 9 years.