### PR TITLE
fix use ccache by default on most systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,12 @@ if (POLICY CMP0072)
     set(OpenGL_GL_PREFERENCE LEGACY)
 endif(POLICY CMP0072)
 
+if (BUILD_WITH_CONDA AND WIN32)
+    option(FREECAD_USE_CCACHE "Auto detect and use ccache during compilation" OFF)
+else()
+    option(FREECAD_USE_CCACHE "Auto detect and use ccache during compilation" ON)
+endif()
+
 if(FREECAD_USE_CCACHE)
     find_program(CCACHE_PROGRAM ccache)  #This check should occur before project()
     if(CCACHE_PROGRAM)

--- a/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
+++ b/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
@@ -20,11 +20,6 @@ macro(InitializeFreeCADBuildOptions)
     else()
         option(FREECAD_USE_QT_FILEDIALOG "Use Qt's file dialog instead of the native one." ON)
     endif()
-    if (BUILD_WITH_CONDA AND WIN32)
-        option(FREECAD_USE_CCACHE "Auto detect and use ccache during compilation" OFF)
-    else()
-        option(FREECAD_USE_CCACHE "Auto detect and use ccache during compilation" ON)
-    endif()
 
     # == Win32 is default behaviour use the LibPack copied in Source tree ==========
     if(MSVC)


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---


to fix my mistake at #9950 I had tested that one locally and ccache was working but turns out it was because in my system ccache's binaries have higher priority in path than the true compiler anyways.