### PR TITLE
Modernize C++: return braced init list

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -593,7 +593,7 @@ std::vector<App::Document*> Application::getDocuments() const
 std::string Application::getUniqueDocumentName(const char *Name, bool tempDoc) const
 {
     if (!Name || *Name == '\0')
-        return std::string();
+        return {};
     std::string CleanName = Base::Tools::getIdentifier(Name);
 
     // name in use?
@@ -3160,7 +3160,7 @@ std::tuple<QString, QString, QString> getCustomPaths()
         userTemp = fi.absoluteFilePath();
     }
 
-    return std::tuple<QString, QString, QString>(userHome, userData, userTemp);
+    return {userHome, userData, userTemp};
 }
 
 /*!

--- a/src/App/ComplexGeoDataPyImp.cpp
+++ b/src/App/ComplexGeoDataPyImp.cpp
@@ -43,7 +43,7 @@ using namespace Base;
 // returns a string which represent the object e.g. when printed in python
 std::string ComplexGeoDataPy::representation() const
 {
-    return std::string("<ComplexGeoData object>");
+    return {"<ComplexGeoData object>"};
 }
 
 PyObject* ComplexGeoDataPy::getElementTypes(PyObject *args)

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3799,7 +3799,7 @@ const char * Document::getObjectName(DocumentObject *pFeat) const
 std::string Document::getUniqueObjectName(const char *Name) const
 {
     if (!Name || *Name == '\0')
-        return std::string();
+        return {};
     std::string CleanName = Base::Tools::getIdentifier(Name);
 
     // name in use?

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -312,7 +312,7 @@ int DocumentObject::isExporting() const {
 
 std::string DocumentObject::getExportName(bool forced) const {
     if(!pcNameInDocument)
-        return std::string();
+        return {};
 
     if(!forced && !isExporting())
         return *pcNameInDocument;

--- a/src/App/DocumentObjectExtensionPyImp.cpp
+++ b/src/App/DocumentObjectExtensionPyImp.cpp
@@ -32,7 +32,7 @@ using namespace App;
 // returns a string which represent the object e.g. when printed in python
 std::string DocumentObjectExtensionPy::representation() const
 {
-    return std::string("<document object extension>");
+    return {"<document object extension>"};
 }
 
 PyObject *DocumentObjectExtensionPy::getCustomAttributes(const char* /*attr*/) const

--- a/src/App/DocumentObjectGroupPyImp.cpp
+++ b/src/App/DocumentObjectGroupPyImp.cpp
@@ -34,7 +34,7 @@ using namespace App;
 // returns a string which represent the object e.g. when printed in python
 std::string DocumentObjectGroupPy::representation() const
 {
-    return std::string("<group object>");
+    return {"<group object>"};
 }
 
 PyObject *DocumentObjectGroupPy::getCustomAttributes(const char* /*attr*/) const

--- a/src/App/DocumentObjectPyImp.cpp
+++ b/src/App/DocumentObjectPyImp.cpp
@@ -55,12 +55,12 @@ Py::String DocumentObjectPy::getName() const
     if (!internal) {
         throw Py::RuntimeError(std::string("This object is currently not part of a document"));
     }
-    return Py::String(std::string(internal));
+    return {std::string(internal)};
 }
 
 Py::String DocumentObjectPy::getFullName() const
 {
-    return Py::String(getDocumentObjectPtr()->getFullName());
+    return {getDocumentObjectPtr()->getFullName()};
 }
 
 Py::Object DocumentObjectPy::getDocument() const
@@ -694,7 +694,7 @@ PyObject*  DocumentObjectPy::getParent(PyObject *args)
 Py::Boolean DocumentObjectPy::getMustExecute() const
 {
     try {
-        return Py::Boolean(getDocumentObjectPtr()->mustExecute()?true:false);
+        return {getDocumentObjectPtr()->mustExecute() ? true : false};
     }
     catch (const Base::Exception& e) {
         throw Py::RuntimeError(e.what());
@@ -741,7 +741,7 @@ Py::Int DocumentObjectPy::getID() const {
 }
 
 Py::Boolean DocumentObjectPy::getRemoving() const {
-    return Py::Boolean(getDocumentObjectPtr()->testStatus(ObjectStatus::Remove));
+    return {getDocumentObjectPtr()->testStatus(ObjectStatus::Remove)};
 }
 
 PyObject *DocumentObjectPy::resolve(PyObject *args)
@@ -813,11 +813,11 @@ PyObject *DocumentObjectPy::adjustRelativeLinks(PyObject *args) {
 }
 
 Py::String DocumentObjectPy::getOldLabel() const {
-    return Py::String(getDocumentObjectPtr()->getOldLabel());
+    return {getDocumentObjectPtr()->getOldLabel()};
 }
 
 Py::Boolean DocumentObjectPy::getNoTouch() const {
-    return Py::Boolean(getDocumentObjectPtr()->testStatus(ObjectStatus::NoTouch));
+    return {getDocumentObjectPtr()->testStatus(ObjectStatus::NoTouch)};
 }
 
 void DocumentObjectPy::setNoTouch(Py::Boolean value) {

--- a/src/App/DocumentObserver.cpp
+++ b/src/App/DocumentObserver.cpp
@@ -364,7 +364,7 @@ std::string SubObjectT::getNewElementName() const {
     std::pair<std::string, std::string> element;
     auto obj = getObject();
     if(!obj)
-        return std::string();
+        return {};
     GeoFeature::resolveElement(obj,subname.c_str(),element);
     return std::move(element.first);
 }
@@ -373,7 +373,7 @@ std::string SubObjectT::getOldElementName(int *index) const {
     std::pair<std::string, std::string> element;
     auto obj = getObject();
     if(!obj)
-        return std::string();
+        return {};
     GeoFeature::resolveElement(obj,subname.c_str(),element);
     if(!index)
         return std::move(element.second);

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -472,7 +472,7 @@ PyObject*  DocumentPy::commitTransaction(PyObject * args)
 }
 
 Py::Boolean DocumentPy::getHasPendingTransaction() const {
-    return Py::Boolean(getDocumentPtr()->hasPendingTransaction());
+    return {getDocumentPtr()->hasPendingTransaction()};
 }
 
 PyObject*  DocumentPy::undo(PyObject * args)
@@ -780,17 +780,17 @@ Py::String  DocumentPy::getDependencyGraph() const
 {
     std::stringstream out;
     getDocumentPtr()->exportGraphviz(out);
-    return Py::String(out.str());
+    return {out.str()};
 }
 
 Py::String DocumentPy::getName() const
 {
-    return Py::String(getDocumentPtr()->getName());
+    return {getDocumentPtr()->getName()};
 }
 
 Py::Boolean DocumentPy::getRecomputesFrozen() const
 {
-    return Py::Boolean(getDocumentPtr()->testStatus(Document::Status::SkipRecompute));
+    return {getDocumentPtr()->testStatus(Document::Status::SkipRecompute)};
 }
 
 void DocumentPy::setRecomputesFrozen(Py::Boolean arg)
@@ -942,35 +942,35 @@ PyObject *DocumentPy::getDependentDocuments(PyObject *args) {
 
 Py::Boolean DocumentPy::getRestoring() const
 {
-    return Py::Boolean(getDocumentPtr()->testStatus(Document::Status::Restoring));
+    return {getDocumentPtr()->testStatus(Document::Status::Restoring)};
 }
 
 Py::Boolean DocumentPy::getPartial() const
 {
-    return Py::Boolean(getDocumentPtr()->testStatus(Document::Status::PartialDoc));
+    return {getDocumentPtr()->testStatus(Document::Status::PartialDoc)};
 }
 
 Py::Boolean DocumentPy::getImporting() const
 {
-    return Py::Boolean(getDocumentPtr()->testStatus(Document::Status::Importing));
+    return {getDocumentPtr()->testStatus(Document::Status::Importing)};
 }
 
 Py::Boolean DocumentPy::getRecomputing() const
 {
-    return Py::Boolean(getDocumentPtr()->testStatus(Document::Status::Recomputing));
+    return {getDocumentPtr()->testStatus(Document::Status::Recomputing)};
 }
 
 Py::Boolean DocumentPy::getTransacting() const
 {
-    return Py::Boolean(getDocumentPtr()->isPerformingTransaction());
+    return {getDocumentPtr()->isPerformingTransaction()};
 }
 
 Py::String DocumentPy::getOldLabel() const
 {
-    return Py::String(getDocumentPtr()->getOldLabel());
+    return {getDocumentPtr()->getOldLabel()};
 }
 
 Py::Boolean DocumentPy::getTemporary() const
 {
-    return Py::Boolean(getDocumentPtr()->testStatus(Document::TempDoc));
+    return {getDocumentPtr()->testStatus(Document::TempDoc)};
 }

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -328,7 +328,7 @@ DynamicProperty::PropData DynamicProperty::getDynamicPropertyData(const Property
     auto it = index.find(const_cast<Property*>(prop));
     if(it != index.end())
         return *it;
-    return PropData();
+    return {};
 }
 
 bool DynamicProperty::changeDynamicProperty(const Property *prop, const char *group, const char *doc) {

--- a/src/App/ElementMap.cpp
+++ b/src/App/ElementMap.cpp
@@ -848,12 +848,12 @@ IndexedName ElementMap::find(const MappedName& name, ElementIDRefs* sids) const
 MappedName ElementMap::find(const IndexedName& idx, ElementIDRefs* sids) const
 {
     if (!idx) {
-        return MappedName();
+        return {};
     }
 
     auto iter = this->indexedNames.find(idx.getType());
     if (iter == this->indexedNames.end()) {
-        return MappedName();
+        return {};
     }
 
     auto& indices = iter->second;

--- a/src/App/ElementNamingUtils.cpp
+++ b/src/App/ElementNamingUtils.cpp
@@ -12,7 +12,7 @@ const char *Data::isMappedElement(const char *name) {
 
 std::string Data::newElementName(const char *name) {
     if(!name)
-        return std::string();
+        return {};
     const char *dot = strrchr(name,'.');
     if(!dot || dot==name)
         return name;
@@ -30,7 +30,7 @@ std::string Data::newElementName(const char *name) {
 
 std::string Data::oldElementName(const char *name) {
     if(!name)
-        return std::string();
+        return {};
     const char *dot = strrchr(name,'.');
     if(!dot || dot==name)
         return name;
@@ -48,7 +48,7 @@ std::string Data::oldElementName(const char *name) {
 
 std::string Data::noElementName(const char *name) {
     if(!name)
-        return std::string();
+        return {};
     auto element = findElementName(name);
     if(element)
         return std::string(name,element-name);

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -449,12 +449,12 @@ Py::Object pyObjectFromAny(const App::any &value) {
 App::any pyObjectToAny(Py::Object value, bool check) {
 
     if(value.isNone())
-        return App::any();
+        return {};
 
     PyObject *pyvalue = value.ptr();
 
     if(!check)
-        return App::any(pyObjectWrap(pyvalue));
+        return {pyObjectWrap(pyvalue)};
 
     if (PyObject_TypeCheck(pyvalue, &Base::QuantityPy::Type)) {
         Base::QuantityPy * qp = static_cast<Base::QuantityPy*>(pyvalue);
@@ -1048,7 +1048,7 @@ ExpressionPtr Expression::updateLabelReference(
         App::DocumentObject *obj, const std::string &ref, const char *newLabel) const
 {
     if(ref.size()<=2)
-        return ExpressionPtr();
+        return {};
     std::vector<std::string> labels;
     for(auto &v : getIdentifiers())
         v.first.getDepLabels(labels);
@@ -1061,7 +1061,7 @@ ExpressionPtr Expression::updateLabelReference(
             return ExpressionPtr(expr);
         }
     }
-    return ExpressionPtr();
+    return {};
 }
 
 class ReplaceObjectExpressionVisitor : public ExpressionVisitor {
@@ -1097,7 +1097,7 @@ ExpressionPtr Expression::replaceObject(const DocumentObject *parent,
     const_cast<Expression*>(this)->visit(v);
 
     if(v.paths.empty())
-        return ExpressionPtr();
+        return {};
 
     // Now make a copy and do the actual replacement
     auto expr = copy();

--- a/src/App/ExpressionTokenizer.cpp
+++ b/src/App/ExpressionTokenizer.cpp
@@ -67,7 +67,7 @@ QString ExpressionTokenizer::perform(const QString& prefix, int pos)
 
     // No tokens
     if (tokens.empty()) {
-        return QString();
+        return {};
     }
 
     prefixEnd = prefix.size();
@@ -114,7 +114,7 @@ QString ExpressionTokenizer::perform(const QString& prefix, int pos)
     if (!stringing && !prefix.isEmpty() &&
             prefixEnd > 0 && prefixEnd <= prefix.size() &&
             prefix[prefixEnd-1] == QChar(32)) {
-        return QString();
+        return {};
     }
 
     if (!stringing) {

--- a/src/App/Extension.cpp
+++ b/src/App/Extension.cpp
@@ -115,11 +115,8 @@ std::string Extension::name() const {
 
     if (pos != std::string::npos)
         return temp.substr(pos+1);
-    else
-        return std::string();
+    return {};
 }
-
-
 
 Property* Extension::extensionGetPropertyByName(const char* name) const {
 

--- a/src/App/ExtensionContainerPyImp.cpp
+++ b/src/App/ExtensionContainerPyImp.cpp
@@ -38,7 +38,7 @@ using namespace App;
 // returns a string which represent the object e.g. when printed in python
 std::string ExtensionContainerPy::representation() const
 {
-    return std::string("<extension>");
+    return {"<extension>"};
 }
 
 int  ExtensionContainerPy::initialization() {

--- a/src/App/ExtensionPyImp.cpp
+++ b/src/App/ExtensionPyImp.cpp
@@ -34,7 +34,7 @@ using namespace App;
 // returns a string which represent the object e.g. when printed in python
 std::string ExtensionPy::representation() const
 {
-    return std::string("<extension>");
+    return {"<extension>"};
 }
 
 PyObject *ExtensionPy::getCustomAttributes(const char* /*attr*/) const

--- a/src/App/FeaturePython.cpp
+++ b/src/App/FeaturePython.cpp
@@ -480,7 +480,7 @@ std::string FeaturePythonImp::getViewProviderName()
         e.ReportException();
     }
 
-    return std::string();
+    return {};
 }
 
 FeaturePythonImp::ValueT

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -235,7 +235,7 @@ void GeoFeatureGroupExtension::extensionOnChanged(const Property* p) {
 std::vector< DocumentObject* > GeoFeatureGroupExtension::getScopedObjectsFromLinks(const DocumentObject* obj, LinkScope scope) {
 
     if(!obj)
-        return std::vector< DocumentObject* >();
+        return {};
 
     //we get all linked objects. We can't use outList() as this includes the links from expressions
     std::vector< App::DocumentObject* > result;
@@ -256,7 +256,7 @@ std::vector< DocumentObject* > GeoFeatureGroupExtension::getScopedObjectsFromLin
 std::vector< DocumentObject* > GeoFeatureGroupExtension::getScopedObjectsFromLink(App::Property* prop, LinkScope scope) {
 
     if(!prop)
-        return std::vector< DocumentObject* >();
+        return {};
 
     std::vector< App::DocumentObject* > result;
     auto link = Base::freecad_dynamic_cast<PropertyLinkBase>(prop);
@@ -321,7 +321,7 @@ void GeoFeatureGroupExtension::getCSInList(const DocumentObject* obj,
 std::vector< DocumentObject* > GeoFeatureGroupExtension::getCSRelevantLinks(const DocumentObject* obj) {
 
     if(!obj)
-        return std::vector< DocumentObject* >();
+        return {};
 
     //get all out links
     std::vector<DocumentObject*> vec;

--- a/src/App/GeoFeatureGroupExtensionPyImp.cpp
+++ b/src/App/GeoFeatureGroupExtensionPyImp.cpp
@@ -33,9 +33,8 @@ using namespace App;
 // returns a string which represents the object e.g. when printed in python
 std::string GeoFeatureGroupExtensionPy::representation() const
 {
-    return std::string("<GeoFeatureGroup object>");
+    return {"<GeoFeatureGroup object>"};
 }
-
 
 PyObject *GeoFeatureGroupExtensionPy::getCustomAttributes(const char* /*attr*/) const
 {

--- a/src/App/GeoFeaturePyImp.cpp
+++ b/src/App/GeoFeaturePyImp.cpp
@@ -34,7 +34,7 @@ using namespace App;
 // returns a string which represents the object e.g. when printed in python
 std::string GeoFeaturePy::representation() const
 {
-    return std::string("<GeoFeature object>");
+    return {"<GeoFeature object>"};
 }
 
 PyObject* GeoFeaturePy::getPaths(PyObject * /*args*/)

--- a/src/App/Graphviz.cpp
+++ b/src/App/Graphviz.cpp
@@ -132,7 +132,7 @@ void Document::exportGraphviz(std::ostream& out) const
         std::string getId(const ObjectIdentifier & path) {
             DocumentObject * docObj = path.getDocumentObject();
             if (!docObj)
-                return std::string();
+                return {};
 
             return std::string((docObj)->getDocument()->getName()) + "#" + docObj->getNameInDocument() + "." + path.getPropertyName() + path.getSubPathStr();
         }

--- a/src/App/GroupExtensionPyImp.cpp
+++ b/src/App/GroupExtensionPyImp.cpp
@@ -36,7 +36,7 @@ using namespace App;
 // returns a string which represent the object e.g. when printed in python
 std::string GroupExtensionPy::representation() const
 {
-    return std::string("<group extension object>");
+    return {"<group extension object>"};
 }
 
 PyObject*  GroupExtensionPy::newObject(PyObject *args)

--- a/src/App/MaterialPyImp.cpp
+++ b/src/App/MaterialPyImp.cpp
@@ -80,7 +80,7 @@ int MaterialPy::PyInit(PyObject* args, PyObject* kwds)
 // returns a string which represents the object e.g. when printed in python
 std::string MaterialPy::representation() const
 {
-    return std::string("<Material object>");
+    return {"<Material object>"};
 }
 
 PyObject* MaterialPy::set(PyObject * args)

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -374,13 +374,13 @@ const std::string &ObjectIdentifier::toString() const
 std::string ObjectIdentifier::toPersistentString() const {
 
     if(!owner)
-        return std::string();
+        return {};
 
     std::ostringstream s;
     ResolveResults result(*this);
 
     if(result.propertyIndex >= (int)components.size())
-        return std::string();
+        return {};
 
     if(localProperty ||
        (result.resolvedProperty &&
@@ -1776,7 +1776,7 @@ App::any ObjectIdentifier::getValue(bool pathValue, bool *isPseudoProperty) cons
     }catch(Py::Exception &) {
         Base::PyException::ThrowException();
     }
-    return App::any();
+    return {};
 }
 
 Py::Object ObjectIdentifier::getPyValue(bool pathValue, bool *isPseudoProperty) const

--- a/src/App/OriginGroupExtensionPyImp.cpp
+++ b/src/App/OriginGroupExtensionPyImp.cpp
@@ -32,7 +32,7 @@ using namespace App;
 // returns a string which represents the object e.g. when printed in python
 std::string OriginGroupExtensionPy::representation() const
 {
-    return std::string("<OriginGroup object>");
+    return {"<OriginGroup object>"};
 }
 
 PyObject *OriginGroupExtensionPy::getCustomAttributes(const char* /*attr*/) const

--- a/src/App/PartPyImp.cpp
+++ b/src/App/PartPyImp.cpp
@@ -32,7 +32,7 @@ using namespace App;
 // returns a string which represents the object e.g. when printed in python
 std::string PartPy::representation() const
 {
-    return std::string("<Part object>");
+    return {"<Part object>"};
 }
 
 PyObject *PartPy::getCustomAttributes(const char* /*attr*/) const

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -158,7 +158,7 @@ public:
 
   unsigned int getMemSize () const override;
 
-  virtual std::string getFullName() const {return std::string();}
+  virtual std::string getFullName() const {return {};}
 
   /// find a property by its name
   virtual Property *getPropertyByName(const char* name) const;

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -45,7 +45,7 @@ using namespace App;
 // returns a string which represent the object e.g. when printed in python
 std::string PropertyContainerPy::representation() const
 {
-    return std::string("<property container>");
+    return {"<property container>"};
 }
 
 PyObject*  PropertyContainerPy::getPropertyByName(PyObject *args)

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -811,7 +811,7 @@ std::string PropertyExpressionEngine::validateExpression(const ObjectIdentifier 
         return e.what();
     }
 
-    return std::string();
+    return {};
 }
 
 /**

--- a/src/App/PropertyGeo.h
+++ b/src/App/PropertyGeo.h
@@ -102,7 +102,7 @@ public:
     bool getPyPathValue(const ObjectIdentifier &path, Py::Object &res) const override;
 
     virtual Base::Unit getUnit() const {
-        return Base::Unit();
+        return {};
     }
 
     bool isSame(const Property &other) const override {

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -147,7 +147,7 @@ std::string PropertyLinkBase::updateLabelReference(const App::DocumentObject *pa
         const char *subname, App::DocumentObject *obj, const std::string &ref, const char *newLabel)
 {
     if(!obj || !obj->getNameInDocument() || !parent || !parent->getNameInDocument())
-        return std::string();
+        return {};
 
     // Because the label is allowed to be the same across different
     // hierarchies, we have to search for all occurrences, and make sure the
@@ -162,7 +162,7 @@ std::string PropertyLinkBase::updateLabelReference(const App::DocumentObject *pa
             return sub;
         }
     }
-    return std::string();
+    return {};
 }
 
 std::vector<std::pair<Property*, std::unique_ptr<Property> > >
@@ -192,7 +192,7 @@ PropertyLinkBase::updateLabelReferences(App::DocumentObject *obj, const char *ne
 
 static std::string propertyName(const Property *prop) {
     if(!prop)
-        return std::string();
+        return {};
     if(!prop->getContainer() || !prop->hasName()) {
         auto xlink = Base::freecad_dynamic_cast<const PropertyXLink>(prop);
         if(xlink)
@@ -1238,7 +1238,7 @@ std::string PropertyLinkBase::tryImportSubName(const App::DocumentObject *obj, c
         const App::Document *doc, const std::map<std::string,std::string> &nameMap)
 {
     if(!doc || !obj || !obj->getNameInDocument())
-        return std::string();
+        return {};
 
     std::ostringstream ss;
     std::string subname(_subname);
@@ -1249,7 +1249,7 @@ std::string PropertyLinkBase::tryImportSubName(const App::DocumentObject *obj, c
         auto sobj = obj->getSubObject(subname.c_str());
         if(!sobj) {
             FC_ERR("Failed to restore label reference " << obj->getFullName() << '.' << subname);
-            return std::string();
+            return {};
         }
         dot[0] = 0;
         if(next[0] == '$') {
@@ -1273,7 +1273,7 @@ std::string PropertyLinkBase::tryImportSubName(const App::DocumentObject *obj, c
     }
     if(sub!=subname.c_str())
         return ss.str();
-    return std::string();
+    return {};
 }
 
 #define ATTR_SHADOWED "shadowed"

--- a/src/App/StringHasherPyImp.cpp
+++ b/src/App/StringHasherPyImp.cpp
@@ -127,7 +127,7 @@ Py::Long StringHasherPy::getSize() const
 
 Py::Boolean StringHasherPy::getSaveAll() const
 {
-    return Py::Boolean(getStringHasherPtr()->getSaveAll());
+    return {getStringHasherPtr()->getSaveAll()};
 }
 
 void StringHasherPy::setSaveAll(Py::Boolean value)

--- a/src/App/StringIDPyImp.cpp
+++ b/src/App/StringIDPyImp.cpp
@@ -66,17 +66,17 @@ Py::List StringIDPy::getRelated() const
 
 Py::String StringIDPy::getData() const
 {
-    return Py::String(getStringIDPtr()->dataToText(this->_index));
+    return {getStringIDPtr()->dataToText(this->_index)};
 }
 
 Py::Boolean StringIDPy::getIsBinary() const
 {
-    return Py::Boolean(getStringIDPtr()->isBinary());
+    return {getStringIDPtr()->isBinary()};
 }
 
 Py::Boolean StringIDPy::getIsHashed() const
 {
-    return Py::Boolean(getStringIDPtr()->isHashed());
+    return {getStringIDPtr()->isHashed()};
 }
 
 Py::Long StringIDPy::getIndex() const

--- a/src/Base/BaseClassPyImp.cpp
+++ b/src/Base/BaseClassPyImp.cpp
@@ -32,7 +32,7 @@ using namespace Base;
 // returns a string which represent the object e.g. when printed in python
 std::string BaseClassPy::representation() const
 {
-    return std::string("<binding object>");
+    return {"<binding object>"};
 }
 
 
@@ -62,7 +62,7 @@ PyObject*  BaseClassPy::getAllDerivedFrom(PyObject *args)
 
 Py::String BaseClassPy::getTypeId() const
 {
-    return Py::String(std::string(getBaseClassPtr()->getTypeId().getName()));
+    return {std::string(getBaseClassPtr()->getTypeId().getName())};
 }
 
 Py::String BaseClassPy::getModule() const
@@ -75,7 +75,7 @@ Py::String BaseClassPy::getModule() const
     else
         module.clear();
 
-    return Py::String(module);
+    return {module};
 }
 
 PyObject *BaseClassPy::getCustomAttributes(const char* /*attr*/) const

--- a/src/Base/CoordinateSystemPyImp.cpp
+++ b/src/Base/CoordinateSystemPyImp.cpp
@@ -35,7 +35,7 @@ using namespace Base;
 // returns a string which represents the object e.g. when printed in python
 std::string CoordinateSystemPy::representation() const
 {
-    return std::string("<CoordinateSystem object>");
+    return {"<CoordinateSystem object>"};
 }
 
 PyObject *CoordinateSystemPy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper

--- a/src/Base/DualNumber.h
+++ b/src/Base/DualNumber.h
@@ -45,48 +45,48 @@ public:
     DualNumber(double re, double du = 0.0)
         : re(re), du(du)
     {}
-    DualNumber operator-() const {return DualNumber(-re,-du);}
+    DualNumber operator-() const {return {-re,-du};}
 };
 
 inline DualNumber operator+(DualNumber a, DualNumber b){
-    return DualNumber(a.re + b.re, a.du + b.du);
+    return {a.re + b.re, a.du + b.du};
 }
 inline DualNumber operator+(DualNumber a, double b){
-    return DualNumber(a.re + b, a.du);
+    return {a.re + b, a.du};
 }
 inline DualNumber operator+(double a, DualNumber b){
-    return DualNumber(a + b.re, b.du);
+    return {a + b.re, b.du};
 }
 
 inline DualNumber operator-(DualNumber a, DualNumber b){
-    return DualNumber(a.re - b.re, a.du - b.du);
+    return {a.re - b.re, a.du - b.du};
 }
 inline DualNumber operator-(DualNumber a, double b){
-    return DualNumber(a.re - b, a.du);
+    return {a.re - b, a.du};
 }
 inline DualNumber operator-(double a, DualNumber b){
-    return DualNumber(a - b.re, -b.du);
+    return {a - b.re, -b.du};
 }
 
 inline DualNumber operator*(DualNumber a, DualNumber b){
-    return DualNumber(a.re * b.re, a.re * b.du + a.du * b.re);
+    return {a.re * b.re, a.re * b.du + a.du * b.re};
 }
 inline DualNumber operator*(double a, DualNumber b){
-    return DualNumber(a * b.re, a * b.du);
+    return {a * b.re, a * b.du};
 }
 inline DualNumber operator*(DualNumber a, double b){
-    return DualNumber(a.re * b, a.du * b);
+    return {a.re * b, a.du * b};
 }
 
 inline DualNumber operator/(DualNumber a, DualNumber b){
-    return DualNumber(a.re / b.re, (a.du * b.re - a.re * b.du) / (b.re * b.re));
+    return {a.re / b.re, (a.du * b.re - a.re * b.du) / (b.re * b.re)};
 }
 inline DualNumber operator/(DualNumber a, double b){
-    return DualNumber(a.re / b, a.du / b);
+    return {a.re / b, a.du / b};
 }
 
 inline DualNumber pow(DualNumber a, double pw){
-    return Base::DualNumber(std::pow(a.re, pw), pw * std::pow(a.re, pw - 1.0) * a.du);
+    return {std::pow(a.re, pw), pw * std::pow(a.re, pw - 1.0) * a.du};
 }
 } //namespace
 

--- a/src/Base/DualQuaternion.cpp
+++ b/src/Base/DualQuaternion.cpp
@@ -28,72 +28,72 @@
 
 Base::DualQuat Base::operator+(Base::DualQuat a, Base::DualQuat b)
 {
-    return DualQuat(
+    return {
                 a.x + b.x,
                 a.y + b.y,
                 a.z + b.z,
                 a.w + b.w
-                );
+                };
 }
 
 Base::DualQuat Base::operator-(Base::DualQuat a, Base::DualQuat b)
 {
-    return DualQuat(
+    return {
                 a.x - b.x,
                 a.y - b.y,
                 a.z - b.z,
                 a.w - b.w
-                );
+                };
 }
 
 Base::DualQuat Base::operator*(Base::DualQuat a, Base::DualQuat b)
 {
-    return DualQuat(
+    return {
                 a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
                 a.w * b.y + a.y * b.w + a.z * b.x - a.x * b.z,
                 a.w * b.z + a.z * b.w + a.x * b.y - a.y * b.x,
                 a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z
-                );
+                };
 }
 
 Base::DualQuat Base::operator*(Base::DualQuat a, double b)
 {
-    return DualQuat(
+    return {
                 a.x * b,
                 a.y * b,
                 a.z * b,
                 a.w * b
-                );
+                };
 }
 
 Base::DualQuat Base::operator*(double a, Base::DualQuat b)
 {
-    return DualQuat(
+    return {
                 b.x * a,
                 b.y * a,
                 b.z * a,
                 b.w * a
-                );
+                };
 }
 
 Base::DualQuat Base::operator*(Base::DualQuat a, Base::DualNumber b)
 {
-    return DualQuat(
+    return {
                 a.x * b,
                 a.y * b,
                 a.z * b,
                 a.w * b
-                );
+                };
 }
 
 Base::DualQuat Base::operator*(Base::DualNumber a, Base::DualQuat b)
 {
-    return DualQuat(
+    return {
                 b.x * a,
                 b.y * a,
                 b.z * a,
                 b.w * a
-                );
+                };
 }
 
 Base::DualQuat::DualQuat(Base::DualQuat re, Base::DualQuat du)
@@ -136,7 +136,7 @@ Base::DualQuat Base::DualQuat::pow(double t, bool shorten) const
     double le = this->vec().length();
     if (le < 1e-12) {
         //special case of no rotation. Interpolate position
-        return DualQuat(this->real(), this->dual()*t);
+        return {this->real(), this->dual()*t};
     }
 
     double normmult = 1.0/le;
@@ -159,8 +159,8 @@ Base::DualQuat Base::DualQuat::pow(double t, bool shorten) const
     pitch *= t;
 
     //back to quaternion
-    return DualQuat(
+    return {
         l * sin(theta/2) + DualQuat(0,0,0,cos(theta/2)),
         m * sin(theta/2) + pitch / 2 * cos(theta/2) * l + DualQuat(0,0,0,-pitch/2*sin(theta/2))
-    );
+    };
 }

--- a/src/Base/DualQuaternion.h
+++ b/src/Base/DualQuaternion.h
@@ -60,19 +60,19 @@ public:
     DualQuat(DualQuat re, DualQuat du);
 
     ///returns dual quaternion for identity placement
-    static DualQuat identity() {return DualQuat(0.0, 0.0, 0.0, 1.0);}
+    static DualQuat identity() {return {0.0, 0.0, 0.0, 1.0};}
 
     ///return a copy with dual part zeroed out
-    DualQuat real() const {return DualQuat(x.re, y.re, z.re, w.re);}
+    DualQuat real() const {return {x.re, y.re, z.re, w.re};}
 
     ///return a real-only quaternion made from dual part of this quaternion.
-    DualQuat dual() const {return DualQuat(x.du, y.du, z.du, w.du);}
+    DualQuat dual() const {return {x.du, y.du, z.du, w.du};}
 
     ///conjugate
-    DualQuat conj() const {return DualQuat(-x, -y, -z, w);}
+    DualQuat conj() const {return {-x, -y, -z, w};}
 
     ///return vector part (with scalar part zeroed out)
-    DualQuat vec() const {return DualQuat(x,y,z,0.0);}
+    DualQuat vec() const {return {x,y,z,0.0};}
 
     ///magnitude of the quaternion
     double length() const {return sqrt(x.re*x.re + y.re*y.re + z.re*z.re + w.re*w.re);}
@@ -86,7 +86,7 @@ public:
     ///ScLERP. t=0.0 returns identity, t=1.0 returns this. t can also be outside of 0..1 bounds.
     DualQuat pow(double t, bool shorten = true) const;
 
-    DualQuat operator-() const {return DualQuat(-x, -y, -z, -w);}
+    DualQuat operator-() const {return {-x, -y, -z, -w};}
 
     //DEBUG
     //void print() const {

--- a/src/Base/FileInfo.cpp
+++ b/src/Base/FileInfo.cpp
@@ -295,7 +295,7 @@ std::string FileInfo::extension() const
 {
     std::string::size_type pos = FileName.find_last_of('.');
     if (pos == std::string::npos)
-        return std::string();
+        return {};
     return FileName.substr(pos+1);
 }
 
@@ -303,7 +303,7 @@ std::string FileInfo::completeExtension() const
 {
     std::string::size_type pos = FileName.find_first_of('.');
     if (pos == std::string::npos)
-        return std::string();
+        return {};
     return FileName.substr(pos+1);
 }
 

--- a/src/Base/Interpreter.cpp
+++ b/src/Base/Interpreter.cpp
@@ -243,7 +243,7 @@ std::string InterpreterSingleton::runString(const char *sCmd)
             throw SystemExitException();
         else {
             PyException::ThrowException();
-            return std::string(); // just to quieten code analyzers
+            return {}; // just to quieten code analyzers
             //throw PyException();
         }
     }
@@ -257,7 +257,7 @@ std::string InterpreterSingleton::runString(const char *sCmd)
     }
     else {
         PyErr_Clear();
-        return std::string();
+        return {};
     }
 }
 

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -980,16 +980,14 @@ std::string ParameterGrp::GetASCII(const char* Name, const char * pPreset) const
     // if not return preset
     if (!pcElem) {
         if (!pPreset)
-            return std::string("");
-        else
-            return std::string(pPreset);
+            return {};
+        return {pPreset};
     }
     // if yes check the value and return
     DOMNode *pcElem2 = pcElem->getFirstChild();
     if (pcElem2)
-        return std::string(StrXUTF8(pcElem2->getNodeValue()).c_str());
-    else
-        return std::string("");
+        return {StrXUTF8(pcElem2->getNodeValue()).c_str()};
+    return {};
 }
 
 std::vector<std::string> ParameterGrp::GetASCIIs(const char * sFilter) const
@@ -1517,7 +1515,7 @@ ParameterManager::~ParameterManager()
 
 Base::Reference<ParameterManager> ParameterManager::Create()
 {
-    return Base::Reference<ParameterManager>(new ParameterManager());
+    return {new ParameterManager()};
 }
 
 void ParameterManager::Init()

--- a/src/Base/PersistencePyImp.cpp
+++ b/src/Base/PersistencePyImp.cpp
@@ -37,7 +37,7 @@ using namespace Base;
 // returns a string which represent the object e.g. when printed in python
 std::string PersistencePy::representation() const
 {
-    return std::string("<persistence object>");
+    return {"<persistence object>"};
 }
 
 
@@ -48,7 +48,7 @@ Py::String PersistencePy::getContent() const
     writer.setForceXML(true);
     getPersistencePtr()->Save(writer);
 
-    return  Py::String (writer.getString());
+    return  {writer.getString()};
 }
 
 Py::Int PersistencePy::getMemSize() const

--- a/src/Base/Placement.cpp
+++ b/src/Base/Placement.cpp
@@ -60,7 +60,7 @@ Placement Placement::fromDualQuaternion(DualQuat qq)
 {
     Rotation rot(qq.x.re, qq.y.re, qq.z.re, qq.w.re);
     DualQuat mvq = 2 * qq.dual() * qq.real().conj();
-    return Placement(Vector3d(mvq.x.re,mvq.y.re, mvq.z.re), rot);
+    return {Vector3d(mvq.x.re,mvq.y.re, mvq.z.re), rot};
 }
 
 Base::Matrix4D Placement::toMatrix() const
@@ -217,7 +217,7 @@ Placement Placement::slerp(const Placement & p0, const Placement & p1, double t)
 {
     Rotation rot = Rotation::slerp(p0.getRotation(), p1.getRotation(), t);
     Vector3d pos = p0.getPosition() * (1.0-t) + p1.getPosition() * t;
-    return Placement(pos, rot);
+    return {pos, rot};
 }
 
 Placement Placement::sclerp(const Placement& p0, const Placement& p1, double t, bool shorten)

--- a/src/Base/PrecisionPyImp.cpp
+++ b/src/Base/PrecisionPyImp.cpp
@@ -33,7 +33,7 @@ using Base::PrecisionPy;
 // returns a string which represents the object e.g. when printed in python
 std::string PrecisionPy::representation() const
 {
-    return std::string("<Precision object>");
+    return {"<Precision object>"};
 }
 
 PyObject* PrecisionPy::angular(PyObject *args)

--- a/src/Base/QuantityPyImp.cpp
+++ b/src/Base/QuantityPyImp.cpp
@@ -604,7 +604,7 @@ void QuantityPy::setUnit(Py::Object arg)
 
 Py::String QuantityPy::getUserString() const
 {
-    return Py::String(getQuantityPtr()->getUserString().toUtf8(),"utf-8");
+    return {getQuantityPtr()->getUserString().toUtf8(),"utf-8"};
 }
 
 Py::Dict QuantityPy::getFormat() const

--- a/src/Base/Rotation.cpp
+++ b/src/Base/Rotation.cpp
@@ -535,12 +535,12 @@ Rotation Rotation::slerp(const Rotation & q0, const Rotation & q1, double t)
     double y = scale0 * q0.quat[1] + scale1 * q1.quat[1];
     double z = scale0 * q0.quat[2] + scale1 * q1.quat[2];
     double w = scale0 * q0.quat[3] + scale1 * q1.quat[3];
-    return Rotation(x, y, z, w);
+    return {x, y, z, w};
 }
 
 Rotation Rotation::identity()
 {
-    return Rotation(0.0, 0.0, 0.0, 1.0);
+    return {0.0, 0.0, 0.0, 1.0};
 }
 
 Rotation Rotation::makeRotationByAxes(Vector3d xdir, Vector3d ydir, Vector3d zdir, const char* priorityOrder)
@@ -684,7 +684,7 @@ Rotation Rotation::makeRotationByAxes(Vector3d xdir, Vector3d ydir, Vector3d zdi
         m[2][i] = finaldirs[i].z;
     }
 
-    return Rotation(m);
+    return {m};
 }
 
 void Rotation::setYawPitchRoll(double y, double p, double r)
@@ -848,12 +848,12 @@ EulerSequence_Parameters translateEulerSequence (const Rotation::EulerSequence t
 
     switch (theSeq)
     {
-    case Rotation::Extrinsic_XYZ: return Params (1, F, F, T);
-    case Rotation::Extrinsic_XZY: return Params (1, T, F, T);
-    case Rotation::Extrinsic_YZX: return Params (2, F, F, T);
-    case Rotation::Extrinsic_YXZ: return Params (2, T, F, T);
-    case Rotation::Extrinsic_ZXY: return Params (3, F, F, T);
-    case Rotation::Extrinsic_ZYX: return Params (3, T, F, T);
+    case Rotation::Extrinsic_XYZ: return {1, F, F, T};
+    case Rotation::Extrinsic_XZY: return {1, T, F, T};
+    case Rotation::Extrinsic_YZX: return {2, F, F, T};
+    case Rotation::Extrinsic_YXZ: return {2, T, F, T};
+    case Rotation::Extrinsic_ZXY: return {3, F, F, T};
+    case Rotation::Extrinsic_ZYX: return {3, T, F, T};
 
     // Conversion of intrinsic angles is made by the same code as for extrinsic,
     // using equivalence rule: intrinsic rotation is equivalent to extrinsic
@@ -861,30 +861,30 @@ EulerSequence_Parameters translateEulerSequence (const Rotation::EulerSequence t
     // Swapping of angles (Alpha <-> Gamma) is done inside conversion procedure;
     // sequence of axes is inverted by setting appropriate parameters here.
     // Note that proper Euler angles (last block below) are symmetric for sequence of axes.
-    case Rotation::Intrinsic_XYZ: return Params (3, T, F, F);
-    case Rotation::Intrinsic_XZY: return Params (2, F, F, F);
-    case Rotation::Intrinsic_YZX: return Params (1, T, F, F);
-    case Rotation::Intrinsic_YXZ: return Params (3, F, F, F);
-    case Rotation::Intrinsic_ZXY: return Params (2, T, F, F);
-    case Rotation::Intrinsic_ZYX: return Params (1, F, F, F);
+    case Rotation::Intrinsic_XYZ: return {3, T, F, F};
+    case Rotation::Intrinsic_XZY: return {2, F, F, F};
+    case Rotation::Intrinsic_YZX: return {1, T, F, F};
+    case Rotation::Intrinsic_YXZ: return {3, F, F, F};
+    case Rotation::Intrinsic_ZXY: return {2, T, F, F};
+    case Rotation::Intrinsic_ZYX: return {1, F, F, F};
 
-    case Rotation::Extrinsic_XYX: return Params (1, F, T, T);
-    case Rotation::Extrinsic_XZX: return Params (1, T, T, T);
-    case Rotation::Extrinsic_YZY: return Params (2, F, T, T);
-    case Rotation::Extrinsic_YXY: return Params (2, T, T, T);
-    case Rotation::Extrinsic_ZXZ: return Params (3, F, T, T);
-    case Rotation::Extrinsic_ZYZ: return Params (3, T, T, T);
+    case Rotation::Extrinsic_XYX: return {1, F, T, T};
+    case Rotation::Extrinsic_XZX: return {1, T, T, T};
+    case Rotation::Extrinsic_YZY: return {2, F, T, T};
+    case Rotation::Extrinsic_YXY: return {2, T, T, T};
+    case Rotation::Extrinsic_ZXZ: return {3, F, T, T};
+    case Rotation::Extrinsic_ZYZ: return {3, T, T, T};
 
-    case Rotation::Intrinsic_XYX: return Params (1, F, T, F);
-    case Rotation::Intrinsic_XZX: return Params (1, T, T, F);
-    case Rotation::Intrinsic_YZY: return Params (2, F, T, F);
-    case Rotation::Intrinsic_YXY: return Params (2, T, T, F);
-    case Rotation::Intrinsic_ZXZ: return Params (3, F, T, F);
-    case Rotation::Intrinsic_ZYZ: return Params (3, T, T, F);
+    case Rotation::Intrinsic_XYX: return {1, F, T, F};
+    case Rotation::Intrinsic_XZX: return {1, T, T, F};
+    case Rotation::Intrinsic_YZY: return {2, F, T, F};
+    case Rotation::Intrinsic_YXY: return {2, T, T, F};
+    case Rotation::Intrinsic_ZXZ: return {3, F, T, F};
+    case Rotation::Intrinsic_ZYZ: return {3, T, T, F};
 
     default:
-    case Rotation::EulerAngles : return Params (3, F, T, F); // = Intrinsic_ZXZ
-    case Rotation::YawPitchRoll: return Params (1, F, F, F); // = Intrinsic_ZYX
+    case Rotation::EulerAngles : return {3, F, T, F}; // = Intrinsic_ZXZ
+    case Rotation::YawPitchRoll: return {1, F, F, F}; // = Intrinsic_ZYX
     };
 }
 

--- a/src/Base/Stream.cpp
+++ b/src/Base/Stream.cpp
@@ -264,7 +264,7 @@ ByteArrayOStreambuf::seekoff(std::streambuf::off_type off,
             endpos = _buffer->size();
             break;
         default:
-            return pos_type(off_type(-1));
+            return {off_type(-1)};
     }
 
     if (endpos != curpos) {
@@ -272,7 +272,7 @@ ByteArrayOStreambuf::seekoff(std::streambuf::off_type off,
             endpos = -1;
     }
 
-    return pos_type(endpos);
+    return {endpos};
 }
 
 std::streambuf::pos_type
@@ -396,7 +396,7 @@ IODeviceOStreambuf::seekoff(std::streambuf::off_type off,
             endpos = device->size();
             break;
         default:
-            return pos_type(off_type(-1));
+            return {off_type(-1)};
     }
 
     if (endpos != curpos) {
@@ -404,7 +404,7 @@ IODeviceOStreambuf::seekoff(std::streambuf::off_type off,
             endpos = -1;
     }
 
-    return pos_type(endpos);
+    return {endpos};
 }
 
 std::streambuf::pos_type
@@ -496,7 +496,7 @@ IODeviceIStreambuf::seekoff(std::streambuf::off_type off,
             endpos = -1;
     }
 
-    return pos_type(endpos);
+    return {endpos};
 }
 
 std::streambuf::pos_type
@@ -696,7 +696,7 @@ PyStreambuf::seekoff(PyStreambuf::off_type offset, PyStreambuf::seekdir dir, PyS
         whence = 2;
         break;
     default:
-        return pos_type(off_type(-1));
+        return {off_type(-1)};
     }
 
     try {
@@ -715,7 +715,7 @@ PyStreambuf::seekoff(PyStreambuf::off_type offset, PyStreambuf::seekdir dir, PyS
     }
     catch(Py::Exception& e) {
         e.clear();
-        return pos_type(off_type(-1));
+        return {off_type(-1)};
     }
 }
 

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -86,12 +86,12 @@ inline std::ostream& blanksN(std::ostream& os, int n)
 
 inline manipulator<int> tabs(int n)
 {
-    return manipulator<int>(&tabsN, n);
+    return {&tabsN, n};
 }
 
 inline manipulator<int> blanks(int n)
 {
-    return manipulator<int>(&blanksN, n);
+    return {&blanksN, n};
 }
 
 // ----------------------------------------------------------------------------
@@ -263,7 +263,7 @@ struct BaseExport Tools
      */
     static inline std::string toStdString(const QString& s) {
         QByteArray tmp = s.toUtf8();
-        return std::string(tmp.constData(), static_cast<size_t>(tmp.size()));
+        return {tmp.constData(), static_cast<size_t>(tmp.size())};
     }
 
     /**

--- a/src/Base/Tools2D.cpp
+++ b/src/Base/Tools2D.cpp
@@ -245,7 +245,7 @@ Vector2d Line2d::FromPos (double fDistance) const
 {
   Vector2d clDir(clV2 - clV1);
   clDir.Normalize();
-  return Vector2d(clV1.x + (clDir.x * fDistance), clV1.y + (clDir.y * fDistance));
+  return {clV1.x + (clDir.x * fDistance), clV1.y + (clDir.y * fDistance)};
 }
 
 bool Line2d::IntersectAndContain (const Line2d& rclLine, Vector2d &rclV) const

--- a/src/Base/Tools2D.h
+++ b/src/Base/Tools2D.h
@@ -229,12 +229,12 @@ inline bool Vector2d::operator== (const Vector2d &v) const
 
 inline Vector2d Vector2d::operator+ () const
 {
-  return Vector2d(x, y);
+  return {x, y};
 }
 
 inline Vector2d Vector2d::operator+ (const Vector2d &v) const
 {
-  return Vector2d(x + v.x, y + v.y);
+  return {x + v.x, y + v.y};
 }
 
 inline Vector2d& Vector2d::operator+= (const Vector2d &v)
@@ -246,12 +246,12 @@ inline Vector2d& Vector2d::operator+= (const Vector2d &v)
 
 inline Vector2d Vector2d::operator- () const
 {
-  return Vector2d(-x, -y);
+  return {-x, -y};
 }
 
 inline Vector2d Vector2d::operator- (const Vector2d &v) const
 {
-  return Vector2d(x - v.x, y - v.y);
+  return {x - v.x, y - v.y};
 }
 
 inline Vector2d& Vector2d::operator-= (const Vector2d &v)
@@ -263,7 +263,7 @@ inline Vector2d& Vector2d::operator-= (const Vector2d &v)
 
 inline Vector2d Vector2d::operator* (double c) const
 {
-  return Vector2d(c * x, c * y);
+  return {c * x, c * y};
 }
 
 inline Vector2d& Vector2d::operator*= (double c)
@@ -280,12 +280,12 @@ inline double Vector2d::operator* (const Vector2d &v) const
 
 inline Vector2d operator* (double c, const Vector2d &v)
 {
-  return Vector2d(c * v.x, c * v.y);
+  return {c * v.x, c * v.y};
 }
 
 inline Vector2d Vector2d::operator/ (double c) const
 {
-  return Vector2d(x / c, y / c);
+  return {x / c, y / c};
 }
 
 inline Vector2d& Vector2d::operator/= (double c)
@@ -363,7 +363,7 @@ inline Vector2d Vector2d::Perpendicular(bool clockwise) const
 
 inline Vector2d Vector2d::FromPolar(double r, double fi)
 {
-  return Vector2d(r * cos(fi), r * sin(fi));
+  return {r * cos(fi), r * sin(fi)};
 }
 
 inline double Vector2d::Distance(const Vector2d& v) const
@@ -549,7 +549,7 @@ inline bool BoundBox2d::Contains(const Vector2d &v, double tolerance) const
 
 inline Vector2d BoundBox2d::GetCenter() const
 {
-  return Vector2d((MinX + MaxX) * 0.5, (MinY + MaxY) * 0.5);
+  return {(MinX + MaxX) * 0.5, (MinY + MaxY) * 0.5};
 }
 
 inline void BoundBox2d::SetVoid()

--- a/src/Base/Type.cpp
+++ b/src/Base/Type.cpp
@@ -125,9 +125,8 @@ string Type::getModuleName(const char* ClassName)
   std::string::size_type pos = temp.find_first_of("::");
 
   if (pos != std::string::npos)
-    return string(temp,0,pos);
-  else
-    return string();
+    return {temp,0,pos};
+  return {};
 }
 
 Type Type::badType()

--- a/src/Base/TypePyImp.cpp
+++ b/src/Base/TypePyImp.cpp
@@ -245,7 +245,7 @@ PyObject* TypePy::createInstanceByName (PyObject *args)
 
 Py::String TypePy::getName() const
 {
-    return Py::String(std::string(getBaseTypePtr()->getName()));
+    return {std::string(getBaseTypePtr()->getName())};
 }
 
 Py::Long TypePy::getKey() const
@@ -263,7 +263,7 @@ Py::String TypePy::getModule() const
     else
         module.clear();
 
-    return Py::String(module);
+    return {module};
 }
 
 PyObject *TypePy::getCustomAttributes(const char* /*attr*/) const

--- a/src/Base/Unit.cpp
+++ b/src/Base/Unit.cpp
@@ -258,7 +258,7 @@ QString Unit::getString() const
     std::stringstream ret;
 
     if (isEmpty())
-        return QString();
+        return {};
 
     if (Sig.Length                  > 0 ||
         Sig.Mass                    > 0 ||
@@ -551,7 +551,7 @@ QString Unit::getTypeString() const
     if (*this == Unit::YoungsModulus)
         return QString::fromLatin1("YoungsModulus");
 
-    return QString();
+    return {};
 }
 
 // SI base units

--- a/src/Base/UnitPyImp.cpp
+++ b/src/Base/UnitPyImp.cpp
@@ -213,7 +213,7 @@ PyObject* UnitPy::richCompare(PyObject *v, PyObject *w, int op)
 
 Py::String UnitPy::getType() const
 {
-    return Py::String(getUnitPtr()->getTypeString().toUtf8(),"utf-8");
+    return {getUnitPtr()->getTypeString().toUtf8(),"utf-8"};
 }
 
 Py::Tuple UnitPy::getSignature() const

--- a/src/Base/UnitsSchema.h
+++ b/src/Base/UnitsSchema.h
@@ -73,7 +73,7 @@ public:
     virtual bool isMultiUnitAngle() const {return false;}
 
     //return the basic length unit for this schema
-    virtual std::string getBasicLengthUnit() const { return std::string("mm"); }
+    virtual std::string getBasicLengthUnit() const { return {"mm"}; }
 };
 
 

--- a/src/Base/UnitsSchemaCentimeters.h
+++ b/src/Base/UnitsSchemaCentimeters.h
@@ -38,7 +38,7 @@ class UnitsSchemaCentimeters: public UnitsSchema
 public:
     QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString) override;
 
-    std::string getBasicLengthUnit() const override { return std::string("cm"); }
+    std::string getBasicLengthUnit() const override { return {"cm"}; }
 };
 
 } // namespace Base

--- a/src/Base/UnitsSchemaImperial1.h
+++ b/src/Base/UnitsSchemaImperial1.h
@@ -41,7 +41,7 @@ public:
     //virtual void setSchemaUnits(void);
     //virtual void resetSchemaUnits(void);
     QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString) override;
-    std::string getBasicLengthUnit() const override { return std::string("in"); }
+    std::string getBasicLengthUnit() const override { return {"in"}; }
 };
 
 /** The schema class for the imperial unit system
@@ -54,7 +54,7 @@ public:
     //virtual void setSchemaUnits(void);
     //virtual void resetSchemaUnits(void);
     QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString) override;
-    std::string getBasicLengthUnit() const override { return std::string("in"); }
+    std::string getBasicLengthUnit() const override { return {"in"}; }
 };
 
 /** The schema class for the imperial unit system
@@ -67,7 +67,7 @@ public:
     //virtual void setSchemaUnits(void);
     //virtual void resetSchemaUnits(void);
     QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString) override;
-    std::string getBasicLengthUnit() const override { return std::string("ft"); }
+    std::string getBasicLengthUnit() const override { return {"ft"}; }
 
     //return true if this schema uses multiple units for length (ex. Ft/In)
     bool isMultiUnitLength() const override {return true;}
@@ -84,7 +84,7 @@ public:
     //virtual void setSchemaUnits(void);
     //virtual void resetSchemaUnits(void);
     QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString) override;
-    std::string getBasicLengthUnit() const override { return std::string("ft"); }
+    std::string getBasicLengthUnit() const override { return {"ft"}; }
 
     //return true if this schema uses multiple units for angles (ex. DMS)
     bool isMultiUnitAngle() const override {return true;}

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1573,7 +1573,7 @@ QPixmap Application::workbenchIcon(const QString& wb) const
         if (!s.isEmpty())
             return icon.pixmap(s[0]);
     }
-    return QPixmap();
+    return {};
 }
 
 QString Application::workbenchToolTip(const QString& wb) const
@@ -1597,7 +1597,7 @@ QString Application::workbenchToolTip(const QString& wb) const
         }
     }
 
-    return QString();
+    return {};
 }
 
 QString Application::workbenchMenuText(const QString& wb) const
@@ -1622,7 +1622,7 @@ QString Application::workbenchMenuText(const QString& wb) const
         }
     }
 
-    return QString();
+    return {};
 }
 
 QStringList Application::workbenches() const

--- a/src/Gui/BitmapFactory.cpp
+++ b/src/Gui/BitmapFactory.cpp
@@ -239,7 +239,7 @@ bool BitmapFactoryInst::loadPixmap(const QString& filename, QPixmap& icon) const
 QPixmap BitmapFactoryInst::pixmap(const char* name) const
 {
     if (!name || *name == '\0')
-        return QPixmap();
+        return {};
 
     // as very first test check whether the pixmap is in the cache
     QMap<std::string, QPixmap>::Iterator it = d->xpmCache.find(name);

--- a/src/Gui/Camera.cpp
+++ b/src/Gui/Camera.cpp
@@ -95,34 +95,34 @@ vz.z=0
 
 SbRotation Camera::top()
 {
-    return SbRotation(0, 0, 0, 1);
+    return {0, 0, 0, 1};
 }
 
 SbRotation Camera::bottom()
 {
-    return SbRotation(1, 0, 0, 0);
+    return {1, 0, 0, 0};
 }
 
 SbRotation Camera::front()
 {
     auto root = (float)(sqrt(2.0)/2.0);
-    return SbRotation(root, 0, 0, root);
+    return {root, 0, 0, root};
 }
 
 SbRotation Camera::rear()
 {
     auto root = (float)(sqrt(2.0)/2.0);
-    return SbRotation(0, root, root, 0);
+    return {0, root, root, 0};
 }
 
 SbRotation Camera::right()
 {
-    return SbRotation(0.5, 0.5, 0.5, 0.5);
+    return {0.5, 0.5, 0.5, 0.5};
 }
 
 SbRotation Camera::left()
 {
-    return SbRotation(-0.5, 0.5, 0.5, -0.5);
+    return {-0.5, 0.5, 0.5, -0.5};
 }
 
 SbRotation Camera::isometric()
@@ -146,17 +146,17 @@ SbRotation Camera::isometric()
     //#p3=App.Rotation(App.Vector(1,1,0),45)
     //p3=App.Rotation(App.Vector(1,1,0),degrees(asin(-sqrt(1.0/3.0))))
     //p4=p3.multiply(p2).multiply(p1)
-    return SbRotation(0.424708f, 0.17592f, 0.339851f, 0.820473f);
+    return {0.424708F, 0.17592F, 0.339851F, 0.820473F};
 }
 
 SbRotation Camera::dimetric()
 {
-    return SbRotation(0.567952f, 0.103751f, 0.146726f, 0.803205f);
+    return {0.567952F, 0.103751F, 0.146726F, 0.803205F};
 }
 
 SbRotation Camera::trimetric()
 {
-    return SbRotation(0.446015f, 0.119509f, 0.229575f, 0.856787f);
+    return {0.446015F, 0.119509F, 0.229575F, 0.856787F};
 }
 
 SbRotation Camera::rotation(Camera::Orientation view)

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -579,7 +579,7 @@ std::string Command::getObjectCmd(const char *Name, const App::Document *doc,
 {
     if(!doc) doc = App::GetApplication().getActiveDocument();
     if(!doc || !Name)
-        return std::string("None");
+        return {"None"};
     std::ostringstream str;
     if(prefix)
         str << prefix;
@@ -594,7 +594,7 @@ std::string Command::getObjectCmd(const App::DocumentObject *obj,
         const char *prefix, const char *postfix, bool gui)
 {
     if(!obj || !obj->getNameInDocument())
-        return std::string("None");
+        return {"None"};
     return getObjectCmd(obj->getNameInDocument(), obj->getDocument(), prefix, postfix,gui);
 }
 

--- a/src/Gui/CommandCompleter.cpp
+++ b/src/Gui/CommandCompleter.cpp
@@ -87,13 +87,13 @@ public:
 
     QModelIndex parent(const QModelIndex &) const override
     {
-        return QModelIndex();
+        return {};
     }
 
     QVariant data(const QModelIndex & index, int role) const override
     {
         if (index.row() < 0 || index.row() >= (int)_Commands.size())
-            return QVariant();
+            return {};
 
         auto &info = _Commands[index.row()];
 
@@ -125,7 +125,7 @@ public:
         default:
             break;
         }
-        return QVariant();
+        return {};
     }
 
     QModelIndex index(int row, int, const QModelIndex &) const override

--- a/src/Gui/CommandPyImp.cpp
+++ b/src/Gui/CommandPyImp.cpp
@@ -44,7 +44,7 @@
 // returns a string which represents the object e.g. when printed in python
 std::string CommandPy::representation() const
 {
-    return std::string("<Command object>");
+    return {"<Command object>"};
 }
 
 PyObject* CommandPy::get(PyObject *args)

--- a/src/Gui/DlgCheckableMessageBox.cpp
+++ b/src/Gui/DlgCheckableMessageBox.cpp
@@ -61,7 +61,7 @@ QPixmap getStandardIcon(QWidget* widget, QStyle::StandardPixmap standardPixmap)
 #endif
     }
 
-    return QPixmap();
+    return {};
 }
 
 void DlgCheckableMessageBox::showMessage(const QString& header, const QString& message, bool check, const QString& checkText)

--- a/src/Gui/DlgCustomizeSpaceball.cpp
+++ b/src/Gui/DlgCustomizeSpaceball.cpp
@@ -202,21 +202,21 @@ QVariant ButtonModel::data (const QModelIndex &index, int role) const
     if (index.row() >= (int)groupVector.size())
     {
         Base::Console().Log("index error in ButtonModel::data\n");
-        return QVariant();
+        return {};
     }
     if (role == Qt::DisplayRole)
-        return QVariant(getLabel(index.row()));
+        return {getLabel(index.row())};
     if (role == Qt::DecorationRole)
     {
         static QPixmap icon(BitmapFactory().pixmap("spaceball_button").scaled
                             (32, 32, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-        return QVariant(icon);
+        return {icon};
     }
     if (role == Qt::UserRole)
-        return QVariant(QString::fromStdString(groupVector.at(index.row())->GetASCII("Command")));
+        return {QString::fromStdString(groupVector.at(index.row())->GetASCII("Command"))};
     if (role == Qt::SizeHintRole)
-        return QVariant(QSize(32, 32));
-    return QVariant();
+        return {QSize(32, 32)};
+    return {};
 }
 
 void ButtonModel::insertButtonRows(int number)
@@ -336,10 +336,12 @@ void CommandView::goClicked(const QModelIndex &index)
 
 CommandNode::CommandNode(NodeType typeIn)
 {
+    //NOLINTBEGIN
     nodeType = typeIn;
     parent = nullptr;
     children.clear();
     aCommand = nullptr;
+    //NOLINTEND
 }
 
 CommandNode::~CommandNode()
@@ -351,8 +353,10 @@ CommandNode::~CommandNode()
 
 CommandModel::CommandModel(QObject *parent) : QAbstractItemModel(parent)
 {
+    //NOLINTBEGIN
     rootNode = nullptr;
     initialize();
+    //NOLINTEND
 }
 
 CommandModel::~CommandModel()
@@ -364,13 +368,13 @@ CommandModel::~CommandModel()
 QModelIndex CommandModel::index(int row, int column, const QModelIndex &parent) const
 {
     if (!rootNode)
-        return QModelIndex();
+        return {};
     if (!parent.isValid())
         return createIndex(row, column, rootNode->children.at(row));
 
     CommandNode *parentNode = nodeFromIndex(parent);
     if (!parentNode)
-        return QModelIndex();
+        return {};
     return createIndex(row, column, parentNode->children.at(row));
 }
 
@@ -378,17 +382,17 @@ QModelIndex CommandModel::parent(const QModelIndex &index) const
 {
     CommandNode *base = nodeFromIndex(index);
     if (!base)
-        return QModelIndex();
+        return {};
     CommandNode *parentNode = base->parent;
     if (!parentNode)
-        return QModelIndex();
+        return {};
     CommandNode *grandParentNode = parentNode->parent;
     if (!grandParentNode)
-        return QModelIndex();
+        return {};
 
     int row = grandParentNode->children.indexOf(parentNode);
     if (row == -1)
-        return QModelIndex();
+        return {};
     return createIndex(row, index.column(), parentNode);
 }
 
@@ -413,19 +417,19 @@ QVariant CommandModel::data(const QModelIndex &index, int role) const
 {
     CommandNode *node = nodeFromIndex(index);
     if (!node)
-        return QVariant();
+        return {};
     if (role == Qt::DisplayRole)
     {
         if (node->nodeType == CommandNode::CommandType)
-            return QVariant(qApp->translate(node->aCommand->className(), node->aCommand->getMenuText()));
+            return {qApp->translate(node->aCommand->className(), node->aCommand->getMenuText())};
         if (node->nodeType == CommandNode::GroupType)
         {
             if (node->children.empty())
-                return QVariant();
+                return {};
             CommandNode *childNode = node->children.at(0);
-            return QVariant(childNode->aCommand->translatedGroupName());
+            return {qApp->translate(childNode->aCommand->className(), childNode->aCommand->getGroupName())};
         }
-        return QVariant();
+        return {};
     }
     if (role == Qt::DecorationRole)
     {
@@ -436,33 +440,35 @@ QVariant CommandModel::data(const QModelIndex &index, int role) const
                                 (32, 32, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
         }
     }
-    if (role == Qt::SizeHintRole)
+    if (role == Qt::SizeHintRole) {
         if (node->nodeType == CommandNode::CommandType)
-            return QVariant(QSize(32, 32));
+            return {QSize(32, 32)};
+    }
     if (role == Qt::UserRole)
     {
         if (node->nodeType == CommandNode::CommandType)
-            return QVariant(QString::fromLatin1(node->aCommand->getName()));
+            return {QString::fromLatin1(node->aCommand->getName())};
         if (node->nodeType == CommandNode::GroupType)
         {
             if (node->children.empty())
-                return QVariant();
+                return {};
             CommandNode *childNode = node->children.at(0);
-            return QVariant(QString::fromLatin1(childNode->aCommand->getGroupName()));
+            return {QString::fromLatin1(childNode->aCommand->getGroupName())};
         }
-        return QVariant();
+        return {};
     }
-    if (role == Qt::ToolTipRole)
+    if (role == Qt::ToolTipRole) {
         if (node->nodeType == CommandNode::CommandType)
-            return QVariant(QString::fromLatin1(node->aCommand->getToolTipText()));
-    return QVariant();
+            return {QString::fromLatin1(node->aCommand->getToolTipText())};
+    }
+    return {};
 }
 
 QVariant CommandModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
     if (role == Qt::DisplayRole && orientation == Qt::Horizontal && section == 0)
-        return QVariant(tr("Commands"));
-    return QVariant();
+        return {tr("Commands")};
+    return {};
 }
 
 Qt::ItemFlags CommandModel::flags (const QModelIndex &index) const
@@ -596,8 +602,10 @@ QStringList CommandModel::orderedGroups()
 
 PrintModel::PrintModel(QObject *parent, ButtonModel *buttonModelIn, CommandModel *commandModelIn) : QAbstractTableModel(parent)
 {
+    //NOLINTBEGIN
     buttonModel = buttonModelIn;
     commandModel = commandModelIn;
+    //NOLINTEND
 }
 
 int PrintModel::rowCount(const QModelIndex &parent) const
@@ -625,28 +633,28 @@ QVariant PrintModel::data(const QModelIndex &index, int role) const
         //command column;
         QString commandName(buttonModel->data(buttonModel->index(index.row(), 0), Qt::UserRole).toString());
         if (commandName.isEmpty())
-            return (QVariant());
+            return {};
 
         QModelIndexList indexList(commandModel->match(commandModel->index(0,0), Qt::UserRole, QVariant(commandName), 1,
                                                    Qt::MatchWrap | Qt::MatchRecursive));
         if (indexList.isEmpty())
-            return QVariant();
+            return {};
 
         return commandModel->data(indexList.at(0), role);
     }
-    return QVariant();
+    return {};
 }
 
 QVariant PrintModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
     if (role != Qt::DisplayRole || orientation != Qt::Horizontal)
-        return QVariant();
+        return {};
     if (section == 0)
-        return QVariant(tr("Button"));
+        return {tr("Button")};
     if (section == 1)
-        return QVariant(tr("Command"));
+        return {tr("Command")};
     else
-        return QVariant();
+        return {};
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/src/Gui/DlgPropertyLink.cpp
+++ b/src/Gui/DlgPropertyLink.cpp
@@ -187,7 +187,7 @@ static inline bool isLinkSub(const QList<App::SubObjectT>& links)
 QString DlgPropertyLink::formatLinks(App::Document *ownerDoc, QList<App::SubObjectT> links)
 {
     if(!ownerDoc || links.empty())
-        return QString();
+        return {};
 
     auto obj = links.front().getObject();
     if(!obj)

--- a/src/Gui/DlgSettingsImageImp.cpp
+++ b/src/Gui/DlgSettingsImageImp.cpp
@@ -131,7 +131,7 @@ void DlgSettingsImageImp::setImageSize( const QSize& s )
  */
 QSize DlgSettingsImageImp::imageSize() const
 {
-    return QSize( ui->spinWidth->value(), ui->spinHeight->value() );
+    return { ui->spinWidth->value(), ui->spinHeight->value() };
 }
 
 /**
@@ -157,7 +157,7 @@ int DlgSettingsImageImp::imageHeight() const
 QString DlgSettingsImageImp::comment() const
 {
     if ( !ui->textEditComment->isEnabled() )
-        return QString();
+        return {};
     else
         return ui->textEditComment->toPlainText();
 }

--- a/src/Gui/DocumentModel.cpp
+++ b/src/Gui/DocumentModel.cpp
@@ -82,7 +82,7 @@ namespace Gui {
         virtual QVariant data(int role) const
         {
             Q_UNUSED(role);
-            return QVariant();
+            return {};
         }
         virtual bool setData (const QVariant & value, int role)
         {
@@ -199,7 +199,7 @@ namespace Gui {
         else if (role == Qt::DisplayRole) {
             return DocumentModel::tr("Application");
         }
-        return QVariant();
+        return {};
     }
 
     // ------------------------------------------------------------------------
@@ -271,7 +271,7 @@ namespace Gui {
             return static_cast<QVariant>(font);
         }
 
-        return QVariant();
+        return {};
     }
 
     // ------------------------------------------------------------------------
@@ -326,7 +326,7 @@ namespace Gui {
             return static_cast<QVariant>(font);
         }
 
-        return QVariant();
+        return {};
     }
 
     // ------------------------------------------------------------------------
@@ -608,7 +608,7 @@ int DocumentModel::columnCount (const QModelIndex & /*parent*/) const
 QVariant DocumentModel::data (const QModelIndex & index, int role) const
 {
     if (!index.isValid())
-        return QVariant();
+        return {};
     return static_cast<DocumentModelIndex*>(index.internalPointer())->data(role);
 }
 
@@ -625,7 +625,7 @@ Qt::ItemFlags DocumentModel::flags(const QModelIndex &index) const
     //    return Qt::ItemIsEnabled;
     //return QAbstractItemModel::flags(index);
     if (!index.isValid())
-        return Qt::ItemFlags();
+        return {};
     return static_cast<DocumentModelIndex*>(index.internalPointer())->flags();
 }
 
@@ -637,14 +637,14 @@ QModelIndex DocumentModel::index (int row, int column, const QModelIndex & paren
     else
         item = static_cast<DocumentModelIndex*>(parent.internalPointer())->child(row);
     if (!item)
-        return QModelIndex();
+        return {};
     return createIndex(row, column, item);
 }
 
 QModelIndex DocumentModel::parent (const QModelIndex & index) const
 {
     if (!index.isValid() || index.internalPointer() == d->rootItem)
-        return QModelIndex();
+        return {};
     DocumentModelIndex* item = nullptr;
     item = static_cast<DocumentModelIndex*>(index.internalPointer());
     DocumentModelIndex* parent = item->parent();
@@ -665,11 +665,11 @@ QVariant DocumentModel::headerData (int section, Qt::Orientation orientation, in
     Q_UNUSED(section);
     if (orientation == Qt::Horizontal) {
         if (role != Qt::DisplayRole)
-            return QVariant();
+            return {};
         return tr("Labels & Attributes");
     }
 
-    return QVariant();
+    return {};
 }
 
 bool DocumentModel::setHeaderData (int, Qt::Orientation, const QVariant &, int)

--- a/src/Gui/DocumentPyImp.cpp
+++ b/src/Gui/DocumentPyImp.cpp
@@ -496,12 +496,12 @@ Py::Int DocumentPy::getEditMode() const
 
 Py::Boolean DocumentPy::getTransacting() const
 {
-    return Py::Boolean(getDocumentPtr()->isPerformingTransaction());
+    return {getDocumentPtr()->isPerformingTransaction()};
 }
 
 Py::Boolean DocumentPy::getModified() const
 {
-    return Py::Boolean(getDocumentPtr()->isModified());
+    return {getDocumentPtr()->isModified()};
 }
 
 PyObject *DocumentPy::getCustomAttributes(const char* attr) const

--- a/src/Gui/DownloadManager.cpp
+++ b/src/Gui/DownloadManager.cpp
@@ -310,11 +310,11 @@ DownloadModel::DownloadModel(DownloadManager *downloadManager, QObject *parent)
 QVariant DownloadModel::data(const QModelIndex &index, int role) const
 {
     if (index.row() < 0 || index.row() >= rowCount(index.parent()))
-        return QVariant();
+        return {};
     if (role == Qt::ToolTipRole)
         if (!m_downloadManager->m_downloads.at(index.row())->downloadedSuccessfully())
             return m_downloadManager->m_downloads.at(index.row())->downloadInfoLabel->text();
-    return QVariant();
+    return {};
 }
 
 int DownloadModel::rowCount(const QModelIndex &parent) const

--- a/src/Gui/ExpressionBinding.cpp
+++ b/src/Gui/ExpressionBinding.cpp
@@ -160,7 +160,7 @@ std::string ExpressionBinding::getExpressionString(bool no_throw) const
         else
             throw;
     }
-    return std::string();
+    return {};
 }
 
 std::string ExpressionBinding::getEscapedExpressionString() const

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -250,7 +250,7 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override
     {
         if (role != Qt::EditRole && role != Qt::DisplayRole && role != Qt::UserRole)
-            return QVariant();
+            return {};
         QVariant variant;
         Info info = getInfo(index);
         _data(info, index.row(), &variant, nullptr, role == Qt::UserRole);
@@ -491,7 +491,7 @@ public:
 
     QModelIndex parent(const QModelIndex & index) const override {
         if (!index.isValid())
-            return QModelIndex();
+            return {};
 
         Info parentInfo = getInfo(index);
         Info grandParentInfo = parentInfo;
@@ -524,7 +524,7 @@ public:
         }
 
 
-        return QModelIndex();
+        return {};
     }
 
     // returns true if successful, false if 'element' identifies a Leaf
@@ -597,13 +597,13 @@ public:
     QModelIndex index(int row, int column,
         const QModelIndex & parent = QModelIndex()) const override {
         if (row < 0)
-            return QModelIndex();
+            return {};
         Info myParentInfoEncoded = Info::root;
 
         // encode the parent's QModelIndex into an 'Info' structure
         bool parentCanHaveChildren = modelIndexToParentInfo(parent, myParentInfoEncoded);
         if (!parentCanHaveChildren) {
-            return QModelIndex();
+            return {};
         }
         return createIndex(row, column, infoId(myParentInfoEncoded));
     }
@@ -695,7 +695,7 @@ QString ExpressionCompleter::pathFromIndex(const QModelIndex& index) const
 {
     auto m = model();
     if (!m || !index.isValid())
-        return QString();
+        return {};
 
     QString res;
     auto parent = index;

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -245,7 +245,7 @@ QString FileDialog::getSaveFileName (QWidget * parent, const QString & caption, 
         setWorkingDirectory(file);
         return file;
     } else {
-        return QString();
+        return {};
     }
 }
 
@@ -314,7 +314,7 @@ QString FileDialog::getOpenFileName(QWidget * parent, const QString & caption, c
         setWorkingDirectory(file);
         return file;
     } else {
-        return QString();
+        return {};
     }
 }
 

--- a/src/Gui/Flag.cpp
+++ b/src/Gui/Flag.cpp
@@ -183,7 +183,7 @@ QSize Flag::sizeHint() const
     QRect r = metric.boundingRect(text);
     w = std::max<int>(w, r.width()+20);
     h = std::max<int>(h, r.height());
-    return QSize(w, h);
+    return {w, h};
 }
 
 // ------------------------------------------------------------------------

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -415,7 +415,7 @@ QByteArray GraphvizView::exportGraph(const QString& format)
     dotProc.setEnvironment(QProcess::systemEnvironment());
     dotProc.start(exe, args);
     if (!dotProc.waitForStarted()) {
-        return QByteArray();
+        return {};
     }
 
     ParameterGrp::handle depGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/DependencyGraph");
@@ -423,12 +423,12 @@ QByteArray GraphvizView::exportGraph(const QString& format)
         flatProc.setEnvironment(QProcess::systemEnvironment());
         flatProc.start(unflatten, flatArgs);
         if (!flatProc.waitForStarted()) {
-            return QByteArray();
+            return {};
         }
         flatProc.write(graphCode.c_str(), graphCode.size());
         flatProc.closeWriteChannel();
         if (!flatProc.waitForFinished())
-            return QByteArray();
+            return {};
 
         dotProc.write(flatProc.readAll());
     }
@@ -437,7 +437,7 @@ QByteArray GraphvizView::exportGraph(const QString& format)
 
     dotProc.closeWriteChannel();
     if (!dotProc.waitForFinished())
-        return QByteArray();
+        return {};
 
     return dotProc.readAll();
 }

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -416,7 +416,7 @@ QByteArray InputField::paramGrpPath() const
 {
     if(_handle.isValid())
         return sGroupString.c_str();
-    return QByteArray();
+    return {};
 }
 
 /// sets the field with a quantity
@@ -567,7 +567,7 @@ void InputField::setPrecision(const int precision)
 
 QString InputField::getFormat() const
 {
-    return QString(QChar::fromLatin1(actQuantity.getFormat().toFormat()));
+    return {QChar::fromLatin1(actQuantity.getFormat().toFormat())};
 }
 
 void InputField::setFormat(const QString& format)

--- a/src/Gui/InputVector.cpp
+++ b/src/Gui/InputVector.cpp
@@ -85,7 +85,7 @@ LocationWidget::~LocationWidget()
 
 QSize LocationWidget::sizeHint() const
 {
-    return QSize(150,100);
+    return {150,100};
 }
 
 void LocationWidget::changeEvent(QEvent* e)

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -341,7 +341,7 @@ QStringList MDIView::redoActions() const
 
 QSize MDIView::minimumSizeHint () const
 {
-    return QSize(400, 300);
+    return {400, 300};
 }
 
 void MDIView::changeEvent(QEvent *e)

--- a/src/Gui/ManualAlignment.cpp
+++ b/src/Gui/ManualAlignment.cpp
@@ -609,7 +609,7 @@ public:
         Base::Vector3d pln_base;
         rot.multVec(plane1_base,pln_base);
         Base::Vector3d dif = plane2_base - pln_base;
-        return Base::Placement(dif, rot);
+        return {dif, rot};
     }
 
     static Base::Placement

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -878,7 +878,7 @@ SbVec3f NavigationStyle::getFocalPoint() const
 {
     SoCamera* cam = viewer->getSoRenderManager()->getCamera();
     if (!cam)
-        return SbVec3f(0,0,0);
+        return {0,0,0};
 
     // Find global coordinates of focal point.
     SbVec3f direction;
@@ -1105,16 +1105,16 @@ SbVec2f NavigationStyle::normalizePixelPos(SbVec2s pixpos)
 {
     const SbViewportRegion & vp = viewer->getSoRenderManager()->getViewportRegion();
     const SbVec2s size(vp.getViewportSizePixels());
-    return SbVec2f ((float) pixpos[0] / (float) std::max((int)(size[0] - 1), 1),
-                    (float) pixpos[1] / (float) std::max((int)(size[1] - 1), 1));
+    return {(float) pixpos[0] / (float) std::max((int)(size[0] - 1), 1),
+            (float) pixpos[1] / (float) std::max((int)(size[1] - 1), 1)};
 }
 
 SbVec2f NavigationStyle::normalizePixelPos(SbVec2f pixpos)
 {
     const SbViewportRegion & vp = viewer->getSoRenderManager()->getViewportRegion();
     const SbVec2s size(vp.getViewportSizePixels());
-    return SbVec2f ( pixpos[0] / (float) std::max((int)(size[0] - 1), 1),
-                     pixpos[1] / (float) std::max((int)(size[1] - 1), 1));
+    return {pixpos[0] / (float) std::max((int)(size[0] - 1), 1),
+            pixpos[1] / (float) std::max((int)(size[1] - 1), 1)};
 }
 
 void NavigationStyle::moveCursorPosition()

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -353,7 +353,7 @@ public:
             return font;
         }
 
-        return QVariant();
+        return {};
     }
 
     Base::LogStyle notificationType;

--- a/src/Gui/NotificationBox.cpp
+++ b/src/Gui/NotificationBox.cpp
@@ -392,7 +392,7 @@ QString NotificationBox::text()
 {
     if (NotificationLabel::instance)
         return NotificationLabel::instance->text();
-    return QString();
+    return {};
 }
 
 Q_GLOBAL_STATIC(QPalette, notificationbox_palette)

--- a/src/Gui/PythonDebugger.cpp
+++ b/src/Gui/PythonDebugger.cpp
@@ -394,7 +394,7 @@ Breakpoint PythonDebugger::getBreakpoint(const QString& fn) const
         }
     }
 
-    return Breakpoint();
+    return {};
 }
 
 bool PythonDebugger::toggleBreakpoint(int line, const QString& fn)

--- a/src/Gui/PythonWorkbenchPyImp.cpp
+++ b/src/Gui/PythonWorkbenchPyImp.cpp
@@ -42,7 +42,7 @@ using namespace Gui;
 // returns a string which represent the object e.g. when printed in python
 std::string PythonWorkbenchPy::representation() const
 {
-    return std::string("<Workbench object>");
+    return {"<Workbench object>"};
 }
 
 /** Appends a new menu */

--- a/src/Gui/QSint/actionpanel/actionbox.cpp
+++ b/src/Gui/QSint/actionpanel/actionbox.cpp
@@ -232,7 +232,7 @@ void ActionBox::addWidget(QWidget * w, QLayout * l)
 
 QSize ActionBox::minimumSizeHint() const
 {
-    return QSize(150,65);
+    return {150,65};
 }
 
 

--- a/src/Gui/QSint/actionpanel/actiongroup.cpp
+++ b/src/Gui/QSint/actionpanel/actiongroup.cpp
@@ -251,7 +251,7 @@ void ActionGroup::setHeaderText(const QString & headerText)
 
 QSize ActionGroup::minimumSizeHint() const
 {
-    return QSize(200,65);
+    return {200,65};
 }
 
 

--- a/src/Gui/QSint/actionpanel/actionpanel.cpp
+++ b/src/Gui/QSint/actionpanel/actionpanel.cpp
@@ -113,7 +113,7 @@ ActionGroup * ActionPanel::createGroup(const QPixmap &icon, const QString &title
 
 QSize ActionPanel::minimumSizeHint() const
 {
-    return QSize(200,150);
+    return {200,150};
 }
 
 

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -311,7 +311,7 @@ QString QuantitySpinBox::boundToName() const
         std::string path = getPath().toString();
         return QString::fromStdString(path);
     }
-    return QString();
+    return {};
 }
 
 /**
@@ -374,7 +374,7 @@ QString Gui::QuantitySpinBox::expressionText() const
     catch (const Base::Exception& e) {
         qDebug() << e.what();
     }
-    return QString();
+    return {};
 }
 
 void QuantitySpinBox::evaluateExpression()

--- a/src/Gui/Quarter/QuarterWidget.cpp
+++ b/src/Gui/Quarter/QuarterWidget.cpp
@@ -1062,10 +1062,10 @@ QuarterWidget::backgroundColor() const
 {
   SbColor4f bg = PRIVATE(this)->sorendermanager->getBackgroundColor();
 
-  return QColor(SbClamp(int(bg[0] * 255.0), 0, 255),
+  return {SbClamp(int(bg[0] * 255.0), 0, 255),
                 SbClamp(int(bg[1] * 255.0), 0, 255),
                 SbClamp(int(bg[2] * 255.0), 0, 255),
-                SbClamp(int(bg[3] * 255.0), 0, 255));
+                SbClamp(int(bg[3] * 255.0), 0, 255)};
 }
 
 /*!
@@ -1142,7 +1142,7 @@ QuarterWidget::removeStateMachine(SoScXMLStateMachine * statemachine)
 QSize
 QuarterWidget::minimumSizeHint() const
 {
-  return QSize(50, 50);
+  return {50, 50};
 }
 
 /*!  Returns a list of grouped actions that corresponds to the

--- a/src/Gui/Quarter/SoQTQuarterAdaptor.cpp
+++ b/src/Gui/Quarter/SoQTQuarterAdaptor.cpp
@@ -754,7 +754,7 @@ SbVec2f SIM::Coin3D::Quarter::SoQTQuarterAdaptor::addFrametime(double starttime)
     this->frametime = (frametime*FPS_FACTOR) + this->frametime*(1.0-FPS_FACTOR);
 
     this->starttime = timeofday;
-    return SbVec2f(1000 * this->drawtime, 1.0f / this->frametime);
+    return {1000 * float(this->drawtime), 1.0F / float(this->frametime)};
 }
 
 #include "moc_SoQTQuarterAdaptor.cpp"

--- a/src/Gui/SceneInspector.cpp
+++ b/src/Gui/SceneInspector.cpp
@@ -64,14 +64,14 @@ QVariant SceneModel::headerData (int section, Qt::Orientation orientation, int r
 {
     if (orientation == Qt::Horizontal) {
         if (role != Qt::DisplayRole)
-            return QVariant();
+            return {};
         if (section == 0)
             return tr("Inventor Tree");
         else if (section == 1)
             return tr("Name");
     }
 
-    return QVariant();
+    return {};
 }
 
 bool SceneModel::setHeaderData (int, Qt::Orientation, const QVariant &, int)

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -518,7 +518,7 @@ std::vector<App::DocumentObject*> SelectionSingleton::getObjectsOfType(const cha
 {
     Base::Type typeId = Base::Type::fromName(typeName);
     if (typeId == Base::Type::badType())
-        return std::vector<App::DocumentObject*>();
+        return {};
     return getObjectsOfType(typeId, pDocName, resolve);
 }
 

--- a/src/Gui/SelectionObjectPyImp.cpp
+++ b/src/Gui/SelectionObjectPyImp.cpp
@@ -70,7 +70,7 @@ PyObject* SelectionObjectPy::isObjectTypeOf(PyObject * args)
 
 Py::String SelectionObjectPy::getObjectName() const
 {
-    return Py::String(getSelectionObjectPtr()->getFeatName());
+    return {getSelectionObjectPtr()->getFeatName()};
 }
 
 Py::Tuple SelectionObjectPy::getSubElementNames() const
@@ -87,17 +87,17 @@ Py::Tuple SelectionObjectPy::getSubElementNames() const
 
 Py::String SelectionObjectPy::getFullName() const
 {
-    return Py::String(getSelectionObjectPtr()->getAsPropertyLinkSubString());
+    return {getSelectionObjectPtr()->getAsPropertyLinkSubString()};
 }
 
 Py::String SelectionObjectPy::getTypeName() const
 {
-    return Py::String(getSelectionObjectPtr()->getTypeName());
+    return {getSelectionObjectPtr()->getTypeName()};
 }
 
 Py::String SelectionObjectPy::getDocumentName() const
 {
-    return Py::String(getSelectionObjectPtr()->getDocName());
+    return {getSelectionObjectPtr()->getDocName()};
 }
 
 Py::Object SelectionObjectPy::getDocument() const
@@ -142,7 +142,7 @@ Py::Tuple SelectionObjectPy::getSubObjects() const
 
 Py::Boolean SelectionObjectPy::getHasSubObjects() const
 {
-    return Py::Boolean(getSelectionObjectPtr()->hasSubNames());
+    return {getSelectionObjectPtr()->hasSubNames()};
 }
 
 Py::Tuple SelectionObjectPy::getPickedPoints() const

--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -1125,7 +1125,7 @@ SoFCSelectionContextBasePtr SoFCSelectionRoot::getNodeContext(
     stack.front() = front;
     if(it!=front->contextMap.end())
         return it->second;
-    return SoFCSelectionContextBasePtr();
+    return {};
 }
 
 SoFCSelectionContextBasePtr

--- a/src/Gui/SyntaxHighlighter.cpp
+++ b/src/Gui/SyntaxHighlighter.cpp
@@ -131,7 +131,7 @@ QColor SyntaxHighlighter::color(const QString& type)
     else if (type == QLatin1String("Python error"))
         return d->cError;
     else
-        return QColor(); // not found
+        return {}; // not found
 }
 
 QColor SyntaxHighlighter::colorByType(SyntaxHighlighter::TColor type)
@@ -159,7 +159,7 @@ QColor SyntaxHighlighter::colorByType(SyntaxHighlighter::TColor type)
     else if (type == SyntaxHighlighter::Error)
         return d->cError;
     else
-        return QColor(); // not found
+        return {}; // not found
 }
 
 void SyntaxHighlighter::colorChanged(const QString& type, const QColor& col)

--- a/src/Gui/TaskView/TaskDialogPython.cpp
+++ b/src/Gui/TaskView/TaskDialogPython.cpp
@@ -742,7 +742,7 @@ QDialogButtonBox::StandardButtons TaskDialogPython::getStandardButtons() const
             Py::Tuple args;
             Py::Int ret(method.apply(args));
             int value = (int)ret;
-            return QDialogButtonBox::StandardButtons(value);
+            return {value};
         }
     }
     catch (Py::Exception&) {

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -154,7 +154,7 @@ QSize TaskBox::minimumSizeHint() const
     // respect the layout's minimum size.
     QSize s1 = QSint::ActionGroup::minimumSizeHint();
     QSize s2 = QWidget::minimumSizeHint();
-    return QSize(qMax(s1.width(), s2.width()), qMax(s1.height(), s2.height()));
+    return {qMax(s1.width(), s2.width()), qMax(s1.height(), s2.height())};
 }
 
 TaskBox::~TaskBox()
@@ -263,7 +263,7 @@ QSize TaskPanel::minimumSizeHint() const
     // respect the layout's minimum size.
     QSize s1 = QSint::ActionPanel::minimumSizeHint();
     QSize s2 = QWidget::minimumSizeHint();
-    return QSize(qMax(s1.width(), s2.width()), qMax(s1.height(), s2.height()));
+    return {qMax(s1.width(), s2.width()), qMax(s1.height(), s2.height())};
 }
 
 

--- a/src/Gui/TextEdit.cpp
+++ b/src/Gui/TextEdit.cpp
@@ -517,7 +517,7 @@ LineMarker::~LineMarker()
 
 QSize LineMarker::sizeHint() const
 {
-    return QSize(textEditor->lineNumberAreaWidth(), 0);
+    return {textEditor->lineNumberAreaWidth(), 0};
 }
 
 void LineMarker::paintEvent(QPaintEvent* e)

--- a/src/Gui/VectorListEditor.cpp
+++ b/src/Gui/VectorListEditor.cpp
@@ -41,15 +41,15 @@ QVariant VectorTableModel::headerData(int section, Qt::Orientation orientation, 
         return section + 1;
 
     if (role != Qt::DisplayRole || orientation != Qt::Horizontal)
-        return QVariant();
+        return {};
     if (section == 0)
-        return QVariant(QLatin1Char('x'));
+        return {QLatin1Char('x')};
     if (section == 1)
-        return QVariant(QLatin1Char('y'));
+        return {QLatin1Char('y')};
     if (section == 2)
-        return QVariant(QLatin1Char('z'));
+        return {QLatin1Char('z')};
     else
-        return QVariant();
+        return {};
 }
 
 int VectorTableModel::columnCount(const QModelIndex&) const
@@ -117,12 +117,12 @@ QVariant VectorTableModel::data(const QModelIndex &index, int role) const
         }
     }
 
-    return QVariant();
+    return {};
 }
 
 QModelIndex VectorTableModel::parent(const QModelIndex &) const
 {
-    return QModelIndex();
+    return {};
 }
 
 void VectorTableModel::setValues(const QList<Base::Vector3d>& d)

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1695,7 +1695,7 @@ SbVec2f View3DInventorViewer::screenCoordsOfPath(SoPath* path) const
         imageCoords[1] += (height-width) / 2.0;
     }
 
-    return SbVec2f(imageCoords[0], imageCoords[1]);
+    return {imageCoords[0], imageCoords[1]};
 }
 
 std::vector<SbVec2f> View3DInventorViewer::getGLPolygon(const std::vector<SbVec2s>& pnts) const
@@ -2319,7 +2319,7 @@ void View3DInventorViewer::setSeekMode(SbBool on)
 SbVec3f View3DInventorViewer::getCenterPointOnFocalPlane() const {
     SoCamera* cam = getSoRenderManager()->getCamera();
     if (!cam)
-        return SbVec3f(0. ,0. ,0. );
+        return {0. ,0. ,0. };
 
     SbVec3f direction;
     cam->orientation.getValue().multVec(SbVec3f(0, 0, -1), direction);
@@ -2439,7 +2439,7 @@ SbVec3f View3DInventorViewer::getViewDirection() const
     SoCamera* cam = this->getSoRenderManager()->getCamera();
 
     if (!cam)  // this is the default
-        return SbVec3f(0,0,-1);
+        return {0,0,-1};
 
     SbVec3f projDir = cam->getViewVolume().getProjectionDirection();
     return projDir;
@@ -2457,7 +2457,7 @@ SbVec3f View3DInventorViewer::getUpDirection() const
     SoCamera* cam = this->getSoRenderManager()->getCamera();
 
     if (!cam)
-        return SbVec3f(0,1,0);
+        return {0,1,0};
 
     SbRotation camrot = cam->orientation.getValue();
     SbVec3f upvec(0, 1, 0); // init to default up vector
@@ -2470,7 +2470,7 @@ SbRotation View3DInventorViewer::getCameraOrientation() const
     SoCamera* cam = this->getSoRenderManager()->getCamera();
 
     if (!cam)
-        return SbRotation(0,0,0,1); // this is the default
+        return {0,0,0,1}; // this is the default
 
     return cam->orientation.getValue();
 }
@@ -2498,7 +2498,7 @@ SbVec2f View3DInventorViewer::getNormalizedPosition(const SbVec2s& pnt) const
         pY = (pY - 0.5f*dY) / fRatio + 0.5f*dY;
     }
 
-    return SbVec2f(pX, pY);
+    return {pX, pY};
 }
 
 SbVec3f View3DInventorViewer::getPointOnFocalPlane(const SbVec2s& pnt) const
@@ -2507,7 +2507,7 @@ SbVec3f View3DInventorViewer::getPointOnFocalPlane(const SbVec2s& pnt) const
     SoCamera* pCam = this->getSoRenderManager()->getCamera();
 
     if (!pCam)  // return invalid point
-        return SbVec3f();
+        return {};
 
     SbViewVolume  vol = pCam->getViewVolume();
 
@@ -2540,7 +2540,7 @@ SbVec2s View3DInventorViewer::getPointOnViewport(const SbVec3f& pnt) const
     auto x = short(std::roundf(pt[0] * sp[0]));
     auto y = short(std::roundf(pt[1] * sp[1]));
 
-    return SbVec2s(x, y);
+    return {x, y};
 }
 
 QPoint View3DInventorViewer::toQPoint(const SbVec2s& pnt) const
@@ -2554,7 +2554,7 @@ QPoint View3DInventorViewer::toQPoint(const SbVec2s& pnt) const
     xpos = int(std::roundf(xpos / dev_pix_ratio));
     ypos = int(std::roundf(ypos / dev_pix_ratio));
 
-    return QPoint(xpos, ypos);
+    return {xpos, ypos};
 }
 
 SbVec2s View3DInventorViewer::fromQPoint(const QPoint& pnt) const
@@ -2615,7 +2615,7 @@ SbVec3f View3DInventorViewer::projectOnNearPlane(const SbVec2f& pt) const
     SoCamera* cam = this->getSoRenderManager()->getCamera();
 
     if (!cam)  // return invalid point
-        return SbVec3f();
+        return {};
 
     SbViewVolume vol = cam->getViewVolume();
     vol.projectPointToLine(pt, pt1, pt2);
@@ -2628,7 +2628,7 @@ SbVec3f View3DInventorViewer::projectOnFarPlane(const SbVec2f& pt) const
     SoCamera* cam = this->getSoRenderManager()->getCamera();
 
     if (!cam)  // return invalid point
-        return SbVec3f();
+        return {};
 
     SbViewVolume vol = cam->getViewVolume();
     vol.projectPointToLine(pt, pt1, pt2);

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -365,12 +365,14 @@ void ViewProvider::setTransformation(const SbMatrix &rcMatrix)
 
 SbMatrix ViewProvider::convert(const Base::Matrix4D &rcMatrix)
 {
+    //NOLINTBEGIN
     double dMtrx[16];
     rcMatrix.getGLMatrix(dMtrx);
-    return SbMatrix(dMtrx[0], dMtrx[1], dMtrx[2],  dMtrx[3],
+    return SbMatrix(dMtrx[0], dMtrx[1], dMtrx[2],  dMtrx[3], // clazy:exclude=rule-of-two-soft
                     dMtrx[4], dMtrx[5], dMtrx[6],  dMtrx[7],
                     dMtrx[8], dMtrx[9], dMtrx[10], dMtrx[11],
                     dMtrx[12],dMtrx[13],dMtrx[14], dMtrx[15]);
+    //NOLINTEND
 }
 
 Base::Matrix4D ViewProvider::convert(const SbMatrix &smat)
@@ -812,7 +814,7 @@ std::string ViewProvider::dropObjectEx(App::DocumentObject* obj, App::DocumentOb
             return ext->extensionDropObjectEx(obj, owner, subname, elements);
     }
     dropObject(obj);
-    return std::string();
+    return {};
 }
 
 int ViewProvider::replaceObject(App::DocumentObject* oldValue, App::DocumentObject* newValue)

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -166,7 +166,7 @@ public:
     /// return a hit element given the picked point which contains the full node path
     virtual bool getElementPicked(const SoPickedPoint *, std::string &subname) const;
     /// return a hit element to the selection path or 0
-    virtual std::string getElement(const SoDetail *) const { return std::string(); }
+    virtual std::string getElement(const SoDetail *) const { return {}; }
     /// return the coin node detail of the subelement
     virtual SoDetail* getDetail(const char *) const { return nullptr; }
 
@@ -203,7 +203,7 @@ public:
     /// return the highlight lines for a given element or the whole shape
     virtual std::vector<Base::Vector3d> getSelectionShape(const char* Element) const {
         (void)Element;
-        return std::vector<Base::Vector3d>();
+        return {};
     }
 
     /** Return the bound box of this view object
@@ -312,7 +312,7 @@ public:
             const char *subname, const std::vector<std::string> &elements) const;
 
     /// return a subname referencing the sub-object holding the dropped objects
-    virtual std::string getDropPrefix() const { return std::string(); }
+    virtual std::string getDropPrefix() const { return {}; }
 
     /** Add an object with full qualified name to the view provider by drag and drop
      *

--- a/src/Gui/ViewProviderDocumentObjectGroup.cpp
+++ b/src/Gui/ViewProviderDocumentObjectGroup.cpp
@@ -53,7 +53,7 @@ ViewProviderDocumentObjectGroup::~ViewProviderDocumentObjectGroup()
 std::vector<std::string> ViewProviderDocumentObjectGroup::getDisplayModes() const
 {
     // empty
-    return std::vector<std::string>();
+    return {};
 }
 
 bool ViewProviderDocumentObjectGroup::isShow() const

--- a/src/Gui/ViewProviderDocumentObjectPyImp.cpp
+++ b/src/Gui/ViewProviderDocumentObjectPyImp.cpp
@@ -74,7 +74,7 @@ void ViewProviderDocumentObjectPy::setObject(Py::Object pyobj)
 
 Py::Boolean ViewProviderDocumentObjectPy::getForceUpdate() const
 {
-    return Py::Boolean(getViewProviderDocumentObjectPtr()->isUpdateForced());
+    return {getViewProviderDocumentObjectPtr()->isUpdateForced()};
 }
 
 void ViewProviderDocumentObjectPy::setForceUpdate(Py::Boolean arg)

--- a/src/Gui/ViewProviderExtension.h
+++ b/src/Gui/ViewProviderExtension.h
@@ -62,13 +62,13 @@ public:
     const Gui::ViewProviderDocumentObject* getExtendedViewProvider() const;
 
     virtual std::vector<App::DocumentObject*> extensionClaimChildren3D() const {
-        return std::vector<App::DocumentObject*>(); }
+        return {}; }
 
     virtual bool extensionOnDelete(const std::vector<std::string> &){ return true;}
     virtual void extensionBeforeDelete(){}
 
     virtual std::vector<App::DocumentObject*> extensionClaimChildren() const {
-        return std::vector<App::DocumentObject*>(); }
+        return {}; }
 
     virtual bool extensionCanDragObjects() const { return false; }
     virtual bool extensionCanDragObject(App::DocumentObject*) const { return true; }
@@ -82,7 +82,7 @@ public:
         { return false; }
     virtual std::string extensionDropObjectEx(App::DocumentObject *obj, App::DocumentObject *,
             const char *, const std::vector<std::string> &)
-        { extensionDropObject(obj); return std::string(); }
+        { extensionDropObject(obj); return {}; }
 
     virtual int extensionReplaceObject(App::DocumentObject* /*oldValue*/, App::DocumentObject* /*newValue*/)
         { return -1; }
@@ -100,7 +100,7 @@ public:
     virtual void extensionAttach(App::DocumentObject* ) { }
     virtual void extensionReattach(App::DocumentObject* ) { }
     virtual void extensionSetDisplayMode(const char* ) { }
-    virtual std::vector<std::string> extensionGetDisplayModes() const {return std::vector<std::string>();}
+    virtual std::vector<std::string> extensionGetDisplayModes() const {return {};}
     virtual void extensionSetupContextMenu(QMenu*, QObject*, const char*) {}
 
     // update data of extended object

--- a/src/Gui/ViewProviderExtensionPyImp.cpp
+++ b/src/Gui/ViewProviderExtensionPyImp.cpp
@@ -37,7 +37,7 @@ using namespace Gui;
 // returns a string which represent the object e.g. when printed in python
 std::string ViewProviderExtensionPy::representation() const
 {
-    return std::string("<view provider extension>");
+    return {"<view provider extension>"};
 }
 
 PyObject* ViewProviderExtensionPy::setIgnoreOverlayIcon(PyObject *args)

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
@@ -72,7 +72,7 @@ std::vector<App::DocumentObject*> ViewProviderGeoFeatureGroupExtension::extensio
         auto objs = ext->Group.getValues();
         return objs;
     }
-    return std::vector<App::DocumentObject*>();
+    return {};
 }
 
 std::vector<App::DocumentObject*> ViewProviderGeoFeatureGroupExtension::extensionClaimChildren() const {

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -111,7 +111,7 @@ void ViewProviderGroupExtension::extensionDropObject(App::DocumentObject* obj) {
 std::vector< App::DocumentObject* > ViewProviderGroupExtension::extensionClaimChildren() const {
 
     auto* group = getExtendedViewProvider()->getObject()->getExtensionByType<App::GroupExtension>();
-    return std::vector<App::DocumentObject*>(group->Group.getValues());
+    return group->Group.getValues();
 }
 
 void ViewProviderGroupExtension::extensionShow() {

--- a/src/Gui/ViewProviderLinkPyImp.cpp
+++ b/src/Gui/ViewProviderLinkPyImp.cpp
@@ -57,7 +57,7 @@ void ViewProviderLinkPy::setDraggingPlacement(Py::Object arg) {
 }
 
 Py::Boolean ViewProviderLinkPy::getUseCenterballDragger() const {
-    return Py::Boolean(getViewProviderLinkPtr()->isUsingCenterballDragger());
+    return {getViewProviderLinkPtr()->isUsingCenterballDragger()};
 }
 
 void ViewProviderLinkPy::setUseCenterballDragger(Py::Boolean arg) {

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -642,7 +642,7 @@ void  ViewProviderPy::setSwitchNode(Py::Object)
 Py::String ViewProviderPy::getIV() const
 {
     std::string buf = Gui::SoFCDB::writeNodesToString(getViewProviderPtr()->getRoot());
-    return Py::String(buf);
+    return {buf};
 }
 
 Py::Object ViewProviderPy::getIcon() const
@@ -666,12 +666,12 @@ void ViewProviderPy::setDefaultMode(Py::Int arg)
 
 Py::Boolean ViewProviderPy::getCanRemoveChildrenFromRoot() const
 {
-    return Py::Boolean(getViewProviderPtr()->canRemoveChildrenFromRoot());
+    return {getViewProviderPtr()->canRemoveChildrenFromRoot()};
 }
 
 Py::Boolean ViewProviderPy::getLinkVisibility() const
 {
-    return Py::Boolean(getViewProviderPtr()->isLinkVisible());
+    return {getViewProviderPtr()->isLinkVisible()};
 }
 
 void ViewProviderPy::setLinkVisibility(Py::Boolean arg)
@@ -681,5 +681,5 @@ void ViewProviderPy::setLinkVisibility(Py::Boolean arg)
 
 Py::String ViewProviderPy::getDropPrefix() const
 {
-    return Py::String(getViewProviderPtr()->getDropPrefix());
+    return {getViewProviderPtr()->getDropPrefix()};
 }

--- a/src/Gui/ViewProviderPythonFeature.cpp
+++ b/src/Gui/ViewProviderPythonFeature.cpp
@@ -96,7 +96,7 @@ QIcon ViewProviderPythonFeatureImp::getIcon() const
     try {
         Py::Object ret(Base::pyCall(py_getIcon.ptr()));
         if(ret.isNone())
-            return QIcon();
+            return {};
 
         if(ret.isString()) {
             std::string content = Py::String(ret).as_std_string("utf-8");
@@ -148,7 +148,7 @@ QIcon ViewProviderPythonFeatureImp::getIcon() const
         }
     }
 
-    return QIcon();
+    return {};
 }
 
 bool ViewProviderPythonFeatureImp::claimChildren(std::vector<App::DocumentObject*> &children) const
@@ -343,7 +343,7 @@ ViewProviderPythonFeatureImp::ValueT ViewProviderPythonFeatureImp::getDetailPath
 
 std::vector<Base::Vector3d> ViewProviderPythonFeatureImp::getSelectionShape(const char* /*Element*/) const
 {
-    return std::vector<Base::Vector3d>();
+    return {};
 }
 
 ViewProviderPythonFeatureImp::ValueT

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1263,7 +1263,7 @@ void StatusWidget::showText(int ms)
 
 QSize StatusWidget::sizeHint () const
 {
-    return QSize(250,100);
+    return {250,100};
 }
 
 void StatusWidget::showEvent(QShowEvent* event)
@@ -1285,7 +1285,7 @@ public:
     }
 
     QSize sizeHint() const override {
-        return QSize(codeEditor->lineNumberAreaWidth(), 0);
+        return {codeEditor->lineNumberAreaWidth(), 0};
     }
 
 protected:

--- a/src/Gui/WorkbenchPyImp.cpp
+++ b/src/Gui/WorkbenchPyImp.cpp
@@ -45,7 +45,7 @@ using namespace Gui;
 // returns a string which represent the object e.g. when printed in python
 std::string WorkbenchPy::representation() const
 {
-    return std::string("<Workbench object>");
+    return {"<Workbench object>"};
 }
 
 /** Retrieves the workbench name */

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -346,19 +346,19 @@ int PropertyItem::decimals() const
 
 QVariant PropertyItem::displayName() const
 {
-    return QVariant(displayText);
+    return {displayText};
 }
 
 QVariant PropertyItem::toolTip(const App::Property* prop) const
 {
     QString str = QApplication::translate("App::Property",
                                           prop->getDocumentation());
-    return QVariant(str);
+    return {str};
 }
 
 QVariant PropertyItem::decoration(const QVariant&) const
 {
-    return QVariant();
+    return {};
 }
 
 QVariant PropertyItem::toString(const QVariant& prop) const
@@ -431,7 +431,7 @@ QVariant PropertyItem::toString(const QVariant& prop) const
 
 QVariant PropertyItem::value(const App::Property* /*prop*/) const
 {
-    return QVariant();
+    return {};
 }
 
 void PropertyItem::setValue(const QVariant& /*value*/)
@@ -449,7 +449,7 @@ void PropertyItem::setEditorData(QWidget * /*editor*/, const QVariant& /*data*/)
 
 QVariant PropertyItem::editorData(QWidget * /*editor*/) const
 {
-    return QVariant();
+    return {};
 }
 
 QWidget* PropertyItem::createExpressionEditor(QWidget* parent, const QObject* receiver, const char* method) const
@@ -476,8 +476,8 @@ QVariant PropertyItem::expressionEditorData(QWidget *editor) const
 {
     auto le = qobject_cast<QLineEdit*>(editor);
     if(le)
-        return QVariant(le->text());
-    return QVariant();
+        return {le->text()};
+    return {};
 }
 
 PropertyEditorWidget* PropertyItem::createPropertyEditorWidget(QWidget* parent) const
@@ -604,14 +604,14 @@ QVariant PropertyItem::data(int column, int role) const
                     ? QVariant::fromValue(QColor(0xFF,0xFF,0x99)) 
                     : QVariant::fromValue(QColor(0,0,0));
             }
-            return QVariant();
+            return {};
         }
         if (role == Qt::DisplayRole) {
             return displayName();
         }
         // no properties set
         if (propertyItems.empty()) {
-            return QVariant();
+            return {};
         }
         else if (role == Qt::ToolTipRole) {
             QString type = QString::fromLatin1("Type: %1\nName: %2").arg(
@@ -625,14 +625,14 @@ QVariant PropertyItem::data(int column, int role) const
             return type;
         }
 
-        return QVariant();
+        return {};
     }
     else {
         // no properties set
         if (propertyItems.empty()) {
             PropertyItem* parent = this->parent();
             if (!parent || !parent->parent()) {
-                return QVariant();
+                return {};
             }
             if (role == Qt::EditRole) {
                 return parent->property(qPrintable(objectName()));
@@ -648,10 +648,10 @@ QVariant PropertyItem::data(int column, int role) const
             else if (role == Qt::ForegroundRole) {
                 if (hasExpression())
                     return QVariant::fromValue(QApplication::palette().color(QPalette::Link));
-                return QVariant();
+                return {};
             }
 
-            return QVariant();
+            return {};
         }
         if (role == Qt::EditRole) {
             return value(propertyItems[0]);
@@ -668,10 +668,10 @@ QVariant PropertyItem::data(int column, int role) const
         else if( role == Qt::ForegroundRole) {
             if (hasExpression())
                 return QVariant::fromValue(QApplication::palette().color(QPalette::Link));
-            return QVariant();
+            return {};
         }
 
-        return QVariant();
+        return {};
     }
 }
 
@@ -735,7 +735,7 @@ QString PropertyItem::expressionAsString() const
         }
     }
 
-    return QString();
+    return {};
 }
 
 // --------------------------------------------------------------------
@@ -751,7 +751,7 @@ QVariant PropertyStringItem::value(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyString::getClassTypeId()));
 
     std::string value = static_cast<const App::PropertyString*>(prop)->getValue();
-    return QVariant(QString::fromUtf8(value.c_str()));
+    return {QString::fromUtf8(value.c_str())};
 }
 
 void PropertyStringItem::setValue(const QVariant& value)
@@ -789,7 +789,7 @@ void PropertyStringItem::setEditorData(QWidget *editor, const QVariant& data) co
 QVariant PropertyStringItem::editorData(QWidget *editor) const
 {
     auto le = qobject_cast<QLineEdit*>(editor);
-    return QVariant(le->text());
+    return {le->text()};
 }
 
 // --------------------------------------------------------------------
@@ -805,7 +805,7 @@ QVariant PropertyFontItem::value(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyFont::getClassTypeId()));
 
     std::string value = static_cast<const App::PropertyFont*>(prop)->getValue();
-    return QVariant(QString::fromUtf8(value.c_str()));
+    return {QString::fromUtf8(value.c_str())};
 }
 
 void PropertyFontItem::setValue(const QVariant& value)
@@ -842,7 +842,7 @@ void PropertyFontItem::setEditorData(QWidget *editor, const QVariant& data) cons
 QVariant PropertyFontItem::editorData(QWidget *editor) const
 {
     auto cb = qobject_cast<QComboBox*>(editor);
-    return QVariant(cb->currentText());
+    return {cb->currentText()};
 }
 
 // --------------------------------------------------------------------
@@ -870,7 +870,7 @@ QVariant PropertyIntegerItem::value(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyInteger::getClassTypeId()));
 
     int value = (int)static_cast<const App::PropertyInteger*>(prop)->getValue();
-    return QVariant(value);
+    return {value};
 }
 
 void PropertyIntegerItem::setValue(const QVariant& value)
@@ -910,7 +910,7 @@ void PropertyIntegerItem::setEditorData(QWidget *editor, const QVariant& data) c
 QVariant PropertyIntegerItem::editorData(QWidget *editor) const
 {
     auto sb = qobject_cast<QSpinBox*>(editor);
-    return QVariant(sb->value());
+    return {sb->value()};
 }
 
 QVariant PropertyIntegerItem::toString(const QVariant& v) const
@@ -920,7 +920,7 @@ QVariant PropertyIntegerItem::toString(const QVariant& v) const
     if (hasExpression())
         string += QString::fromLatin1("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
 
-    return QVariant(string);
+    return {string};
 }
 
 
@@ -937,7 +937,7 @@ QVariant PropertyIntegerConstraintItem::value(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyIntegerConstraint::getClassTypeId()));
 
     int value = (int)static_cast<const App::PropertyIntegerConstraint*>(prop)->getValue();
-    return QVariant(value);
+    return {value};
 }
 
 void PropertyIntegerConstraintItem::setValue(const QVariant& value)
@@ -993,7 +993,7 @@ void PropertyIntegerConstraintItem::setEditorData(QWidget *editor, const QVarian
 QVariant PropertyIntegerConstraintItem::editorData(QWidget *editor) const
 {
     auto sb = qobject_cast<QSpinBox*>(editor);
-    return QVariant(sb->value());
+    return {sb->value()};
 }
 
 QVariant PropertyIntegerConstraintItem::toString(const QVariant& v) const
@@ -1003,7 +1003,7 @@ QVariant PropertyIntegerConstraintItem::toString(const QVariant& v) const
     if (hasExpression())
         string += QString::fromLatin1("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
 
-    return QVariant(string);
+    return {string};
 }
 
 
@@ -1023,7 +1023,7 @@ QVariant PropertyFloatItem::toString(const QVariant& prop) const
     if (hasExpression())
         data += QString::fromLatin1("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
 
-    return QVariant(data);
+    return {data};
 }
 
 QVariant PropertyFloatItem::value(const App::Property* prop) const
@@ -1031,7 +1031,7 @@ QVariant PropertyFloatItem::value(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyFloat::getClassTypeId()));
 
     double value = static_cast<const App::PropertyFloat*>(prop)->getValue();
-    return QVariant(value);
+    return {value};
 }
 
 void PropertyFloatItem::setValue(const QVariant& value)
@@ -1072,7 +1072,7 @@ void PropertyFloatItem::setEditorData(QWidget *editor, const QVariant& data) con
 QVariant PropertyFloatItem::editorData(QWidget *editor) const
 {
     auto sb = qobject_cast<QDoubleSpinBox*>(editor);
-    return QVariant(sb->value());
+    return {sb->value()};
 }
 
 // --------------------------------------------------------------------
@@ -1091,7 +1091,7 @@ QVariant PropertyUnitItem::toString(const QVariant& prop) const
     if (hasExpression())
         string += QString::fromLatin1("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
 
-    return QVariant(string);
+    return {string};
 }
 
 QVariant PropertyUnitItem::value(const App::Property* prop) const
@@ -1199,7 +1199,7 @@ QVariant PropertyFloatConstraintItem::toString(const QVariant& prop) const
 {
     double value = prop.toDouble();
     QString data = QLocale().toString(value, 'f', decimals());
-    return QVariant(data);
+    return {data};
 }
 
 QVariant PropertyFloatConstraintItem::value(const App::Property* prop) const
@@ -1207,7 +1207,7 @@ QVariant PropertyFloatConstraintItem::value(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyFloatConstraint::getClassTypeId()));
 
     double value = static_cast<const App::PropertyFloatConstraint*>(prop)->getValue();
-    return QVariant(value);
+    return {value};
 }
 
 void PropertyFloatConstraintItem::setValue(const QVariant& value)
@@ -1265,7 +1265,7 @@ void PropertyFloatConstraintItem::setEditorData(QWidget *editor, const QVariant&
 QVariant PropertyFloatConstraintItem::editorData(QWidget *editor) const
 {
     auto sb = qobject_cast<QDoubleSpinBox*>(editor);
-    return QVariant(sb->value());
+    return {sb->value()};
 }
 
 // --------------------------------------------------------------------
@@ -1308,7 +1308,7 @@ QVariant PropertyBoolItem::value(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyBool::getClassTypeId()));
     
     bool value = static_cast<const App::PropertyBool*>(prop)->getValue();
-    return QVariant(value);
+    return {value};
 }
 
 void PropertyBoolItem::setValue(const QVariant& value)
@@ -1340,7 +1340,7 @@ void PropertyBoolItem::setEditorData(QWidget *editor, const QVariant& data) cons
 QVariant PropertyBoolItem::editorData(QWidget *editor) const
 {
     auto cb = qobject_cast<QComboBox*>(editor);
-    return QVariant(cb->currentText());
+    return {cb->currentText()};
 }
 
 // ---------------------------------------------------------------
@@ -1407,7 +1407,7 @@ QVariant PropertyVectorItem::toString(const QVariant& prop) const
              loc.toString(value.z, 'f', 2));
     if (hasExpression())
         data += QString::fromLatin1("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
-    return QVariant(data);
+    return {data};
 }
 
 QVariant PropertyVectorItem::value(const App::Property* prop) const
@@ -1460,7 +1460,7 @@ void PropertyVectorItem::setEditorData(QWidget *editor, const QVariant& data) co
 QVariant PropertyVectorItem::editorData(QWidget *editor) const
 {
     auto le = qobject_cast<QLineEdit*>(editor);
-    return QVariant(le->text());
+    return {le->text()};
 }
 
 double PropertyVectorItem::x() const
@@ -1624,7 +1624,7 @@ QVariant PropertyVectorListItem::toString(const QVariant& prop) const
 
     if (hasExpression())
         data += QString::fromLatin1("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
-    return QVariant(data);
+    return {data};
 }
 
 QVariant PropertyVectorListItem::value(const App::Property* prop) const
@@ -1704,7 +1704,7 @@ QVariant PropertyVectorDistanceItem::toString(const QVariant& prop) const
            Base::Quantity(value.z, Base::Unit::Length).getUserString() + QString::fromLatin1("]");
     if (hasExpression())
         data += QString::fromLatin1("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
-    return QVariant(data);
+    return {data};
 }
 
 
@@ -1758,7 +1758,7 @@ QWidget* PropertyVectorDistanceItem::createEditor(QWidget* parent, const QObject
 QVariant PropertyVectorDistanceItem::editorData(QWidget *editor) const
 {
     auto le = qobject_cast<QLineEdit*>(editor);
-    return QVariant(le->text());
+    return {le->text()};
 }
 
 Base::Quantity PropertyVectorDistanceItem::x() const
@@ -1914,7 +1914,7 @@ QVariant PropertyMatrixItem::toString(const QVariant& prop) const
             loc.toString(value[3][1], 'f', 2),
             loc.toString(value[3][2], 'f', 2),
             loc.toString(value[3][3], 'f', 2));
-    return QVariant(text);
+    return {text};
 }
 
 QVariant PropertyMatrixItem::value(const App::Property* prop) const
@@ -1930,7 +1930,7 @@ QVariant PropertyMatrixItem::toolTip(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyMatrix::getClassTypeId()));
 
     const Base::Matrix4D& value = static_cast<const App::PropertyMatrix*>(prop)->getValue();
-    return QVariant(QString::fromStdString(value.analyse()));
+    return {QString::fromStdString(value.analyse())};
 }
 
 void PropertyMatrixItem::setValue(const QVariant& value)
@@ -1994,7 +1994,7 @@ void PropertyMatrixItem::setEditorData(QWidget *editor, const QVariant& data) co
 QVariant PropertyMatrixItem::editorData(QWidget *editor) const
 {
     auto le = qobject_cast<QLineEdit*>(editor);
-    return QVariant(le->text());
+    return {le->text()};
 }
 
 double PropertyMatrixItem::getA11() const
@@ -2381,7 +2381,7 @@ QVariant PropertyRotationItem::toolTip(const App::Property* prop) const
                             loc.toString(dir.y, 'f', decimals()),
                             loc.toString(dir.z, 'f', decimals()),
                             Base::Quantity(angle, Base::Unit::Angle).getUserString());
-    return QVariant(data);
+    return {data};
 }
 
 QVariant PropertyRotationItem::toString(const QVariant& prop) const
@@ -2398,7 +2398,7 @@ QVariant PropertyRotationItem::toString(const QVariant& prop) const
                             loc.toString(dir.y, 'f', 2),
                             loc.toString(dir.z, 'f', 2),
                             Base::Quantity(angle, Base::Unit::Angle).getUserString());
-    return QVariant(data);
+    return {data};
 }
 
 void PropertyRotationItem::setValue(const QVariant& value)
@@ -2439,7 +2439,7 @@ void PropertyRotationItem::setEditorData(QWidget *editor, const QVariant& data) 
 QVariant PropertyRotationItem::editorData(QWidget *editor) const
 {
     Q_UNUSED(editor)
-    return QVariant();
+    return {};
 }
 
 void PropertyRotationItem::propertyBound()
@@ -2682,7 +2682,7 @@ QVariant PropertyPlacementItem::toolTip(const App::Property* prop) const
                             Base::Quantity(pos.x, Base::Unit::Length).getUserString(),
                             Base::Quantity(pos.y, Base::Unit::Length).getUserString(),
                             Base::Quantity(pos.z, Base::Unit::Length).getUserString());
-    return QVariant(data);
+    return {data};
 }
 
 QVariant PropertyPlacementItem::toString(const QVariant& prop) const
@@ -2703,7 +2703,7 @@ QVariant PropertyPlacementItem::toString(const QVariant& prop) const
                             Base::Quantity(pos.x, Base::Unit::Length).getUserString(),
                             Base::Quantity(pos.y, Base::Unit::Length).getUserString(),
                             Base::Quantity(pos.z, Base::Unit::Length).getUserString());
-    return QVariant(data);
+    return {data};
 }
 
 void PropertyPlacementItem::setValue(const QVariant& value)
@@ -2815,8 +2815,8 @@ QVariant PropertyEnumItem::value(const App::Property* prop) const
 
     const auto prop_enum = static_cast<const App::PropertyEnumeration*>(prop);
     if(!prop_enum->isValid())
-        return QVariant(QString());
-    return QVariant(QString::fromUtf8(prop_enum->getValueAsString()));
+        return {QString()};
+    return {QString::fromUtf8(prop_enum->getValueAsString())};
 }
 
 void PropertyEnumItem::setValue(const QVariant& value)
@@ -2992,10 +2992,10 @@ void PropertyEnumItem::setEditorData(QWidget *editor, const QVariant& data) cons
 QVariant PropertyEnumItem::editorData(QWidget *editor) const
 {
     if (auto cb = qobject_cast<QComboBox*>(editor))
-        return QVariant(cb->currentText());
+        return {cb->currentText()};
     else if (auto btn = qobject_cast<QPushButton*>(editor))
         return btn->text();
-    return QVariant();
+    return {};
 }
 
 // ---------------------------------------------------------------
@@ -3027,7 +3027,7 @@ QVariant PropertyStringListItem::editorData(QWidget *editor) const
     auto le = qobject_cast<Gui::LabelEditor*>(editor);
     QString complete = le->text();
     QStringList list = complete.split(QChar::fromLatin1('\n'));
-    return QVariant(list);
+    return {list};
 }
 
 QVariant PropertyStringListItem::toString(const QVariant& prop) const
@@ -3040,7 +3040,7 @@ QVariant PropertyStringListItem::toString(const QVariant& prop) const
 
     QString text = QString::fromUtf8("[%1]").arg(list.join(QLatin1String(",")));
 
-    return QVariant(text);
+    return {text};
 }
 
 QVariant PropertyStringListItem::value(const App::Property* prop) const
@@ -3052,7 +3052,7 @@ QVariant PropertyStringListItem::value(const App::Property* prop) const
         list << QString::fromUtf8(jt.c_str());
     }
 
-    return QVariant(list);
+    return {list};
 }
 
 void PropertyStringListItem::setValue(const QVariant& value)
@@ -3107,7 +3107,7 @@ QVariant PropertyFloatListItem::editorData(QWidget *editor) const
     auto le = qobject_cast<Gui::LabelEditor*>(editor);
     QString complete = le->text();
     QStringList list = complete.split(QChar::fromLatin1('\n'));
-    return QVariant(list);
+    return {list};
 }
 
 QVariant PropertyFloatListItem::toString(const QVariant& prop) const
@@ -3118,7 +3118,7 @@ QVariant PropertyFloatListItem::toString(const QVariant& prop) const
         list.append(QLatin1String("..."));
     }
     QString text = QString::fromUtf8("[%1]").arg(list.join(QLatin1String(",")));
-    return QVariant(text);
+    return {text};
 }
 
 QVariant PropertyFloatListItem::value(const App::Property* prop) const
@@ -3131,7 +3131,7 @@ QVariant PropertyFloatListItem::value(const App::Property* prop) const
         list << QString::number(jt, 'f', decimals());
     }
 
-    return QVariant(list);
+    return {list};
 }
 
 void PropertyFloatListItem::setValue(const QVariant& value)
@@ -3181,7 +3181,7 @@ QVariant PropertyIntegerListItem::editorData(QWidget *editor) const
     auto le = qobject_cast<Gui::LabelEditor*>(editor);
     QString complete = le->text();
     QStringList list = complete.split(QChar::fromLatin1('\n'));
-    return QVariant(list);
+    return {list};
 }
 
 QVariant PropertyIntegerListItem::toString(const QVariant& prop) const
@@ -3193,7 +3193,7 @@ QVariant PropertyIntegerListItem::toString(const QVariant& prop) const
     }
     QString text = QString::fromUtf8("[%1]").arg(list.join(QLatin1String(",")));
 
-    return QVariant(text);
+    return {text};
 }
 
 QVariant PropertyIntegerListItem::value(const App::Property* prop) const
@@ -3206,7 +3206,7 @@ QVariant PropertyIntegerListItem::value(const App::Property* prop) const
         list << QString::number(jt);
     }
 
-    return QVariant(list);
+    return {list};
 }
 
 void PropertyIntegerListItem::setValue(const QVariant& value)
@@ -3250,7 +3250,7 @@ QVariant PropertyColorItem::toString(const QVariant& prop) const
     auto value = prop.value<QColor>();
     QString color = QString::fromLatin1("[%1, %2, %3]")
         .arg(value.red()).arg(value.green()).arg(value.blue());
-    return QVariant(color);
+    return {color};
 }
 
 QVariant PropertyColorItem::value(const App::Property* prop) const
@@ -3361,7 +3361,7 @@ QColor PropertyMaterialItem::getDiffuseColor() const
 {
     QVariant value = data(1, Qt::EditRole);
     if (!value.canConvert<Material>())
-        return QColor();
+        return {};
 
     auto val = value.value<Material>();
     return val.diffuseColor;
@@ -3382,7 +3382,7 @@ QColor PropertyMaterialItem::getAmbientColor() const
 {
     QVariant value = data(1, Qt::EditRole);
     if (!value.canConvert<Material>())
-        return QColor();
+        return {};
 
     auto val = value.value<Material>();
     return val.ambientColor;
@@ -3403,7 +3403,7 @@ QColor PropertyMaterialItem::getSpecularColor() const
 {
     QVariant value = data(1, Qt::EditRole);
     if (!value.canConvert<Material>())
-        return QColor();
+        return {};
 
     auto val = value.value<Material>();
     return val.specularColor;
@@ -3424,7 +3424,7 @@ QColor PropertyMaterialItem::getEmissiveColor() const
 {
     QVariant value = data(1, Qt::EditRole);
     if (!value.canConvert<Material>())
-        return QColor();
+        return {};
 
     auto val = value.value<Material>();
     return val.emissiveColor;
@@ -3503,7 +3503,7 @@ QVariant PropertyMaterialItem::toString(const QVariant& prop) const
     QColor value = val.diffuseColor;
     QString color = QString::fromLatin1("[%1, %2, %3]")
         .arg(value.red()).arg(value.green()).arg(value.blue());
-    return QVariant(color);
+    return {color};
 }
 
 QVariant PropertyMaterialItem::toolTip(const App::Property* prop) const
@@ -3532,7 +3532,7 @@ QVariant PropertyMaterialItem::toolTip(const App::Property* prop) const
         .arg(value.transparency)
         ;
 
-    return QVariant(data);
+    return {data};
 }
 
 QVariant PropertyMaterialItem::value(const App::Property* prop) const
@@ -3617,7 +3617,7 @@ QVariant PropertyMaterialItem::editorData(QWidget *editor) const
     auto cb = qobject_cast<Gui::ColorButton*>(editor);
     QVariant value = data(1, Qt::EditRole);
     if (!value.canConvert<Material>())
-        return QVariant();
+        return {};
 
     auto val = value.value<Material>();
     val.diffuseColor = cb->color();
@@ -3674,14 +3674,14 @@ QColor PropertyMaterialListItem::getDiffuseColor() const
 {
     QVariant value = data(1, Qt::EditRole);
     if (!value.canConvert<QVariantList>())
-        return QColor();
+        return {};
 
     QVariantList list = value.toList();
     if (list.isEmpty())
-        return QColor();
+        return {};
 
     if (!list[0].canConvert<Material>())
-        return QColor();
+        return {};
 
     auto mat = list[0].value<Material>();
     return mat.diffuseColor;
@@ -3710,14 +3710,14 @@ QColor PropertyMaterialListItem::getAmbientColor() const
 {
     QVariant value = data(1, Qt::EditRole);
     if (!value.canConvert<QVariantList>())
-        return QColor();
+        return {};
 
     QVariantList list = value.toList();
     if (list.isEmpty())
-        return QColor();
+        return {};
 
     if (!list[0].canConvert<Material>())
-        return QColor();
+        return {};
 
     auto mat = list[0].value<Material>();
     return mat.ambientColor;
@@ -3746,14 +3746,14 @@ QColor PropertyMaterialListItem::getSpecularColor() const
 {
     QVariant value = data(1, Qt::EditRole);
     if (!value.canConvert<QVariantList>())
-        return QColor();
+        return {};
 
     QVariantList list = value.toList();
     if (list.isEmpty())
-        return QColor();
+        return {};
 
     if (!list[0].canConvert<Material>())
-        return QColor();
+        return {};
 
     auto mat = list[0].value<Material>();
     return mat.specularColor;
@@ -3782,14 +3782,14 @@ QColor PropertyMaterialListItem::getEmissiveColor() const
 {
     QVariant value = data(1, Qt::EditRole);
     if (!value.canConvert<QVariantList>())
-        return QColor();
+        return {};
 
     QVariantList list = value.toList();
     if (list.isEmpty())
-        return QColor();
+        return {};
 
     if (!list[0].canConvert<Material>())
-        return QColor();
+        return {};
 
     auto mat = list[0].value<Material>();
     return mat.emissiveColor;
@@ -3889,14 +3889,14 @@ void PropertyMaterialListItem::setTransparency(float t)
 QVariant PropertyMaterialListItem::decoration(const QVariant& value) const
 {
     if (!value.canConvert<QVariantList>())
-        return QVariant();
+        return {};
 
     QVariantList list = value.toList();
     if (list.isEmpty())
-        return QVariant();
+        return {};
 
     if (!list[0].canConvert<Material>())
-        return QVariant();
+        return {};
 
     // use the diffuse color
     auto mat = list[0].value<Material>();
@@ -3912,21 +3912,21 @@ QVariant PropertyMaterialListItem::decoration(const QVariant& value) const
 QVariant PropertyMaterialListItem::toString(const QVariant& prop) const
 {
     if (!prop.canConvert<QVariantList>())
-        return QVariant();
+        return {};
 
     QVariantList list = prop.toList();
     if (list.isEmpty())
-        return QVariant();
+        return {};
 
     if (!list[0].canConvert<Material>())
-        return QVariant();
+        return {};
 
     // use the diffuse color
     auto mat = list[0].value<Material>();
     QColor value = mat.diffuseColor;
     QString color = QString::fromLatin1("[%1, %2, %3]")
         .arg(value.red()).arg(value.green()).arg(value.blue());
-    return QVariant(color);
+    return {color};
 }
 
 QVariant PropertyMaterialListItem::toolTip(const App::Property* prop) const
@@ -3935,7 +3935,7 @@ QVariant PropertyMaterialListItem::toolTip(const App::Property* prop) const
 
     const std::vector<App::Material>& values = static_cast<const App::PropertyMaterialList*>(prop)->getValues();
     if (values.empty())
-        return QVariant();
+        return {};
 
     App::Material value = values.front();
     auto dc = value.diffuseColor.asValue<QColor>();
@@ -3959,7 +3959,7 @@ QVariant PropertyMaterialListItem::toolTip(const App::Property* prop) const
         .arg(value.transparency)
         ;
 
-    return QVariant(data);
+    return {data};
 }
 
 QVariant PropertyMaterialListItem::value(const App::Property* prop) const
@@ -4072,14 +4072,14 @@ QVariant PropertyMaterialListItem::editorData(QWidget *editor) const
     auto cb = qobject_cast<Gui::ColorButton*>(editor);
     QVariant value = data(1, Qt::EditRole);
     if (!value.canConvert<QVariantList>())
-        return QVariant();
+        return {};
 
     QVariantList list = value.toList();
     if (list.isEmpty())
-        return QVariant();
+        return {};
 
     if (!list[0].canConvert<Material>())
-        return QVariant();
+        return {};
 
     // use the diffuse color
     auto mat = list[0].value<Material>();
@@ -4102,7 +4102,7 @@ QVariant PropertyFileItem::value(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyFile::getClassTypeId()));
 
     std::string value = static_cast<const App::PropertyFile*>(prop)->getValue();
-    return QVariant(QString::fromUtf8(value.c_str()));
+    return {QString::fromUtf8(value.c_str())};
 }
 
 void PropertyFileItem::setValue(const QVariant& value)
@@ -4145,7 +4145,7 @@ void PropertyFileItem::setEditorData(QWidget *editor, const QVariant& data) cons
 QVariant PropertyFileItem::editorData(QWidget *editor) const
 {
     auto fc = qobject_cast<Gui::FileChooser*>(editor);
-    return QVariant(fc->fileName());
+    return {fc->fileName()};
 }
 
 // --------------------------------------------------------------------
@@ -4161,7 +4161,7 @@ QVariant PropertyPathItem::value(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyPath::getClassTypeId()));
 
     std::string value = static_cast<const App::PropertyPath*>(prop)->getValue().string();
-    return QVariant(QString::fromUtf8(value.c_str()));
+    return {QString::fromUtf8(value.c_str())};
 }
 
 void PropertyPathItem::setValue(const QVariant& value)
@@ -4197,7 +4197,7 @@ void PropertyPathItem::setEditorData(QWidget *editor, const QVariant& data) cons
 QVariant PropertyPathItem::editorData(QWidget *editor) const
 {
     auto fc = qobject_cast<Gui::FileChooser*>(editor);
-    return QVariant(fc->fileName());
+    return {fc->fileName()};
 }
 
 // --------------------------------------------------------------------
@@ -4213,7 +4213,7 @@ QVariant PropertyTransientFileItem::value(const App::Property* prop) const
     assert(prop && prop->getTypeId().isDerivedFrom(App::PropertyFileIncluded::getClassTypeId()));
 
     std::string value = static_cast<const App::PropertyFileIncluded*>(prop)->getValue();
-    return QVariant(QString::fromUtf8(value.c_str()));
+    return {QString::fromUtf8(value.c_str())};
 }
 
 void PropertyTransientFileItem::setValue(const QVariant& value)
@@ -4258,7 +4258,7 @@ void PropertyTransientFileItem::setEditorData(QWidget *editor, const QVariant& d
 QVariant PropertyTransientFileItem::editorData(QWidget *editor) const
 {
     auto fc = qobject_cast<Gui::FileChooser*>(editor);
-    return QVariant(fc->fileName());
+    return {fc->fileName()};
 }
 
 // ---------------------------------------------------------------
@@ -4445,11 +4445,11 @@ QVariant PropertyLinkItem::value(const App::Property* prop) const
 {
     auto propLink = Base::freecad_dynamic_cast<App::PropertyLinkBase>(prop);
     if(!propLink)
-        return QVariant();
+        return {};
 
     auto links = DlgPropertyLink::getLinksFromProperty(propLink);
     if(links.empty())
-        return QVariant();
+        return {};
 
     return QVariant::fromValue(links);
 }

--- a/src/Gui/propertyeditor/PropertyModel.cpp
+++ b/src/Gui/propertyeditor/PropertyModel.cpp
@@ -67,7 +67,7 @@ int PropertyModel::columnCount ( const QModelIndex & parent ) const
 QVariant PropertyModel::data ( const QModelIndex & index, int role ) const
 {
     if (!index.isValid())
-        return QVariant();
+        return {};
 
     auto item = static_cast<PropertyItem*>(index.internalPointer());
     return item->data(index.column(), role);
@@ -124,19 +124,19 @@ QModelIndex PropertyModel::index ( int row, int column, const QModelIndex & pare
     if (childItem)
         return createIndex(row, column, childItem);
     else
-        return QModelIndex();
+        return {};
 }
 
 QModelIndex PropertyModel::parent ( const QModelIndex & index ) const
 {
     if (!index.isValid())
-        return QModelIndex();
+        return {};
 
     auto childItem = static_cast<PropertyItem*>(index.internalPointer());
     PropertyItem *parentItem = childItem->parent();
 
     if (parentItem == rootItem)
-        return QModelIndex();
+        return {};
 
     return createIndex(parentItem->row(), 0, parentItem);
 }
@@ -157,14 +157,14 @@ QVariant PropertyModel::headerData (int section, Qt::Orientation orientation, in
 {
     if (orientation == Qt::Horizontal) {
         if (role != Qt::DisplayRole)
-            return QVariant();
+            return {};
         if (section == 0)
             return tr("Property");
         if (section == 1)
             return tr("Value");
     }
 
-    return QVariant();
+    return {};
 }
 
 bool PropertyModel::setHeaderData (int, Qt::Orientation, const QVariant &, int)
@@ -189,11 +189,11 @@ QStringList PropertyModel::propertyPathFromIndex(const QModelIndex& index) const
 QModelIndex PropertyModel::propertyIndexFromPath(const QStringList& path) const
 {
     if (path.size() < 2)
-        return QModelIndex();
+        return {};
 
     auto it = groupItems.find(path.front());
     if (it == groupItems.end())
-        return QModelIndex();
+        return {};
 
     PropertyItem *item = it->second.groupItem;
     QModelIndex index = this->index(item->row(), 0, QModelIndex());

--- a/src/Tools/generateTemplates/templateClassPyExport.py
+++ b/src/Tools/generateTemplates/templateClassPyExport.py
@@ -17,13 +17,15 @@ class TemplateClassPyExport(template.ModelTemplate):
         path = self.path
         exportName = self.export.Name
         dirname = self.dirname
+
         def escapeString(s, indent=4):
             """Escapes a string for use as literal in C++ code"""
-            s = s.strip() # This allows UserDocu-tags on their own lines without adding whitespace
-            s = s.replace('\\', '\\\\')
+            s = s.strip()  # This allows UserDocu-tags on their own lines without adding whitespace
+            s = s.replace("\\", "\\\\")
             s = s.replace('"', '\\"')
-            s = s.replace('\n', f'\\n"\n{" "*indent}"')
+            s = s.replace("\n", f'\\n"\n{" "*indent}"')
             return s
+
         print("TemplateClassPyExport", path + exportName)
         # Imp.cpp must not exist, neither in path nor in dirname
         if not os.path.exists(path + exportName + "Imp.cpp"):
@@ -869,7 +871,7 @@ int @self.export.Name@::finalization()
 // returns a string which represents the object e.g. when printed in python
 std::string @self.export.Name@::representation() const
 {
-    return std::string("<@self.export.Twin@ object>");
+    return {"<@self.export.Twin@ object>"};
 }
 + for i in self.export.Methode:
 


### PR DESCRIPTION
Use braced init lists to avoid type repetition. This PR affects the code of the core system.