### PR TITLE
OpenSCAD: a test internally uses the DXF importer

### DIFF
--- a/src/Mod/OpenSCAD/OpenSCADTest/app/test_importCSG.py
+++ b/src/Mod/OpenSCAD/OpenSCADTest/app/test_importCSG.py
@@ -121,6 +121,10 @@ class TestImportCSG(unittest.TestCase):
         FreeCAD.closeDocument(doc.Name)
 
     def test_import_text(self):
+        # This uses the DXF importer that may pop-up modal dialogs
+        # if not all 3rd party libraries are installed
+        if FreeCAD.GuiUp:
+            return
         try:
             doc = self.utility_create_scad("text(\"X\");","text") # Keep it short to keep the test fast-ish
             text = doc.getObject("text")


### PR DESCRIPTION
If not all 3rd party packages are installed the DXF importer opens a modal dialog and blocks the tests

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
