### PR TITLE
[Notif area] Fixes and disable for 0.21

### DIFF
--- a/src/Gui/DlgSettingsNotificationArea.cpp
+++ b/src/Gui/DlgSettingsNotificationArea.cpp
@@ -41,35 +41,24 @@ DlgSettingsNotificationArea::DlgSettingsNotificationArea(QWidget* parent)
     ui->setupUi(this);
 
     connect(ui->NotificationAreaEnabled, &QCheckBox::stateChanged, [this](int state) {
-        if (state == Qt::CheckState::Checked) {
-            ui->NonIntrusiveNotificationsEnabled->setEnabled(true);
-            ui->maxDuration->setEnabled(true);
-            ui->maxDuration->setEnabled(true);
-            ui->minDuration->setEnabled(true);
-            ui->maxNotifications->setEnabled(true);
-            ui->maxWidgetMessages->setEnabled(true);
-            ui->autoRemoveUserNotifications->setEnabled(true);
-            ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->setEnabled(true);
-            ui->preventNonIntrusiveNotificationsWhenWindowNotActive->setEnabled(true);
-            ui->developerErrorSubscriptionEnabled->setEnabled(true);
-            ui->developerWarningSubscriptionEnabled->setEnabled(true);
+        bool enabled = state == Qt::CheckState::Checked;
+
+        ui->NonIntrusiveNotificationsEnabled->setEnabled(enabled);
+        ui->maxDuration->setEnabled(enabled);
+        ui->maxDuration->setEnabled(enabled);
+        ui->minDuration->setEnabled(enabled);
+        ui->maxNotifications->setEnabled(enabled);
+        ui->maxWidgetMessages->setEnabled(enabled);
+        ui->autoRemoveUserNotifications->setEnabled(enabled);
+        ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->setEnabled(enabled);
+        ui->preventNonIntrusiveNotificationsWhenWindowNotActive->setEnabled(enabled);
+        ui->developerErrorSubscriptionEnabled->setEnabled(enabled);
+        ui->developerWarningSubscriptionEnabled->setEnabled(enabled);
+        if (enabled) {
             QMessageBox::information(this,
                                      tr("Notification Area"),
                                      tr("Activation of the Notification Area only takes effect "
                                         "after an application restart."));
-        }
-        else {
-            ui->NonIntrusiveNotificationsEnabled->setEnabled(false);
-            ui->maxDuration->setEnabled(false);
-            ui->maxDuration->setEnabled(false);
-            ui->minDuration->setEnabled(false);
-            ui->maxNotifications->setEnabled(false);
-            ui->maxWidgetMessages->setEnabled(false);
-            ui->autoRemoveUserNotifications->setEnabled(false);
-            ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->setEnabled(false);
-            ui->preventNonIntrusiveNotificationsWhenWindowNotActive->setEnabled(false);
-            ui->developerErrorSubscriptionEnabled->setEnabled(false);
-            ui->developerWarningSubscriptionEnabled->setEnabled(false);
             // N.B: Deactivation is handled by the Notification Area itself, as it listens to all
             // its configuration parameters.
         }

--- a/src/Gui/DlgSettingsNotificationArea.cpp
+++ b/src/Gui/DlgSettingsNotificationArea.cpp
@@ -41,18 +41,12 @@ DlgSettingsNotificationArea::DlgSettingsNotificationArea(QWidget* parent)
     ui->setupUi(this);
 
     adaptUiToAreaEnabledState(ui->NotificationAreaEnabled->isChecked());
-
     connect(ui->NotificationAreaEnabled, &QCheckBox::stateChanged, [this](int state) {
         bool enabled = state == Qt::CheckState::Checked;
         this->adaptUiToAreaEnabledState(enabled);
 
         if (enabled) {
-            QMessageBox::information(this,
-                                     tr("Notification Area"),
-                                     tr("Activation of the Notification Area only takes effect "
-                                        "after an application restart."));
-            // N.B: Deactivation is handled by the Notification Area itself, as it listens to all
-            // its configuration parameters.
+            this->requireRestart();
         }
     });
 }

--- a/src/Gui/DlgSettingsNotificationArea.cpp
+++ b/src/Gui/DlgSettingsNotificationArea.cpp
@@ -40,20 +40,12 @@ DlgSettingsNotificationArea::DlgSettingsNotificationArea(QWidget* parent)
 {
     ui->setupUi(this);
 
+    adaptUiToAreaEnabledState(ui->NotificationAreaEnabled->isChecked());
+
     connect(ui->NotificationAreaEnabled, &QCheckBox::stateChanged, [this](int state) {
         bool enabled = state == Qt::CheckState::Checked;
+        this->adaptUiToAreaEnabledState(enabled);
 
-        ui->NonIntrusiveNotificationsEnabled->setEnabled(enabled);
-        ui->maxDuration->setEnabled(enabled);
-        ui->maxDuration->setEnabled(enabled);
-        ui->minDuration->setEnabled(enabled);
-        ui->maxNotifications->setEnabled(enabled);
-        ui->maxWidgetMessages->setEnabled(enabled);
-        ui->autoRemoveUserNotifications->setEnabled(enabled);
-        ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->setEnabled(enabled);
-        ui->preventNonIntrusiveNotificationsWhenWindowNotActive->setEnabled(enabled);
-        ui->developerErrorSubscriptionEnabled->setEnabled(enabled);
-        ui->developerWarningSubscriptionEnabled->setEnabled(enabled);
         if (enabled) {
             QMessageBox::information(this,
                                      tr("Notification Area"),
@@ -98,6 +90,21 @@ void DlgSettingsNotificationArea::loadSettings()
     ui->preventNonIntrusiveNotificationsWhenWindowNotActive->onRestore();
     ui->developerErrorSubscriptionEnabled->onRestore();
     ui->developerWarningSubscriptionEnabled->onRestore();
+}
+
+void DlgSettingsNotificationArea::adaptUiToAreaEnabledState(bool enabled)
+{
+    ui->NonIntrusiveNotificationsEnabled->setEnabled(enabled);
+    ui->maxDuration->setEnabled(enabled);
+    ui->maxDuration->setEnabled(enabled);
+    ui->minDuration->setEnabled(enabled);
+    ui->maxNotifications->setEnabled(enabled);
+    ui->maxWidgetMessages->setEnabled(enabled);
+    ui->autoRemoveUserNotifications->setEnabled(enabled);
+    ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->setEnabled(enabled);
+    ui->preventNonIntrusiveNotificationsWhenWindowNotActive->setEnabled(enabled);
+    ui->developerErrorSubscriptionEnabled->setEnabled(enabled);
+    ui->developerWarningSubscriptionEnabled->setEnabled(enabled);
 }
 
 void DlgSettingsNotificationArea::changeEvent(QEvent* e)

--- a/src/Gui/DlgSettingsNotificationArea.h
+++ b/src/Gui/DlgSettingsNotificationArea.h
@@ -50,6 +50,9 @@ protected:
     void changeEvent(QEvent *e) override;
 
 private:
+    void adaptUiToAreaEnabledState(bool enabled);
+
+private:
     std::unique_ptr<Ui_DlgSettingsNotificationArea> ui;
 };
 

--- a/src/Gui/DlgSettingsNotificationArea.ui
+++ b/src/Gui/DlgSettingsNotificationArea.ui
@@ -29,7 +29,7 @@
          <string>Enable Notification Area</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>NotificationAreaEnabled</cstring>

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -394,7 +394,7 @@ MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
 
     auto hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/NotificationArea");
 
-    auto notificationAreaEnabled = hGrp->GetBool("NotificationAreaEnabled", true);
+    auto notificationAreaEnabled = hGrp->GetBool("NotificationAreaEnabled", false);
 
     if(notificationAreaEnabled) {
         NotificationArea* notificationArea = new NotificationArea(statusBar());


### PR DESCRIPTION
This does : 
- Fix a ui bug, if area disabled when you open the pref page, the rest of the parameters are not disabled. 
- remove unecessary qmessagebox
- Disable area by default for 0.21 bacause it is not polished enough yet.

I have no strong feeling for the disabling, someone told me that it's not polished enough yet to the point of being very annoying. So I suggest disabling it for the 0.21 release and re-enable it in next development cycle to enable polishing it.


Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
