### PR TITLE
Pref: Theme: Solves #10136

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -377,6 +377,8 @@ void DlgSettingsGeneral::saveThemes()
     QString sheet = QString::fromStdString(hGrp->GetASCII("StyleSheet"));
     bool tiledBackground = hGrp->GetBool("TiledBackground", false);
     Application::Instance->setStyleSheet(sheet, tiledBackground);
+
+    themeChanged = false;
 }
 
 void DlgSettingsGeneral::loadThemes()

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -355,18 +355,26 @@ void DlgSettingsGeneral::loadSettings()
 
 void DlgSettingsGeneral::saveThemes()
 {
-    // First we save the name of the theme
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow");
 
-    std::string theme = ui->themesCombobox->currentText().toStdString();
-    hGrp->SetASCII("Theme", theme);
+    // First we check if the theme has actually changed.
+    std::string previousTheme = hGrp->GetASCII("Theme", "").c_str();
+    std::string newTheme = ui->themesCombobox->currentText().toStdString();
+
+    if (previousTheme == newTheme) {
+        themeChanged = false;
+        return;
+    }
+
+    // Save the name of the theme
+    hGrp->SetASCII("Theme", newTheme);
 
     // Then we apply the themepack.
     Application::Instance->prefPackManager()->rescan();
     auto packs = Application::Instance->prefPackManager()->preferencePacks();
 
     for (const auto& pack : packs) {
-        if (pack.first == theme) {
+        if (pack.first == newTheme) {
 
             Application::Instance->prefPackManager()->apply(pack.first);
             break;

--- a/src/Gui/PreferencePages/DlgSettingsTheme.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsTheme.cpp
@@ -84,6 +84,8 @@ void DlgSettingsTheme::saveStyleSheet()
     hGrp->SetASCII("StyleSheet", (const char*)sheet.toByteArray());
     bool tiledBackground = hGrp->GetBool("TiledBackground", false);
     Application::Instance->setStyleSheet(sheet.toString(), tiledBackground);
+
+    styleSheetChanged = false;
 }
 
 void DlgSettingsTheme::loadStyleSheet()
@@ -142,7 +144,6 @@ void DlgSettingsTheme::loadStyleSheet()
 
 void DlgSettingsTheme::onStyleSheetChanged(int index) {
     Q_UNUSED(index);
-    Base::Console().Warning("Hello");
     styleSheetChanged = true;
 }
 


### PR DESCRIPTION
Solves #10136

> - The Classic, Dark or Light theme modifies the background color of the 3d view. If after switching to another theme and adjusting the background colors under Display > Colors then the colors won't be accepted and rejected to the default colors of the theme. The only way to get the custom colors accepted is to close the the preferences dialog after changing the theme and reopening it again. This is extremely annoying behaviour.
> - Whenever choosing a style sheet in the Theme tab a warning "Hello" is written to the report view

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
