### PR TITLE
add cstdint behind ifdef __GNUC__ for compiling under alpine linux

### DIFF
--- a/src/Base/Builder3D.h
+++ b/src/Base/Builder3D.h
@@ -26,6 +26,10 @@
 
 // Std. configurations
 
+#ifdef __GNUC__
+# include <cstdint>
+#endif
+
 #include <sstream>
 #include <vector>
 #include <Base/Tools3D.h>


### PR DESCRIPTION
note: in other headers there is a mix of including #ifdef __GNUC__

Sadly I did not catch this during the RC window but a patch in the aport can make this work for Alpine specifically, cannot say if this affects other systems.