### PR TITLE
App: Fix crash and undefined behavior in StringHasherPy and StringIDPy

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -114,6 +114,8 @@
 #include "PropertyFile.h"
 #include "PropertyLinks.h"
 #include "PropertyPythonObject.h"
+#include "StringHasherPy.h"
+#include "StringIDPy.h"
 #include "TextDocument.h"
 #include "Transactions.h"
 #include "VRMLObject.h"
@@ -310,6 +312,9 @@ void Application::setupPythonTypes()
 
     Base::Interpreter().addType(&App::MaterialPy::Type, pAppModule, "Material");
     Base::Interpreter().addType(&App::MetadataPy::Type, pAppModule, "Metadata");
+
+    Base::Interpreter().addType(&App::StringHasherPy::Type, pAppModule, "StringHasher");
+    Base::Interpreter().addType(&App::StringIDPy::Type, pAppModule, "StringID");
 
     // Add document types
     Base::Interpreter().addType(&App::PropertyContainerPy::Type, pAppModule, "PropertyContainer");
@@ -2108,6 +2113,10 @@ void Application::initTypes()
     App::FunctionExpression        ::init();
     App::RangeExpression           ::init();
     App::PyObjectExpression        ::init();
+
+    // Topological naming classes
+    App::StringHasher              ::init();
+    App::StringID                  ::init();
 
     // register transaction type
     new App::TransactionProducer<TransactionDocumentObject>

--- a/src/App/StringHasherPyImp.cpp
+++ b/src/App/StringHasherPyImp.cpp
@@ -32,14 +32,14 @@ using namespace App;
 // returns a string which represent the object e.g. when printed in python
 std::string StringHasherPy::representation() const
 {
-   std::ostringstream str;
-   str << "<StringHasher at " << getStringHasherPtr() << ">";
-   return str.str();
+    std::ostringstream str;
+    str << "<StringHasher at " << getStringHasherPtr() << ">";
+    return str.str();
 }
 
 PyObject *StringHasherPy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper
 {
-   return new StringHasherPy(new StringHasher);
+    return new StringHasherPy(new StringHasher);
 }
 
 // constructor method
@@ -56,14 +56,15 @@ int StringHasherPy::PyInit(PyObject* args, PyObject* kwds)
 
 PyObject* StringHasherPy::isSame(PyObject *args)
 {
-   PyObject *other;
-   if (!PyArg_ParseTuple(args, "O!", &StringHasherPy::Type, &other)) {
-       return nullptr;
-   }
-   auto otherHasher = static_cast<StringHasherPy*>(other)->getStringHasherPtr();
-   bool same = getStringHasherPtr() == otherHasher;
+    PyObject *other;
+    if (!PyArg_ParseTuple(args, "O!", &StringHasherPy::Type, &other)) {
+        return nullptr;
+    }
 
-   return PyBool_FromLong(same ? 1 : 0);
+    auto otherHasher = static_cast<StringHasherPy*>(other)->getStringHasherPtr();
+    bool same = getStringHasherPtr() == otherHasher;
+
+    return  PyBool_FromLong(same ? 1 : 0);
 }
 
 PyObject* StringHasherPy::getID(PyObject *args)
@@ -77,6 +78,7 @@ PyObject* StringHasherPy::getID(PyObject *args)
                 if (!sid) {
                     Py_Return;
                 }
+
                 return sid.getPyObject();
             }
             PY_CATCH;
@@ -96,8 +98,8 @@ PyObject* StringHasherPy::getID(PyObject *args)
             QByteArray data;
             StringIDRef sid;
             if (PyObject_IsTrue(base64)) {
-               data = QByteArray::fromBase64(QByteArray::fromRawData(txt.c_str(),txt.size()));
-               sid = getStringHasherPtr()->getID(data,true);
+                data = QByteArray::fromBase64(QByteArray::fromRawData(txt.c_str(),txt.size()));
+                sid = getStringHasherPtr()->getID(data,true);
             }
             else {
                 sid = getStringHasherPtr()->getID(txt.c_str(),txt.size());
@@ -113,43 +115,52 @@ PyObject* StringHasherPy::getID(PyObject *args)
     return nullptr;
 }
 
-Py::Int StringHasherPy::getCount() const {
-   return Py::Int((long)getStringHasherPtr()->count());
+Py::Long StringHasherPy::getCount() const
+{
+    return Py::Long(PyLong_FromSize_t(getStringHasherPtr()->count()), true);
 }
 
-Py::Int StringHasherPy::getSize() const {
-   return Py::Int((long)getStringHasherPtr()->size());
+Py::Long StringHasherPy::getSize() const
+{
+    return Py::Long(PyLong_FromSize_t(getStringHasherPtr()->size()), true);
 }
 
-Py::Boolean StringHasherPy::getSaveAll() const {
-   return Py::Boolean(getStringHasherPtr()->getSaveAll());
+Py::Boolean StringHasherPy::getSaveAll() const
+{
+    return Py::Boolean(getStringHasherPtr()->getSaveAll());
 }
 
-void StringHasherPy::setSaveAll(Py::Boolean value) {
-   getStringHasherPtr()->setSaveAll(value);
+void StringHasherPy::setSaveAll(Py::Boolean value)
+{
+    getStringHasherPtr()->setSaveAll(value);
 }
 
-Py::Int StringHasherPy::getThreshold() const {
-   return Py::Int((long)getStringHasherPtr()->getThreshold());
+Py::Long StringHasherPy::getThreshold() const
+{
+    return Py::Long(getStringHasherPtr()->getThreshold());
 }
 
-void StringHasherPy::setThreshold(Py::Int value) {
-   getStringHasherPtr()->setThreshold(value);
+void StringHasherPy::setThreshold(Py::Long value)
+{
+    getStringHasherPtr()->setThreshold(value);
 }
 
-Py::Dict StringHasherPy::getTable() const {
-   Py::Dict dict;
-   for(auto &v : getStringHasherPtr()->getIDMap())
-       dict.setItem(Py::Int(v.first),Py::String(v.second.dataToText()));
-   return dict;
+Py::Dict StringHasherPy::getTable() const
+{
+    Py::Dict dict;
+    for (const auto &v : getStringHasherPtr()->getIDMap()) {
+        dict.setItem(Py::Long(v.first), Py::String(v.second.dataToText()));
+    }
+
+    return dict;
 }
 
 PyObject *StringHasherPy::getCustomAttributes(const char* /*attr*/) const
 {
-   return nullptr;
+    return nullptr;
 }
 
 int StringHasherPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
 {
-   return 0;
+    return 0;
 }

--- a/src/App/StringIDPyImp.cpp
+++ b/src/App/StringIDPyImp.cpp
@@ -32,61 +32,69 @@ using namespace App;
 // returns a string which represent the object e.g. when printed in python
 std::string StringIDPy::representation() const
 {
-   return getStringIDPtr()->toString(_index);
+    return getStringIDPtr()->toString(this->_index);
 }
 
 PyObject* StringIDPy::isSame(PyObject *args)
 {
-   PyObject *other = nullptr;
-   if (!PyArg_ParseTuple(args, "O!", &StringIDPy::Type, &other)) {
-       return nullptr;
-   }
+    PyObject *other = nullptr;
+    if (!PyArg_ParseTuple(args, "O!", &StringIDPy::Type, &other)) {
+        return nullptr;
+    }
 
-   auto *otherPy = static_cast<StringIDPy*>(other);
-   bool same = (otherPy->getStringIDPtr() == this->getStringIDPtr())
-               && (otherPy->_index == this->_index);
+    auto *otherPy = static_cast<StringIDPy*>(other);
+    bool same = (otherPy->getStringIDPtr() == this->getStringIDPtr())
+                && (otherPy->_index == this->_index);
 
-   return PyBool_FromLong(same ? 1 : 0);
+    return PyBool_FromLong(same ? 1 : 0);
 }
 
-Py::Int StringIDPy::getValue() const {
-   return Py::Int(getStringIDPtr()->value());
+Py::Long StringIDPy::getValue() const
+{
+    return Py::Long(getStringIDPtr()->value());
 }
 
-Py::List StringIDPy::getRelated() const {
-   Py::List list;
-   for (const auto &id : getStringIDPtr()->relatedIDs()) {
-       list.append(Py::Long(id.value()));
-}
-   return list;
+Py::List StringIDPy::getRelated() const
+{
+    Py::List list;
+    for (const auto &id : getStringIDPtr()->relatedIDs()) {
+        list.append(Py::Long(id.value()));
+    }
+
+    return list;
 }
 
-Py::String StringIDPy::getData() const {
-   return {Py::String(getStringIDPtr()->dataToText(this->_index))};
+Py::String StringIDPy::getData() const
+{
+    return Py::String(getStringIDPtr()->dataToText(this->_index));
 }
 
-Py::Boolean StringIDPy::getIsBinary() const {
-   return {getStringIDPtr()->isBinary()};
+Py::Boolean StringIDPy::getIsBinary() const
+{
+    return Py::Boolean(getStringIDPtr()->isBinary());
 }
 
-Py::Boolean StringIDPy::getIsHashed() const {
-   return {getStringIDPtr()->isHashed()};
+Py::Boolean StringIDPy::getIsHashed() const
+{
+    return Py::Boolean(getStringIDPtr()->isHashed());
 }
 
-Py::Int StringIDPy::getIndex() const {
-   return Py::Int(this->_index);
+Py::Long StringIDPy::getIndex() const
+{
+    return Py::Long(this->_index);
 }
 
-void StringIDPy::setIndex(Py::Int index) {
-   this->_index = index;
+void StringIDPy::setIndex(Py::Long index)
+{
+    this->_index = index;
 }
 
 PyObject *StringIDPy::getCustomAttributes(const char* /*attr*/) const
 {
-   return nullptr;
+    return nullptr;
 }
 
 int StringIDPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
 {
-   return 0;
+    return 0;
 }

--- a/src/App/StringIDPyImp.cpp
+++ b/src/App/StringIDPyImp.cpp
@@ -38,13 +38,15 @@ std::string StringIDPy::representation() const
 PyObject* StringIDPy::isSame(PyObject *args)
 {
    PyObject *other = nullptr;
-   if (PyArg_ParseTuple(args, "O!", &StringIDPy::Type, &other) == 0) { // convert args: Python->C
-       return Py::new_reference_to(Py::False());
+   if (!PyArg_ParseTuple(args, "O!", &StringIDPy::Type, &other)) {
+       return nullptr;
    }
+
    auto *otherPy = static_cast<StringIDPy*>(other);
-   return Py::new_reference_to(Py::Boolean(
-       otherPy->getStringIDPtr() == this->getStringIDPtr()
-       && otherPy->_index == this->_index));
+   bool same = (otherPy->getStringIDPtr() == this->getStringIDPtr())
+               && (otherPy->_index == this->_index);
+
+   return PyBool_FromLong(same ? 1 : 0);
 }
 
 Py::Int StringIDPy::getValue() const {

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(Test_SRCS
     BaseTests.py
     Document.py
     Metadata.py
+    StringHasher.py
     Menu.py
     TestApp.py
     TestGui.py

--- a/src/Mod/Test/Init.py
+++ b/src/Mod/Test/Init.py
@@ -28,5 +28,6 @@ FreeCAD.__unit_test__ += [ "BaseTests",
                            "UnitTests",
                            "Document",
                            "Metadata",
+                           "StringHasher",
                            "UnicodeTests",
                            "TestPythonSyntax" ]

--- a/src/Mod/Test/StringHasher.py
+++ b/src/Mod/Test/StringHasher.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+#***************************************************************************
+#*   Copyright (c) 2023 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+#*                                                                         *
+#*   This file is part of FreeCAD.                                         *
+#*                                                                         *
+#*   FreeCAD is free software: you can redistribute it and/or modify it    *
+#*   under the terms of the GNU Lesser General Public License as           *
+#*   published by the Free Software Foundation, either version 2.1 of the  *
+#*   License, or (at your option) any later version.                       *
+#*                                                                         *
+#*   FreeCAD is distributed in the hope that it will be useful, but        *
+#*   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+#*   Lesser General Public License for more details.                       *
+#*                                                                         *
+#*   You should have received a copy of the GNU Lesser General Public      *
+#*   License along with FreeCAD. If not, see                               *
+#*   <https://www.gnu.org/licenses/>.                                      *
+#*                                                                         *
+#**************************************************************************/
+
+import FreeCAD
+import unittest
+
+
+class TestStringHasher(unittest.TestCase):
+    def setUp(self):
+        self.strHash = FreeCAD.StringHasher()
+        self.strID = self.strHash.getID("A")
+
+    def testInit(self):
+        with self.assertRaises(TypeError):
+            FreeCAD.StringHasher(0)
+
+    def testGetID(self):
+        with self.assertRaises(ValueError):
+            self.strHash.getID(0)
+
+    def testStringHasherIsSame(self):
+        with self.assertRaises(TypeError):
+            self.strHash.isSame(0)
+
+    def testStringIDIsSame(self):
+        with self.assertRaises(TypeError):
+            self.strID.isSame(0)


### PR DESCRIPTION
The `StringHasherPy::getID` function crash if the first argument is an integer less or equal to 0.
If the first argument is a string, the signature is changed to explicitly receive a boolean in the optional second argument.

In `StringHasherPy::isSame` and `StringID::isSame` currently returns a result with an exception set if the argument isn't `App.StringHasherPy` (`App.StringID`). This is undefined behavior and must be avoided.

Other changes:
- In `StringHasherPy::PyInit` explicitly avoid parameters.
- In `StringHasherPy::getCount` and `StringHasherPy::getSize` use `PyLong_FromSize_t` to get the `PyLongObject` from `size_t`.
- Change PyCXX `Py::Int` to `Py::Long`.

The second commit change indentation to four spaces.

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
