### PR TITLE
link gmock

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(Tests_run)
 add_subdirectory(lib)
 add_subdirectory(src)
 target_include_directories(Tests_run PUBLIC ${Python3_INCLUDE_DIRS} ${XercesC_INCLUDE_DIRS})
-target_link_libraries(Tests_run gtest_main ${Google_Tests_LIBS} FreeCADApp)
+target_link_libraries(Tests_run gtest_main gmock_main ${Google_Tests_LIBS} FreeCADApp)
 
 add_executable(Sketcher_tests_run)
 add_subdirectory(src/Mod/Sketcher)


### PR DESCRIPTION
Enable gmock (not previously linked) so it can be used in google tests
---
