### PR TITLE
[Bugfix]Gui: detach field sensor of draggers and handle post-call of callbacks

### DIFF
--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -128,7 +128,8 @@ TDragger::TDragger()
 
 TDragger::~TDragger()
 {
-
+    fieldSensor.setData(nullptr);
+    fieldSensor.detach();
 }
 
 void TDragger::buildFirstInstance()
@@ -216,9 +217,12 @@ void TDragger::fieldSensorCB(void *f, SoSensor *)
 {
     auto sudoThis = static_cast<TDragger *>(f);
 
-  SbMatrix matrix = sudoThis->getMotionMatrix(); // clazy:exclude=rule-of-two-soft
-  sudoThis->workFieldsIntoTransform(matrix);
-  sudoThis->setMotionMatrix(matrix);
+    if(!f)
+      return;
+
+    SbMatrix matrix = sudoThis->getMotionMatrix(); // clazy:exclude=rule-of-two-soft
+    sudoThis->workFieldsIntoTransform(matrix);
+    sudoThis->setMotionMatrix(matrix);
 }
 
 void TDragger::valueChangedCB(void *, SoDragger *d)
@@ -402,7 +406,8 @@ RDragger::RDragger()
 
 RDragger::~RDragger()
 {
-
+    fieldSensor.setData(nullptr);
+    fieldSensor.detach();
 }
 
 void RDragger::buildFirstInstance()
@@ -488,9 +493,12 @@ void RDragger::fieldSensorCB(void *f, SoSensor *)
 {
     auto sudoThis = static_cast<RDragger *>(f);
 
-  SbMatrix matrix = sudoThis->getMotionMatrix(); // clazy:exclude=rule-of-two-soft
-  sudoThis->workFieldsIntoTransform(matrix);
-  sudoThis->setMotionMatrix(matrix);
+    if(!f)
+      return;
+
+    SbMatrix matrix = sudoThis->getMotionMatrix(); // clazy:exclude=rule-of-two-soft
+    sudoThis->workFieldsIntoTransform(matrix);
+    sudoThis->setMotionMatrix(matrix);
 }
 
 void RDragger::valueChangedCB(void *, SoDragger *d)


### PR DESCRIPTION
This is an attempt to fix #9465 

I can't test at all (no Mac) but AFAIK nobody really can as this only happens on prebuilt versions, and not on own build ones.
So at some time, only way to test may be to merge and see. :smile:

I did this because the reported framestack makes me think to symptoms of a Coin sensor that wouldn't be correctly detached.
Looking at the code, I indeed found the `fieldSensor` of `TDragger` and `RDragger` to not be detached.*They now are detached in instance dtor.

As sensor data is instance itself (`this`) and because Coin can still call the static callback after the instance is destructed, I make sure to nullify the sensor data in dtor and check for it being not null in sensor callback.

:crossed_fingers: for Mac users :rofl: 