### PR TITLE
[GUI] QuantitySpinBox Regex Optimization #10067 Ammendum

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -170,6 +170,9 @@ public:
         if (locale.positiveSign() != plus)
             copy.replace(locale.positiveSign(), plus);
 
+        QString reverseUnitStr = unitStr;
+        std::reverse(reverseUnitStr.begin(), reverseUnitStr.end());
+
         //Prep for expression parser
         //This regex matches chunks between +,-,$,^ accounting for matching parenthesis.
         QRegularExpression chunkRe(QString::fromUtf8("(?<=^|[\\+\\-])((\\((?>[^()]|(?2))*\\))|[^\\+\\-\n])*(?=$|[\\+\\-])"));
@@ -202,12 +205,12 @@ public:
             }
 
             //Add default units to string if none are present
-            if (!copyChunk.contains(unitStr)){ // Fast check
+            if (!copyChunk.contains(reverseUnitStr)){ // Fast check
                 QRegularExpression unitsRe(QString::fromStdString("(?<=\\b|[^a-zA-Z])("+regexUnits+")(?=\\b|[^a-zA-Z])|°|″|′|\"|'|\\p{L}\\.\\p{L}|\\[\\p{L}"));
 
                 QRegularExpressionMatch match = unitsRe.match(copyChunk);
                 if (!match.hasMatch() && !copyChunk.isEmpty()) //If no units are found, use default units
-                    copyChunk.prepend(QString::fromUtf8(")")+unitStr+QString::fromUtf8("1(*")); // Add units to the end of chunk *(1unit)
+                    copyChunk.prepend(QString::fromUtf8(")")+reverseUnitStr+QString::fromUtf8("1(*")); // Add units to the end of chunk *(1unit)
             }
 
             std::reverse(copyChunk.begin(), copyChunk.end());


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---

Addendum to #10067, A bug in line 210 where the unitStr variable didn't get reversed when line 213 was added, causing the appended string to be *(1tinu) instead of the correct *(1unit). 

https://github.com/FreeCAD/FreeCAD/issues/10082