### PR TITLE
App/Toponaming: Fix Python 3.11 compile issue

### DIFF
--- a/src/App/StringHasher.h
+++ b/src/App/StringHasher.h
@@ -23,6 +23,8 @@
 #ifndef APP_STRING_ID_H
 #define APP_STRING_ID_H
 
+#include <FCConfig.h>
+
 #include <bitset>
 #include <memory>
 


### PR DESCRIPTION
Need to ensure the Qt 'slots' macro is undefined by including FCConfig.h.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR