### PR TITLE
Path: fix test failure with MSYS2 build

### DIFF
--- a/src/Mod/Path/PathTests/TestPathPost.py
+++ b/src/Mod/Path/PathTests/TestPathPost.py
@@ -474,7 +474,10 @@ class TestOutputNameSubstitution(unittest.TestCase):
         outlist = PathPost.buildPostList(self.job)
         subpart, objs = outlist[0]
         filename = PathPost.resolveFileName(self.job, subpart, 0)
-        self.assertEqual(filename, f"{self.macro}outfile.nc")
+        self.assertEqual(
+            os.path.normpath(filename),
+            os.path.normpath(f"{self.macro}outfile.nc")
+        )
 
     def test040(self):
         # unused substitution strings should be ignored


### PR DESCRIPTION
The two path names have different path separators and thus are considered as different

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
