### PR TITLE
Mesh: modernize C++: use range-based for loop

### DIFF
--- a/src/Mod/Mesh/App/Core/Approximation.cpp
+++ b/src/Mod/Mesh/App/Core/Approximation.cpp
@@ -104,8 +104,8 @@ Base::Vector3f Approximation::GetGravity() const
 {
     Base::Vector3f clGravity;
     if (!_vPoints.empty()) {
-        for (std::list<Base::Vector3f>::const_iterator it = _vPoints.begin(); it!=_vPoints.end(); ++it)
-            clGravity += *it;
+        for (const auto& vPoint : _vPoints)
+            clGravity += vPoint;
         clGravity *= 1.0f / float(_vPoints.size());
     }
     return clGravity;
@@ -155,11 +155,11 @@ float PlaneFit::Fit()
     double sxx,sxy,sxz,syy,syz,szz,mx,my,mz;
     sxx=sxy=sxz=syy=syz=szz=mx=my=mz=0.0;
 
-    for (std::list<Base::Vector3f>::iterator it = _vPoints.begin(); it!=_vPoints.end(); ++it) {
-        sxx += double(it->x * it->x); sxy += double(it->x * it->y);
-        sxz += double(it->x * it->z); syy += double(it->y * it->y);
-        syz += double(it->y * it->z); szz += double(it->z * it->z);
-        mx  += double(it->x); my += double(it->y); mz += double(it->z);
+    for (const auto & vPoint : _vPoints) {
+        sxx += double(vPoint.x * vPoint.x); sxy += double(vPoint.x * vPoint.y);
+        sxz += double(vPoint.x * vPoint.z); syy += double(vPoint.y * vPoint.y);
+        syz += double(vPoint.y * vPoint.z); szz += double(vPoint.z * vPoint.z);
+        mx  += double(vPoint.x); my += double(vPoint.y); mz += double(vPoint.z);
     }
 
     size_t nSize = _vPoints.size();
@@ -377,8 +377,7 @@ void PlaneFit::ProjectToPlane ()
     Base::Vector3f cGravity(GetGravity());
     Base::Vector3f cNormal (GetNormal ());
 
-    for (std::list< Base::Vector3f >::iterator it = _vPoints.begin(); it != _vPoints.end(); ++it) {
-        Base::Vector3f& cPnt = *it;
+    for (auto & cPnt : _vPoints) {
         float fD = (cPnt - cGravity) * cNormal;
         cPnt = cPnt - fD * cNormal;
     }
@@ -412,10 +411,10 @@ std::vector<Base::Vector3f> PlaneFit::GetLocalPoints() const
       //Base::Vector3d ez = Base::convertTo<Base::Vector3d>(this->_vDirW);
 
         localPoints.insert(localPoints.begin(), _vPoints.begin(), _vPoints.end());
-        for (std::vector<Base::Vector3f>::iterator it = localPoints.begin(); it != localPoints.end(); ++it) {
-            Base::Vector3d clPoint = Base::convertTo<Base::Vector3d>(*it);
+        for (auto & localPoint : localPoints) {
+            Base::Vector3d clPoint = Base::convertTo<Base::Vector3d>(localPoint);
             clPoint.TransformToCoordinateSystem(bs, ex, ey);
-            it->Set(static_cast<float>(clPoint.x), static_cast<float>(clPoint.y), static_cast<float>(clPoint.z));
+            localPoint.Set(static_cast<float>(clPoint.x), static_cast<float>(clPoint.y), static_cast<float>(clPoint.z));
         }
     }
 
@@ -774,9 +773,9 @@ double SurfaceFit::PolynomFit()
     // Get S(P) = sum[(P*Vi)^2 - 2*(P*Vi)*zi + zi^2]
     double sigma = 0;
     FunctionContainer clFuncCont(_fCoeff);
-    for (std::vector<Base::Vector3d>::const_iterator it = transform.begin(); it != transform.end(); ++it) {
-        double u = it->x;
-        double v = it->y;
+    for (const auto & it : transform) {
+        double u = it.x;
+        double v = it.y;
         double z = clFuncCont.F(u, v, 0.0);
         sigma += z*z;
     }
@@ -1082,10 +1081,10 @@ Base::Vector3f CylinderFit::GetInitialAxisFromNormals(const std::vector<Base::Ve
     double sxx,sxy,sxz,syy,syz,szz;
     sxx = sxy = sxz = syy = syz = szz = 0.0;
 
-    for (std::vector<Base::Vector3f>::const_iterator it = n.begin(); it != n.end(); ++it) {
-        sxx += double(it->x * it->x); sxy += double(it->x * it->y);
-        sxz += double(it->x * it->z); syy += double(it->y * it->y);
-        syz += double(it->y * it->z); szz += double(it->z * it->z);
+    for (auto it : n) {
+        sxx += double(it.x * it.x); sxy += double(it.x * it.y);
+        sxz += double(it.x * it.z); syy += double(it.y * it.y);
+        syz += double(it.y * it.z); szz += double(it.z * it.z);
     }
 
     Eigen::Matrix3d covMat = Eigen::Matrix3d::Zero();
@@ -1272,8 +1271,7 @@ void CylinderFit::ProjectToCylinder()
     Base::Vector3f cBase(GetBase());
     Base::Vector3f cAxis(GetAxis());
 
-    for (std::list< Base::Vector3f >::iterator it = _vPoints.begin(); it != _vPoints.end(); ++it) {
-        Base::Vector3f& cPnt = *it;
+    for (auto & cPnt : _vPoints) {
         if (cPnt.DistanceToLine(cBase, cAxis) > 0) {
             Base::Vector3f proj;
             cBase.ProjectToPlane(cPnt, cAxis, proj);
@@ -1408,9 +1406,7 @@ float SphereFit::GetStdDeviation() const
 
 void SphereFit::ProjectToSphere()
 {
-    for (std::list< Base::Vector3f >::iterator it = _vPoints.begin(); it != _vPoints.end(); ++it) {
-        Base::Vector3f& cPnt = *it;
-
+    for (auto & cPnt : _vPoints) {
         // Compute unit vector from sphere centre to point.
         // Because this vector is orthogonal to the sphere's surface at the
         // intersection point we can easily compute the projection point on the
@@ -1435,8 +1431,8 @@ void SphereFit::ProjectToSphere()
 
 PolynomialFit::PolynomialFit()
 {
-    for (int i=0; i<9; i++)
-        _fCoeff[i] = 0.0f;
+    for (float & i : _fCoeff)
+        i = 0.0f;
 }
 
 PolynomialFit::~PolynomialFit()

--- a/src/Mod/Mesh/App/Core/Builder.cpp
+++ b/src/Mod/Mesh/App/Core/Builder.cpp
@@ -77,9 +77,9 @@ void MeshBuilder::Initialize (size_t ctFacets, bool deletion)
     }
     else
     {
-        for (MeshPointArray::_TConstIterator it1 = _meshKernel._aclPointArray.begin(); it1 != _meshKernel._aclPointArray.end(); ++it1)
+        for (const auto & it1 : _meshKernel._aclPointArray)
         {
-            MeshPointIterator pit = _points.insert(*it1);
+            MeshPointIterator pit = _points.insert(it1);
             _pointsIterator.push_back(pit);
         }
         _ptIdx = _points.size();
@@ -158,11 +158,9 @@ void MeshBuilder::SetNeighbourhood ()
     std::set<Edge> edges;
     FacetIndex facetIdx = 0;
 
-    for (MeshFacetArray::_TIterator it = _meshKernel._aclFacetArray.begin(); it != _meshKernel._aclFacetArray.end(); ++it)
+    for (auto & mf : _meshKernel._aclFacetArray)
     {
         this->_seq->next(true); // allow to cancel
-        MeshFacet& mf = *it;
-
         for (int i = 0; i < 3; i++)
         {
             Edge edge(mf._aulPoints[i], mf._aulPoints[(i+1)%3], facetIdx);
@@ -202,10 +200,10 @@ void MeshBuilder::SetNeighbourhood ()
 void MeshBuilder::RemoveUnreferencedPoints()
 {
     _meshKernel._aclPointArray.SetFlag(MeshPoint::INVALID);
-    for ( MeshFacetArray::_TConstIterator it = _meshKernel._aclFacetArray.begin(); it != _meshKernel._aclFacetArray.end(); ++it )
+    for (const auto & it : _meshKernel._aclFacetArray)
     {
-        for ( int i=0; i<3; i++ )
-            _meshKernel._aclPointArray[it->_aulPoints[i]].ResetInvalid();
+        for (PointIndex point : it._aulPoints)
+            _meshKernel._aclPointArray[point].ResetInvalid();
     }
 
     unsigned long uValidPts = std::count_if(_meshKernel._aclPointArray.begin(),
@@ -220,8 +218,8 @@ void MeshBuilder::Finish (bool freeMemory)
     // now we can resize the vertex array to the exact size and copy the vertices with their correct positions in the array
     PointIndex i=0;
     _meshKernel._aclPointArray.resize(_pointsIterator.size());
-    for ( std::vector<MeshPointIterator>::iterator it = _pointsIterator.begin(); it != _pointsIterator.end(); ++it)
-        _meshKernel._aclPointArray[i++] = *(it->first);
+    for (const auto & it : _pointsIterator)
+        _meshKernel._aclPointArray[i++] = *(it.first);
 
     // free all memory of the internal structures
     // Note: this scope is needed to free memory immediately
@@ -246,8 +244,8 @@ void MeshBuilder::Finish (bool freeMemory)
             try {
                 FacetIndex i=0;
                 MeshFacetArray faces(siz);
-                for ( MeshFacetArray::_TIterator it = _meshKernel._aclFacetArray.begin(); it != _meshKernel._aclFacetArray.end(); ++it )
-                    faces[i++]=*it;
+                for (const auto & it : _meshKernel._aclFacetArray)
+                    faces[i++] = it;
                 _meshKernel._aclFacetArray.swap(faces);
             } catch ( const Base::MemoryException&) {
                 // sorry, we cannot reduce the memory
@@ -318,10 +316,10 @@ void MeshFastBuilder::AddFacet (const Base::Vector3f* facetPoints)
 void MeshFastBuilder::AddFacet (const MeshGeomFacet& facetPoints)
 {
     Private::Vertex v;
-    for (int i=0; i<3; i++) {
-        v.x = facetPoints._aclPoints[i].x;
-        v.y = facetPoints._aclPoints[i].y;
-        v.z = facetPoints._aclPoints[i].z;
+    for (const auto& pnt : facetPoints._aclPoints) {
+        v.x = pnt.x;
+        v.y = pnt.y;
+        v.z = pnt.z;
         p->verts.push_back(v);
     }
 }
@@ -361,8 +359,8 @@ void MeshFastBuilder::Finish ()
 
     MeshPointArray rPoints;
     rPoints.reserve(static_cast<size_t>(vertex_count));
-    for (QVector<Private::Vertex>::iterator v = verts.begin(); v != verts.end(); ++v) {
-        rPoints.push_back(MeshPoint(v->x, v->y, v->z));
+    for (const auto & v : verts) {
+        rPoints.push_back(MeshPoint(v.x, v.y, v.z));
     }
 
     _meshKernel.Adopt(rPoints, rFacets, true);

--- a/src/Mod/Mesh/App/Core/Curvature.cpp
+++ b/src/Mod/Mesh/App/Core/Curvature.cpp
@@ -72,8 +72,8 @@ void MeshCurvature::ComputePerFace(bool parallel)
 
     if (!parallel) {
         Base::SequencerLauncher seq("Curvature estimation", mySegment.size());
-        for (std::vector<FacetIndex>::iterator it = mySegment.begin(); it != mySegment.end(); ++it) {
-            CurvatureInfo info = face.Compute(*it);
+        for (FacetIndex it : mySegment) {
+            CurvatureInfo info = face.Compute(it);
             myCurvature.push_back(info);
             seq.next();
         }
@@ -86,8 +86,8 @@ void MeshCurvature::ComputePerFace(bool parallel)
         QFutureWatcher<CurvatureInfo> watcher;
         watcher.setFuture(future);
         watcher.waitForFinished();
-        for (QFuture<CurvatureInfo>::const_iterator it = future.begin(); it != future.end(); ++it) {
-            myCurvature.push_back(*it);
+        for (const auto & it : future) {
+            myCurvature.push_back(it);
         }
     }
 }
@@ -308,9 +308,9 @@ void MeshCurvature::ComputePerVertex()
     std::vector<int> aIdx;
     aIdx.reserve(3*myKernel.CountFacets());
     const MeshFacetArray& raFts = myKernel.GetFacets();
-    for (MeshFacetArray::const_iterator jt = raFts.begin(); jt != raFts.end(); ++jt) {
-        for (int i=0; i<3; i++) {
-            aIdx.push_back((int)jt->_aulPoints[i]);
+    for (const auto & it : raFts) {
+        for (PointIndex point : it._aulPoints) {
+            aIdx.push_back(int(point));
         }
     }
 
@@ -393,8 +393,8 @@ CurvatureInfo FacetCurvature::Compute(FacetIndex index) const
     std::vector<Base::Vector3f> fitPoints;
     const MeshPointArray& verts = myKernel.GetPoints();
     fitPoints.reserve(point_indices.size());
-    for (std::set<PointIndex>::iterator it = point_indices.begin(); it != point_indices.end(); ++it) {
-        fitPoints.push_back(verts[*it] - face_gravity);
+    for (PointIndex it : point_indices) {
+        fitPoints.push_back(verts[it] - face_gravity);
     }
 
     float fMin, fMax;

--- a/src/Mod/Mesh/App/Core/CylinderFit.cpp
+++ b/src/Mod/Mesh/App/Core/CylinderFit.cpp
@@ -198,8 +198,7 @@ void CylinderFit::ProjectToCylinder()
     Base::Vector3f cBase(_vBase.x, _vBase.y, _vBase.z);
     Base::Vector3f cAxis(_vAxis.x, _vAxis.y, _vAxis.z);
 
-    for (std::list< Base::Vector3f >::iterator it = _vPoints.begin(); it != _vPoints.end(); ++it) {
-        Base::Vector3f& cPnt = *it;
+    for (auto & cPnt : _vPoints) {
         if (cPnt.DistanceToLine(cBase, cAxis) > 0) {
             Base::Vector3f proj;
             cBase.ProjectToPlane(cPnt, cAxis, proj);

--- a/src/Mod/Mesh/App/Core/Decimation.cpp
+++ b/src/Mod/Mesh/App/Core/Decimation.cpp
@@ -57,8 +57,8 @@ void MeshSimplify::simplify(float tolerance, float reduction)
         Simplify::Triangle t;
         t.deleted = 0;
         t.dirty = 0;
-        for (int j = 0; j < 4; j++)
-            t.err[j] = 0.0;
+        for (double & j : t.err)
+            j = 0.0;
         for (int j = 0; j < 3; j++)
             t.v[j] = facets[i]._aulPoints[j];
         alg.triangles.push_back(t);
@@ -72,23 +72,23 @@ void MeshSimplify::simplify(float tolerance, float reduction)
     // Simplification done
     MeshPointArray new_points;
     new_points.reserve(alg.vertices.size());
-    for (std::size_t i = 0; i < alg.vertices.size(); i++) {
-        new_points.push_back(alg.vertices[i].p);
+    for (const auto & vertex : alg.vertices) {
+        new_points.push_back(vertex.p);
     }
 
     std::size_t numFacets = 0;
-    for (std::size_t i = 0; i < alg.triangles.size(); i++) {
-        if (!alg.triangles[i].deleted)
+    for (const auto & triangle : alg.triangles) {
+        if (!triangle.deleted)
             numFacets++;
     }
     MeshFacetArray new_facets;
     new_facets.reserve(numFacets);
-    for (std::size_t i = 0; i < alg.triangles.size(); i++) {
-        if (!alg.triangles[i].deleted) {
+    for (const auto & triangle : alg.triangles) {
+        if (!triangle.deleted) {
             MeshFacet face;
-            face._aulPoints[0] = alg.triangles[i].v[0];
-            face._aulPoints[1] = alg.triangles[i].v[1];
-            face._aulPoints[2] = alg.triangles[i].v[2];
+            face._aulPoints[0] = triangle.v[0];
+            face._aulPoints[1] = triangle.v[1];
+            face._aulPoints[2] = triangle.v[2];
             new_facets.push_back(face);
         }
     }
@@ -115,8 +115,8 @@ void MeshSimplify::simplify(int targetSize)
         Simplify::Triangle t;
         t.deleted = 0;
         t.dirty = 0;
-        for (int j = 0; j < 4; j++)
-            t.err[j] = 0.0;
+        for (double & j : t.err)
+            j = 0.0;
         for (int j = 0; j < 3; j++)
             t.v[j] = facets[i]._aulPoints[j];
         alg.triangles.push_back(t);
@@ -128,23 +128,23 @@ void MeshSimplify::simplify(int targetSize)
     // Simplification done
     MeshPointArray new_points;
     new_points.reserve(alg.vertices.size());
-    for (std::size_t i = 0; i < alg.vertices.size(); i++) {
-        new_points.push_back(alg.vertices[i].p);
+    for (const auto & vertex : alg.vertices) {
+        new_points.push_back(vertex.p);
     }
 
     std::size_t numFacets = 0;
-    for (std::size_t i = 0; i < alg.triangles.size(); i++) {
-        if (!alg.triangles[i].deleted)
+    for (const auto & triangle : alg.triangles) {
+        if (!triangle.deleted)
             numFacets++;
     }
     MeshFacetArray new_facets;
     new_facets.reserve(numFacets);
-    for (std::size_t i = 0; i < alg.triangles.size(); i++) {
-        if (!alg.triangles[i].deleted) {
+    for (const auto & triangle : alg.triangles) {
+        if (!triangle.deleted) {
             MeshFacet face;
-            face._aulPoints[0] = alg.triangles[i].v[0];
-            face._aulPoints[1] = alg.triangles[i].v[1];
-            face._aulPoints[2] = alg.triangles[i].v[2];
+            face._aulPoints[0] = triangle.v[0];
+            face._aulPoints[1] = triangle.v[1];
+            face._aulPoints[2] = triangle.v[2];
             new_facets.push_back(face);
         }
     }

--- a/src/Mod/Mesh/App/Core/Degeneration.cpp
+++ b/src/Mod/Mesh/App/Core/Degeneration.cpp
@@ -42,16 +42,16 @@ using namespace MeshCore;
 bool MeshEvalInvalids::Evaluate()
 {
   const MeshFacetArray& rFaces = _rclMesh.GetFacets();
-  for ( MeshFacetArray::_TConstIterator it = rFaces.begin(); it != rFaces.end(); ++it )
+  for (const auto & it : rFaces)
   {
-    if ( !it->IsValid() )
+    if ( !it.IsValid() )
       return false;
   }
 
   const MeshPointArray& rPoints = _rclMesh.GetPoints();
-  for ( MeshPointArray::_TConstIterator jt = rPoints.begin(); jt != rPoints.end(); ++jt )
+  for (const auto & it : rPoints)
   {
-    if ( !jt->IsValid() )
+    if ( !it.IsValid() )
       return false;
   }
 
@@ -205,11 +205,11 @@ bool MeshFixDuplicatePoints::Fixup()
 
     // now set all facets to the correct index
     MeshFacetArray& rFacets = _rclMesh._aclFacetArray;
-    for (MeshFacetArray::_TIterator it = rFacets.begin(); it != rFacets.end(); ++it) {
-        for (int i=0; i<3; i++) {
-            std::map<PointIndex, PointIndex>::iterator pt = mapPointIndex.find(it->_aulPoints[i]);
+    for (auto & it : rFacets) {
+        for (PointIndex & point : it._aulPoints) {
+            std::map<PointIndex, PointIndex>::iterator pt = mapPointIndex.find(point);
             if (pt != mapPointIndex.end())
-                it->_aulPoints[i] = pt->second;
+                point = pt->second;
         }
     }
 
@@ -225,8 +225,8 @@ bool MeshFixDuplicatePoints::Fixup()
 bool MeshEvalNaNPoints::Evaluate()
 {
     const MeshPointArray& rPoints = _rclMesh.GetPoints();
-    for (MeshPointArray::_TConstIterator it = rPoints.begin(); it != rPoints.end(); ++it) {
-        if (boost::math::isnan(it->x) || boost::math::isnan(it->y) || boost::math::isnan(it->z))
+    for (const auto & it : rPoints) {
+        if (boost::math::isnan(it.x) || boost::math::isnan(it.y) || boost::math::isnan(it.z))
             return false;
     }
 
@@ -818,21 +818,20 @@ bool MeshEvalDentsOnSurface::Evaluate()
         std::set<PointIndex> nb = clPt2Facets.NeighbourPoints(point,1);
         const std::set<FacetIndex>& faces = clPt2Facets[index];
 
-        for (std::set<PointIndex>::iterator pt = nb.begin(); pt != nb.end(); ++pt) {
-            const MeshPoint& mp = rPntAry[*pt];
-            for (std::set<FacetIndex>::const_iterator
-                ft = faces.begin(); ft != faces.end(); ++ft) {
+        for (PointIndex pt : nb) {
+            const MeshPoint& mp = rPntAry[pt];
+            for (FacetIndex ft : faces) {
                     // the point must not be part of the facet we test
-                    if (f_beg[*ft]._aulPoints[0] == *pt)
+                    if (f_beg[ft]._aulPoints[0] == pt)
                         continue;
-                    if (f_beg[*ft]._aulPoints[1] == *pt)
+                    if (f_beg[ft]._aulPoints[1] == pt)
                         continue;
-                    if (f_beg[*ft]._aulPoints[2] == *pt)
+                    if (f_beg[ft]._aulPoints[2] == pt)
                         continue;
                     // is the point projectable onto the facet?
-                    rTriangle = _rclMesh.GetFacet(f_beg[*ft]);
+                    rTriangle = _rclMesh.GetFacet(f_beg[ft]);
                     if (rTriangle.IntersectWithLine(mp,rTriangle.GetNormal(),tmp)) {
-                        const std::set<FacetIndex>& f = clPt2Facets[*pt];
+                        const std::set<FacetIndex>& f = clPt2Facets[pt];
                         this->indices.insert(this->indices.end(), f.begin(), f.end());
                         break;
                     }
@@ -923,10 +922,10 @@ bool MeshEvalFoldsOnBoundary::Evaluate()
     const MeshFacetArray& rFacAry = _rclMesh.GetFacets();
     for (MeshFacetArray::_TConstIterator it = rFacAry.begin(); it != rFacAry.end(); ++it) {
         if (it->CountOpenEdges() == 2) {
-            for (int i=0; i<3; i++) {
-                if (it->_aulNeighbours[i] != FACET_INDEX_MAX) {
+            for (FacetIndex nbIndex : it->_aulNeighbours) {
+                if (nbIndex != FACET_INDEX_MAX) {
                     MeshGeomFacet f1 = _rclMesh.GetFacet(*it);
-                    MeshGeomFacet f2 = _rclMesh.GetFacet(it->_aulNeighbours[i]);
+                    MeshGeomFacet f2 = _rclMesh.GetFacet(nbIndex);
                     float cos_angle = f1.GetNormal() * f2.GetNormal();
                     if (cos_angle <= 0.5f) // ~ 60 degree
                         indices.push_back(it-rFacAry.begin());
@@ -999,8 +998,7 @@ bool MeshEvalBorderFacet::Evaluate()
 
     for (f_it = facets.begin(); f_it != f_end; ++f_it) {
         bool ok = true;
-        for (int i=0; i<3; i++) {
-            PointIndex index = f_it->_aulPoints[i];
+        for (PointIndex index : f_it->_aulPoints) {
             if (vv_it[index].size() == vf_it[index].size()) {
                 ok = false;
                 break;
@@ -1021,9 +1019,9 @@ bool MeshEvalRangeFacet::Evaluate()
     const MeshFacetArray& rFaces = _rclMesh.GetFacets();
     FacetIndex ulCtFacets = rFaces.size();
 
-    for (MeshFacetArray::_TConstIterator it = rFaces.begin(); it != rFaces.end(); ++it) {
-        for (int i = 0; i < 3; i++) {
-            if ((it->_aulNeighbours[i] >= ulCtFacets) && (it->_aulNeighbours[i] < FACET_INDEX_MAX)) {
+    for (const auto & it : rFaces) {
+        for (FacetIndex nbFacet : it._aulNeighbours) {
+            if ((nbFacet >= ulCtFacets) && (nbFacet < FACET_INDEX_MAX)) {
                 return false;
             }
         }
@@ -1040,8 +1038,8 @@ std::vector<FacetIndex> MeshEvalRangeFacet::GetIndices() const
 
     FacetIndex ind=0;
     for (MeshFacetArray::_TConstIterator it = rFaces.begin(); it != rFaces.end(); ++it, ind++) {
-        for (int i = 0; i < 3; i++) {
-            if ((it->_aulNeighbours[i] >= ulCtFacets) && (it->_aulNeighbours[i] < FACET_INDEX_MAX)) {
+        for (FacetIndex nbIndex : it->_aulNeighbours) {
+            if ((nbIndex >= ulCtFacets) && (nbIndex < FACET_INDEX_MAX)) {
                 aInds.push_back(ind);
                 break;
             }
@@ -1064,10 +1062,10 @@ bool MeshEvalRangePoint::Evaluate()
     const MeshFacetArray& rFaces = _rclMesh.GetFacets();
     PointIndex ulCtPoints = _rclMesh.CountPoints();
 
-    for (MeshFacetArray::_TConstIterator it = rFaces.begin(); it != rFaces.end(); ++it) {
-        if (std::find_if(it->_aulPoints, it->_aulPoints + 3, [ulCtPoints](PointIndex i) {
+    for (const auto & it : rFaces) {
+        if (std::find_if(it._aulPoints, it._aulPoints + 3, [ulCtPoints](PointIndex i) {
             return i >= ulCtPoints;
-        }) < it->_aulPoints + 3)
+        }) < it._aulPoints + 3)
             return false;
     }
 
@@ -1103,8 +1101,8 @@ bool MeshFixRangePoint::Fixup()
         // 'DeleteFacets' will segfault. But setting all point indices to 0 works.
         std::vector<PointIndex> invalid = eval.GetIndices();
         if (!invalid.empty()) {
-            for (std::vector<PointIndex>::iterator it = invalid.begin(); it != invalid.end(); ++it) {
-                _rclMesh.SetFacetPoints(*it, 0, 0, 0);
+            for (PointIndex it : invalid) {
+                _rclMesh.SetFacetPoints(it, 0, 0, 0);
             }
 
             _rclMesh.DeleteFacets(invalid);
@@ -1119,9 +1117,9 @@ bool MeshEvalCorruptedFacets::Evaluate()
 {
   const MeshFacetArray& rFaces = _rclMesh.GetFacets();
 
-  for ( MeshFacetArray::_TConstIterator it = rFaces.begin(); it != rFaces.end(); ++it ) {
+  for (const auto & it : rFaces) {
     // dupicated point indices
-    if (it->IsDegenerated())
+    if (it.IsDegenerated())
       return false;
   }
 

--- a/src/Mod/Mesh/App/Core/Elements.cpp
+++ b/src/Mod/Mesh/App/Core/Elements.cpp
@@ -77,12 +77,12 @@ void MeshPointArray::ResetFlag (MeshPoint::TFlagType tF) const
 
 void MeshPointArray::SetProperty (unsigned long ulVal) const
 {
-  for (_TConstIterator pP = begin(); pP != end(); ++pP) pP->SetProperty(ulVal);
+  for (const auto & pP : *this) pP.SetProperty(ulVal);
 }
 
 void MeshPointArray::ResetInvalid () const
 {
-  for (_TConstIterator pP = begin(); pP != end(); ++pP) pP->ResetInvalid();
+  for (const auto & pP : *this) pP.ResetInvalid();
 }
 
 MeshPointArray& MeshPointArray::operator = (const MeshPointArray &rclPAry)
@@ -95,8 +95,8 @@ MeshPointArray& MeshPointArray::operator = (const MeshPointArray &rclPAry)
 
 void MeshPointArray::Transform(const Base::Matrix4D& mat)
 {
-  for (_TIterator pP = begin(); pP != end(); ++pP)
-    mat.multVec(*pP,*pP);
+  for (auto & pP : *this)
+    mat.multVec(pP,pP);
 }
 
 MeshFacetArray::MeshFacetArray(const MeshFacetArray& ary)
@@ -159,12 +159,12 @@ void MeshFacetArray::ResetFlag (MeshFacet::TFlagType tF) const
 
 void MeshFacetArray::SetProperty (unsigned long ulVal) const
 {
-  for (_TConstIterator pF = begin(); pF != end(); ++pF) pF->SetProperty(ulVal);
+  for (const auto & pF : *this) pF.SetProperty(ulVal);
 }
 
 void MeshFacetArray::ResetInvalid () const
 {
-  for (_TConstIterator pF = begin(); pF != end(); ++pF) pF->ResetInvalid();
+  for (const auto & pF : *this) pF.ResetInvalid();
 }
 
 MeshFacetArray& MeshFacetArray::operator = (const MeshFacetArray &rclFAry)
@@ -186,9 +186,9 @@ bool MeshGeomEdge::ContainedByOrIntersectBoundingBox ( const Base::BoundBox3f &r
     return true;
 
   // Test whether one of the corner points is in BB
-  for (int i=0;i<2;i++)
+  for (const auto& pnt : _aclPoints)
   {
-    if (rclBB.IsInBox(_aclPoints[i]))
+    if (rclBB.IsInBox(pnt))
       return true;
   }
 
@@ -1494,8 +1494,8 @@ bool MeshGeomFacet::IsPointOfSphere(const MeshGeomFacet& rFacet) const
   radius = CenterOfCircumCircle(center);
   radius *= radius;
 
-  for (int i=0; i<3; i++) {
-    float dist = Base::DistanceP2(rFacet._aclPoints[i], center);
+  for (const auto& pnt : rFacet._aclPoints) {
+    float dist = Base::DistanceP2(pnt, center);
     if (dist < radius)
       return true;
   }

--- a/src/Mod/Mesh/App/Core/Elements.h
+++ b/src/Mod/Mesh/App/Core/Elements.h
@@ -873,8 +873,8 @@ inline bool MeshGeomFacet::ContainedByOrIntersectBoundingBox ( const Base::Bound
         return true;
 
     // Test, whether one of the corner points is in BB
-    for (int i=0;i<3;i++) {
-        if (rclBB.IsInBox(_aclPoints[i]))
+    for (auto pnt : _aclPoints) {
+        if (rclBB.IsInBox(pnt))
             return true;
     }
 

--- a/src/Mod/Mesh/App/Core/Grid.cpp
+++ b/src/Mod/Mesh/App/Core/Grid.cpp
@@ -748,9 +748,9 @@ bool MeshFacetGrid::Verify() const
   {
     std::vector<ElementIndex> aulElements;
     it.GetElements( aulElements );
-    for ( std::vector<ElementIndex>::iterator itF = aulElements.begin(); itF != aulElements.end(); ++itF )
+    for (ElementIndex element : aulElements)
     {
-      cF.Set( *itF );
+      cF.Set( element );
       if (!cF->IntersectBoundingBox(it.GetBoundBox()))
         return false; // no intersection between facet although the facet is in grid
     }
@@ -906,14 +906,14 @@ unsigned long MeshFacetGrid::SearchNearestFromPoint (const Base::Vector3f &rclPt
 
   Inside(clBB, aulFacets, rclPt, fMaxSearchArea, true);
 
-  for (std::vector<ElementIndex>::const_iterator pI = aulFacets.begin(); pI != aulFacets.end(); ++pI)
+  for (ElementIndex facet : aulFacets)
   {
     float fDist;
 
-    if (clFTool.Distance(rclPt, *pI, fMinDist, fDist))
+    if (clFTool.Distance(rclPt, facet, fMinDist, fDist))
     {
       fMinDist   = fDist;
-      ulFacetInd = *pI;
+      ulFacetInd = facet;
     }
   }
 
@@ -1006,13 +1006,13 @@ void MeshFacetGrid::SearchNearestFacetInGrid(unsigned long ulX, unsigned long ul
                                              ElementIndex &rulFacetInd) const
 {
   const std::set<ElementIndex> &rclSet = _aulGrid[ulX][ulY][ulZ];
-  for (std::set<ElementIndex>::const_iterator pI = rclSet.begin(); pI != rclSet.end(); ++pI)
+  for (ElementIndex pI : rclSet)
   {
-    float fDist = _pclMesh->GetFacet(*pI).DistanceToPoint(rclPt);
+    float fDist = _pclMesh->GetFacet(pI).DistanceToPoint(rclPt);
     if (fDist < rfMinDist)
     {
       rfMinDist   = fDist;
-      rulFacetInd = *pI;
+      rulFacetInd = pI;
     }
   }
 }
@@ -1090,9 +1090,9 @@ bool MeshPointGrid::Verify() const
   {
     std::vector<ElementIndex> aulElements;
     it.GetElements( aulElements );
-    for ( std::vector<ElementIndex>::iterator itP = aulElements.begin(); itP != aulElements.end(); ++itP )
+    for (ElementIndex element : aulElements)
     {
-      cP.Set( *itP );
+      cP.Set( element );
       if (!it.GetBoundBox().IsInBox(*cP))
         return false; // point doesn't lie inside the grid element
     }

--- a/src/Mod/Mesh/App/Core/IO/ReaderOBJ.cpp
+++ b/src/Mod/Mesh/App/Core/IO/ReaderOBJ.cpp
@@ -209,8 +209,8 @@ bool ReaderOBJ::Load(std::istream &str)
             _material->binding = MeshIO::PER_VERTEX;
             _material->diffuseColor.reserve(meshPoints.size());
 
-            for (MeshPointArray::iterator it = meshPoints.begin(); it != meshPoints.end(); ++it) {
-                unsigned long prop = it->_ulProp;
+            for (const auto & it : meshPoints) {
+                unsigned long prop = it._ulProp;
                 App::Color c;
                 c.setPackedValue(static_cast<uint32_t>(prop));
                 _material->diffuseColor.push_back(c);
@@ -312,32 +312,32 @@ bool ReaderOBJ::LoadMaterial(std::istream &str)
         }
     }
 
-    for (auto it = _materialNames.begin(); it != _materialNames.end(); ++it) {
+    for (const auto & it : _materialNames) {
         {
-            auto jt = materialAmbientColor.find(it->first);
+            auto jt = materialAmbientColor.find(it.first);
             if (jt != materialAmbientColor.end()) {
-                std::vector<App::Color> mat(it->second, jt->second);
+                std::vector<App::Color> mat(it.second, jt->second);
                 ambientColor.insert(ambientColor.end(), mat.begin(), mat.end());
             }
         }
         {
-            auto jt = materialDiffuseColor.find(it->first);
+            auto jt = materialDiffuseColor.find(it.first);
             if (jt != materialDiffuseColor.end()) {
-                std::vector<App::Color> mat(it->second, jt->second);
+                std::vector<App::Color> mat(it.second, jt->second);
                 diffuseColor.insert(diffuseColor.end(), mat.begin(), mat.end());
             }
         }
         {
-            auto jt = materialSpecularColor.find(it->first);
+            auto jt = materialSpecularColor.find(it.first);
             if (jt != materialSpecularColor.end()) {
-                std::vector<App::Color> mat(it->second, jt->second);
+                std::vector<App::Color> mat(it.second, jt->second);
                 specularColor.insert(specularColor.end(), mat.begin(), mat.end());
             }
         }
         {
-            auto jt = materialTransparency.find(it->first);
+            auto jt = materialTransparency.find(it.first);
             if (jt != materialTransparency.end()) {
-                std::vector<float> transp(it->second, jt->second);
+                std::vector<float> transp(it.second, jt->second);
                 transparency.insert(transparency.end(), transp.begin(), transp.end());
             }
         }

--- a/src/Mod/Mesh/App/Core/IO/Writer3MF.cpp
+++ b/src/Mod/Mesh/App/Core/IO/Writer3MF.cpp
@@ -128,10 +128,10 @@ bool Writer3MF::SaveObject(std::ostream &str, int id, const MeshKernel& mesh) co
 
     // facet indices
     str << Base::blanks(4) << "<triangles>\n";
-    for (MeshFacetArray::_TConstIterator it = rFacets.begin(); it != rFacets.end(); ++it) {
-        str << Base::blanks(5) << "<triangle v1=\"" << it->_aulPoints[0]
-                                      << "\" v2=\"" << it->_aulPoints[1]
-                                      << "\" v3=\"" << it->_aulPoints[2]
+    for (const auto & it : rFacets) {
+        str << Base::blanks(5) << "<triangle v1=\"" << it._aulPoints[0]
+                                      << "\" v2=\"" << it._aulPoints[1]
+                                      << "\" v3=\"" << it._aulPoints[2]
                                       << "\" />\n";
     }
     str << Base::blanks(4) << "</triangles>\n";

--- a/src/Mod/Mesh/App/Core/IO/WriterOBJ.cpp
+++ b/src/Mod/Mesh/App/Core/IO/WriterOBJ.cpp
@@ -192,10 +192,10 @@ bool WriterOBJ::Save(std::ostream& out)
         else {
             // facet indices (no texture and normal indices)
             std::size_t faceIdx = 1;
-            for (MeshFacetArray::_TConstIterator it = rFacets.begin(); it != rFacets.end(); ++it) {
-                out << "f " << it->_aulPoints[0]+1 << "//" << faceIdx << " "
-                            << it->_aulPoints[1]+1 << "//" << faceIdx << " "
-                            << it->_aulPoints[2]+1 << "//" << faceIdx << '\n';
+            for (const auto & it : rFacets) {
+                out << "f " << it._aulPoints[0]+1 << "//" << faceIdx << " "
+                            << it._aulPoints[1]+1 << "//" << faceIdx << " "
+                            << it._aulPoints[2]+1 << "//" << faceIdx << '\n';
                 seq.next(true); // allow to cancel
                 faceIdx++;
             }
@@ -212,34 +212,34 @@ bool WriterOBJ::Save(std::ostream& out)
             App::Color prev;
             const std::vector<App::Color>& Kd = _material->diffuseColor;
 
-            for (std::vector<Group>::const_iterator gt = _groups.begin(); gt != _groups.end(); ++gt) {
-                out << "g " << Base::Tools::escapedUnicodeFromUtf8(gt->name.c_str()) << '\n';
-                for (std::vector<FacetIndex>::const_iterator it = gt->indices.begin(); it != gt->indices.end(); ++it) {
-                    const MeshFacet& f = rFacets[*it];
-                    if (first || prev != Kd[*it]) {
+            for (const auto & gt : _groups) {
+                out << "g " << Base::Tools::escapedUnicodeFromUtf8(gt.name.c_str()) << '\n';
+                for (FacetIndex it : gt.indices) {
+                    const MeshFacet& f = rFacets[it];
+                    if (first || prev != Kd[it]) {
                         first = false;
-                        prev = Kd[*it];
+                        prev = Kd[it];
                         std::vector<App::Color>::iterator c_it = std::find(colors.begin(), colors.end(), prev);
                         if (c_it != colors.end()) {
                             out << "usemtl material_" << (c_it - colors.begin()) << '\n';
                         }
                     }
 
-                    out << "f " << f._aulPoints[0]+1 << "//" << *it + 1 << " "
-                                << f._aulPoints[1]+1 << "//" << *it + 1 << " "
-                                << f._aulPoints[2]+1 << "//" << *it + 1 << '\n';
+                    out << "f " << f._aulPoints[0]+1 << "//" << it + 1 << " "
+                                << f._aulPoints[1]+1 << "//" << it + 1 << " "
+                                << f._aulPoints[2]+1 << "//" << it + 1 << '\n';
                     seq.next(true); // allow to cancel
                 }
             }
         }
         else {
-            for (std::vector<Group>::const_iterator gt = _groups.begin(); gt != _groups.end(); ++gt) {
-                out << "g " << Base::Tools::escapedUnicodeFromUtf8(gt->name.c_str()) << '\n';
-                for (std::vector<FacetIndex>::const_iterator it = gt->indices.begin(); it != gt->indices.end(); ++it) {
-                    const MeshFacet& f = rFacets[*it];
-                    out << "f " << f._aulPoints[0]+1 << "//" << *it + 1 << " "
-                                << f._aulPoints[1]+1 << "//" << *it + 1 << " "
-                                << f._aulPoints[2]+1 << "//" << *it + 1 << '\n';
+            for (const auto & gt : _groups) {
+                out << "g " << Base::Tools::escapedUnicodeFromUtf8(gt.name.c_str()) << '\n';
+                for (FacetIndex it : gt.indices) {
+                    const MeshFacet& f = rFacets[it];
+                    out << "f " << f._aulPoints[0]+1 << "//" << it + 1 << " "
+                                << f._aulPoints[1]+1 << "//" << it + 1 << " "
+                                << f._aulPoints[2]+1 << "//" << it + 1 << '\n';
                     seq.next(true); // allow to cancel
                 }
             }

--- a/src/Mod/Mesh/App/Core/KDTree.cpp
+++ b/src/Mod/Mesh/App/Core/KDTree.cpp
@@ -97,16 +97,16 @@ MeshKDTree::MeshKDTree() : d(new Private)
 MeshKDTree::MeshKDTree(const std::vector<Base::Vector3f>& points) : d(new Private)
 {
     PointIndex index=0;
-    for (std::vector<Base::Vector3f>::const_iterator it = points.begin(); it != points.end(); ++it) {
-        d->kd_tree.insert(Point3d(*it, index++));
+    for (auto it : points) {
+        d->kd_tree.insert(Point3d(it, index++));
     }
 }
 
 MeshKDTree::MeshKDTree(const MeshPointArray& points) : d(new Private)
 {
     PointIndex index=0;
-    for (MeshPointArray::_TConstIterator it = points.begin(); it != points.end(); ++it) {
-        d->kd_tree.insert(Point3d(*it, index++));
+    for (const auto & it : points) {
+        d->kd_tree.insert(Point3d(it, index++));
     }
 }
 
@@ -124,16 +124,16 @@ void MeshKDTree::AddPoint(Base::Vector3f& point)
 void MeshKDTree::AddPoints(const std::vector<Base::Vector3f>& points)
 {
     PointIndex index=d->kd_tree.size();
-    for (std::vector<Base::Vector3f>::const_iterator it = points.begin(); it != points.end(); ++it) {
-        d->kd_tree.insert(Point3d(*it, index++));
+    for (auto it : points) {
+        d->kd_tree.insert(Point3d(it, index++));
     }
 }
 
 void MeshKDTree::AddPoints(const MeshPointArray& points)
 {
     PointIndex index=d->kd_tree.size();
-    for (MeshPointArray::_TConstIterator it = points.begin(); it != points.end(); ++it) {
-        d->kd_tree.insert(Point3d(*it, index++));
+    for (const auto & it : points) {
+        d->kd_tree.insert(Point3d(it, index++));
     }
 }
 
@@ -192,6 +192,6 @@ void MeshKDTree::FindInRange(const Base::Vector3f& p, float range, std::vector<P
     std::vector<Point3d> v;
     d->kd_tree.find_within_range(Point3d(p,0), range, std::back_inserter(v));
     indices.reserve(v.size());
-    for (std::vector<Point3d>::iterator it = v.begin(); it != v.end(); ++it)
-        indices.push_back(it->i);
+    for (const auto & it : v)
+        indices.push_back(it.i);
 }

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -69,8 +69,8 @@ namespace MeshCore {
 std::string& ltrim(std::string& str)
 {
     std::string::size_type pos=0;
-    for (std::string::iterator it = str.begin(); it != str.end(); ++it) {
-        if (*it != 0x20 && *it != 0x09)
+    for (char it : str) {
+        if (it != 0x20 && it != 0x09)
             break;
         pos++;
     }
@@ -808,14 +808,13 @@ bool MeshInput::LoadPLY (std::istream &inp)
     if (num_z != 1)
         return false;
 
-    for (std::vector<std::pair<std::string, Ply::Number> >::iterator it =
-        vertex_props.begin(); it != vertex_props.end(); ++it) {
-        if (it->first == "diffuse_red")
-            it->first = "red";
-        else if (it->first == "diffuse_green")
-            it->first = "green";
-        else if (it->first == "diffuse_blue")
-            it->first = "blue";
+    for (auto & it : vertex_props) {
+        if (it.first == "diffuse_red")
+            it.first = "red";
+        else if (it.first == "diffuse_green")
+            it.first = "green";
+        else if (it.first == "diffuse_blue")
+            it.first = "blue";
     }
 
     // check if valid colors are set
@@ -848,8 +847,8 @@ bool MeshInput::LoadPLY (std::istream &inp)
         for (std::size_t i = 0; i < v_count && std::getline(inp, line); i++) {
             // go through the vertex properties
             std::map<std::string, float> prop_values;
-            for (std::vector<std::pair<std::string, Number> >::iterator it = vertex_props.begin(); it != vertex_props.end(); ++it) {
-                switch (it->second) {
+            for (const auto & it : vertex_props) {
+                switch (it.second) {
                 case int8:
                 case int16:
                 case int32:
@@ -857,7 +856,7 @@ bool MeshInput::LoadPLY (std::istream &inp)
                         if (boost::regex_search(line, what, rx_s)) {
                             int v;
                             v = boost::lexical_cast<int>(what[1]);
-                            prop_values[it->first] = static_cast<float>(v);
+                            prop_values[it.first] = static_cast<float>(v);
                             line = line.substr(what[0].length());
                         }
                         else {
@@ -871,7 +870,7 @@ bool MeshInput::LoadPLY (std::istream &inp)
                         if (boost::regex_search(line, what, rx_u)) {
                             int v;
                             v = boost::lexical_cast<int>(what[1]);
-                            prop_values[it->first] = static_cast<float>(v);
+                            prop_values[it.first] = static_cast<float>(v);
                             line = line.substr(what[0].length());
                         }
                         else {
@@ -884,7 +883,7 @@ bool MeshInput::LoadPLY (std::istream &inp)
                         if (boost::regex_search(line, what, rx_d)) {
                             double v;
                             v = boost::lexical_cast<double>(what[1]);
-                            prop_values[it->first] = static_cast<float>(v);
+                            prop_values[it.first] = static_cast<float>(v);
                             line = line.substr(what[0].length());
                         }
                         else {
@@ -931,47 +930,47 @@ bool MeshInput::LoadPLY (std::istream &inp)
         for (std::size_t i = 0; i < v_count; i++) {
             // go through the vertex properties
             std::map<std::string, float> prop_values;
-            for (std::vector<std::pair<std::string, Number> >::iterator it = vertex_props.begin(); it != vertex_props.end(); ++it) {
-                switch (it->second) {
+            for (const auto & it : vertex_props) {
+                switch (it.second) {
                 case int8:
                     {
                         int8_t v; is >> v;
-                        prop_values[it->first] = static_cast<float>(v);
+                        prop_values[it.first] = static_cast<float>(v);
                     } break;
                 case uint8:
                     {
                         uint8_t v; is >> v;
-                        prop_values[it->first] = static_cast<float>(v);
+                        prop_values[it.first] = static_cast<float>(v);
                     } break;
                 case int16:
                     {
                         int16_t v; is >> v;
-                        prop_values[it->first] = static_cast<float>(v);
+                        prop_values[it.first] = static_cast<float>(v);
                     } break;
                 case uint16:
                     {
                         uint16_t v; is >> v;
-                        prop_values[it->first] = static_cast<float>(v);
+                        prop_values[it.first] = static_cast<float>(v);
                     } break;
                 case int32:
                     {
                         int32_t v; is >> v;
-                        prop_values[it->first] = static_cast<float>(v);
+                        prop_values[it.first] = static_cast<float>(v);
                     } break;
                 case uint32:
                     {
                         uint32_t v; is >> v;
-                        prop_values[it->first] = static_cast<float>(v);
+                        prop_values[it.first] = static_cast<float>(v);
                     } break;
                 case float32:
                     {
                         float v; is >> v;
-                        prop_values[it->first] = v;
+                        prop_values[it.first] = v;
                     } break;
                 case float64:
                     {
                         double v; is >> v;
-                        prop_values[it->first] = static_cast<float>(v);
+                        prop_values[it.first] = static_cast<float>(v);
                     } break;
                 default:
                     return false;
@@ -1000,8 +999,8 @@ bool MeshInput::LoadPLY (std::istream &inp)
                 is >> f1 >> f2 >> f3;
                 if (f1 < v_count && f2 < v_count && f3 < v_count)
                     meshFacets.push_back(MeshFacet(f1,f2,f3));
-                for (std::vector<Number>::iterator it = face_props.begin(); it != face_props.end(); ++it) {
-                    switch (*it) {
+                for (auto it : face_props) {
+                    switch (it) {
                     case int8:
                         {
                             int8_t v; is >> v;
@@ -1532,8 +1531,8 @@ bool MeshInput::LoadNastran (std::istream &rstrIn)
 
     // Check the triangles to make sure the vertices they refer to actually exist:
     for (const auto& tri : mTria) {
-        for (int i = 0; i < 3; ++i) {
-            if (mNode.find(tri.second.iV[i]) == mNode.end()) {
+        for (int i : tri.second.iV) {
+            if (mNode.find(i) == mNode.end()) {
                 Base::Console().Error("CTRIA3 element refers to a node that does not exist, or could not be read.\n");
                 return false;
             }
@@ -1542,8 +1541,8 @@ bool MeshInput::LoadNastran (std::istream &rstrIn)
 
     // Check the quads to make sure the vertices they refer to actually exist:
     for (const auto& quad : mQuad) {
-        for (int i = 0; i < 4; ++i) {
-            if (mNode.find(quad.second.iV[i]) == mNode.end()) {
+        for (int i : quad.second.iV) {
+            if (mNode.find(i) == mNode.end()) {
                 Base::Console().Error("CQUAD4 element refers to a node that does not exist, or could not be read.\n");
                 return false;
             }
@@ -1555,30 +1554,30 @@ bool MeshInput::LoadNastran (std::istream &rstrIn)
         index = 0;
     else
         index = mTria.rbegin()->first + 1;
-    for (std::map <int, QUAD>::iterator QI=mQuad.begin(); QI!=mQuad.end(); ++QI) {
+    for (const auto & QI : mQuad) {
         for (int i = 0; i < 2; i++) {
-            float fDx = mNode[(*QI).second.iV[i+2]].x - mNode[(*QI).second.iV[i]].x;
-            float fDy = mNode[(*QI).second.iV[i+2]].y - mNode[(*QI).second.iV[i]].y;
-            float fDz = mNode[(*QI).second.iV[i+2]].z - mNode[(*QI).second.iV[i]].z;
+            float fDx = mNode[QI.second.iV[i+2]].x - mNode[QI.second.iV[i]].x;
+            float fDy = mNode[QI.second.iV[i+2]].y - mNode[QI.second.iV[i]].y;
+            float fDz = mNode[QI.second.iV[i+2]].z - mNode[QI.second.iV[i]].z;
             fLength[i] = fDx*fDx + fDy*fDy + fDz*fDz;
         }
         if (fLength[0] < fLength[1]) {
-            mTria[index].iV[0] = (*QI).second.iV[0];
-            mTria[index].iV[1] = (*QI).second.iV[1];
-            mTria[index].iV[2] = (*QI).second.iV[2];
+            mTria[index].iV[0] = QI.second.iV[0];
+            mTria[index].iV[1] = QI.second.iV[1];
+            mTria[index].iV[2] = QI.second.iV[2];
 
-            mTria[index+1].iV[0] = (*QI).second.iV[0];
-            mTria[index+1].iV[1] = (*QI).second.iV[2];
-            mTria[index+1].iV[2] = (*QI).second.iV[3];
+            mTria[index+1].iV[0] = QI.second.iV[0];
+            mTria[index+1].iV[1] = QI.second.iV[2];
+            mTria[index+1].iV[2] = QI.second.iV[3];
         }
         else {
-            mTria[index].iV[0] = (*QI).second.iV[0];
-            mTria[index].iV[1] = (*QI).second.iV[1];
-            mTria[index].iV[2] = (*QI).second.iV[3];
+            mTria[index].iV[0] = QI.second.iV[0];
+            mTria[index].iV[1] = QI.second.iV[1];
+            mTria[index].iV[2] = QI.second.iV[3];
 
-            mTria[index+1].iV[0] = (*QI).second.iV[1];
-            mTria[index+1].iV[1] = (*QI).second.iV[2];
-            mTria[index+1].iV[2] = (*QI).second.iV[3];
+            mTria[index+1].iV[0] = QI.second.iV[1];
+            mTria[index+1].iV[1] = QI.second.iV[2];
+            mTria[index+1].iV[2] = QI.second.iV[3];
         }
 
         index += 2;
@@ -1586,16 +1585,16 @@ bool MeshInput::LoadNastran (std::istream &rstrIn)
 
     // Applying the nodes
     vVertices.reserve(mNode.size());
-    for (std::map<int, NODE>::iterator MI=mNode.begin(); MI!=mNode.end(); ++MI) {
-        vVertices.push_back(Base::Vector3f(MI->second.x, MI->second.y, MI->second.z));
+    for (const auto & MI : mNode) {
+        vVertices.push_back(Base::Vector3f(MI.second.x, MI.second.y, MI.second.z));
     }
 
     // Converting data to Mesh. Negative conversion for right orientation of normal-vectors.
     vTriangle.reserve(mTria.size());
-    for (std::map<int, TRIA>::iterator MI=mTria.begin(); MI!=mTria.end(); ++MI) {
-        clMeshFacet._aulPoints[0] = (*MI).second.iV[1];
-        clMeshFacet._aulPoints[1] = (*MI).second.iV[0];
-        clMeshFacet._aulPoints[2] = (*MI).second.iV[2];
+    for (const auto & MI : mTria) {
+        clMeshFacet._aulPoints[0] = MI.second.iV[1];
+        clMeshFacet._aulPoints[1] = MI.second.iV[0];
+        clMeshFacet._aulPoints[2] = MI.second.iV[2];
         vTriangle.push_back (clMeshFacet);
     }
 
@@ -1958,10 +1957,10 @@ bool MeshOutput::SaveAsciiSTL (std::ostream &rstrOut) const
         rstrOut << "    outer loop\n";
 
         // vertices
-        for (int i = 0; i < 3; i++) {
-            rstrOut << "      vertex "  << pclFacet->_aclPoints[i].x << " "
-                                        << pclFacet->_aclPoints[i].y << " "
-                                        << pclFacet->_aclPoints[i].z << '\n';
+        for (const auto& pnt : pclFacet->_aclPoints) {
+            rstrOut << "      vertex "  << pnt.x << " "
+                                        << pnt.y << " "
+                                        << pnt.z << '\n';
         }
 
         rstrOut << "    endloop\n";
@@ -2094,10 +2093,10 @@ bool MeshOutput::SaveSMF (std::ostream &out) const
     }
 
     // facet indices
-    for (MeshFacetArray::_TConstIterator it = rFacets.begin(); it != rFacets.end(); ++it) {
-        out << "f " << it->_aulPoints[0]+1 << " "
-                    << it->_aulPoints[1]+1 << " "
-                    << it->_aulPoints[2]+1 << '\n';
+    for (const auto & it : rFacets) {
+        out << "f " << it._aulPoints[0]+1 << " "
+                    << it._aulPoints[1]+1 << " "
+                    << it._aulPoints[2]+1 << '\n';
         seq.next(true); // allow to cancel
     }
 
@@ -2175,10 +2174,10 @@ bool MeshOutput::SaveAsymptote(std::ostream &out) const
         out << "draw(surface(";
 
         // vertices
-        for (int i = 0; i < 3; i++) {
-            out << '(' << pclFacet->_aclPoints[i].x << ", "
-                       << pclFacet->_aclPoints[i].y << ", "
-                       << pclFacet->_aclPoints[i].z << ")--";
+        for (const auto& pnt : pclFacet->_aclPoints) {
+            out << '(' << pnt.x << ", "
+                       << pnt.y << ", "
+                       << pnt.z << ")--";
         }
 
         out << "cycle";
@@ -2283,10 +2282,10 @@ bool MeshOutput::SaveOFF (std::ostream &out) const
     }
 
     // facet indices (no texture and normal indices)
-    for (MeshFacetArray::_TConstIterator it = rFacets.begin(); it != rFacets.end(); ++it) {
-        out << "3 " << it->_aulPoints[0]
-            << " " << it->_aulPoints[1]
-            << " " << it->_aulPoints[2] << '\n';
+    for (const auto & it : rFacets) {
+        out << "3 " << it._aulPoints[0]
+            << " " << it._aulPoints[1]
+            << " " << it._aulPoints[2] << '\n';
         seq.next(true); // allow to cancel
     }
 
@@ -2438,21 +2437,21 @@ bool MeshOutput::SaveMeshNode (std::ostream &rstrOut)
     rstrOut << "[" << '\n';
     if (this->apply_transform) {
         Base::Vector3f pt;
-        for (MeshPointArray::_TConstIterator it = rPoints.begin(); it != rPoints.end(); ++it) {
-            pt = this->_transform * *it;
+        for (const auto & it : rPoints) {
+            pt = this->_transform * it;
             rstrOut << "v " << pt.x << " " << pt.y << " " << pt.z << '\n';
         }
     }
     else {
-        for (MeshPointArray::_TConstIterator it = rPoints.begin(); it != rPoints.end(); ++it) {
-            rstrOut << "v " << it->x << " " << it->y << " " << it->z << '\n';
+        for (const auto & it : rPoints) {
+            rstrOut << "v " << it.x << " " << it.y << " " << it.z << '\n';
         }
     }
     // facet indices (no texture and normal indices)
-    for (MeshFacetArray::_TConstIterator it = rFacets.begin(); it != rFacets.end(); ++it) {
-        rstrOut << "f " << it->_aulPoints[0]+1 << " "
-                        << it->_aulPoints[1]+1 << " "
-                        << it->_aulPoints[2]+1 << '\n';
+    for (const auto & it : rFacets) {
+        rstrOut << "f " << it._aulPoints[0]+1 << " "
+                        << it._aulPoints[1]+1 << " "
+                        << it._aulPoints[2]+1 << '\n';
     }
     rstrOut << "]" << '\n';
 
@@ -2473,8 +2472,8 @@ void MeshOutput::SaveXML (Base::Writer &writer) const
     writer.incInd();
     if (this->apply_transform) {
         Base::Vector3f pt;
-        for (MeshPointArray::_TConstIterator itp = rPoints.begin(); itp != rPoints.end(); ++itp) {
-            pt = this->_transform * *itp;
+        for (const auto & it : rPoints) {
+            pt = this->_transform * it;
             writer.Stream() <<  writer.ind() << "<P "
                             << "x=\"" <<  pt.x << "\" "
                             << "y=\"" <<  pt.y << "\" "
@@ -2483,11 +2482,11 @@ void MeshOutput::SaveXML (Base::Writer &writer) const
         }
     }
     else {
-        for (MeshPointArray::_TConstIterator itp = rPoints.begin(); itp != rPoints.end(); ++itp) {
+        for (const auto & it : rPoints) {
             writer.Stream() <<  writer.ind() << "<P "
-                            << "x=\"" <<  itp->x << "\" "
-                            << "y=\"" <<  itp->y << "\" "
-                            << "z=\"" <<  itp->z << "\"/>"
+                            << "x=\"" <<  it.x << "\" "
+                            << "y=\"" <<  it.y << "\" "
+                            << "z=\"" <<  it.z << "\"/>"
                             << '\n';
         }
     }
@@ -2498,14 +2497,14 @@ void MeshOutput::SaveXML (Base::Writer &writer) const
     writer.Stream() << writer.ind() << "<Faces Count=\"" << _rclMesh.CountFacets() << "\">" << '\n';
 
     writer.incInd();
-    for (MeshFacetArray::_TConstIterator it = rFacets.begin(); it != rFacets.end(); ++it) {
+    for (const auto & it : rFacets) {
         writer.Stream() << writer.ind() << "<F "
-                        << "p0=\"" <<  it->_aulPoints[0] << "\" "
-                        << "p1=\"" <<  it->_aulPoints[1] << "\" "
-                        << "p2=\"" <<  it->_aulPoints[2] << "\" "
-                        << "n0=\"" <<  it->_aulNeighbours[0] << "\" "
-                        << "n1=\"" <<  it->_aulNeighbours[1] << "\" "
-                        << "n2=\"" <<  it->_aulNeighbours[2] << "\"/>"
+                        << "p0=\"" <<  it._aulPoints[0] << "\" "
+                        << "p1=\"" <<  it._aulPoints[1] << "\" "
+                        << "p2=\"" <<  it._aulPoints[2] << "\" "
+                        << "n0=\"" <<  it._aulNeighbours[0] << "\" "
+                        << "n1=\"" <<  it._aulNeighbours[1] << "\" "
+                        << "n2=\"" <<  it._aulNeighbours[2] << "\"/>"
                         << '\n';
     }
     writer.decInd();
@@ -2579,8 +2578,8 @@ bool MeshOutput::SaveIDTF (std::ostream &str) const
     str << Base::tabs(4) << "}\n";
     str << Base::tabs(3) << "}\n";
     str << Base::tabs(3) << "MESH_FACE_POSITION_LIST {\n";
-    for (MeshFacetArray::_TConstIterator it = fts.begin(); it != fts.end(); ++it) {
-        str << Base::tabs(4) << it->_aulPoints[0] << " " << it->_aulPoints[1] << " " << it->_aulPoints[2] << '\n';
+    for (const auto & ft : fts) {
+        str << Base::tabs(4) << ft._aulPoints[0] << " " << ft._aulPoints[1] << " " << ft._aulPoints[2] << '\n';
     }
     str << Base::tabs(3) << "}\n";
     str << Base::tabs(3) << "MESH_FACE_NORMAL_LIST {\n";
@@ -2596,13 +2595,13 @@ bool MeshOutput::SaveIDTF (std::ostream &str) const
     }
     str << Base::tabs(3) << "}\n";
     str << Base::tabs(3) << "MODEL_POSITION_LIST {\n";
-    for (MeshPointArray::_TConstIterator it = pts.begin(); it != pts.end(); ++it) {
-        str << Base::tabs(4) << it->x << " " << it->y << " " << it->z << '\n';
+    for (const auto & pt : pts) {
+        str << Base::tabs(4) << pt.x << " " << pt.y << " " << pt.z << '\n';
     }
     str << Base::tabs(3) << "}\n";
     str << Base::tabs(3) << "MODEL_NORMAL_LIST {\n";
-    for (MeshFacetArray::_TConstIterator it = fts.begin(); it != fts.end(); ++it) {
-        MeshGeomFacet face = _rclMesh.GetFacet(*it);
+    for (const auto & ft : fts) {
+        MeshGeomFacet face = _rclMesh.GetFacet(ft);
         Base::Vector3f normal = face.GetNormal();
         str << Base::tabs(4) << normal.x << " " << normal.y << " " << normal.z << '\n';
         str << Base::tabs(4) << normal.x << " " << normal.y << " " << normal.z << '\n';
@@ -2640,26 +2639,26 @@ triplot t xt yt zt 'b'
 
     str << "light on\n";
     str << "list t ";
-    for (MeshFacetArray::_TConstIterator it = fts.begin(); it != fts.end(); ++it) {
-        str << it->_aulPoints[0] << " " << it->_aulPoints[1] << " " << it->_aulPoints[2] << " | ";
+    for (const auto & ft : fts) {
+        str << ft._aulPoints[0] << " " << ft._aulPoints[1] << " " << ft._aulPoints[2] << " | ";
     }
     str << std::endl;
 
     str << "list xt ";
-    for (MeshPointArray::_TConstIterator it = pts.begin(); it != pts.end(); ++it) {
-        str << it->x << " ";
+    for (const auto & pt : pts) {
+        str << pt.x << " ";
     }
     str << std::endl;
 
     str << "list yt ";
-    for (MeshPointArray::_TConstIterator it = pts.begin(); it != pts.end(); ++it) {
-        str << it->y << " ";
+    for (const auto & pt : pts) {
+        str << pt.y << " ";
     }
     str << std::endl;
 
     str << "list zt ";
-    for (MeshPointArray::_TConstIterator it = pts.begin(); it != pts.end(); ++it) {
-        str << it->z << " ";
+    for (const auto & pt : pts) {
+        str << pt.z << " ";
     }
     str << std::endl;
 
@@ -2786,14 +2785,14 @@ bool MeshOutput::SaveX3DContent (std::ostream &out, bool exportViewpoints) const
     }
 
     out << "coordIndex=\"";
-    for (MeshFacetArray::_TConstIterator it = fts.begin(); it != fts.end(); ++it) {
-        out << it->_aulPoints[0] << " " << it->_aulPoints[1] << " " << it->_aulPoints[2] << " -1 ";
+    for (const auto & ft : fts) {
+        out << ft._aulPoints[0] << " " << ft._aulPoints[1] << " " << ft._aulPoints[2] << " -1 ";
     }
     out << "\">\n";
 
     out << "          <Coordinate point=\"";
-    for (MeshPointArray::_TConstIterator it = pts.begin(); it != pts.end(); ++it) {
-        out << it->x << " " << it->y << " " << it->z << ", ";
+    for (const auto & pt : pts) {
+        out << pt.x << " " << pt.y << " " << pt.z << ", ";
     }
     out << "\"/>\n";
 
@@ -2936,10 +2935,10 @@ bool MeshOutput::SavePython (std::ostream &str) const
     str << "faces = [\n";
     for (clIter.Init(); clIter.More(); clIter.Next()) {
         const MeshGeomFacet& rFacet = *clIter;
-        for (int i = 0; i < 3; i++) {
-            str << "[" << rFacet._aclPoints[i].x
-                << "," << rFacet._aclPoints[i].y
-                << "," << rFacet._aclPoints[i].z
+        for (const auto& pnt : rFacet._aclPoints) {
+            str << "[" << pnt.x
+                << "," << pnt.y
+                << "," << pnt.z
                 << "],";
         }
         str << '\n';
@@ -3117,20 +3116,20 @@ void MeshCleanup::RemoveInvalids()
     // Now go through the facets and invalidate facets with wrong indices
     // If a facet is valid all its referenced points are validated again
     // Points that are not referenced are still invalid and thus can be deleted
-    for (MeshFacetArray::_TIterator it = facetArray.begin(); it != facetArray.end(); ++it) {
-        for (int i=0; i<3; i++) {
+    for (auto & it : facetArray) {
+        for (PointIndex point : it._aulPoints) {
             // vertex index out of range
-            if (it->_aulPoints[i] >= numPoints) {
-                it->SetInvalid();
+            if (point >= numPoints) {
+                it.SetInvalid();
                 break;
             }
         }
 
         // validate referenced points
-        if (it->IsValid()) {
-            pointArray[it->_aulPoints[0]].ResetInvalid();
-            pointArray[it->_aulPoints[1]].ResetInvalid();
-            pointArray[it->_aulPoints[2]].ResetInvalid();
+        if (it.IsValid()) {
+            pointArray[it._aulPoints[0]].ResetInvalid();
+            pointArray[it._aulPoints[1]].ResetInvalid();
+            pointArray[it._aulPoints[2]].ResetInvalid();
         }
     }
 
@@ -3236,10 +3235,10 @@ MeshPointFacetAdjacency::~MeshPointFacetAdjacency()
 void MeshPointFacetAdjacency::Build()
 {
     std::vector<std::size_t> numFacetAdjacency(numPoints);
-    for (MeshFacetArray::iterator it = facets.begin(); it != facets.end(); ++it) {
-        numFacetAdjacency[it->_aulPoints[0]]++;
-        numFacetAdjacency[it->_aulPoints[1]]++;
-        numFacetAdjacency[it->_aulPoints[2]]++;
+    for (const auto & it : facets) {
+        numFacetAdjacency[it._aulPoints[0]]++;
+        numFacetAdjacency[it._aulPoints[1]]++;
+        numFacetAdjacency[it._aulPoints[2]]++;
     }
 
     pointFacetAdjacency.resize(numPoints);
@@ -3248,8 +3247,8 @@ void MeshPointFacetAdjacency::Build()
 
     std::size_t numFacets = facets.size();
     for (std::size_t i = 0; i < numFacets; i++) {
-        for (int j = 0; j < 3; j++) {
-            pointFacetAdjacency[facets[i]._aulPoints[j]].push_back(i);
+        for (PointIndex ptIndex : facets[i]._aulPoints) {
+            pointFacetAdjacency[ptIndex].push_back(i);
         }
     }
 }
@@ -3265,11 +3264,11 @@ void MeshPointFacetAdjacency::SetFacetNeighbourhood()
 
             bool success = false;
             const std::vector<std::size_t>& refFacets = pointFacetAdjacency[n1];
-            for (std::vector<std::size_t>::const_iterator it = refFacets.begin(); it != refFacets.end(); ++it) {
-                if (*it != index) {
-                    MeshFacet& facet2 = facets[*it];
+            for (std::size_t it : refFacets) {
+                if (it != index) {
+                    MeshFacet& facet2 = facets[it];
                     if (facet2.HasPoint(n2)) {
-                        facet1._aulNeighbours[i] = *it;
+                        facet1._aulNeighbours[i] = it;
                         success = true;
                         break;
                     }

--- a/src/Mod/Mesh/App/Core/Projection.cpp
+++ b/src/Mod/Mesh/App/Core/Projection.cpp
@@ -165,12 +165,12 @@ bool MeshProjection::projectLineOnMesh(const MeshFacetGrid& grid,
 
     // cut all facets with plane
     std::list< std::pair<Base::Vector3f, Base::Vector3f> > cutLine;
-    for (std::vector<FacetIndex>::iterator it = facets.begin(); it != facets.end(); ++it) {
+    for (FacetIndex facet : facets) {
         Base::Vector3f e1, e2;
-        MeshGeomFacet tria = kernel.GetFacet(*it);
+        MeshGeomFacet tria = kernel.GetFacet(facet);
         if (bboxInsideRectangle(tria.GetBoundBox(), v1, v2, vd)) {
             if (tria.IntersectWithPlane(base, normal, e1, e2)) {
-                if ((*it != f1) && (*it != f2)) {
+                if ((facet != f1) && (facet != f2)) {
                     // inside cut line
                     if (!isPointInsideDistance(v1, v2, e1) ||
                         !isPointInsideDistance(v1, v2, e2)) {
@@ -180,7 +180,7 @@ bool MeshProjection::projectLineOnMesh(const MeshFacetGrid& grid,
                     cutLine.emplace_back(e1, e2);
                 }
                 else {
-                    if (*it == f1) { // start facet
+                    if (facet == f1) { // start facet
                         if (((e2 - v1) * dir) > 0.0f)
                             cutLine.emplace_back(v1, e2);
                         else
@@ -189,7 +189,7 @@ bool MeshProjection::projectLineOnMesh(const MeshFacetGrid& grid,
                         //start = it - facets.begin();
                     }
 
-                    if (*it == f2) { // end facet
+                    if (facet == f2) { // end facet
                         if (((e2 - v2) * -dir) > 0.0f)
                             cutLine.emplace_back(v2, e2);
                         else

--- a/src/Mod/Mesh/App/Core/Segmentation.cpp
+++ b/src/Mod/Mesh/App/Core/Segmentation.cpp
@@ -53,9 +53,9 @@ void MeshSurfaceSegment::AddSegment(const std::vector<FacetIndex>& segm)
 
 MeshSegment MeshSurfaceSegment::FindSegment(FacetIndex index) const
 {
-    for (std::vector<MeshSegment>::const_iterator it = segments.begin(); it != segments.end(); ++it) {
-        if (std::find(it->begin(), it->end(), index) != it->end())
-            return *it;
+    for (const auto & segment : segments) {
+        if (std::find(segment.begin(), segment.end(), index) != segment.end())
+            return segment;
     }
 
     return MeshSegment();
@@ -90,8 +90,8 @@ bool MeshDistancePlanarSegment::TestFacet (const MeshFacet& face) const
     if (!fitter->Done())
         fitter->Fit();
     MeshGeomFacet triangle = kernel.GetFacet(face);
-    for (int i=0; i<3; i++) {
-        if (fabs(fitter->GetDistanceToPlane(triangle._aclPoints[i])) > tolerance)
+    for (auto pnt : triangle._aclPoints) {
+        if (fabs(fitter->GetDistanceToPlane(pnt)) > tolerance)
             return false;
     }
 
@@ -417,8 +417,8 @@ void MeshDistanceGenericSurfaceFitSegment::Initialize(FacetIndex index)
 bool MeshDistanceGenericSurfaceFitSegment::TestInitialFacet(FacetIndex index) const
 {
     MeshGeomFacet triangle = kernel.GetFacet(index);
-    for (int i=0; i<3; i++) {
-        if (fabs(fitter->GetDistanceToSurface(triangle._aclPoints[i])) > tolerance)
+    for (auto pnt : triangle._aclPoints) {
+        if (fabs(fitter->GetDistanceToSurface(pnt)) > tolerance)
             return false;
     }
     return fitter->TestTriangle(triangle);
@@ -429,8 +429,8 @@ bool MeshDistanceGenericSurfaceFitSegment::TestFacet (const MeshFacet& face) con
     if (!fitter->Done())
         fitter->Fit();
     MeshGeomFacet triangle = kernel.GetFacet(face);
-    for (int i=0; i<3; i++) {
-        if (fabs(fitter->GetDistanceToSurface(triangle._aclPoints[i])) > tolerance)
+    for (auto ptIndex : triangle._aclPoints) {
+        if (fabs(fitter->GetDistanceToSurface(ptIndex)) > tolerance)
             return false;
     }
 
@@ -452,8 +452,8 @@ std::vector<float> MeshDistanceGenericSurfaceFitSegment::Parameters() const
 
 bool MeshCurvaturePlanarSegment::TestFacet (const MeshFacet &rclFacet) const
 {
-    for (int i=0; i<3; i++) {
-        const CurvatureInfo& ci = info[rclFacet._aulPoints[i]];
+    for (PointIndex ptIndex : rclFacet._aulPoints) {
+        const CurvatureInfo& ci = info[ptIndex];
         if (fabs(ci.fMinCurvature) > tolerance)
             return false;
         if (fabs(ci.fMaxCurvature) > tolerance)
@@ -465,8 +465,8 @@ bool MeshCurvaturePlanarSegment::TestFacet (const MeshFacet &rclFacet) const
 
 bool MeshCurvatureCylindricalSegment::TestFacet (const MeshFacet &rclFacet) const
 {
-    for (int i=0; i<3; i++) {
-        const CurvatureInfo& ci = info[rclFacet._aulPoints[i]];
+    for (PointIndex ptIndex : rclFacet._aulPoints) {
+        const CurvatureInfo& ci = info[ptIndex];
         float fMax = std::max<float>(fabs(ci.fMaxCurvature), fabs(ci.fMinCurvature));
         float fMin = std::min<float>(fabs(ci.fMaxCurvature), fabs(ci.fMinCurvature));
         if (fMin > toleranceMin)
@@ -480,8 +480,8 @@ bool MeshCurvatureCylindricalSegment::TestFacet (const MeshFacet &rclFacet) cons
 
 bool MeshCurvatureSphericalSegment::TestFacet (const MeshFacet &rclFacet) const
 {
-    for (int i=0; i<3; i++) {
-        const CurvatureInfo& ci = info[rclFacet._aulPoints[i]];
+    for (PointIndex ptIndex : rclFacet._aulPoints) {
+        const CurvatureInfo& ci = info[ptIndex];
         if (ci.fMaxCurvature * ci.fMinCurvature < 0)
             return false;
         float diff;
@@ -498,8 +498,8 @@ bool MeshCurvatureSphericalSegment::TestFacet (const MeshFacet &rclFacet) const
 
 bool MeshCurvatureFreeformSegment::TestFacet (const MeshFacet &rclFacet) const
 {
-    for (int i=0; i<3; i++) {
-        const CurvatureInfo& ci = info[rclFacet._aulPoints[i]];
+    for (PointIndex ptIndex : rclFacet._aulPoints) {
+        const CurvatureInfo& ci = info[ptIndex];
         if (fabs(ci.fMinCurvature-c2) > toleranceMin)
             return false;
         if (fabs(ci.fMaxCurvature-c1) > toleranceMax)
@@ -552,7 +552,7 @@ void MeshSegmentAlgorithm::FindSegments(std::vector<MeshSurfaceSegmentPtr>& segm
     cAlgo.CountFacetFlag(MeshCore::MeshFacet::VISIT);
     std::vector<FacetIndex> resetVisited;
 
-    for (std::vector<MeshSurfaceSegmentPtr>::iterator it = segm.begin(); it != segm.end(); ++it) {
+    for (auto & it : segm) {
         cAlgo.ResetFacetsFlag(resetVisited, MeshCore::MeshFacet::VISIT);
         resetVisited.clear();
 
@@ -567,10 +567,10 @@ void MeshSegmentAlgorithm::FindSegments(std::vector<MeshSurfaceSegmentPtr>& segm
         while (startFacet != FACET_INDEX_MAX) {
             // collect all facets of the same geometry
             std::vector<FacetIndex> indices;
-            (*it)->Initialize(startFacet);
-            if ((*it)->TestInitialFacet(startFacet))
+            it->Initialize(startFacet);
+            if (it->TestInitialFacet(startFacet))
                 indices.push_back(startFacet);
-            MeshSurfaceVisitor pv(**it, indices);
+            MeshSurfaceVisitor pv(*it, indices);
             myKernel.VisitNeighbourFacets(pv, startFacet);
 
             // add or discard the segment
@@ -578,7 +578,7 @@ void MeshSegmentAlgorithm::FindSegments(std::vector<MeshSurfaceSegmentPtr>& segm
                 resetVisited.push_back(startFacet);
             }
             else {
-                (*it)->AddSegment(indices);
+                it->AddSegment(indices);
             }
 
             // search for the next start facet

--- a/src/Mod/Mesh/App/Core/SetOperations.cpp
+++ b/src/Mod/Mesh/App/Core/SetOperations.cpp
@@ -353,18 +353,18 @@ void SetOperations::TriangulateMesh (const MeshKernel &cutMesh, int side)
     tria.TriangulatePolygon();
 
     std::vector<MeshFacet> facets = tria.GetFacets();
-    for (std::vector<MeshFacet>::iterator it = facets.begin(); it != facets.end(); ++it)
+    for (auto & it : facets)
     {
-      if ((it->_aulPoints[0] == it->_aulPoints[1]) ||
-          (it->_aulPoints[1] == it->_aulPoints[2]) ||
-          (it->_aulPoints[2] == it->_aulPoints[0]))
+      if ((it._aulPoints[0] == it._aulPoints[1]) ||
+          (it._aulPoints[1] == it._aulPoints[2]) ||
+          (it._aulPoints[2] == it._aulPoints[0]))
       { // two same triangle corner points
         continue;
       }
 
-      MeshGeomFacet facet(points[it->_aulPoints[0]],
-                          points[it->_aulPoints[1]],
-                          points[it->_aulPoints[2]]);
+      MeshGeomFacet facet(points[it._aulPoints[0]],
+                          points[it._aulPoints[1]],
+                          points[it._aulPoints[2]]);
 
       //if (side == 1)
       // _builder.addSingleTriangle(facet._aclPoints[0], facet._aclPoints[1], facet._aclPoints[2], true, 3, 0, 1, 1);
@@ -666,16 +666,16 @@ void MeshIntersection::getIntersection(std::list<MeshIntersection::Tuple>& intsc
         cMFI2.Set(index);
         facet2 = *cMFI2;
 
-        for (std::vector<FacetIndex>::iterator jt = elements.begin(); jt != elements.end(); ++jt) {
-            if (boxes2[index] && boxes1[*jt]) {
-                cMFI1.Set(*jt);
+        for (FacetIndex element : elements) {
+            if (boxes2[index] && boxes1[element]) {
+                cMFI1.Set(element);
                 facet1 = *cMFI1;
                 int ret = facet1.IntersectWithFacet(facet2, pt1, pt2);
                 if (ret == 2) {
                     Tuple d;
                     d.p1 = pt1;
                     d.p2 = pt2;
-                    d.f1 = *jt;
+                    d.f1 = element;
                     d.f2 = index;
                     intsct.push_back(d);
                 }
@@ -719,9 +719,9 @@ bool MeshIntersection::testIntersection(const MeshKernel& k1,
         cMFI2.Set(index);
         facet2 = *cMFI2;
 
-        for (std::vector<FacetIndex>::iterator jt = elements.begin(); jt != elements.end(); ++jt) {
-            if (boxes2[index] && boxes1[*jt]) {
-                cMFI1.Set(*jt);
+        for (FacetIndex element : elements) {
+            if (boxes2[index] && boxes1[element]) {
+                cMFI1.Set(element);
                 facet1 = *cMFI1;
                 int ret = facet1.IntersectWithFacet(facet2, pt1, pt2);
                 if (ret == 2) {

--- a/src/Mod/Mesh/App/Core/Smoothing.cpp
+++ b/src/Mod/Mesh/App/Core/Smoothing.cpp
@@ -125,8 +125,8 @@ void PlaneFitSmoothing::SmoothPoints(unsigned int iterations, const std::vector<
 
     for (unsigned int i=0; i<iterations; i++) {
         Base::Vector3f N, L;
-        for (std::vector<PointIndex>::const_iterator it = point_indices.begin(); it != point_indices.end(); ++it) {
-            v_it.Set(*it);
+        for (PointIndex it : point_indices) {
+            v_it.Set(it);
             MeshCore::PlaneFit pf;
             pf.AddPoint(*v_it);
             center = *v_it;
@@ -220,11 +220,11 @@ void LaplaceSmoothing::Umbrella(const MeshRefPointToPoints& vv_it,
     const MeshCore::MeshPointArray& points = kernel.GetPoints();
     MeshCore::MeshPointArray::_TConstIterator v_beg = points.begin();
 
-    for (std::vector<PointIndex>::const_iterator pos = point_indices.begin(); pos != point_indices.end(); ++pos) {
-        const std::set<PointIndex>& cv = vv_it[*pos];
+    for (PointIndex it : point_indices) {
+        const std::set<PointIndex>& cv = vv_it[it];
         if (cv.size() < 3)
             continue;
-        if (cv.size() != vf_it[*pos].size()) {
+        if (cv.size() != vf_it[it].size()) {
             // do nothing for border points
             continue;
         }
@@ -236,15 +236,15 @@ void LaplaceSmoothing::Umbrella(const MeshRefPointToPoints& vv_it,
         double delx=0.0,dely=0.0,delz=0.0;
         std::set<PointIndex>::const_iterator cv_it;
         for (cv_it = cv.begin(); cv_it !=cv.end(); ++cv_it) {
-            delx += w*static_cast<double>((v_beg[*cv_it]).x-(v_beg[*pos]).x);
-            dely += w*static_cast<double>((v_beg[*cv_it]).y-(v_beg[*pos]).y);
-            delz += w*static_cast<double>((v_beg[*cv_it]).z-(v_beg[*pos]).z);
+            delx += w*static_cast<double>((v_beg[*cv_it]).x-(v_beg[it]).x);
+            dely += w*static_cast<double>((v_beg[*cv_it]).y-(v_beg[it]).y);
+            delz += w*static_cast<double>((v_beg[*cv_it]).z-(v_beg[it]).z);
         }
 
-        float x = static_cast<float>(static_cast<double>((v_beg[*pos]).x)+stepsize*delx);
-        float y = static_cast<float>(static_cast<double>((v_beg[*pos]).y)+stepsize*dely);
-        float z = static_cast<float>(static_cast<double>((v_beg[*pos]).z)+stepsize*delz);
-        kernel.SetPoint(*pos,x,y,z);
+        float x = static_cast<float>(static_cast<double>((v_beg[it]).x)+stepsize*delx);
+        float y = static_cast<float>(static_cast<double>((v_beg[it]).y)+stepsize*dely);
+        float z = static_cast<float>(static_cast<double>((v_beg[it]).z)+stepsize*delz);
+        kernel.SetPoint(it,x,y,z);
     }
 }
 

--- a/src/Mod/Mesh/App/Core/SphereFit.cpp
+++ b/src/Mod/Mesh/App/Core/SphereFit.cpp
@@ -125,10 +125,8 @@ float SphereFit::GetStdDeviation() const
 
 void SphereFit::ProjectToSphere()
 {
-	for (std::list< Base::Vector3f >::iterator it = _vPoints.begin(); it != _vPoints.end(); ++it) {
-		Base::Vector3f& cPnt = *it;
-
-		// Compute unit vector from sphere centre to point.
+	for (auto & cPnt : _vPoints) {
+			// Compute unit vector from sphere centre to point.
 		// Because this vector is orthogonal to the sphere's surface at the
 		// intersection point we can easily compute the projection point on the
 		// closest surface point using the radius of the sphere

--- a/src/Mod/Mesh/App/Core/Tools.cpp
+++ b/src/Mod/Mesh/App/Core/Tools.cpp
@@ -82,17 +82,17 @@ unsigned long MeshSearchNeighbours::NeighboursFromFacet (FacetIndex ulFacetIdx, 
 
         std::set<PointIndex> aclTmp;
         aclTmp.swap(_aclOuter);
-        for (std::set<FacetIndex>::iterator pI = aclTmp.begin(); pI != aclTmp.end(); ++pI) {
-            const std::set<FacetIndex> &rclISet = _clPt2Fa[*pI];
+        for (PointIndex pI : aclTmp) {
+            const std::set<FacetIndex> &rclISet = _clPt2Fa[pI];
             // search all facets hanging on this point
-            for (std::set<FacetIndex>::const_iterator pJ = rclISet.begin(); pJ != rclISet.end(); ++pJ) {
-                const MeshFacet &rclF = f_beg[*pJ];
+            for (FacetIndex pJ : rclISet) {
+                const MeshFacet &rclF = f_beg[pJ];
 
                 if (!rclF.IsFlag(MeshFacet::MARKED)) {
                     bool bLF = CheckDistToFacet(rclF);
                     bFound = bFound || bLF;
                     rclF.SetFlag(MeshFacet::MARKED);
-                    aclTestedFacet.push_back(f_beg+*pJ);
+                    aclTestedFacet.push_back(f_beg+pJ);
                 }
             }
             ulVisited += rclISet.size();
@@ -109,11 +109,10 @@ unsigned long MeshSearchNeighbours::NeighboursFromFacet (FacetIndex ulFacetIdx, 
     }
 
     // reset marked facets, points
-    for (std::vector<MeshFacetArray::_TConstIterator>::iterator pF = aclTestedFacet.begin();
-        pF != aclTestedFacet.end(); ++pF)
-        (*pF)->ResetFlag(MeshFacet::MARKED);
-    for (std::set<PointIndex>::iterator pR = _aclResult.begin(); pR != _aclResult.end(); ++pR)
-        _rclPAry[*pR].ResetFlag(MeshPoint::MARKED);
+    for (auto & pF : aclTestedFacet)
+        pF->ResetFlag(MeshFacet::MARKED);
+    for (PointIndex pR : _aclResult)
+        _rclPAry[pR].ResetFlag(MeshPoint::MARKED);
 
 
     // copy points in result container
@@ -175,17 +174,17 @@ unsigned long MeshSearchNeighbours::NeighboursFromSampledFacets (FacetIndex ulFa
 
         std::set<PointIndex> aclTmp;
         aclTmp.swap(_aclOuter);
-        for (std::set<PointIndex>::iterator pI = aclTmp.begin(); pI != aclTmp.end(); ++pI) {
-            const std::set<FacetIndex> &rclISet = _clPt2Fa[*pI];
+        for (PointIndex pI : aclTmp) {
+            const std::set<FacetIndex> &rclISet = _clPt2Fa[pI];
             // search all facets hanging on this point
-            for (std::set<FacetIndex>::const_iterator pJ = rclISet.begin(); pJ != rclISet.end(); ++pJ) {
-                const MeshFacet &rclF = f_beg[*pJ];
+            for (FacetIndex pJ : rclISet) {
+                const MeshFacet &rclF = f_beg[pJ];
 
                 if (!rclF.IsFlag(MeshFacet::MARKED)) {
-                    bool bLF = AccumulateNeighbours(rclF, *pJ);
+                    bool bLF = AccumulateNeighbours(rclF, pJ);
                     bFound = bFound || bLF;
                     rclF.SetFlag(MeshFacet::MARKED);
-                    aclTestedFacet.push_back(f_beg+*pJ);
+                    aclTestedFacet.push_back(f_beg+pJ);
                 }
             }
             ulVisited += rclISet.size();
@@ -193,17 +192,17 @@ unsigned long MeshSearchNeighbours::NeighboursFromSampledFacets (FacetIndex ulFa
     }
 
     // reset marked facets
-    for (std::vector<MeshFacetArray::_TConstIterator>::iterator pF = aclTestedFacet.begin(); pF != aclTestedFacet.end(); ++pF)
-        (*pF)->ResetFlag(MeshFacet::MARKED);
+    for (auto & pF : aclTestedFacet)
+        pF->ResetFlag(MeshFacet::MARKED);
 
     // copy points in result container
     raclResultPoints.resize(_aclPointsResult.size());
     std::copy(_aclPointsResult.begin(), _aclPointsResult.end(), raclResultPoints.begin());
 
     // facet points
-    for (std::set<PointIndex>::iterator pI = _aclResult.begin(); pI != _aclResult.end(); ++pI) {
-        if (InnerPoint(_rclPAry[*pI]))
-            raclResultPoints.push_back(_rclPAry[*pI]);
+    for (PointIndex pI : _aclResult) {
+        if (InnerPoint(_rclPAry[pI]))
+            raclResultPoints.push_back(_rclPAry[pI]);
     }
 
     return ulVisited;
@@ -213,8 +212,7 @@ bool MeshSearchNeighbours::AccumulateNeighbours (const MeshFacet &rclF, FacetInd
 {
     int  k = 0;
 
-    for (int i = 0; i < 3; i++) {
-        PointIndex ulPIdx = rclF._aulPoints[i];
+    for (PointIndex ulPIdx : rclF._aulPoints) {
         _aclOuter.insert(ulPIdx);
         _aclResult.insert(ulPIdx);
 
@@ -231,12 +229,12 @@ bool MeshSearchNeighbours::AccumulateNeighbours (const MeshFacet &rclF, FacetInd
         bFound = TriangleCutsSphere(rclF);
 
         if (bFound) {
-            std::vector<Base::Vector3f> &rclT = _aclSampledFacets[ulFIdx];
+            const std::vector<Base::Vector3f> &rclT = _aclSampledFacets[ulFIdx];
             std::vector<Base::Vector3f> clTmp;
             clTmp.reserve(rclT.size());
-            for (std::vector<Base::Vector3f>::iterator pI = rclT.begin(); pI != rclT.end(); ++pI) {
-                if (InnerPoint(*pI))
-                    clTmp.push_back(*pI);
+            for (const auto & pI : rclT) {
+                if (InnerPoint(pI))
+                    clTmp.push_back(pI);
             }
             _aclPointsResult.insert(_aclPointsResult.end(), clTmp.begin(), clTmp.end());
         }
@@ -249,8 +247,8 @@ bool MeshSearchNeighbours::ExpandRadius (unsigned long ulMinPoints)
 {
     // add facets from current level
     _aclResult.insert(_aclOuter.begin(), _aclOuter.end());
-    for (std::set<PointIndex>::iterator pI = _aclOuter.begin(); pI != _aclOuter.end(); ++pI)
-        _rclPAry[*pI].SetFlag(MeshPoint::MARKED);
+    for (PointIndex pI : _aclOuter)
+        _rclPAry[pI].SetFlag(MeshPoint::MARKED);
 
     if (_aclResult.size() < ulMinPoints) {
         _fMaxDistanceP2 *= float(ulMinPoints) / float(_aclResult.size());
@@ -287,15 +285,15 @@ unsigned long MeshSearchNeighbours::NeighboursFacetFromFacet (FacetIndex ulFacet
 
         std::set<PointIndex> aclTmp;
         aclTmp.swap(_aclOuter);
-        for (std::set<PointIndex>::iterator pI = aclTmp.begin(); pI != aclTmp.end(); ++pI) {
-            const std::set<FacetIndex> &rclISet = _clPt2Fa[*pI];
+        for (PointIndex pI : aclTmp) {
+            const std::set<FacetIndex> &rclISet = _clPt2Fa[pI];
             // search all facets hanging on this point
-            for (std::set<PointIndex>::const_iterator pJ = rclISet.begin(); pJ != rclISet.end(); ++pJ) {
-                const MeshFacet &rclF = f_beg[*pJ];
+            for (FacetIndex pJ : rclISet) {
+                const MeshFacet &rclF = f_beg[pJ];
 
-                for (int i = 0; i < 3; i++) {
-                    if (Base::DistanceP2(_clCenter, _rclPAry[rclF._aulPoints[i]]) < _fMaxDistanceP2) {
-                        aulFacetSet.insert(*pJ);
+                for (PointIndex ptIndex : rclF._aulPoints) {
+                    if (Base::DistanceP2(_clCenter, _rclPAry[ptIndex]) < _fMaxDistanceP2) {
+                        aulFacetSet.insert(pJ);
                         break;
                     }
                 }
@@ -305,7 +303,7 @@ unsigned long MeshSearchNeighbours::NeighboursFacetFromFacet (FacetIndex ulFacet
 
                     bFound = bFound || bLF;
                     rclF.SetFlag(MeshFacet::MARKED);
-                    aclTestedFacet.push_back(f_beg+*pJ);
+                    aclTestedFacet.push_back(f_beg+pJ);
                 }
             }
             ulVisited += rclISet.size();
@@ -313,10 +311,10 @@ unsigned long MeshSearchNeighbours::NeighboursFacetFromFacet (FacetIndex ulFacet
     }
 
     // reset marked facets, points
-    for (std::vector<MeshFacetArray::_TConstIterator>::iterator pF = aclTestedFacet.begin(); pF != aclTestedFacet.end(); ++pF)
-        (*pF)->ResetFlag(MeshFacet::MARKED);
-    for (std::set<PointIndex>::iterator pR = _aclResult.begin(); pR != _aclResult.end(); ++pR)
-        _rclPAry[*pR].ResetFlag(MeshPoint::MARKED);
+    for (auto & pF : aclTestedFacet)
+        pF->ResetFlag(MeshFacet::MARKED);
+    for (PointIndex pR : _aclResult)
+        _rclPAry[pR].ResetFlag(MeshPoint::MARKED);
 
     // copy points in result container
     raclResultPoints.resize(_aclResult.size());

--- a/src/Mod/Mesh/App/Core/Tools.h
+++ b/src/Mod/Mesh/App/Core/Tools.h
@@ -97,9 +97,8 @@ inline bool MeshSearchNeighbours::CheckDistToFacet (const MeshFacet &rclF)
 {
   bool bFound = false;
 
-  for (int i = 0; i < 3; i++)
+  for (PointIndex ulPIdx : rclF._aulPoints)
   {
-    PointIndex ulPIdx = rclF._aulPoints[i];
     if (!_rclPAry[ulPIdx].IsFlag(MeshPoint::MARKED))
     {
       if (Base::DistanceP2(_clCenter, _rclPAry[ulPIdx]) < _fMaxDistanceP2)

--- a/src/Mod/Mesh/App/Core/Triangulation.cpp
+++ b/src/Mod/Mesh/App/Core/Triangulation.cpp
@@ -130,16 +130,16 @@ std::vector<Base::Vector3f> AbstractPolygonTriangulator::AddedPoints() const
     // Apply the inverse transformation to project back to world coordinates
     std::vector<Base::Vector3f> added;
     added.reserve(_newpoints.size());
-    for (std::vector<Base::Vector3f>::const_iterator pt = _newpoints.begin(); pt != _newpoints.end(); ++pt)
-        added.push_back(_inverse * *pt);
+    for (auto point : _newpoints)
+        added.push_back(_inverse * point);
     return added;
 }
 
 Base::Matrix4D AbstractPolygonTriangulator::GetTransformToFitPlane() const
 {
     PlaneFit planeFit;
-    for (std::vector<Base::Vector3f>::const_iterator it = _points.begin(); it!=_points.end(); ++it)
-        planeFit.AddPoint(*it);
+    for (auto point : _points)
+        planeFit.AddPoint(point);
 
     if (planeFit.Fit() >= FLOAT_MAX)
         throw Base::RuntimeError("Plane fit failed");
@@ -183,8 +183,8 @@ std::vector<Base::Vector3f> AbstractPolygonTriangulator::ProjectToFitPlane()
     Base::Vector3f ey(static_cast<float>(_inverse[0][1]),
                       static_cast<float>(_inverse[1][1]),
                       static_cast<float>(_inverse[2][1]));
-    for (std::vector<Base::Vector3f>::iterator jt = proj.begin(); jt!=proj.end(); ++jt)
-        jt->TransformToCoordinateSystem(bs, ex, ey);
+    for (auto & jt : proj)
+        jt.TransformToCoordinateSystem(bs, ex, ey);
     return proj;
 }
 
@@ -205,15 +205,14 @@ void AbstractPolygonTriangulator::PostProcessing(const std::vector<Base::Vector3
                       static_cast<float>(_inverse[1][1]),
                       static_cast<float>(_inverse[2][1]));
 
-    for (std::vector<Base::Vector3f>::const_iterator it = points.begin(); it != points.end(); ++it) {
-        Base::Vector3f pt = *it;
+    for (auto pt : points) {
         pt.TransformToCoordinateSystem(bs, ex, ey);
         polyFit.AddPoint(pt);
     }
 
     if (polyFit.CountPoints() >= uMinPts && polyFit.Fit() < FLOAT_MAX) {
-        for (std::vector<Base::Vector3f>::iterator pt = _newpoints.begin(); pt != _newpoints.end(); ++pt)
-            pt->z = static_cast<float>(polyFit.Value(pt->x, pt->y));
+        for (auto & newpoint : _newpoints)
+            newpoint.z = static_cast<float>(polyFit.Value(newpoint.x, newpoint.y));
     }
 }
 
@@ -653,8 +652,8 @@ bool DelaunayTriangulator::Triangulate()
 
     std::vector<Wm4::Vector2d> akVertex;
     akVertex.reserve(_points.size());
-    for (std::vector<Base::Vector3f>::iterator it = _points.begin(); it != _points.end(); ++it) {
-        akVertex.emplace_back(static_cast<double>(it->x), static_cast<double>(it->y));
+    for (const auto & point : _points) {
+        akVertex.emplace_back(static_cast<double>(point.x), static_cast<double>(point.y));
     }
 
     Wm4::Delaunay2d del(static_cast<int>(akVertex.size()), &(akVertex[0]), 0.001, false, Wm4::Query::QT_INT64);

--- a/src/Mod/Mesh/App/Core/Trim.cpp
+++ b/src/Mod/Mesh/App/Core/Trim.cpp
@@ -111,8 +111,8 @@ bool MeshTrimming::HasIntersection(const MeshGeomFacet& rclFacet) const
     Base::Line2d clFacLine, clPolyLine;
     Base::Vector2d S;
     // is corner of facet inside the polygon
-    for (size_t i=0; i<3; i++) {
-        Base::Vector3f clPt2d = myProj->operator ()(rclFacet._aclPoints[i]);
+    for (auto pnt : rclFacet._aclPoints) {
+        Base::Vector3f clPt2d = myProj->operator ()(pnt);
         if (myPoly.Contains(Base::Vector2d(clPt2d.x, clPt2d.y)) == myInner)
             return true;
         else
@@ -146,8 +146,8 @@ bool MeshTrimming::HasIntersection(const MeshGeomFacet& rclFacet) const
 bool MeshTrimming::PolygonContainsCompleteFacet(bool bInner, FacetIndex ulIndex) const
 {
     const MeshFacet &rclFacet = myMesh._aclFacetArray[ulIndex];
-    for (int i=0; i<3; i++) {
-        const MeshPoint &rclFacPt = myMesh._aclPointArray[rclFacet._aulPoints[i]];
+    for (PointIndex ptIndex : rclFacet._aulPoints) {
+        const MeshPoint &rclFacPt = myMesh._aclPointArray[ptIndex];
         Base::Vector3f clPt = (*myProj)(rclFacPt);
         if (myPoly.Contains(Base::Vector2d(clPt.x, clPt.y)) != bInner)
             return false;
@@ -163,8 +163,8 @@ bool MeshTrimming::IsPolygonPointInFacet(FacetIndex ulIndex, Base::Vector3f& clP
     Base::Polygon2d clFacPoly;
     const MeshGeomFacet &rclFacet = myMesh.GetFacet(ulIndex);
 
-    for (int i=0; i<3; i++) {
-        Base::Vector3f clPt = (*myProj)(rclFacet._aclPoints[i]);
+    for (auto pnt : rclFacet._aclPoints) {
+        Base::Vector3f clPt = (*myProj)(pnt);
         clFacPoly.Add(Base::Vector2d(clPt.x, clPt.y));
     }
 
@@ -352,8 +352,8 @@ bool MeshTrimming::CreateFacets(FacetIndex ulFacetPos, int iSide, const std::vec
         int iCtPtsOn=0;
         Base::Vector3f clFacPnt;
         Base::Vector2d clProjPnt;
-        for (int i=0; i<3; i++) {
-            clFacPnt = (*myProj)(myMesh._aclPointArray[facet._aulPoints[i]]);
+        for (PointIndex ptIndex : facet._aulPoints) {
+            clFacPnt = (*myProj)(myMesh._aclPointArray[ptIndex]);
             clProjPnt = Base::Vector2d(clFacPnt.x, clFacPnt.y);
             if (myPoly.Intersect(clProjPnt, double(MESH_MIN_PT_DIST)))
                 ++iCtPtsOn;
@@ -418,8 +418,8 @@ bool MeshTrimming::CreateFacets(FacetIndex ulFacetPos, int iSide, const std::vec
         int iCtPts=0;
         Base::Vector3f clFacPnt;
         Base::Vector2d clProjPnt;
-        for (int i=0; i<3; i++) {
-            clFacPnt = (*myProj)(myMesh._aclPointArray[facet._aulPoints[i]]);
+        for (PointIndex ptIndex : facet._aulPoints) {
+            clFacPnt = (*myProj)(myMesh._aclPointArray[ptIndex]);
             clProjPnt = Base::Vector2d(clFacPnt.x, clFacPnt.y);
             if (myPoly.Contains(clProjPnt) == myInner)
                 ++iCtPts;
@@ -461,8 +461,8 @@ bool MeshTrimming::CreateFacets(FacetIndex ulFacetPos, int iSide, const std::vec
         int iCtPts=0;
         Base::Vector3f clFacPnt;
         Base::Vector2d clProjPnt;
-        for (int i=0; i<3; i++) {
-            clFacPnt = (*myProj)(myMesh._aclPointArray[facet._aulPoints[i]]);
+        for (PointIndex ptIndex : facet._aulPoints) {
+            clFacPnt = (*myProj)(myMesh._aclPointArray[ptIndex]);
             clProjPnt = Base::Vector2d(clFacPnt.x, clFacPnt.y);
             if (myPoly.Contains(clProjPnt) == myInner)
                 ++iCtPts;
@@ -638,8 +638,8 @@ bool MeshTrimming::CreateFacets(FacetIndex ulFacetPos, int iSide, const std::vec
     int iCtPts=0;
     Base::Vector3f clFacPnt;
     Base::Vector2d clProjPnt;
-    for (int i=0; i<3; i++) {
-        clFacPnt = (*myProj)(myMesh._aclPointArray[facet._aulPoints[i]]);
+    for (PointIndex ptIndex : facet._aulPoints) {
+        clFacPnt = (*myProj)(myMesh._aclPointArray[ptIndex]);
         clProjPnt = Base::Vector2d(clFacPnt.x, clFacPnt.y);
         if (myPoly.Contains(clProjPnt) == myInner)
             ++iCtPts;
@@ -725,21 +725,21 @@ void MeshTrimming::TrimFacets(const std::vector<FacetIndex>& raulFacets, std::ve
     int iSide;
 
     Base::SequencerLauncher seq("trimming facets...", raulFacets.size());
-    for (std::vector<FacetIndex>::const_iterator it=raulFacets.begin(); it!=raulFacets.end(); ++it) {
+    for (FacetIndex index : raulFacets) {
         clIntsct.clear();
-        if (!IsPolygonPointInFacet(*it, clP)) {
+        if (!IsPolygonPointInFacet(index, clP)) {
             // facet must be trimmed
-            if (!PolygonContainsCompleteFacet(myInner, *it)) {
+            if (!PolygonContainsCompleteFacet(myInner, index)) {
                 // generate new facets
-                if (GetIntersectionPointsOfPolygonAndFacet(*it, iSide, clIntsct))
-                    CreateFacets(*it, iSide, clIntsct, myTriangles);
+                if (GetIntersectionPointsOfPolygonAndFacet(index, iSide, clIntsct))
+                    CreateFacets(index, iSide, clIntsct, myTriangles);
             }
         }
         // facet contains a polygon point
         else {
             // generate new facets
-            if (GetIntersectionPointsOfPolygonAndFacet(*it, iSide, clIntsct))
-                CreateFacets(*it, iSide, clIntsct, clP, myTriangles);
+            if (GetIntersectionPointsOfPolygonAndFacet(index, iSide, clIntsct))
+                CreateFacets(index, iSide, clIntsct, clP, myTriangles);
         }
         seq.next();
     }

--- a/src/Mod/Mesh/App/Core/TrimByPlane.cpp
+++ b/src/Mod/Mesh/App/Core/TrimByPlane.cpp
@@ -66,14 +66,14 @@ void MeshTrimByPlane::CheckFacets(const MeshFacetGrid& rclGrid, const Base::Vect
     checkElements.erase(std::unique(checkElements.begin(), checkElements.end()), checkElements.end());
 
     trimFacets.reserve(checkElements.size()/2); // reserve some memory
-    for (auto it = checkElements.begin(); it != checkElements.end(); ++it) {
-        MeshGeomFacet clFacet = myMesh.GetFacet(*it);
+    for (FacetIndex element : checkElements) {
+        MeshGeomFacet clFacet = myMesh.GetFacet(element);
         if (clFacet.IntersectWithPlane(base, normal)) {
-            trimFacets.push_back(*it);
-            removeFacets.push_back(*it);
+            trimFacets.push_back(element);
+            removeFacets.push_back(element);
         }
         else if (clFacet._aclPoints[0].DistanceToPlane(base, normal) > 0.0f) {
-            removeFacets.push_back(*it);
+            removeFacets.push_back(element);
         }
     }
 
@@ -141,8 +141,8 @@ void MeshTrimByPlane::TrimFacets(const std::vector<FacetIndex>& trimFacets, cons
                                  const Base::Vector3f& normal, std::vector<MeshGeomFacet>& trimmedFacets)
 {
     trimmedFacets.reserve(2 * trimFacets.size());
-    for (auto it = trimFacets.begin(); it != trimFacets.end(); ++it) {
-        MeshGeomFacet facet = myMesh.GetFacet(*it);
+    for (FacetIndex index : trimFacets) {
+        MeshGeomFacet facet = myMesh.GetFacet(index);
         float dist1 = facet._aclPoints[0].DistanceToPlane(base, normal);
         float dist2 = facet._aclPoints[1].DistanceToPlane(base, normal);
         float dist3 = facet._aclPoints[2].DistanceToPlane(base, normal);

--- a/src/Mod/Mesh/App/Core/Visitor.cpp
+++ b/src/Mod/Mesh/App/Core/Visitor.cpp
@@ -100,14 +100,14 @@ unsigned long MeshKernel::VisitNeighbourFacetsOverCorners (MeshFacetVisitor &rcl
             for (int i = 0; i < 3; i++) {
                 const MeshFacet &rclFacet = raclFAry[*pCurrFacet];
                 const std::set<FacetIndex>& raclNB = clRPF[rclFacet._aulPoints[i]];
-                for (std::set<FacetIndex>::const_iterator pINb = raclNB.begin(); pINb != raclNB.end(); ++pINb) {
-                    if (!pFBegin[*pINb].IsFlag(MeshFacet::VISIT)) {
+                for (FacetIndex pINb : raclNB) {
+                    if (!pFBegin[pINb].IsFlag(MeshFacet::VISIT)) {
                         // only visit if VISIT Flag not set
                         ulVisited++;
-                        FacetIndex ulFInd = *pINb;
+                        FacetIndex ulFInd = pINb;
                         aclNextLevel.push_back(ulFInd);
-                        pFBegin[*pINb].SetFlag(MeshFacet::VISIT);
-                        if (!rclFVisitor.Visit(pFBegin[*pINb], raclFAry[*pCurrFacet], ulFInd, ulLevel))
+                        pFBegin[pINb].SetFlag(MeshFacet::VISIT);
+                        if (!rclFVisitor.Visit(pFBegin[pINb], raclFAry[*pCurrFacet], ulFInd, ulLevel))
                             return ulVisited;
                     }
                 }
@@ -136,14 +136,14 @@ unsigned long MeshKernel::VisitNeighbourPoints (MeshPointVisitor &rclPVisitor, P
         // visit all neighbours of the current level
         for (clCurrIter = aclCurrentLevel.begin(); clCurrIter < aclCurrentLevel.end(); ++clCurrIter) {
             const std::set<PointIndex>& raclNB = clNPs[*clCurrIter];
-            for (std::set<PointIndex>::const_iterator pINb = raclNB.begin(); pINb != raclNB.end(); ++pINb) {
-                if (!pPBegin[*pINb].IsFlag(MeshPoint::VISIT)) {
+            for (PointIndex pINb : raclNB) {
+                if (!pPBegin[pINb].IsFlag(MeshPoint::VISIT)) {
                     // only visit if VISIT Flag not set
                     ulVisited++;
-                    PointIndex ulPInd = *pINb;
+                    PointIndex ulPInd = pINb;
                     aclNextLevel.push_back(ulPInd);
-                    pPBegin[*pINb].SetFlag(MeshPoint::VISIT);
-                    if (!rclPVisitor.Visit(pPBegin[*pINb], *(pPBegin + (*clCurrIter)), ulPInd, ulLevel))
+                    pPBegin[pINb].SetFlag(MeshPoint::VISIT);
+                    if (!rclPVisitor.Visit(pPBegin[pINb], *(pPBegin + (*clCurrIter)), ulPInd, ulLevel))
                         return ulVisited;
                 }
             }
@@ -200,8 +200,8 @@ bool MeshPlaneVisitor::AllowVisit (const MeshFacet& face, const MeshFacet&,
     if (!fitter->Done())
         fitter->Fit();
     MeshGeomFacet triangle = mesh.GetFacet(face);
-    for (int i=0; i<3; i++) {
-        if (fabs(fitter->GetDistanceToPlane(triangle._aclPoints[i])) > max_deviation)
+    for (const auto& pnt : triangle._aclPoints) {
+        if (fabs(fitter->GetDistanceToPlane(pnt)) > max_deviation)
             return false;
     }
     return true;

--- a/src/Mod/Mesh/App/Core/Visitor.h
+++ b/src/Mod/Mesh/App/Core/Visitor.h
@@ -105,8 +105,8 @@ inline bool MeshSearchNeighbourFacetsVisitor::Visit (const MeshFacet &rclFacet, 
         _bFacetsFoundInCurrentLevel = false;
     }
 
-    for (int i = 0; i < 3; i++) {
-        if (Base::Distance(_clCenter, _rclMeshBase.GetPoint(rclFacet._aulPoints[i])) < _fRadius) {
+    for (PointIndex ptIndex : rclFacet._aulPoints) {
+        if (Base::Distance(_clCenter, _rclMeshBase.GetPoint(ptIndex)) < _fRadius) {
             _vecFacets.push_back(ulFInd);
             _bFacetsFoundInCurrentLevel = true;
             return true;

--- a/src/Mod/Mesh/App/EdgePyImp.cpp
+++ b/src/Mod/Mesh/App/EdgePyImp.cpp
@@ -143,11 +143,11 @@ Py::List EdgePy::getPoints() const
     EdgePy::PointerType edge = this->getEdgePtr();
 
     Py::List pts;
-    for (int i=0; i<2; i++) {
+    for (const auto & pnt : edge->_aclPoints) {
         Py::Tuple pt(3);
-        pt.setItem(0, Py::Float(edge->_aclPoints[i].x));
-        pt.setItem(1, Py::Float(edge->_aclPoints[i].y));
-        pt.setItem(2, Py::Float(edge->_aclPoints[i].z));
+        pt.setItem(0, Py::Float(pnt.x));
+        pt.setItem(1, Py::Float(pnt.y));
+        pt.setItem(2, Py::Float(pnt.z));
         pts.append(pt);
     }
 

--- a/src/Mod/Mesh/App/Exporter.cpp
+++ b/src/Mod/Mesh/App/Exporter.cpp
@@ -428,13 +428,13 @@ bool ExporterAMF::addMesh(const char *name, const MeshObject & mesh)
         facet = &(*clIter);
 
         // For each vertex in facet
-        for (auto i(0); i < 3; ++i) {
-            vertItr = vertices.find(facet->_aclPoints[i]);
+        for (auto pnt : facet->_aclPoints) {
+            vertItr = vertices.find(pnt);
 
             if ( vertItr == vertices.end() ) {
                 facets.push_back(vertexCount);
 
-                vertices[facet->_aclPoints[i]] = vertexCount++;
+                vertices[pnt] = vertexCount++;
 
                 // Output facet
                 *outputStreamPtr << "\t\t\t\t<vertex>\n"
@@ -442,7 +442,7 @@ bool ExporterAMF::addMesh(const char *name, const MeshObject & mesh)
                 for ( auto j(0); j < 3; ++j) {
                     char axis('x' + j);
                     *outputStreamPtr << "\t\t\t\t\t\t<" << axis << '>'
-                                     << facet->_aclPoints[i][j]
+                                     << pnt[j]
                                      << "</" << axis << ">\n";
                 }
                 *outputStreamPtr << "\t\t\t\t\t</coordinates>\n"

--- a/src/Mod/Mesh/App/FeatureMeshCurvature.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshCurvature.cpp
@@ -63,12 +63,12 @@ App::DocumentObjectExecReturn *Curvature::execute()
 
     std::vector<CurvatureInfo> values;
     values.reserve(curv.size());
-    for (std::vector<MeshCore::CurvatureInfo>::const_iterator it = curv.begin(); it != curv.end(); ++it) {
+    for (const auto & it : curv) {
         CurvatureInfo ci;
-        ci.cMaxCurvDir = it->cMaxCurvDir;
-        ci.cMinCurvDir = it->cMinCurvDir;
-        ci.fMaxCurvature = it->fMaxCurvature;
-        ci.fMinCurvature = it->fMinCurvature;
+        ci.cMaxCurvDir = it.cMaxCurvDir;
+        ci.cMinCurvDir = it.cMinCurvDir;
+        ci.fMaxCurvature = it.fMaxCurvature;
+        ci.fMinCurvature = it.fMinCurvature;
         values.push_back(ci);
     }
 

--- a/src/Mod/Mesh/App/FeatureMeshSegmentByMesh.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshSegmentByMesh.cpp
@@ -117,12 +117,12 @@ App::DocumentObjectExecReturn *SegmentByMesh::execute()
         MeshFacetIterator cFIt(rMeshKernel);
 
         // get the nearest facet to the user (front clipping plane)
-        for ( std::vector<MeshCore::FacetIndex>::iterator it = faces.begin(); it != faces.end(); ++it ) {
-            cFIt.Set(*it);
+        for (MeshCore::FacetIndex it : faces) {
+            cFIt.Set(it);
             float dist = (float)fabs(cFIt->GetGravityPoint().DistanceToPlane( cBase, cNormal ));
             if ( dist < fDist ) {
                 fDist = dist;
-                uIdx = *it;
+                uIdx = it;
             }
         }
 
@@ -141,8 +141,8 @@ App::DocumentObjectExecReturn *SegmentByMesh::execute()
         }
     }
 
-    for ( std::vector<MeshCore::FacetIndex>::iterator it = faces.begin(); it != faces.end(); ++it )
-        aFaces.push_back( rMeshKernel.GetFacet(*it) );
+    for (MeshCore::FacetIndex it : faces)
+        aFaces.push_back( rMeshKernel.GetFacet(it) );
 
     std::unique_ptr<MeshObject> pcKernel(new MeshObject);
     pcKernel->addFacets(aFaces);

--- a/src/Mod/Mesh/App/Mesh.cpp
+++ b/src/Mod/Mesh/App/Mesh.cpp
@@ -374,11 +374,11 @@ void MeshObject::save(const char* file, MeshCore::MeshIO::Format f,
     // go through the segment list and put them to the exporter when
     // the "save" flag is set
     std::vector<MeshCore::Group> groups;
-    for (std::size_t index = 0; index < this->_segments.size(); index++) {
-        if (this->_segments[index].isSaved()) {
+    for (const auto & segment : this->_segments) {
+        if (segment.isSaved()) {
             MeshCore::Group g;
-            g.indices = this->_segments[index].getIndices();
-            g.name = this->_segments[index].getName();
+            g.indices = segment.getIndices();
+            g.name = segment.getName();
             groups.push_back(g);
         }
     }
@@ -403,11 +403,11 @@ void MeshObject::save(std::ostream& str, MeshCore::MeshIO::Format f,
     // go through the segment list and put them to the exporter when
     // the "save" flag is set
     std::vector<MeshCore::Group> groups;
-    for (std::size_t index = 0; index < this->_segments.size(); index++) {
-        if (this->_segments[index].isSaved()) {
+    for (const auto & segment : this->_segments) {
+        if (segment.isSaved()) {
             MeshCore::Group g;
-            g.indices = this->_segments[index].getIndices();
-            g.name = this->_segments[index].getName();
+            g.indices = segment.getIndices();
+            g.name = segment.getName();
             groups.push_back(g);
         }
     }
@@ -566,18 +566,18 @@ void MeshObject::addFacets(const std::vector<Data::ComplexGeoData::Facet> &facet
 {
     std::vector<MeshCore::MeshFacet> facet_v;
     facet_v.reserve(facets.size());
-    for (std::vector<Data::ComplexGeoData::Facet>::const_iterator it = facets.begin(); it != facets.end(); ++it) {
+    for (auto facet : facets) {
         MeshCore::MeshFacet f;
-        f._aulPoints[0] = it->I1;
-        f._aulPoints[1] = it->I2;
-        f._aulPoints[2] = it->I3;
+        f._aulPoints[0] = facet.I1;
+        f._aulPoints[1] = facet.I2;
+        f._aulPoints[2] = facet.I3;
         facet_v.push_back(f);
     }
 
     std::vector<Base::Vector3f> point_v;
     point_v.reserve(points.size());
-    for (std::vector<Base::Vector3d>::const_iterator it = points.begin(); it != points.end(); ++it) {
-        Base::Vector3f p((float)it->x,(float)it->y,(float)it->z);
+    for (const auto & point : points) {
+        Base::Vector3f p((float)point.x,(float)point.y,(float)point.z);
         point_v.push_back(p);
     }
 
@@ -594,18 +594,18 @@ void MeshObject::setFacets(const std::vector<Data::ComplexGeoData::Facet> &facet
 {
     MeshCore::MeshFacetArray facet_v;
     facet_v.reserve(facets.size());
-    for (std::vector<Data::ComplexGeoData::Facet>::const_iterator it = facets.begin(); it != facets.end(); ++it) {
+    for (auto facet : facets) {
         MeshCore::MeshFacet f;
-        f._aulPoints[0] = it->I1;
-        f._aulPoints[1] = it->I2;
-        f._aulPoints[2] = it->I3;
+        f._aulPoints[0] = facet.I1;
+        f._aulPoints[1] = facet.I2;
+        f._aulPoints[2] = facet.I3;
         facet_v.push_back(f);
     }
 
     MeshCore::MeshPointArray point_v;
     point_v.reserve(points.size());
-    for (std::vector<Base::Vector3d>::const_iterator it = points.begin(); it != points.end(); ++it) {
-        Base::Vector3f p((float)it->x,(float)it->y,(float)it->z);
+    for (const auto & point : points) {
+        Base::Vector3f p((float)point.x,(float)point.y,(float)point.z);
         point_v.push_back(p);
     }
 
@@ -646,36 +646,32 @@ void MeshObject::deletedFacets(const std::vector<FacetIndex>& remFacets)
         return; // nothing to do
     // set an array with the original indices and mark the removed as MeshCore::FACET_INDEX_MAX
     std::vector<FacetIndex> f_indices(_kernel.CountFacets()+remFacets.size());
-    for (std::vector<FacetIndex>::const_iterator it = remFacets.begin();
-        it != remFacets.end(); ++it) {
-        f_indices[*it] = MeshCore::FACET_INDEX_MAX;
+    for (FacetIndex remFacet : remFacets) {
+        f_indices[remFacet] = MeshCore::FACET_INDEX_MAX;
     }
 
     FacetIndex index = 0;
-    for (std::vector<FacetIndex>::iterator it = f_indices.begin();
-        it != f_indices.end(); ++it) {
-            if (*it == 0)
-                *it = index++;
+    for (FacetIndex& it : f_indices) {
+        if (it == 0)
+            it = index++;
     }
 
     // the array serves now as LUT to set the new indices in the segments
-    for (std::vector<Segment>::iterator it = this->_segments.begin();
-        it != this->_segments.end(); ++it) {
-            std::vector<FacetIndex> segm = it->_indices;
-            for (std::vector<FacetIndex>::iterator jt = segm.begin();
-                jt != segm.end(); ++jt) {
-                    *jt = f_indices[*jt];
-            }
+    for (auto & segment : this->_segments) {
+        std::vector<FacetIndex> segm = segment._indices;
+        for (FacetIndex & jt : segm) {
+            jt = f_indices[jt];
+        }
 
-            // remove the invalid indices
-            std::sort(segm.begin(), segm.end());
-            std::vector<FacetIndex>::iterator ft = std::find_if
-                (segm.begin(), segm.end(), [](FacetIndex v) {
-                    return v == MeshCore::FACET_INDEX_MAX;
-                });
-            if (ft != segm.end())
-                segm.erase(ft, segm.end());
-            it->_indices = segm;
+        // remove the invalid indices
+        std::sort(segm.begin(), segm.end());
+        std::vector<FacetIndex>::iterator ft = std::find_if
+            (segm.begin(), segm.end(), [](FacetIndex v) {
+                return v == MeshCore::FACET_INDEX_MAX;
+            });
+        if (ft != segm.end())
+            segm.erase(ft, segm.end());
+        segment._indices = segm;
     }
 }
 
@@ -830,11 +826,10 @@ void MeshObject::updateMesh() const
     MeshCore::MeshAlgorithm alg(_kernel);
     alg.ResetFacetFlag(MeshCore::MeshFacet::SEGMENT);
     alg.ResetPointFlag(MeshCore::MeshPoint::SEGMENT);
-    for (std::vector<Segment>::const_iterator it = this->_segments.begin();
-        it != this->_segments.end(); ++it) {
+    for (const auto & segment : this->_segments) {
             std::vector<PointIndex> points;
-            points = _kernel.GetFacetPoints(it->getIndices());
-            alg.SetFacetsFlag(it->getIndices(), MeshCore::MeshFacet::SEGMENT);
+            points = _kernel.GetFacetPoints(segment.getIndices());
+            alg.SetFacetsFlag(segment.getIndices(), MeshCore::MeshFacet::SEGMENT);
             alg.SetPointsFlag(points, MeshCore::MeshPoint::SEGMENT);
     }
 }
@@ -869,14 +864,14 @@ unsigned long MeshObject::getPointDegree(const std::vector<FacetIndex>& indices,
     const MeshCore::MeshFacetArray& faces = _kernel.GetFacets();
     std::vector<PointIndex> pointDeg(_kernel.CountPoints());
 
-    for (MeshCore::MeshFacetArray::_TConstIterator it = faces.begin(); it != faces.end(); ++it) {
-        pointDeg[it->_aulPoints[0]]++;
-        pointDeg[it->_aulPoints[1]]++;
-        pointDeg[it->_aulPoints[2]]++;
+    for (const auto & face : faces) {
+        pointDeg[face._aulPoints[0]]++;
+        pointDeg[face._aulPoints[1]]++;
+        pointDeg[face._aulPoints[2]]++;
     }
 
-    for (std::vector<PointIndex>::const_iterator it = indices.begin(); it != indices.end(); ++it) {
-        const MeshCore::MeshFacet& face = faces[*it];
+    for (FacetIndex it : indices) {
+        const MeshCore::MeshFacet& face = faces[it];
         pointDeg[face._aulPoints[0]]--;
         pointDeg[face._aulPoints[1]]--;
         pointDeg[face._aulPoints[2]]--;
@@ -955,8 +950,8 @@ void MeshObject::offsetSpecial2(float fSize)
         if (fliped.empty())
             break;
 
-        for( std::set<FacetIndex>::iterator It= fliped.begin();It!=fliped.end();++It)
-            alg.CollapseFacet(*It);
+        for(FacetIndex It : fliped)
+            alg.CollapseFacet(It);
         fliped.clear();
     }
 
@@ -1071,9 +1066,9 @@ void MeshObject::crossSections(const std::vector<MeshObject::TPlane>& planes, st
 
     MeshCore::MeshFacetGrid grid(kernel);
     MeshCore::MeshAlgorithm algo(kernel);
-    for (std::vector<MeshObject::TPlane>::const_iterator it = planes.begin(); it != planes.end(); ++it) {
+    for (const auto & plane : planes) {
         MeshObject::TPolylines polylines;
-        algo.CutWithPlane(it->first, it->second, grid, polylines, fMinEps, bConnectPolygons);
+        algo.CutWithPlane(plane.first, plane.second, grid, polylines, fMinEps, bConnectPolygons);
         sections.push_back(polylines);
     }
 }
@@ -1339,10 +1334,10 @@ void MeshObject::splitEdges()
 
     MeshCore::MeshFacetIterator cIter(_kernel);
     MeshCore::MeshTopoAlgorithm topalg(_kernel);
-    for (std::vector<std::pair<FacetIndex, FacetIndex> >::iterator it = adjacentFacet.begin(); it != adjacentFacet.end(); ++it) {
-        cIter.Set(it->first);
+    for (const auto & it : adjacentFacet) {
+        cIter.Set(it.first);
         Base::Vector3f mid = 0.5f*(cIter->_aclPoints[0]+cIter->_aclPoints[2]);
-        topalg.SplitEdge(it->first, it->second, mid);
+        topalg.SplitEdge(it.first, it.second, mid);
     }
 
     // clear the segments because we don't know how the new
@@ -1392,8 +1387,8 @@ void MeshObject::collapseFacet(FacetIndex facet)
 void MeshObject::collapseFacets(const std::vector<FacetIndex>& facets)
 {
     MeshCore::MeshTopoAlgorithm alg(_kernel);
-    for (std::vector<FacetIndex>::const_iterator it = facets.begin(); it != facets.end(); ++it) {
-        alg.CollapseFacet(*it);
+    for (FacetIndex it : facets) {
+        alg.CollapseFacet(it);
     }
 
     deletedFacets(facets);
@@ -1932,8 +1927,8 @@ void MeshObject::addSegment(const Segment& s)
 void MeshObject::addSegment(const std::vector<FacetIndex>& inds)
 {
     unsigned long maxIndex = _kernel.CountFacets();
-    for (std::vector<FacetIndex>::const_iterator it = inds.begin(); it != inds.end(); ++it) {
-        if (*it >= maxIndex)
+    for (FacetIndex it : inds) {
+        if (it >= maxIndex)
             throw Base::IndexError("Index out of range");
     }
 
@@ -1956,8 +1951,8 @@ MeshObject* MeshObject::meshFromSegment(const std::vector<FacetIndex>& indices) 
     facets.reserve(indices.size());
     const MeshCore::MeshPointArray& kernel_p = _kernel.GetPoints();
     const MeshCore::MeshFacetArray& kernel_f = _kernel.GetFacets();
-    for (std::vector<FacetIndex>::const_iterator it = indices.begin(); it != indices.end(); ++it) {
-        facets.push_back(kernel_f[*it]);
+    for (FacetIndex it : indices) {
+        facets.push_back(kernel_f[it]);
     }
 
     MeshCore::MeshKernel kernel;
@@ -1998,8 +1993,8 @@ std::vector<Segment> MeshObject::getSegmentsOfType(MeshObject::GeometryType type
         finder.FindSegments(surfaces);
 
         const std::vector<MeshCore::MeshSegment>& data = surf->GetSegments();
-        for (std::vector<MeshCore::MeshSegment>::const_iterator it = data.begin(); it != data.end(); ++it) {
-            segm.emplace_back(this, *it, false);
+        for (const auto & it : data) {
+            segm.emplace_back(this, it, false);
         }
     }
 

--- a/src/Mod/Mesh/App/MeshProperties.cpp
+++ b/src/Mod/Mesh/App/MeshProperties.cpp
@@ -154,8 +154,8 @@ void PropertyNormalList::SaveDocFile (Base::Writer &writer) const
     Base::OutputStream str(writer.Stream());
     uint32_t uCt = (uint32_t)getSize();
     str << uCt;
-    for (std::vector<Base::Vector3f>::const_iterator it = _lValueList.begin(); it != _lValueList.end(); ++it) {
-        str << it->x << it->y << it->z;
+    for (auto it : _lValueList) {
+        str << it.x << it.y << it.z;
     }
 }
 
@@ -165,8 +165,8 @@ void PropertyNormalList::RestoreDocFile(Base::Reader &reader)
     uint32_t uCt=0;
     str >> uCt;
     std::vector<Base::Vector3f> values(uCt);
-    for (std::vector<Base::Vector3f>::iterator it = values.begin(); it != values.end(); ++it) {
-        str >> it->x >> it->y >> it->z;
+    for (auto & it : values) {
+        str >> it.x >> it.y >> it.z;
     }
     setValues(values);
 }
@@ -257,40 +257,40 @@ std::vector<float> PropertyCurvatureList::getCurvature( int mode ) const
 
     // Mean curvature
     if (mode == MeanCurvature) {
-        for ( std::vector<Mesh::CurvatureInfo>::const_iterator it=fCurvInfo.begin();it!=fCurvInfo.end(); ++it )
+        for (const auto & it : fCurvInfo)
         {
-            fValues.push_back( 0.5f*(it->fMaxCurvature+it->fMinCurvature) );
+            fValues.push_back( 0.5f*(it.fMaxCurvature+it.fMinCurvature) );
         }
     }
     // Gaussian curvature
     else if (mode == GaussCurvature) {
-        for ( std::vector<Mesh::CurvatureInfo>::const_iterator it=fCurvInfo.begin();it!=fCurvInfo.end(); ++it )
+        for (const auto & it : fCurvInfo)
         {
-            fValues.push_back( it->fMaxCurvature * it->fMinCurvature );
+            fValues.push_back( it.fMaxCurvature * it.fMinCurvature );
         }
     }
     // Maximum curvature
     else if (mode == MaxCurvature) {
-        for ( std::vector<Mesh::CurvatureInfo>::const_iterator it=fCurvInfo.begin();it!=fCurvInfo.end(); ++it )
+        for (const auto & it : fCurvInfo)
         {
-          fValues.push_back( it->fMaxCurvature );
+          fValues.push_back( it.fMaxCurvature );
         }
     }
     // Minimum curvature
     else if (mode == MinCurvature) {
-        for ( std::vector<Mesh::CurvatureInfo>::const_iterator it=fCurvInfo.begin();it!=fCurvInfo.end(); ++it )
+        for (const auto & it : fCurvInfo)
         {
-          fValues.push_back( it->fMinCurvature );
+          fValues.push_back( it.fMinCurvature );
         }
     }
     // Absolute curvature
     else if (mode == AbsCurvature) {
-        for ( std::vector<Mesh::CurvatureInfo>::const_iterator it=fCurvInfo.begin();it!=fCurvInfo.end(); ++it )
+        for (const auto & it : fCurvInfo)
         {
-            if ( fabs(it->fMaxCurvature) > fabs(it->fMinCurvature) )
-                fValues.push_back( it->fMaxCurvature );
+            if ( fabs(it.fMaxCurvature) > fabs(it.fMinCurvature) )
+                fValues.push_back( it.fMaxCurvature );
             else
-                fValues.push_back( it->fMinCurvature );
+                fValues.push_back( it.fMinCurvature );
         }
     }
 
@@ -357,10 +357,10 @@ void PropertyCurvatureList::SaveDocFile (Base::Writer &writer) const
     Base::OutputStream str(writer.Stream());
     uint32_t uCt = (uint32_t)getSize();
     str << uCt;
-    for (std::vector<CurvatureInfo>::const_iterator it = _lValueList.begin(); it != _lValueList.end(); ++it) {
-        str << it->fMaxCurvature << it->fMinCurvature;
-        str << it->cMaxCurvDir.x << it->cMaxCurvDir.y << it->cMaxCurvDir.z;
-        str << it->cMinCurvDir.x << it->cMinCurvDir.y << it->cMinCurvDir.z;
+    for (const auto & it : _lValueList) {
+        str << it.fMaxCurvature << it.fMinCurvature;
+        str << it.cMaxCurvDir.x << it.cMaxCurvDir.y << it.cMaxCurvDir.z;
+        str << it.cMinCurvDir.x << it.cMinCurvDir.y << it.cMinCurvDir.z;
     }
 }
 
@@ -370,10 +370,10 @@ void PropertyCurvatureList::RestoreDocFile(Base::Reader &reader)
     uint32_t uCt=0;
     str >> uCt;
     std::vector<CurvatureInfo> values(uCt);
-    for (std::vector<CurvatureInfo>::iterator it = values.begin(); it != values.end(); ++it) {
-        str >> it->fMaxCurvature >> it->fMinCurvature;
-        str >> it->cMaxCurvDir.x >> it->cMaxCurvDir.y >> it->cMaxCurvDir.z;
-        str >> it->cMinCurvDir.x >> it->cMinCurvDir.y >> it->cMinCurvDir.z;
+    for (auto & it : values) {
+        str >> it.fMaxCurvature >> it.fMinCurvature;
+        str >> it.cMaxCurvDir.x >> it.cMaxCurvDir.y >> it.cMaxCurvDir.z;
+        str >> it.cMinCurvDir.x >> it.cMinCurvDir.y >> it.cMinCurvDir.z;
     }
 
     setValues(values);
@@ -382,19 +382,19 @@ void PropertyCurvatureList::RestoreDocFile(Base::Reader &reader)
 PyObject* PropertyCurvatureList::getPyObject()
 {
     Py::List list;
-    for (std::vector<CurvatureInfo>::const_iterator it = _lValueList.begin(); it != _lValueList.end(); ++it) {
+    for (const auto & it : _lValueList) {
         Py::Tuple tuple(4);
-        tuple.setItem(0, Py::Float(it->fMaxCurvature));
-        tuple.setItem(1, Py::Float(it->fMinCurvature));
+        tuple.setItem(0, Py::Float(it.fMaxCurvature));
+        tuple.setItem(1, Py::Float(it.fMinCurvature));
         Py::Tuple maxDir(3);
-        maxDir.setItem(0, Py::Float(it->cMaxCurvDir.x));
-        maxDir.setItem(1, Py::Float(it->cMaxCurvDir.y));
-        maxDir.setItem(2, Py::Float(it->cMaxCurvDir.z));
+        maxDir.setItem(0, Py::Float(it.cMaxCurvDir.x));
+        maxDir.setItem(1, Py::Float(it.cMaxCurvDir.y));
+        maxDir.setItem(2, Py::Float(it.cMaxCurvDir.z));
         tuple.setItem(2, maxDir);
         Py::Tuple minDir(3);
-        minDir.setItem(0, Py::Float(it->cMinCurvDir.x));
-        minDir.setItem(1, Py::Float(it->cMinCurvDir.y));
-        minDir.setItem(2, Py::Float(it->cMinCurvDir.z));
+        minDir.setItem(0, Py::Float(it.cMinCurvDir.x));
+        minDir.setItem(1, Py::Float(it.cMinCurvDir.y));
+        minDir.setItem(2, Py::Float(it.cMinCurvDir.z));
         tuple.setItem(3, minDir);
         list.append(tuple);
     }
@@ -847,8 +847,8 @@ void PropertyMeshKernel::setPointIndices(const std::vector<std::pair<PointIndex,
 {
     aboutToSetValue();
     MeshCore::MeshKernel& kernel = _meshObject->getKernel();
-    for (std::vector<std::pair<PointIndex, Base::Vector3f> >::const_iterator it = inds.begin(); it != inds.end(); ++it)
-        kernel.SetPoint(it->first, it->second);
+    for (const auto & it : inds)
+        kernel.SetPoint(it.first, it.second);
     hasSetValue();
 }
 

--- a/src/Mod/Mesh/App/MeshPyImp.cpp
+++ b/src/Mod/Mesh/App/MeshPyImp.cpp
@@ -382,12 +382,12 @@ PyObject*  MeshPy::crossSections(PyObject *args)
 
     // convert to Python objects
     Py::List crossSections;
-    for (std::vector<MeshObject::TPolylines>::iterator it = sections.begin(); it != sections.end(); ++it) {
+    for (const auto & it : sections) {
         Py::List section;
-        for (MeshObject::TPolylines::const_iterator jt = it->begin(); jt != it->end(); ++jt) {
+        for (const auto & jt : it) {
             Py::List polyline;
-            for (std::vector<Base::Vector3f>::const_iterator kt = jt->begin(); kt != jt->end(); ++kt) {
-                polyline.append(Py::asObject(new Base::VectorPy(*kt)));
+            for (auto kt : jt) {
+                polyline.append(Py::asObject(new Base::VectorPy(kt)));
             }
             section.append(polyline);
         }
@@ -669,10 +669,10 @@ PyObject*  MeshPy::addFacets(PyObject *args)
                 else {
                     // 9 consecutive floats expected
                     int index=0;
-                    for (int i=0; i<3; i++) {
-                        facet._aclPoints[i].x = (float)(double)Py::Float(seq[index++]);
-                        facet._aclPoints[i].y = (float)(double)Py::Float(seq[index++]);
-                        facet._aclPoints[i].z = (float)(double)Py::Float(seq[index++]);
+                    for (auto & point : facet._aclPoints) {
+                        point.x = (float)(double)Py::Float(seq[index++]);
+                        point.y = (float)(double)Py::Float(seq[index++]);
+                        point.z = (float)(double)Py::Float(seq[index++]);
                     }
                     facet.CalcNormal();
                     facets.push_back(facet);
@@ -749,8 +749,8 @@ PyObject* MeshPy::getInternalFacets(PyObject *args)
     const std::vector<FacetIndex>& indices = eval.GetIndices();
     Py::List ary(indices.size());
     Py::List::size_type pos=0;
-    for (std::vector<FacetIndex>::const_iterator it = indices.begin(); it != indices.end(); ++it) {
-        ary[pos++] = Py::Long(*it);
+    for (FacetIndex index : indices) {
+        ary[pos++] = Py::Long(index);
     }
 
     return Py::new_reference_to(ary);
@@ -881,8 +881,8 @@ PyObject* MeshPy::getSegment(PyObject *args)
 
     Py::List ary;
     const std::vector<FacetIndex>& segm = getMeshObjectPtr()->getSegment(index).getIndices();
-    for (std::vector<FacetIndex>::const_iterator it = segm.begin(); it != segm.end(); ++it) {
-        ary.append(Py::Long(*it));
+    for (FacetIndex it : segm) {
+        ary.append(Py::Long(it));
     }
 
     return Py::new_reference_to(ary);
@@ -896,8 +896,8 @@ PyObject* MeshPy::getSeparateComponents(PyObject *args)
     Py::List meshesList;
     std::vector<std::vector<FacetIndex> > segs;
     segs = getMeshObjectPtr()->getComponents();
-    for (unsigned int i=0; i<segs.size(); i++) {
-        MeshObject* mesh = getMeshObjectPtr()->meshFromSegment(segs[i]);
+    for (const auto & it : segs) {
+        MeshObject* mesh = getMeshObjectPtr()->meshFromSegment(it);
         meshesList.append(Py::Object(new MeshPy(mesh),true));
     }
     return Py::new_reference_to(meshesList);
@@ -911,8 +911,8 @@ PyObject* MeshPy::getFacetSelection(PyObject *args)
     Py::List ary;
     std::vector<FacetIndex> facets;
     getMeshObjectPtr()->getFacetsFromSelection(facets);
-    for (std::vector<FacetIndex>::const_iterator it = facets.begin(); it != facets.end(); ++it) {
-        ary.append(Py::Long((int)*it));
+    for (FacetIndex facet : facets) {
+        ary.append(Py::Long(int(facet)));
     }
 
     return Py::new_reference_to(ary);
@@ -926,8 +926,8 @@ PyObject* MeshPy::getPointSelection(PyObject *args)
     Py::List ary;
     std::vector<PointIndex> points;
     getMeshObjectPtr()->getPointsFromSelection(points);
-    for (std::vector<PointIndex>::const_iterator it = points.begin(); it != points.end(); ++it) {
-        ary.append(Py::Long((int)*it));
+    for (PointIndex point : points) {
+        ary.append(Py::Long(int(point)));
     }
 
     return Py::new_reference_to(ary);
@@ -1688,8 +1688,8 @@ PyObject*  MeshPy::cut(PyObject *args)
 
     Base::ViewProjMatrix proj(mat);
     Base::Polygon2d polygon2d;
-    for (std::vector<Base::Vector3f>::const_iterator it = polygon.begin(); it != polygon.end(); ++it)
-        polygon2d.Add(Base::Vector2d(it->x, it->y));
+    for (auto it : polygon)
+        polygon2d.Add(Base::Vector2d(it.x, it.y));
     getMeshObjectPtr()->cut(polygon2d, proj, MeshObject::CutType(mode));
 
     Py_Return;
@@ -1722,8 +1722,8 @@ PyObject*  MeshPy::trim(PyObject *args)
 
     Base::ViewOrthoProjMatrix proj(mat);
     Base::Polygon2d polygon2d;
-    for (std::vector<Base::Vector3f>::const_iterator it = polygon.begin(); it != polygon.end(); ++it)
-        polygon2d.Add(Base::Vector2d(it->x, it->y));
+    for (auto it : polygon)
+        polygon2d.Add(Base::Vector2d(it.x, it.y));
     getMeshObjectPtr()->trim(polygon2d, proj, MeshObject::CutType(mode));
 
     Py_Return;
@@ -1861,11 +1861,11 @@ PyObject*  MeshPy::getPlanarSegments(PyObject *args)
         (Mesh::MeshObject::PLANE, dev, minFacets);
 
     Py::List s;
-    for (std::vector<Mesh::Segment>::iterator it = segments.begin(); it != segments.end(); ++it) {
-        const std::vector<FacetIndex>& segm = it->getIndices();
+    for (const auto & segment : segments) {
+        const std::vector<FacetIndex>& segm = segment.getIndices();
         Py::List ary;
-        for (std::vector<FacetIndex>::const_iterator jt = segm.begin(); jt != segm.end(); ++jt) {
-            ary.append(Py::Long(*jt));
+        for (FacetIndex jt : segm) {
+            ary.append(Py::Long(jt));
         }
         s.append(ary);
     }
@@ -1901,11 +1901,11 @@ PyObject*  MeshPy::getSegmentsOfType(PyObject *args)
         (geoType, dev, minFacets);
 
     Py::List s;
-    for (std::vector<Mesh::Segment>::iterator it = segments.begin(); it != segments.end(); ++it) {
-        const std::vector<FacetIndex>& segm = it->getIndices();
+    for (const auto & segment : segments) {
+        const std::vector<FacetIndex>& segm = segment.getIndices();
         Py::List ary;
-        for (std::vector<FacetIndex>::const_iterator jt = segm.begin(); jt != segm.end(); ++jt) {
-            ary.append(Py::Long((int)*jt));
+        for (FacetIndex jt : segm) {
+            ary.append(Py::Long(int(jt)));
         }
         s.append(ary);
     }
@@ -1939,12 +1939,12 @@ PyObject*  MeshPy::getSegmentsByCurvature(PyObject *args)
     finder.FindSegments(segm);
 
     Py::List list;
-    for (std::vector<MeshCore::MeshSurfaceSegmentPtr>::iterator segmIt = segm.begin(); segmIt != segm.end(); ++segmIt) {
-        const std::vector<MeshCore::MeshSegment>& data = (*segmIt)->GetSegments();
-        for (std::vector<MeshCore::MeshSegment>::const_iterator it = data.begin(); it != data.end(); ++it) {
+    for (const auto & segmIt : segm) {
+        const std::vector<MeshCore::MeshSegment>& data = segmIt->GetSegments();
+        for (const auto & it : data) {
             Py::List ary;
-            for (MeshCore::MeshSegment::const_iterator jt = it->begin(); jt != it->end(); ++jt) {
-                ary.append(Py::Long((int)*jt));
+            for (FacetIndex jt : it) {
+                ary.append(Py::Long(int(jt)));
             }
             list.append(ary);
         }
@@ -2047,17 +2047,15 @@ Py::Tuple MeshPy::getTopology() const
     getMeshObjectPtr()->getFaces(Points, Facets, 0.0);
     Py::Tuple tuple(2);
     Py::List vertex;
-    for (std::vector<Base::Vector3d>::const_iterator it = Points.begin();
-        it != Points.end(); ++it)
-        vertex.append(Py::asObject(new Base::VectorPy(*it)));
+    for (const auto & Point : Points)
+        vertex.append(Py::asObject(new Base::VectorPy(Point)));
     tuple.setItem(0, vertex);
     Py::List facet;
-    for (std::vector<Data::ComplexGeoData::Facet>::const_iterator
-        it = Facets.begin(); it != Facets.end(); ++it) {
+    for (auto it : Facets) {
         Py::Tuple f(3);
-        f.setItem(0,Py::Long((int)it->I1));
-        f.setItem(1,Py::Long((int)it->I2));
-        f.setItem(2,Py::Long((int)it->I3));
+        f.setItem(0,Py::Long((int)it.I1));
+        f.setItem(1,Py::Long((int)it.I2));
+        f.setItem(2,Py::Long((int)it.I3));
         facet.append(f);
     }
     tuple.setItem(1, facet);

--- a/src/Mod/Mesh/Gui/DlgDecimating.cpp
+++ b/src/Mod/Mesh/Gui/DlgDecimating.cpp
@@ -159,8 +159,7 @@ bool TaskDecimating::accept()
     if (absolute) {
         targetSize = widget->targetNumberOfTriangles();
     }
-    for (std::vector<Mesh::Feature*>::const_iterator it = meshes.begin(); it != meshes.end(); ++it) {
-        Mesh::Feature* mesh = *it;
+    for (auto mesh : meshes) {
         Mesh::MeshObject* mm = mesh->Mesh.startEditing();
         if (absolute) {
             mm->decimate(targetSize);

--- a/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
@@ -156,10 +156,10 @@ DlgEvaluateMeshImp::DlgEvaluateMeshImp(QWidget* parent, Qt::WindowFlags fl)
 DlgEvaluateMeshImp::~DlgEvaluateMeshImp()
 {
     // no need to delete child widgets, Qt does it all for us
-    for (std::map<std::string, ViewProviderMeshDefects*>::iterator it = d->vp.begin(); it != d->vp.end(); ++it) {
+    for (const auto& it : d->vp) {
         if (d->view)
-            d->view->getViewer()->removeViewProvider(it->second);
-        delete it->second;
+            d->view->getViewer()->removeViewProvider(it.second);
+        delete it.second;
     }
 
     try {
@@ -314,8 +314,8 @@ void DlgEvaluateMeshImp::slotDeletedDocument(const App::Document& Doc)
 {
     if (&Doc == getDocument()) {
         // the view is already destroyed
-        for (std::map<std::string, ViewProviderMeshDefects*>::iterator it = d->vp.begin(); it != d->vp.end(); ++it) {
-            delete it->second;
+        for (const auto& it : d->vp) {
+            delete it.second;
         }
 
         d->vp.clear();
@@ -373,10 +373,10 @@ void DlgEvaluateMeshImp::removeViewProvider(const char* name)
 
 void DlgEvaluateMeshImp::removeViewProviders()
 {
-    for (std::map<std::string, ViewProviderMeshDefects*>::iterator it = d->vp.begin(); it != d->vp.end(); ++it) {
+    for (const auto& it : d->vp) {
         if (d->view)
-            d->view->getViewer()->removeViewProvider(it->second);
-        delete it->second;
+            d->view->getViewer()->removeViewProvider(it.second);
+        delete it.second;
     }
     d->vp.clear();
 }
@@ -387,9 +387,9 @@ void DlgEvaluateMeshImp::onMeshNameButtonActivated(int i)
 
     d->meshFeature = nullptr;
     std::vector<App::DocumentObject*> objs = getDocument()->getObjectsOfType(Mesh::Feature::getClassTypeId());
-    for (std::vector<App::DocumentObject*>::iterator it = objs.begin(); it != objs.end(); ++it) {
-        if (item == QLatin1String((*it)->getNameInDocument())) {
-            d->meshFeature = (Mesh::Feature*)(*it);
+    for (auto obj : objs) {
+        if (item == QLatin1String(obj->getNameInDocument())) {
+            d->meshFeature = static_cast<Mesh::Feature*>(obj);
             break;
         }
     }
@@ -407,16 +407,16 @@ void DlgEvaluateMeshImp::refreshList()
     QVector<QPair<QString, QString> > items;
     if (this->getDocument()) {
         std::vector<App::DocumentObject*> objs = this->getDocument()->getObjectsOfType(Mesh::Feature::getClassTypeId());
-        for (std::vector<App::DocumentObject*>::iterator it = objs.begin(); it != objs.end(); ++it) {
-            items.push_back(qMakePair(QString::fromUtf8((*it)->Label.getValue()),
-                                      QString::fromLatin1((*it)->getNameInDocument())));
+        for (auto obj : objs) {
+            items.push_back(qMakePair(QString::fromUtf8(obj->Label.getValue()),
+                                      QString::fromLatin1(obj->getNameInDocument())));
         }
     }
 
     d->ui.meshNameButton->clear();
     d->ui.meshNameButton->addItem(tr("No selection"));
-    for (QVector<QPair<QString, QString> >::iterator it = items.begin(); it != items.end(); ++it)
-        d->ui.meshNameButton->addItem(it->first, it->second);
+    for (const auto & item : items)
+        d->ui.meshNameButton->addItem(item.first, item.second);
     d->ui.meshNameButton->setDisabled(items.empty());
     cleanInformation();
 }
@@ -433,10 +433,12 @@ void DlgEvaluateMeshImp::showInformation()
     d->ui.analyzeFoldsButton->setEnabled(true);
     d->ui.analyzeAllTogether->setEnabled(true);
 
-    const MeshKernel& rMesh = d->meshFeature->Mesh.getValue().getKernel();
-    d->ui.textLabel4->setText(QString::fromLatin1("%1").arg(rMesh.CountFacets()));
-    d->ui.textLabel5->setText(QString::fromLatin1("%1").arg(rMesh.CountEdges()));
-    d->ui.textLabel6->setText(QString::fromLatin1("%1").arg(rMesh.CountPoints()));
+    if (d->meshFeature) {
+        const MeshKernel& rMesh = d->meshFeature->Mesh.getValue().getKernel();
+        d->ui.textLabel4->setText(QString::fromLatin1("%1").arg(rMesh.CountFacets()));
+        d->ui.textLabel5->setText(QString::fromLatin1("%1").arg(rMesh.CountEdges()));
+        d->ui.textLabel6->setText(QString::fromLatin1("%1").arg(rMesh.CountPoints()));
+    }
 }
 
 void DlgEvaluateMeshImp::cleanInformation()

--- a/src/Mod/Mesh/Gui/DlgSmoothing.cpp
+++ b/src/Mod/Mesh/Gui/DlgSmoothing.cpp
@@ -183,8 +183,8 @@ bool TaskSmoothing::accept()
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Mesh Smoothing"));
 
     bool hasSelection = false;
-    for (std::vector<App::DocumentObject*>::const_iterator it = meshes.begin(); it != meshes.end(); ++it) {
-        Mesh::Feature* mesh = static_cast<Mesh::Feature*>(*it);
+    for (auto it : meshes) {
+        Mesh::Feature* mesh = static_cast<Mesh::Feature*>(it);
         std::vector<Mesh::FacetIndex> selection;
         if (widget->smoothSelection()) {
             // clear the selection before editing the mesh to avoid

--- a/src/Mod/Mesh/Gui/PropertyEditorMesh.cpp
+++ b/src/Mod/Mesh/Gui/PropertyEditorMesh.cpp
@@ -64,8 +64,8 @@ QVariant PropertyMeshKernelItem::value(const App::Property*) const
     int ctF = 0;
 
     const std::vector<App::Property*>& props = getPropertyData();
-    for (std::vector<App::Property*>::const_iterator pt = props.begin(); pt != props.end(); ++pt) {
-        Mesh::PropertyMeshKernel* pPropMesh = (Mesh::PropertyMeshKernel*)(*pt);
+    for (auto prop : props) {
+        Mesh::PropertyMeshKernel* pPropMesh = (Mesh::PropertyMeshKernel*)prop;
         const MeshKernel& rMesh = pPropMesh->getValue().getKernel();
         ctP += (int)rMesh.CountPoints();
         ctE += (int)rMesh.CountEdges();
@@ -110,8 +110,8 @@ int PropertyMeshKernelItem::countPoints() const
 {
     int ctP = 0;
     const std::vector<App::Property*>& props = getPropertyData();
-    for (std::vector<App::Property*>::const_iterator pt = props.begin(); pt != props.end(); ++pt) {
-        Mesh::PropertyMeshKernel* pPropMesh = (Mesh::PropertyMeshKernel*)(*pt);
+    for (auto prop : props) {
+        Mesh::PropertyMeshKernel* pPropMesh = (Mesh::PropertyMeshKernel*)prop;
         const MeshKernel& rMesh = pPropMesh->getValue().getKernel();
         ctP += (int)rMesh.CountPoints();
     }
@@ -123,8 +123,8 @@ int PropertyMeshKernelItem::countEdges() const
 {
     int ctE = 0;
     const std::vector<App::Property*>& props = getPropertyData();
-    for (std::vector<App::Property*>::const_iterator pt = props.begin(); pt != props.end(); ++pt) {
-        Mesh::PropertyMeshKernel* pPropMesh = (Mesh::PropertyMeshKernel*)(*pt);
+    for (auto prop : props) {
+        Mesh::PropertyMeshKernel* pPropMesh = (Mesh::PropertyMeshKernel*)prop;
         const MeshKernel& rMesh = pPropMesh->getValue().getKernel();
         ctE += (int)rMesh.CountEdges();
     }
@@ -136,8 +136,8 @@ int PropertyMeshKernelItem::countFaces() const
 {
     int ctF = 0;
     const std::vector<App::Property*>& props = getPropertyData();
-    for (std::vector<App::Property*>::const_iterator pt = props.begin(); pt != props.end(); ++pt) {
-        Mesh::PropertyMeshKernel* pPropMesh = (Mesh::PropertyMeshKernel*)(*pt);
+    for (auto prop : props) {
+        Mesh::PropertyMeshKernel* pPropMesh = (Mesh::PropertyMeshKernel*)prop;
         const MeshKernel& rMesh = pPropMesh->getValue().getKernel();
         ctF += (int)rMesh.CountFacets();
     }

--- a/src/Mod/Mesh/Gui/Segmentation.cpp
+++ b/src/Mod/Mesh/Gui/Segmentation.cpp
@@ -112,10 +112,10 @@ void Segmentation::accept()
     std::string labelname = "Segments ";
     labelname += myMesh->Label.getValue();
     group->Label.setValue(labelname);
-    for (std::vector<MeshCore::MeshSurfaceSegmentPtr>::iterator it = segm.begin(); it != segm.end(); ++it) {
-        const std::vector<MeshCore::MeshSegment>& data = (*it)->GetSegments();
-        for (std::vector<MeshCore::MeshSegment>::const_iterator jt = data.begin(); jt != data.end(); ++jt) {
-            Mesh::MeshObject* segment = mesh->meshFromSegment(*jt);
+    for (const auto & it : segm) {
+        const std::vector<MeshCore::MeshSegment>& data = it->GetSegments();
+        for (const auto & jt : data) {
+            Mesh::MeshObject* segment = mesh->meshFromSegment(jt);
             Mesh::Feature* feaSegm = static_cast<Mesh::Feature*>(group->addObject("Mesh::Feature", "Segment"));
             Mesh::MeshObject* feaMesh = feaSegm->Mesh.startEditing();
             feaMesh->swap(*segment);
@@ -123,7 +123,7 @@ void Segmentation::accept()
             delete segment;
 
             std::stringstream label;
-            label << feaSegm->Label.getValue() << " (" << (*it)->GetType() << ")";
+            label << feaSegm->Label.getValue() << " (" << it->GetType() << ")";
             feaSegm->Label.setValue(label.str());
         }
     }

--- a/src/Mod/Mesh/Gui/SegmentationBestFit.cpp
+++ b/src/Mod/Mesh/Gui/SegmentationBestFit.cpp
@@ -485,10 +485,10 @@ void SegmentationBestFit::accept()
     std::string labelname = "Segments ";
     labelname += myMesh->Label.getValue();
     group->Label.setValue(labelname);
-    for (std::vector<MeshCore::MeshSurfaceSegmentPtr>::iterator it = segm.begin(); it != segm.end(); ++it) {
-        const std::vector<MeshCore::MeshSegment>& data = (*it)->GetSegments();
-        for (std::vector<MeshCore::MeshSegment>::const_iterator jt = data.begin(); jt != data.end(); ++jt) {
-            Mesh::MeshObject* segment = mesh->meshFromSegment(*jt);
+    for (const auto & it : segm) {
+        const std::vector<MeshCore::MeshSegment>& data = it->GetSegments();
+        for (const auto & jt : data) {
+            Mesh::MeshObject* segment = mesh->meshFromSegment(jt);
             Mesh::Feature* feaSegm = static_cast<Mesh::Feature*>(group->addObject("Mesh::Feature", "Segment"));
             Mesh::MeshObject* feaMesh = feaSegm->Mesh.startEditing();
             feaMesh->swap(*segment);
@@ -496,7 +496,7 @@ void SegmentationBestFit::accept()
             delete segment;
 
             std::stringstream label;
-            label << feaSegm->Label.getValue() << " (" << (*it)->GetType() << ")";
+            label << feaSegm->Label.getValue() << " (" << it->GetType() << ")";
             feaSegm->Label.setValue(label.str());
         }
     }

--- a/src/Mod/Mesh/Gui/SoFCMeshObject.cpp
+++ b/src/Mod/Mesh/Gui/SoFCMeshObject.cpp
@@ -261,11 +261,10 @@ void SoSFMeshObject::writeValue(SoOutput *out) const
     const MeshCore::MeshPointArray& rPoints = value->getKernel().GetPoints();
     std::vector<float> verts;
     verts.reserve(3*rPoints.size());
-    for (MeshCore::MeshPointArray::_TConstIterator it = rPoints.begin();
-        it != rPoints.end(); ++it) {
-        verts.push_back(it->x);
-        verts.push_back(it->y);
-        verts.push_back(it->z);
+    for (const auto & rPoint : rPoints) {
+        verts.push_back(rPoint.x);
+        verts.push_back(rPoint.y);
+        verts.push_back(rPoint.z);
     }
 
     int32_t countPt = (int32_t)verts.size();
@@ -275,11 +274,10 @@ void SoSFMeshObject::writeValue(SoOutput *out) const
     const MeshCore::MeshFacetArray& rFacets = value->getKernel().GetFacets();
     std::vector<uint32_t> faces;
     faces.reserve(3*rFacets.size());
-    for (MeshCore::MeshFacetArray::_TConstIterator it = rFacets.begin();
-        it != rFacets.end(); ++it) {
-        faces.push_back((int32_t)it->_aulPoints[0]);
-        faces.push_back((int32_t)it->_aulPoints[1]);
-        faces.push_back((int32_t)it->_aulPoints[2]);
+    for (const auto & rFacet : rFacets) {
+        faces.push_back((int32_t)rFacet._aulPoints[0]);
+        faces.push_back((int32_t)rFacet._aulPoints[1]);
+        faces.push_back((int32_t)rFacet._aulPoints[2]);
     }
 
     int32_t countFt = (int32_t)faces.size();
@@ -749,11 +747,11 @@ void SoFCMeshObjectShape::drawFaces(const Mesh::MeshObject * mesh, SoMaterialBun
         }
         else {
             // clockwise ordering
-            for (MeshCore::MeshFacetArray::_TConstIterator it = rFacets.begin(); it != rFacets.end(); ++it)
+            for (const auto & rFacet : rFacets)
             {
-                const MeshCore::MeshPoint& v0 = rPoints[it->_aulPoints[0]];
-                const MeshCore::MeshPoint& v1 = rPoints[it->_aulPoints[1]];
-                const MeshCore::MeshPoint& v2 = rPoints[it->_aulPoints[2]];
+                const MeshCore::MeshPoint& v0 = rPoints[rFacet._aulPoints[0]];
+                const MeshCore::MeshPoint& v1 = rPoints[rFacet._aulPoints[1]];
+                const MeshCore::MeshPoint& v2 = rPoints[rFacet._aulPoints[2]];
 
                 // Calculate the normal n = -(v1-v0)x(v2-v0)
                 float n[3];
@@ -771,11 +769,11 @@ void SoFCMeshObjectShape::drawFaces(const Mesh::MeshObject * mesh, SoMaterialBun
     }
     else {
         glBegin(GL_TRIANGLES);
-        for (MeshCore::MeshFacetArray::_TConstIterator it = rFacets.begin(); it != rFacets.end(); ++it)
+        for (const auto & rFacet : rFacets)
         {
-            glVertex(rPoints[it->_aulPoints[0]]);
-            glVertex(rPoints[it->_aulPoints[1]]);
-            glVertex(rPoints[it->_aulPoints[2]]);
+            glVertex(rPoints[rFacet._aulPoints[0]]);
+            glVertex(rPoints[rFacet._aulPoints[1]]);
+            glVertex(rPoints[rFacet._aulPoints[2]]);
         }
         glEnd();
     }
@@ -887,13 +885,13 @@ void SoFCMeshObjectShape::generateGLArrays(SoState * state)
     face_indices.resize(3 * cF.size());
 
     int indexed = 0;
-    for (MeshCore::MeshFacetArray::const_iterator it = cF.begin(); it != cF.end(); ++it) {
-        Base::Vector3f n = kernel.GetFacet(*it).GetNormal();
-        for (int i=0; i<3; i++) {
+    for (const auto & it : cF) {
+        Base::Vector3f n = kernel.GetFacet(it).GetNormal();
+        for (Mesh::PointIndex ptIndex : it._aulPoints) {
             face_vertices.push_back(n.x);
             face_vertices.push_back(n.y);
             face_vertices.push_back(n.z);
-            const Base::Vector3f& v = cP[it->_aulPoints[i]];
+            const Base::Vector3f& v = cP[ptIndex];
             face_vertices.push_back(v.x);
             face_vertices.push_back(v.y);
             face_vertices.push_back(v.z);
@@ -1093,11 +1091,11 @@ void SoFCMeshObjectShape::generatePrimitives(SoAction* action)
     beginShape(action, TRIANGLES, &faceDetail);
     try
     {
-        for (MeshCore::MeshFacetArray::_TConstIterator it = rFacets.begin(); it != rFacets.end(); ++it)
+        for (const auto & rFacet : rFacets)
         {
-            const MeshCore::MeshPoint& v0 = rPoints[it->_aulPoints[0]];
-            const MeshCore::MeshPoint& v1 = rPoints[it->_aulPoints[1]];
-            const MeshCore::MeshPoint& v2 = rPoints[it->_aulPoints[2]];
+            const MeshCore::MeshPoint& v0 = rPoints[rFacet._aulPoints[0]];
+            const MeshCore::MeshPoint& v1 = rPoints[rFacet._aulPoints[1]];
+            const MeshCore::MeshPoint& v2 = rPoints[rFacet._aulPoints[2]];
 
             // Calculate the normal n = (v1-v0)x(v2-v0)
             SbVec3f n;
@@ -1110,28 +1108,28 @@ void SoFCMeshObjectShape::generatePrimitives(SoAction* action)
 
             // Vertex 0
             if (mbind == PER_VERTEX_INDEXED || mbind == PER_FACE_INDEXED) {
-                pointDetail.setMaterialIndex(it->_aulPoints[0]);
-                vertex.setMaterialIndex(it->_aulPoints[0]);
+                pointDetail.setMaterialIndex(rFacet._aulPoints[0]);
+                vertex.setMaterialIndex(rFacet._aulPoints[0]);
             }
-            pointDetail.setCoordinateIndex(it->_aulPoints[0]);
+            pointDetail.setCoordinateIndex(rFacet._aulPoints[0]);
             vertex.setPoint(sbvec3f(v0));
             shapeVertex(&vertex);
 
             // Vertex 1
             if (mbind == PER_VERTEX_INDEXED || mbind == PER_FACE_INDEXED) {
-                pointDetail.setMaterialIndex(it->_aulPoints[1]);
-                vertex.setMaterialIndex(it->_aulPoints[1]);
+                pointDetail.setMaterialIndex(rFacet._aulPoints[1]);
+                vertex.setMaterialIndex(rFacet._aulPoints[1]);
             }
-            pointDetail.setCoordinateIndex(it->_aulPoints[1]);
+            pointDetail.setCoordinateIndex(rFacet._aulPoints[1]);
             vertex.setPoint(sbvec3f(v1));
             shapeVertex(&vertex);
 
             // Vertex 2
             if (mbind == PER_VERTEX_INDEXED || mbind == PER_FACE_INDEXED) {
-                pointDetail.setMaterialIndex(it->_aulPoints[2]);
-                vertex.setMaterialIndex(it->_aulPoints[2]);
+                pointDetail.setMaterialIndex(rFacet._aulPoints[2]);
+                vertex.setMaterialIndex(rFacet._aulPoints[2]);
             }
-            pointDetail.setCoordinateIndex(it->_aulPoints[2]);
+            pointDetail.setCoordinateIndex(rFacet._aulPoints[2]);
             vertex.setPoint(sbvec3f(v2));
             shapeVertex(&vertex);
 
@@ -1314,9 +1312,9 @@ void SoFCMeshSegmentShape::drawFaces(const Mesh::MeshObject * mesh, SoMaterialBu
         glBegin(GL_TRIANGLES);
         if (ccw) {
             // counterclockwise ordering
-            for (std::vector<Mesh::FacetIndex>::const_iterator it = rSegm.begin(); it != rSegm.end(); ++it)
+            for (Mesh::FacetIndex it : rSegm)
             {
-                const MeshCore::MeshFacet& f = rFacets[*it];
+                const MeshCore::MeshFacet& f = rFacets[it];
                 const MeshCore::MeshPoint& v0 = rPoints[f._aulPoints[0]];
                 const MeshCore::MeshPoint& v1 = rPoints[f._aulPoints[1]];
                 const MeshCore::MeshPoint& v2 = rPoints[f._aulPoints[2]];
@@ -1328,7 +1326,7 @@ void SoFCMeshSegmentShape::drawFaces(const Mesh::MeshObject * mesh, SoMaterialBu
                 n[2] = (v1.x-v0.x)*(v2.y-v0.y)-(v1.y-v0.y)*(v2.x-v0.x);
 
                 if(perFace)
-                mb->send(*it, true);
+                mb->send(it, true);
                 glNormal(n);
                 if(perVertex)
                 mb->send(f._aulPoints[0], true);
@@ -1343,9 +1341,9 @@ void SoFCMeshSegmentShape::drawFaces(const Mesh::MeshObject * mesh, SoMaterialBu
         }
         else {
             // clockwise ordering
-            for (std::vector<Mesh::FacetIndex>::const_iterator it = rSegm.begin(); it != rSegm.end(); ++it)
+            for (Mesh::FacetIndex it : rSegm)
             {
-                const MeshCore::MeshFacet& f = rFacets[*it];
+                const MeshCore::MeshFacet& f = rFacets[it];
                 const MeshCore::MeshPoint& v0 = rPoints[f._aulPoints[0]];
                 const MeshCore::MeshPoint& v1 = rPoints[f._aulPoints[1]];
                 const MeshCore::MeshPoint& v2 = rPoints[f._aulPoints[2]];
@@ -1366,9 +1364,9 @@ void SoFCMeshSegmentShape::drawFaces(const Mesh::MeshObject * mesh, SoMaterialBu
     }
     else {
         glBegin(GL_TRIANGLES);
-        for (std::vector<Mesh::FacetIndex>::const_iterator it = rSegm.begin(); it != rSegm.end(); ++it)
+        for (Mesh::FacetIndex it : rSegm)
         {
-            const MeshCore::MeshFacet& f = rFacets[*it];
+            const MeshCore::MeshFacet& f = rFacets[it];
             glVertex(rPoints[f._aulPoints[0]]);
             glVertex(rPoints[f._aulPoints[1]]);
             glVertex(rPoints[f._aulPoints[2]]);
@@ -1506,9 +1504,9 @@ void SoFCMeshSegmentShape::generatePrimitives(SoAction* action)
     beginShape(action, TRIANGLES, &faceDetail);
     try
     {
-        for (std::vector<Mesh::FacetIndex>::const_iterator it = rSegm.begin(); it != rSegm.end(); ++it)
+        for (Mesh::FacetIndex it : rSegm)
         {
-            const MeshCore::MeshFacet& f = rFacets[*it];
+            const MeshCore::MeshFacet& f = rFacets[it];
             const MeshCore::MeshPoint& v0 = rPoints[f._aulPoints[0]];
             const MeshCore::MeshPoint& v1 = rPoints[f._aulPoints[1]];
             const MeshCore::MeshPoint& v2 = rPoints[f._aulPoints[2]];
@@ -1578,12 +1576,11 @@ void SoFCMeshSegmentShape::computeBBox(SoAction *action, SbBox3f &box, SbVec3f &
             const MeshCore::MeshPointArray& rPoint = mesh->getKernel().GetPoints();
             const MeshCore::MeshFacetArray& rFaces = mesh->getKernel().GetFacets();
 
-            for (std::vector<Mesh::FacetIndex>::const_iterator it = indices.begin();
-                it != indices.end(); ++it) {
-                    const MeshCore::MeshFacet& face = rFaces[*it];
-                    cBox.Add(rPoint[face._aulPoints[0]]);
-                    cBox.Add(rPoint[face._aulPoints[1]]);
-                    cBox.Add(rPoint[face._aulPoints[2]]);
+            for (Mesh::FacetIndex index : indices) {
+                const MeshCore::MeshFacet& face = rFaces[index];
+                cBox.Add(rPoint[face._aulPoints[0]]);
+                cBox.Add(rPoint[face._aulPoints[1]]);
+                cBox.Add(rPoint[face._aulPoints[2]]);
             }
 
             box.setBounds(SbVec3f(cBox.MinX,cBox.MinY,cBox.MinZ),
@@ -1660,11 +1657,11 @@ void SoFCMeshObjectBoundary::drawLines(const Mesh::MeshObject * mesh) const
     // Use the data structure directly and not through MeshFacetIterator as this
     // class is quite slowly (at least for rendering)
     glBegin(GL_LINES);
-    for (MeshCore::MeshFacetArray::_TConstIterator it = rFacets.begin(); it != rFacets.end(); ++it) {
+    for (const auto & rFacet : rFacets) {
         for (int i=0; i<3; i++) {
-            if (it->_aulNeighbours[i] == MeshCore::FACET_INDEX_MAX) {
-                glVertex(rPoints[it->_aulPoints[i]]);
-                glVertex(rPoints[it->_aulPoints[(i+1)%3]]);
+            if (rFacet._aulNeighbours[i] == MeshCore::FACET_INDEX_MAX) {
+                glVertex(rPoints[rFacet._aulPoints[i]]);
+                glVertex(rPoints[rFacet._aulPoints[(i+1)%3]]);
             }
         }
     }
@@ -1691,20 +1688,20 @@ void SoFCMeshObjectBoundary::generatePrimitives(SoAction* action)
     vertex.setDetail(&pointDetail);
 
     beginShape(action, LINES, &lineDetail);
-    for (MeshCore::MeshFacetArray::_TConstIterator it = rFacets.begin(); it != rFacets.end(); ++it)
+    for (const auto & rFacet : rFacets)
     {
         for (int i=0; i<3; i++) {
-            if (it->_aulNeighbours[i] == MeshCore::FACET_INDEX_MAX) {
-                const MeshCore::MeshPoint& v0 = rPoints[it->_aulPoints[i]];
-                const MeshCore::MeshPoint& v1 = rPoints[it->_aulPoints[(i+1)%3]];
+            if (rFacet._aulNeighbours[i] == MeshCore::FACET_INDEX_MAX) {
+                const MeshCore::MeshPoint& v0 = rPoints[rFacet._aulPoints[i]];
+                const MeshCore::MeshPoint& v1 = rPoints[rFacet._aulPoints[(i+1)%3]];
 
                 // Vertex 0
-                pointDetail.setCoordinateIndex(it->_aulPoints[i]);
+                pointDetail.setCoordinateIndex(rFacet._aulPoints[i]);
                 vertex.setPoint(sbvec3f(v0));
                 shapeVertex(&vertex);
 
                 // Vertex 1
-                pointDetail.setCoordinateIndex(it->_aulPoints[(i+1)%3]);
+                pointDetail.setCoordinateIndex(rFacet._aulPoints[(i+1)%3]);
                 vertex.setPoint(sbvec3f(v1));
                 shapeVertex(&vertex);
 
@@ -1729,8 +1726,8 @@ void SoFCMeshObjectBoundary::computeBBox(SoAction *action, SbBox3f &box, SbVec3f
     const MeshCore::MeshPointArray & rPoints = mesh->getKernel().GetPoints();
     if (!rPoints.empty()) {
         Base::BoundBox3f cBox;
-        for (MeshCore::MeshPointArray::_TConstIterator it = rPoints.begin(); it != rPoints.end(); ++it)
-            cBox.Add(*it);
+        for (const auto & rPoint : rPoints)
+            cBox.Add(rPoint);
         box.setBounds(SbVec3f(cBox.MinX,cBox.MinY,cBox.MinZ),
                       SbVec3f(cBox.MaxX,cBox.MaxY,cBox.MaxZ));
         Base::Vector3f mid = cBox.GetCenter();
@@ -1757,9 +1754,9 @@ void SoFCMeshObjectBoundary::getPrimitiveCount(SoGetPrimitiveCountAction * actio
 
     // Count number of open edges first
     int ctEdges=0;
-    for (MeshCore::MeshFacetArray::_TConstIterator jt = rFaces.begin(); jt != rFaces.end(); ++jt) {
-        for (int i=0; i<3; i++) {
-            if (jt->_aulNeighbours[i] == MeshCore::FACET_INDEX_MAX) {
+    for (const auto & rFace : rFaces) {
+        for (Mesh::FacetIndex nbIndex : rFace._aulNeighbours) {
+            if (nbIndex == MeshCore::FACET_INDEX_MAX) {
                 ctEdges++;
             }
         }

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -503,10 +503,10 @@ App::PropertyColorList* ViewProviderMesh::getColorProperty() const
     if (pcObject) {
         std::map<std::string,App::Property*> Map;
         pcObject->getPropertyMap(Map);
-        for (std::map<std::string,App::Property*>::iterator it = Map.begin(); it != Map.end(); ++it) {
-            Base::Type type = it->second->getTypeId();
+        for (const auto & it : Map) {
+            Base::Type type = it.second->getTypeId();
             if (type == App::PropertyColorList::getClassTypeId()) {
-                App::PropertyColorList* colors = static_cast<App::PropertyColorList*>(it->second);
+                App::PropertyColorList* colors = static_cast<App::PropertyColorList*>(it.second);
                 return colors;
             }
         }
@@ -599,8 +599,8 @@ void ViewProviderMesh::setColorField(const std::vector<App::Color>& val, SoMFCol
     SbColor* col = field.startEditing();
 
     std::size_t i=0;
-    for (std::vector<App::Color>::const_iterator it = val.begin(); it != val.end(); ++it) {
-        col[i++].setValue(it->r, it->g, it->b);
+    for (auto it : val) {
+        col[i++].setValue(it.r, it.g, it.b);
     }
 
     field.finishEditing();
@@ -631,10 +631,10 @@ Mesh::PropertyMaterial* ViewProviderMesh::getMaterialProperty() const
     if (pcObject) {
         std::map<std::string,App::Property*> Map;
         pcObject->getPropertyMap(Map);
-        for (std::map<std::string,App::Property*>::iterator it = Map.begin(); it != Map.end(); ++it) {
-            Base::Type type = it->second->getTypeId();
+        for (const auto & it : Map) {
+            Base::Type type = it.second->getTypeId();
             if (type == Mesh::PropertyMaterial::getClassTypeId()) {
-                Mesh::PropertyMaterial* material = static_cast<Mesh::PropertyMaterial*>(it->second);
+                Mesh::PropertyMaterial* material = static_cast<Mesh::PropertyMaterial*>(it.second);
                 return material;
             }
         }
@@ -872,11 +872,11 @@ bool ViewProviderMesh::createToolMesh(const std::vector<SbVec2f>& rclPoly, const
     bool ok = cTria.TriangulatePolygon();
 
     std::vector<MeshFacet> faces = cTria.GetFacets();
-    for (std::vector<MeshFacet>::iterator itF = faces.begin(); itF != faces.end(); ++itF) {
+    for (const auto & face : faces) {
         MeshGeomFacet topFacet;
-        topFacet._aclPoints[0] = top[itF->_aulPoints[0]];
-        topFacet._aclPoints[1] = top[itF->_aulPoints[1]];
-        topFacet._aclPoints[2] = top[itF->_aulPoints[2]];
+        topFacet._aclPoints[0] = top[face._aulPoints[0]];
+        topFacet._aclPoints[1] = top[face._aulPoints[1]];
+        topFacet._aclPoints[2] = top[face._aulPoints[2]];
         if (topFacet.GetNormal() * rcNormal < 0) {
             std::swap(topFacet._aclPoints[1], topFacet._aclPoints[2]);
             topFacet.CalcNormal();
@@ -884,9 +884,9 @@ bool ViewProviderMesh::createToolMesh(const std::vector<SbVec2f>& rclPoly, const
         aFaces.push_back(topFacet);
 
         MeshGeomFacet botFacet;
-        botFacet._aclPoints[0] = bottom[itF->_aulPoints[0]];
-        botFacet._aclPoints[1] = bottom[itF->_aulPoints[1]];
-        botFacet._aclPoints[2] = bottom[itF->_aulPoints[2]];
+        botFacet._aclPoints[0] = bottom[face._aulPoints[0]];
+        botFacet._aclPoints[1] = bottom[face._aulPoints[1]];
+        botFacet._aclPoints[2] = bottom[face._aulPoints[2]];
         if (botFacet.GetNormal() * rcNormal > 0) {
             std::swap(botFacet._aclPoints[1], botFacet._aclPoints[2]);
             botFacet.CalcNormal();
@@ -976,8 +976,8 @@ void ViewProviderMesh::clipMeshCallback(void * ud, SoEventCallback * n)
     if (!views.empty()) {
         Gui::Application::Instance->activeDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Cut"));
         bool commitCommand = false;
-        for (std::vector<Gui::ViewProvider*>::iterator it = views.begin(); it != views.end(); ++it) {
-            ViewProviderMesh* self = static_cast<ViewProviderMesh*>(*it);
+        for (auto it : views) {
+            ViewProviderMesh* self = static_cast<ViewProviderMesh*>(it);
             if (self->getEditingMode() > -1) {
                 self->finishEditing();
                 SoCamera* cam = view->getSoRenderManager()->getCamera();
@@ -1039,8 +1039,8 @@ void ViewProviderMesh::trimMeshCallback(void * ud, SoEventCallback * n)
     if (!views.empty()) {
         Gui::Application::Instance->activeDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Trim"));
         bool commitCommand = false;
-        for (std::vector<Gui::ViewProvider*>::iterator it = views.begin(); it != views.end(); ++it) {
-            ViewProviderMesh* self = static_cast<ViewProviderMesh*>(*it);
+        for (auto it : views) {
+            ViewProviderMesh* self = static_cast<ViewProviderMesh*>(it);
             if (self->getEditingMode() > -1) {
                 self->finishEditing();
                 SoCamera* cam = view->getSoRenderManager()->getCamera();
@@ -1120,8 +1120,8 @@ void ViewProviderMesh::partMeshCallback(void * ud, SoEventCallback * cb)
 
     try {
         std::vector<Gui::ViewProvider*> views = view->getViewProvidersOfType(ViewProviderMesh::getClassTypeId());
-        for (std::vector<Gui::ViewProvider*>::iterator it = views.begin(); it != views.end(); ++it) {
-            ViewProviderMesh* that = static_cast<ViewProviderMesh*>(*it);
+        for (auto view : views) {
+            ViewProviderMesh* that = static_cast<ViewProviderMesh*>(view);
             if (that->getEditingMode() > -1) {
                 that->finishEditing();
                 Base::Placement plm = static_cast<Mesh::Feature*>(that->getObject())->Placement.getValue();
@@ -1184,8 +1184,8 @@ void ViewProviderMesh::segmMeshCallback(void * ud, SoEventCallback * cb)
 
     try {
         std::vector<Gui::ViewProvider*> views = view->getViewProvidersOfType(ViewProviderMesh::getClassTypeId());
-        for (std::vector<Gui::ViewProvider*>::iterator it = views.begin(); it != views.end(); ++it) {
-            ViewProviderMesh* that = static_cast<ViewProviderMesh*>(*it);
+        for (auto view : views) {
+            ViewProviderMesh* that = static_cast<ViewProviderMesh*>(view);
             if (that->getEditingMode() > -1) {
                 that->finishEditing();
                 Base::Placement plm = static_cast<Mesh::Feature*>(that->getObject())->Placement.getValue();
@@ -1249,8 +1249,8 @@ void ViewProviderMesh::selectGLCallback(void * ud, SoEventCallback * n)
 
     std::vector<Gui::ViewProvider*> views;
     views = view->getViewProvidersOfType(ViewProviderMesh::getClassTypeId());
-    for (std::vector<Gui::ViewProvider*>::iterator it = views.begin(); it != views.end(); ++it) {
-        ViewProviderMesh* that = static_cast<ViewProviderMesh*>(*it);
+    for (auto it : views) {
+        ViewProviderMesh* that = static_cast<ViewProviderMesh*>(it);
         if (that->getEditingMode() > -1) {
             that->finishEditing();
             that->selectArea(x, y, w, h, view->getSoRenderManager()->getViewportRegion(), view->getSoRenderManager()->getCamera());
@@ -1267,8 +1267,8 @@ void ViewProviderMesh::getFacetsFromPolygon(const std::vector<SbVec2f>& picked,
 {
     const bool ok = true;
     Base::Polygon2d polygon;
-    for (std::vector<SbVec2f>::const_iterator it = picked.begin(); it != picked.end(); ++it)
-        polygon.Add(Base::Vector2d((*it)[0],(*it)[1]));
+    for (auto it : picked)
+        polygon.Add(Base::Vector2d(it[0],it[1]));
 
     // Get the attached mesh property
     Mesh::PropertyMeshKernel& meshProp = static_cast<Mesh::Feature*>(pcObject)->Mesh;
@@ -1495,8 +1495,8 @@ void ViewProviderMesh::trimMesh(const std::vector<SbVec2f>& polygon,
     Mesh::MeshObject* mesh = static_cast<Mesh::Feature*>(pcObject)->Mesh.startEditing();
 
     Base::Polygon2d polygon2d;
-    for (std::vector<SbVec2f>::const_iterator it = polygon.begin(); it != polygon.end(); ++it)
-        polygon2d.Add(Base::Vector2d((*it)[0],(*it)[1]));
+    for (auto it : polygon)
+        polygon2d.Add(Base::Vector2d(it[0],it[1]));
 
     Mesh::MeshObject::CutType type = inner ?
         Mesh::MeshObject::INNER :
@@ -1584,9 +1584,9 @@ void ViewProviderMesh::faceInfoCallback(void * ud, SoEventCallback * n)
             view->getWidget()->setCursor(QCursor(Qt::ArrowCursor));
             view->removeEventCallback(SoMouseButtonEvent::getClassTypeId(), faceInfoCallback,ud);
             std::list<Gui::GLGraphicsItem*> glItems = view->getGraphicsItemsOfType(Gui::GLFlagWindow::getClassTypeId());
-            for (std::list<Gui::GLGraphicsItem*>::iterator it = glItems.begin(); it != glItems.end(); ++it) {
-                view->removeGraphicsItem(*it);
-                delete *it;
+            for (auto glItem : glItems) {
+                view->removeGraphicsItem(glItem);
+                delete glItem;
             }
 
             // See comment below
@@ -1715,21 +1715,21 @@ void ViewProviderMesh::markPartCallback(void * ud, SoEventCallback * n)
                 view->removeEventCallback(SoMouseButtonEvent::getClassTypeId(), markPartCallback,ud);
 
                 std::vector<ViewProvider*> views = view->getViewProvidersOfType(ViewProviderMesh::getClassTypeId());
-                for (std::vector<ViewProvider*>::iterator it = views.begin(); it != views.end(); ++it) {
-                    static_cast<ViewProviderMesh*>(*it)->clearSelection();
+                for (auto view : views) {
+                    static_cast<ViewProviderMesh*>(view)->clearSelection();
                 }
             }
             else if (cf == id) {
                 std::vector<ViewProvider*> views = view->getViewProvidersOfType(ViewProviderMesh::getClassTypeId());
-                for (std::vector<ViewProvider*>::iterator it = views.begin(); it != views.end(); ++it) {
-                    static_cast<ViewProviderMesh*>(*it)->clearSelection();
+                for (auto view : views) {
+                    static_cast<ViewProviderMesh*>(view)->clearSelection();
                 }
             }
             else if (rm == id) {
                 Gui::Application::Instance->activeDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Delete"));
                 std::vector<ViewProvider*> views = view->getViewProvidersOfType(ViewProviderMesh::getClassTypeId());
-                for (std::vector<ViewProvider*>::iterator it = views.begin(); it != views.end(); ++it) {
-                    static_cast<ViewProviderMesh*>(*it)->deleteSelection();
+                for (auto view : views) {
+                    static_cast<ViewProviderMesh*>(view)->deleteSelection();
                 }
                 view->redraw();
                 Gui::Application::Instance->activeDocument()->commitCommand();
@@ -1799,10 +1799,10 @@ void ViewProviderMesh::fillHole(Mesh::FacetIndex uFacet)
     std::vector<MeshCore::MeshFacet> newFacets;
     std::vector<Base::Vector3f> newPoints;
     unsigned long numberOfOldPoints = rKernel.CountPoints();
-    for (std::list<std::vector<Mesh::PointIndex> >::iterator it = boundaries.begin(); it != boundaries.end(); ++it) {
-        if (it->size() < 3/* || it->size() > 200*/)
+    for (const auto & it : boundaries) {
+        if (it.size() < 3/* || it->size() > 200*/)
             continue;
-        boundary = *it;
+        boundary = it;
         MeshCore::MeshFacetArray faces;
         MeshCore::MeshPointArray points;
         MeshCore::QuasiDelaunayTriangulator cTria/*(0.05f)*/;
@@ -1820,11 +1820,11 @@ void ViewProviderMesh::fillHole(Mesh::FacetIndex uFacet)
                     newPoints.push_back(*pt);
                  }
             }
-            for (MeshCore::MeshFacetArray::_TIterator kt = faces.begin(); kt != faces.end(); ++kt ) {
-                kt->_aulPoints[0] = boundary[kt->_aulPoints[0]];
-                kt->_aulPoints[1] = boundary[kt->_aulPoints[1]];
-                kt->_aulPoints[2] = boundary[kt->_aulPoints[2]];
-                newFacets.push_back(*kt);
+            for (auto & face : faces) {
+                face._aulPoints[0] = boundary[face._aulPoints[0]];
+                face._aulPoints[1] = boundary[face._aulPoints[1]];
+                face._aulPoints[2] = boundary[face._aulPoints[2]];
+                newFacets.push_back(face);
             }
         }
     }
@@ -2134,8 +2134,8 @@ void ViewProviderMesh::highlightSelection()
     SbColor* cols = pcShapeMaterial->diffuseColor.startEditing();
     for (int i=0; i<uCtFacets; i++)
         cols[i].setValue(c.r,c.g,c.b);
-    for (std::vector<Mesh::FacetIndex>::iterator it = selection.begin(); it != selection.end(); ++it)
-        cols[*it].setValue(1.0f,0.0f,0.0f);
+    for (Mesh::FacetIndex it : selection)
+        cols[it].setValue(1.0f,0.0f,0.0f);
     pcShapeMaterial->diffuseColor.finishEditing();
 }
 
@@ -2170,13 +2170,13 @@ void ViewProviderMesh::highlightComponents()
     pcShapeMaterial->diffuseColor.setNum(uCtFacets);
 
     SbColor* cols = pcShapeMaterial->diffuseColor.startEditing();
-    for (std::vector<std::vector<Mesh::FacetIndex> >::iterator it = comps.begin(); it != comps.end(); ++it) {
+    for (const auto & comp : comps) {
         float fMax = (float)RAND_MAX;
         float fRed = (float)rand()/fMax;
         float fGrn = (float)rand()/fMax;
         float fBlu = (float)rand()/fMax;
-        for (std::vector<Mesh::FacetIndex>::iterator jt = it->begin(); jt != it->end(); ++jt) {
-            cols[*jt].setValue(fRed,fGrn,fBlu);
+        for (Mesh::FacetIndex jt : comp) {
+            cols[jt].setValue(fRed,fGrn,fBlu);
         }
     }
     pcShapeMaterial->diffuseColor.finishEditing();
@@ -2226,8 +2226,8 @@ void ViewProviderMesh::highlightSegments(const std::vector<App::Color>& colors)
             float fRed = colors[i].r;
             float fGrn = colors[i].g;
             float fBlu = colors[i].b;
-            for (std::vector<Mesh::FacetIndex>::iterator it = segm.begin(); it != segm.end(); ++it) {
-                cols[*it].setValue(fRed,fGrn,fBlu);
+            for (Mesh::FacetIndex it : segm) {
+                cols[it].setValue(fRed,fGrn,fBlu);
             }
         }
         pcShapeMaterial->diffuseColor.finishEditing();
@@ -2364,11 +2364,11 @@ void ViewProviderIndexedFaceSet::showOpenEdges(bool show)
         int index=0;
         const MeshCore::MeshKernel& rMesh = static_cast<Mesh::Feature*>(pcObject)->Mesh.getValue().getKernel();
         const MeshCore::MeshFacetArray& rFaces = rMesh.GetFacets();
-        for (MeshCore::MeshFacetArray::_TConstIterator it = rFaces.begin(); it != rFaces.end(); ++it) {
+        for (const auto & rFace : rFaces) {
             for (int i=0; i<3; i++) {
-                if (it->_aulNeighbours[i] == MeshCore::FACET_INDEX_MAX) {
-                    lines->coordIndex.set1Value(index++,it->_aulPoints[i]);
-                    lines->coordIndex.set1Value(index++,it->_aulPoints[(i+1)%3]);
+                if (rFace._aulNeighbours[i] == MeshCore::FACET_INDEX_MAX) {
+                    lines->coordIndex.set1Value(index++,rFace._aulPoints[i]);
+                    lines->coordIndex.set1Value(index++,rFace._aulPoints[(i+1)%3]);
                     lines->coordIndex.set1Value(index++,SO_END_LINE_INDEX);
                 }
             }

--- a/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
@@ -160,9 +160,9 @@ void ViewProviderMeshCurvature::init(const Mesh::PropertyCurvatureList* pCurvInf
     aMinValues.reserve(fCurvInfo.size());
     aMaxValues.reserve(fCurvInfo.size());
 
-    for ( std::vector<Mesh::CurvatureInfo>::const_iterator jt=fCurvInfo.begin();jt!=fCurvInfo.end(); ++jt ) {
-        aMinValues.push_back( jt->fMinCurvature );
-        aMaxValues.push_back( jt->fMaxCurvature );
+    for (const auto & jt : fCurvInfo) {
+        aMinValues.push_back( jt.fMinCurvature );
+        aMaxValues.push_back( jt.fMaxCurvature );
     }
 
     if ( aMinValues.empty() || aMaxValues.empty() )
@@ -173,15 +173,15 @@ void ViewProviderMeshCurvature::init(const Mesh::PropertyCurvatureList* pCurvInf
 
     // histogram over all values
     std::map<int, int> aHistogram;
-    for ( std::vector<float>::const_iterator kt = aMinValues.begin(); kt != aMinValues.end(); ++kt ) {
-        int grp = (int)(10.0f*( *kt - fMin )/( fMax - fMin ));
+    for (float aMinValue : aMinValues) {
+        int grp = (int)(10.0f*( aMinValue - fMin )/( fMax - fMin ));
         aHistogram[grp]++;
     }
 
     float fRMin=-1.0f;
-    for ( std::map<int, int>::iterator mIt = aHistogram.begin(); mIt != aHistogram.end(); ++mIt ) {
-        if ( (float)mIt->second / (float)aMinValues.size() > 0.15f ) {
-            fRMin = mIt->first * ( fMax - fMin )/10.0f + fMin;
+    for (const auto & mIt : aHistogram) {
+        if ( (float)mIt.second / (float)aMinValues.size() > 0.15f ) {
+            fRMin = mIt.first * ( fMax - fMin )/10.0f + fMin;
             break;
         }
     }
@@ -191,8 +191,8 @@ void ViewProviderMeshCurvature::init(const Mesh::PropertyCurvatureList* pCurvInf
 
     // histogram over all values
     aHistogram.clear();
-    for ( std::vector<float>::const_iterator it2 = aMaxValues.begin(); it2 != aMaxValues.end(); ++it2 ) {
-        int grp = (int)(10.0f*( *it2 - fMin )/( fMax - fMin ));
+    for (float aMaxValue : aMaxValues) {
+        int grp = (int)(10.0f*( aMaxValue - fMin )/( fMax - fMin ));
         aHistogram[grp]++;
     }
 
@@ -445,9 +445,9 @@ public:
             (App::DocumentObjectGroup::getClassTypeId());
         App::DocumentObjectGroup* group = nullptr;
         std::string internalname = "CurvatureGroup";
-        for (std::vector<App::DocumentObject*>::iterator it = groups.begin(); it != groups.end(); ++it) {
-            if (internalname == (*it)->getNameInDocument()) {
-                group = static_cast<App::DocumentObjectGroup*>(*it);
+        for (const auto & it : groups) {
+            if (internalname == it->getNameInDocument()) {
+                group = static_cast<App::DocumentObjectGroup*>(it);
                 break;
             }
         }
@@ -460,8 +460,8 @@ public:
             (group->addObject("App::AnnotationLabel", internalname.c_str()));
         QStringList lines = s.split(QLatin1String("\n"));
         std::vector<std::string> text;
-        for (QStringList::Iterator it = lines.begin(); it != lines.end(); ++it)
-            text.emplace_back((const char*)it->toLatin1());
+        for (const auto & line : lines)
+            text.emplace_back((const char*)line.toLatin1());
         anno->LabelText.setValues(text);
         std::stringstream str;
         str << "Curvature info (" << group->Group.getSize() << ")";

--- a/src/Mod/Mesh/Gui/ViewProviderDefects.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderDefects.cpp
@@ -149,10 +149,9 @@ void ViewProviderMeshOrientation::showDefects(const std::vector<Mesh::ElementInd
     MeshCore::MeshFacetIterator cF(rMesh);
     int i=0;
     int j=0;
-    for (std::vector<Mesh::ElementIndex>::const_iterator it = inds.begin(); it != inds.end(); ++it) {
-        cF.Set(*it);
-        for (int k=0; k<3; k++) {
-            Base::Vector3f cP = cF->_aclPoints[k];
+    for (Mesh::ElementIndex ind : inds) {
+        cF.Set(ind);
+        for (auto cP : cF->_aclPoints) {
             // move a bit in opposite normal direction to overlay the original faces
             cP -= 0.001f * cF->GetNormal();
             pcCoords->point.set1Value(i++,cP.x,cP.y,cP.z);
@@ -277,8 +276,8 @@ void ViewProviderMeshNonManifoldPoints::showDefects(const std::vector<Mesh::Elem
     pcCoords->point.setNum(inds.size());
     MeshCore::MeshPointIterator cP(rMesh);
     int i = 0;
-    for ( std::vector<Mesh::ElementIndex>::const_iterator it = inds.begin(); it != inds.end(); ++it ) {
-        cP.Set(*it);
+    for (Mesh::ElementIndex ind : inds) {
+        cP.Set(ind);
         pcCoords->point.set1Value(i++,cP->x,cP->y,cP->z);
     }
 
@@ -343,10 +342,9 @@ void ViewProviderMeshDuplicatedFaces::showDefects(const std::vector<Mesh::Elemen
     MeshCore::MeshFacetIterator cF(rMesh);
     int i=0;
     int j=0;
-    for (std::vector<Mesh::ElementIndex>::const_iterator it = inds.begin(); it != inds.end(); ++it) {
-        cF.Set(*it);
-        for (int k=0; k<3; k++) {
-            Base::Vector3f cP = cF->_aclPoints[k];
+    for (Mesh::ElementIndex ind : inds) {
+        cF.Set(ind);
+        for (auto cP : cF->_aclPoints) {
             // move a bit in normal direction to overlay the original faces
             cP += 0.001f * cF->GetNormal();
             pcCoords->point.set1Value(i++,cP.x,cP.y,cP.z);
@@ -406,8 +404,8 @@ void ViewProviderMeshDuplicatedPoints::showDefects(const std::vector<Mesh::Eleme
     pcCoords->point.setNum(inds.size());
     MeshCore::MeshPointIterator cP(rMesh);
     int i = 0;
-    for ( std::vector<Mesh::ElementIndex>::const_iterator it = inds.begin(); it != inds.end(); ++it ) {
-        cP.Set(*it);
+    for (Mesh::ElementIndex ind : inds) {
+        cP.Set(ind);
         pcCoords->point.set1Value(i++,cP->x,cP->y,cP->z);
     }
 
@@ -465,8 +463,8 @@ void ViewProviderMeshDegenerations::showDefects(const std::vector<Mesh::ElementI
     MeshCore::MeshFacetIterator cF(rMesh);
     int i=0;
     int j=0;
-    for (std::vector<Mesh::ElementIndex>::const_iterator it = inds.begin(); it != inds.end(); ++it) {
-        cF.Set(*it);
+    for (Mesh::ElementIndex ind : inds) {
+        cF.Set(ind);
         const MeshCore::MeshPoint& rE0 = cF->_aclPoints[0];
         const MeshCore::MeshPoint& rE1 = cF->_aclPoints[1];
         const MeshCore::MeshPoint& rE2 = cF->_aclPoints[2];
@@ -572,10 +570,9 @@ void ViewProviderMeshIndices::showDefects(const std::vector<Mesh::ElementIndex>&
         MeshCore::MeshFacetIterator cF(rMesh);
         int i=0;
         int j=0;
-        for (std::vector<Mesh::ElementIndex>::const_iterator it = inds.begin(); it != inds.end(); ++it) {
-            cF.Set(*it);
-            for (int k=0; k<3; k++) {
-                Base::Vector3f cP = cF->_aclPoints[k];
+        for (Mesh::ElementIndex ind : inds) {
+            cF.Set(ind);
+            for (auto cP : cF->_aclPoints) {
                 // move a bit in opposite normal direction to overlay the original faces
                 cP -= 0.001f * cF->GetNormal();
                 pcCoords->point.set1Value(i++,cP.x,cP.y,cP.z);
@@ -651,9 +648,9 @@ void ViewProviderMeshSelfIntersections::showDefects(const std::vector<Mesh::Elem
     pcCoords->point.setNum(2*lines.size());
     int i=0;
     int j=0;
-    for (std::vector<std::pair<Base::Vector3f, Base::Vector3f> >::const_iterator it = lines.begin(); it != lines.end(); ++it) {
-        pcCoords->point.set1Value(i++,it->first.x,it->first.y,it->first.z);
-        pcCoords->point.set1Value(i++,it->second.x,it->second.y,it->second.z);
+    for (const auto & line : lines) {
+        pcCoords->point.set1Value(i++,line.first.x,line.first.y,line.first.z);
+        pcCoords->point.set1Value(i++,line.second.x,line.second.y,line.second.z);
         pcLines->numVertices.set1Value(j++, 2);
     }
 
@@ -718,10 +715,9 @@ void ViewProviderMeshFolds::showDefects(const std::vector<Mesh::ElementIndex>& i
     MeshCore::MeshFacetIterator cF(rMesh);
     int i=0;
     int j=0;
-    for (std::vector<Mesh::ElementIndex>::const_iterator it = inds.begin(); it != inds.end(); ++it) {
-        cF.Set(*it);
-        for (int k=0; k<3; k++) {
-            Base::Vector3f cP = cF->_aclPoints[k];
+    for (Mesh::ElementIndex ind : inds) {
+        cF.Set(ind);
+        for (auto cP : cF->_aclPoints) {
             // move a bit in normal direction to overlay the original faces
             cP += 0.001f * cF->GetNormal();
             pcCoords->point.set1Value(i++,cP.x,cP.y,cP.z);

--- a/src/Mod/Mesh/Gui/ViewProviderMeshFaceSet.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderMeshFaceSet.cpp
@@ -163,11 +163,11 @@ void ViewProviderMeshFaceSet::showOpenEdges(bool show)
             int index=0;
             const MeshCore::MeshKernel& rMesh = static_cast<Mesh::Feature*>(pcObject)->Mesh.getValue().getKernel();
             const MeshCore::MeshFacetArray& rFaces = rMesh.GetFacets();
-            for (MeshCore::MeshFacetArray::_TConstIterator it = rFaces.begin(); it != rFaces.end(); ++it) {
+            for (const auto & rFace : rFaces) {
                 for (int i=0; i<3; i++) {
-                    if (it->_aulNeighbours[i] == MeshCore::FACET_INDEX_MAX) {
-                        lines->coordIndex.set1Value(index++,it->_aulPoints[i]);
-                        lines->coordIndex.set1Value(index++,it->_aulPoints[(i+1)%3]);
+                    if (rFace._aulNeighbours[i] == MeshCore::FACET_INDEX_MAX) {
+                        lines->coordIndex.set1Value(index++,rFace._aulPoints[i]);
+                        lines->coordIndex.set1Value(index++,rFace._aulPoints[(i+1)%3]);
                         lines->coordIndex.set1Value(index++,SO_END_LINE_INDEX);
                     }
                 }

--- a/src/Mod/Mesh/Gui/Workbench.cpp
+++ b/src/Mod/Mesh/Gui/Workbench.cpp
@@ -114,10 +114,10 @@ public:
         Base::BoundBox3d bbox;
         unsigned long countPoints=0, countFacets=0;
         std::vector<Mesh::Feature*> mesh = Gui::Selection().getObjectsOfType<Mesh::Feature>();
-        for (std::vector<Mesh::Feature*>::iterator it = mesh.begin(); it != mesh.end(); ++it) {
-            countPoints += (*it)->Mesh.getValue().countPoints();
-            countFacets += (*it)->Mesh.getValue().countFacets();
-            bbox.Add((*it)->Mesh.getBoundingBox());
+        for (auto it : mesh) {
+            countPoints += it->Mesh.getValue().countPoints();
+            countFacets += it->Mesh.getValue().countFacets();
+            bbox.Add(it->Mesh.getBoundingBox());
         }
 
         if (countPoints > 0) {


### PR DESCRIPTION
Replaces old-style for loops with the more efficient range-based for loops. This PR affects the code in the Mesh module.