### PR TITLE
AddonManager: Avoid dictionary.keys() where possible

### DIFF
--- a/src/Mod/AddonManager/addonmanager_devmode_add_content.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_add_content.py
@@ -588,7 +588,7 @@ class EditDependency:
         # display name, but keeping track of their official name as well (stored in the UserRole)
         for repo in AM_INSTANCE.item_model.repos:
             repo_dict[repo.display_name.lower()] = (repo.display_name, repo.name)
-        sorted_keys = sorted(repo_dict.keys())
+        sorted_keys = sorted(repo_dict)
         for item in sorted_keys:
             self.dialog.dependencyComboBox.addItem(
                 repo_dict[item][0], repo_dict[item][1]


### PR DESCRIPTION
See #6015.

No huge speed improvements expected here.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
