### PR TITLE
Fix boost 1.78 workaround

### DIFF
--- a/src/boost_regex.hpp
+++ b/src/boost_regex.hpp
@@ -10,6 +10,7 @@
 #   define NOMINMAX
 #  endif
 #  include <Windows.h>
+#  undef BASETYPES
 # endif
 #endif
 


### PR DESCRIPTION
I had to add this in order to get FreeCAD to compile on windows with conda and boost 1.78
see https://forum.freecad.org/viewtopic.php?t=79268 and https://github.com/boostorg/regex/blob/boost-1.78.0/include/boost/regex/v5/w32_regex_traits.hpp#L119-L236

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
