### PR TITLE
clang-format: Align long function arguments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 # Generated from CLion C/C++ Code Style settings
 BasedOnStyle: LLVM
 AccessModifierOffset: -4
-AlignAfterOpenBracket: BlockIndent
+AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: None
 AlignOperands: DontAlign
 AllowAllArgumentsOnNextLine: false


### PR DESCRIPTION
See issue #9994