### PR TITLE
TD: Correct translation in TaskComplexSection

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
+++ b/src/Mod/TechDraw/Gui/TaskComplexSection.cpp
@@ -169,9 +169,7 @@ void TaskComplexSection::setUiPrimary()
     //don't allow updates until a direction is picked
     ui->pbUpdateNow->setEnabled(false);
     ui->cbLiveUpdate->setEnabled(false);
-    QString msgLiteral =
-        QString::fromUtf8(QT_TRANSLATE_NOOP("TaskComplexSection", "No direction set"));
-    ui->lPendingUpdates->setText(msgLiteral);
+    ui->lPendingUpdates->setText(tr("No direction set"));
 }
 
 void TaskComplexSection::setUiEdit()


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/261

- [X]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR