### PR TITLE
Gui: Add rotation center indicator

### DIFF
--- a/src/Gui/DlgSettingsNavigation.cpp
+++ b/src/Gui/DlgSettingsNavigation.cpp
@@ -86,6 +86,7 @@ void DlgSettingsNavigation::saveSettings()
     ui->checkBoxZoomAtCursor->onSave();
     ui->checkBoxInvertZoom->onSave();
     ui->checkBoxDisableTilt->onSave();
+    ui->checkBoxShowRotationCenter->onSave();
     ui->spinBoxZoomStep->onSave();
     ui->checkBoxUseAutoRotation->onSave();
     ui->qspinNewDocScale->onSave();
@@ -122,6 +123,7 @@ void DlgSettingsNavigation::loadSettings()
     ui->checkBoxZoomAtCursor->onRestore();
     ui->checkBoxInvertZoom->onRestore();
     ui->checkBoxDisableTilt->onRestore();
+    ui->checkBoxShowRotationCenter->onRestore();
     ui->spinBoxZoomStep->onRestore();
     ui->checkBoxUseAutoRotation->onRestore();
     ui->qspinNewDocScale->onRestore();

--- a/src/Gui/DlgSettingsNavigation.ui
+++ b/src/Gui/DlgSettingsNavigation.ui
@@ -615,6 +615,25 @@ Mouse tilting is not disabled by this setting.</string>
         </property>
        </widget>
       </item>
+      <item row="9" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBoxShowRotationCenter">
+        <property name="toolTip">
+         <string>Show the rotation center when dragging.</string>
+        </property>
+        <property name="text">
+         <string>Enable rotation center indication</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowRotationCenter</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -1031,6 +1031,11 @@ void NavigationStyle::saveCursorPosition(const SoEvent * const ev)
     this->globalPos.setValue(QCursor::pos().x(), QCursor::pos().y());
     this->localPos = ev->getPosition();
 
+    // mode is WindowCenter
+    if (!PRIVATE(this)->rotationCenterMode) {
+        setRotationCenter(getFocalPoint());
+    }
+
     //Option to get point on model (slow) or always on focal plane (fast)
     //
     // mode is ScenePointAtCursor to get exact point if possible

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -862,10 +862,9 @@ void NavigationStyle::doRotate(SoCamera * camera, float angle, const SbVec2f& po
 
 }
 
-SbVec3f NavigationStyle::getRotationCenter(SbBool* ok) const
+SbVec3f NavigationStyle::getRotationCenter(SbBool& found) const
 {
-    if (ok)
-        *ok = PRIVATE(this)->rotationCenterFound;
+    found = PRIVATE(this)->rotationCenterFound;
     return PRIVATE(this)->rotationCenter;
 }
 
@@ -1412,12 +1411,14 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
     case DRAGGING:
         // Set up initial projection point for the projector object when
         // first starting a drag operation.
+        viewer->showRotationCenter(true);
         this->spinprojector->project(this->lastmouseposition);
         this->interactiveCountInc();
         this->clearLog();
         break;
 
     case SPINNING:
+        viewer->showRotationCenter(true);
         this->interactiveCountInc();
         viewer->getSoRenderManager()->scheduleRedraw();
         break;
@@ -1442,6 +1443,8 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
     switch (oldmode) {
     case SPINNING:
     case DRAGGING:
+        viewer->showRotationCenter(false);
+        [[fallthrough]];
     case PANNING:
     case ZOOMING:
     case BOXZOOM:

--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -172,6 +172,8 @@ public:
     void setOrbitStyle(OrbitStyle style);
     OrbitStyle getOrbitStyle() const;
 
+    SbVec3f getRotationCenter(SbBool&) const;
+
 protected:
     void initialize();
     void finalize();
@@ -187,7 +189,6 @@ protected:
     SbBool seekToPoint(const SbVec2s screenpos);
     void seekToPoint(const SbVec3f& scenepos);
     SbBool lookAtPoint(const SbVec2s screenpos);
-    SbVec3f getRotationCenter(SbBool*) const;
 
     void reorientCamera(SoCamera * camera, const SbRotation & rot);
     void panCamera(SoCamera * camera,

--- a/src/Gui/PreferencePackTemplates/View.cfg
+++ b/src/Gui/PreferencePackTemplates/View.cfg
@@ -18,6 +18,7 @@
           <FCInt Name="CornerCoordSystemSize" Value="10"/>
           <FCBool Name="CheckBoxSelectionCheckBoxes" Value="1"/>
           <FCBool Name="InvertZoom" Value="1"/>
+          <FCBool Name="ShowRotationCenter" Value="1"/>
           <FCInt Name="NaviStepByTurn" Value="8"/>
           <FCText Name="NavigationStyle">Gui::CADNavigationStyle</FCText>
           <FCInt Name="OrbitStyle" Value="1"/>

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1278,7 +1278,11 @@ void View3DInventorViewer::showRotationCenter(bool show)
     SoNode* scene = getSceneGraph();
     auto sep = static_cast<SoSeparator*>(scene);
 
-    if (show) {
+    bool showEnabled = App::GetApplication()
+                           .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+                           ->GetBool("ShowRotationCenter", true);
+
+    if (show && showEnabled) {
         SbBool found;
         SbVec3f center = navigation->getRotationCenter(found);
 

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -413,6 +413,8 @@ public:
     void setAxisCross(bool b);
     bool hasAxisCross();
 
+    void showRotationCenter(bool show);
+
     void setEnabledFPSCounter(bool b);
     void setEnabledNaviCube(bool b);
     bool isEnabledNaviCube() const;
@@ -508,6 +510,8 @@ private:
     // big one in the middle
     SoShapeScale* axisCross;
     SoGroup* axisGroup;
+
+    SoGroup* rotationCenterGroup;
 
     //stuff needed to draw the fps counter
     bool fpsEnabled;


### PR DESCRIPTION
- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
Adds an option to show the rotation center while dragging. I personally like to see the center of rotation while dragging, maybe other people like it too. Besides, it could be useful for finding problems regarding the rotation center.

https://github.com/FreeCAD/FreeCAD/assets/14298143/ab540721-3a36-41bd-a7a1-252a301b8b00

