### PR TITLE
Inspection: modernize C++: use equals default

### DIFF
--- a/src/Mod/Inspection/App/AppInspection.cpp
+++ b/src/Mod/Inspection/App/AppInspection.cpp
@@ -37,8 +37,6 @@ public:
         initialize("This module is the Inspection module."); // register with Python
     }
 
-    ~Module() override {}
-
 private:
 };
 

--- a/src/Mod/Inspection/App/InspectionFeature.cpp
+++ b/src/Mod/Inspection/App/InspectionFeature.cpp
@@ -67,9 +67,7 @@ InspectActualMesh::InspectActualMesh(const Mesh::MeshObject& rMesh) : _mesh(rMes
     _bApply = _clTrf != tmp;
 }
 
-InspectActualMesh::~InspectActualMesh()
-{
-}
+InspectActualMesh::~InspectActualMesh() = default;
 
 unsigned long InspectActualMesh::countPoints() const
 {
@@ -545,15 +543,9 @@ bool InspectNominalShape::isBelowFace(const gp_Pnt& pnt3d) const
 
 TYPESYSTEM_SOURCE(Inspection::PropertyDistanceList, App::PropertyLists)
 
-PropertyDistanceList::PropertyDistanceList()
-{
+PropertyDistanceList::PropertyDistanceList() = default;
 
-}
-
-PropertyDistanceList::~PropertyDistanceList()
-{
-
-}
+PropertyDistanceList::~PropertyDistanceList() = default;
 
 void PropertyDistanceList::setSize(int newSize)
 {
@@ -754,9 +746,7 @@ Feature::Feature()
     ADD_PROPERTY(Distances,(0.0));
 }
 
-Feature::~Feature()
-{
-}
+Feature::~Feature() = default;
 
 short Feature::mustExecute() const
 {
@@ -953,10 +943,6 @@ App::DocumentObjectExecReturn* Feature::execute()
 PROPERTY_SOURCE(Inspection::Group, App::DocumentObjectGroup)
 
 
-Group::Group()
-{
-}
+Group::Group() = default;
 
-Group::~Group()
-{
-}
+Group::~Group() = default;

--- a/src/Mod/Inspection/App/InspectionFeature.h
+++ b/src/Mod/Inspection/App/InspectionFeature.h
@@ -50,8 +50,8 @@ namespace Inspection
 class InspectionExport InspectActualGeometry
 {
 public:
-    InspectActualGeometry() {}
-    virtual ~InspectActualGeometry() {}
+    InspectActualGeometry() = default;
+    virtual ~InspectActualGeometry() = default;
     /// Number of points to be checked
     virtual unsigned long countPoints() const = 0;
     virtual Base::Vector3f getPoint(unsigned long) const = 0;
@@ -101,8 +101,8 @@ private:
 class InspectionExport InspectNominalGeometry
 {
 public:
-    InspectNominalGeometry() {}
-    virtual ~InspectNominalGeometry() {}
+    InspectNominalGeometry() = default;
+    virtual ~InspectNominalGeometry() = default;
     virtual float getDistance(const Base::Vector3f&) const = 0;
 };
 

--- a/src/Mod/Inspection/Gui/AppInspectionGui.cpp
+++ b/src/Mod/Inspection/Gui/AppInspectionGui.cpp
@@ -44,8 +44,6 @@ public:
         initialize("This module is the InspectionGui module."); // register with Python
     }
 
-    ~Module() override {}
-
 private:
 };
 

--- a/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
+++ b/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
@@ -445,7 +445,7 @@ class ViewProviderProxyObject : public QObject
 {
 public:
     explicit ViewProviderProxyObject(QWidget* w) : QObject(nullptr), widget(w) {}
-    ~ViewProviderProxyObject() override {}
+    ~ViewProviderProxyObject() override = default;
     void customEvent(QEvent *) override
     {
         if (!widget.isNull()) {
@@ -682,13 +682,9 @@ PROPERTY_SOURCE(InspectionGui::ViewProviderInspectionGroup, Gui::ViewProviderDoc
 /**
  * Creates the view provider for an object group.
  */
-ViewProviderInspectionGroup::ViewProviderInspectionGroup()
-{
-}
+ViewProviderInspectionGroup::ViewProviderInspectionGroup() = default;
 
-ViewProviderInspectionGroup::~ViewProviderInspectionGroup()
-{
-}
+ViewProviderInspectionGroup::~ViewProviderInspectionGroup() = default;
 
 /**
  * Returns the pixmap for the opened list item.

--- a/src/Mod/Inspection/Gui/VisualInspection.cpp
+++ b/src/Mod/Inspection/Gui/VisualInspection.cpp
@@ -54,9 +54,7 @@ public:
     {
     }
 
-    ~SingleSelectionItem () override
-    {
-    }
+    ~SingleSelectionItem () override = default;
 
     SingleSelectionItem* getCompetitiveItem() const
     {

--- a/src/Mod/Inspection/Gui/Workbench.cpp
+++ b/src/Mod/Inspection/Gui/Workbench.cpp
@@ -33,13 +33,9 @@ using namespace InspectionGui;
 /// @namespace InspectionGui @class Workbench
 TYPESYSTEM_SOURCE(InspectionGui::Workbench, Gui::StdWorkbench)
 
-Workbench::Workbench()
-{
-}
+Workbench::Workbench() = default;
 
-Workbench::~Workbench()
-{
-}
+Workbench::~Workbench() = default;
 
 Gui::MenuItem* Workbench::setupMenuBar() const
 {


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html
This PR affects the code of the Inspection module.