### PR TITLE
[Sketcher] Fix minor icon missing bug...

### DIFF
--- a/src/Mod/Sketcher/Profiles.py
+++ b/src/Mod/Sketcher/Profiles.py
@@ -53,7 +53,7 @@ class _CommandProfileHexagon1:
 
     def GetResources(self):
         return {
-            "Pixmap": "Sketcher_ProfilesHexagon1",
+            "Pixmap": "Sketcher_CreateHexagon",
             "MenuText": QtCore.QT_TRANSLATE_NOOP(
                 "Sketcher_ProfilesHexagon1", "Creates a hexagonal profile"
             ),


### PR DESCRIPTION
...icon was moved to _obsolete_ in 2020.

This is to stop `Cannot find icon: Sketcher_ProfilesHexagon1` warning being raised when _Customize->Keyboard->Category->Sketcher_ is selected. Found while investigating replacing a shortcut.