### PR TITLE
Draft: Fix get_diffuse_color function

### DIFF
--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -346,8 +346,6 @@ removeHidden = remove_hidden
 
 def get_diffuse_color(objs):
     """Get a (cumulative) diffuse color from one or more objects.
-    Part::Feature objects are processed. Objects with Groups are recursively
-    checked for those objects.
 
     If all tuples in the result are identical a list with a single tuple is
     returned. In theory all faces of an object can be set to the same diffuse
@@ -364,7 +362,49 @@ def get_diffuse_color(objs):
         The list will be empty if no valid object is found.
     """
     def _get_color(obj):
-        if obj.isDerivedFrom("Part::Feature"):
+        if hasattr(obj, "ColoredElements"):
+            if hasattr(obj, "Count") or hasattr(obj, "ElementCount"):
+                # Link and Link array.
+                if hasattr(obj, "Count"):
+                    count = obj.Count
+                    base = obj.Base
+                else:
+                    count = obj.ElementCount if obj.ElementCount > 0 else 1
+                    base = obj.LinkedObject
+                if base is None:
+                    return []
+                cols = _get_color(base) * count
+                if obj.ColoredElements is None:
+                    return cols
+                face_num = len(base.Shape.Faces)
+                for elm, overide in zip(obj.ColoredElements[1], obj.ViewObject.OverrideColorList):
+                    if "Face" in elm: # Examples: "Face3" and "1.Face6". Int before "." is zero-based, other int is 1-based.
+                        if "." in elm:
+                            elm0, elm1 = elm.split(".")
+                            i = (int(elm0) * face_num) + int(elm1[4:]) - 1
+                            cols[i] = overide
+                        else:
+                            i = int(elm[4:]) - 1
+                            for j in range(count):
+                                cols[(j * face_num) + i] = overide
+                return cols
+            elif hasattr(obj, "ElementList"):
+                # LinkGroup
+                cols = []
+                for sub in obj.ElementList:
+                    sub_cols = _get_color(sub)
+                    if obj.ColoredElements is None:
+                        cols += sub_cols
+                    else:
+                        for elm, overide in zip(obj.ColoredElements[1], obj.ViewObject.OverrideColorList):
+                            if sub.Name + ".Face" in elm:
+                                i = int(elm[(len(sub.Name) + 5):]) - 1
+                                sub_cols[i] = overide
+                        cols += sub_cols
+                return cols
+            else:
+                return []
+        elif hasattr(obj.ViewObject, "DiffuseColor"):
             if len(obj.ViewObject.DiffuseColor) == len(obj.Shape.Faces):
                 return obj.ViewObject.DiffuseColor
             else:
@@ -382,7 +422,8 @@ def get_diffuse_color(objs):
     if not isinstance(objs, list):
         # Quick check to avoid processing a single object:
         obj = objs
-        if obj.isDerivedFrom("Part::Feature") \
+        if not hasattr(obj, "ColoredElements") \
+                and hasattr(obj.ViewObject, "DiffuseColor") \
                 and (len(obj.ViewObject.DiffuseColor) == 1 \
                         or len(obj.ViewObject.DiffuseColor) == len(obj.Shape.Faces)):
             return obj.ViewObject.DiffuseColor

--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -35,6 +35,7 @@ to execute the instructions stored in internal lists.
 # \brief Provides the ToDo static class to run commands with a time delay.
 
 import traceback
+import sys
 import PySide.QtCore as QtCore
 
 import FreeCAD as App


### PR DESCRIPTION
The get_diffuse_color function wrongly assumed that all Part::Feature objects have a DiffuseColor property. Added handling of objects with a ColoredElements property (Link, Link array, LinkGroup).

Fixes #9900.

Additionally: While debugging found a missing import in todo.py.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
