### PR TITLE
[Core] Warn user if using deprecated backup extension

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2518,6 +2518,17 @@ void Application::setStyleSheet(const QString& qssFile, bool tiledBackground)
     }
 }
 
+void Application::checkForDeprecatedSettings()
+{
+    // From 0.21, `FCBak` will be the intended default backup format
+    // TODO: Check for `FCStd#` and warn user.
+    bool useFCBakExtension = App::GetApplication().GetParameterGroupByPath
+        ("User parameter:BaseApp/Preferences/Document")->GetBool("UseFCBakExtension", true);
+    if (!useFCBakExtension) {
+        Base::Console().Warning("`.FCStd#` backup format is deprecated from 0.21 and may be removed in future versions. Please use `.FCBak` instead.\n");
+    }
+}
+
 void Application::checkForPreviousCrashes()
 {
     try {

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -192,6 +192,8 @@ public:
 
     /// true when the application shutting down
     bool isClosing();
+
+    void checkForDeprecatedSettings();
     void checkForPreviousCrashes();
 
     /** @name workbench handling */

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1448,6 +1448,9 @@ void MainWindow::delayedStartup()
         return;
     }
 
+    // TODO: Check for deprecated settings
+    Application::Instance->checkForDeprecatedSettings();
+
     // Create new document?
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("Document");
     if (hGrp->GetBool("CreateNewDoc", false)) {


### PR DESCRIPTION
A minimal version of #9668. Only warns the user to manually change the backup system to `FCBak`.

#9668 fails only in the github CI (outside of tests), and only with the commit not included here.