### PR TITLE
App/Toponaming: Tweak ComplexGeoData destructor

### DIFF
--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -60,8 +60,6 @@ ComplexGeoData::ComplexGeoData()
 {
 }
 
-ComplexGeoData::~ComplexGeoData() = default;
-
 Data::Segment* ComplexGeoData::getSubElementByName(const char* name) const
 {
     int index = 0;

--- a/src/App/ComplexGeoData.h
+++ b/src/App/ComplexGeoData.h
@@ -85,7 +85,7 @@ public:
     /// Constructor
     ComplexGeoData();
     /// Destructor
-    ~ComplexGeoData() override;
+    virtual ~ComplexGeoData() = default;
 
     /** @name Sub-element management */
     //@{


### PR DESCRIPTION
MSVC seems to prefer this destructor: in debug mode on Windows I get a segmentation fault on the destruction of a shared_ptr with the original code, and this eliminates the problem. @wwmayer do you have any insight?

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR