### PR TITLE
Fix build of "tests" on macOS

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,10 +37,26 @@ endif()
 add_executable(Tests_run)
 add_subdirectory(lib)
 add_subdirectory(src)
-target_include_directories(Tests_run PUBLIC ${Python3_INCLUDE_DIRS} ${XercesC_INCLUDE_DIRS})
-target_link_libraries(Tests_run gtest_main gmock_main ${Google_Tests_LIBS} FreeCADApp)
+target_include_directories(Tests_run PUBLIC
+    ${Python3_INCLUDE_DIRS}
+    ${XercesC_INCLUDE_DIRS}
+)
+target_link_libraries(Tests_run
+    gtest_main
+    gmock_main
+    ${Google_Tests_LIBS}
+    FreeCADApp
+)
 
 add_executable(Sketcher_tests_run)
 add_subdirectory(src/Mod/Sketcher)
-target_include_directories(Sketcher_tests_run PUBLIC ${EIGEN3_INCLUDE_DIR} ${OCC_INCLUDE_DIR} ${Python3_INCLUDE_DIRS})
-target_link_libraries(Sketcher_tests_run gtest_main ${Google_Tests_LIBS} Sketcher)
+target_include_directories(Sketcher_tests_run PUBLIC
+    ${EIGEN3_INCLUDE_DIR}
+    ${OCC_INCLUDE_DIR}
+    ${Python3_INCLUDE_DIRS}
+)
+target_link_libraries(Sketcher_tests_run
+    gtest_main
+    ${Google_Tests_LIBS}
+    Sketcher
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ target_include_directories(Sketcher_tests_run PUBLIC
     ${EIGEN3_INCLUDE_DIR}
     ${OCC_INCLUDE_DIR}
     ${Python3_INCLUDE_DIRS}
+    ${XercesC_INCLUDE_DIRS}
 )
 target_link_libraries(Sketcher_tests_run
     gtest_main


### PR DESCRIPTION
This fixes a similar issue as in https://github.com/FreeCAD/FreeCAD/pull/9657.
The first commit only applies a trivial reformat to break the multi-item lines. The second fixes the issue, among with more explanation in the commit message.

Please consider this for a potential v0.21.1 release, too, as commit 532b391 in there as well.

---

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).
