### PR TITLE
[0.21][Sketcher] Fix minor icon missing bug...

### DIFF
--- a/src/Mod/Sketcher/Profiles.py
+++ b/src/Mod/Sketcher/Profiles.py
@@ -53,7 +53,7 @@ class _CommandProfileHexagon1:
 
     def GetResources(self):
         return {
-            "Pixmap": "Sketcher_ProfilesHexagon1",
+            "Pixmap": "Sketcher_CreateHexagon",
             "MenuText": QtCore.QT_TRANSLATE_NOOP(
                 "Sketcher_ProfilesHexagon1", "Creates a hexagonal profile"
             ),


### PR DESCRIPTION
...icon was moved to obsolete in 2020
Backport of https://github.com/FreeCAD/FreeCAD/commit/fec225ddccc911d3e8d921a26abde183c18bdb76