### PR TITLE
Addon Manager: Fix #9828, hang on no internet

### DIFF
--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -402,7 +402,11 @@ def blocking_get(url: str, method=None) -> bytes:
     if fci.FreeCADGui and method is None or method == "networkmanager":
         NetworkManager.InitializeNetworkManager()
         p = NetworkManager.AM_NETWORK_MANAGER.blocking_get(url)
-        p = p.data()
+        if p:
+            try:
+                p = p.data()
+            except AttributeError:
+                pass
     elif requests and method is None or method == "requests":
         response = requests.get(url)
         if response.status_code == 200:


### PR DESCRIPTION
Add some error checking to ensure valid results are returned by blocking_get.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR