### PR TITLE
Path: make export macro accessible in header file

### DIFF
--- a/src/Mod/Path/PathGlobal.h
+++ b/src/Mod/Path/PathGlobal.h
@@ -44,4 +44,13 @@
 #endif
 #endif
 
+// PathSimulator
+#ifndef PathSimulatorExport
+#ifdef PathSimulator_EXPORTS
+#  define PathSimulatorExport      FREECAD_DECL_EXPORT
+#else
+#  define PathSimulatorExport      FREECAD_DECL_IMPORT
+#endif
+#endif
+
 #endif //PATH_GLOBAL_H

--- a/src/Mod/Path/PathSimulator/App/PreCompiled.h
+++ b/src/Mod/Path/PathSimulator/App/PreCompiled.h
@@ -25,19 +25,6 @@
 
 #include <FCConfig.h>
 
-// Exporting of App classes
-#ifdef FC_OS_WIN32
-# define PathSimulatorExport __declspec(dllexport)
-# define PathExport  __declspec(dllimport)
-# define PartExport __declspec(dllimport)
-# define MeshExport __declspec(dllimport)
-#else // for Linux
-# define PathSimulatorExport
-# define PathExport
-# define PartExport
-# define MeshExport
-#endif
-
 #ifdef _PreComp_
 
 // standard


### PR DESCRIPTION
It's not recommended any more to keep the export macro in the PreCompiled.h because many IDEs fail to fetch the export macro and raise a parsing error instead.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
