### PR TITLE
[TD]Last minute fixes for v0.21

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -1664,7 +1664,7 @@ bool DrawViewPart::prefHardViz()
 
 bool DrawViewPart::prefSeamViz()
 {
-    return Preferences::getPreferenceGroup("HLR")->GetBool("SeamViz", true);
+    return Preferences::getPreferenceGroup("HLR")->GetBool("SeamViz", false);
 }
 
 bool DrawViewPart::prefSmoothViz()

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLR.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLR.ui
@@ -260,7 +260,7 @@ Fast, but result is a collection of short straight lines.</string>
            <string>Show Seam Lines</string>
           </property>
           <property name="checked">
-           <bool>true</bool>
+           <bool>false</bool>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>SeamViz</cstring>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLRImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLRImp.cpp
@@ -58,7 +58,9 @@ void DlgPrefsTechDrawHLRImp::saveSettings()
 
 void DlgPrefsTechDrawHLRImp::loadSettings()
 {
+    // set defaults for HLR
     ui->pcbSeamViz->onRestore();
+
     ui->pcbSmoothViz->onRestore();
     ui->pcbHardViz->onRestore();
     ui->pcbPolygon->onRestore();

--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -493,7 +493,6 @@ void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
     if (featLeader->StartSymbol.getValue() != ArrowType::NONE) {
         m_arrow1->setStyle(featLeader->StartSymbol.getValue());
         m_arrow1->setWidth(getLineWidth());
-        //        TODO: variable size arrow heads
         m_arrow1->setSize(QGIArrow::getPrefArrowSize());
         m_arrow1->setDirMode(true);
         m_arrow1->setDirection(stdX);
@@ -516,6 +515,7 @@ void QGILeaderLine::setArrows(std::vector<QPointF> pathPoints)
     if (featLeader->EndSymbol.getValue() != ArrowType::NONE) {
         m_arrow2->setStyle(featLeader->EndSymbol.getValue());
         m_arrow2->setWidth(getLineWidth());
+        m_arrow2->setSize(QGIArrow::getPrefArrowSize());
         m_arrow2->setDirMode(true);
         m_arrow2->setDirection(-stdX);
         if (pathPoints.size() > 1) {


### PR DESCRIPTION
This PR includes 3 fixes to be included in v0.21:
- add 1 line of code to support scaling of end symbol on leaders
- change the default preference for seam lines to false
- improve text scaling and position in RichTextAnnotations exported to Svg

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
