### PR TITLE
Spreadsheet: Fix build on macOS

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -47,9 +47,9 @@ SheetModel::SheetModel(Sheet* _sheet, QObject* parent) : QAbstractTableModel(par
 {
     //NOLINTBEGIN
     cellUpdatedConnection =
-        sheet->cellUpdated.connect(bind(&SheetModel::cellUpdated, this, sp::_1));
+        sheet->cellUpdated.connect(std::bind(&SheetModel::cellUpdated, this, sp::_1));
     rangeUpdatedConnection =
-        sheet->rangeUpdated.connect(bind(&SheetModel::rangeUpdated, this, sp::_1));
+        sheet->rangeUpdated.connect(std::bind(&SheetModel::rangeUpdated, this, sp::_1));
     //NOLINTEND
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -99,8 +99,8 @@ SheetView::SheetView(Gui::Document *pcDocument, App::DocumentObject *docObj, QWi
     connect(ui->cellAlias, &LineEdit::textEdited, this, &SheetView::aliasChanged);
 
     //NOLINTBEGIN
-    columnWidthChangedConnection = sheet->columnWidthChanged.connect(bind(&SheetView::resizeColumn, this, sp::_1, sp::_2));
-    rowHeightChangedConnection = sheet->rowHeightChanged.connect(bind(&SheetView::resizeRow, this, sp::_1, sp::_2));
+    columnWidthChangedConnection = sheet->columnWidthChanged.connect(std::bind(&SheetView::resizeColumn, this, sp::_1, sp::_2));
+    rowHeightChangedConnection = sheet->rowHeightChanged.connect(std::bind(&SheetView::resizeRow, this, sp::_1, sp::_2));
     //NOLINTEND
 
     connect( model, &QAbstractItemModel::dataChanged, this, &SheetView::modelUpdated);


### PR DESCRIPTION
The recent migration from boost::bind to std::bind, see [1], broke the build on Mac (Apple clang version 13.0.0 (clang-1300.0.29.30) on macOS-11.7.8).

In all other cases the `boost::bind` was replaced by `std::bind` (among with the place holders) but in these two spread sheet files
 - src/Mod/Spreadsheet/Gui/SheetModel.cpp
 - src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp

the original code only referenced `bind`, which used to get resolved to `boost::bind` but now raises this error:
```
/Users/jonas/src/FreeCAD/FreeCAD-git/src/Mod/Spreadsheet/Gui/SheetModel.cpp:50:36: error: use of undeclared identifier 'bind'; did you mean 'boost::bind'?
        sheet->cellUpdated.connect(bind(&SheetModel::cellUpdated, this, sp::_1));
                                   ^~~~
                                   boost::bind
```
This commit changes this to `std::bind` expicitly, just like it's done in the other files. This works on my system/compiler.

[1]: https://github.com/FreeCAD/FreeCAD/commit/68d22d864b801231c83c0ef961073ac5f8764aa4

---

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [x ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).
