### PR TITLE
Draft: make_sketch should not change Autoconstraints of sketch

### DIFF
--- a/src/Mod/Draft/draftmake/make_sketch.py
+++ b/src/Mod/Draft/draftmake/make_sketch.py
@@ -82,7 +82,6 @@ def make_sketch(objects_list, autoconstraints=False, addTo=None,
     start_point = 1
     end_point = 2
     middle_point = 3
-    deletable = None
 
     if App.GuiUp:
         v_dir = gui_utils.get_3d_view().getViewDirection()
@@ -153,9 +152,6 @@ def make_sketch(objects_list, autoconstraints=False, addTo=None,
         nobj = addTo
     else:
         nobj = App.ActiveDocument.addObject("Sketcher::SketchObject", name)
-        deletable = nobj
-        if App.GuiUp:
-            nobj.ViewObject.Autoconstraints = False
 
     # Collect constraints and add in one go to improve performance
     constraints = []


### PR DESCRIPTION
Changing the Autoconstraints property of the new sketch's ViewObject is unnecessary and confuses users.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=80367

Additionally:
Removed the `deletable` variable as it was not used.

- [x]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

---
