### PR TITLE
Remove the PR template text

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,0 @@
-Thank you for creating a pull request to contribute to FreeCAD! Place an "X" in between the brackets below to "check off" to confirm that you have satisfied the requirement, or ask for help in the [FreeCAD forum](https://forum.freecadweb.org/viewforum.php?f=10) if there is something you don't understand.
-
-- [ ]  Your Pull Request meets the requirements outlined in section 5 of [CONTRIBUTING.md](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md) for a Valid PR
-
-Please remember to update the Wiki with the features added or changed once this PR is merged.  
-**Note**: If you don't have wiki access, then please mention your contribution on the [1.0 Changelog Forum Thread](https://forum.freecad.org/viewtopic.php?f=10&t=69438).
-
----


### PR DESCRIPTION
Closes https://github.com/FreeCAD/FreeCAD/discussions/10196 and https://github.com/FreeCAD/FreeCAD/discussions/10195

The template text appears to have almost the exact opposite of the intended effect: by having pre-filled text in the description field, many contributors are not adding a description of their PR at all, and they are unlikely to be reading the text that is present. This PR removes the text entirely: one of the jobs of Maintainers is to onboard new contributors. If a PR does not meet the requirements of CONTRIBUTING.md, a Maintainer should respond to the PR personally and help guide the new contributor through the process.

We discussed this at the Vancouver FreeCAD Hackathon in 2023 and came to the general consensus that we should try running without the template text.