### PR TITLE
Disable Robot, Inspection, Reverse engineering, OpenSCAD by default.

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -424,7 +424,7 @@ QStringList DlgSettingsWorkbenchesImp::getDisabledWorkbenches()
     ParameterGrp::handle hGrp;
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
-    disabled_wbs = QString::fromStdString(hGrp->GetASCII("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench,ReverseEngineeringWorkbench"));
+    disabled_wbs = QString::fromStdString(hGrp->GetASCII("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench,ReverseEngineeringWorkbench,OpenSCADWorkbench"));
 #if QT_VERSION >= QT_VERSION_CHECK(5,15,0)
     unfiltered_disabled_wbs_list = disabled_wbs.split(QLatin1String(","), Qt::SkipEmptyParts);
 #else

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -424,7 +424,7 @@ QStringList DlgSettingsWorkbenchesImp::getDisabledWorkbenches()
     ParameterGrp::handle hGrp;
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
-    disabled_wbs = QString::fromStdString(hGrp->GetASCII("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench"));
+    disabled_wbs = QString::fromStdString(hGrp->GetASCII("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench,ReverseEngineeringWorkbench"));
 #if QT_VERSION >= QT_VERSION_CHECK(5,15,0)
     unfiltered_disabled_wbs_list = disabled_wbs.split(QLatin1String(","), Qt::SkipEmptyParts);
 #else

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -424,7 +424,7 @@ QStringList DlgSettingsWorkbenchesImp::getDisabledWorkbenches()
     ParameterGrp::handle hGrp;
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
-    disabled_wbs = QString::fromStdString(hGrp->GetASCII("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench"));
+    disabled_wbs = QString::fromStdString(hGrp->GetASCII("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench"));
 #if QT_VERSION >= QT_VERSION_CHECK(5,15,0)
     unfiltered_disabled_wbs_list = disabled_wbs.split(QLatin1String(","), Qt::SkipEmptyParts);
 #else

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -424,7 +424,7 @@ QStringList DlgSettingsWorkbenchesImp::getDisabledWorkbenches()
     ParameterGrp::handle hGrp;
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
-    disabled_wbs = QString::fromStdString(hGrp->GetASCII("Disabled", "NoneWorkbench,TestWorkbench"));
+    disabled_wbs = QString::fromStdString(hGrp->GetASCII("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench"));
 #if QT_VERSION >= QT_VERSION_CHECK(5,15,0)
     unfiltered_disabled_wbs_list = disabled_wbs.split(QLatin1String(","), Qt::SkipEmptyParts);
 #else

--- a/src/Mod/AddonManager/Addon.py
+++ b/src/Mod/AddonManager/Addon.py
@@ -610,7 +610,7 @@ class Addon:
         wbName = self.get_workbench_name()
 
         # Add the wb to the list of disabled if it was not already
-        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench,ReverseEngineeringWorkbench")
+        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench,ReverseEngineeringWorkbench,OpenSCADWorkbench")
         # print(f"start disabling {disabled_wbs}")
         disabled_wbs_list = disabled_wbs.split(",")
         if not (wbName in disabled_wbs_list):
@@ -641,7 +641,7 @@ class Addon:
     def remove_from_disabled_wbs(self, wbName: str):
         pref = fci.ParamGet("User parameter:BaseApp/Preferences/Workbenches")
 
-        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench,ReverseEngineeringWorkbench")
+        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench,ReverseEngineeringWorkbench,OpenSCADWorkbench")
         # print(f"start enabling : {disabled_wbs}")
         disabled_wbs_list = disabled_wbs.split(",")
         disabled_wbs = ""

--- a/src/Mod/AddonManager/Addon.py
+++ b/src/Mod/AddonManager/Addon.py
@@ -610,7 +610,7 @@ class Addon:
         wbName = self.get_workbench_name()
 
         # Add the wb to the list of disabled if it was not already
-        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench")
+        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench,ReverseEngineeringWorkbench")
         # print(f"start disabling {disabled_wbs}")
         disabled_wbs_list = disabled_wbs.split(",")
         if not (wbName in disabled_wbs_list):
@@ -641,7 +641,7 @@ class Addon:
     def remove_from_disabled_wbs(self, wbName: str):
         pref = fci.ParamGet("User parameter:BaseApp/Preferences/Workbenches")
 
-        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench")
+        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench,ReverseEngineeringWorkbench")
         # print(f"start enabling : {disabled_wbs}")
         disabled_wbs_list = disabled_wbs.split(",")
         disabled_wbs = ""

--- a/src/Mod/AddonManager/Addon.py
+++ b/src/Mod/AddonManager/Addon.py
@@ -610,7 +610,7 @@ class Addon:
         wbName = self.get_workbench_name()
 
         # Add the wb to the list of disabled if it was not already
-        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench")
+        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench")
         # print(f"start disabling {disabled_wbs}")
         disabled_wbs_list = disabled_wbs.split(",")
         if not (wbName in disabled_wbs_list):
@@ -641,7 +641,7 @@ class Addon:
     def remove_from_disabled_wbs(self, wbName: str):
         pref = fci.ParamGet("User parameter:BaseApp/Preferences/Workbenches")
 
-        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench")
+        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench")
         # print(f"start enabling : {disabled_wbs}")
         disabled_wbs_list = disabled_wbs.split(",")
         disabled_wbs = ""

--- a/src/Mod/AddonManager/Addon.py
+++ b/src/Mod/AddonManager/Addon.py
@@ -610,7 +610,7 @@ class Addon:
         wbName = self.get_workbench_name()
 
         # Add the wb to the list of disabled if it was not already
-        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench")
+        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench")
         # print(f"start disabling {disabled_wbs}")
         disabled_wbs_list = disabled_wbs.split(",")
         if not (wbName in disabled_wbs_list):
@@ -641,7 +641,7 @@ class Addon:
     def remove_from_disabled_wbs(self, wbName: str):
         pref = fci.ParamGet("User parameter:BaseApp/Preferences/Workbenches")
 
-        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench")
+        disabled_wbs = pref.GetString("Disabled", "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench")
         # print(f"start enabling : {disabled_wbs}")
         disabled_wbs_list = disabled_wbs.split(",")
         disabled_wbs = ""


### PR DESCRIPTION
Second step to solve #8692 by disabling some seldomly used workbenches : 
- Robot : Seldomly used
- Inspection : Still very early stage and probably seldomly used. Also it appears this workbench has a single command. It could probably be best in core than in a separate wb...
- Reverse Engineering: wiki says : "At the moment there is no functionality present in this workbench. It is used as a sandbox by the programmers." Though it seems to actually have a single tool that is mesh related.
- OpenSCAD : This requires an external installation to work so there's no reason to be enabled by default.


Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).

---
