### PR TITLE
[TD]small fixes

### DIFF
--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -193,6 +193,25 @@ TechDraw::BaseGeomPtr CosmeticEdge::scaledGeometry(const double scale)
     return newGeom;
 }
 
+TechDraw::BaseGeomPtr CosmeticEdge::scaledAndRotatedGeometry(const double scale, const double rotDegrees)
+{
+    TopoDS_Edge e = m_geometry->getOCCEdge();
+//    TopoDS_Shape s = TechDraw::scaleShape(e, scale);
+    // Mirror shape in Y and scale
+    TopoDS_Shape s = TechDraw::mirrorShape(e, gp_Pnt(0.0, 0.0, 0.0), scale);
+    // rotate using OXYZ as the coordinate system
+    s = TechDraw::rotateShape(s, gp_Ax2(), rotDegrees);
+    s = TechDraw::mirrorShape(s);
+    TopoDS_Edge newEdge = TopoDS::Edge(s);
+    TechDraw::BaseGeomPtr newGeom = TechDraw::BaseGeom::baseFactory(newEdge);
+    newGeom->setClassOfEdge(ecHARD);
+    newGeom->setHlrVisible( true);
+    newGeom->setCosmetic(true);
+    newGeom->source(COSMETICEDGE);
+    newGeom->setCosmeticTag(getTagAsString());
+    return newGeom;
+}
+
 std::string CosmeticEdge::toString() const
 {
     std::stringstream ss;

--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -198,10 +198,10 @@ TechDraw::BaseGeomPtr CosmeticEdge::scaledAndRotatedGeometry(const double scale,
     TopoDS_Edge e = m_geometry->getOCCEdge();
 //    TopoDS_Shape s = TechDraw::scaleShape(e, scale);
     // Mirror shape in Y and scale
-    TopoDS_Shape s = TechDraw::mirrorShape(e, gp_Pnt(0.0, 0.0, 0.0), scale);
+    TopoDS_Shape s = ShapeUtils::mirrorShape(e, gp_Pnt(0.0, 0.0, 0.0), scale);
     // rotate using OXYZ as the coordinate system
-    s = TechDraw::rotateShape(s, gp_Ax2(), rotDegrees);
-    s = TechDraw::mirrorShape(s);
+    s = ShapeUtils::rotateShape(s, gp_Ax2(), rotDegrees);
+    s = ShapeUtils::mirrorShape(s);
     TopoDS_Edge newEdge = TopoDS::Edge(s);
     TechDraw::BaseGeomPtr newGeom = TechDraw::BaseGeom::baseFactory(newEdge);
     newGeom->setClassOfEdge(ecHARD);

--- a/src/Mod/TechDraw/App/Cosmetic.h
+++ b/src/Mod/TechDraw/App/Cosmetic.h
@@ -77,6 +77,7 @@ public:
     void initialize();
     TopoDS_Edge TopoDS_EdgeFromVectors(const Base::Vector3d& pt1, const Base::Vector3d& pt2);
     TechDraw::BaseGeomPtr scaledGeometry(const double scale);
+    TechDraw::BaseGeomPtr scaledAndRotatedGeometry(const double scale, const double rotDegrees);
 
     std::string toString() const override;
     void dump(const char* title) const;

--- a/src/Mod/TechDraw/App/CosmeticExtension.cpp
+++ b/src/Mod/TechDraw/App/CosmeticExtension.cpp
@@ -34,6 +34,7 @@
 
 using namespace TechDraw;
 using namespace std;
+using DU = DrawUtil;
 
 EXTENSION_PROPERTY_SOURCE(TechDraw::CosmeticExtension, App::DocumentObjectExtension)
 
@@ -81,25 +82,29 @@ void CosmeticExtension::clearCosmeticVertexes()
 //add the cosmetic verts to owner's geometry vertex list
 void CosmeticExtension::addCosmeticVertexesToGeom()
 {
-    //    Base::Console().Message("CE::addCosmeticVertexesToGeom()\n");
+//    Base::Console().Message("CE::addCosmeticVertexesToGeom()\n");
     const std::vector<TechDraw::CosmeticVertex*> cVerts = CosmeticVertexes.getValues();
     for (auto& cv : cVerts) {
         double scale = getOwner()->getScale();
-        int iGV = getOwner()->getGeometryObject()->addCosmeticVertex(cv->scaled(scale), cv->getTagAsString());
+        double rotDegrees = getOwner()->Rotation.getValue();
+        Base::Vector3d cvPosition = cv->rotatedAndScaled(scale, rotDegrees);
+        int iGV = getOwner()->getGeometryObject()->addCosmeticVertex(cvPosition, cv->getTagAsString());
         cv->linkGeom = iGV;
     }
 }
 
 int CosmeticExtension::add1CVToGV(const std::string& tag)
 {
-    //    Base::Console().Message("CE::add1CVToGV(%s)\n", tag.c_str());
+//    Base::Console().Message("CE::add1CVToGV(%s)\n", tag.c_str());
     TechDraw::CosmeticVertex* cv = getCosmeticVertex(tag);
     if (!cv) {
         Base::Console().Message("CE::add1CVToGV - cv %s not found\n", tag.c_str());
         return 0;
     }
     double scale = getOwner()->getScale();
-    int iGV = getOwner()->getGeometryObject()->addCosmeticVertex(cv->scaled(scale), cv->getTagAsString());
+    double rotDegrees = getOwner()->Rotation.getValue();
+    Base::Vector3d cvPosition = cv->rotatedAndScaled(scale, rotDegrees);
+    int iGV = getOwner()->getGeometryObject()->addCosmeticVertex(cvPosition, cv->getTagAsString());
     cv->linkGeom = iGV;
     return iGV;
 }
@@ -156,7 +161,7 @@ int CosmeticExtension::getCVIndex(const std::string& tag)
 std::string CosmeticExtension::addCosmeticVertex(const Base::Vector3d& pos)
 {
 //    Base::Console().Message("CEx::addCosmeticVertex(%s)\n",
- //                           DrawUtil::formatVector(pos).c_str());
+//                             DrawUtil::formatVector(pos).c_str());
     std::vector<CosmeticVertex*> verts = CosmeticVertexes.getValues();
     Base::Vector3d tempPos = DrawUtil::invertY(pos);
     TechDraw::CosmeticVertex* cv = new TechDraw::CosmeticVertex(tempPos);

--- a/src/Mod/TechDraw/App/CosmeticExtension.cpp
+++ b/src/Mod/TechDraw/App/CosmeticExtension.cpp
@@ -56,6 +56,7 @@ CosmeticExtension::~CosmeticExtension()
     // delete any entries.
 }
 
+/// get a pointer to the parent view
 TechDraw::DrawViewPart*  CosmeticExtension::getOwner()
 {
     return static_cast<TechDraw::DrawViewPart*>(getExtendedObject());
@@ -69,6 +70,7 @@ TechDraw::DrawViewPart*  CosmeticExtension::getOwner()
 //mirror again before creation.
 
 // this is never called!
+/// remove all the cosmetic vertices in the property list
 void CosmeticExtension::clearCosmeticVertexes()
 {
     std::vector<TechDraw::CosmeticVertex*> cVerts = CosmeticVertexes.getValues();
@@ -79,7 +81,7 @@ void CosmeticExtension::clearCosmeticVertexes()
     CosmeticVertexes.setValues(noVerts);
 }
 
-//add the cosmetic verts to owner's geometry vertex list
+/// add the cosmetic verts in the property list to view's vertex geometry list
 void CosmeticExtension::addCosmeticVertexesToGeom()
 {
 //    Base::Console().Message("CE::addCosmeticVertexesToGeom()\n");
@@ -93,6 +95,7 @@ void CosmeticExtension::addCosmeticVertexesToGeom()
     }
 }
 
+/// add a single cosmetic vertex in the property list to the view's vertex geometry list
 int CosmeticExtension::add1CVToGV(const std::string& tag)
 {
 //    Base::Console().Message("CE::add1CVToGV(%s)\n", tag.c_str());
@@ -109,7 +112,7 @@ int CosmeticExtension::add1CVToGV(const std::string& tag)
     return iGV;
 }
 
-//update Vertex geometry with current CV's
+/// update the parent view's vertex geometry with all the cosmetic vertices in the list property
 void CosmeticExtension::refreshCVGeoms()
 {
     //    Base::Console().Message("CE::refreshCVGeoms()\n");
@@ -126,6 +129,7 @@ void CosmeticExtension::refreshCVGeoms()
 }
 
 //what is the CV's position in the big geometry q
+/// find the position of a cosmetic vertex with the given tag in the parent view's geometry list
 int CosmeticExtension::getCVIndex(const std::string& tag)
 {
     //    Base::Console().Message("CE::getCVIndex(%s)\n", tag.c_str());
@@ -156,8 +160,8 @@ int CosmeticExtension::getCVIndex(const std::string& tag)
     return -1;
 }
 
-//returns unique CV id
-//only adds cv to cvlist property.  does not add to display geometry until dvp executes.
+/// adds a cosmetic vertex to the property list.  does not add to display geometry until dvp executes.
+/// returns unique CV id
 std::string CosmeticExtension::addCosmeticVertex(const Base::Vector3d& pos)
 {
 //    Base::Console().Message("CEx::addCosmeticVertex(%s)\n",
@@ -171,22 +175,22 @@ std::string CosmeticExtension::addCosmeticVertex(const Base::Vector3d& pos)
     return result;
 }
 
-//get CV by unique id
-TechDraw::CosmeticVertex* CosmeticExtension::getCosmeticVertex(const std::string& tag) const
+/// retrieve a cosmetic vertex by unique id
+TechDraw::CosmeticVertex* CosmeticExtension::getCosmeticVertex(const std::string& tagString) const
 {
 //    Base::Console().Message("CEx::getCosmeticVertex(%s)\n", tagString.c_str());
     const std::vector<TechDraw::CosmeticVertex*> verts = CosmeticVertexes.getValues();
     for (auto& cv: verts) {
         std::string cvTag = cv->getTagAsString();
-        if (cvTag == tag) {
+        if (cvTag == tagString) {
             return cv;
         }
     }
     return nullptr;
 }
 
-// find the cosmetic vertex corresponding to selection name (Vertex5)
-// used when selecting
+/// retrieve a cosmetic vertex by selection name (Vertex5)
+/// used when selecting
 TechDraw::CosmeticVertex* CosmeticExtension::getCosmeticVertexBySelection(const std::string& name) const
 {
 //    Base::Console().Message("CEx::getCVBySelection(%s)\n", name.c_str());
@@ -203,7 +207,7 @@ TechDraw::CosmeticVertex* CosmeticExtension::getCosmeticVertexBySelection(const 
     return getCosmeticVertex(v->getCosmeticTag());
 }
 
-//overload for index only
+/// retrieve a cosmetic vertex by index (the 5 in Vertex5)
 TechDraw::CosmeticVertex* CosmeticExtension::getCosmeticVertexBySelection(const int i) const
 {
 //    Base::Console().Message("CEx::getCVBySelection(%d)\n", i);
@@ -213,6 +217,7 @@ TechDraw::CosmeticVertex* CosmeticExtension::getCosmeticVertexBySelection(const 
     return getCosmeticVertexBySelection(vName);
 }
 
+/// remove the cosmetic vertex with the given tag from the list property
 void CosmeticExtension::removeCosmeticVertex(const std::string& delTag)
 {
 //    Base::Console().Message("DVP::removeCV(%s)\n", delTag.c_str());
@@ -228,6 +233,7 @@ void CosmeticExtension::removeCosmeticVertex(const std::string& delTag)
     CosmeticVertexes.setValues(newVerts);
 }
 
+/// remove the cosmetic vertices with the given tags from the list property
 void CosmeticExtension::removeCosmeticVertex(const std::vector<std::string>& delTags)
 {
     for (auto& t: delTags) {
@@ -238,6 +244,7 @@ void CosmeticExtension::removeCosmeticVertex(const std::vector<std::string>& del
 //********** Cosmetic Edge *****************************************************
 
 // this is never called!
+/// remove all the cosmetic edges for this view
 void CosmeticExtension::clearCosmeticEdges()
 {
     std::vector<TechDraw::CosmeticEdge*> cEdges = CosmeticEdges.getValues();
@@ -248,14 +255,15 @@ void CosmeticExtension::clearCosmeticEdges()
     CosmeticEdges.setValues(noEdges);
 }
 
-//add the cosmetic edges to geometry edge list
+/// add the cosmetic edges to geometry edge list
 void CosmeticExtension::addCosmeticEdgesToGeom()
 {
-    //    Base::Console().Message("CEx::addCosmeticEdgesToGeom()\n");
+//    Base::Console().Message("CEx::addCosmeticEdgesToGeom()\n");
     const std::vector<TechDraw::CosmeticEdge*> cEdges = CosmeticEdges.getValues();
     for (auto& ce : cEdges) {
         double scale = getOwner()->getScale();
-        TechDraw::BaseGeomPtr scaledGeom = ce->scaledGeometry(scale);
+        double rotDegrees = getOwner()->Rotation.getValue();
+        TechDraw::BaseGeomPtr scaledGeom = ce->scaledAndRotatedGeometry(scale, rotDegrees);
         if (!scaledGeom)
             continue;
         //        int iGE =
@@ -263,6 +271,7 @@ void CosmeticExtension::addCosmeticEdgesToGeom()
     }
 }
 
+/// add a single cosmetic edge to the geometry edge list
 int CosmeticExtension::add1CEToGE(const std::string& tag)
 {
     //    Base::Console().Message("CEx::add1CEToGE(%s) 2\n", tag.c_str());
@@ -271,13 +280,15 @@ int CosmeticExtension::add1CEToGE(const std::string& tag)
         Base::Console().Message("CEx::add1CEToGE 2 - ce %s not found\n", tag.c_str());
         return -1;
     }
-    TechDraw::BaseGeomPtr scaledGeom = ce->scaledGeometry(getOwner()->getScale());
+    double scale = getOwner()->getScale();
+    double rotDegrees = getOwner()->Rotation.getValue();
+    TechDraw::BaseGeomPtr scaledGeom = ce->scaledAndRotatedGeometry(scale, rotDegrees);
     int iGE = getOwner()->getGeometryObject()->addCosmeticEdge(scaledGeom, tag);
 
     return iGE;
 }
 
-//update Edge geometry with current CE's
+/// update Edge geometry with current CE's
 void CosmeticExtension::refreshCEGeoms()
 {
     //    Base::Console().Message("CEx::refreshCEGeoms()\n");
@@ -292,8 +303,8 @@ void CosmeticExtension::refreshCEGeoms()
     addCosmeticEdgesToGeom();
 }
 
-//returns unique CE id
-//only adds ce to celist property.  does not add to display geometry until dvp executes.
+/// adds a new cosmetic edge to the list property.  does not add to display geometry until dvp executes.
+/// returns unique CE id
 std::string CosmeticExtension::addCosmeticEdge(Base::Vector3d start,
                                                Base::Vector3d end)
 {
@@ -305,6 +316,8 @@ std::string CosmeticExtension::addCosmeticEdge(Base::Vector3d start,
     return ce->getTagAsString();
 }
 
+/// adds a new cosmetic edge to the list property.  does not add to display geometry until dvp executes.
+/// returns unique CE id
 std::string CosmeticExtension::addCosmeticEdge(TechDraw::BaseGeomPtr bg)
 {
 //    Base::Console().Message("CEx::addCosmeticEdge(bg: %X)\n", bg);
@@ -315,7 +328,7 @@ std::string CosmeticExtension::addCosmeticEdge(TechDraw::BaseGeomPtr bg)
     return ce->getTagAsString();
 }
 
-//get CE by unique id
+/// retrieve a CE by unique id
 TechDraw::CosmeticEdge* CosmeticExtension::getCosmeticEdge(const std::string& tagString) const
 {
 //    Base::Console().Message("CEx::getCosmeticEdge(%s)\n", tagString.c_str());
@@ -332,8 +345,8 @@ TechDraw::CosmeticEdge* CosmeticExtension::getCosmeticEdge(const std::string& ta
     return nullptr;
 }
 
-// find the cosmetic edge corresponding to selection name (Edge5)
-// used when selecting
+/// find the cosmetic edge corresponding to selection name (Edge5)
+/// used when selecting
 TechDraw::CosmeticEdge* CosmeticExtension::getCosmeticEdgeBySelection(const std::string& name) const
 {
 //    Base::Console().Message("CEx::getCEBySelection(%s)\n", name.c_str());
@@ -351,7 +364,7 @@ TechDraw::CosmeticEdge* CosmeticExtension::getCosmeticEdgeBySelection(const std:
     return getCosmeticEdge(base->getCosmeticTag());
 }
 
-//overload for index only
+/// find the cosmetic edge corresponding to the input parameter (the 5 in Edge5)
 TechDraw::CosmeticEdge* CosmeticExtension::getCosmeticEdgeBySelection(int i) const
 {
 //    Base::Console().Message("CEx::getCEBySelection(%d)\n", i);
@@ -360,6 +373,7 @@ TechDraw::CosmeticEdge* CosmeticExtension::getCosmeticEdgeBySelection(int i) con
     return getCosmeticEdgeBySelection(edgeName.str());
 }
 
+/// remove the cosmetic edge with the given tag from the list property
 void CosmeticExtension::removeCosmeticEdge(const std::string& delTag)
 {
 //    Base::Console().Message("DVP::removeCE(%s)\n", delTag.c_str());
@@ -375,6 +389,8 @@ void CosmeticExtension::removeCosmeticEdge(const std::string& delTag)
     CosmeticEdges.setValues(newEdges);
 }
 
+
+/// remove the cosmetic edges with the given tags from the list property
 void CosmeticExtension::removeCosmeticEdge(const std::vector<std::string>& delTags)
 {
     for (auto& t: delTags) {

--- a/src/Mod/TechDraw/App/CosmeticVertex.cpp
+++ b/src/Mod/TechDraw/App/CosmeticVertex.cpp
@@ -35,9 +35,11 @@
 #include "CosmeticVertexPy.h"
 #include "LineGroup.h"
 #include "Preferences.h"
+#include "DrawUtil.h"
 
 using namespace TechDraw;
 using namespace std;
+using DU = DrawUtil;
 
 TYPESYSTEM_SOURCE(TechDraw::CosmeticVertex, Base::Persistence)
 
@@ -73,6 +75,7 @@ CosmeticVertex::CosmeticVertex(const TechDraw::CosmeticVertex* cv) : TechDraw::V
 
 CosmeticVertex::CosmeticVertex(const Base::Vector3d& loc) : TechDraw::Vertex(loc)
 {
+//    Base::Console().Message("CV::CV(%s)\n", DU::formatVector(loc).c_str());
     permaPoint = loc;
     linkGeom = -1;
     color = Preferences::vertexColor();
@@ -175,6 +178,18 @@ void CosmeticVertex::Restore(Base::XMLReader &reader)
 Base::Vector3d CosmeticVertex::scaled(const double factor)
 {
     return permaPoint * factor;
+}
+
+Base::Vector3d CosmeticVertex::rotatedAndScaled(const double scale, const double rotDegrees)
+{
+    Base::Vector3d scaledPoint = scaled(scale);
+    if (rotDegrees != 0.0) {
+        // invert the Y coordinate so the rotation math works out
+        scaledPoint = DU::invertY(scaledPoint);
+        scaledPoint.RotateZ(rotDegrees * M_PI / 180.0);
+        scaledPoint = DU::invertY(scaledPoint);
+    }
+    return scaledPoint;
 }
 
 boost::uuids::uuid CosmeticVertex::getTag() const

--- a/src/Mod/TechDraw/App/CosmeticVertex.h
+++ b/src/Mod/TechDraw/App/CosmeticVertex.h
@@ -53,6 +53,7 @@ public:
     std::string toString() const;
     void dump(const char* title) override;
     Base::Vector3d scaled(const double factor);
+    Base::Vector3d rotatedAndScaled(const double scale, const double rotDegrees);
 
     static bool restoreCosmetic();
 

--- a/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
@@ -1074,7 +1074,6 @@ void execLine2Points(Gui::Command* cmd)
         return;
     }
 
-    double scale = baseFeat->getScale();
     std::vector<Base::Vector3d> points;
     std::vector<bool> is3d;
     //get the 2D points
@@ -1083,8 +1082,7 @@ void execLine2Points(Gui::Command* cmd)
             int idx = DrawUtil::getIndexFromName(v2d);
             TechDraw::VertexPtr v = baseFeat->getProjVertexByIndex(idx);
             if (v) {
-                Base::Vector3d p = DrawUtil::invertY(v->point());
-                points.push_back(p / scale);
+                points.push_back(v->point());
                 is3d.push_back(false);
             }
         }

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -306,7 +306,7 @@ void MDIViewPage::printPdf(std::string file)
     QString filename = QString::fromUtf8(file.data(), file.size());
     QPrinter printer(QPrinter::HighResolution);
     // setPdfVersion sets the printied PDF Version to comply with PDF/A-1b, more details under: https://www.kdab.com/creating-pdfa-documents-qt/
-    printer.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
+//    printer.setPdfVersion(QPagedPaintDevice::PdfVersion_A1b);
     printer.setFullPage(true);
     printer.setOutputFileName(filename);
 

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -292,8 +292,6 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *views << "TechDraw_ActiveView";
     *views << "TechDraw_ProjectionGroup";
     *views << "TechDraw_SectionGroup";
-    //    *views << "TechDraw_SectionView";
-    //    *views << "TechDraw_ComplexSection";
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_ArchView";
@@ -322,13 +320,10 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *dims << "TechDraw_AngleDimension";
     *dims << "TechDraw_3PtAngleDimension";
     *dims << "TechDraw_ExtentGroup";
-    //    *dims << "TechDraw_HorizontalExtentDimension";
-    //    *dims << "TechDraw_VerticalExtentDimension";
     *dims << "TechDraw_LinkDimension";
     *dims << "TechDraw_Balloon";
     *dims << "TechDraw_AxoLengthDimension";
     *dims << "TechDraw_LandmarkDimension";
-    //    *dims << "TechDraw_Dimension"
     *dims << "TechDraw_DimensionRepair";
 
     Gui::ToolBarItem* extattribs = new Gui::ToolBarItem(root);
@@ -336,61 +331,29 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *extattribs << "TechDraw_ExtensionSelectLineAttributes";
     *extattribs << "TechDraw_ExtensionChangeLineAttributes";
     *extattribs << "TechDraw_ExtensionExtendShortenLineGroup";
-    //    *extattribs << "TechDraw_ExtensionExtendLine";
-    //    *extattribs << "TechDraw_ExtensionShortenLine";
     *extattribs << "TechDraw_ExtensionLockUnlockView";
     *extattribs << "TechDraw_ExtensionPositionSectionView";
     *extattribs << "TechDraw_ExtensionPosChainDimensionGroup";
-    //    *extattribs << "TechDraw_ExtensionPosHorizChainDimension";
-    //    *extattribs << "TechDraw_ExtensionPosVertChainDimension";
-    //    *extattribs << "TechDraw_ExtensionPosObliqueChainDimension";
     *extattribs << "TechDraw_ExtensionCascadeDimensionGroup";
-    //    *extattribs << "TechDraw_ExtensionCascadeHorizDimension";
-    //    *extattribs << "TechDraw_ExtensionCascadeVertDimension";
-    //    *extattribs << "TechDraw_ExtensionCascadeObliqueDimension";
     *extattribs << "TechDraw_ExtensionAreaAnnotation";
     *extattribs << "TechDraw_ExtensionCustomizeFormat";
 
     Gui::ToolBarItem* extcenter = new Gui::ToolBarItem(root);
     extcenter->setCommand("TechDraw Centerlines");
     *extcenter << "TechDraw_ExtensionCircleCenterLinesGroup";
-    //    *extcenter << "TechDraw_ExtensionCircleCenterLines";
-    //    *extcenter << "TechDraw_ExtensionHoleCircle";
     *extcenter << "TechDraw_ExtensionThreadsGroup";
-    //    *extcenter << "TechDraw_ExtensionThreadHoleSide";
-    //    *extcenter << "TechDraw_ExtensionThreadHoleBottom";
-    //    *extcenter << "TechDraw_ExtensionThreadBoltSide";
-    //    *extcenter << "TechDraw_ExtensionThreadBoltBottom";
     *extcenter << "TechDraw_ExtensionVertexAtIntersection";
     *extcenter << "TechDraw_ExtensionDrawCirclesGroup";
-    //    *extcenter << "TechDraw_ExtensionDrawCosmCircle";
-    //    *extcenter << "TechDraw_ExtensionDrawCosmArc";
-    //    *extcenter << "TechDraw_ExtensionDrawCosmCircle3Points";
     *extcenter << "TechDraw_ExtensionLinePPGroup";
-    //    *extcenter << "TechDraw_ExtensionLineParallel";
-    //    *extcenter << "TechDraw_ExtensionLinePerpendicular";
 
     Gui::ToolBarItem* extdimensions = new Gui::ToolBarItem(root);
     extdimensions->setCommand("TechDraw Extend Dimensions");
     *extdimensions << "TechDraw_ExtensionCreateChainDimensionGroup";
-    //    *extdimensions << "TechDraw_ExtensionCreateHorizChainDimension";
-    //    *extdimensions << "TechDraw_ExtensionCreateVertChainDimension";
-    //    *extdimensions << "TechDraw_ExtensionCreateObliqueChainDimension";
     *extdimensions << "TechDraw_ExtensionCreateCoordDimensionGroup";
-    //    *extdimensions << "TechDraw_ExtensionCreateHorizCoordDimension";
-    //    *extdimensions << "TechDraw_ExtensionCreateVertCoordDimension";
-    //    *extdimensions << "TechDraw_ExtensionCreateObliqueCoordDimension";
     *extdimensions << "TechDraw_ExtensionChamferDimensionGroup";
-    //    *extdimensions << "TechDraw_ExtensionCreateHorizChamferDimension";
-    //    *extdimensions << "TechDraw_ExtensionCreateVertChamferDimension";
     *extdimensions << "TechDraw_ExtensionCreateLengthArc";
     *extdimensions << "TechDraw_ExtensionInsertPrefixGroup";
-    //    *extdimensions << "TechDraw_ExtensionInsertDiameter";
-    //    *extdimensions << "TechDraw_ExtensionInsertSquare";
-    //    *extdimensions << "TechDraw_ExtensionRemovePrefixChar";
     *extdimensions << "TechDraw_ExtensionIncreaseDecreaseGroup";
-    //    *extdimensions << "TechDraw_ExtensionIncreaseDecimal";
-    //    *extdimensions << "TechDraw_ExtensionDecreaseDecimal";
 
     Gui::ToolBarItem* file = new Gui::ToolBarItem(root);
     file->setCommand("TechDraw File Access");
@@ -412,9 +375,6 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *anno << "TechDraw_RichTextAnnotation";
     *anno << "TechDraw_CosmeticVertexGroup";
     *anno << "TechDraw_CenterLineGroup";
-    //    *anno << "TechDraw_FaceCenterLine";
-    //    *anno << "TechDraw_2LineCenterLine";
-    //    *anno << "TechDraw_2PointCenterLine";
     *anno << "TechDraw_2PointCosmeticLine";
     *anno << "TechDraw_CosmeticEraser";
     *anno << "TechDraw_DecorateLine";
@@ -442,15 +402,12 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *views << "TechDraw_ActiveView";
     *views << "TechDraw_ProjectionGroup";
     *views << "TechDraw_SectionGroup";
-    //    *views << "TechDraw_SectionView";
-    //    *views << "TechDraw_ComplexSection";
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_SpreadsheetView";
     *views << "TechDraw_MoveView";
     *views << "TechDraw_ShareView";
     *views << "TechDraw_ProjectShape";
-
 
     Gui::ToolBarItem* clips = new Gui::ToolBarItem(root);
     clips->setCommand("TechDraw Clips");
@@ -472,13 +429,10 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *dims << "TechDraw_AngleDimension";
     *dims << "TechDraw_3PtAngleDimension";
     *dims << "TechDraw_ExtentGroup";
-    //    *dims << "TechDraw_HorizontalExtentDimension";
-    //    *dims << "TechDraw_VerticalExtentDimension";
     *dims << "TechDraw_LinkDimension";
     *dims << "TechDraw_Balloon";
     *dims << "TechDraw_AxoLengthDimension";
     *dims << "TechDraw_LandmarkDimension";
-    //    *dims << "TechDraw_Dimension";
     *dims << "TechDraw_DimensionRepair";
 
     Gui::ToolBarItem* extattribs = new Gui::ToolBarItem(root);
@@ -486,61 +440,29 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *extattribs << "TechDraw_ExtensionSelectLineAttributes";
     *extattribs << "TechDraw_ExtensionChangeLineAttributes";
     *extattribs << "TechDraw_ExtensionExtendShortenLineGroup";
-    //    *extattribs << "TechDraw_ExtensionExtendLine";
-    //    *extattribs << "TechDraw_ExtensionShortenLine";
     *extattribs << "TechDraw_ExtensionLockUnlockView";
     *extattribs << "TechDraw_ExtensionPositionSectionView";
     *extattribs << "TechDraw_ExtensionPosChainDimensionGroup";
-    //    *extattribs << "TechDraw_ExtensionPosHorizChainDimension";
-    //    *extattribs << "TechDraw_ExtensionPosVertChainDimension";
-    //    *extattribs << "TechDraw_ExtensionPosObliqueChainDimension";
     *extattribs << "TechDraw_ExtensionCascadeDimensionGroup";
-    //    *extattribs << "TechDraw_ExtensionCascadeHorizDimension";
-    //    *extattribs << "TechDraw_ExtensionCascadeVertDimension";
-    //    *extattribs << "TechDraw_ExtensionCascadeObliqueDimension";
     *extattribs << "TechDraw_ExtensionAreaAnnotation";
     *extattribs << "TechDraw_ExtensionCustomizeFormat";
 
     Gui::ToolBarItem* extcenter = new Gui::ToolBarItem(root);
     extcenter->setCommand("TechDraw Centerlines");
     *extcenter << "TechDraw_ExtensionCircleCenterLinesGroup";
-    //    *extcenter << "TechDraw_ExtensionCircleCenterLines";
-    //    *extcenter << "TechDraw_ExtensionHoleCircle";
     *extcenter << "TechDraw_ExtensionThreadsGroup";
-    //    *extcenter << "TechDraw_ExtensionThreadHoleSide";
-    //    *extcenter << "TechDraw_ExtensionThreadHoleBottom";
-    //    *extcenter << "TechDraw_ExtensionThreadBoltSide";
-    //    *extcenter << "TechDraw_ExtensionThreadBoltBottom";
     *extcenter << "TechDraw_ExtensionVertexAtIntersection";
     *extcenter << "TechDraw_ExtensionDrawCirclesGroup";
-    //    *extcenter << "TechDraw_ExtensionDrawCosmCircle";
-    //    *extcenter << "TechDraw_ExtensionDrawCosmArc";
-    //    *extcenter << "TechDraw_ExtensionDrawCosmCircle3Points";
     *extcenter << "TechDraw_ExtensionLinePPGroup";
-    //    *extcenter << "TechDraw_ExtensionLineParallel";
-    //    *extcenter << "TechDraw_ExtensionLinePerpendicular";
 
     Gui::ToolBarItem* extdimensions = new Gui::ToolBarItem(root);
     extdimensions->setCommand("TechDraw Extend Dimensions");
     *extdimensions << "TechDraw_ExtensionCreateChainDimensionGroup";
-    //    *extdimensions << "TechDraw_ExtensionCreateHorizChainDimension";
-    //    *extdimensions << "TechDraw_ExtensionCreateVertChainDimension";
-    //    *extdimensions << "TechDraw_ExtensionCreateObliqueChainDimension";
     *extdimensions << "TechDraw_ExtensionCreateCoordDimensionGroup";
-    //    *extdimensions << "TechDraw_ExtensionCreateHorizCoordDimension";
-    //    *extdimensions << "TechDraw_ExtensionCreateVertCoordDimension";
-    //    *extdimensions << "TechDraw_ExtensionCreateObliqueCoordDimension";
     *extdimensions << "TechDraw_ExtensionChamferDimensionGroup";
-    //    *extdimensions << "TechDraw_ExtensionCreateHorizChamferDimension";
-    //    *extdimensions << "TechDraw_ExtensionCreateVertChamferDimension";
     *extdimensions << "TechDraw_ExtensionCreateLengthArc";
     *extdimensions << "TechDraw_ExtensionInsertPrefixGroup";
-    //    *extdimensions << "TechDraw_ExtensionInsertDiameter";
-    //    *extdimensions << "TechDraw_ExtensionInsertSquare";
-    //    *extdimensions << "TechDraw_ExtensionRemovePrefixChar";
     *extdimensions << "TechDraw_ExtensionIncreaseDecreaseGroup";
-    //    *extdimensions << "TechDraw_ExtensionIncreaseDecimal";
-    //    *extdimensions << "TechDraw_ExtensionDecreaseDecimal";
 
     Gui::ToolBarItem* file = new Gui::ToolBarItem(root);
     file->setCommand("TechDraw File Access");
@@ -562,9 +484,6 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *anno << "TechDraw_RichTextAnnotation";
     *anno << "TechDraw_CosmeticVertexGroup";
     *anno << "TechDraw_CenterLineGroup";
-    //    *anno << "TechDraw_FaceCenterLine";
-    //    *anno << "TechDraw_2LineCenterLine";
-    //    *anno << "TechDraw_2PointCenterLine";
     *anno << "TechDraw_2PointCosmeticLine";
     *anno << "TechDraw_CosmeticEraser";
     *anno << "TechDraw_DecorateLine";


### PR DESCRIPTION
This PR 
- fixes an issue with pdf export reported here: https://forum.freecad.org/viewtopic.php?t=80532&sid=39976b8ae9944d1bf07cc52c4b231882
- fixes a mistake in the splitting of GeometryObject
- allow cosmetic vertices and edges to rotate with the parent view.