### PR TITLE
Gui: Tweak size of developer warning

### DIFF
--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -292,7 +292,7 @@ private:
     bool setupReportView(const std::string&);
     bool setupPythonConsole(const std::string&);
 
-    void RenderDevBuildWarning(QPainter &painter, int x, int y) const;
+    static void renderDevBuildWarning(QPainter &painter, const QPoint startPosition, const QSize maxSize);
 
 private Q_SLOTS:
     /**


### PR DESCRIPTION
Ensure that the warning adapts to the font size and text length as needed.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR