### PR TITLE
Modernize C++: return braced init list

### DIFF
--- a/src/Base/Interpreter.cpp
+++ b/src/Base/Interpreter.cpp
@@ -287,7 +287,7 @@ std::string InterpreterSingleton::runStringWithKey(const char *psCmd, const char
         }
         else {
             PyException::ThrowException();
-            return std::string(); // just to quieten code analyzers
+            return {}; // just to quieten code analyzers
         }
     }
     Py_DECREF(presult);

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -426,7 +426,7 @@ QVariant PropertyItem::toString(const QVariant& prop) const
         ss << "ERR!";
     }
 
-    return QVariant(QString::fromUtf8(ss.str().c_str()));
+    return {QString::fromUtf8(ss.str().c_str())};
 }
 
 QVariant PropertyItem::value(const App::Property* /*prop*/) const

--- a/src/Mod/Fem/App/FemPostPipelinePyImp.cpp
+++ b/src/Mod/Fem/App/FemPostPipelinePyImp.cpp
@@ -37,7 +37,7 @@ using namespace Fem;
 // returns a string which represents the object e.g. when printed in python
 std::string FemPostPipelinePy::representation() const
 {
-    return std::string("<FemPostPipeline object>");
+    return {"<FemPostPipeline object>"};
 }
 
 PyObject* FemPostPipelinePy::read(PyObject *args)

--- a/src/Mod/Fem/Gui/PropertyFemMeshItem.cpp
+++ b/src/Mod/Fem/Gui/PropertyFemMeshItem.cpp
@@ -115,7 +115,7 @@ QVariant PropertyFemMeshItem::value(const App::Property*) const
     out << QObject::tr("Polyhedrons") << ": " << ctH << ", ";
     out << QObject::tr("Groups") << ": " << ctG;
     out << ']';
-    return QVariant(str);
+    return {str};
 }
 
 QVariant PropertyFemMeshItem::toolTip(const App::Property* prop) const
@@ -145,7 +145,7 @@ void PropertyFemMeshItem::setEditorData(QWidget* editor, const QVariant& data) c
 QVariant PropertyFemMeshItem::editorData(QWidget* editor) const
 {
     Q_UNUSED(editor);
-    return QVariant();
+    return {};
 }
 
 int PropertyFemMeshItem::countNodes() const

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
@@ -130,7 +130,7 @@ void ViewProviderFemConstraint::setDisplayMode(const char* ModeName)
 
 std::vector<App::DocumentObject*> ViewProviderFemConstraint::claimChildren()const
 {
-    return std::vector<App::DocumentObject*>();
+    return {};
 }
 
 void ViewProviderFemConstraint::setupContextMenu(QMenu *menu, QObject *receiver, const char *member)

--- a/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
@@ -416,7 +416,7 @@ std::string ViewProviderFemMesh::getElement(const SoDetail* detail) const
                 str << "Node" << vertex;
             }
             else {
-                return std::string();
+                return {};
             }
         }
     }
@@ -455,7 +455,7 @@ SoDetail* ViewProviderFemMesh::getDetail(const char* subelement) const
 
 std::vector<Base::Vector3d> ViewProviderFemMesh::getSelectionShape(const char* /*Element*/) const
 {
-    return std::vector<Base::Vector3d>();
+    return {};
 }
 
 std::set<long> ViewProviderFemMesh::getHighlightNodes() const

--- a/src/Mod/Fem/Gui/ViewProviderFemMeshPyImp.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemMeshPyImp.cpp
@@ -21,7 +21,7 @@ using namespace FemGui;
 // returns a string which represents the object e.g. when printed in python
 std::string ViewProviderFemMeshPy::representation() const
 {
-    return std::string("<ViewProviderFemMesh object>");
+    return {"<ViewProviderFemMesh object>"};
 }
 
 

--- a/src/Mod/Fem/Gui/ViewProviderFemPostPipelinePyImp.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostPipelinePyImp.cpp
@@ -33,7 +33,7 @@ using namespace FemGui;
 // returns a string which represents the object e.g. when printed in python
 std::string ViewProviderFemPostPipelinePy::representation() const
 {
-    return std::string("<ViewProviderFemPostPipeline object>");
+    return {"<ViewProviderFemPostPipeline object>"};
 }
 
 PyObject *ViewProviderFemPostPipelinePy::updateColorBars(PyObject *args)

--- a/src/Mod/Import/App/ImportOCAF2.cpp
+++ b/src/Mod/Import/App/ImportOCAF2.cpp
@@ -991,7 +991,7 @@ TDF_Label ExportOCAF2::findComponent(const char *subname, TDF_Label label, TDF_L
         Handle(XCAFDoc_GraphNode) ret;
         if(labels.Length() && (FindSHUO(labels,ret) || aShapeTool->SetSHUO(labels,ret)))
             return ret->Label();
-        return TDF_Label();
+        return {};
     }
     TDF_LabelSequence components;
     TDF_Label ref;
@@ -1018,7 +1018,7 @@ TDF_Label ExportOCAF2::findComponent(const char *subname, TDF_Label label, TDF_L
             }
         }
     }
-    return TDF_Label();
+    return {};
 }
 
 void ExportOCAF2::setupObject(TDF_Label label, App::DocumentObject *obj,
@@ -1191,7 +1191,7 @@ TDF_Label ExportOCAF2::exportObject(App::DocumentObject* parentObj,
     if(!obj || shape.isNull()) {
         if (obj)
             FC_WARN(obj->getFullName() << " has null shape");
-        return TDF_Label();
+        return {};
     }
 
     //sub may contain more than one hierarchy, e.g. Assembly container may use

--- a/src/Mod/Import/App/StepShapePyImp.cpp
+++ b/src/Mod/Import/App/StepShapePyImp.cpp
@@ -31,7 +31,7 @@ using namespace Import;
 // returns a string which represents the object e.g. when printed in python
 std::string StepShapePy::representation() const
 {
-    return std::string("<StepShape object>");
+    return {"<StepShape object>"};
 }
 
 PyObject *StepShapePy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -99,7 +99,7 @@ gp_Pnt ImpExpDxfRead::makePoint(const double* p)
         sp2 = sp2 * optionScaling;
         sp3 = sp3 * optionScaling;
     }
-    return gp_Pnt(sp1,sp2,sp3);
+    return {sp1,sp2,sp3};
 }
 
 void ImpExpDxfRead::OnReadLine(const double* s, const double* e, bool /*hidden*/)

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -534,7 +534,7 @@ private:
         auto vp = Gui::Application::Instance->getViewProvider(obj);
         if(vp)
             return vp->getElementColors(subname);
-        return std::map<std::string,App::Color>();
+        return {};
     }
 
     Py::Object exportOptions(const Py::Tuple& args)

--- a/src/Mod/Mesh/App/Core/Elements.h
+++ b/src/Mod/Mesh/App/Core/Elements.h
@@ -965,7 +965,7 @@ inline void MeshFacet::GetEdge (unsigned short usSide, MeshHelpEdge &rclEdge) co
 
 inline std::pair<PointIndex, PointIndex> MeshFacet::GetEdge (unsigned short usSide) const
 {
-    return std::pair<PointIndex, PointIndex>(_aulPoints[usSide], _aulPoints[(usSide+1)%3]);
+    return {_aulPoints[usSide], _aulPoints[(usSide+1)%3]};
 }
 
 inline void MeshFacet::Transpose (PointIndex ulOrig, PointIndex ulNew)

--- a/src/Mod/Mesh/App/Core/Evaluation.cpp
+++ b/src/Mod/Mesh/App/Core/Evaluation.cpp
@@ -186,7 +186,7 @@ std::vector<FacetIndex> MeshEvalOrientation::GetIndices() const
     FacetIndex ulStartFacet, ulVisited;
 
     if (_rclMesh.CountFacets() == 0)
-        return std::vector<FacetIndex>();
+        return {};
 
     // reset VISIT flags
     MeshAlgorithm cAlg(_rclMesh);

--- a/src/Mod/Mesh/App/Core/Segmentation.cpp
+++ b/src/Mod/Mesh/App/Core/Segmentation.cpp
@@ -58,7 +58,7 @@ MeshSegment MeshSurfaceSegment::FindSegment(FacetIndex index) const
             return segment;
     }
 
-    return MeshSegment();
+    return {};
 }
 
 // --------------------------------------------------------

--- a/src/Mod/Mesh/App/EdgePyImp.cpp
+++ b/src/Mod/Mesh/App/EdgePyImp.cpp
@@ -135,7 +135,7 @@ PyObject* EdgePy::unbound(PyObject *args)
 
 Py::Boolean EdgePy::getBound() const
 {
-    return Py::Boolean(getEdgePtr()->isBound());
+    return {getEdgePtr()->isBound()};
 }
 
 Py::List EdgePy::getPoints() const

--- a/src/Mod/Mesh/App/FacetPyImp.cpp
+++ b/src/Mod/Mesh/App/FacetPyImp.cpp
@@ -136,7 +136,7 @@ Py::Long FacetPy::getIndex() const
 
 Py::Boolean FacetPy::getBound() const
 {
-    return Py::Boolean(getFacetPtr()->isBound());
+    return {getFacetPtr()->isBound()};
 }
 
 Py::Object FacetPy::getNormal() const

--- a/src/Mod/Mesh/App/Mesh.h
+++ b/src/Mod/Mesh/App/Mesh.h
@@ -397,14 +397,14 @@ public:
     /** @name Iterator */
     //@{
     const_point_iterator points_begin() const
-    { return const_point_iterator(this, 0); }
+    { return {this, 0}; }
     const_point_iterator points_end() const
-    { return const_point_iterator(this, countPoints()); }
+    { return {this, countPoints()}; }
 
     const_facet_iterator facets_begin() const
-    { return const_facet_iterator(this, 0); }
+    { return {this, 0}; }
     const_facet_iterator facets_end() const
-    { return const_facet_iterator(this, countFacets()); }
+    { return {this, countFacets()}; }
 
     using const_segment_iterator = std::vector<Segment>::const_iterator;
     const_segment_iterator segments_begin() const

--- a/src/Mod/Mesh/App/MeshPointPyImp.cpp
+++ b/src/Mod/Mesh/App/MeshPointPyImp.cpp
@@ -93,7 +93,7 @@ Py::Long MeshPointPy::getIndex() const
 
 Py::Boolean MeshPointPy::getBound() const
 {
-    return Py::Boolean(getMeshPointPtr()->Index != UINT_MAX);
+    return {getMeshPointPtr()->Index != UINT_MAX};
 }
 
 Py::Object MeshPointPy::getNormal() const

--- a/src/Mod/Mesh/App/Segment.h
+++ b/src/Mod/Mesh/App/Segment.h
@@ -95,9 +95,9 @@ public:
     };
 
     const_facet_iterator facets_begin() const
-    { return const_facet_iterator(this, _indices.begin()); }
+    { return {this, _indices.begin()}; }
     const_facet_iterator facets_end() const
-    { return const_facet_iterator(this, _indices.end()); }
+    { return {this, _indices.end()}; }
 };
 
 } // namespace Mesh

--- a/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
@@ -1362,7 +1362,7 @@ void DockEvaluateMeshImp::closeEvent(QCloseEvent*)
  */
 QSize DockEvaluateMeshImp::sizeHint () const
 {
-    return QSize(371, 579);
+    return {371, 579};
 }
 
 #include "moc_DlgEvaluateMeshImp.cpp"

--- a/src/Mod/Mesh/Gui/PropertyEditorMesh.cpp
+++ b/src/Mod/Mesh/Gui/PropertyEditorMesh.cpp
@@ -73,7 +73,7 @@ QVariant PropertyMeshKernelItem::value(const App::Property*) const
     }
 
     QString  str = QObject::tr("[Points: %1, Edges: %2, Faces: %3]").arg(ctP).arg(ctE).arg(ctF);
-    return QVariant(str);
+    return {str};
 }
 
 QVariant PropertyMeshKernelItem::toolTip(const App::Property* prop) const
@@ -103,7 +103,7 @@ void PropertyMeshKernelItem::setEditorData(QWidget *editor, const QVariant& data
 QVariant PropertyMeshKernelItem::editorData(QWidget *editor) const
 {
     Q_UNUSED(editor);
-    return QVariant();
+    return {};
 }
 
 int PropertyMeshKernelItem::countPoints() const

--- a/src/Mod/Mesh/Gui/SoFCMeshObject.cpp
+++ b/src/Mod/Mesh/Gui/SoFCMeshObject.cpp
@@ -581,7 +581,7 @@ inline void glNormal(float* n)
 // Helper function: convert Vec to SbVec3f
 inline SbVec3f sbvec3f(const Base::Vector3f& _v)
 {
-    return SbVec3f(_v.x, _v.y, _v.z);
+    return {_v.x, _v.y, _v.z};
 }
 
 SO_NODE_SOURCE(SoFCMeshObjectShape)

--- a/src/Mod/MeshPart/Gui/CrossSections.cpp
+++ b/src/Mod/MeshPart/Gui/CrossSections.cpp
@@ -96,7 +96,7 @@ public:
     }
     std::vector<std::string> getDisplayModes() const override
     {
-        return std::vector<std::string>();
+        return {};
     }
     void setCoords(const std::vector<Base::Vector3f>& v)
     {

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -170,7 +170,7 @@ PartExport std::list<TopoDS_Edge> sort_Edges(double tol3d, std::list<TopoDS_Edge
     }
 
     if (edge_points.empty())
-        return std::list<TopoDS_Edge>();
+        return {};
 
     std::list<TopoDS_Edge> sorted;
     gp_Pnt first, last;

--- a/src/Mod/Part/App/AttachEnginePyImp.cpp
+++ b/src/Mod/Part/App/AttachEnginePyImp.cpp
@@ -40,7 +40,7 @@ using namespace Attacher;
 // returns a string which represents the object e.g. when printed in python
 std::string AttachEnginePy::representation() const
 {
-    return std::string("<Attacher::AttachEngine>");
+    return {"<Attacher::AttachEngine>"};
 }
 
 PyObject* AttachEnginePy::PyMake(struct _typeobject *, PyObject *, PyObject *)
@@ -94,7 +94,7 @@ int AttachEnginePy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
 Py::String AttachEnginePy::getAttacherType() const
 {
-    return  Py::String(std::string(this->getAttachEnginePtr()->getTypeId().getName()));
+    return {std::string(this->getAttachEnginePtr()->getTypeId().getName())};
 }
 
 /**
@@ -114,7 +114,7 @@ Py::String AttachEnginePy::getMode() const
 {
     try {
         AttachEngine &attacher = *(this->getAttachEnginePtr());
-        return Py::String(attacher.getModeName(attacher.mapMode));
+        return {attacher.getModeName(attacher.mapMode)};
     } ATTACHERPY_STDCATCH_ATTR;
 }
 
@@ -171,7 +171,7 @@ Py::Boolean AttachEnginePy::getReverse() const
 {
     try {
         AttachEngine &attacher = *(this->getAttachEnginePtr());
-        return Py::Boolean(attacher.mapReverse);
+        return {attacher.mapReverse};
     } ATTACHERPY_STDCATCH_ATTR;
 }
 

--- a/src/Mod/Part/App/AttachExtensionPyImp.cpp
+++ b/src/Mod/Part/App/AttachExtensionPyImp.cpp
@@ -33,7 +33,7 @@ using namespace Part;
 // returns a string which represents the object e.g. when printed in python
 std::string AttachExtensionPy::representation() const
 {
-    return std::string("<Part::AttachableObject>");
+    return {"<Part::AttachableObject>"};
 }
 
 PyObject* AttachExtensionPy::positionBySupport(PyObject *args)

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -622,7 +622,7 @@ std::string AttachEngine::getModeName(eMapMode mmode)
 {
     if(mmode < 0 || mmode >= mmDummy_NumberOfModes)
         throw AttachEngineException("AttachEngine::getModeName: Attachment Mode index is out of range");
-    return std::string(AttachEngine::eMapModeStrings[mmode]);
+    return {AttachEngine::eMapModeStrings[mmode]};
 }
 
 eMapMode AttachEngine::getModeByName(const std::string &modeName)

--- a/src/Mod/Part/App/BRepFeat/MakePrismPyImp.cpp
+++ b/src/Mod/Part/App/BRepFeat/MakePrismPyImp.cpp
@@ -99,7 +99,7 @@ int MakePrismPy::PyInit(PyObject* args, PyObject* kwds)
 // returns a string which represents the object e.g. when printed in python
 std::string MakePrismPy::representation() const
 {
-    return std::string("<BRepFeat_MakePrism object>");
+    return {"<BRepFeat_MakePrism object>"};
 }
 
 PyObject* MakePrismPy::init(PyObject *args,  PyObject* kwds)

--- a/src/Mod/Part/App/BRepOffsetAPI_MakeFillingPyImp.cpp
+++ b/src/Mod/Part/App/BRepOffsetAPI_MakeFillingPyImp.cpp
@@ -116,7 +116,7 @@ int BRepOffsetAPI_MakeFillingPy::PyInit(PyObject* args, PyObject* kwds)
 // returns a string which represents the object e.g. when printed in python
 std::string BRepOffsetAPI_MakeFillingPy::representation() const
 {
-    return std::string("<BRepOffsetAPI_MakeFilling object>");
+    return {"<BRepOffsetAPI_MakeFilling object>"};
 }
 
 PyObject* BRepOffsetAPI_MakeFillingPy::setConstrParam(PyObject *args, PyObject *kwds)

--- a/src/Mod/Part/App/BRepOffsetAPI_MakePipeShellPyImp.cpp
+++ b/src/Mod/Part/App/BRepOffsetAPI_MakePipeShellPyImp.cpp
@@ -68,7 +68,7 @@ int BRepOffsetAPI_MakePipeShellPy::PyInit(PyObject* /*args*/, PyObject* /*kwd*/)
 // returns a string which represents the object e.g. when printed in python
 std::string BRepOffsetAPI_MakePipeShellPy::representation() const
 {
-    return std::string("<BRepOffsetAPI_MakePipeShell object>");
+    return {"<BRepOffsetAPI_MakePipeShell object>"};
 }
 
 PyObject* BRepOffsetAPI_MakePipeShellPy::setFrenetMode(PyObject *args)

--- a/src/Mod/Part/App/BodyBasePyImp.cpp
+++ b/src/Mod/Part/App/BodyBasePyImp.cpp
@@ -33,9 +33,8 @@ using namespace Part;
 // returns a string which represents the object e.g. when printed in python
 std::string BodyBasePy::representation() const
 {
-    return std::string("<body object>");
+    return {"<body object>"};
 }
-
 
 PyObject *BodyBasePy::getCustomAttributes(const char* /*attr*/) const
 {

--- a/src/Mod/Part/App/ChFi2d/ChFi2d_AnaFilletAlgoPyImp.cpp
+++ b/src/Mod/Part/App/ChFi2d/ChFi2d_AnaFilletAlgoPyImp.cpp
@@ -81,7 +81,7 @@ int ChFi2d_AnaFilletAlgoPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 // returns a string which represents the object e.g. when printed in python
 std::string ChFi2d_AnaFilletAlgoPy::representation() const
 {
-    return std::string("<AnaFilletAlgo object>");
+    return {"<AnaFilletAlgo object>"};
 }
 
 PyObject* ChFi2d_AnaFilletAlgoPy::init(PyObject *args)

--- a/src/Mod/Part/App/ChFi2d/ChFi2d_ChamferAPIPyImp.cpp
+++ b/src/Mod/Part/App/ChFi2d/ChFi2d_ChamferAPIPyImp.cpp
@@ -75,7 +75,7 @@ int ChFi2d_ChamferAPIPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 // returns a string which represents the object e.g. when printed in python
 std::string ChFi2d_ChamferAPIPy::representation() const
 {
-    return std::string("<ChamferAPI object>");
+    return {"<ChamferAPI object>"};
 }
 
 PyObject* ChFi2d_ChamferAPIPy::init(PyObject *args)

--- a/src/Mod/Part/App/ChFi2d/ChFi2d_FilletAPIPyImp.cpp
+++ b/src/Mod/Part/App/ChFi2d/ChFi2d_FilletAPIPyImp.cpp
@@ -84,7 +84,7 @@ int ChFi2d_FilletAPIPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 // returns a string which represents the object e.g. when printed in python
 std::string ChFi2d_FilletAPIPy::representation() const
 {
-    return std::string("<FilletAPI object>");
+    return {"<FilletAPI object>"};
 }
 
 PyObject* ChFi2d_FilletAPIPy::init(PyObject *args)

--- a/src/Mod/Part/App/ChFi2d/ChFi2d_FilletAlgoPyImp.cpp
+++ b/src/Mod/Part/App/ChFi2d/ChFi2d_FilletAlgoPyImp.cpp
@@ -85,7 +85,7 @@ int ChFi2d_FilletAlgoPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 // returns a string which represents the object e.g. when printed in python
 std::string ChFi2d_FilletAlgoPy::representation() const
 {
-    return std::string("<FilletAlgo object>");
+    return {"<FilletAlgo object>"};
 }
 
 PyObject* ChFi2d_FilletAlgoPy::init(PyObject *args)

--- a/src/Mod/Part/App/FaceMaker.cpp
+++ b/src/Mod/Part/App/FaceMaker.cpp
@@ -172,12 +172,12 @@ TYPESYSTEM_SOURCE(Part::FaceMakerSimple, Part::FaceMakerPublic)
 
 std::string Part::FaceMakerSimple::getUserFriendlyName() const
 {
-    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Simple"));
+    return {QT_TRANSLATE_NOOP("Part_FaceMaker","Simple")};
 }
 
 std::string Part::FaceMakerSimple::getBriefExplanation() const
 {
-    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Makes separate plane face from every wire independently. No support for holes; wires can be on different planes."));
+    return {QT_TRANSLATE_NOOP("Part_FaceMaker","Makes separate plane face from every wire independently. No support for holes; wires can be on different planes.")};
 }
 
 void Part::FaceMakerSimple::Build_Essence()

--- a/src/Mod/Part/App/FaceMakerBullseye.cpp
+++ b/src/Mod/Part/App/FaceMakerBullseye.cpp
@@ -55,12 +55,12 @@ void FaceMakerBullseye::setPlane(const gp_Pln &plane)
 
 std::string FaceMakerBullseye::getUserFriendlyName() const
 {
-    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Bull's-eye facemaker"));
+    return {QT_TRANSLATE_NOOP("Part_FaceMaker","Bull's-eye facemaker")};
 }
 
 std::string FaceMakerBullseye::getBriefExplanation() const
 {
-    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Supports making planar faces with holes with islands."));
+    return {QT_TRANSLATE_NOOP("Part_FaceMaker","Supports making planar faces with holes with islands.")};
 }
 
 void FaceMakerBullseye::Build_Essence()

--- a/src/Mod/Part/App/FaceMakerCheese.cpp
+++ b/src/Mod/Part/App/FaceMakerCheese.cpp
@@ -189,7 +189,7 @@ TopoDS_Shape FaceMakerCheese::makeFace(std::list<TopoDS_Wire>& wires)
 TopoDS_Shape FaceMakerCheese::makeFace(const std::vector<TopoDS_Wire>& w)
 {
     if (w.empty())
-        return TopoDS_Shape();
+        return {};
 
     //FIXME: Need a safe method to sort wire that the outermost one comes last
     // Currently it's done with the diagonal lengths of the bounding boxes
@@ -237,19 +237,19 @@ TopoDS_Shape FaceMakerCheese::makeFace(const std::vector<TopoDS_Wire>& w)
         return TopoDS_Shape(std::move(comp));
     }
     else {
-        return TopoDS_Shape(); // error
+        return {}; // error
     }
 }
 
 
 std::string FaceMakerCheese::getUserFriendlyName() const
 {
-    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Cheese facemaker"));
+    return {QT_TRANSLATE_NOOP("Part_FaceMaker","Cheese facemaker")};
 }
 
 std::string FaceMakerCheese::getBriefExplanation() const
 {
-    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Supports making planar faces with holes, but no islands inside holes."));
+    return {QT_TRANSLATE_NOOP("Part_FaceMaker","Supports making planar faces with holes, but no islands inside holes.")};
 }
 
 void FaceMakerCheese::Build_Essence()

--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -334,12 +334,12 @@ TYPESYSTEM_SOURCE(Part::FaceMakerExtrusion, Part::FaceMakerCheese)
 
 std::string FaceMakerExtrusion::getUserFriendlyName() const
 {
-    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker", "Part Extrude facemaker"));
+    return {QT_TRANSLATE_NOOP("Part_FaceMaker", "Part Extrude facemaker")};
 }
 
 std::string FaceMakerExtrusion::getBriefExplanation() const
 {
-    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker", "Supports making faces with holes, does not support nesting."));
+    return {QT_TRANSLATE_NOOP("Part_FaceMaker", "Supports making faces with holes, does not support nesting.")};
 }
 
 #if OCC_VERSION_HEX >= 0x070600

--- a/src/Mod/Part/App/GeomPlate/BuildPlateSurfacePyImp.cpp
+++ b/src/Mod/Part/App/GeomPlate/BuildPlateSurfacePyImp.cpp
@@ -128,7 +128,7 @@ int BuildPlateSurfacePy::PyInit(PyObject* args, PyObject* kwds)
 // returns a string which represents the object e.g. when printed in python
 std::string BuildPlateSurfacePy::representation() const
 {
-    return std::string("<GeomPlate_BuildPlateSurface object>");
+    return {"<GeomPlate_BuildPlateSurface object>"};
 }
 
 PyObject* BuildPlateSurfacePy::init(PyObject *args)

--- a/src/Mod/Part/App/GeomPlate/CurveConstraintPyImp.cpp
+++ b/src/Mod/Part/App/GeomPlate/CurveConstraintPyImp.cpp
@@ -118,7 +118,7 @@ int CurveConstraintPy::PyInit(PyObject* args, PyObject* kwds)
 // returns a string which represents the object e.g. when printed in python
 std::string CurveConstraintPy::representation() const
 {
-    return std::string("<GeomPlate_CurveConstraint object>");
+    return {"<GeomPlate_CurveConstraint object>"};
 }
 
 PyObject* CurveConstraintPy::setOrder(PyObject *args)

--- a/src/Mod/Part/App/GeomPlate/PointConstraintPyImp.cpp
+++ b/src/Mod/Part/App/GeomPlate/PointConstraintPyImp.cpp
@@ -70,7 +70,7 @@ int PointConstraintPy::PyInit(PyObject* args, PyObject* kwds)
 // returns a string which represents the object e.g. when printed in python
 std::string PointConstraintPy::representation() const
 {
-    return std::string("<GeomPlate_PointConstraint object>");
+    return {"<GeomPlate_PointConstraint object>"};
 }
 
 PyObject* PointConstraintPy::setOrder(PyObject *args)

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -4705,7 +4705,7 @@ gp_Vec GeomCone::getDN(double u, double v, int Nu, int Nv) const
     Handle(Geom_ConicalSurface) s = Handle(Geom_ConicalSurface)::DownCast(handle());
     Standard_RangeError_Raise_if (Nu + Nv < 1 || Nu < 0 || Nv < 0, " ");
     if (Nv > 1) {
-        return gp_Vec (0.0, 0.0, 0.0);
+        return {0.0, 0.0, 0.0};
     }
     else {
       return ElSLib__ConeDN(u, v, s->Position(), s->RefRadius(), s->SemiAngle(), Nu, Nv);

--- a/src/Mod/Part/App/Geometry2d.cpp
+++ b/src/Mod/Part/App/Geometry2d.cpp
@@ -156,7 +156,7 @@ Geometry2d *Geom2dPoint::clone() const
 
 Base::Vector2d Geom2dPoint::getPoint()const
 {
-    return Base::Vector2d(myPoint->X(),myPoint->Y());
+    return {myPoint->X(),myPoint->Y()};
 }
 
 void Geom2dPoint::setPoint(const Base::Vector2d& p)
@@ -247,7 +247,7 @@ Base::Vector2d Geom2dCurve::pointAtParameter(double u) const
     Geom2dLProp_CLProps2d prop(c,u,0,Precision::Confusion());
 
     const gp_Pnt2d &point=prop.Value();
-    return Base::Vector2d(point.X(),point.Y());
+    return {point.X(),point.Y()};
 }
 
 Base::Vector2d Geom2dCurve::firstDerivativeAtParameter(double u) const
@@ -256,7 +256,7 @@ Base::Vector2d Geom2dCurve::firstDerivativeAtParameter(double u) const
     Geom2dLProp_CLProps2d prop(c,u,1,Precision::Confusion());
 
     const gp_Vec2d &vec=prop.D1();
-    return Base::Vector2d(vec.X(),vec.Y());
+    return {vec.X(),vec.Y()};
 }
 
 Base::Vector2d Geom2dCurve::secondDerivativeAtParameter(double u) const
@@ -265,7 +265,7 @@ Base::Vector2d Geom2dCurve::secondDerivativeAtParameter(double u) const
     Geom2dLProp_CLProps2d prop(c,u,2,Precision::Confusion());
 
     const gp_Vec2d &vec=prop.D2();
-    return Base::Vector2d(vec.X(),vec.Y());
+    return {vec.X(),vec.Y()};
 }
 
 bool Geom2dCurve::normal(double u, gp_Dir2d& dir) const
@@ -568,7 +568,7 @@ void Geom2dBSplineCurve::makeC1Continuous(double tol)
 std::list<Geometry2d*> Geom2dBSplineCurve::toBiArcs(double /*tolerance*/) const
 {
     Standard_Failure::Raise("Not yet implemented");
-    return std::list<Geometry2d*>();
+    return {};
 }
 
 unsigned int Geom2dBSplineCurve::getMemSize() const
@@ -607,7 +607,7 @@ Base::Vector2d Geom2dConic::getLocation() const
 {
     Handle(Geom2d_Conic) conic = Handle(Geom2d_Conic)::DownCast(handle());
     const gp_Pnt2d& loc = conic->Location();
-    return Base::Vector2d(loc.X(),loc.Y());
+    return {loc.X(),loc.Y()};
 }
 
 void Geom2dConic::setLocation(const Base::Vector2d& Center)
@@ -685,7 +685,7 @@ Base::Vector2d Geom2dArcOfConic::getLocation() const
     Handle(Geom2d_TrimmedCurve) curve = Handle(Geom2d_TrimmedCurve)::DownCast(handle());
     Handle(Geom2d_Conic) conic = Handle(Geom2d_Conic)::DownCast(curve->BasisCurve());
     const gp_Pnt2d& loc = conic->Location();
-    return Base::Vector2d(loc.X(),loc.Y());
+    return {loc.X(),loc.Y()};
 }
 
 void Geom2dArcOfConic::setLocation(const Base::Vector2d& Center)
@@ -723,7 +723,7 @@ Base::Vector2d Geom2dArcOfConic::getStartPoint() const
 {
     Handle(Geom2d_TrimmedCurve) curve = Handle(Geom2d_TrimmedCurve)::DownCast(handle());
     gp_Pnt2d pnt = curve->StartPoint();
-    return Base::Vector2d(pnt.X(), pnt.Y());
+    return {pnt.X(), pnt.Y()};
 }
 
 /*!
@@ -734,7 +734,7 @@ Base::Vector2d Geom2dArcOfConic::getEndPoint() const
 {
     Handle(Geom2d_TrimmedCurve) curve = Handle(Geom2d_TrimmedCurve)::DownCast(handle());
     gp_Pnt2d pnt = curve->EndPoint();
-    return Base::Vector2d(pnt.X(), pnt.Y());
+    return {pnt.X(), pnt.Y()};
 }
 
 /*!
@@ -948,7 +948,7 @@ Base::Vector2d Geom2dCircle::getCircleCenter (const Base::Vector2d &p1, const Ba
     double x = (w0*p1.x + w1*p2.x + w2*p3.x)/wx;
     double y = (w0*p1.y + w1*p2.y + w2*p3.y)/wx;
 
-    return Base::Vector2d(x, y);
+    return {x, y};
 }
 
 // -------------------------------------------------
@@ -1148,7 +1148,7 @@ void Geom2dEllipse::setMinorRadius(double Radius)
 Base::Vector2d Geom2dEllipse::getMajorAxisDir() const
 {
     gp_Dir2d xdir = myCurve->XAxis().Direction();
-    return Base::Vector2d(xdir.X(), xdir.Y());
+    return {xdir.X(), xdir.Y()};
 }
 
 /*!
@@ -1319,7 +1319,7 @@ Base::Vector2d Geom2dArcOfEllipse::getMajorAxisDir() const
     Handle(Geom2d_Ellipse) c = Handle(Geom2d_Ellipse)::DownCast(myCurve->BasisCurve());
     assert(!c.IsNull());
     gp_Dir2d xdir = c->XAxis().Direction();
-    return Base::Vector2d(xdir.X(), xdir.Y());
+    return {xdir.X(), xdir.Y()};
 }
 
 /*!
@@ -1933,13 +1933,13 @@ void Geom2dLine::setLine(const Base::Vector2d& Pos, const Base::Vector2d& Dir)
 Base::Vector2d Geom2dLine::getPos() const
 {
     gp_Pnt2d Pos = this->myCurve->Lin2d().Location();
-    return Base::Vector2d(Pos.X(),Pos.Y());
+    return {Pos.X(),Pos.Y()};
 }
 
 Base::Vector2d Geom2dLine::getDir() const
 {
     gp_Dir2d Dir = this->myCurve->Lin2d().Direction();
-    return Base::Vector2d(Dir.X(),Dir.Y());
+    return {Dir.X(),Dir.Y()};
 }
 
 const Handle(Geom2d_Geometry)& Geom2dLine::handle() const
@@ -2050,14 +2050,14 @@ Base::Vector2d Geom2dLineSegment::getStartPoint() const
 {
     Handle(Geom2d_TrimmedCurve) this_curve = Handle(Geom2d_TrimmedCurve)::DownCast(handle());
     gp_Pnt2d pnt = this_curve->StartPoint();
-    return Base::Vector2d(pnt.X(), pnt.Y());
+    return {pnt.X(), pnt.Y()};
 }
 
 Base::Vector2d Geom2dLineSegment::getEndPoint() const
 {
     Handle(Geom2d_TrimmedCurve) this_curve = Handle(Geom2d_TrimmedCurve)::DownCast(handle());
     gp_Pnt2d pnt = this_curve->EndPoint();
-    return Base::Vector2d(pnt.X(), pnt.Y());
+    return {pnt.X(), pnt.Y()};
 }
 
 void Geom2dLineSegment::setPoints(const Base::Vector2d& Start, const Base::Vector2d& End)

--- a/src/Mod/Part/App/GeometryBoolExtensionPyImp.cpp
+++ b/src/Mod/Part/App/GeometryBoolExtensionPyImp.cpp
@@ -83,7 +83,7 @@ int GeometryBoolExtensionPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
 Py::Boolean GeometryBoolExtensionPy::getValue() const
 {
-    return Py::Boolean(this->getGeometryBoolExtensionPtr()->getValue());
+    return {this->getGeometryBoolExtensionPtr()->getValue()};
 }
 
 void GeometryBoolExtensionPy::setValue(Py::Boolean value)

--- a/src/Mod/Part/App/GeometryExtensionPyImp.cpp
+++ b/src/Mod/Part/App/GeometryExtensionPyImp.cpp
@@ -80,7 +80,7 @@ Py::String GeometryExtensionPy::getName() const
 {
     std::string name = this->getGeometryExtensionPtr()->getName();
 
-    return Py::String(name);
+    return {name};
 }
 
 void GeometryExtensionPy::setName(Py::String arg)

--- a/src/Mod/Part/App/GeometryPyImp.cpp
+++ b/src/Mod/Part/App/GeometryPyImp.cpp
@@ -428,7 +428,7 @@ PyObject* GeometryPy::getExtensions(PyObject *args)
 Py::String GeometryPy::getTag() const
 {
     std::string tmp = boost::uuids::to_string(getGeometryPtr()->getTag());
-    return Py::String(tmp);
+    return {tmp};
 }
 
 PyObject *GeometryPy::getCustomAttributes(const char* /*attr*/) const

--- a/src/Mod/Part/App/GeometryStringExtensionPyImp.cpp
+++ b/src/Mod/Part/App/GeometryStringExtensionPyImp.cpp
@@ -86,7 +86,7 @@ int GeometryStringExtensionPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
 Py::String GeometryStringExtensionPy::getValue() const
 {
-    return Py::String(this->getGeometryStringExtensionPtr()->getValue());
+    return {this->getGeometryStringExtensionPtr()->getValue()};
 }
 
 void GeometryStringExtensionPy::setValue(Py::String value)

--- a/src/Mod/Part/App/HLRBRep/HLRBRep_AlgoPyImp.cpp
+++ b/src/Mod/Part/App/HLRBRep/HLRBRep_AlgoPyImp.cpp
@@ -61,7 +61,7 @@ int HLRBRep_AlgoPy::PyInit(PyObject* /*args*/, PyObject* /*kwds*/)
 // returns a string which represents the object e.g. when printed in python
 std::string HLRBRep_AlgoPy::representation() const
 {
-    return std::string("<HLRBRep_Algo object>");
+    return {"<HLRBRep_Algo object>"};
 }
 
 PyObject* HLRBRep_AlgoPy::add(PyObject *args)

--- a/src/Mod/Part/App/HLRBRep/HLRBRep_PolyAlgoPyImp.cpp
+++ b/src/Mod/Part/App/HLRBRep/HLRBRep_PolyAlgoPyImp.cpp
@@ -75,7 +75,7 @@ int HLRBRep_PolyAlgoPy::PyInit(PyObject* args, PyObject* /*kwds*/)
 // returns a string which represents the object e.g. when printed in python
 std::string HLRBRep_PolyAlgoPy::representation() const
 {
-    return std::string("<HLRBRep_PolyAlgo object>");
+    return {"<HLRBRep_PolyAlgo object>"};
 }
 
 PyObject* HLRBRep_PolyAlgoPy::setProjector(PyObject *args, PyObject *kwds)

--- a/src/Mod/Part/App/HLRBRep/HLRToShapePyImp.cpp
+++ b/src/Mod/Part/App/HLRBRep/HLRToShapePyImp.cpp
@@ -52,7 +52,7 @@ int HLRToShapePy::PyInit(PyObject* args, PyObject* /*kwds*/)
 // returns a string which represents the object e.g. when printed in python
 std::string HLRToShapePy::representation() const
 {
-    return std::string("<HLRBRep_HLRToShape object>");
+    return {"<HLRBRep_HLRToShape object>"};
 }
 
 PyObject* HLRToShapePy::vCompound(PyObject *args)

--- a/src/Mod/Part/App/HLRBRep/PolyHLRToShapePyImp.cpp
+++ b/src/Mod/Part/App/HLRBRep/PolyHLRToShapePyImp.cpp
@@ -54,7 +54,7 @@ int PolyHLRToShapePy::PyInit(PyObject* args, PyObject* /*kwds*/)
 // returns a string which represents the object e.g. when printed in python
 std::string PolyHLRToShapePy::representation() const
 {
-    return std::string("<HLRBRep_PolyHLRToShape object>");
+    return {"<HLRBRep_PolyHLRToShape object>"};
 }
 
 PyObject* PolyHLRToShapePy::update(PyObject *args)

--- a/src/Mod/Part/App/Part2DObject.cpp
+++ b/src/Mod/Part/App/Part2DObject.cpp
@@ -99,7 +99,7 @@ Base::Axis Part2DObject::getAxis(int axId) const
     else if (axId == N_Axis) {
         return Base::Axis(Base::Vector3d(0,0,0), Base::Vector3d(0,0,1));
     }
-    return Base::Axis();
+    return {};
 }
 
 bool Part2DObject::seekTrimPoints(const std::vector<Geometry *> &geomlist,

--- a/src/Mod/Part/App/Part2DObjectPyImp.cpp
+++ b/src/Mod/Part/App/Part2DObjectPyImp.cpp
@@ -35,10 +35,8 @@ using namespace Part;
 // returns a string which represents the object e.g. when printed in python
 std::string Part2DObjectPy::representation() const
 {
-    return std::string("<Part::Part2DObject>");
+    return {"<Part::Part2DObject>"};
 }
-
-
 
 PyObject *Part2DObjectPy::getCustomAttributes(const char* /*attr*/) const
 {

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -451,7 +451,7 @@ TopoShape Feature::getTopoShape(const App::DocumentObject *obj, const char *subn
         bool resolveLink, bool transform, bool noElementMap)
 {
     if(!obj || !obj->getNameInDocument())
-        return TopoShape();
+        return {};
 
     std::vector<App::DocumentObject*> linkStack;
 

--- a/src/Mod/Part/App/PartFeaturePyImp.cpp
+++ b/src/Mod/Part/App/PartFeaturePyImp.cpp
@@ -34,7 +34,7 @@ using namespace Part;
 // returns a string which represent the object e.g. when printed in python
 std::string PartFeaturePy::representation() const
 {
-    return std::string("<Part::PartFeature>");
+    return {"<Part::PartFeature>"};
 }
 
 PyObject *PartFeaturePy::getCustomAttributes(const char* ) const

--- a/src/Mod/Part/App/RectangularTrimmedSurfacePyImp.cpp
+++ b/src/Mod/Part/App/RectangularTrimmedSurfacePyImp.cpp
@@ -38,7 +38,7 @@ using namespace Part;
 // returns a string which represents the object e.g. when printed in python
 std::string RectangularTrimmedSurfacePy::representation() const
 {
-    return std::string("<RectangularTrimmedSurface object>");
+    return {"<RectangularTrimmedSurface object>"};
 }
 
 PyObject *RectangularTrimmedSurfacePy::PyMake(struct _typeobject *, PyObject *, PyObject *)

--- a/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPyImp.cpp
+++ b/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPyImp.cpp
@@ -108,7 +108,7 @@ PyObject* UnifySameDomainPy::initialize(PyObject *args, PyObject* kwds)
 // returns a string which represents the object e.g. when printed in python
 std::string UnifySameDomainPy::representation() const
 {
-    return std::string("<ShapeUpgrade_UnifySameDomain object>");
+    return {"<ShapeUpgrade_UnifySameDomain object>"};
 }
 
 PyObject* UnifySameDomainPy::allowInternalEdges(PyObject *args)

--- a/src/Mod/Part/App/SurfaceOfExtrusionPyImp.cpp
+++ b/src/Mod/Part/App/SurfaceOfExtrusionPyImp.cpp
@@ -40,7 +40,7 @@ using namespace Part;
 // returns a string which represents the object e.g. when printed in python
 std::string SurfaceOfExtrusionPy::representation() const
 {
-    return std::string("<SurfaceOfExtrusion object>");
+    return {"<SurfaceOfExtrusion object>"};
 }
 
 PyObject *SurfaceOfExtrusionPy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper

--- a/src/Mod/Part/App/SurfaceOfRevolutionPyImp.cpp
+++ b/src/Mod/Part/App/SurfaceOfRevolutionPyImp.cpp
@@ -38,7 +38,7 @@ using namespace Part;
 // returns a string which represents the object e.g. when printed in python
 std::string SurfaceOfRevolutionPy::representation() const
 {
-    return std::string("<SurfaceOfRevolution object>");
+    return {"<SurfaceOfRevolution object>"};
 }
 
 PyObject *SurfaceOfRevolutionPy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -270,7 +270,7 @@ TYPESYSTEM_SOURCE(Part::ShapeSegment , Data::Segment)
 
 std::string ShapeSegment::getName() const
 {
-    return std::string();
+    return {};
 }
 
 // ------------------------------------------------
@@ -325,13 +325,13 @@ TopoDS_Shape TopoShape::getSubShape(TopAbs_ShapeEnum type, int index, bool silen
 {
     if(index <= 0) {
         if(silent)
-            return TopoDS_Shape();
+            return {};
         Standard_Failure::Raise("Unsupported sub-shape type");
     }
 
     if (this->_Shape.IsNull()) {
         if(silent)
-            return TopoDS_Shape();
+            return {};
         Standard_Failure::Raise("Cannot get sub-shape from empty shape");
     }
 
@@ -350,12 +350,12 @@ TopoDS_Shape TopoShape::getSubShape(TopAbs_ShapeEnum type, int index, bool silen
         }
     } catch(Standard_Failure &) {
         if(silent)
-            return TopoDS_Shape();
+            return {};
         throw;
     }
     if(!silent)
         Standard_Failure::Raise("Index out of bound");
-    return TopoDS_Shape();
+    return {};
 }
 
 unsigned long TopoShape::countSubShapes(const char* Type) const
@@ -2122,7 +2122,7 @@ TopoDS_Shape TopoShape::makeTube(double radius, double tol, int cont, int maxdeg
         return mkBuilder.Shape();
     }
 
-    return TopoDS_Shape();
+    return {};
 }
 
 
@@ -3009,7 +3009,7 @@ TopoDS_Shape TopoShape::makeOffset2D(double offset, short joinType, bool fill, b
 
     //assemble output compound
     if (shapesToReturn.empty())
-        return TopoDS_Shape(); //failure
+        return {}; //failure
     if (shapesToReturn.size() > 1 || forceOutputCompound){
         TopoDS_Compound result;
         BRep_Builder builder;

--- a/src/Mod/Part/App/modelRefine.cpp
+++ b/src/Mod/Part/App/modelRefine.cpp
@@ -393,7 +393,7 @@ TopoDS_Face FaceTypedPlane::buildFace(const FaceVectorType &faces) const
     std::vector<EdgeVectorType> splitEdges;
     this->boundarySplit(faces, splitEdges);
     if (splitEdges.empty())
-        return TopoDS_Face();
+        return {};
     std::vector<EdgeVectorType>::iterator splitIt;
     for (splitIt = splitEdges.begin(); splitIt != splitEdges.end(); ++splitIt)
     {
@@ -409,7 +409,7 @@ TopoDS_Face FaceTypedPlane::buildFace(const FaceVectorType &faces) const
 
     BRepLib_MakeFace faceMaker(wires.at(0), Standard_True);
     if (faceMaker.Error() != BRepLib_FaceDone)
-        return TopoDS_Face();
+        return {};
     TopoDS_Face current = faceMaker.Face();
     if (wires.size() > 1)
     {
@@ -419,11 +419,11 @@ TopoDS_Face FaceTypedPlane::buildFace(const FaceVectorType &faces) const
             faceFix.Add(wires.at(index));
         faceFix.Perform();
         if (faceFix.Status(ShapeExtend_FAIL))
-            return TopoDS_Face();
+            return {};
         faceFix.FixOrientation();
         faceFix.Perform();
         if(faceFix.Status(ShapeExtend_FAIL))
-            return TopoDS_Face();
+            return {};
         current = faceFix.Face();
     }
 
@@ -967,7 +967,7 @@ TopoDS_Face FaceTypedBSpline::buildFace(const FaceVectorType &faces) const
     std::vector<EdgeVectorType> splitEdges;
     this->boundarySplit(faces, splitEdges);
     if (splitEdges.empty())
-        return TopoDS_Face();
+        return {};
     std::vector<EdgeVectorType>::iterator splitIt;
     for (splitIt = splitEdges.begin(); splitIt != splitEdges.end(); ++splitIt)
     {
@@ -984,19 +984,19 @@ TopoDS_Face FaceTypedBSpline::buildFace(const FaceVectorType &faces) const
     //make face from surface and outer wire.
     Handle(Geom_BSplineSurface) surface = Handle(Geom_BSplineSurface)::DownCast(BRep_Tool::Surface(faces.at(0)));
     if (!surface)
-        return TopoDS_Face();
+        return {};
     std::vector<TopoDS_Wire>::iterator wireIt;
     wireIt = wires.begin();
     BRepBuilderAPI_MakeFace faceMaker(surface, *wireIt);
     if (!faceMaker.IsDone())
-        return TopoDS_Face();
+        return {};
 
     //add additional boundaries.
     for (wireIt++; wireIt != wires.end(); ++wireIt)
     {
         faceMaker.Add(*wireIt);
         if (!faceMaker.IsDone())
-            return TopoDS_Face();
+            return {};
     }
 
     //fix newly constructed face. Orientation doesn't seem to get fixed the first call.
@@ -1004,11 +1004,11 @@ TopoDS_Face FaceTypedBSpline::buildFace(const FaceVectorType &faces) const
     faceFixer.SetContext(new ShapeBuild_ReShape());
     faceFixer.Perform();
     if (faceFixer.Status(ShapeExtend_FAIL))
-        return TopoDS_Face();
+        return {};
     faceFixer.FixOrientation();
     faceFixer.Perform();
     if (faceFixer.Status(ShapeExtend_FAIL))
-        return TopoDS_Face();
+        return {};
 
     return faceFixer.Face();
 }

--- a/src/Mod/Part/Gui/CrossSections.cpp
+++ b/src/Mod/Part/Gui/CrossSections.cpp
@@ -93,7 +93,7 @@ public:
     }
     std::vector<std::string> getDisplayModes() const override
     {
-        return std::vector<std::string>();
+        return {};
     }
     void setCoords(const std::vector<Base::Vector3f>& v)
     {

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -549,7 +549,7 @@ void PartGui::DlgProjectionOnSurface::create_projection_wire(std::vector<SShapeS
 TopoDS_Shape PartGui::DlgProjectionOnSurface::create_compound(const std::vector<SShapeStore>& iShapeVec)
 {
   if (iShapeVec.empty())
-      return TopoDS_Shape();
+      return {};
 
   TopoDS_Compound aCompound;
   TopoDS_Builder aBuilder;
@@ -856,7 +856,7 @@ TopoDS_Wire PartGui::DlgProjectionOnSurface::sort_and_heal_wire(const std::vecto
   shapeAnalyzer.ConnectEdgesToWires(shapeList, 0.0001, false, aWireHandle);
   shapeAnalyzer.ConnectWiresToWires(aWireHandle, 0.0001, false, aWireWireHandle);
   if (!aWireWireHandle)
-      return TopoDS_Wire();
+      return {};
   for (auto it = 1; it <= aWireWireHandle->Length(); ++it)
   {
     auto aShape = TopoDS::Wire(aWireWireHandle->Value(it));
@@ -871,7 +871,7 @@ TopoDS_Wire PartGui::DlgProjectionOnSurface::sort_and_heal_wire(const std::vecto
     Q_UNUSED(retVal);
     return TopoDS::Wire(aWireFramFix.Shape());
   }
-  return TopoDS_Wire();
+  return {};
 }
 
 void PartGui::DlgProjectionOnSurface::create_face_extrude(std::vector<SShapeStore>& iCurrentShape)

--- a/src/Mod/Part/Gui/TaskCheckGeometry.cpp
+++ b/src/Mod/Part/Gui/TaskCheckGeometry.cpp
@@ -275,10 +275,10 @@ ResultModel::~ResultModel()
 QModelIndex ResultModel::index(int row, int column, const QModelIndex &parent) const
 {
     if (!root)
-        return QModelIndex();
+        return {};
     ResultEntry *parentNode = nodeFromIndex(parent);
     if (!parentNode)
-        return QModelIndex();
+        return {};
     return createIndex(row, column, parentNode->children.at(row));
 }
 
@@ -286,13 +286,13 @@ QModelIndex ResultModel::parent(const QModelIndex &child) const
 {
     ResultEntry *childNode = nodeFromIndex(child);
     if (!childNode)
-        return QModelIndex();
+        return {};
     ResultEntry *parentNode = childNode->parent;
     if (!parentNode)
-        return QModelIndex();
+        return {};
     ResultEntry *grandParentNode = parentNode->parent;
     if (!grandParentNode)
-        return QModelIndex();
+        return {};
     int row = grandParentNode->children.indexOf(parentNode);
     return createIndex(row, 0, parentNode);
 }
@@ -314,10 +314,10 @@ int ResultModel::columnCount(const QModelIndex &parent) const
 QVariant ResultModel::data(const QModelIndex &index, int role) const
 {
     if (role != Qt::DisplayRole)
-        return QVariant();
+        return {};
     ResultEntry *node = nodeFromIndex(index);
     if (!node)
-        return QVariant();
+        return {};
     switch (index.column())
     {
     case 0:
@@ -327,13 +327,13 @@ QVariant ResultModel::data(const QModelIndex &index, int role) const
     case 2:
         return QVariant(node->error);
     }
-    return QVariant();
+    return {};
 }
 
 QVariant ResultModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
     if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
-        return QVariant();
+        return {};
     switch (section)
     {
     case 0:
@@ -343,7 +343,7 @@ QVariant ResultModel::headerData(int section, Qt::Orientation orientation, int r
     case 2:
         return QVariant(QString(tr("Error")));
     }
-    return QVariant();
+    return {};
 }
 
 void ResultModel::setResults(ResultEntry *resultsIn)

--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -1711,13 +1711,13 @@ PartGui::VectorAdapter PartGui::TaskMeasureAngular::buildAdapter(const PartGui::
     {
       TopoDS_Shape edgeShape;
       if (!getShapeFromStrings(edgeShape, current.documentName, current.objectName, current.subObjectName,&mat))
-        return VectorAdapter();
+        return {};
       TopoDS_Edge edge = TopoDS::Edge(edgeShape);
       // make edge orientation so that end of edge closest to pick is head of vector.
       TopoDS_Vertex firstVertex = TopExp::FirstVertex(edge, Standard_True);
       TopoDS_Vertex lastVertex = TopExp::LastVertex(edge, Standard_True);
       if (firstVertex.IsNull() || lastVertex.IsNull())
-        return VectorAdapter();
+        return {};
       gp_Vec firstPoint = PartGui::convert(firstVertex);
       gp_Vec lastPoint = PartGui::convert(lastVertex);
       Base::Vector3d v(current.x,current.y,current.z);
@@ -1738,7 +1738,7 @@ PartGui::VectorAdapter PartGui::TaskMeasureAngular::buildAdapter(const PartGui::
     {
       TopoDS_Shape faceShape;
       if (!getShapeFromStrings(faceShape, current.documentName, current.objectName, current.subObjectName,&mat))
-        return VectorAdapter();
+        return {};
 
       TopoDS_Face face = TopoDS::Face(faceShape);
       Base::Vector3d v(current.x,current.y,current.z);
@@ -1754,9 +1754,9 @@ PartGui::VectorAdapter PartGui::TaskMeasureAngular::buildAdapter(const PartGui::
   assert(current2.shapeType == DimSelections::Vertex);
   TopoDS_Shape vertexShape1, vertexShape2;
   if(!getShapeFromStrings(vertexShape1, current1.documentName, current1.objectName, current1.subObjectName))
-    return VectorAdapter();
+    return {};
   if(!getShapeFromStrings(vertexShape2, current2.documentName, current2.objectName, current2.subObjectName))
-    return VectorAdapter();
+    return {};
 
   TopoDS_Vertex vertex1 = TopoDS::Vertex(vertexShape1);
   TopoDS_Vertex vertex2 = TopoDS::Vertex(vertexShape2);

--- a/src/Mod/Part/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/Part/Gui/ViewProviderBoolean.cpp
@@ -171,7 +171,7 @@ ViewProviderMultiFuse::~ViewProviderMultiFuse()
 
 std::vector<App::DocumentObject*> ViewProviderMultiFuse::claimChildren()const
 {
-    return std::vector<App::DocumentObject*>(static_cast<Part::MultiFuse*>(getObject())->Shapes.getValues());
+    return static_cast<Part::MultiFuse*>(getObject())->Shapes.getValues();
 }
 
 QIcon ViewProviderMultiFuse::getIcon() const
@@ -310,7 +310,7 @@ ViewProviderMultiCommon::~ViewProviderMultiCommon()
 
 std::vector<App::DocumentObject*> ViewProviderMultiCommon::claimChildren()const
 {
-    return std::vector<App::DocumentObject*>(static_cast<Part::MultiCommon*>(getObject())->Shapes.getValues());
+    return static_cast<Part::MultiCommon*>(getObject())->Shapes.getValues();
 }
 
 QIcon ViewProviderMultiCommon::getIcon() const

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -578,12 +578,12 @@ std::vector<Base::Vector3d> ViewProviderPartExt::getModelPoints(const SoPickedPo
     }
 
     // if something went wrong returns an empty array
-    return std::vector<Base::Vector3d>();
+    return {};
 }
 
 std::vector<Base::Vector3d> ViewProviderPartExt::getSelectionShape(const char* /*Element*/) const
 {
-    return std::vector<Base::Vector3d>();
+    return {};
 }
 
 void ViewProviderPartExt::setHighlightedFaces(const std::vector<App::Color>& colors)

--- a/src/Mod/Part/Gui/ViewProviderPlaneParametric.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPlaneParametric.cpp
@@ -74,7 +74,7 @@ ViewProviderFace::~ViewProviderFace()
 
 std::vector<App::DocumentObject*> ViewProviderFace::claimChildren() const
 {
-    return std::vector<App::DocumentObject*>(static_cast<Part::Face*>(getObject())->Sources.getValues());
+    return static_cast<Part::Face*>(getObject())->Sources.getValues();
 }
 
 bool ViewProviderFace::canDragObjects() const

--- a/src/Mod/PartDesign/App/BodyPyImp.cpp
+++ b/src/Mod/PartDesign/App/BodyPyImp.cpp
@@ -35,7 +35,7 @@ using namespace PartDesign;
 // returns a string which represents the object e.g. when printed in python
 std::string BodyPy::representation() const
 {
-    return std::string("<body object>");
+    return {"<body object>"};
 }
 
 

--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -77,7 +77,7 @@ TopoDS_Shape Feature::getSolid(const TopoDS_Shape& shape)
         return xp.Current();
     }
 
-    return TopoDS_Shape();
+    return {};
 }
 
 int Feature::countSolids(const TopoDS_Shape& shape, TopAbs_ShapeEnum type)

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1647,7 +1647,7 @@ void Hole::updateProps()
 
 static gp_Pnt toPnt(gp_Vec dir)
 {
-    return gp_Pnt(dir.X(), dir.Y(), dir.Z());
+    return {dir.X(), dir.Y(), dir.Z()};
 }
 
 App::DocumentObjectExecReturn* Hole::execute()

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -340,16 +340,19 @@ bool getReferencedSelection(const App::DocumentObject* thisObj, const Gui::Selec
 
 QString getRefStr(const App::DocumentObject* obj, const std::vector<std::string>& sub)
 {
-    if (!obj)
-        return QString::fromLatin1("");
+    if (!obj) {
+        return {};
+    }
 
-    if (PartDesign::Feature::isDatum(obj))
+    if (PartDesign::Feature::isDatum(obj)) {
         return QString::fromLatin1(obj->getNameInDocument());
-    else if (!sub.empty())
+    }
+    else if (!sub.empty()) {
         return QString::fromLatin1(obj->getNameInDocument()) + QString::fromLatin1(":") +
                QString::fromLatin1(sub.front().c_str());
-    else
-        return QString();
+    }
+
+    return {};
 }
 
 std::string buildLinkSubPythonStr(const App::DocumentObject* obj, const std::vector<std::string>& subs)

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -135,7 +135,7 @@ void TaskSketchBasedParameters::exitSelectionMode()
 QVariant TaskSketchBasedParameters::setUpToFace(const QString& text)
 {
     if (text.isEmpty())
-        return QVariant();
+        return {};
 
     QStringList parts = text.split(QChar::fromLatin1(':'));
     if (parts.length() < 2)
@@ -144,15 +144,15 @@ QVariant TaskSketchBasedParameters::setUpToFace(const QString& text)
     // Check whether this is the name of an App::Plane or Part::Datum feature
     App::DocumentObject* obj = vp->getObject()->getDocument()->getObject(parts[0].toLatin1());
     if (!obj)
-        return QVariant();
+        return {};
 
     if (obj->getTypeId().isDerivedFrom(App::Plane::getClassTypeId())) {
         // everything is OK (we assume a Part can only have exactly 3 App::Plane objects located at the base of the feature tree)
-        return QVariant();
+        return {};
     }
     else if (obj->getTypeId().isDerivedFrom(Part::Datum::getClassTypeId())) {
         // it's up to the document to check that the datum plane is in the same body
-        return QVariant();
+        return {};
     }
     else {
         // We must expect that "parts[1]" is the translation of "Face" followed by an ID.
@@ -162,7 +162,7 @@ QVariant TaskSketchBasedParameters::setUpToFace(const QString& text)
         QRegularExpression rx(name);
         QRegularExpressionMatch match;
         if (parts[1].indexOf(rx, 0, &match) < 0) {
-            return QVariant();
+            return {};
         }
 
         int faceId = match.captured(1).toInt();
@@ -200,7 +200,7 @@ QVariant TaskSketchBasedParameters::objectNameByLabel(const QString& label,
         }
     }
 
-    return QVariant(); // no such feature found
+    return {}; // no such feature found
 }
 
 QString TaskSketchBasedParameters::getFaceReference(const QString& obj, const QString& sub) const
@@ -209,7 +209,7 @@ QString TaskSketchBasedParameters::getFaceReference(const QString& obj, const QS
     QString o = obj.left(obj.indexOf(QString::fromLatin1(":")));
 
     if (o.isEmpty())
-        return QString();
+        return {};
 
     return QString::fromLatin1(R"((App.getDocument("%1").%2, ["%3"]))")
             .arg(QString::fromLatin1(doc->getName()), o, sub);
@@ -223,7 +223,7 @@ QString TaskSketchBasedParameters::make2DLabel(const App::DocumentObject* sectio
     }
     else if (subValues.empty()) {
         Base::Console().Error("No valid subelement linked in %s\n", section->Label.getValue());
-        return QString();
+        return {};
     }
     else {
         return QString::fromStdString((std::string(section->getNameInDocument()) + ":" + subValues[0]));

--- a/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
@@ -190,7 +190,7 @@ std::string ViewProviderDatum::getElement(const SoDetail* detail) const
             return datumType.toStdString();
     }
 
-    return std::string("");
+    return {};
 }
 
 SoDetail* ViewProviderDatum::getDetail(const char* subelement) const

--- a/src/Mod/PartDesign/Gui/ViewProviderDatumCS.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatumCS.cpp
@@ -248,7 +248,7 @@ std::string ViewProviderDatumCoordinateSystem::getElement(const SoDetail* detail
         }
     }
 
-    return std::string();
+    return {};
 }
 
 SoDetail* ViewProviderDatumCoordinateSystem::getDetail(const char* subelement) const

--- a/src/Mod/PartDesign/Gui/ViewProviderMultiTransform.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderMultiTransform.cpp
@@ -53,7 +53,7 @@ std::vector<App::DocumentObject*> ViewProviderMultiTransform::claimChildren() co
 {
     PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(getObject());
     if (!pcMultiTransform)
-        return std::vector<App::DocumentObject*>(); // TODO: Show error?
+        return {}; // TODO: Show error?
 
     std::vector<App::DocumentObject*> transformFeatures = pcMultiTransform->Transformations.getValues();
     return transformFeatures;

--- a/src/Mod/PartDesign/Gui/ViewProviderPyImp.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPyImp.cpp
@@ -34,7 +34,7 @@ using namespace PartDesignGui;
 // returns a string which represent the object e.g. when printed in python
 std::string ViewProviderPy::representation() const
 {
-    return std::string("<PartDesign::ViewProvider>");
+    return {"<PartDesign::ViewProvider>"};
 }
 
 PyObject *ViewProviderPy::getCustomAttributes(const char* ) const

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -272,7 +272,7 @@ std::string ViewProviderSubShapeBinder::dropObjectEx(App::DocumentObject* obj, A
 {
     auto self = dynamic_cast<PartDesign::SubShapeBinder*>(getObject());
     if (!self)
-        return std::string();
+        return {};
     std::map<App::DocumentObject*, std::vector<std::string> > values;
     if (!subname) subname = "";
     std::string sub(subname);
@@ -293,7 +293,7 @@ std::string ViewProviderSubShapeBinder::dropObjectEx(App::DocumentObject* obj, A
     self->setLinks(std::move(values), QApplication::keyboardModifiers() == Qt::ControlModifier);
     if (self->Relative.getValue())
         updatePlacement(false);
-    return std::string();
+    return {};
 }
 
 

--- a/src/Mod/Points/App/Points.h
+++ b/src/Mod/Points/App/Points.h
@@ -182,9 +182,9 @@ public:
     /** @name Iterator */
     //@{
     const_point_iterator begin() const
-    { return const_point_iterator(this, _Points.begin()); }
+    { return {this, _Points.begin()}; }
     const_point_iterator end() const
-    { return const_point_iterator(this, _Points.end()); }
+    { return {this, _Points.end()}; }
     const_reverse_iterator rbegin() const
     { return const_reverse_iterator(end()); }
     const_reverse_iterator rend() const

--- a/src/Mod/Points/App/PointsPyImp.cpp
+++ b/src/Mod/Points/App/PointsPyImp.cpp
@@ -41,7 +41,7 @@ using namespace Points;
 // returns a string which represents the object e.g. when printed in python
 std::string PointsPy::representation() const
 {
-    return std::string("<PointKernel object>");
+    return {"<PointKernel object>"};
 }
 
 PyObject *PointsPy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper

--- a/src/Mod/Robot/App/RobotAlgos.h
+++ b/src/Mod/Robot/App/RobotAlgos.h
@@ -25,6 +25,8 @@
 
 #include <Base/Placement.h>
 #include <Base/Vector3D.h>
+#include <Mod/Robot/RobotGlobal.h>
+#include "kdl_cp/frames_io.hpp"
 
 
 namespace Robot

--- a/src/Mod/Robot/App/RobotObjectPyImp.cpp
+++ b/src/Mod/Robot/App/RobotObjectPyImp.cpp
@@ -32,7 +32,7 @@ using namespace Robot;
 // returns a string which represents the object e.g. when printed in python
 std::string RobotObjectPy::representation() const
 {
-    return std::string("<RobotObject object>");
+    return {"<RobotObject object>"};
 }
 
 

--- a/src/Mod/Robot/App/Trajectory.cpp
+++ b/src/Mod/Robot/App/Trajectory.cpp
@@ -119,10 +119,9 @@ double Trajectory::getDuration(int n) const
 
 Placement Trajectory::getPosition(double time)const
 {
-    if(pcTrajectory)
+    if (pcTrajectory)
         return Placement(toPlacement(pcTrajectory->Pos(time)));
-    else
-        return Placement();
+    return {};
 }
 
 double Trajectory::getVelocity(double time)const
@@ -236,7 +235,7 @@ void Trajectory::generateTrajectory()
 std::string Trajectory::getUniqueWaypointName(const char *Name) const
 {
     if (!Name || *Name == '\0')
-        return std::string();
+        return {};
 
     // check for first character whether it's a digit
     std::string CleanName = Name;

--- a/src/Mod/Robot/App/WaypointPyImp.cpp
+++ b/src/Mod/Robot/App/WaypointPyImp.cpp
@@ -148,7 +148,7 @@ void  WaypointPy::setVelocity(Py::Float arg)
 
 Py::String WaypointPy::getName() const
 {
-    return Py::String(getWaypointPtr()->Name.c_str());
+    return {getWaypointPtr()->Name};
 }
 
 void WaypointPy::setName(Py::String arg)
@@ -202,7 +202,7 @@ void WaypointPy::setPos(Py::Object arg)
 
 Py::Boolean WaypointPy::getCont() const
 {
-    return Py::Boolean(getWaypointPtr()->Cont);
+    return {getWaypointPtr()->Cont};
 }
 
 void WaypointPy::setCont(Py::Boolean arg)

--- a/src/Mod/Robot/Gui/ViewProviderTrajectoryCompound.cpp
+++ b/src/Mod/Robot/Gui/ViewProviderTrajectoryCompound.cpp
@@ -60,5 +60,5 @@ void ViewProviderTrajectoryCompound::unsetEdit(int)
 
 std::vector<App::DocumentObject*> ViewProviderTrajectoryCompound::claimChildren()const
 {
-    return std::vector<App::DocumentObject*>(static_cast<Robot::TrajectoryCompound *>(getObject())->Source.getValues());
+    return static_cast<Robot::TrajectoryCompound *>(getObject())->Source.getValues();
 }

--- a/src/Mod/Spreadsheet/App/PropertyColumnWidthsPyImp.cpp
+++ b/src/Mod/Spreadsheet/App/PropertyColumnWidthsPyImp.cpp
@@ -33,7 +33,7 @@ using namespace Spreadsheet;
 // returns a string which represents the object e.g. when printed in python
 std::string PropertyColumnWidthsPy::representation() const
 {
-    return std::string("<PropertyColumnWidths object>");
+    return {"<PropertyColumnWidths object>"};
 }
 
 PyObject *PropertyColumnWidthsPy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper

--- a/src/Mod/Spreadsheet/App/PropertyRowHeightsPyImp.cpp
+++ b/src/Mod/Spreadsheet/App/PropertyRowHeightsPyImp.cpp
@@ -33,7 +33,7 @@ using namespace Spreadsheet;
 // returns a string which represents the object e.g. when printed in python
 std::string PropertyRowHeightsPy::representation() const
 {
-    return std::string("<PropertyRowHeights object>");
+    return {"<PropertyRowHeights object>"};
 }
 
 PyObject *PropertyRowHeightsPy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper

--- a/src/Mod/Spreadsheet/App/PropertySheetPyImp.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheetPyImp.cpp
@@ -33,7 +33,7 @@ using namespace Spreadsheet;
 // returns a string which represents the object e.g. when printed in python
 std::string PropertySheetPy::representation() const
 {
-    return std::string("<PropertySheet object>");
+    return {"<PropertySheet object>"};
 }
 
 PyObject *PropertySheetPy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -1399,8 +1399,7 @@ std::string Sheet::getAddressFromAlias(const std::string &alias) const
 
     if (cell)
         return cell->getAddress().toString();
-    else
-        return std::string();
+    return {};
 }
 
 /**

--- a/src/Mod/Spreadsheet/App/SheetPyImp.cpp
+++ b/src/Mod/Spreadsheet/App/SheetPyImp.cpp
@@ -40,7 +40,7 @@ using namespace App;
 // returns a string which represents the object e.g. when printed in python
 std::string SheetPy::representation() const
 {
-    return std::string("<Sheet object>");
+    return {"<Sheet object>"};
 }
 
 PyObject *SheetPy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -176,8 +176,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
 
         if (cell->getStringContent(str))
             return QVariant(QString::fromUtf8(str.c_str()));
-        else
-            return QVariant();
+        return {};
     }
 
     // Get display value as computed property
@@ -195,8 +194,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
             if (cell->getAlias(alias)) {
                 return QVariant::fromValue(aliasBgColor);
             }
-            else
-                return QVariant();
+            return {};
         }
     }
 
@@ -250,23 +248,23 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
             case Qt::DisplayRole:
                 if (cell->getExpression()) {
                     std::string str;
-                    if (cell->getStringContent(str))
-                        if (!str.empty() && str[0] == '=')
+                    if (cell->getStringContent(str)) {
+                        if (!str.empty() && str[0] == '=') {
                             // If this is a real computed value, indicate that a recompute is
                             // needed before we can display it
                             return QVariant(QLatin1String("#PENDING"));
-                        else
+                        }
+                        else {
                             // If it's just a simple value, display the new value, but still
                             // format it as a pending value to indicate to the user that
                             // a recompute is needed
                             return QVariant(QString::fromUtf8(str.c_str()));
-                    else
-                        return QVariant();
+                        }
+                    }
                 }
-                else
-                    return QVariant();
+                return {};
             default:
-                return QVariant();
+                return {};
         }
     }
     else if (prop->isDerivedFrom(App::PropertyString::getClassTypeId())) {
@@ -299,7 +297,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
                 return QVariant::fromValue(qtAlignment);
             }
             default:
-                return QVariant();
+                return {};
         }
     }
     else if (prop->isDerivedFrom(App::PropertyQuantity::getClassTypeId())) {
@@ -359,7 +357,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
                 return formatCellDisplay(v, cell);
             }
             default:
-                return QVariant();
+                return {};
         }
     }
     else if (prop->isDerivedFrom(App::PropertyFloat::getClassTypeId())
@@ -421,7 +419,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
                 return formatCellDisplay(v, cell);
             }
             default:
-                return QVariant();
+                return {};
         }
     }
     else if (prop->isDerivedFrom(App::PropertyPythonObject::getClassTypeId())) {
@@ -470,11 +468,11 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
                 return formatCellDisplay(v, cell);
             }
             default:
-                return QVariant();
+                return {};
         }
     }
 
-    return QVariant();
+    return {};
 }
 
 QVariant SheetModel::headerData(int section, Qt::Orientation orientation, int role) const
@@ -502,7 +500,7 @@ QVariant SheetModel::headerData(int section, Qt::Orientation orientation, int ro
             return QString::number(section + 1);
         }
     }
-    return QVariant();
+    return {};
 }
 
 void SheetModel::setCellData(QModelIndex index, QString str)

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
@@ -94,7 +94,7 @@ QSize SpreadsheetDelegate::sizeHint(const QStyleOptionViewItem & option, const Q
 {
     Q_UNUSED(option);
     Q_UNUSED(index);
-    return QSize();
+    return {};
 }
 
 static inline void drawBorder(QPainter *painter, const QStyleOptionViewItem &option,

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheetPyImp.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheetPyImp.cpp
@@ -32,7 +32,7 @@ using namespace SpreadsheetGui;
 // returns a string which represents the object e.g. when printed in python
 std::string ViewProviderSpreadsheetPy::representation() const
 {
-    return std::string("<ViewProviderSpreadsheet object>");
+    return {"<ViewProviderSpreadsheet object>"};
 }
 
 PyObject* ViewProviderSpreadsheetPy::getView(PyObject* args)


### PR DESCRIPTION
Use braced init lists to avoid type repetition. This PR affects the code of most application modules.