### PR TITLE
[TD]allow delete of dependents on delete of parent

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -314,17 +314,10 @@ bool ViewProviderViewPart::onDelete(const std::vector<std::string> &)
     // get child views
     auto viewSection = getViewObject()->getSectionRefs();
     auto viewDetail = getViewObject()->getDetailRefs();
-    auto viewLeader = getViewObject()->getLeaders();
-    auto viewDimension = getViewObject()->getDimensions();
-    auto viewBalloon = getViewObject()->getBalloons();
 
-    if (!viewDimension.empty() ||
-             !viewBalloon.empty() ||
-             !viewSection.empty() ||
-             !viewDetail.empty() ||
-             !viewLeader.empty()) {
+    if (!viewSection.empty() || !viewDetail.empty()) {
         bodyMessageStream << qApp->translate("Std_Delete",
-            "You cannot delete this view because it has one or more dependent objects that would become broken.");
+            "You cannot delete this view because it has one or more dependent views that would become broken.");
         QMessageBox::warning(Gui::getMainWindow(),
             qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,
             QMessageBox::Ok);


### PR DESCRIPTION
- deleting a dvp will now delete any hatches, dimensions or balloons belonging to it.
- deleting a dvp that is the base view for a section or detail is still blocked.
- https://forum.freecad.org/viewtopic.php?t=79548
- 
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
