### PR TITLE
[TD]reduce number of tiles for svg hatching

### DIFF
--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -303,6 +303,7 @@ double Preferences::GapASME()
     return factor;
 }
 
+//! current setting for reporting progress of HLR/face finding
 bool Preferences::reportProgress()
 {
     return getPreferenceGroup("General")->GetBool("ReportProgress", false);
@@ -318,11 +319,13 @@ void Preferences::lightOnDark(bool state)
     getPreferenceGroup("Colors")->SetBool("LightOnDark", state);
 }
 
+//! current setting (on/off) for monochrome display
 bool Preferences::monochrome()
 {
     return getPreferenceGroup("Colors")->GetBool("Monochrome", false);
 }
 
+//! set monochrome display on/off
 void Preferences::monochrome(bool state)
 {
     Base::Console().Message("Pref::useLightText - set to %d\n", state);
@@ -336,6 +339,8 @@ App::Color Preferences::lightTextColor()
     return result;
 }
 
+//! attempt to lighten the give color
+// not currently used
 App::Color Preferences::lightenColor(App::Color orig)
 {
     // get component colours on [0, 255]
@@ -366,6 +371,7 @@ App::Color Preferences::lightenColor(App::Color orig)
     return App::Color(redF, greenF, blueF, orig.a);
 }
 
+//! color to use for monochrome display
 App::Color Preferences::getAccessibleColor(App::Color orig)
 {
     if (Preferences::lightOnDark() && Preferences::monochrome()) {
@@ -377,12 +383,22 @@ App::Color Preferences::getAccessibleColor(App::Color orig)
     return orig;
 }
 
+//! automatic correction of dimension references on/off
 bool Preferences::autoCorrectDimRefs()
 {
     return getPreferenceGroup("Dimensions")->GetBool("AutoCorrectRefs", true);
 }
 
+//! number of times to clean the output edges from HLR
 int Preferences::scrubCount()
 {
     return getPreferenceGroup("General")->GetInt("ScrubCount", 0);
 }
+
+//! Returns the factor for the overlap of svg tiles when hatching faces
+double Preferences::svgHatchFactor()
+{
+    double factor = getPreferenceGroup("Decorations")->GetFloat("SvgOverlapFactor", 1.25);
+    return factor;
+}
+

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -102,6 +102,8 @@ public:
 
     static bool autoCorrectDimRefs();
     static int scrubCount();
+
+    static double svgHatchFactor();
 };
 
 }//end namespace TechDraw


### PR DESCRIPTION
This PR is a follow-on to  #9985.  It reduces the number of svg tiles used to create the face overlay.  Additional detail here: https://forum.freecad.org/viewtopic.php?t=79823

- reduce the size of the overlay area from 200% to an adjustable size with a default of 125%.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
