### PR TITLE
[Pref] Change the default of 'Save thumbnail on doc save'

### DIFF
--- a/src/Gui/AutoSaver.cpp
+++ b/src/Gui/AutoSaver.cpp
@@ -161,7 +161,7 @@ void AutoSaver::saveDocument(const std::string& name, AutoSaveProperty& saver)
         // associated 3d view is not active
         Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetParameterGroupByPath
             ("User parameter:BaseApp/Preferences/Document");
-        bool save = hGrp->GetBool("SaveThumbnail",false);
+        bool save = hGrp->GetBool("SaveThumbnail",true);
         hGrp->SetBool("SaveThumbnail",false);
 
         getMainWindow()->showMessage(tr("Please wait until the AutoRecovery file has been saved..."), 5000);

--- a/src/Gui/DlgSettingsDocument.ui
+++ b/src/Gui/DlgSettingsDocument.ui
@@ -340,6 +340,9 @@ automatically run a file recovery when it is started.</string>
           <property name="toolTip">
            <string>A thumbnail will be stored when document is saved</string>
           </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
           <property name="text">
            <string>Save thumbnail into project file when saving document</string>
           </property>

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1350,7 +1350,7 @@ void Document::Save (Base::Writer &writer) const
         writer.addFile("GuiDocument.xml", this);
 
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document");
-        if (hGrp->GetBool("SaveThumbnail", false)) {
+        if (hGrp->GetBool("SaveThumbnail", true)) {
             int size = hGrp->GetInt("ThumbnailSize", 128);
             size = Base::clamp<int>(size, 64, 512);
             std::list<MDIView*> mdi = getMDIViews();


### PR DESCRIPTION
Change the default state of the setting 'Save thumbnail on doc save' to true.
With this the thumbnail is saved by default.

@sliptonic 

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
