### PR TITLE
modernize C++: avoid bind

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -477,6 +477,7 @@ Document* Application::newDocument(const char * Name, const char * UserName, boo
     DocMap[name] = doc;
     _pActiveDoc = doc;
 
+    //NOLINTBEGIN
     // connect the signals to the application for the new document
     _pActiveDoc->signalBeforeChange.connect(std::bind(&App::Application::slotBeforeChangeDocument, this, sp::_1, sp::_2));
     _pActiveDoc->signalChanged.connect(std::bind(&App::Application::slotChangedDocument, this, sp::_1, sp::_2));
@@ -497,6 +498,7 @@ Document* Application::newDocument(const char * Name, const char * UserName, boo
     _pActiveDoc->signalStartSave.connect(std::bind(&App::Application::slotStartSaveDocument, this, sp::_1, sp::_2));
     _pActiveDoc->signalFinishSave.connect(std::bind(&App::Application::slotFinishSaveDocument, this, sp::_1, sp::_2));
     _pActiveDoc->signalChangePropertyEditor.connect(std::bind(&App::Application::slotChangePropertyEditor, this, sp::_1, sp::_2));
+    //NOLINTEND
 
     // make sure that the active document is set in case no GUI is up
     {

--- a/src/App/DocumentObserver.cpp
+++ b/src/App/DocumentObserver.cpp
@@ -546,8 +546,10 @@ class DocumentWeakPtrT::Private {
 public:
     explicit Private(App::Document* doc) : _document(doc) {
         if (doc) {
+            //NOLINTBEGIN
             connectApplicationDeletedDocument = App::GetApplication().signalDeleteDocument.connect(std::bind
                 (&Private::deletedDocument, this, sp::_1));
+            //NOLINTEND
         }
     }
 
@@ -626,6 +628,7 @@ public:
     void set(App::DocumentObject* obj) {
         object = obj;
         if (obj) {
+            //NOLINTBEGIN
             indocument = true;
             connectApplicationDeletedDocument = App::GetApplication().signalDeleteDocument.connect(std::bind
             (&Private::deletedDocument, this, sp::_1));
@@ -634,6 +637,7 @@ public:
             (&Private::createdObject, this, sp::_1));
             connectDocumentDeletedObject = doc->signalDeletedObject.connect(std::bind
             (&Private::deletedObject, this, sp::_1));
+            //NOLINTEND
         }
     }
     App::DocumentObject* get() const noexcept {
@@ -701,12 +705,14 @@ bool DocumentObjectWeakPtrT::operator!= (const DocumentObjectWeakPtrT& p) const 
 
 DocumentObserver::DocumentObserver() : _document(nullptr)
 {
+    //NOLINTBEGIN
     this->connectApplicationCreatedDocument = App::GetApplication().signalNewDocument.connect(std::bind
         (&DocumentObserver::slotCreatedDocument, this, sp::_1));
     this->connectApplicationDeletedDocument = App::GetApplication().signalDeleteDocument.connect(std::bind
         (&DocumentObserver::slotDeletedDocument, this, sp::_1));
     this->connectApplicationActivateDocument = App::GetApplication().signalActiveDocument.connect(std::bind
         (&DocumentObserver::slotActivateDocument, this, sp::_1));
+    //NOLINTEND
 }
 
 DocumentObserver::DocumentObserver(Document* doc) : DocumentObserver()
@@ -735,6 +741,7 @@ void DocumentObserver::attachDocument(Document* doc)
         detachDocument();
         _document = doc;
 
+        //NOLINTBEGIN
         this->connectDocumentCreatedObject = _document->signalNewObject.connect(std::bind
             (&DocumentObserver::slotCreatedObject, this, sp::_1));
         this->connectDocumentDeletedObject = _document->signalDeletedObject.connect(std::bind
@@ -745,6 +752,7 @@ void DocumentObserver::attachDocument(Document* doc)
             (&DocumentObserver::slotRecomputedObject, this, sp::_1));
         this->connectDocumentRecomputed = _document->signalRecomputed.connect(std::bind
             (&DocumentObserver::slotRecomputedDocument, this, sp::_1));
+        //NOLINTEND
     }
 }
 

--- a/src/App/DocumentObserverPython.cpp
+++ b/src/App/DocumentObserverPython.cpp
@@ -78,6 +78,7 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj) : inst(obj
     }\
     while(0);
 
+    //NOLINTBEGIN
 #define FC_PY_ELEMENT_ARG2(_name1, _name2) do {\
         FC_PY_GetCallable(obj.ptr(), "slot" #_name1, py##_name1.py);\
         if (!py##_name1.py.isNone())\
@@ -115,6 +116,7 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj) : inst(obj
     FC_PY_ELEMENT_ARG2(ChangePropertyEditor, ChangePropertyEditor)
     FC_PY_ELEMENT_ARG2(BeforeAddingDynamicExtension, BeforeAddingDynamicExtension)
     FC_PY_ELEMENT_ARG2(AddedDynamicExtension, AddedDynamicExtension)
+    //NOLINTEND
 }
 
 DocumentObserverPython::~DocumentObserverPython() = default;

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -352,8 +352,10 @@ void GroupExtension::extensionOnChanged(const Property* p) {
         _Conns.clear();
         for(auto obj : Group.getValue()) {
             if(obj && obj->getNameInDocument()) {
+                //NOLINTBEGIN
                 _Conns[obj] = obj->signalChanged.connect(std::bind(
                             &GroupExtension::slotChildChanged,this,sp::_1, sp::_2));
+                //NOLINTEND
             }
         }
     }

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -1539,8 +1539,10 @@ void LinkBaseExtension::updateGroup() {
             if(!conn.connected()) {
                 FC_LOG("new group connection " << getExtendedObject()->getFullName()
                         << " -> " << group->getFullName());
+                //NOLINTBEGIN
                 conn = group->signalChanged.connect(
                         std::bind(&LinkBaseExtension::slotChangedPlainGroup,this,sp::_1,sp::_2));
+                //NOLINTEND
             }
             std::size_t count = children.size();
             ext->getAllChildren(children,childSet);
@@ -1553,8 +1555,10 @@ void LinkBaseExtension::updateGroup() {
                 if(!conn.connected()) {
                     FC_LOG("new group connection " << getExtendedObject()->getFullName()
                             << " -> " << child->getFullName());
+                    //NOLINTBEGIN
                     conn = child->signalChanged.connect(
                             std::bind(&LinkBaseExtension::slotChangedPlainGroup,this,sp::_1,sp::_2));
+                    //NOLINTEND
                 }
             }
         }

--- a/src/App/MergeDocuments.cpp
+++ b/src/App/MergeDocuments.cpp
@@ -73,10 +73,12 @@ private:
 
 MergeDocuments::MergeDocuments(App::Document* doc) : guiup(false), verbose(true), stream(nullptr), appdoc(doc)
 {
+    //NOLINTBEGIN
     connectExport = doc->signalExportObjects.connect
         (std::bind(&MergeDocuments::exportObject, this, sp::_1, sp::_2));
     connectImport = doc->signalImportObjects.connect
         (std::bind(&MergeDocuments::importObject, this, sp::_1, sp::_2));
+    //NOLINTEND
 
     QCoreApplication* app = QCoreApplication::instance();
     if (app && app->inherits("QApplication")) {

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -181,12 +181,16 @@ void PropertyExpressionEngine::hasSetValue()
                         std::string key = objName + propName;
                         auto &propDeps = pimpl->propMap[key];
                         if(propDeps.empty()) {
-                            if(!propName.empty())
+                            //NOLINTBEGIN
+                            if(!propName.empty()) {
                                 pimpl->conns.emplace_back(obj->signalChanged.connect(std::bind(
                                             &PropertyExpressionEngine::slotChangedProperty,this,sp::_1,sp::_2)));
-                            else
+                            }
+                            else {
                                 pimpl->conns.emplace_back(obj->signalChanged.connect(std::bind(
                                             &PropertyExpressionEngine::slotChangedObject,this,sp::_1,sp::_2)));
+                            }
+                            //NOLINTEND
                         }
                         propDeps.push_back(e.first);
                     }

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -2661,6 +2661,7 @@ public:
         myPos = pos;
         myPath = myPos->first.toUtf8().constData();
         App::Application &app = App::GetApplication();
+        //NOLINTBEGIN
         connFinishRestoreDocument = app.signalFinishRestoreDocument.connect(
             std::bind(&DocInfo::slotFinishRestoreDocument,this,sp::_1));
         connPendingReloadDocument = app.signalPendingReloadDocument.connect(
@@ -2669,6 +2670,7 @@ public:
             std::bind(&DocInfo::slotDeleteDocument,this,sp::_1));
         connSaveDocument = app.signalSaveDocument.connect(
             std::bind(&DocInfo::slotSaveDocument,this,sp::_1));
+        //NOLINTEND
 
         QString fullpath(getFullPath());
         if(fullpath.isEmpty())

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -644,7 +644,9 @@ WorkbenchGroup::WorkbenchGroup (  Command* pcCmd, QObject * parent )
 {
     refreshWorkbenchList();
 
+    //NOLINTBEGIN
     Application::Instance->signalRefreshWorkbenches.connect(std::bind(&WorkbenchGroup::refreshWorkbenchList, this));
+    //NOLINTEND
 
     connect(getMainWindow(), &MainWindow::workbenchActivated,
         this, &WorkbenchGroup::onWorkbenchActivated);

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -357,6 +357,7 @@ Application::Application(bool GUIenabled)
 {
     //App::GetApplication().Attach(this);
     if (GUIenabled) {
+        //NOLINTBEGIN
         App::GetApplication().signalNewDocument.connect(
             std::bind(&Gui::Application::slotNewDocument, this, sp::_1, sp::_2));
         App::GetApplication().signalDeleteDocument.connect(
@@ -369,6 +370,7 @@ Application::Application(bool GUIenabled)
             std::bind(&Gui::Application::slotRelabelDocument, this, sp::_1));
         App::GetApplication().signalShowHidden.connect(
             std::bind(&Gui::Application::slotShowHidden, this, sp::_1));
+        //NOLINTEND
 
         // install the last active language
         ParameterGrp::handle hPGrp =
@@ -821,6 +823,7 @@ void Application::slotNewDocument(const App::Document& Doc, bool isMainDoc)
     auto pDoc = new Gui::Document(const_cast<App::Document*>(&Doc),this);
     d->documents[&Doc] = pDoc;
 
+    //NOLINTBEGIN
     // connect the signals to the application for the new document
     pDoc->signalNewObject.connect(std::bind(&Gui::Application::slotNewObject, this, sp::_1));
     pDoc->signalDeletedObject.connect(std::bind(&Gui::Application::slotDeletedObject,
@@ -833,6 +836,7 @@ void Application::slotNewDocument(const App::Document& Doc, bool isMainDoc)
         this, sp::_1));
     pDoc->signalInEdit.connect(std::bind(&Gui::Application::slotInEdit, this, sp::_1));
     pDoc->signalResetEdit.connect(std::bind(&Gui::Application::slotResetEdit, this, sp::_1));
+    //NOLINTEND
 
     signalNewDocument(*pDoc, isMainDoc);
     if (isMainDoc)

--- a/src/Gui/AutoSaver.cpp
+++ b/src/Gui/AutoSaver.cpp
@@ -57,8 +57,10 @@ AutoSaver* AutoSaver::self = nullptr;
 AutoSaver::AutoSaver(QObject* parent)
   : QObject(parent), timeout(900000), compressed(true)
 {
+    //NOLINTBEGIN
     App::GetApplication().signalNewDocument.connect(std::bind(&AutoSaver::slotCreateDocument, this, sp::_1));
     App::GetApplication().signalDeleteDocument.connect(std::bind(&AutoSaver::slotDeleteDocument, this, sp::_1));
+    //NOLINTEND
 }
 
 AutoSaver::~AutoSaver()
@@ -243,10 +245,12 @@ void AutoSaver::timerEvent(QTimerEvent * event)
 
 AutoSaveProperty::AutoSaveProperty(const App::Document* doc) : timerId(-1)
 {
+    //NOLINTBEGIN
     documentNew = const_cast<App::Document*>(doc)->signalNewObject.connect
         (std::bind(&AutoSaveProperty::slotNewObject, this, sp::_1));
     documentMod = const_cast<App::Document*>(doc)->signalChangedObject.connect
         (std::bind(&AutoSaveProperty::slotChangePropertyData, this, sp::_2));
+    //NOLINTEND
 }
 
 AutoSaveProperty::~AutoSaveProperty()

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1263,8 +1263,9 @@ PythonCommand::PythonCommand(const char* name, PyObject * pcPyCommand, const cha
 
     auto& rcCmdMgr = Gui::Application::Instance->commandManager();
 
-    connPyCmdInitialized = rcCmdMgr.signalPyCmdInitialized.connect(
-        std::bind(&PythonCommand::onActionInit, this));
+    connPyCmdInitialized = rcCmdMgr.signalPyCmdInitialized.connect([this]() {
+        this->onActionInit();
+    });
 }
 
 PythonCommand::~PythonCommand()
@@ -1494,8 +1495,9 @@ PythonGroupCommand::PythonGroupCommand(const char* name, PyObject * pcPyCommand)
 
     auto& rcCmdMgr = Gui::Application::Instance->commandManager();
 
-    connPyCmdInitialized = rcCmdMgr.signalPyCmdInitialized.connect(
-        std::bind(&PythonGroupCommand::onActionInit, this));
+    connPyCmdInitialized = rcCmdMgr.signalPyCmdInitialized.connect([this]() {
+        this->onActionInit();
+    });
 }
 
 PythonGroupCommand::~PythonGroupCommand()

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -876,7 +876,9 @@ StdCmdUserEditMode::StdCmdUserEditMode()
     sPixmap       = "Std_UserEditModeDefault";
     eType         = ForEdit;
 
-    this->getGuiApplication()->signalUserEditModeChanged.connect(std::bind(&StdCmdUserEditMode::updateIcon, this, sp::_1));
+    this->getGuiApplication()->signalUserEditModeChanged.connect([this](int mode) {
+        this->updateIcon(mode);
+    });
 }
 
 Gui::Action * StdCmdUserEditMode::createAction()

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -657,7 +657,9 @@ StdCmdDrawStyle::StdCmdDrawStyle()
     sPixmap       = "DrawStyleAsIs";
     eType         = Alter3DView;
 
-    this->getGuiApplication()->signalActivateView.connect(std::bind(&StdCmdDrawStyle::updateIcon, this, sp::_1));
+    this->getGuiApplication()->signalActivateView.connect([this](auto view) {
+        this->updateIcon(view);
+    });
 }
 
 Gui::Action * StdCmdDrawStyle::createAction()

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -137,11 +137,13 @@ Model::Model(QObject *parentIn, const Gui::Document &documentIn) : QGraphicsScen
   connect(this->editingFinishedAction, &QAction::triggered,
           this, &Model::editingFinishedSlot);
 
+  //NOLINTBEGIN
   connectNewObject = documentIn.signalNewObject.connect(std::bind(&Model::slotNewObject, this, sp::_1));
   connectDelObject = documentIn.signalDeletedObject.connect(std::bind(&Model::slotDeleteObject, this, sp::_1));
   connectChgObject = documentIn.signalChangedObject.connect(std::bind(&Model::slotChangeObject, this, sp::_1, sp::_2));
   connectEdtObject = documentIn.signalInEdit.connect(std::bind(&Model::slotInEdit, this, sp::_1));
   connectResObject = documentIn.signalResetEdit.connect(std::bind(&Model::slotResetEdit, this, sp::_1));
+  //NOLINTEND
 
   for (auto obj : documentIn.getDocument()->getObjects()) {
     auto vpd = Base::freecad_dynamic_cast<Gui::ViewProviderDocumentObject>(documentIn.getViewProvider(obj));
@@ -248,9 +250,11 @@ void Model::slotNewObject(const ViewProviderDocumentObject &VPDObjectIn)
   icon->setPixmap(VPDObjectIn.getIcon().pixmap(iconSize, iconSize));
   (*theGraph)[virginVertex].stateIcon->setPixmap(passPixmap);
   (*theGraph)[virginVertex].text->setFont(this->font());
+  //NOLINTBEGIN
   (*theGraph)[virginVertex].connChangeIcon =
       const_cast<Gui::ViewProviderDocumentObject&>(VPDObjectIn).signalChangeIcon.connect(
           std::bind(&Model::slotChangeIcon, this, boost::cref(VPDObjectIn), icon));
+  //NOLINTEND
 
   graphDirty = true;
   lastAddedVertex = Graph::null_vertex();

--- a/src/Gui/DAGView/DAGView.cpp
+++ b/src/Gui/DAGView/DAGView.cpp
@@ -50,8 +50,10 @@ View::View(QWidget* parentIn): QGraphicsView(parentIn)
 {
   this->setRenderHint(QPainter::Antialiasing, true);
   this->setRenderHint(QPainter::TextAntialiasing, true);
+  //NOLINTBEGIN
   conActive = Application::Instance->signalActiveDocument.connect(std::bind(&View::slotActiveDocument, this, sp::_1));
   conDelete = Application::Instance->signalDeleteDocument.connect(std::bind(&View::slotDeleteDocument, this, sp::_1));
+  //NOLINTEND
 
   //just update the dagview when the gui process is idle.
   connect(QAbstractEventDispatcher::instance(), &QAbstractEventDispatcher::awake,

--- a/src/Gui/DlgDisplayPropertiesImp.cpp
+++ b/src/Gui/DlgDisplayPropertiesImp.cpp
@@ -156,9 +156,11 @@ DlgDisplayPropertiesImp::DlgDisplayPropertiesImp(bool floating, QWidget* parent,
 
     Gui::Selection().Attach(this);
 
+    //NOLINTBEGIN
     d->connectChangedObject =
     Gui::Application::Instance->signalChangedObject.connect(std::bind
         (&DlgDisplayPropertiesImp::slotChangedObject, this, sp::_1, sp::_2));
+    //NOLINTEND
 }
 
 /**

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -160,6 +160,7 @@ Document::Document(App::Document* pcDocument,Application * app)
     d->_editingViewer = nullptr;
     d->_editMode = 0;
 
+    //NOLINTBEGIN
     // Setup the connections
     d->connectNewObject = pcDocument->signalNewObject.connect
         (std::bind(&Gui::Document::slotNewObject, this, sp::_1));
@@ -214,6 +215,7 @@ Document::Document(App::Document* pcDocument,Application * app)
         (std::bind(&Gui::Document::slotTransactionAppend, this, sp::_1, sp::_2));
     d->connectTransactionRemove = pcDocument->signalTransactionRemove.connect
         (std::bind(&Gui::Document::slotTransactionRemove, this, sp::_1, sp::_2));
+    //NOLINTEND
 
     // pointer to the python class
     // NOTE: As this Python object doesn't get returned to the interpreter we

--- a/src/Gui/DocumentModel.cpp
+++ b/src/Gui/DocumentModel.cpp
@@ -360,12 +360,14 @@ DocumentModel::DocumentModel(QObject* parent)
         ViewProviderIndex   ::init();
     }
 
+    //NOLINTBEGIN
     // Setup connections
     Application::Instance->signalNewDocument.connect(std::bind(&DocumentModel::slotNewDocument, this, sp::_1));
     Application::Instance->signalDeleteDocument.connect(std::bind(&DocumentModel::slotDeleteDocument, this, sp::_1));
     Application::Instance->signalRenameDocument.connect(std::bind(&DocumentModel::slotRenameDocument, this, sp::_1));
     Application::Instance->signalActiveDocument.connect(std::bind(&DocumentModel::slotActiveDocument, this, sp::_1));
     Application::Instance->signalRelabelDocument.connect(std::bind(&DocumentModel::slotRelabelDocument, this, sp::_1));
+    //NOLINTEND
 }
 
 DocumentModel::~DocumentModel()
@@ -375,6 +377,7 @@ DocumentModel::~DocumentModel()
 
 void DocumentModel::slotNewDocument(const Gui::Document& Doc)
 {
+    //NOLINTBEGIN
     Doc.signalNewObject.connect(std::bind(&DocumentModel::slotNewObject, this, sp::_1));
     Doc.signalDeletedObject.connect(std::bind(&DocumentModel::slotDeleteObject, this, sp::_1));
     Doc.signalChangedObject.connect(std::bind(&DocumentModel::slotChangeObject, this, sp::_1, sp::_2));
@@ -382,6 +385,7 @@ void DocumentModel::slotNewDocument(const Gui::Document& Doc)
     Doc.signalActivatedObject.connect(std::bind(&DocumentModel::slotActiveObject, this, sp::_1));
     Doc.signalInEdit.connect(std::bind(&DocumentModel::slotInEdit, this, sp::_1));
     Doc.signalResetEdit.connect(std::bind(&DocumentModel::slotResetEdit, this, sp::_1));
+    //NOLINTEND
 
     QModelIndex parent = createIndex(0,0,d->rootItem);
     int count_docs = d->rootItem->childCount();

--- a/src/Gui/DocumentObserver.cpp
+++ b/src/Gui/DocumentObserver.cpp
@@ -240,8 +240,10 @@ class DocumentWeakPtrT::Private {
 public:
     Private(Gui::Document* doc) : _document(doc) {
         if (doc) {
+            //NOLINTBEGIN
             connectApplicationDeletedDocument = doc->signalDeleteDocument.connect(std::bind
                 (&Private::deletedDocument, this, sp::_1));
+            //NOLINTEND
         }
     }
 
@@ -323,6 +325,7 @@ public:
         object = obj;
         try {
             if (obj) {
+                //NOLINTBEGIN
                 Gui::Document* doc = obj->getDocument();
                 indocument = true;
                 connectApplicationDeletedDocument = doc->signalDeleteDocument.connect(std::bind
@@ -331,6 +334,7 @@ public:
                     (&Private::createdObject, this, sp::_1));
                 connectDocumentDeletedObject = doc->signalDeletedObject.connect(std::bind
                     (&Private::deletedObject, this, sp::_1));
+                //NOLINTEND
             }
         }
         catch (const Base::RuntimeError&) {
@@ -425,6 +429,7 @@ void DocumentObserver::attachDocument(Document* doc)
     if (!doc)
         return;
 
+    //NOLINTBEGIN
     this->connectDocumentCreatedObject = doc->signalNewObject.connect(std::bind
         (&DocumentObserver::slotCreatedObject, this, sp::_1));
     this->connectDocumentDeletedObject = doc->signalDeletedObject.connect(std::bind
@@ -445,6 +450,7 @@ void DocumentObserver::attachDocument(Document* doc)
         (&DocumentObserver::slotRedoDocument, this, sp::_1));
     this->connectDocumentDelete = doc->signalDeleteDocument.connect(std::bind
         (&DocumentObserver::slotDeleteDocument, this, sp::_1));
+    //NOLINTEND
 }
 
 void DocumentObserver::detachDocument()

--- a/src/Gui/DocumentObserverPython.cpp
+++ b/src/Gui/DocumentObserverPython.cpp
@@ -58,6 +58,7 @@ void DocumentObserverPython::removeObserver(const Py::Object& obj)
 
 DocumentObserverPython::DocumentObserverPython(const Py::Object& obj) : inst(obj)
 {
+    //NOLINTBEGIN
 #define FC_PY_ELEMENT_ARG1(_name1, _name2) do {\
         FC_PY_GetCallable(obj.ptr(), "slot" #_name1, py##_name1.py);\
         if (!py##_name1.py.isNone())\
@@ -85,6 +86,7 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj) : inst(obj
     FC_PY_ELEMENT_ARG2(ChangedObject, ChangedObject)
     FC_PY_ELEMENT_ARG1(InEdit, InEdit)
     FC_PY_ELEMENT_ARG1(ResetEdit, ResetEdit)
+    //NOLINTEND
 }
 
 DocumentObserverPython::~DocumentObserverPython()

--- a/src/Gui/DocumentRecovery.cpp
+++ b/src/Gui/DocumentRecovery.cpp
@@ -576,8 +576,10 @@ void DocumentRecovery::cleanup(QDir& tmp, const QList<QFileInfo>& dirs, const QS
 
 bool DocumentRecoveryFinder::checkForPreviousCrashes()
 {
+    //NOLINTBEGIN
     DocumentRecoveryHandler handler;
     handler.checkForPreviousCrashes(std::bind(&DocumentRecoveryFinder::checkDocumentDirs, this, sp::_1, sp::_2, sp::_3));
+    //NOLINTEND
 
     return showRecoveryDialogIfNeeded();
 }

--- a/src/Gui/ExpressionBinding.cpp
+++ b/src/Gui/ExpressionBinding.cpp
@@ -111,9 +111,11 @@ void ExpressionBinding::bind(const App::ObjectIdentifier &_path)
     //connect to be informed about changes
     DocumentObject * docObj = path.getDocumentObject();
     if (docObj) {
+        //NOLINTBEGIN
         expressionchanged = docObj->ExpressionEngine.expressionChanged.connect(std::bind(&ExpressionBinding::expressionChange, this, sp::_1));
         App::Document* doc = docObj->getDocument();
         objectdeleted = doc->signalDeletedObject.connect(std::bind(&ExpressionBinding::objectDeleted, this, sp::_1));
+        //NOLINTEND
     }
 }
 

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -253,10 +253,12 @@ GraphvizView::GraphvizView(App::Document & _doc, QWidget* parent)
     connect(thread, &GraphvizWorker::error, this, &GraphvizView::error);
     connect(thread, &GraphvizWorker::svgFileRead, this, &GraphvizView::svgFileRead);
 
+    //NOLINTBEGIN
     // Connect signal from document
     recomputeConnection = _doc.signalRecomputed.connect(std::bind(&GraphvizView::updateSvgItem, this, sp::_1));
     undoConnection = _doc.signalUndo.connect(std::bind(&GraphvizView::updateSvgItem, this, sp::_1));
     redoConnection = _doc.signalRedo.connect(std::bind(&GraphvizView::updateSvgItem, this, sp::_1));
+    //NOLINTEND
 
     updateSvgItem(_doc);
 }

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -67,9 +67,11 @@ MDIView::MDIView(Gui::Document* pcDocument,QWidget* parent, Qt::WindowFlags wfla
 
     if (pcDocument)
     {
+      //NOLINTBEGIN
       connectDelObject = pcDocument->signalDeletedObject.connect
         (std::bind(&ActiveObjectList::objectDeleted, &ActiveObjects, sp::_1));
       assert(connectDelObject.connected());
+      //NOLINTEND
     }
 }
 

--- a/src/Gui/ManualAlignment.cpp
+++ b/src/Gui/ManualAlignment.cpp
@@ -654,9 +654,11 @@ ManualAlignment* ManualAlignment::_instance = nullptr;
 ManualAlignment::ManualAlignment()
   : myViewer(nullptr), myDocument(nullptr), myPickPoints(3), d(new Private)
 {
+    //NOLINTBEGIN
     // connect with the application's signal for deletion of documents
     this->connectApplicationDeletedDocument = Gui::Application::Instance->signalDeleteDocument
         .connect(std::bind(&ManualAlignment::slotDeletedDocument, this, sp::_1));
+    //NOLINTEND
 
     // setup sensor connection
     d->sensorCam1 = new SoNodeSensor(Private::syncCameraCB, this);
@@ -849,8 +851,10 @@ void ManualAlignment::startAlignment(Base::Type mousemodel)
     // Connect to the document's signal as we want to be notified when something happens
     if (this->connectDocumentDeletedObject.connected())
         this->connectDocumentDeletedObject.disconnect();
+    //NOLINTBEGIN
     this->connectDocumentDeletedObject = myDocument->signalDeletedObject.connect(std::bind
         (&ManualAlignment::slotDeletedObject, this, sp::_1));
+    //NOLINTEND
 
     continueAlignment();
 }

--- a/src/Gui/MergeDocuments.cpp
+++ b/src/Gui/MergeDocuments.cpp
@@ -76,11 +76,13 @@ private:
 
 MergeDocuments::MergeDocuments(App::Document* doc) : stream(nullptr), appdoc(doc)
 {
+    //NOLINTBEGIN
     connectExport = doc->signalExportObjects.connect
         (std::bind(&MergeDocuments::exportObject, this, sp::_1, sp::_2));
     connectImport = doc->signalImportObjects.connect
         (std::bind(&MergeDocuments::importObject, this, sp::_1, sp::_2));
     document = Gui::Application::Instance->getDocument(doc);
+    //NOLINTEND
 }
 
 MergeDocuments::~MergeDocuments()

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -825,11 +825,13 @@ NotificationArea::NotificationArea(QWidget* parent)
     });
 
 
+    //NOLINTBEGIN
     // Connection to the finish restore signal to rearm Critical messages modal mode when action is
     // user initiated
     pImp->finishRestoreDocumentConnection =
         App::GetApplication().signalFinishRestoreDocument.connect(
             std::bind(&Gui::NotificationArea::slotRestoreFinished, this, sp::_1));
+    //NOLINTEND
 
     // Initialisation of the timer to inhibit continuous updates of the notification system in case
     // clusters of messages arrive (so as to delay the actual notification until the whole cluster

--- a/src/Gui/Placement.cpp
+++ b/src/Gui/Placement.cpp
@@ -393,8 +393,10 @@ void Placement::setupSignalMapper()
 
 void Placement::setupDocument()
 {
+    //NOLINTBEGIN
     connectAct = Application::Instance->signalActiveDocument.connect
         (std::bind(&Placement::slotActiveDocument, this, sp::_1));
+    //NOLINTEND
     App::Document* activeDoc = App::GetApplication().getActiveDocument();
     if (activeDoc) {
         handler.appendDocument(activeDoc->getName());

--- a/src/Gui/PropertyView.cpp
+++ b/src/Gui/PropertyView.cpp
@@ -101,6 +101,7 @@ PropertyView::PropertyView(QWidget *parent)
     // connect after adding all tabs, so adding doesn't thrash the parameter
     connect(tabs, &QTabWidget::currentChanged, this, &PropertyView::tabChanged);
 
+    //NOLINTBEGIN
     this->connectPropData =
     App::GetApplication().signalChangedObject.connect(std::bind
         (&PropertyView::slotChangePropertyData, this, sp::_2));
@@ -136,6 +137,7 @@ PropertyView::PropertyView(QWidget *parent)
                 std::bind(&PropertyView::slotDeletedObject, this, sp::_1));
     this->connectChangedDocument = App::GetApplication().signalChangedDocument.connect(
             std::bind(&PropertyView::slotChangePropertyData, this, sp::_2));
+    //NOLINTEND
 }
 
 PropertyView::~PropertyView()

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -131,8 +131,10 @@ void SelectionObserver::attachSelection()
         auto &signal = newStyle ? Selection().signalSelectionChanged3 :
                        oldStyle ? Selection().signalSelectionChanged2 :
                                   Selection().signalSelectionChanged  ;
+        //NOLINTBEGIN
         connectSelection = signal.connect(std::bind
             (&SelectionObserver::_onSelectionChanged, this, sp::_1));
+        //NOLINTEND
 
         if (!filterDocName.empty()) {
             Selection().addSelectionGate(
@@ -1613,8 +1615,10 @@ SelectionSingleton::SelectionSingleton()
     hz = 0;
     ActiveGate = nullptr;
     gateResolve = ResolveMode::OldStyleElement;
+    //NOLINTBEGIN
     App::GetApplication().signalDeletedObject.connect(std::bind(&Gui::SelectionSingleton::slotDeletedObject, this, sp::_1));
     signalSelectionChanged.connect(std::bind(&Gui::SelectionSingleton::slotSelectionChanged, this, sp::_1));
+    //NOLINTEND
 }
 
 /**

--- a/src/Gui/TaskElementColors.cpp
+++ b/src/Gui/TaskElementColors.cpp
@@ -332,10 +332,12 @@ ElementColors::ElementColors(ViewProviderDocumentObject* vp, bool noHide)
 
     Selection().addSelectionGate(d, ResolveMode::NoResolve);
 
+    //NOLINTBEGIN
     d->connectDelDoc = Application::Instance->signalDeleteDocument.connect(std::bind
         (&ElementColors::slotDeleteDocument, this, sp::_1));
     d->connectDelObj = Application::Instance->signalDeletedObject.connect(std::bind
         (&ElementColors::slotDeleteObject, this, sp::_1));
+    //NOLINTEND
 
     d->populate();
 }

--- a/src/Gui/TaskView/TaskAppearance.cpp
+++ b/src/Gui/TaskView/TaskAppearance.cpp
@@ -55,9 +55,11 @@ TaskAppearance::TaskAppearance(QWidget *parent)
     this->groupLayout()->addWidget(proxy);
     Gui::Selection().Attach(this);
 
+    //NOLINTBEGIN
     this->connectChangedObject =
     Gui::Application::Instance->signalChangedObject.connect(std::bind
         (&TaskAppearance::slotChangedObject, this, sp::_1, sp::_2));
+    //NOLINTEND
 }
 
 TaskAppearance::~TaskAppearance()

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -293,7 +293,8 @@ TaskView::TaskView(QWidget *parent)
 
     Gui::Selection().Attach(this);
 
-    connectApplicationActiveDocument = 
+    //NOLINTBEGIN
+    connectApplicationActiveDocument =
     App::GetApplication().signalActiveDocument.connect
         (std::bind(&Gui::TaskView::TaskView::slotActiveDocument, this, sp::_1));
     connectApplicationDeleteDocument = 
@@ -305,6 +306,7 @@ TaskView::TaskView(QWidget *parent)
     connectApplicationRedoDocument = 
     App::GetApplication().signalRedoDocument.connect
         (std::bind(&Gui::TaskView::TaskView::slotRedoDocument, this, sp::_1));
+    //NOLINTEND
 }
 
 TaskView::~TaskView()
@@ -401,7 +403,9 @@ void TaskView::keyPressEvent(QKeyEvent* ke)
             func->setAutoDelete(true);
             Gui::Document* doc = Gui::Application::Instance->getDocument(ActiveDialog->getDocumentName().c_str());
             if (doc) {
-                func->setFunction(std::bind(&Document::resetEdit, doc));
+                func->setFunction([doc](){
+                    doc->resetEdit();
+                });
                 func->singleShot(0);
             }
         }

--- a/src/Gui/TextDocumentEditorView.cpp
+++ b/src/Gui/TextDocumentEditorView.cpp
@@ -107,10 +107,12 @@ void TextDocumentEditorView::setupEditor()
 
 void TextDocumentEditorView::setupConnection()
 {
+    //NOLINTBEGIN
     textConnection = textDocument->connectText(
             std::bind(&TextDocumentEditorView::sourceChanged, this));
     labelConnection = textDocument->connectLabel(
             std::bind(&TextDocumentEditorView::labelChanged, this));
+    //NOLINTEND
 }
 
 void TextDocumentEditorView::sourceChanged()

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -216,6 +216,7 @@ public:
     DocumentObjectData(DocumentItem* docItem, ViewProviderDocumentObject* vpd)
         : docItem(docItem), viewObject(vpd), rootItem(nullptr)
     {
+        //NOLINTBEGIN
         // Setup connections
         connectIcon = viewObject->signalChangeIcon.connect(
             std::bind(&DocumentObjectData::slotChangeIcon, this));
@@ -223,6 +224,7 @@ public:
             std::bind(&DocumentObjectData::slotChangeToolTip, this, sp::_1));
         connectStat = viewObject->signalChangeStatusTip.connect(
             std::bind(&DocumentObjectData::slotChangeStatusTip, this, sp::_1));
+        //NOLINTEND
 
         removeChildrenFromRoot = viewObject->canRemoveChildrenFromRoot();
         itemHidden = !viewObject->showInTree();
@@ -462,6 +464,7 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
     connect(this->searchObjectsAction, &QAction::triggered,
             this, &TreeWidget::onSearchObjects);
 
+    //NOLINTBEGIN
     // Setup connections
     connectNewDocument = Application::Instance->signalNewDocument.connect(std::bind(&TreeWidget::slotNewDocument, this, sp::_1, sp::_2));
     connectDelDocument = Application::Instance->signalDeleteDocument.connect(std::bind(&TreeWidget::slotDeleteDocument, this, sp::_1));
@@ -475,6 +478,7 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
     // for
     connectChangedViewObj = Application::Instance->signalChangedObject.connect(
         std::bind(&TreeWidget::slotChangedViewObject, this, sp::_1, sp::_2));
+    //NOLINTEND
 
     setupResizableColumn(this);
     this->header()->setStretchLastSection(false);
@@ -2562,10 +2566,12 @@ void TreeWidget::onUpdateStatus()
         auto doc = v.first->getDocument();
 
         if (!docItem->connectChgObject.connected()) {
+            //NOLINTBEGIN
             docItem->connectChgObject = docItem->document()->signalChangedObject.connect(
                 std::bind(&TreeWidget::slotChangeObject, this, sp::_1, sp::_2));
             docItem->connectTouchedObject = doc->signalTouchedObject.connect(
                 std::bind(&TreeWidget::slotTouchedObject, this, sp::_1));
+            //NOLINTEND
         }
 
         if (doc->testStatus(App::Document::PartialDoc))
@@ -3214,6 +3220,7 @@ void TreeWidget::selectLinkedObject(App::DocumentObject* linked) {
 DocumentItem::DocumentItem(const Gui::Document* doc, QTreeWidgetItem* parent)
     : QTreeWidgetItem(parent, TreeWidget::DocumentType), pDocument(const_cast<Gui::Document*>(doc))
 {
+    //NOLINTBEGIN
     // Setup connections
     connectNewObject = doc->signalNewObject.connect(std::bind(&DocumentItem::slotNewObject, this, sp::_1));
     connectDelObject = doc->signalDeletedObject.connect(
@@ -3235,6 +3242,7 @@ DocumentItem::DocumentItem(const Gui::Document* doc, QTreeWidgetItem* parent)
     connectRecomputed = adoc->signalRecomputed.connect(std::bind(&DocumentItem::slotRecomputed, this, sp::_1, sp::_2));
     connectRecomputedObj = adoc->signalRecomputedObject.connect(
         std::bind(&DocumentItem::slotRecomputedObject, this, sp::_1));
+    //NOLINTEND
 
     setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable/*|Qt::ItemIsEditable*/);
 

--- a/src/Gui/UiLoader.cpp
+++ b/src/Gui/UiLoader.cpp
@@ -624,10 +624,12 @@ Py::Object UiLoaderPy::load(const Py::Tuple& args)
 
 Py::Object UiLoaderPy::createWidget(const Py::Tuple& args)
 {
+    //NOLINTBEGIN
     return wrapFromWidgetFactory(args, std::bind(&UiLoader::createWidget, loader.get(),
                                                  std::placeholders::_1,
                                                  std::placeholders::_2,
                                                  std::placeholders::_3));
+    //NOLINTEND
 }
 
 Py::Object UiLoaderPy::addPluginPath(const Py::Tuple& args)

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -233,7 +233,9 @@ void ViewProvider::eventCallback(void * ud, SoEventCallback * node)
 
                         auto func = new Gui::TimerFunction();
                         func->setAutoDelete(true);
-                        func->setFunction(std::bind(&Document::resetEdit, doc));
+                        func->setFunction([doc]() {
+                            doc->resetEdit();
+                        });
                         func->singleShot(0);
                     }
                 }

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -272,7 +272,9 @@ void ViewProviderDocumentObject::addDefaultAction(QMenu* menu, const QString& te
     QAction* act = menu->addAction(text);
     act->setData(QVariant((int)ViewProvider::Default));
     auto func = new Gui::ActionFunction(menu);
-    func->trigger(act, std::bind(&ViewProviderDocumentObject::startDefaultEditMode, this));
+    func->trigger(act, [this](){
+        this->startDefaultEditMode();
+    });
 }
 
 void ViewProviderDocumentObject::setModeSwitch() {

--- a/src/Gui/ViewProviderImagePlane.cpp
+++ b/src/Gui/ViewProviderImagePlane.cpp
@@ -146,7 +146,9 @@ void ViewProviderImagePlane::setupContextMenu(QMenu* menu, QObject* receiver, co
     Gui::ActionFunction* func = new Gui::ActionFunction(menu);
     QAction* action = menu->addAction(QObject::tr("Change image..."));
     action->setIcon(QIcon(QLatin1String("images:image-scaling.svg")));
-    func->trigger(action, std::bind(&ViewProviderImagePlane::manipulateImage, this));
+    func->trigger(action, [this](){
+        this->manipulateImage();
+    });
 
     ViewProviderGeometryObject::setupContextMenu(menu, receiver, member);
 }

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -194,8 +194,10 @@ public:
         :ref(0),pcLinked(vp)
     {
         FC_LOG("new link to " << pcLinked->getObject()->getFullName());
+        //NOLINTBEGIN
         connChangeIcon = vp->signalChangeIcon.connect(
                 std::bind(&LinkInfo::slotChangeIcon,this));
+        //NOLINTEND
         vp->forceUpdate(true);
         sensor.setFunction(sensorCB);
         sensor.setData(this);

--- a/src/Gui/ViewProviderOriginGroupExtension.cpp
+++ b/src/Gui/ViewProviderOriginGroupExtension.cpp
@@ -97,11 +97,13 @@ void ViewProviderOriginGroupExtension::extensionAttach(App::DocumentObject *pcOb
     assert ( adoc );
     assert ( gdoc );
 
+    //NOLINTBEGIN
     connectChangedObjectApp = adoc->signalChangedObject.connect (
             std::bind ( &ViewProviderOriginGroupExtension::slotChangedObjectApp, this, sp::_1) );
 
     connectChangedObjectGui = gdoc->signalChangedObject.connect (
             std::bind ( &ViewProviderOriginGroupExtension::slotChangedObjectGui, this, sp::_1) );
+    //NOLINTEND
 }
 
 void ViewProviderOriginGroupExtension::extensionUpdateData( const App::Property* prop ) {

--- a/src/Gui/ViewProviderPart.cpp
+++ b/src/Gui/ViewProviderPart.cpp
@@ -71,7 +71,9 @@ void ViewProviderPart::setupContextMenu(QMenu* menu, QObject* receiver, const ch
 {
     auto func = new Gui::ActionFunction(menu);
     QAction* act = menu->addAction(QObject::tr("Toggle active part"));
-    func->trigger(act, std::bind(&ViewProviderPart::doubleClicked, this));
+    func->trigger(act, [this](){
+        this->doubleClicked();
+    });
 
     ViewProviderDragger::setupContextMenu(menu, receiver, member);
 }

--- a/src/Gui/ViewProviderTextDocument.cpp
+++ b/src/Gui/ViewProviderTextDocument.cpp
@@ -74,7 +74,9 @@ void ViewProviderTextDocument::setupContextMenu(QMenu* menu, QObject* receiver, 
 {
     auto func = new Gui::ActionFunction(menu);
     QAction* act = menu->addAction(QObject::tr("Edit text"));
-    func->trigger(act, std::bind(&ViewProviderTextDocument::doubleClicked, this));
+    func->trigger(act, [this](){
+        this->doubleClicked();
+    });
 
     ViewProviderDocumentObject::setupContextMenu(menu, receiver, member);
 }

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -161,7 +161,9 @@ void ViewProviderFemAnalysis::setupContextMenu(QMenu *menu, QObject *, const cha
 {
     Gui::ActionFunction *func = new Gui::ActionFunction(menu);
     QAction *act = menu->addAction(tr("Activate analysis"));
-    func->trigger(act, std::bind(&ViewProviderFemAnalysis::doubleClicked, this));
+    func->trigger(act, [this](){
+        this->doubleClicked();
+    });
 }
 
 bool ViewProviderFemAnalysis::setEdit(int ModNum)

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -69,10 +69,12 @@ namespace sp = std::placeholders;
 
 void FunctionWidget::setViewProvider(ViewProviderFemPostFunction* view)
 {
+    //NOLINTBEGIN
     m_view = view;
     m_object = static_cast<Fem::FemPostFunction*>(view->getObject());
     m_connection = m_object->getDocument()->signalChangedObject.connect(
         std::bind(&FunctionWidget::onObjectsChanged, this, sp::_1, sp::_2));
+    //NOLINTEND
 }
 
 void FunctionWidget::onObjectsChanged(const App::DocumentObject& obj, const App::Property& p) {

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -111,8 +111,10 @@ public:
 
 private:
     FemPostObjectSelectionObserver() {
+        //NOLINTBEGIN
         this->connectSelection = Gui::Selection().signalSelectionChanged.connect(
             std::bind(&FemPostObjectSelectionObserver::selectionChanged, this, sp::_1));
+        //NOLINTEND
     }
 
     ~FemPostObjectSelectionObserver() = default;

--- a/src/Mod/Mesh/App/Core/Curvature.cpp
+++ b/src/Mod/Mesh/App/Core/Curvature.cpp
@@ -79,8 +79,10 @@ void MeshCurvature::ComputePerFace(bool parallel)
         }
     }
     else {
+        //NOLINTBEGIN
         QFuture<CurvatureInfo> future = QtConcurrent::mapped
             (mySegment, std::bind(&FacetCurvature::Compute, &face, sp::_1));
+        //NOLINTEND
         QFutureWatcher<CurvatureInfo> watcher;
         watcher.setFuture(future);
         watcher.waitForFinished();

--- a/src/Mod/Mesh/Gui/MeshEditor.cpp
+++ b/src/Mod/Mesh/Gui/MeshEditor.cpp
@@ -476,8 +476,10 @@ void MeshFillHole::startEditing(MeshGui::ViewProviderMesh* vp)
     //viewer->setRedirectToSceneGraph(true);
     viewer->addEventCallback(SoEvent::getClassTypeId(),
         MeshFillHole::fileHoleCallback, this);
+    //NOLINTBEGIN
     myConnection = App::GetApplication().signalChangedObject.connect(
         std::bind(&MeshFillHole::slotChangedObject, this, sp::_1, sp::_2));
+    //NOLINTEND
 
     Gui::coinRemoveAllChildren(myBoundariesRoot);
     myBoundariesRoot->addChild(viewer->getHeadlight());

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -777,19 +777,25 @@ void ViewProviderMesh::setupContextMenu(QMenu* menu, QObject* receiver, const ch
     act->setCheckable(true);
     act->setChecked(pcMatBinding->value.getValue() == SoMaterialBinding::PER_FACE &&
                     highlightMode == HighlighMode::Component);
-    func->toggle(act, std::bind(&ViewProviderMesh::setHighlightedComponents, this, sp::_1));
+    func->toggle(act, [this](bool on){
+        this->setHighlightedComponents(on);
+    });
 
     QAction* seg = menu->addAction(QObject::tr("Display segments"));
     seg->setCheckable(true);
     seg->setChecked(pcMatBinding->value.getValue() == SoMaterialBinding::PER_FACE &&
                     highlightMode == HighlighMode::Segment);
-    func->toggle(seg, std::bind(&ViewProviderMesh::setHighlightedSegments, this, sp::_1));
+    func->toggle(seg, [this](bool on){
+        this->setHighlightedSegments(on);
+    });
 
     QAction* col = menu->addAction(QObject::tr("Display colors"));
     col->setVisible(canHighlightColors());
     col->setCheckable(true);
     col->setChecked(highlightMode == HighlighMode::Color);
-    func->toggle(col, std::bind(&ViewProviderMesh::setHighlightedColors, this, sp::_1));
+    func->toggle(col, [this](bool on){
+        this->setHighlightedColors(on);
+    });
 }
 
 bool ViewProviderMesh::setEdit(int ModNum)
@@ -994,7 +1000,9 @@ void ViewProviderMesh::clipMeshCallback(void * ud, SoEventCallback * n)
                     Gui::TimerFunction* func = new Gui::TimerFunction();
                     func->setAutoDelete(true);
                     MeshSplit* split = new MeshSplit(self, clPoly, proj);
-                    func->setFunction(std::bind(&MeshSplit::cutMesh, split));
+                    func->setFunction([split](){
+                        split->cutMesh();
+                    });
                     func->singleShot(0);
                 }
             }
@@ -1055,7 +1063,9 @@ void ViewProviderMesh::trimMeshCallback(void * ud, SoEventCallback * n)
                     Gui::TimerFunction* func = new Gui::TimerFunction();
                     func->setAutoDelete(true);
                     MeshSplit* split = new MeshSplit(self, clPoly, proj);
-                    func->setFunction(std::bind(&MeshSplit::trimMesh, split));
+                    func->setFunction([split](){
+                        split->trimMesh();
+                    });
                     func->singleShot(0);
                 }
             }

--- a/src/Mod/MeshPart/Gui/CrossSections.cpp
+++ b/src/Mod/MeshPart/Gui/CrossSections.cpp
@@ -294,10 +294,12 @@ void CrossSections::apply()
 
         MeshCore::MeshFacetGrid grid(kernel);
 
+        //NOLINTBEGIN
         MeshCrossSection cs(kernel, grid, a, b, c, connectEdges, eps);
         QFuture< std::list<TopoDS_Wire> > future = QtConcurrent::mapped
             (d, std::bind(&MeshCrossSection::section, &cs, sp::_1));
         future.waitForFinished();
+        //NOLINTEND
 
         TopoDS_Compound comp;
         BRep_Builder builder;

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -207,12 +207,14 @@ struct ShapeCache {
         if(inited)
             return;
         inited = true;
+        //NOLINTBEGIN
         App::GetApplication().signalDeleteDocument.connect(
                 std::bind(&ShapeCache::slotDeleteDocument, this, sp::_1));
         App::GetApplication().signalDeletedObject.connect(
                 std::bind(&ShapeCache::slotClear, this, sp::_1));
         App::GetApplication().signalChangedObject.connect(
                 std::bind(&ShapeCache::slotChanged, this, sp::_1,sp::_2));
+        //NOLINTEND
     }
 
     void slotDeleteDocument(const App::Document &doc) {

--- a/src/Mod/Part/Gui/DlgBooleanOperation.cpp
+++ b/src/Mod/Part/Gui/DlgBooleanOperation.cpp
@@ -93,10 +93,12 @@ DlgBooleanOperation::DlgBooleanOperation(QWidget* parent)
             this, &DlgBooleanOperation::currentItemChanged);
     connect(ui->secondShape, &QTreeWidget::currentItemChanged,
             this, &DlgBooleanOperation::currentItemChanged);
+    //NOLINTBEGIN
     this->connectNewObject = App::GetApplication().signalNewObject.connect(std::bind
         (&DlgBooleanOperation::slotCreatedObject, this, sp::_1));
     this->connectModObject = App::GetApplication().signalChangedObject.connect(std::bind
         (&DlgBooleanOperation::slotChangedObject, this, sp::_1, sp::_2));
+    //NOLINTEND
     findShapes();
 }
 

--- a/src/Mod/Part/Gui/DlgFilletEdges.cpp
+++ b/src/Mod/Part/Gui/DlgFilletEdges.cpp
@@ -244,10 +244,12 @@ DlgFilletEdges::DlgFilletEdges(FilletType type, Part::FilletBase* fillet, QWidge
     Gui::Selection().addSelectionGate(d->selection);
 
     d->fillet = fillet;
+    //NOLINTBEGIN
     d->connectApplicationDeletedObject = App::GetApplication().signalDeletedObject
         .connect(std::bind(&DlgFilletEdges::onDeleteObject, this, sp::_1));
     d->connectApplicationDeletedDocument = App::GetApplication().signalDeleteDocument
         .connect(std::bind(&DlgFilletEdges::onDeleteDocument, this, sp::_1));
+    //NOLINTEND
     // set tree view with three columns
     FilletRadiusModel* model = new FilletRadiusModel(this);
     connect(model, &FilletRadiusModel::toggleCheckState,

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -224,9 +224,11 @@ TaskAttacher::TaskAttacher(Gui::ViewProviderDocumentObject *ViewProvider, QWidge
     selectMapMode(eMapMode(pcAttach->MapMode.getValue()));
     updatePreview();
 
+    //NOLINTBEGIN
     // connect object deletion with slot
     auto bnd1 = std::bind(&TaskAttacher::objectDeleted, this, sp::_1);
     auto bnd2 = std::bind(&TaskAttacher::documentDeleted, this, sp::_1);
+    //NOLINTEND
     Gui::Document* document = Gui::Application::Instance->getDocument(ViewProvider->getObject()->getDocument());
     connectDelObject = document->signalDeletedObject.connect(bnd1);
     connectDelDocument = document->signalDeleteDocument.connect(bnd2);

--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -94,7 +94,9 @@ struct MeasureInfo {
     {
         if(!_MeasureInfoInited) {
             _MeasureInfoInited = true;
+            //NOLINTBEGIN
             App::GetApplication().signalDeleteDocument.connect(std::bind(slotDeleteDocument, sp::_1));
+            //NOLINTEND
         }
     }
 };

--- a/src/Mod/Part/Gui/TaskFaceColors.cpp
+++ b/src/Mod/Part/Gui/TaskFaceColors.cpp
@@ -251,12 +251,14 @@ FaceColors::FaceColors(ViewProviderPartExt* vp, QWidget* parent)
     FaceSelection* gate = new FaceSelection(d->vp->getObject());
     Gui::Selection().addSelectionGate(gate);
 
+    //NOLINTBEGIN
     d->connectDelDoc = Gui::Application::Instance->signalDeleteDocument.connect(std::bind
         (&FaceColors::slotDeleteDocument, this, sp::_1));
     d->connectDelObj = Gui::Application::Instance->signalDeletedObject.connect(std::bind
         (&FaceColors::slotDeleteObject, this, sp::_1));
     d->connectUndoDoc = d->doc->signalUndoDocument.connect(std::bind
         (&FaceColors::slotUndoDocument, this, sp::_1));
+    //NOLINTEND
 }
 
 FaceColors::~FaceColors()

--- a/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
@@ -118,7 +118,9 @@ void ViewProviderAttachExtension::extensionSetupContextMenu(QMenu* menu, QObject
         QAction* act = menu->addAction(QObject::tr("Attachment editor"));
         if (Gui::Control().activeDialog())
             act->setDisabled(true);
-        func->trigger(act, std::bind(&ViewProviderAttachExtension::showAttachmentEditor, this));
+        func->trigger(act, [this](){
+            this->showAttachmentEditor();
+        });
     }
 }
 

--- a/src/Mod/Part/Gui/ViewProviderPrimitive.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPrimitive.cpp
@@ -55,7 +55,9 @@ void ViewProviderPrimitive::setupContextMenu(QMenu* menu, QObject* receiver, con
     Gui::ActionFunction* func = new Gui::ActionFunction(menu);
     QAction* act = menu->addAction(QObject::tr("Edit %1").arg(QString::fromUtf8(getObject()->Label.getValue())));
     act->setData(QVariant((int)ViewProvider::Default));
-    func->trigger(act, std::bind(&ViewProviderPrimitive::startDefaultEditMode, this));
+    func->trigger(act, [this](){
+        this->startDefaultEditMode();
+    });
 
     ViewProviderPart::setupContextMenu(menu, receiver, member);
 }

--- a/src/Mod/Part/Gui/ViewProviderSpline.cpp
+++ b/src/Mod/Part/Gui/ViewProviderSpline.cpp
@@ -97,7 +97,9 @@ void ViewProviderSplineExtension::extensionSetupContextMenu(QMenu* menu, QObject
     QAction* act = menu->addAction(QObject::tr("Show control points"));
     act->setCheckable(true);
     act->setChecked(ControlPoints.getValue());
-    func->toggle(act, std::bind(&ViewProviderSplineExtension::toggleControlPoints, this, sp::_1));
+    func->toggle(act, [this](bool on) {
+        this->toggleControlPoints(on);
+    });
 }
 
 void ViewProviderSplineExtension::extensionUpdateData(const App::Property* prop)

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -257,8 +257,10 @@ void ShapeBinder::onSettingDocument()
 {
     App::Document* document = getDocument();
     if (document) {
+        //NOLINTBEGIN
         this->connectDocumentChangedObject = document->signalChangedObject.connect(std::bind
             (&ShapeBinder::slotChangedObject, this, sp::_1, sp::_2));
+        //NOLINTEND
     }
 }
 
@@ -833,9 +835,11 @@ void SubShapeBinder::onChanged(const App::Property* prop) {
         else if (contextDoc != Context.getValue()->getDocument()
             || !connRecomputedObj.connected())
         {
+            //NOLINTBEGIN
             contextDoc = Context.getValue()->getDocument();
             connRecomputedObj = contextDoc->signalRecomputedObject.connect(
                 std::bind(&SubShapeBinder::slotRecomputedObject, this, sp::_1));
+            //NOLINTEND
         }
     }
     else if (!isRestoring()) {

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -250,8 +250,10 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
     ui->ThreadDepth->bind(pcHole->ThreadDepth);
     ui->CustomThreadClearance->bind(pcHole->CustomThreadClearance);
 
+    //NOLINTBEGIN
     connectPropChanged = App::GetApplication().signalChangePropertyEditor.connect(
             std::bind(&TaskHoleParameters::changedObject, this, sp::_1, sp::_2));
+    //NOLINTEND
 
     this->groupLayout()->addWidget(proxy);
 }

--- a/src/Mod/PartDesign/Gui/TaskTransformedMessages.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedMessages.cpp
@@ -49,7 +49,11 @@ TaskTransformedMessages::TaskTransformedMessages(ViewProviderTransformed *transf
     this->groupLayout()->addWidget(proxy);
     ui->labelTransformationStatus->setText(transformedView->getMessage());
 
-    connectionDiagnosis = transformedView->signalDiagnosis.connect(std::bind(&PartDesignGui::TaskTransformedMessages::slotDiagnosis, this, sp::_1));
+    //NOLINTBEGIN
+    connectionDiagnosis = transformedView->signalDiagnosis.connect(
+        std::bind(&PartDesignGui::TaskTransformedMessages::slotDiagnosis, this, sp::_1)
+    );
+    //NOLINTEND
 }
 
 TaskTransformedMessages::~TaskTransformedMessages()

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -91,11 +91,13 @@ void ViewProviderBody::attach(App::DocumentObject *pcFeat)
     assert ( adoc );
     assert ( gdoc );
 
+    //NOLINTBEGIN
     connectChangedObjectApp = adoc->signalChangedObject.connect (
             std::bind ( &ViewProviderBody::slotChangedObjectApp, this, sp::_1, sp::_2) );
 
     connectChangedObjectGui = gdoc->signalChangedObject.connect (
             std::bind ( &ViewProviderBody::slotChangedObjectGui, this, sp::_1, sp::_2) );
+    //NOLINTEND
 }
 
 // TODO on activating the body switch to the "Through" mode (2015-09-05, Fat-Zer)
@@ -131,7 +133,9 @@ void ViewProviderBody::setupContextMenu(QMenu* menu, QObject* receiver, const ch
     Q_UNUSED(member);
     Gui::ActionFunction* func = new Gui::ActionFunction(menu);
     QAction* act = menu->addAction(tr("Toggle active body"));
-    func->trigger(act, std::bind(&ViewProviderBody::doubleClicked, this));
+    func->trigger(act, [this]() {
+        this->doubleClicked();
+    });
 
     Gui::ViewProviderGeometryObject::setupContextMenu(menu, receiver, member); // clazy:exclude=skipped-base-method
 }

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -442,11 +442,13 @@ void Workbench::activated()
     if(App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/PartDesign")->GetBool("SwitchToTask", true))
         Gui::Control().showTaskView();
 
+    //NOLINTBEGIN
     // Let us be notified when a document is activated, so that we can update the ActivePartObject
     activeDoc = Gui::Application::Instance->signalActiveDocument.connect(std::bind(&Workbench::slotActiveDocument, this, sp::_1));
     createDoc = App::GetApplication().signalNewDocument.connect(std::bind(&Workbench::slotNewDocument, this, sp::_1));
     finishDoc = App::GetApplication().signalFinishRestoreDocument.connect(std::bind(&Workbench::slotFinishRestoreDocument, this, sp::_1));
     deleteDoc = App::GetApplication().signalDeleteDocument.connect(std::bind(&Workbench::slotDeleteDocument, this, sp::_1));
+    //NOLINTEND
 }
 
 void Workbench::deactivated()

--- a/src/Mod/PartDesign/Gui/WorkflowManager.cpp
+++ b/src/Mod/PartDesign/Gui/WorkflowManager.cpp
@@ -48,12 +48,14 @@ WorkflowManager::WorkflowManager() {
         slotFinishRestoreDocument ( *doc );
    }
 
+    //NOLINTBEGIN
     connectNewDocument = App::GetApplication().signalNewDocument.connect(
             std::bind( &WorkflowManager::slotNewDocument, this, sp::_1 ) );
     connectFinishRestoreDocument = App::GetApplication().signalFinishRestoreDocument.connect(
             std::bind( &WorkflowManager::slotFinishRestoreDocument, this, sp::_1 ) );
     connectDeleteDocument = App::GetApplication().signalDeleteDocument.connect(
             std::bind( &WorkflowManager::slotDeleteDocument, this, sp::_1 ) );
+    //NOLINTEND
 }
 
 WorkflowManager::~WorkflowManager() {

--- a/src/Mod/ReverseEngineering/App/ApproxSurface.cpp
+++ b/src/Mod/ReverseEngineering/App/ApproxSurface.cpp
@@ -1091,8 +1091,10 @@ bool BSplineParameterCorrection::SolveWithSmoothing(double fWeight)
     std::vector<int> columns(ulDim);
     std::generate(columns.begin(), columns.end(), Base::iotaGen<int>(0));
     ScalarProduct scalar(M);
+    //NOLINTBEGIN
     QFuture< std::vector<double> > future = QtConcurrent::mapped
         (columns, std::bind(&ScalarProduct::multiply, &scalar, sp::_1));
+    //NOLINTEND
     QFutureWatcher< std::vector<double> > watcher;
     watcher.setFuture(future);
     watcher.waitForFinished();

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -152,6 +152,7 @@ SketchObject::SketchObject()
 
     noRecomputes = false;
 
+    //NOLINTBEGIN
     ExpressionEngine.setValidator(
         std::bind(&Sketcher::SketchObject::validateExpression, this, sp::_1, sp::_2));
 
@@ -159,6 +160,7 @@ SketchObject::SketchObject()
         std::bind(&Sketcher::SketchObject::constraintsRemoved, this, sp::_1));
     constraintsRenamedConn = Constraints.signalConstraintsRenamed.connect(
         std::bind(&Sketcher::SketchObject::constraintsRenamed, this, sp::_1));
+    //NOLINTEND
 
     analyser = new SketchAnalysis(this);
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -944,8 +944,10 @@ TaskSketcherConstraints::TaskSketcherConstraints(ViewProviderSketch* sketchView)
                      this,
                      &TaskSketcherConstraints::onFilterListItemChanged);
 
+    //NOLINTBEGIN
     connectionConstraintsChanged = sketchView->signalConstraintsChanged.connect(
         std::bind(&SketcherGui::TaskSketcherConstraints::slotConstraintsChanged, this));
+    //NOLINTEND
 
     this->groupLayout()->addWidget(proxy);
 
@@ -953,9 +955,11 @@ TaskSketcherConstraints::TaskSketcherConstraints(ViewProviderSketch* sketchView)
 
     ui->listWidgetConstraints->setStyleSheet(QString::fromLatin1("margin-top: 0px"));
 
+    //NOLINTBEGIN
     Gui::Application* app = Gui::Application::Instance;
     changedSketchView = app->signalChangedObject.connect(
         std::bind(&TaskSketcherConstraints::onChangedSketchView, this, sp::_1, sp::_2));
+    //NOLINTEND
 
     slotConstraintsChanged();// Populate constraints list
     // Initialize special filters

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -1070,8 +1070,10 @@ void TaskSketcherElements::connectSignals()
     QObject::connect(
         ui->filterButton, &QToolButton::clicked, ui->filterButton, &QToolButton::showMenu);
 
+    //NOLINTBEGIN
     connectionElementsChanged = sketchView->signalElementsChanged.connect(
         std::bind(&SketcherGui::TaskSketcherElements::slotElementsChanged, this));
+    //NOLINTEND
 }
 
 /* filter functions --------------------------------------------------- */

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
@@ -52,8 +52,10 @@ TaskSketcherMessages::TaskSketcherMessages(ViewProviderSketch* sketchView)
 
     this->groupLayout()->addWidget(proxy);
 
+    //NOLINTBEGIN
     connectionSetUp = sketchView->signalSetUp.connect(std::bind(
         &SketcherGui::TaskSketcherMessages::slotSetUp, this, sp::_1, sp::_2, sp::_3, sp::_4));
+    //NOLINTEND
 
     ui->labelConstrainStatus->setOpenExternalLinks(false);
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3232,10 +3232,12 @@ bool ViewProviderSketch::setEdit(int ModNum)
     // a draw(true) via ViewProvider::UpdateData.
     getSketchObject()->solve(true);
 
+    //NOLINTBEGIN
     connectUndoDocument = getDocument()->signalUndoDocument.connect(
         std::bind(&ViewProviderSketch::slotUndoDocument, this, sp::_1));
     connectRedoDocument = getDocument()->signalRedoDocument.connect(
         std::bind(&ViewProviderSketch::slotRedoDocument, this, sp::_1));
+    //NOLINTEND
 
     // Enable solver initial solution update while dragging.
     getSketchObject()->setRecalculateInitialSolutionWhileMovingPoint(

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -849,7 +849,7 @@ void PropertySheet::insertRows(int row, int count)
     boost::copy( data | boost::adaptors::map_keys, std::back_inserter(keys));
 
     /* Sort them */
-    std::sort(keys.begin(), keys.end(), std::bind(&PropertySheet::rowSortFunc, this, sp::_1, sp::_2));
+    std::sort(keys.begin(), keys.end(), std::bind(&PropertySheet::rowSortFunc, this, sp::_1, sp::_2)); //NOLINT
 
     MoveCellsExpressionVisitor<PropertySheet> visitor(*this,
             CellAddress(row, CellAddress::MAX_COLUMNS), count, 0);
@@ -1047,7 +1047,7 @@ void PropertySheet::removeColumns(int col, int count)
     boost::copy(data | boost::adaptors::map_keys, std::back_inserter(keys));
 
     /* Sort them */
-    std::sort(keys.begin(), keys.end(), std::bind(&PropertySheet::colSortFunc, this, sp::_1, sp::_2));
+    std::sort(keys.begin(), keys.end(), std::bind(&PropertySheet::colSortFunc, this, sp::_1, sp::_2)); //NOLINT
 
     MoveCellsExpressionVisitor<PropertySheet> visitor(*this,
             CellAddress(CellAddress::MAX_ROWS, col + count - 1), 0, -count);
@@ -1414,8 +1414,10 @@ void PropertySheet::slotChangedObject(const App::DocumentObject &obj, const App:
 }
 
 void PropertySheet::onAddDep(App::DocumentObject *obj) {
+    //NOLINTBEGIN
     depConnections[obj] = obj->signalChanged.connect(std::bind(
                 &PropertySheet::slotChangedObject, this, sp::_1, sp::_2));
+    //NOLINTEND
 }
 
 void PropertySheet::onRemoveDep(App::DocumentObject *obj) {

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -45,10 +45,12 @@ namespace sp = std::placeholders;
 
 SheetModel::SheetModel(Sheet* _sheet, QObject* parent) : QAbstractTableModel(parent), sheet(_sheet)
 {
+    //NOLINTBEGIN
     cellUpdatedConnection =
         sheet->cellUpdated.connect(bind(&SheetModel::cellUpdated, this, sp::_1));
     rangeUpdatedConnection =
         sheet->rangeUpdated.connect(bind(&SheetModel::rangeUpdated, this, sp::_1));
+    //NOLINTEND
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Spreadsheet");

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -98,8 +98,10 @@ SheetView::SheetView(Gui::Document *pcDocument, App::DocumentObject *docObj, QWi
     connect(ui->cellAlias, &ExpressionLineEdit::editingFinished, this, [this]() {confirmAliasChanged(ui->cellAlias->text()); });
     connect(ui->cellAlias, &LineEdit::textEdited, this, &SheetView::aliasChanged);
 
+    //NOLINTBEGIN
     columnWidthChangedConnection = sheet->columnWidthChanged.connect(bind(&SheetView::resizeColumn, this, sp::_1, sp::_2));
     rowHeightChangedConnection = sheet->rowHeightChanged.connect(bind(&SheetView::resizeRow, this, sp::_1, sp::_2));
+    //NOLINTEND
 
     connect( model, &QAbstractItemModel::dataChanged, this, &SheetView::modelUpdated);
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -114,10 +114,12 @@ MDIViewPage::MDIViewPage(ViewProviderPage* pageVp, Gui::Document* doc, QWidget* 
     tabText += QString::fromUtf8("[*]");
     setWindowTitle(tabText);
 
+    //NOLINTBEGIN
     //get informed by App side about deleted DocumentObjects
     App::Document* appDoc = m_vpPage->getDocument()->getDocument();
     auto bnd = std::bind(&MDIViewPage::onDeleteObject, this, sp::_1);
     connectDeletedObject = appDoc->signalDeletedObject.connect(bnd);
+    //NOLINTEND
 }
 
 MDIViewPage::~MDIViewPage() { connectDeletedObject.disconnect(); }

--- a/src/Mod/TechDraw/Gui/ViewProviderBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderBalloon.cpp
@@ -87,7 +87,9 @@ void ViewProviderBalloon::setupContextMenu(QMenu* menu, QObject* receiver, const
     Gui::ActionFunction* func = new Gui::ActionFunction(menu);
     QAction* act = menu->addAction(QObject::tr("Edit %1").arg(QString::fromUtf8(getObject()->Label.getValue())));
     act->setData(QVariant((int)ViewProvider::Default));
-    func->trigger(act, std::bind(&ViewProviderBalloon::startDefaultEditMode, this));
+    func->trigger(act, [this]() {
+        this->startDefaultEditMode();
+    });
 
     ViewProviderDrawingView::setupContextMenu(menu, receiver, member);
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -122,7 +122,9 @@ void ViewProviderDimension::setupContextMenu(QMenu* menu, QObject* receiver, con
     Gui::ActionFunction* func = new Gui::ActionFunction(menu);
     QAction* act = menu->addAction(QObject::tr("Edit %1").arg(QString::fromUtf8(getObject()->Label.getValue())));
     act->setData(QVariant((int)ViewProvider::Default));
-    func->trigger(act, std::bind(&ViewProviderDimension::startDefaultEditMode, this));
+    func->trigger(act, [this](){
+        this->startDefaultEditMode();
+    });
 
     ViewProviderDrawingView::setupContextMenu(menu, receiver, member);
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -79,8 +79,10 @@ void ViewProviderDrawingView::attach(App::DocumentObject *pcFeat)
 //    Base::Console().Message("VPDV::attach(%s)\n", pcFeat->getNameInDocument());
     ViewProviderDocumentObject::attach(pcFeat);
 
+    //NOLINTBEGIN
     auto bnd = std::bind(&ViewProviderDrawingView::onGuiRepaint, this, sp::_1);
     auto bndProgressMessage = std::bind(&ViewProviderDrawingView::onProgressMessage, this, sp::_1, sp::_2, sp::_3);
+    //NOLINTEND
     auto feature = getViewObject();
     if (feature) {
         const char* temp = feature->getNameInDocument();

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -114,7 +114,9 @@ void ViewProviderPage::attach(App::DocumentObject* pcFeat)
 {
     ViewProviderDocumentObject::attach(pcFeat);
 
+    //NOLINTBEGIN
     auto bnd = std::bind(&ViewProviderPage::onGuiRepaint, this, sp::_1);
+    //NOLINTEND
     TechDraw::DrawPage* feature = dynamic_cast<TechDraw::DrawPage*>(pcFeat);
     if (feature) {
         connectGuiRepaint = feature->signalGuiPaint.connect(bnd);


### PR DESCRIPTION
In many cases std::bind() is kept because the code is much simpler

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
