### PR TITLE
Gui: Improve object center rotation mode

### DIFF
--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -1078,8 +1078,9 @@ void NavigationStyle::saveCursorPosition(const SoEvent * const ev)
         if (!cam) // no camera
             return;
 
+        // Get the bounding box center of the physical object group
         SoGetBoundingBoxAction action(viewer->getSoRenderManager()->getViewportRegion());
-        action.apply(viewer->getSceneGraph());
+        action.apply(viewer->objectGroup);
         SbBox3f boundingBox = action.getBoundingBox();
         SbVec3f boundingBoxCenter = boundingBox.getCenter();
         setRotationCenter(boundingBoxCenter);

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -332,6 +332,7 @@ View3DInventorViewer::View3DInventorViewer(QWidget* parent, const QtGLWidget* sh
     : Quarter::SoQTQuarterAdaptor(parent, sharewidget)
     , SelectionObserver(false, ResolveMode::NoResolve)
     , editViewProvider(nullptr)
+    , objectGroup(nullptr)
     , navigation(nullptr)
     , renderType(Native)
     , framebuffer(nullptr)
@@ -350,6 +351,7 @@ View3DInventorViewer::View3DInventorViewer(const QtGLFormat& format, QWidget* pa
     : Quarter::SoQTQuarterAdaptor(format, parent, sharewidget)
     , SelectionObserver(false, ResolveMode::NoResolve)
     , editViewProvider(nullptr)
+    , objectGroup(nullptr)
     , navigation(nullptr)
     , renderType(Native)
     , framebuffer(nullptr)
@@ -477,6 +479,11 @@ void View3DInventorViewer::init()
     pcEditingRoot->addChild(pcEditingTransform);
     pcViewProviderRoot->addChild(pcEditingRoot);
 
+    // Create group for the physical object
+    objectGroup = new SoGroup();
+    objectGroup->ref();
+    pcViewProviderRoot->addChild(objectGroup);
+
     // Set our own render action which show a bounding box if
     // the SoFCSelection::BOX style is set
     //
@@ -564,6 +571,8 @@ View3DInventorViewer::~View3DInventorViewer()
     coinRemoveAllChildren(this->pcViewProviderRoot);
     this->pcViewProviderRoot->unref();
     this->pcViewProviderRoot = nullptr;
+    this->objectGroup->unref();
+    this->objectGroup = nullptr;
     this->backlight->unref();
     this->backlight = nullptr;
 
@@ -754,8 +763,15 @@ void View3DInventorViewer::addViewProvider(ViewProvider* pcProvider)
     SoSeparator* root = pcProvider->getRoot();
 
     if (root) {
-        if(pcProvider->canAddToSceneGraph())
-            pcViewProviderRoot->addChild(root);
+        if (pcProvider->canAddToSceneGraph()) {
+            // Add to the physical object group if related to the physical object otherwise add to the scene graph
+            if (pcProvider->isPartOfPhysicalObject()) {
+                objectGroup->addChild(root);
+            }
+            else {
+                pcViewProviderRoot->addChild(root);
+            }
+        }
         _ViewProviderMap[root] = pcProvider;
     }
 
@@ -779,9 +795,15 @@ void View3DInventorViewer::removeViewProvider(ViewProvider* pcProvider)
     SoSeparator* root = pcProvider->getRoot();
 
     if (root) {
-        int index = pcViewProviderRoot->findChild(root);
-        if(index>=0)
+        int index = objectGroup->findChild(root);
+        if (index >= 0) {
+            objectGroup->removeChild(index);
+        }
+
+        index = pcViewProviderRoot->findChild(root);
+        if (index >= 0) {
             pcViewProviderRoot->removeChild(index);
+        }
         _ViewProviderMap.erase(root);
     }
 

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -483,7 +483,10 @@ private:
     SoSeparator * foregroundroot;
     SoDirectionalLight* backlight;
 
+    // Scene graph root
     SoSeparator * pcViewProviderRoot;
+    // Child group in the scene graph that contains view providers related to the physical object
+    SoGroup* objectGroup;
 
     std::unique_ptr<View3DInventorSelection> inventorSelection;
 

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -142,6 +142,8 @@ public:
     virtual SoSeparator* getBackRoot() const;
     ///Indicate whether to be added to scene graph or not
     virtual bool canAddToSceneGraph() const {return true;}
+    // Indicate whether to be added to object group (true) or only to scene graph (false)
+    virtual bool isPartOfPhysicalObject() const {return true;}
 
     /** deliver the children belonging to this object
       * this method is used to deliver the objects to

--- a/src/Gui/ViewProviderMeasureDistance.cpp
+++ b/src/Gui/ViewProviderMeasureDistance.cpp
@@ -120,6 +120,11 @@ ViewProviderMeasureDistance::~ViewProviderMeasureDistance()
     pLines->unref();
 }
 
+bool ViewProviderMeasureDistance::isPartOfPhysicalObject() const
+{
+    return false;
+}
+
 void ViewProviderMeasureDistance::onChanged(const App::Property* prop)
 {
     if (prop == &Mirror || prop == &DistFactor) {
@@ -311,6 +316,11 @@ ViewProviderPointMarker::~ViewProviderPointMarker()
 {
     pCoords->unref();
     pMarker->unref();
+}
+
+bool ViewProviderPointMarker::isPartOfPhysicalObject() const
+{
+    return false;
 }
 
 void ViewProviderMeasureDistance::measureDistanceCallback(void * ud, SoEventCallback * n)

--- a/src/Gui/ViewProviderMeasureDistance.h
+++ b/src/Gui/ViewProviderMeasureDistance.h
@@ -66,6 +66,7 @@ class GuiExport ViewProviderPointMarker : public ViewProviderDocumentObject
 public:
     ViewProviderPointMarker();
     ~ViewProviderPointMarker() override;
+    bool isPartOfPhysicalObject() const override;
 
 protected:
     SoCoordinate3    * pCoords;
@@ -81,6 +82,7 @@ public:
     /// Constructor
     ViewProviderMeasureDistance();
     ~ViewProviderMeasureDistance() override;
+    bool isPartOfPhysicalObject() const override;
 
     // Display properties
     App::PropertyColor          TextColor;


### PR DESCRIPTION
- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
---
This is my attempt to fix #9911. I created a group in `pcViewProviderRoot` called `objectGroup` which contains basically everything that is allowed to affect the rotation center. Things that should not affect the rotation center are directly added as a child of `pcViewProviderRoot`. The axis cross is directly added to `pcViewProviderRoot` and should no longer affect the rotation center. I also excluded the measure distance tool from `objectGroup` because I think it could affect the rotation center too much in some cases.

I am not sure if this is the best way to fix the object center rotation mode but I think it is a step in the right direction. If there is a better way to fix this or if there are more things that should be excluded from the `objectGroup` please let me know.

This PR does not depend on #9909 but I recommend it for testing.
