### PR TITLE
set toolbar icon size when starting FreeCAD GUI from Python

### DIFF
--- a/src/Main/FreeCADGuiPy.cpp
+++ b/src/Main/FreeCADGuiPy.cpp
@@ -305,6 +305,12 @@ QWidget* setupMainWindow()
             mw->setWindowTitle(QString::fromLatin1(App::Application::Config()["ExeName"].c_str()));
         }
 
+        // set toolbar icon size
+        ParameterGrp::handle hGrp = Gui::WindowParameter::getDefaultParameter()->GetGroup("General");
+        int size = hGrp->GetInt("ToolbarIconSize", 0);
+        if (size >= 16) // must not be lower than this
+            mw->setIconSize(QSize(size,size));
+
         if (!SoDB::isInitialized()) {
             // init the Inventor subsystem
             SoDB::init();


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

When starting the FreeCAD GUI from a Python Interpreter (via `FreeCADGui.showMainWindow()`), some steps are missing in the function `setupMainWindow` compared to a normal start of FreeCAD. One of these missing steps is that the toolbar icon size is not set according to the user settings.
The added lines are copied from file src/Gui/Application.cpp and only slightly modified.

Ideas for further modifications are described in my topic in the FreeCAD forum:
https://forum.freecad.org/viewtopic.php?t=79283
