### PR TITLE
Part: ignore whole selected objects for Part linear/angular measurement tool

### DIFF
--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -560,6 +560,9 @@ PartGui::TaskMeasureLinear::~TaskMeasureLinear()
 
 void PartGui::TaskMeasureLinear::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
+  if (msg.pSubName[0] == '\0')
+    return; // ignore whole objects selected in the model tree, e.g. when toggling the visibility of an object
+
   if (buttonSelectedIndex == 0)
   {
     if (msg.Type == Gui::SelectionChanges::AddSelection)
@@ -1557,6 +1560,9 @@ PartGui::TaskMeasureAngular::~TaskMeasureAngular()
 
 void PartGui::TaskMeasureAngular::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
+  if (msg.pSubName[0] == '\0')
+    return; // ignore whole objects selected in the model tree, e.g. when toggling the visibility of an object
+
   TopoDS_Shape shape;
   Base::Matrix4D mat;
   if (!getShapeFromStrings(shape, std::string(msg.pDocName),


### PR DESCRIPTION
As soon as the measurement tool from the Part workbench is activated, every selected object/element will be immediately chosen as one of the two reference elements for measurements.
Selecting an object in the tree just in order to hide it for accessing other elements is not possible anymore without a workaround.

The added code lines of this pull request will ignore selected whole objects (objects whose subelement name is an empty string). So objects in the tree can be accessed again as shown in the following animation.
![demo_measurement](https://github.com/FreeCAD/FreeCAD/assets/119257544/4db85dad-8adb-4b9d-8a71-ada8104933fd)
(In the animation, the visibility of the cube is toggled by pressing the space bar.)

I don't know any case where this new behaviour would break anything -- rather the opposite: without this PR I was able to reproducibly crash FreeCAD when selecting objects in the tree while the measurement task was active.

I also checked if measurements using a simple "Point" object from the Draft workbench as a reference still works, and yes, it does.

---

Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR

Please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).