### PR TITLE
Bump build version to 0.22 and make it obvious it's a developer build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ project(FreeCAD)
 
 set(PACKAGE_VERSION_NAME "Vulcan")
 set(PACKAGE_VERSION_MAJOR "0")
-set(PACKAGE_VERSION_MINOR "21")
+set(PACKAGE_VERSION_MINOR "22")
 set(PACKAGE_VERSION_PATCH "0") # number of patch release (e.g. "4" for the 0.18.4 release)
 set(PACKAGE_VERSION_SUFFIX "dev") # either "dev" for development snapshot or "" (empty string)
 set(PACKAGE_BUILD_VERSION "0") # used when the same FreeCAD version will be re-released (for example using an updated LibPack)

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2478,6 +2478,7 @@ void Application::initConfig(int argc, char ** argv)
         App::Application::Config()["BuildVersionMajor"  ] = FCVersionMajor;
         App::Application::Config()["BuildVersionMinor"  ] = FCVersionMinor;
         App::Application::Config()["BuildVersionPoint"  ] = FCVersionPoint;
+        App::Application::Config()["BuildVersionSuffix" ] = FCVersionSuffix;
         App::Application::Config()["BuildRevision"      ] = FCRevision;
         App::Application::Config()["BuildRepositoryURL" ] = FCRepositoryURL;
         App::Application::Config()["BuildRevisionDate"  ] = FCRevisionDate;
@@ -2557,21 +2558,23 @@ void Application::initConfig(int argc, char ** argv)
         // Remove banner if FreeCAD is invoked via the -c command as regular
         // Python interpreter
         if (!(mConfig["Verbose"] == "Strict"))
-            Base::Console().Message("%s %s, Libs: %s.%s.%sR%s\n%s",
+            Base::Console().Message("%s %s, Libs: %s.%s.%s%sR%s\n%s",
                               mConfig["ExeName"].c_str(),
                               mConfig["ExeVersion"].c_str(),
                               mConfig["BuildVersionMajor"].c_str(),
                               mConfig["BuildVersionMinor"].c_str(),
                               mConfig["BuildVersionPoint"].c_str(),
+                              mConfig["BuildVersionSuffix"].c_str(),
                               mConfig["BuildRevision"].c_str(),
                               mConfig["CopyrightInfo"].c_str());
         else
-            Base::Console().Message("%s %s, Libs: %s.%s.%sR%s\n",
+            Base::Console().Message("%s %s, Libs: %s.%s.%s%sR%s\n",
                               mConfig["ExeName"].c_str(),
                               mConfig["ExeVersion"].c_str(),
                               mConfig["BuildVersionMajor"].c_str(),
                               mConfig["BuildVersionMinor"].c_str(),
                               mConfig["BuildVersionPoint"].c_str(),
+                              mConfig["BuildVersionSuffix"].c_str(),
                               mConfig["BuildRevision"].c_str());
     }
     LoadParameters();

--- a/src/Build/Version.h.cmake
+++ b/src/Build/Version.h.cmake
@@ -1,9 +1,10 @@
 
 // Version Number
-#define FCVersionMajor "${PACKAGE_VERSION_MAJOR}"
-#define FCVersionMinor "${PACKAGE_VERSION_MINOR}"
-#define FCVersionName  "${PACKAGE_VERSION_NAME}"
-#define FCVersionPoint "${PACKAGE_VERSION_PATCH}"
+#define FCVersionMajor  "${PACKAGE_VERSION_MAJOR}"
+#define FCVersionMinor  "${PACKAGE_VERSION_MINOR}"
+#define FCVersionName   "${PACKAGE_VERSION_NAME}"
+#define FCVersionPoint  "${PACKAGE_VERSION_PATCH}"
+#define FCVersionSuffix "${PACKAGE_VERSION_SUFFIX}"
 // test: $Format:Hash (%H), Date: %ci$
 #define FCRevision      "${PACKAGE_WCREF}"      //Highest committed revision number
 #define FCRevisionDate  "${PACKAGE_WCDATE}"     //Date of highest committed revision

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2129,8 +2129,9 @@ void Application::runApplication()
         QString major  = QString::fromLatin1(config["BuildVersionMajor"].c_str());
         QString minor  = QString::fromLatin1(config["BuildVersionMinor"].c_str());
         QString point = QString::fromLatin1(config["BuildVersionPoint"].c_str());
+        QString suffix = QString::fromLatin1(config["BuildVersionSuffix"].c_str());
         QString title =
-            QString::fromLatin1("%1 %2.%3.%4").arg(mainApp.applicationName(), major, minor, point);
+            QString::fromLatin1("%1 %2.%3.%4%5").arg(mainApp.applicationName(), major, minor, point, suffix);
         mw.setWindowTitle(title);
     }
     else {

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -292,6 +292,8 @@ private:
     bool setupReportView(const std::string&);
     bool setupPythonConsole(const std::string&);
 
+    void RenderDevBuildWarning(QPainter &painter, int x, int y) const;
+
 private Q_SLOTS:
     /**
      * \internal

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -375,6 +375,7 @@ void AboutDialog::setupLabels()
     QString major  = QString::fromLatin1(config["BuildVersionMajor"].c_str());
     QString minor  = QString::fromLatin1(config["BuildVersionMinor"].c_str());
     QString point  = QString::fromLatin1(config["BuildVersionPoint"].c_str());
+    QString suffix = QString::fromLatin1(config["BuildVersionSuffix"].c_str());
     QString build  = QString::fromLatin1(config["BuildRevision"].c_str());
     QString disda  = QString::fromLatin1(config["BuildRevisionDate"].c_str());
     QString mturl  = QString::fromLatin1(config["MaintainerUrl"].c_str());
@@ -393,7 +394,7 @@ void AboutDialog::setupLabels()
     }
 
     QString version = ui->labelBuildVersion->text();
-    version.replace(QString::fromLatin1("Unknown"), QString::fromLatin1("%1.%2.%3").arg(major, minor, point));
+    version.replace(QString::fromLatin1("Unknown"), QString::fromLatin1("%1.%2.%3%4").arg(major, minor, point, suffix));
     ui->labelBuildVersion->setText(version);
 
     QString revision = ui->labelBuildRevision->text();
@@ -787,6 +788,7 @@ void AboutDialog::copyToClipboard()
     QString major  = QString::fromLatin1(config["BuildVersionMajor"].c_str());
     QString minor  = QString::fromLatin1(config["BuildVersionMinor"].c_str());
     QString point  = QString::fromLatin1(config["BuildVersionPoint"].c_str());
+    QString suffix = QString::fromLatin1(config["BuildVersionSuffix"].c_str());
     QString build  = QString::fromLatin1(config["BuildRevision"].c_str());
 
     QString deskEnv = QProcessEnvironment::systemEnvironment().value(QStringLiteral("XDG_CURRENT_DESKTOP"), QString());
@@ -803,7 +805,7 @@ void AboutDialog::copyToClipboard()
     str << "[code]\n";
     str << "OS: " << prettyProductInfoWrapper() << deskInfo << '\n';
     str << "Word size of " << exe << ": " << QSysInfo::WordSize << "-bit\n";
-    str << "Version: " << major << "." << minor << "." << point << "." << build;
+    str << "Version: " << major << "." << minor << "." << point << suffix << "." << build;
     char *appimage = getenv("APPIMAGE");
     if (appimage)
         str << " AppImage";


### PR DESCRIPTION
This PR sets the version to 0.22.0dev. It then ensures that the "dev" suffix shows in the places where we show the version (including the title bar), and adds a prominent (translatable) warning label to the splashscreen.

<img width="416" alt="Screenshot 2023-08-03 at 10 57 31 PM" src="https://github.com/FreeCAD/FreeCAD/assets/216920/8607d2e4-293c-4e86-adef-78e0f53f05d8">

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR