### PR TITLE
Mesh: modernize C++: use equals default

### DIFF
--- a/src/Mod/Mesh/App/AppMeshPy.cpp
+++ b/src/Mod/Mesh/App/AppMeshPy.cpp
@@ -129,8 +129,6 @@ public:
                    "\n");
     }
 
-    ~Module() override {}
-
 private:
     Py::Object invoke_method_varargs(void *method_def, const Py::Tuple &args) override
     {

--- a/src/Mod/Mesh/App/Core/Algorithm.h
+++ b/src/Mod/Mesh/App/Core/Algorithm.h
@@ -54,10 +54,7 @@ class AbstractPolygonTriangulator;
 class MeshExport MeshAlgorithm
 {
 public:
-  /// Construction
   explicit MeshAlgorithm (const MeshKernel &rclM) : _rclMesh(rclM) { }
-  /// Destruction
-  ~MeshAlgorithm () { }
 
 public:
   /**
@@ -344,8 +341,8 @@ protected:
 class MeshExport MeshCollector
 {
 public:
-    MeshCollector(){}
-    virtual ~MeshCollector(){}
+    MeshCollector() = default;
+    virtual ~MeshCollector() = default;
     virtual void Append(const MeshCore::MeshKernel&, FacetIndex index) = 0;
 };
 
@@ -353,7 +350,6 @@ class MeshExport PointCollector : public MeshCollector
 {
 public:
     explicit PointCollector(std::vector<PointIndex>& ind) : indices(ind){}
-    ~PointCollector() override{}
     void Append(const MeshCore::MeshKernel& kernel, FacetIndex index) override
     {
         PointIndex ulP1, ulP2, ulP3;
@@ -371,7 +367,6 @@ class MeshExport FacetCollector : public MeshCollector
 {
 public:
     explicit FacetCollector(std::vector<FacetIndex>& ind) : indices(ind){}
-    ~FacetCollector() override{}
     void Append(const MeshCore::MeshKernel&, FacetIndex index) override
     {
         indices.push_back(index);
@@ -393,9 +388,6 @@ public:
     /// Construction
     explicit MeshRefPointToFacets (const MeshKernel &rclM) : _rclMesh(rclM)
     { Rebuild(); }
-    /// Destruction
-    ~MeshRefPointToFacets ()
-    { }
 
     /// Rebuilds up data structure
     void Rebuild ();
@@ -432,9 +424,6 @@ public:
     /// Construction
     explicit MeshRefFacetToFacets (const MeshKernel &rclM) : _rclMesh(rclM)
     { Rebuild(); }
-    /// Destruction
-    ~MeshRefFacetToFacets ()
-    { }
     /// Rebuilds up data structure
     void Rebuild ();
 
@@ -461,9 +450,6 @@ public:
     /// Construction
     explicit MeshRefPointToPoints (const MeshKernel &rclM) : _rclMesh(rclM)
     { Rebuild(); }
-    /// Destruction
-    ~MeshRefPointToPoints ()
-    { }
 
     /// Rebuilds up data structure
     void Rebuild ();
@@ -490,9 +476,6 @@ public:
     /// Construction
     explicit MeshRefEdgeToFacets (const MeshKernel &rclM) : _rclMesh(rclM)
     { Rebuild(); }
-    /// Destruction
-    ~MeshRefEdgeToFacets ()
-    { }
 
     /// Rebuilds up data structure
     void Rebuild ();
@@ -529,9 +512,6 @@ public:
     /// Construction
     explicit MeshRefNormalToPoints (const MeshKernel &rclM) : _rclMesh(rclM)
     { Rebuild(); }
-    /// Destruction
-    ~MeshRefNormalToPoints ()
-    { }
 
     /// Rebuilds up data structure
     void Rebuild ();

--- a/src/Mod/Mesh/App/Core/Approximation.cpp
+++ b/src/Mod/Mesh/App/Core/Approximation.cpp
@@ -142,10 +142,6 @@ PlaneFit::PlaneFit()
 {
 }
 
-PlaneFit::~PlaneFit()
-{
-}
-
 float PlaneFit::Fit()
 {
     _bIsFitted = true;
@@ -1038,10 +1034,6 @@ CylinderFit::CylinderFit()
 {
 }
 
-CylinderFit::~CylinderFit()
-{
-}
-
 Base::Vector3f CylinderFit::GetInitialAxisFromNormals(const std::vector<Base::Vector3f>& n) const
 {
 #if 0
@@ -1308,11 +1300,6 @@ SphereFit::SphereFit()
 {
 }
 
-SphereFit::~SphereFit()
-{
-
-}
-
 float SphereFit::GetRadius() const
 {
     if (_bIsFitted)
@@ -1433,10 +1420,6 @@ PolynomialFit::PolynomialFit()
 {
     for (float & i : _fCoeff)
         i = 0.0f;
-}
-
-PolynomialFit::~PolynomialFit()
-{
 }
 
 float PolynomialFit::Fit()

--- a/src/Mod/Mesh/App/Core/Approximation.h
+++ b/src/Mod/Mesh/App/Core/Approximation.h
@@ -53,10 +53,8 @@ public:
   explicit PolynomialSurface (const Real afCoeff[6])
   { for (int i=0; i<6; i++) m_afCoeff[i] = afCoeff[i]; }
 
-  virtual ~PolynomialSurface () {}
-
   // the function
-  virtual Real F (const Vector3<Real>& rkP) const
+  Real F (const Vector3<Real>& rkP) const override
   {
     return ( m_afCoeff[0]*rkP.X()*rkP.X() +
              m_afCoeff[1]*rkP.Y()*rkP.Y() +
@@ -67,25 +65,25 @@ public:
   }
 
   // first-order partial derivatives
-  virtual Real FX (const Vector3<Real>& rkP) const
+  Real FX (const Vector3<Real>& rkP) const override
   { return (Real)(2.0*m_afCoeff[0]*rkP.X() + m_afCoeff[2] + m_afCoeff[4]*rkP.Y()); }
-  virtual Real FY (const Vector3<Real>& rkP) const
+  Real FY (const Vector3<Real>& rkP) const override
   { return (Real)(2.0*m_afCoeff[1]*rkP.Y() + m_afCoeff[3] + m_afCoeff[4]*rkP.X()); }
-  virtual Real FZ (const Vector3<Real>& /*rkP*/) const
+  Real FZ (const Vector3<Real>& /*rkP*/) const override
   { return (Real)-1.0; }
 
   // second-order partial derivatives
-  virtual Real FXX (const Vector3<Real>& /*rkP*/) const
+  Real FXX (const Vector3<Real>& /*rkP*/) const override
   { return (Real)(2.0*m_afCoeff[0]); }
-  virtual Real FXY (const Vector3<Real>& /*rkP*/) const
+  Real FXY (const Vector3<Real>& /*rkP*/) const override
   { return (Real)(m_afCoeff[4]); }
-  virtual Real FXZ (const Vector3<Real>& /*rkP*/) const
+  Real FXZ (const Vector3<Real>& /*rkP*/) const override
   { return (Real)0.0; }
-  virtual Real FYY (const Vector3<Real>& /*rkP*/) const
+  Real FYY (const Vector3<Real>& /*rkP*/) const override
   { return (Real)(2.0*m_afCoeff[1]); }
-  virtual Real FYZ (const Vector3<Real>& /*rkP*/) const
+  Real FYZ (const Vector3<Real>& /*rkP*/) const override
   { return (Real)0.0; }
-  virtual Real FZZ (const Vector3<Real>& /*rkP*/) const
+  Real FZZ (const Vector3<Real>& /*rkP*/) const override
   { return (Real)0.0; }
 
 protected:
@@ -184,14 +182,7 @@ protected:
 class MeshExport PlaneFit : public Approximation
 {
 public:
-    /**
-     * Construction
-     */
     PlaneFit();
-    /**
-     * Destruction
-     */
-    ~PlaneFit() override;
     Base::Vector3f GetBase() const;
     Base::Vector3f GetDirU() const;
     Base::Vector3f GetDirV() const;
@@ -262,16 +253,7 @@ protected:
 class MeshExport QuadraticFit : public Approximation
 {
 public:
-    /**
-     * Construction
-     */
-    QuadraticFit() : Approximation() {
-        std::fill(_fCoeff, _fCoeff+10, 0.0);
-    }
-    /**
-     * Destruction
-     */
-    ~QuadraticFit() override{}
+    QuadraticFit() = default;
     /**
      * Get the quadric coefficients
      * @param ulIndex Number of coefficient (0..9)
@@ -321,8 +303,8 @@ public:
     void CalcEigenValues(double &dLambda1, double &dLambda2, double &dLambda3,
                          Base::Vector3f &clEV1, Base::Vector3f &clEV2, Base::Vector3f &clEV3) const;
 
-protected:
-    double _fCoeff[ 10 ];  /**< Coefficients of the fit */
+private:
+    double _fCoeff[ 10 ]{};  /**< Coefficients of the fit */
 };
 
 // -------------------------------------------------------------------------------
@@ -339,14 +321,7 @@ protected:
 class MeshExport SurfaceFit : public PlaneFit
 {
 public:
-    /**
-     * Construction
-     */
     SurfaceFit();
-    /**
-     * Destruction
-     */
-    ~SurfaceFit() override{}
 
     bool GetCurvatureInfo(double x, double y, double z, double &rfCurv0, double &rfCurv1,
                           Base::Vector3f &rkDir0, Base::Vector3f &rkDir1, double &dDistance);
@@ -383,14 +358,7 @@ protected:
 class MeshExport CylinderFit : public Approximation
 {
 public:
-    /**
-     * Construction
-     */
     CylinderFit();
-    /**
-     * Destruction
-     */
-    ~CylinderFit() override;
     float GetRadius() const;
     Base::Vector3f GetBase() const;
     void SetInitialValues(const Base::Vector3f&, const Base::Vector3f&);
@@ -442,14 +410,7 @@ protected:
 class MeshExport SphereFit : public Approximation
 {
 public:
-    /**
-     * Construction
-     */
     SphereFit();
-    /**
-     * Destruction
-     */
-    ~SphereFit() override;
     float GetRadius() const;
     Base::Vector3f GetCenter() const;
     /**
@@ -645,21 +606,14 @@ private:
     /**
      * Private construction.
      */
-    FunctionContainer(){}
+    FunctionContainer() = default;
 };
 
 class MeshExport PolynomialFit : public Approximation
 {
 public:
-    /**
-     * Construction
-     */
     PolynomialFit();
 
-    /**
-     * Destruction
-     */
-    ~PolynomialFit() override;
     float Fit() override;
     float Value(float x, float y) const;
 

--- a/src/Mod/Mesh/App/Core/Curvature.cpp
+++ b/src/Mod/Mesh/App/Core/Curvature.cpp
@@ -64,8 +64,6 @@ MeshCurvature::MeshCurvature(const MeshKernel& kernel, const std::vector<FacetIn
 
 void MeshCurvature::ComputePerFace(bool parallel)
 {
-    Base::Vector3f rkDir0, rkDir1, rkPnt;
-    Base::Vector3f rkNormal;
     myCurvature.clear();
     MeshRefPointToFacets search(myKernel);
     FacetCurvature face(myKernel, search, myRadius, myMinPoints);

--- a/src/Mod/Mesh/App/Core/CylinderFit.cpp
+++ b/src/Mod/Mesh/App/Core/CylinderFit.cpp
@@ -81,10 +81,6 @@ CylinderFit::CylinderFit()
 {
 }
 
-CylinderFit::~CylinderFit()
-{
-}
-
 // Set approximations before calling the fitting
 void CylinderFit::SetApproximations(double radius, const Base::Vector3d &base, const Base::Vector3d &axis)
 {

--- a/src/Mod/Mesh/App/Core/CylinderFit.h
+++ b/src/Mod/Mesh/App/Core/CylinderFit.h
@@ -51,11 +51,6 @@ public:
      */
     CylinderFit();
     /**
-     * Destruction
-     */
-    ~CylinderFit() override;
-
-    /**
      * Set approximations before calling Fit()
      */
     void SetApproximations(double radius, const Base::Vector3d &base, const Base::Vector3d &axis);

--- a/src/Mod/Mesh/App/Core/Decimation.cpp
+++ b/src/Mod/Mesh/App/Core/Decimation.cpp
@@ -34,10 +34,6 @@ MeshSimplify::MeshSimplify(MeshKernel& mesh)
 {
 }
 
-MeshSimplify::~MeshSimplify()
-{
-}
-
 void MeshSimplify::simplify(float tolerance, float reduction)
 {
     Simplify alg;

--- a/src/Mod/Mesh/App/Core/Decimation.h
+++ b/src/Mod/Mesh/App/Core/Decimation.h
@@ -34,7 +34,6 @@ class MeshExport MeshSimplify
 {
 public:
     MeshSimplify(MeshKernel&);//explicit bombs
-    ~MeshSimplify();
     void simplify(float tolerance, float reduction);
     void simplify(int targetSize);
 

--- a/src/Mod/Mesh/App/Core/Definitions.cpp
+++ b/src/Mod/Mesh/App/Core/Definitions.cpp
@@ -40,9 +40,7 @@ float  MeshDefinitions::_fMinEdgeLength       =  MESH_MIN_EDGE_LEN;
 bool   MeshDefinitions::_bRemoveMinLength     =  MESH_REMOVE_MIN_LEN;
 float  MeshDefinitions::_fMinEdgeAngle        =  Base::toRadians<float>(MESH_MIN_EDGE_ANGLE);
 
-MeshDefinitions::MeshDefinitions ()
-{
-}
+MeshDefinitions::MeshDefinitions () = default;
 
 void MeshDefinitions::SetMinPointDistance (float fMin)
 {

--- a/src/Mod/Mesh/App/Core/Definitions.h
+++ b/src/Mod/Mesh/App/Core/Definitions.h
@@ -81,8 +81,6 @@ class MeshExport MeshDefinitions
 {
 public:
   MeshDefinitions ();
-  virtual ~MeshDefinitions ()
-  {}
 
   static float  _fMinPointDistance;
   static float  _fMinPointDistanceP2;

--- a/src/Mod/Mesh/App/Core/Degeneration.h
+++ b/src/Mod/Mesh/App/Core/Degeneration.h
@@ -51,10 +51,6 @@ public:
    */
   explicit MeshEvalInvalids (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
   /**
-   * Destruction.
-   */
-  ~MeshEvalInvalids () override { }
-  /**
    * Searches for as 'Invalid' marked points or facets.
    */
   bool Evaluate () override;
@@ -77,10 +73,6 @@ public:
    */
   explicit MeshFixInvalids (MeshKernel &rclM) : MeshValidation( rclM ) { }
   /**
-   * Destruction.
-   */
-  ~MeshFixInvalids () override { }
-  /**
    * Remove invalid elements.
    */
   bool Fixup () override;
@@ -101,10 +93,6 @@ public:
    * Construction.
    */
   explicit MeshEvalDuplicatePoints (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /**
-   * Destruction.
-   */
-  ~MeshEvalDuplicatePoints () override { }
   /**
    * Merges points to one if the distance between them is less than the global \a MeshDefinitions::_fMinPointDistanceD1.
    */
@@ -128,10 +116,6 @@ public:
    */
   explicit MeshFixDuplicatePoints (MeshKernel &rclM) : MeshValidation( rclM ) { }
   /**
-   * Destruction.
-   */
-  ~MeshFixDuplicatePoints () override { }
-  /**
    * Merges duplicated points.
    */
   bool Fixup () override;
@@ -149,10 +133,6 @@ public:
    * Construction.
    */
   explicit MeshEvalNaNPoints (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /**
-   * Destruction.
-   */
-  ~MeshEvalNaNPoints () override { }
   /**
    * Returns false if a point with NaN coordinate is found.
    */
@@ -176,10 +156,6 @@ public:
    */
   explicit MeshFixNaNPoints (MeshKernel &rclM) : MeshValidation( rclM ) { }
   /**
-   * Destruction.
-   */
-  ~MeshFixNaNPoints () override { }
-  /**
    * Merges duplicated points.
    */
   bool Fixup () override;
@@ -199,10 +175,6 @@ public:
    * Construction.
    */
   explicit MeshEvalDuplicateFacets (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /**
-   * Destruction.
-   */
-  ~MeshEvalDuplicateFacets () override { }
   /**
    * Searches for duplicated facets.
    */
@@ -226,10 +198,6 @@ public:
    */
   explicit MeshFixDuplicateFacets (MeshKernel &rclM) : MeshValidation( rclM ) { }
   /**
-   * Destruction.
-   */
-  ~MeshFixDuplicateFacets () override { }
-  /**
    * Removes duplicated facets.
    */
   bool Fixup () override;
@@ -246,10 +214,6 @@ public:
    * Construction.
    */
   explicit MeshEvalInternalFacets (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /**
-   * Destruction.
-   */
-  ~MeshEvalInternalFacets () override { }
   /**
    * Identify internal facets.
    */
@@ -282,10 +246,6 @@ public:
   MeshEvalDegeneratedFacets (const MeshKernel &rclM, float fEps)
       : MeshEvaluation(rclM), fEpsilon(fEps) {}
   /**
-   * Destruction.
-   */
-  ~MeshEvalDegeneratedFacets () override { }
-  /**
    * Searches degenerated facets.
    */
   bool Evaluate () override;
@@ -316,10 +276,6 @@ public:
   MeshFixDegeneratedFacets (MeshKernel &rclM, float fEps)
       : MeshValidation(rclM), fEpsilon(fEps) { }
   /**
-   * Destruction.
-   */
-  ~MeshFixDegeneratedFacets () override { }
-  /**
    * Removes degenerated facets.
    */
   bool Fixup () override;
@@ -346,10 +302,6 @@ public:
      */
   explicit MeshRemoveNeedles (MeshKernel &rclM, float fMinEdgeLen = 0.05f)
       : MeshValidation(rclM), fMinEdgeLength(std::min(fMinEdgeLen, 0.25f)) {}
-  /**
-   * Destruction.
-   */
-  ~MeshRemoveNeedles () override { }
   /**
    * Removes all facets with an edge smaller than \a fMinEdgeLength without leaving holes or gaps
    * in the mesh.
@@ -379,10 +331,6 @@ public:
   explicit MeshFixCaps (MeshKernel &rclM, float fMaxAng = 2.61f, float fFactor = 0.25f) // ~150 degree
       : MeshValidation(rclM), fMaxAngle(fMaxAng), fSplitFactor(fFactor) { }
   /**
-   * Destruction.
-   */
-  ~MeshFixCaps () override { }
-  /**
    */
   bool Fixup () override;
 
@@ -405,10 +353,6 @@ public:
    */
   MeshEvalDeformedFacets (const MeshKernel &rclM, float fMinAngle, float fMaxAngle)
       : MeshEvaluation(rclM), fMinAngle(fMinAngle), fMaxAngle(fMaxAngle) { }
-  /**
-   * Destruction.
-   */
-  ~MeshEvalDeformedFacets () override { }
   /**
    * Searches deformed facets.
    */
@@ -440,10 +384,6 @@ public:
       : MeshValidation(rclM), fMinAngle(fMinAngle), fMaxAngle(fMaxAngle),
         fMaxSwapAngle(fSwapAngle), fEpsilon(fEps) { }
   /**
-   * Destruction.
-   */
-  ~MeshFixDeformedFacets () override { }
-  /**
    * Removes deformed facets.
    */
   bool Fixup () override;
@@ -472,10 +412,6 @@ public:
   explicit MeshFixMergeFacets (MeshKernel &rclM)
       : MeshValidation(rclM) { }
   /**
-   * Destruction.
-   */
-  ~MeshFixMergeFacets () override { }
-  /**
    * Removes deformed facets.
    */
   bool Fixup () override;
@@ -489,7 +425,6 @@ class MeshExport MeshEvalDentsOnSurface : public MeshEvaluation
 {
 public:
     explicit MeshEvalDentsOnSurface (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-    ~MeshEvalDentsOnSurface() override {}
 
     bool Evaluate() override;
     std::vector<FacetIndex> GetIndices() const;
@@ -502,7 +437,6 @@ class MeshExport MeshFixDentsOnSurface : public MeshValidation
 {
 public:
     explicit MeshFixDentsOnSurface (MeshKernel &rclM) : MeshValidation( rclM ) { }
-    ~MeshFixDentsOnSurface() override {}
 
     bool Fixup() override;
 };
@@ -516,7 +450,6 @@ class MeshExport MeshEvalFoldsOnSurface : public MeshEvaluation
 {
 public:
     explicit MeshEvalFoldsOnSurface (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-    ~MeshEvalFoldsOnSurface() override {}
 
     bool Evaluate() override;
     std::vector<FacetIndex> GetIndices() const;
@@ -535,7 +468,6 @@ class MeshExport MeshEvalFoldsOnBoundary : public MeshEvaluation
 {
 public:
     explicit MeshEvalFoldsOnBoundary (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-    ~MeshEvalFoldsOnBoundary() override {}
 
     bool Evaluate() override;
     std::vector<FacetIndex> GetIndices() const;
@@ -548,7 +480,6 @@ class MeshExport MeshFixFoldsOnBoundary : public MeshValidation
 {
 public:
     explicit MeshFixFoldsOnBoundary (MeshKernel &rclM) : MeshValidation( rclM ) { }
-    ~MeshFixFoldsOnBoundary() override {}
 
     bool Fixup() override;
 };
@@ -561,7 +492,6 @@ class MeshExport MeshEvalFoldOversOnSurface : public MeshEvaluation
 {
 public:
     explicit MeshEvalFoldOversOnSurface (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-    ~MeshEvalFoldOversOnSurface() override {}
 
     bool Evaluate() override;
     std::vector<FacetIndex> GetIndices() const
@@ -581,7 +511,6 @@ class MeshExport MeshEvalBorderFacet : public MeshEvaluation
 public:
   MeshEvalBorderFacet (const MeshKernel &rclB, std::vector<FacetIndex>& f)
     : MeshEvaluation(rclB), _facets(f) {}
-  ~MeshEvalBorderFacet () override {}
   bool Evaluate() override;
 
 protected:
@@ -607,10 +536,6 @@ public:
    */
   explicit MeshEvalRangeFacet (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
   /**
-   * Destruction.
-   */
-  ~MeshEvalRangeFacet () override { }
-  /**
    * Searches for facets that has neighbour facet indices out of range.
    */
   bool Evaluate () override;
@@ -633,10 +558,6 @@ public:
    */
   explicit MeshFixRangeFacet (MeshKernel &rclM) : MeshValidation( rclM ) { }
   /**
-   * Destruction.
-   */
-  ~MeshFixRangeFacet () override { }
-  /**
    * Fixes facets with neighbour indices out of range.
    */
   bool Fixup () override;
@@ -654,10 +575,6 @@ public:
    * Construction.
    */
   explicit MeshEvalRangePoint (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /**
-   * Destruction.
-   */
-  ~MeshEvalRangePoint () override { }
   /**
    * Searches for facets that has point indices out of range.
    */
@@ -681,10 +598,6 @@ public:
    */
   explicit MeshFixRangePoint (MeshKernel &rclM) : MeshValidation( rclM ) { }
   /**
-   * Destruction.
-   */
-  ~MeshFixRangePoint () override { }
-  /**
    * Fixes facets with point indices out of range.
    */
   bool Fixup () override;
@@ -703,10 +616,6 @@ public:
    * Construction.
    */
   explicit MeshEvalCorruptedFacets (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /**
-   * Destruction.
-   */
-  ~MeshEvalCorruptedFacets () override { }
   /**
    * Searches for corrupted facets.
    */
@@ -731,10 +640,6 @@ public:
    */
   explicit MeshFixCorruptedFacets (MeshKernel &rclM) : MeshValidation( rclM ) { }
   /**
-   * Destruction.
-   */
-  ~MeshFixCorruptedFacets () override { }
-  /**
    * Removes corrupted facets.
    */
   bool Fixup () override;
@@ -752,10 +657,6 @@ public:
    * Construction.
    */
   explicit MeshEvalPointOnEdge (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /**
-   * Destruction.
-   */
-  ~MeshEvalPointOnEdge () override { }
   /**
    * Searches for points that lie on edge of triangle.
    */
@@ -786,10 +687,6 @@ public:
    * Construction.
    */
   explicit MeshFixPointOnEdge (MeshKernel &rclM, bool fill = false) : MeshValidation( rclM ), fillBoundary(fill) { }
-  /**
-   * Destruction.
-   */
-  ~MeshFixPointOnEdge () override { }
   /**
    * Removes points that lie on edges of triangles.
    */

--- a/src/Mod/Mesh/App/Core/Elements.cpp
+++ b/src/Mod/Mesh/App/Core/Elements.cpp
@@ -36,10 +36,9 @@
 using namespace MeshCore;
 using namespace Wm4;
 
-MeshPointArray::MeshPointArray(const MeshPointArray& ary)
-  : TMeshPointArray(ary)
-{
-}
+MeshPointArray::MeshPointArray(const MeshPointArray& ary) = default;
+
+MeshPointArray::MeshPointArray(MeshPointArray&& ary) = default;
 
 PointIndex MeshPointArray::Get (const MeshPoint &rclPoint)
 {
@@ -85,13 +84,9 @@ void MeshPointArray::ResetInvalid () const
   for (const auto & pP : *this) pP.ResetInvalid();
 }
 
-MeshPointArray& MeshPointArray::operator = (const MeshPointArray &rclPAry)
-{
-//  std::vector<MeshPoint>::operator=(rclPAry);
-  TMeshPointArray::operator=(rclPAry);
+MeshPointArray& MeshPointArray::operator = (const MeshPointArray &rclPAry) = default;
 
-  return *this;
-}
+MeshPointArray& MeshPointArray::operator = (MeshPointArray &&rclPAry) = default;
 
 void MeshPointArray::Transform(const Base::Matrix4D& mat)
 {
@@ -99,11 +94,9 @@ void MeshPointArray::Transform(const Base::Matrix4D& mat)
     mat.multVec(pP,pP);
 }
 
-MeshFacetArray::MeshFacetArray(const MeshFacetArray& ary)
-  : TMeshFacetArray(ary)
-{
-}
+MeshFacetArray::MeshFacetArray(const MeshFacetArray& ary) = default;
 
+MeshFacetArray::MeshFacetArray(MeshFacetArray&& ary) = default;
 
 void MeshFacetArray::Erase (_TIterator pIter)
 {
@@ -167,11 +160,9 @@ void MeshFacetArray::ResetInvalid () const
   for (const auto & pF : *this) pF.ResetInvalid();
 }
 
-MeshFacetArray& MeshFacetArray::operator = (const MeshFacetArray &rclFAry)
-{
-  TMeshFacetArray::operator=(rclFAry);
-  return *this;
-}
+MeshFacetArray& MeshFacetArray::operator = (const MeshFacetArray &rclFAry) = default;
+
+MeshFacetArray& MeshFacetArray::operator = (MeshFacetArray &&rclFAry) = default;
 
 // -----------------------------------------------------------------
 
@@ -201,7 +192,7 @@ bool MeshGeomEdge::ContainedByOrIntersectBoundingBox ( const Base::BoundBox3f &r
 
 Base::BoundBox3f MeshGeomEdge::GetBoundBox () const
 {
-  return Base::BoundBox3f(_aclPoints,2);
+  return {_aclPoints,2};
 }
 
 bool MeshGeomEdge::IntersectBoundingBox (const Base::BoundBox3f &rclBB) const

--- a/src/Mod/Mesh/App/Core/Elements.h
+++ b/src/Mod/Mesh/App/Core/Elements.h
@@ -110,8 +110,9 @@ public:
   MeshPoint () : _ucFlag(0), _ulProp(0) { }
   inline MeshPoint (float x, float y, float z);
   inline MeshPoint (const Base::Vector3f &rclPt);//explicit bombs
-  inline MeshPoint (const MeshPoint &rclPt);
-  ~MeshPoint () { }
+  inline MeshPoint (const MeshPoint &rclPt) = default;
+  inline MeshPoint (MeshPoint &&rclPt) = default;
+  ~MeshPoint () = default;
   //@}
 
 public:
@@ -136,7 +137,8 @@ public:
   //@}
 
   // Assignment
-  inline MeshPoint& operator = (const MeshPoint &rclPt);
+  inline MeshPoint& operator = (const MeshPoint &rclPt) = default;
+  inline MeshPoint& operator = (MeshPoint &&rclPt) = default;
 
   // compare operator
   inline bool operator == (const MeshPoint &rclPt) const;
@@ -239,9 +241,10 @@ public:
   /** @name Construction */
   //@{
   inline MeshFacet ();
-  inline MeshFacet(const MeshFacet &rclF);
+  inline MeshFacet(const MeshFacet &rclF) = default;
+  inline MeshFacet(MeshFacet &&rclF) = default;
   inline MeshFacet(PointIndex p1,PointIndex p2,PointIndex p3,FacetIndex n1=FACET_INDEX_MAX,FacetIndex n2=FACET_INDEX_MAX,FacetIndex n3=FACET_INDEX_MAX);
-  ~MeshFacet () { }
+  ~MeshFacet () = default;
   //@}
 
   /** @name Flag state
@@ -270,7 +273,8 @@ public:
   //@}
 
   // Assignment
-  inline MeshFacet& operator = (const MeshFacet &rclF);
+  inline MeshFacet& operator = (const MeshFacet &rclF) = default;
+  inline MeshFacet& operator = (MeshFacet &&rclF) = default;
   inline void SetVertices(PointIndex,PointIndex,PointIndex);
   inline void SetNeighbours(FacetIndex,FacetIndex,FacetIndex);
 
@@ -370,9 +374,14 @@ public:
   MeshGeomFacet ();
   /// Constructor with the corner points
   MeshGeomFacet (const Base::Vector3f &v1,const Base::Vector3f &v2,const Base::Vector3f &v3);
+  MeshGeomFacet(const MeshGeomFacet&) = default;
+  MeshGeomFacet(MeshGeomFacet&&) = default;
    /// Destruction
-  ~MeshGeomFacet () { }
+  ~MeshGeomFacet () = default;
   //@}
+
+  MeshGeomFacet& operator = (const MeshGeomFacet&) = default;
+  MeshGeomFacet& operator = (MeshGeomFacet&&) = default;
 
 public:
   /**
@@ -580,13 +589,14 @@ public:
   /** @name Construction */
   //@{
   // constructor
-  MeshPointArray () { }
+  MeshPointArray () = default;
   // constructor
   explicit MeshPointArray (PointIndex ulSize) : TMeshPointArray(ulSize) { }
   /// copy-constructor
   MeshPointArray (const MeshPointArray&);
+  MeshPointArray (MeshPointArray&&);
   // Destructor
-  ~MeshPointArray () { }
+  ~MeshPointArray () = default;
   //@}
 
   /** @name Flag state
@@ -605,6 +615,7 @@ public:
 
   // Assignment
   MeshPointArray& operator = (const MeshPointArray &rclPAry);
+  MeshPointArray& operator = (MeshPointArray &&rclPAry);
   void Transform(const Base::Matrix4D&);
   /**
    * Searches for the first point index  Two points are equal if the distance is less
@@ -634,13 +645,14 @@ public:
     /** @name Construction */
     //@{
     /// constructor
-    MeshFacetArray () { }
+    MeshFacetArray () = default;
     /// constructor
     explicit MeshFacetArray (FacetIndex ulSize) : TMeshFacetArray(ulSize) { }
     /// copy-constructor
     MeshFacetArray (const MeshFacetArray&);
+    MeshFacetArray (MeshFacetArray&&);
     /// destructor
-    ~MeshFacetArray () { }
+    ~MeshFacetArray () = default;
     //@}
 
     /** @name Flag state
@@ -660,6 +672,7 @@ public:
 
     // Assignment
     MeshFacetArray& operator = (const MeshFacetArray &rclFAry);
+    MeshFacetArray& operator = (MeshFacetArray &&rclFAry);
 
     /**
      * Removes the facet from the array the iterator points to. All neighbour
@@ -687,11 +700,15 @@ public:
         : rPoints(points)
     {
     }
+    ~MeshPointModifier() = default;
 
-    MeshPointModifier(const MeshPointModifier& c)
-        : rPoints(c.rPoints)
-    {
-    }
+    MeshPointArray& GetPoints() const { return rPoints; }
+
+    MeshPointModifier(const MeshPointModifier& c) = default;
+    MeshPointModifier(MeshPointModifier&& c) = default;
+
+    MeshPointModifier& operator = (const MeshPointModifier& c) = delete;
+    MeshPointModifier& operator = (MeshPointModifier&& c) = delete;
 
 private:
     MeshPointArray& rPoints;
@@ -708,11 +725,12 @@ public:
         : rFacets(facets)
     {
     }
+    ~MeshFacetModifier() = default;
 
-    MeshFacetModifier(const MeshFacetModifier& c)
-        : rFacets(c.rFacets)
-    {
-    }
+    MeshFacetModifier(const MeshFacetModifier& c) = default;
+    MeshFacetModifier(MeshFacetModifier&& c) = default;
+    MeshFacetModifier& operator = (const MeshFacetModifier& c) = delete;
+    MeshFacetModifier& operator = (MeshFacetModifier&& c) = delete;
 
     /**
      * Replaces the index of the corner point of the facet at position \a pos
@@ -729,48 +747,17 @@ private:
 };
 
 inline MeshPoint::MeshPoint (float x, float y, float z)
-#ifdef _MSC_VER
-: Vector3f(x, y, z),
-#else
-: Base::Vector3f(x, y, z),
-#endif
-  _ucFlag(0),
-  _ulProp(0)
+  : Base::Vector3f(x, y, z),
+    _ucFlag(0),
+    _ulProp(0)
 {
 }
 
 inline MeshPoint::MeshPoint (const Base::Vector3f &rclPt)
-#ifdef _MSC_VER
-: Vector3f(rclPt),
-#else
-: Base::Vector3f(rclPt),
-#endif
-  _ucFlag(0),
-  _ulProp(0)
+  : Base::Vector3f(rclPt),
+    _ucFlag(0),
+    _ulProp(0)
 {
-}
-
-inline MeshPoint::MeshPoint (const MeshPoint &rclPt)
-#ifdef _MSC_VER
-: Vector3f(rclPt),
-#else
-: Base::Vector3f(rclPt),
-#endif
-  _ucFlag(rclPt._ucFlag),
-  _ulProp(rclPt._ulProp)
-{
-}
-
-inline MeshPoint& MeshPoint::operator = (const MeshPoint &rclPt)
-{
-#ifdef _MSC_VER
-    Vector3f::operator=(rclPt);
-#else
-    Base::Vector3f::operator=(rclPt);
-#endif
-    _ucFlag = rclPt._ucFlag;
-    _ulProp = rclPt._ulProp;
-    return *this;
 }
 
 inline bool MeshPoint::operator == (const MeshPoint &rclPt) const
@@ -844,7 +831,7 @@ inline void MeshGeomFacet::AdjustCirculationDirection ()
 
 inline Base::BoundBox3f MeshGeomFacet::GetBoundBox () const
 {
-    return Base::BoundBox3f(_aclPoints, 3);
+    return {_aclPoints, 3};
 }
 
 inline float MeshGeomFacet::Perimeter() const
@@ -900,19 +887,6 @@ inline MeshFacet::MeshFacet ()
     memset(_aulPoints, 0xff, sizeof(PointIndex) * 3);
 }
 
-inline MeshFacet::MeshFacet(const MeshFacet &rclF)
-: _ucFlag(rclF._ucFlag),
-  _ulProp(rclF._ulProp)
-{
-    _aulPoints[0] = rclF._aulPoints[0];
-    _aulPoints[1] = rclF._aulPoints[1];
-    _aulPoints[2] = rclF._aulPoints[2];
-
-    _aulNeighbours[0] = rclF._aulNeighbours[0];
-    _aulNeighbours[1] = rclF._aulNeighbours[1];
-    _aulNeighbours[2] = rclF._aulNeighbours[2];
-}
-
 inline MeshFacet::MeshFacet(PointIndex p1,PointIndex p2,PointIndex p3,
                             FacetIndex n1,FacetIndex n2,FacetIndex n3)
 : _ucFlag(0),
@@ -925,22 +899,6 @@ inline MeshFacet::MeshFacet(PointIndex p1,PointIndex p2,PointIndex p3,
     _aulNeighbours[0] = n1;
     _aulNeighbours[1] = n2;
     _aulNeighbours[2] = n3;
-}
-
-inline MeshFacet& MeshFacet::operator = (const MeshFacet &rclF)
-{
-    _ucFlag          = rclF._ucFlag;
-    _ulProp          = rclF._ulProp;
-
-    _aulPoints[0]    = rclF._aulPoints[0];
-    _aulPoints[1]    = rclF._aulPoints[1];
-    _aulPoints[2]    = rclF._aulPoints[2];
-
-    _aulNeighbours[0] = rclF._aulNeighbours[0];
-    _aulNeighbours[1] = rclF._aulNeighbours[1];
-    _aulNeighbours[2] = rclF._aulNeighbours[2];
-
-    return *this;
 }
 
 void MeshFacet::SetVertices(PointIndex p1,PointIndex p2,PointIndex p3)

--- a/src/Mod/Mesh/App/Core/Evaluation.cpp
+++ b/src/Mod/Mesh/App/Core/Evaluation.cpp
@@ -123,10 +123,6 @@ MeshEvalOrientation::MeshEvalOrientation (const MeshKernel& rclM)
 {
 }
 
-MeshEvalOrientation::~MeshEvalOrientation()
-{
-}
-
 bool MeshEvalOrientation::Evaluate ()
 {
     const MeshFacetArray& rFAry = _rclMesh.GetFacets();
@@ -267,10 +263,6 @@ MeshFixOrientation::MeshFixOrientation (MeshKernel& rclM)
 {
 }
 
-MeshFixOrientation::~MeshFixOrientation()
-{
-}
-
 bool MeshFixOrientation::Fixup ()
 {
     MeshTopoAlgorithm(_rclMesh).HarmonizeNormals();
@@ -281,10 +273,6 @@ bool MeshFixOrientation::Fixup ()
 
 MeshEvalSolid::MeshEvalSolid (const MeshKernel& rclM)
   :MeshEvaluation( rclM )
-{
-}
-
-MeshEvalSolid::~MeshEvalSolid()
 {
 }
 

--- a/src/Mod/Mesh/App/Core/Evaluation.h
+++ b/src/Mod/Mesh/App/Core/Evaluation.h
@@ -45,7 +45,7 @@ class MeshExport MeshEvaluation
 {
 public:
   explicit MeshEvaluation (const MeshKernel &rclB) : _rclMesh(rclB) {}
-  virtual ~MeshEvaluation () {}
+  virtual ~MeshEvaluation () = default;
 
   /**
    * Evaluates the mesh kernel with respect to certain criteria. Must be reimplemented by every
@@ -71,7 +71,7 @@ class MeshExport MeshValidation
 {
 public:
   explicit MeshValidation (MeshKernel &rclB) : _rclMesh(rclB) {}
-  virtual ~MeshValidation () {}
+  virtual ~MeshValidation () = default;
 
   /**
    * This function attempts to change the mesh kernel to be valid according to the checked
@@ -143,7 +143,6 @@ class MeshExport MeshEvalOrientation : public MeshEvaluation
 {
 public:
     explicit MeshEvalOrientation (const MeshKernel& rclM);
-    ~MeshEvalOrientation() override;
     bool Evaluate () override;
     std::vector<FacetIndex> GetIndices() const;
 
@@ -159,7 +158,6 @@ class MeshExport MeshFixOrientation : public MeshValidation
 {
 public:
     explicit MeshFixOrientation (MeshKernel& rclM);
-    ~MeshFixOrientation() override;
     bool Fixup() override;
 };
 
@@ -173,7 +171,6 @@ class MeshExport MeshEvalSolid : public MeshEvaluation
 {
 public:
   explicit MeshEvalSolid (const MeshKernel& rclM);
-  ~MeshEvalSolid() override;
   bool Evaluate () override;
 };
 
@@ -189,7 +186,6 @@ class MeshExport MeshEvalTopology : public MeshEvaluation
 {
 public:
     explicit MeshEvalTopology (const MeshKernel &rclB) : MeshEvaluation(rclB) {}
-    ~MeshEvalTopology () override {}
     bool Evaluate () override;
 
     void GetFacetManifolds (std::vector<FacetIndex> &raclFacetIndList) const;
@@ -211,7 +207,6 @@ class MeshExport MeshFixTopology : public MeshValidation
 public:
     MeshFixTopology (MeshKernel &rclB, const std::list<std::vector<FacetIndex> >& mf)
       : MeshValidation(rclB), nonManifoldList(mf) {}
-    ~MeshFixTopology () override {}
     bool Fixup() override;
 
     const std::vector<FacetIndex>& GetDeletedFaces() const { return deletedFaces; }
@@ -233,7 +228,6 @@ class MeshExport MeshEvalPointManifolds : public MeshEvaluation
 {
 public:
     explicit MeshEvalPointManifolds (const MeshKernel &rclB) : MeshEvaluation(rclB) {}
-    ~MeshEvalPointManifolds () override {}
     bool Evaluate () override;
 
     void GetFacetIndices (std::vector<FacetIndex> &facets) const;
@@ -259,7 +253,6 @@ class MeshExport MeshEvalSingleFacet : public MeshEvalTopology
 {
 public:
   explicit MeshEvalSingleFacet (const MeshKernel &rclB) : MeshEvalTopology(rclB) {}
-  ~MeshEvalSingleFacet () override {}
   bool Evaluate () override;
 };
 
@@ -272,7 +265,6 @@ class MeshExport MeshFixSingleFacet : public MeshValidation
 public:
   MeshFixSingleFacet (MeshKernel &rclB, const std::vector<std::list<FacetIndex> >& mf)
     : MeshValidation(rclB), _raclManifoldList(mf) {}
-  ~MeshFixSingleFacet () override {}
   bool Fixup() override;
 
 protected:
@@ -289,7 +281,6 @@ class MeshExport MeshEvalSelfIntersection : public MeshEvaluation
 {
 public:
     explicit MeshEvalSelfIntersection (const MeshKernel &rclB) : MeshEvaluation(rclB) {}
-    ~MeshEvalSelfIntersection () override {}
     /// Evaluate the mesh and return if true if there are self intersections
     bool Evaluate () override;
     /// collect all intersection lines
@@ -308,7 +299,6 @@ class MeshExport MeshFixSelfIntersection : public MeshValidation
 public:
     MeshFixSelfIntersection (MeshKernel &rclB, const std::vector<std::pair<FacetIndex, FacetIndex> >& si)
         : MeshValidation(rclB), selfIntersectons(si) {}
-    ~MeshFixSelfIntersection () override {}
     std::vector<FacetIndex> GetFacets() const;
     bool Fixup() override;
 
@@ -327,7 +317,6 @@ class MeshExport MeshEvalNeighbourhood : public MeshEvaluation
 {
 public:
   explicit MeshEvalNeighbourhood (const MeshKernel &rclB) : MeshEvaluation(rclB) {}
-  ~MeshEvalNeighbourhood () override {}
   bool Evaluate () override;
   std::vector<FacetIndex> GetIndices() const;
 };
@@ -340,7 +329,6 @@ class MeshExport MeshFixNeighbourhood : public MeshValidation
 {
 public:
   explicit MeshFixNeighbourhood (MeshKernel &rclB) : MeshValidation(rclB) {}
-  ~MeshFixNeighbourhood () override {}
   bool Fixup() override;
 };
 
@@ -358,7 +346,6 @@ class MeshExport MeshEigensystem : public MeshEvaluation
 {
 public:
   explicit MeshEigensystem (const MeshKernel &rclB);
-  ~MeshEigensystem () override {}
 
   /** Returns the transformation matrix. */
   Base::Matrix4D Transform() const;

--- a/src/Mod/Mesh/App/Core/Grid.h
+++ b/src/Mod/Mesh/App/Core/Grid.h
@@ -64,7 +64,7 @@ protected:
 
 public:
   /// Destruction
-  virtual ~MeshGrid () { }
+  virtual ~MeshGrid () = default;
 
 public:
   /** Attaches the mesh kernel to this grid, an already attached mesh gets detached. The grid gets rebuilt
@@ -193,7 +193,7 @@ public:
   /// Construction
   MeshFacetGrid (const MeshKernel &rclM, float fGridLen);
   /// Destruction
-  ~MeshFacetGrid () override { }
+  ~MeshFacetGrid () override = default;
   //@}
 
   /** @name Search */
@@ -254,7 +254,7 @@ public:
   /// Construction
   MeshPointGrid (const MeshKernel &rclM, unsigned long ulX, unsigned long ulY, unsigned long ulZ);
   /// Destruction
-  ~MeshPointGrid () override {}
+  ~MeshPointGrid () override = default;
   //@}
 
   /** Finds all points that lie in the same grid as the point \a rclPoint. */

--- a/src/Mod/Mesh/App/Core/Info.h
+++ b/src/Mod/Mesh/App/Core/Info.h
@@ -37,7 +37,7 @@ class MeshExport MeshInfo
 {
 public:
   explicit MeshInfo (const MeshKernel &rclM);
-  virtual ~MeshInfo () {}
+  virtual ~MeshInfo () = default;
   /**
    * Writes general information about the mesh structure into the stream.
    */

--- a/src/Mod/Mesh/App/Core/Iterator.h
+++ b/src/Mod/Mesh/App/Core/Iterator.h
@@ -272,7 +272,7 @@ class MeshFastFacetIterator
 {
 public:
   inline explicit MeshFastFacetIterator (const MeshKernel &rclM);
-  virtual ~MeshFastFacetIterator () {}
+  virtual ~MeshFastFacetIterator () = default;
 
   void Init () { _clIter = _rclFAry.begin(); }
   inline void Next ();

--- a/src/Mod/Mesh/App/Core/KDTree.cpp
+++ b/src/Mod/Mesh/App/Core/KDTree.cpp
@@ -39,17 +39,13 @@ struct Point3d
    {
    }
 
-   Point3d(const Point3d& pnt) : p(pnt.p), i(pnt.i)
-   {
-   }
+   Point3d(const Point3d& pnt) = default;
 
    Point3d(Point3d&& pnt) : p(pnt.p), i(pnt.i)
    {
    }
 
-   ~Point3d()
-   {
-   }
+   ~Point3d() = default;
 
    inline value_type operator[](const int N) const
    {
@@ -66,16 +62,13 @@ struct Point3d
       return (this->p) != (other.p);
    }
 
-   inline void operator=(const Point3d& other)
-   {
-       this->p = other.p;
-       this->i = other.i;
-   }
+   inline Point3d& operator=(const Point3d& other) = default;
 
-   inline void operator=(Point3d&& other)
+   inline Point3d& operator=(Point3d&& other)
    {
        this->p = other.p;
        this->i = other.i;
+       return *this;
    }
 
    Base::Vector3f p;

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -3098,10 +3098,6 @@ MeshCleanup::MeshCleanup(MeshPointArray& p, MeshFacetArray& f)
 {
 }
 
-MeshCleanup::~MeshCleanup()
-{
-}
-
 void MeshCleanup::SetMaterial(Material* mat)
 {
     materialArray = mat;
@@ -3226,10 +3222,6 @@ MeshPointFacetAdjacency::MeshPointFacetAdjacency(std::size_t p, MeshFacetArray& 
   , facets(f)
 {
     Build();
-}
-
-MeshPointFacetAdjacency::~MeshPointFacetAdjacency()
-{
 }
 
 void MeshPointFacetAdjacency::Build()

--- a/src/Mod/Mesh/App/Core/MeshIO.h
+++ b/src/Mod/Mesh/App/Core/MeshIO.h
@@ -73,8 +73,8 @@ namespace MeshIO {
 
 struct MeshExport Material
 {
-    Material() : binding(MeshIO::OVERALL) {}
-    MeshIO::Binding binding;
+    Material() = default;
+    MeshIO::Binding binding{MeshIO::OVERALL};
     mutable std::string library;
 
     std::vector<App::Color> ambientColor;  /**< Defines the ambient color. */
@@ -105,7 +105,6 @@ public:
         : _rclMesh(rclM), _material(nullptr){}
     MeshInput (MeshKernel &rclM, Material* m)
         : _rclMesh(rclM), _material(m){}
-    virtual ~MeshInput () { }
     const std::vector<std::string>& GetGroupNames() const {
         return _groupNames;
     }
@@ -165,7 +164,6 @@ public:
         : _rclMesh(rclM), _material(nullptr), apply_transform(false){}
     MeshOutput (const MeshKernel &rclM, const Material* m)
         : _rclMesh(rclM), _material(m), apply_transform(false){}
-    virtual ~MeshOutput () { }
     void SetObjectName(const std::string& n)
     { objectName = n; }
     void SetGroups(const std::vector<Group>& g) {
@@ -264,7 +262,6 @@ public:
       \param f -- the facet array
      */
     MeshCleanup(MeshPointArray& p, MeshFacetArray& f);
-    ~MeshCleanup();
 
     /*!
       \brief Set the material array.
@@ -310,7 +307,6 @@ public:
       \param f -- the facet array
      */
     MeshPointFacetAdjacency(std::size_t p, MeshFacetArray& f);
-    ~MeshPointFacetAdjacency();
 
     /*!
       \brief Set the neighbourhood of two adjacent facets.

--- a/src/Mod/Mesh/App/Core/Projection.cpp
+++ b/src/Mod/Mesh/App/Core/Projection.cpp
@@ -41,10 +41,6 @@ MeshProjection::MeshProjection(const MeshKernel& mesh)
 {
 }
 
-MeshProjection::~MeshProjection()
-{
-}
-
 bool MeshProjection::bboxInsideRectangle(const Base::BoundBox3f& bbox,
                                          const Base::Vector3f& p1,
                                          const Base::Vector3f& p2,

--- a/src/Mod/Mesh/App/Core/Projection.h
+++ b/src/Mod/Mesh/App/Core/Projection.h
@@ -47,7 +47,6 @@ class MeshExport MeshProjection
 {
 public:
     explicit MeshProjection(const MeshKernel&);
-    ~MeshProjection();
 
     bool projectLineOnMesh(const MeshFacetGrid& grid, const Base::Vector3f& p1, FacetIndex f1,
         const Base::Vector3f& p2, FacetIndex f2, const Base::Vector3f& view,

--- a/src/Mod/Mesh/App/Core/Segmentation.cpp
+++ b/src/Mod/Mesh/App/Core/Segmentation.cpp
@@ -516,10 +516,6 @@ MeshSurfaceVisitor::MeshSurfaceVisitor (MeshSurfaceSegment& segm, std::vector<Fa
 {
 }
 
-MeshSurfaceVisitor::~MeshSurfaceVisitor ()
-{
-}
-
 bool MeshSurfaceVisitor::AllowVisit (const MeshFacet& face, const MeshFacet&,
                                      FacetIndex, unsigned long, unsigned short)
 {

--- a/src/Mod/Mesh/App/Core/Segmentation.h
+++ b/src/Mod/Mesh/App/Core/Segmentation.h
@@ -44,7 +44,7 @@ class MeshExport MeshSurfaceSegment
 public:
     explicit MeshSurfaceSegment(unsigned long minFacets)
         : minFacets(minFacets) {}
-    virtual ~MeshSurfaceSegment() {}
+    virtual ~MeshSurfaceSegment() = default;
     virtual bool TestFacet (const MeshFacet &rclFacet) const = 0;
     virtual const char* GetType() const = 0;
     virtual void Initialize(FacetIndex);
@@ -92,8 +92,8 @@ protected:
 class MeshExport AbstractSurfaceFit
 {
 public:
-    AbstractSurfaceFit(){}
-    virtual ~AbstractSurfaceFit(){}
+    AbstractSurfaceFit() = default;
+    virtual ~AbstractSurfaceFit() = default;
     virtual const char* GetType() const = 0;
     virtual void Initialize(const MeshGeomFacet&) = 0;
     virtual bool TestTriangle(const MeshGeomFacet&) const = 0;
@@ -257,7 +257,6 @@ class MeshExport MeshSurfaceVisitor : public MeshFacetVisitor
 {
 public:
     MeshSurfaceVisitor (MeshSurfaceSegment& segm, std::vector<FacetIndex> &indices);
-    ~MeshSurfaceVisitor () override;
     bool AllowVisit (const MeshFacet& face, const MeshFacet&,
                      FacetIndex, unsigned long, unsigned short neighbourIndex) override;
     bool Visit (const MeshFacet & face, const MeshFacet &,

--- a/src/Mod/Mesh/App/Core/SetOperations.cpp
+++ b/src/Mod/Mesh/App/Core/SetOperations.cpp
@@ -54,10 +54,6 @@ SetOperations::SetOperations (const MeshKernel &cutMesh1, const MeshKernel &cutM
 {
 }
 
-SetOperations::~SetOperations ()
-{
-}
-
 void SetOperations::Do ()
 {
  _minDistanceToPoint = 0.000001f;

--- a/src/Mod/Mesh/App/Core/SetOperations.h
+++ b/src/Mod/Mesh/App/Core/SetOperations.h
@@ -57,8 +57,6 @@ public:
 
   /// Construction
   SetOperations (const MeshKernel &cutMesh1, const MeshKernel &cutMesh2, MeshKernel &result, OperationType opType, float minDistanceToPoint = 1e-5f);
-  /// Destruction
-  virtual ~SetOperations ();
 
 public:
 
@@ -81,9 +79,7 @@ private:
     public:
       MeshPoint         pt1, pt2;              // edge
 
-      Edge ()
-      {
-      }
+      Edge () = default;
 
       Edge (MeshPoint p1, MeshPoint p2)
       {
@@ -208,9 +204,6 @@ public:
         : kernel1(m1)
         , kernel2(m2)
         , minDistance(dist)
-    {
-    }
-    ~MeshIntersection()
     {
     }
 

--- a/src/Mod/Mesh/App/Core/Smoothing.cpp
+++ b/src/Mod/Mesh/App/Core/Smoothing.cpp
@@ -41,9 +41,7 @@ AbstractSmoothing::AbstractSmoothing(MeshKernel& m)
 {
 }
 
-AbstractSmoothing::~AbstractSmoothing()
-{
-}
+AbstractSmoothing::~AbstractSmoothing() = default;
 
 void AbstractSmoothing::initialize(Component comp, Continuity cont)
 {
@@ -54,10 +52,6 @@ void AbstractSmoothing::initialize(Component comp, Continuity cont)
 PlaneFitSmoothing::PlaneFitSmoothing(MeshKernel& m)
   : AbstractSmoothing(m)
   , maximum(FLT_MAX)
-{
-}
-
-PlaneFitSmoothing::~PlaneFitSmoothing()
 {
 }
 
@@ -173,10 +167,6 @@ LaplaceSmoothing::LaplaceSmoothing(MeshKernel& m)
 {
 }
 
-LaplaceSmoothing::~LaplaceSmoothing()
-{
-}
-
 void LaplaceSmoothing::Umbrella(const MeshRefPointToPoints& vv_it,
                                 const MeshRefPointToFacets& vf_it, double stepsize)
 {
@@ -273,10 +263,6 @@ TaubinSmoothing::TaubinSmoothing(MeshKernel& m)
 {
 }
 
-TaubinSmoothing::~TaubinSmoothing()
-{
-}
-
 void TaubinSmoothing::Smooth(unsigned int iterations)
 {
     MeshCore::MeshRefPointToPoints vv_it(kernel);
@@ -328,10 +314,6 @@ inline Base::Vector3d find_median(std::vector<AngleNormal> &container)
 
 MedianFilterSmoothing::MedianFilterSmoothing(MeshKernel& m)
   : AbstractSmoothing(m), weights(1)
-{
-}
-
-MedianFilterSmoothing::~MedianFilterSmoothing()
 {
 }
 

--- a/src/Mod/Mesh/App/Core/Smoothing.h
+++ b/src/Mod/Mesh/App/Core/Smoothing.h
@@ -70,7 +70,6 @@ class MeshExport PlaneFitSmoothing : public AbstractSmoothing
 {
 public:
     explicit PlaneFitSmoothing(MeshKernel&);
-    ~PlaneFitSmoothing() override;
     void SetMaximum(float max) {
         maximum = max;
     }
@@ -85,7 +84,6 @@ class MeshExport LaplaceSmoothing : public AbstractSmoothing
 {
 public:
     explicit LaplaceSmoothing(MeshKernel&);
-    ~LaplaceSmoothing() override;
     void Smooth(unsigned int) override;
     void SmoothPoints(unsigned int, const std::vector<PointIndex>&) override;
     void SetLambda(double l) { lambda = l;}
@@ -105,7 +103,6 @@ class MeshExport TaubinSmoothing : public LaplaceSmoothing
 {
 public:
     explicit TaubinSmoothing(MeshKernel&);
-    ~TaubinSmoothing() override;
     void Smooth(unsigned int) override;
     void SmoothPoints(unsigned int, const std::vector<PointIndex>&) override;
     void SetMicro(double m) { micro = m;}
@@ -123,7 +120,6 @@ class MeshExport MedianFilterSmoothing : public AbstractSmoothing
 {
 public:
     explicit MedianFilterSmoothing(MeshKernel&);
-    ~MedianFilterSmoothing() override;
     void SetWeight(int w) {
         weights = w;
     }

--- a/src/Mod/Mesh/App/Core/SphereFit.cpp
+++ b/src/Mod/Mesh/App/Core/SphereFit.cpp
@@ -42,10 +42,6 @@ SphereFit::SphereFit()
 	_maxIter(50)
 {}
 
-SphereFit::~SphereFit()
-{
-}
-
 // Set approximations before calling the fitting
 void SphereFit::SetApproximations(double radius, const Base::Vector3d &center)
 {

--- a/src/Mod/Mesh/App/Core/SphereFit.h
+++ b/src/Mod/Mesh/App/Core/SphereFit.h
@@ -42,10 +42,6 @@ public:
      * Construction
      */
     SphereFit();
-    /**
-     * Destruction
-     */
-    ~SphereFit() override;
 
     /**
      * Set approximations before calling Fit()

--- a/src/Mod/Mesh/App/Core/Tools.h
+++ b/src/Mod/Mesh/App/Core/Tools.h
@@ -43,7 +43,7 @@ class MeshSearchNeighbours
 {
 public:
   explicit MeshSearchNeighbours ( const MeshKernel &rclM, float fSampleDistance = 1.0f);
-  virtual ~MeshSearchNeighbours () {}
+  ~MeshSearchNeighbours () = default;
   /** Re-initilaizes internal structures. */
   void Reinit (float fSampleDistance);
   /** Collects all neighbour points from the facet (by index), the result are the points of the facets lying

--- a/src/Mod/Mesh/App/Core/TopoAlgorithm.cpp
+++ b/src/Mod/Mesh/App/Core/TopoAlgorithm.cpp
@@ -1664,10 +1664,6 @@ MeshComponents::MeshComponents( const MeshKernel& rclMesh )
 {
 }
 
-MeshComponents::~MeshComponents()
-{
-}
-
 void MeshComponents::SearchForComponents(TMode tMode, std::vector<std::vector<FacetIndex> >& aclT) const
 {
   // all facets

--- a/src/Mod/Mesh/App/Core/TopoAlgorithm.h
+++ b/src/Mod/Mesh/App/Core/TopoAlgorithm.h
@@ -47,7 +47,7 @@ class MeshExport MeshTopoAlgorithm
 public:
     // construction/destruction
     explicit MeshTopoAlgorithm (MeshKernel &rclM);
-    virtual ~MeshTopoAlgorithm ();
+    ~MeshTopoAlgorithm ();
 
 public:
     /** @name Topological Operations */
@@ -331,7 +331,6 @@ public:
     enum TMode {OverEdge, OverPoint};
 
     explicit MeshComponents( const MeshKernel& rclMesh );
-    ~MeshComponents();
 
     /**
      * Searches for 'isles' of the mesh. If \a tMode is \a OverEdge then facets

--- a/src/Mod/Mesh/App/Core/Triangulation.cpp
+++ b/src/Mod/Mesh/App/Core/Triangulation.cpp
@@ -275,13 +275,7 @@ void AbstractPolygonTriangulator::Done()
 
 // -------------------------------------------------------------
 
-EarClippingTriangulator::EarClippingTriangulator()
-{
-}
-
-EarClippingTriangulator::~EarClippingTriangulator()
-{
-}
+EarClippingTriangulator::EarClippingTriangulator() = default;
 
 bool EarClippingTriangulator::Triangulate()
 {
@@ -466,13 +460,7 @@ bool EarClippingTriangulator::Triangulate::Process(const std::vector<Base::Vecto
 
 // -------------------------------------------------------------
 
-QuasiDelaunayTriangulator::QuasiDelaunayTriangulator()
-{
-}
-
-QuasiDelaunayTriangulator::~QuasiDelaunayTriangulator()
-{
-}
+QuasiDelaunayTriangulator::QuasiDelaunayTriangulator() = default;
 
 bool QuasiDelaunayTriangulator::Triangulate()
 {
@@ -627,13 +615,7 @@ struct Vertex2d_EqualTo
 }
 }
 
-DelaunayTriangulator::DelaunayTriangulator()
-{
-}
-
-DelaunayTriangulator::~DelaunayTriangulator()
-{
-}
+DelaunayTriangulator::DelaunayTriangulator() = default;
 
 bool DelaunayTriangulator::Triangulate()
 {
@@ -699,13 +681,7 @@ bool DelaunayTriangulator::Triangulate()
 
 // -------------------------------------------------------------
 
-FlatTriangulator::FlatTriangulator()
-{
-}
-
-FlatTriangulator::~FlatTriangulator()
-{
-}
+FlatTriangulator::FlatTriangulator() = default;
 
 bool FlatTriangulator::Triangulate()
 {
@@ -745,10 +721,6 @@ ConstraintDelaunayTriangulator::ConstraintDelaunayTriangulator(float area)
 {
     // silent warning: -Wunused-private-field
     (void)fMaxArea;
-}
-
-ConstraintDelaunayTriangulator::~ConstraintDelaunayTriangulator()
-{
 }
 
 bool ConstraintDelaunayTriangulator::Triangulate()

--- a/src/Mod/Mesh/App/Core/Triangulation.h
+++ b/src/Mod/Mesh/App/Core/Triangulation.h
@@ -33,8 +33,8 @@ class MeshKernel;
 class MeshExport TriangulationVerifier
 {
 public:
-    TriangulationVerifier() {}
-    virtual ~TriangulationVerifier() {}
+    TriangulationVerifier() = default;
+    virtual ~TriangulationVerifier() = default;
     virtual bool Accept(const Base::Vector3f& n,
                         const Base::Vector3f& p1,
                         const Base::Vector3f& p2,
@@ -148,7 +148,6 @@ class MeshExport EarClippingTriangulator : public AbstractPolygonTriangulator
 {
 public:
     EarClippingTriangulator();
-    ~EarClippingTriangulator() override;
 
 protected:
     bool Triangulate() override;
@@ -190,7 +189,6 @@ class MeshExport QuasiDelaunayTriangulator : public EarClippingTriangulator
 {
 public:
     QuasiDelaunayTriangulator();
-    ~QuasiDelaunayTriangulator() override;
 
 protected:
     bool Triangulate() override;
@@ -200,7 +198,6 @@ class MeshExport DelaunayTriangulator : public AbstractPolygonTriangulator
 {
 public:
     DelaunayTriangulator();
-    ~DelaunayTriangulator() override;
 
 protected:
     bool Triangulate() override;
@@ -210,7 +207,6 @@ class MeshExport FlatTriangulator : public AbstractPolygonTriangulator
 {
 public:
     FlatTriangulator();
-    ~FlatTriangulator() override;
 
     void PostProcessing(const std::vector<Base::Vector3f>&) override;
 
@@ -222,7 +218,6 @@ class MeshExport ConstraintDelaunayTriangulator : public AbstractPolygonTriangul
 {
 public:
     explicit ConstraintDelaunayTriangulator(float area);
-    ~ConstraintDelaunayTriangulator() override;
 
 protected:
     bool Triangulate() override;

--- a/src/Mod/Mesh/App/Core/Trim.cpp
+++ b/src/Mod/Mesh/App/Core/Trim.cpp
@@ -40,10 +40,6 @@ MeshTrimming::MeshTrimming(MeshKernel &rclM, const Base::ViewProjMethod* pclProj
 {
 }
 
-MeshTrimming::~MeshTrimming()
-{
-}
-
 void MeshTrimming::SetInnerOrOuter(TMode tMode)
 {
     switch (tMode)

--- a/src/Mod/Mesh/App/Core/Trim.h
+++ b/src/Mod/Mesh/App/Core/Trim.h
@@ -40,7 +40,6 @@ public:
 
 public:
     MeshTrimming(MeshKernel& mesh, const Base::ViewProjMethod* pclProj, const Base::Polygon2d& rclPoly);
-    ~MeshTrimming();
 
 public:
     /**

--- a/src/Mod/Mesh/App/Core/TrimByPlane.cpp
+++ b/src/Mod/Mesh/App/Core/TrimByPlane.cpp
@@ -37,10 +37,6 @@ MeshTrimByPlane::MeshTrimByPlane(MeshKernel &rclM)
 {
 }
 
-MeshTrimByPlane::~MeshTrimByPlane()
-{
-}
-
 void MeshTrimByPlane::CheckFacets(const MeshFacetGrid& rclGrid, const Base::Vector3f& base, const Base::Vector3f& normal,
                                   std::vector<FacetIndex> &trimFacets, std::vector<FacetIndex>& removeFacets) const
 {

--- a/src/Mod/Mesh/App/Core/TrimByPlane.h
+++ b/src/Mod/Mesh/App/Core/TrimByPlane.h
@@ -36,7 +36,6 @@ class MeshExport MeshTrimByPlane
 {
 public:
     explicit MeshTrimByPlane(MeshKernel& mesh);
-    ~MeshTrimByPlane();
 
 public:
     /**

--- a/src/Mod/Mesh/App/Core/Visitor.h
+++ b/src/Mod/Mesh/App/Core/Visitor.h
@@ -44,9 +44,9 @@ class MeshExport MeshFacetVisitor
 {
 public:
     /// Construction
-    MeshFacetVisitor() { }
+    MeshFacetVisitor() = default;
     /// Denstruction
-    virtual ~MeshFacetVisitor() { }
+    virtual ~MeshFacetVisitor() = default;
     /** Needs to be implemented in sub-classes.
      * \a rclFacet is the currently visited facet with the index \a ulFInd, \a rclFrom
      * is the last visited facet and \a ulLevel indicates the ring number around the start facet.
@@ -79,7 +79,7 @@ class MeshExport MeshSearchNeighbourFacetsVisitor : public MeshFacetVisitor
 {
 public:
     MeshSearchNeighbourFacetsVisitor (const MeshKernel &rclMesh, float fRadius, FacetIndex ulStartFacetIdx);
-    ~MeshSearchNeighbourFacetsVisitor () override {}
+    ~MeshSearchNeighbourFacetsVisitor () override = default;
     /** Checks the facet if it lies inside the search radius. */
     inline bool Visit (const MeshFacet &rclFacet, const MeshFacet &rclFrom, FacetIndex ulFInd, unsigned long ulLevel) override;
     /** Resets the VISIT flag of already visited facets. */
@@ -175,9 +175,9 @@ class MeshExport MeshPointVisitor
 {
 public:
     /// Construction
-    MeshPointVisitor() { }
+    MeshPointVisitor() = default;
     /// Denstruction
-    virtual ~MeshPointVisitor() { }
+    virtual ~MeshPointVisitor() = default;
     /** Needs to be implemented in sub-classes.
      * \a rclPoint is the currently visited point with the index \a ulPInd, \a rclFrom
      * is the last visited point  and \a ulLevel indicates the ring number around the start point.

--- a/src/Mod/Mesh/App/Edge.cpp
+++ b/src/Mod/Mesh/App/Edge.cpp
@@ -52,9 +52,7 @@ Edge::Edge(const Edge& e)
     }
 }
 
-Edge::~Edge()
-{
-}
+Edge::~Edge() = default;
 
 void Edge::operator = (const Edge& e)
 {

--- a/src/Mod/Mesh/App/Exporter.cpp
+++ b/src/Mod/Mesh/App/Exporter.cpp
@@ -81,8 +81,7 @@ expandSubObjectNames(const App::DocumentObject *obj,
     return res;
 }
 
-Exporter::Exporter()
-{ }
+Exporter::Exporter() = default;
 
 //static
 std::string Exporter::xmlEscape(const std::string &input)

--- a/src/Mod/Mesh/App/Facet.cpp
+++ b/src/Mod/Mesh/App/Facet.cpp
@@ -55,9 +55,7 @@ Facet::Facet(const Facet& f)
     }
 }
 
-Facet::~Facet()
-{
-}
+Facet::~Facet() = default;
 
 void Facet::operator = (const Facet& f)
 {

--- a/src/Mod/Mesh/App/FeatureMeshDefects.cpp
+++ b/src/Mod/Mesh/App/FeatureMeshDefects.cpp
@@ -44,10 +44,6 @@ FixDefects::FixDefects()
   ADD_PROPERTY(Epsilon  ,(0));
 }
 
-FixDefects::~FixDefects()
-{
-}
-
 short FixDefects::mustExecute() const
 {
     if (Source.isTouched())
@@ -64,13 +60,7 @@ App::DocumentObjectExecReturn *FixDefects::execute()
 
 PROPERTY_SOURCE(Mesh::HarmonizeNormals, Mesh::FixDefects)
 
-HarmonizeNormals::HarmonizeNormals()
-{
-}
-
-HarmonizeNormals::~HarmonizeNormals()
-{
-}
+HarmonizeNormals::HarmonizeNormals() = default;
 
 App::DocumentObjectExecReturn *HarmonizeNormals::execute()
 {
@@ -93,13 +83,7 @@ App::DocumentObjectExecReturn *HarmonizeNormals::execute()
 
 PROPERTY_SOURCE(Mesh::FlipNormals, Mesh::FixDefects)
 
-FlipNormals::FlipNormals()
-{
-}
-
-FlipNormals::~FlipNormals()
-{
-}
+FlipNormals::FlipNormals() = default;
 
 App::DocumentObjectExecReturn *FlipNormals::execute()
 {
@@ -122,13 +106,7 @@ App::DocumentObjectExecReturn *FlipNormals::execute()
 
 PROPERTY_SOURCE(Mesh::FixNonManifolds, Mesh::FixDefects)
 
-FixNonManifolds::FixNonManifolds()
-{
-}
-
-FixNonManifolds::~FixNonManifolds()
-{
-}
+FixNonManifolds::FixNonManifolds() = default;
 
 App::DocumentObjectExecReturn *FixNonManifolds::execute()
 {
@@ -151,13 +129,7 @@ App::DocumentObjectExecReturn *FixNonManifolds::execute()
 
 PROPERTY_SOURCE(Mesh::FixDuplicatedFaces, Mesh::FixDefects)
 
-FixDuplicatedFaces::FixDuplicatedFaces()
-{
-}
-
-FixDuplicatedFaces::~FixDuplicatedFaces()
-{
-}
+FixDuplicatedFaces::FixDuplicatedFaces() = default;
 
 App::DocumentObjectExecReturn *FixDuplicatedFaces::execute()
 {
@@ -180,13 +152,7 @@ App::DocumentObjectExecReturn *FixDuplicatedFaces::execute()
 
 PROPERTY_SOURCE(Mesh::FixDuplicatedPoints, Mesh::FixDefects)
 
-FixDuplicatedPoints::FixDuplicatedPoints()
-{
-}
-
-FixDuplicatedPoints::~FixDuplicatedPoints()
-{
-}
+FixDuplicatedPoints::FixDuplicatedPoints() = default;
 
 App::DocumentObjectExecReturn *FixDuplicatedPoints::execute()
 {
@@ -209,13 +175,7 @@ App::DocumentObjectExecReturn *FixDuplicatedPoints::execute()
 
 PROPERTY_SOURCE(Mesh::FixDegenerations, Mesh::FixDefects)
 
-FixDegenerations::FixDegenerations()
-{
-}
-
-FixDegenerations::~FixDegenerations()
-{
-}
+FixDegenerations::FixDegenerations() = default;
 
 App::DocumentObjectExecReturn *FixDegenerations::execute()
 {
@@ -243,10 +203,6 @@ FixDeformations::FixDeformations()
   ADD_PROPERTY(MaxAngle  ,(5.0f));
 }
 
-FixDeformations::~FixDeformations()
-{
-}
-
 App::DocumentObjectExecReturn *FixDeformations::execute()
 {
     App::DocumentObject* link = Source.getValue();
@@ -270,13 +226,7 @@ App::DocumentObjectExecReturn *FixDeformations::execute()
 
 PROPERTY_SOURCE(Mesh::FixIndices, Mesh::FixDefects)
 
-FixIndices::FixIndices()
-{
-}
-
-FixIndices::~FixIndices()
-{
-}
+FixIndices::FixIndices() = default;
 
 App::DocumentObjectExecReturn *FixIndices::execute()
 {
@@ -305,10 +255,6 @@ FillHoles::FillHoles()
     ADD_PROPERTY(MaxArea,(0.1f));
 }
 
-FillHoles::~FillHoles()
-{
-}
-
 App::DocumentObjectExecReturn *FillHoles::execute()
 {
     App::DocumentObject* link = Source.getValue();
@@ -335,10 +281,6 @@ PROPERTY_SOURCE(Mesh::RemoveComponents, Mesh::FixDefects)
 RemoveComponents::RemoveComponents()
 {
     ADD_PROPERTY(RemoveCompOfSize,(0));
-}
-
-RemoveComponents::~RemoveComponents()
-{
 }
 
 App::DocumentObjectExecReturn *RemoveComponents::execute()

--- a/src/Mod/Mesh/App/FeatureMeshDefects.h
+++ b/src/Mod/Mesh/App/FeatureMeshDefects.h
@@ -42,7 +42,6 @@ class MeshExport FixDefects : public Mesh::Feature
 public:
   /// Constructor
   FixDefects();
-  ~FixDefects() override;
 
   /** @name Properties */
   //@{
@@ -72,7 +71,6 @@ class MeshExport HarmonizeNormals : public Mesh::FixDefects
 public:
   /// Constructor
   HarmonizeNormals();
-  ~HarmonizeNormals() override;
 
   /** @name methods override Feature */
   //@{
@@ -92,7 +90,6 @@ class MeshExport FlipNormals : public Mesh::FixDefects
 public:
   /// Constructor
   FlipNormals();
-  ~FlipNormals() override;
 
   /** @name methods override Feature */
   //@{
@@ -112,7 +109,6 @@ class MeshExport FixNonManifolds : public Mesh::FixDefects
 public:
   /// Constructor
   FixNonManifolds();
-  ~FixNonManifolds() override;
 
   /** @name methods override Feature */
   //@{
@@ -132,7 +128,6 @@ class MeshExport FixDuplicatedFaces : public Mesh::FixDefects
 public:
   /// Constructor
   FixDuplicatedFaces();
-  ~FixDuplicatedFaces() override;
 
   /** @name methods override Feature */
   //@{
@@ -152,7 +147,6 @@ class MeshExport FixDuplicatedPoints : public Mesh::FixDefects
 public:
   /// Constructor
   FixDuplicatedPoints();
-  ~FixDuplicatedPoints() override;
 
   /** @name methods override Feature */
   //@{
@@ -172,7 +166,6 @@ class MeshExport FixDegenerations : public Mesh::FixDefects
 public:
   /// Constructor
   FixDegenerations();
-  ~FixDegenerations() override;
 
   /** @name methods override Feature */
   //@{
@@ -192,7 +185,6 @@ class MeshExport FixDeformations : public Mesh::FixDefects
 public:
   /// Constructor
   FixDeformations();
-  ~FixDeformations() override;
 
   /** @name Properties */
   //@{
@@ -216,7 +208,6 @@ class MeshExport FixIndices : public Mesh::FixDefects
 public:
   /// Constructor
   FixIndices();
-  ~FixIndices() override;
 
   /** @name methods override Feature */
   //@{
@@ -236,7 +227,6 @@ class MeshExport FillHoles : public Mesh::FixDefects
 public:
   /// Constructor
   FillHoles();
-  ~FillHoles() override;
   App::PropertyInteger FillupHolesOfLength;
   App::PropertyFloat MaxArea;
 
@@ -258,7 +248,6 @@ class MeshExport RemoveComponents : public Mesh::FixDefects
 public:
   /// Constructor
   RemoveComponents();
-  ~RemoveComponents() override;
   App::PropertyInteger RemoveCompOfSize;
 
   /** @name methods override Feature */

--- a/src/Mod/Mesh/App/Importer.h
+++ b/src/Mod/Mesh/App/Importer.h
@@ -43,8 +43,6 @@ class Importer
 {
 public:
     explicit Importer(App::Document*);
-    ~Importer() = default;
-
     void load(const std::string& fileName);
 
 private:

--- a/src/Mod/Mesh/App/Mesh.cpp
+++ b/src/Mod/Mesh/App/Mesh.cpp
@@ -61,9 +61,7 @@ const float MeshObject::Epsilon = 1.0e-5F;
 TYPESYSTEM_SOURCE(Mesh::MeshObject, Data::ComplexGeoData)
 TYPESYSTEM_SOURCE(Mesh::MeshSegment, Data::Segment)
 
-MeshObject::MeshObject()
-{
-}
+MeshObject::MeshObject() = default;
 
 MeshObject::MeshObject(const MeshCore::MeshKernel& Kernel)
   : _kernel(Kernel)
@@ -84,9 +82,7 @@ MeshObject::MeshObject(const MeshObject& mesh)
     copySegments(mesh);
 }
 
-MeshObject::~MeshObject()
-{
-}
+MeshObject::~MeshObject() = default;
 
 std::vector<const char*> MeshObject::getElementTypes() const
 {
@@ -2011,22 +2007,13 @@ MeshObject::const_point_iterator::const_point_iterator(const MeshObject* mesh, P
     this->_point.Mesh = _mesh;
 }
 
-MeshObject::const_point_iterator::const_point_iterator(const MeshObject::const_point_iterator& fi)
-  : _mesh(fi._mesh), _point(fi._point), _p_it(fi._p_it)
-{
-}
+MeshObject::const_point_iterator::const_point_iterator
+(const MeshObject::const_point_iterator& fi) = default;
 
-MeshObject::const_point_iterator::~const_point_iterator()
-{
-}
+MeshObject::const_point_iterator::~const_point_iterator() = default;
 
-MeshObject::const_point_iterator& MeshObject::const_point_iterator::operator=(const MeshObject::const_point_iterator& pi)
-{
-    this->_mesh  = pi._mesh;
-    this->_point = pi._point;
-    this->_p_it  = pi._p_it;
-    return *this;
-}
+MeshObject::const_point_iterator& MeshObject::const_point_iterator::operator=
+(const MeshObject::const_point_iterator& pi) = default;
 
 void MeshObject::const_point_iterator::dereference()
 {
@@ -2080,22 +2067,13 @@ MeshObject::const_facet_iterator::const_facet_iterator(const MeshObject* mesh, F
     this->_facet.Mesh = _mesh;
 }
 
-MeshObject::const_facet_iterator::const_facet_iterator(const MeshObject::const_facet_iterator& fi)
-  : _mesh(fi._mesh), _facet(fi._facet), _f_it(fi._f_it)
-{
-}
+MeshObject::const_facet_iterator::const_facet_iterator
+(const MeshObject::const_facet_iterator& fi) = default;
 
-MeshObject::const_facet_iterator::~const_facet_iterator()
-{
-}
+MeshObject::const_facet_iterator::~const_facet_iterator() = default;
 
-MeshObject::const_facet_iterator& MeshObject::const_facet_iterator::operator=(const MeshObject::const_facet_iterator& fi)
-{
-    this->_mesh  = fi._mesh;
-    this->_facet = fi._facet;
-    this->_f_it  = fi._f_it;
-    return *this;
-}
+MeshObject::const_facet_iterator& MeshObject::const_facet_iterator::operator=
+(const MeshObject::const_facet_iterator& fi) = default;
 
 void MeshObject::const_facet_iterator::dereference()
 {

--- a/src/Mod/Mesh/App/MeshFeature.cpp
+++ b/src/Mod/Mesh/App/MeshFeature.cpp
@@ -42,10 +42,6 @@ Feature::Feature()
     ADD_PROPERTY_TYPE(Mesh,(MeshObject()),0,App::Prop_Output,"The mesh kernel");
 }
 
-Feature::~Feature()
-{
-}
-
 App::DocumentObjectExecReturn *Feature::execute()
 {
     this->Mesh.touch();

--- a/src/Mod/Mesh/App/MeshFeature.h
+++ b/src/Mod/Mesh/App/MeshFeature.h
@@ -59,7 +59,6 @@ class MeshExport Feature : public App::GeoFeature
 public:
     /// Constructor
     Feature();
-    ~Feature() override;
 
     /** @name Properties */
     //@{

--- a/src/Mod/Mesh/App/MeshProperties.cpp
+++ b/src/Mod/Mesh/App/MeshProperties.cpp
@@ -45,15 +45,7 @@ TYPESYSTEM_SOURCE(Mesh::PropertyCurvatureList , App::PropertyLists)
 TYPESYSTEM_SOURCE(Mesh::PropertyMaterial , App::Property)
 TYPESYSTEM_SOURCE(Mesh::PropertyMeshKernel , App::PropertyComplexGeoData)
 
-PropertyNormalList::PropertyNormalList()
-{
-
-}
-
-PropertyNormalList::~PropertyNormalList()
-{
-
-}
+PropertyNormalList::PropertyNormalList() = default;
 
 void PropertyNormalList::setSize(int newSize)
 {
@@ -224,15 +216,7 @@ void PropertyNormalList::transformGeometry(const Base::Matrix4D &mat)
 
 // ----------------------------------------------------------------------------
 
-PropertyCurvatureList::PropertyCurvatureList()
-{
-
-}
-
-PropertyCurvatureList::~PropertyCurvatureList()
-{
-
-}
+PropertyCurvatureList::PropertyCurvatureList() = default;
 
 void PropertyCurvatureList::setValue(const CurvatureInfo& lValue)
 {

--- a/src/Mod/Mesh/App/MeshProperties.h
+++ b/src/Mod/Mesh/App/MeshProperties.h
@@ -53,7 +53,6 @@ class MeshExport PropertyNormalList: public App::PropertyLists
 
 public:
     PropertyNormalList();
-    ~PropertyNormalList() override;
 
     void setSize(int newSize) override;
     int getSize() const override;
@@ -120,7 +119,6 @@ public:
 
 public:
     PropertyCurvatureList();
-    ~PropertyCurvatureList() override;
 
     void setSize(int newSize) override{_lValueList.resize(newSize);}
     int getSize() const override {return _lValueList.size();}
@@ -169,7 +167,6 @@ class MeshExport PropertyMaterial : public App::Property
 
 public:
     PropertyMaterial() = default;
-    ~PropertyMaterial() override = default;
 
     /** Sets the property
      */

--- a/src/Mod/Mesh/App/Segment.cpp
+++ b/src/Mod/Mesh/App/Segment.cpp
@@ -78,18 +78,21 @@ const std::vector<FacetIndex>& Segment::getIndices() const
     return _indices;
 }
 
-Segment::Segment(const Segment& s)
-  : _mesh(s._mesh)
-  , _indices(s._indices)
-  , _name(s._name)
-  , _color(s._color)
-  , _save(s._save)
-  , _modifykernel(s._modifykernel)
-{
+Segment::Segment(const Segment& s) = default;
 
+Segment::Segment(Segment&& s) = default;
+
+Segment& Segment::operator = (const Segment& s)
+{
+    // Do not copy the MeshObject pointer
+    if (this != &s)
+        this->_indices = s._indices;
+    if (_modifykernel)
+        _mesh->updateMesh();
+    return *this;
 }
 
-const Segment& Segment::operator = (const Segment& s)
+Segment& Segment::operator = (Segment&& s)
 {
     // Do not copy the MeshObject pointer
     if (this != &s)
@@ -106,7 +109,8 @@ bool Segment::operator == (const Segment& s) const
 
 // ----------------------------------------------------------------------------
 
-Segment::const_facet_iterator::const_facet_iterator(const Segment* segm, std::vector<FacetIndex>::const_iterator it)
+Segment::const_facet_iterator::const_facet_iterator
+(const Segment* segm, std::vector<FacetIndex>::const_iterator it)
   : _segment(segm), _f_it(segm->_mesh->getKernel()), _it(it)
 {
     this->_f_it.Set(0);
@@ -114,23 +118,19 @@ Segment::const_facet_iterator::const_facet_iterator(const Segment* segm, std::ve
     this->_facet.Mesh = _segment->_mesh;
 }
 
-Segment::const_facet_iterator::const_facet_iterator(const Segment::const_facet_iterator& fi)
-  : _segment(fi._segment), _facet(fi._facet), _f_it(fi._f_it), _it(fi._it)
-{
-}
+Segment::const_facet_iterator::const_facet_iterator
+(const Segment::const_facet_iterator& fi) = default;
 
-Segment::const_facet_iterator::~const_facet_iterator()
-{
-}
+Segment::const_facet_iterator::const_facet_iterator
+(Segment::const_facet_iterator&& fi) = default;
 
-Segment::const_facet_iterator& Segment::const_facet_iterator::operator=(const Segment::const_facet_iterator& fi)
-{
-    this->_segment = fi._segment;
-    this->_facet   = fi._facet;
-    this->_f_it    = fi._f_it;
-    this->_it      = fi._it;
-    return *this;
-}
+Segment::const_facet_iterator::~const_facet_iterator() = default;
+
+Segment::const_facet_iterator& Segment::const_facet_iterator::operator=
+(const Segment::const_facet_iterator& fi) = default;
+
+Segment::const_facet_iterator& Segment::const_facet_iterator::operator=
+(Segment::const_facet_iterator&& fi) = default;
 
 void Segment::const_facet_iterator::dereference() const
 {

--- a/src/Mod/Mesh/App/Segment.h
+++ b/src/Mod/Mesh/App/Segment.h
@@ -42,13 +42,16 @@ class MeshExport Segment
 public:
     Segment(const MeshObject*, bool mod);
     Segment(const MeshObject*, const std::vector<FacetIndex>& inds, bool mod);
+    ~Segment() = default;
     void addIndices(const std::vector<FacetIndex>& inds);
     void removeIndices(const std::vector<FacetIndex>& inds);
     const std::vector<FacetIndex>& getIndices() const;
     bool isEmpty() const { return _indices.empty(); }
 
     Segment(const Segment&);
-    const Segment& operator = (const Segment&);
+    Segment(Segment&&);
+    Segment& operator = (const Segment&);
+    Segment& operator = (Segment&&);
     bool operator == (const Segment&) const;
 
     void setName(const std::string& n) { _name = n; }
@@ -77,9 +80,11 @@ public:
     public:
         const_facet_iterator(const Segment*, std::vector<FacetIndex>::const_iterator);
         const_facet_iterator(const const_facet_iterator& fi);
+        const_facet_iterator(const_facet_iterator&& fi);
         ~const_facet_iterator();
 
         const_facet_iterator& operator=(const const_facet_iterator& fi);
+        const_facet_iterator& operator=(const_facet_iterator&& fi);
         const Facet& operator*() const;
         const Facet* operator->() const;
         bool operator==(const const_facet_iterator& fi) const;

--- a/src/Mod/Mesh/Gui/AppMeshGui.cpp
+++ b/src/Mod/Mesh/Gui/AppMeshGui.cpp
@@ -80,8 +80,6 @@ public:
         initialize("This module is the MeshGui module."); // register with Python
     }
 
-    ~Module() override {}
-
 private:
     Py::Object convertToSTL(const Py::Tuple& args)
     {

--- a/src/Mod/Mesh/Gui/DlgDecimating.cpp
+++ b/src/Mod/Mesh/Gui/DlgDecimating.cpp
@@ -48,9 +48,7 @@ DlgDecimating::DlgDecimating(QWidget* parent, Qt::WindowFlags fl)
     onCheckAbsoluteNumberToggled(false);
 }
 
-DlgDecimating::~DlgDecimating()
-{
-}
+DlgDecimating::~DlgDecimating() = default;
 
 bool DlgDecimating::isAbsoluteNumber() const
 {
@@ -134,11 +132,6 @@ TaskDecimating::TaskDecimating()
         const Mesh::MeshObject& mm = mesh->Mesh.getValue();
         widget->setNumberOfTriangles(static_cast<int>(mm.countFacets()));
     }
-}
-
-TaskDecimating::~TaskDecimating()
-{
-    // automatically deleted in the sub-class
 }
 
 bool TaskDecimating::accept()

--- a/src/Mod/Mesh/Gui/DlgDecimating.h
+++ b/src/Mod/Mesh/Gui/DlgDecimating.h
@@ -61,7 +61,6 @@ class TaskDecimating : public Gui::TaskView::TaskDialog
 
 public:
     TaskDecimating();
-    ~TaskDecimating() override;
 
 public:
     bool accept() override;

--- a/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
@@ -78,9 +78,6 @@ public:
         , epsilonDegenerated(0.0f)
     {
     }
-    ~Private()
-    {
-    }
 
     void showFoldsFunction(bool on)
     {

--- a/src/Mod/Mesh/Gui/DlgRegularSolidImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgRegularSolidImp.cpp
@@ -100,10 +100,7 @@ DlgRegularSolidImp::DlgRegularSolidImp(QWidget* parent, Qt::WindowFlags fl)
 /**
  *  Destroys the object and frees any allocated resources
  */
-DlgRegularSolidImp::~DlgRegularSolidImp()
-{
-    // no need to delete child widgets, Qt does it all for us
-}
+DlgRegularSolidImp::~DlgRegularSolidImp() = default;
 
 void DlgRegularSolidImp::changeEvent(QEvent *e)
 {

--- a/src/Mod/Mesh/Gui/DlgSettingsMeshView.cpp
+++ b/src/Mod/Mesh/Gui/DlgSettingsMeshView.cpp
@@ -45,10 +45,7 @@ DlgSettingsMeshView::DlgSettingsMeshView(QWidget* parent)
 /**
  *  Destroys the object and frees any allocated resources
  */
-DlgSettingsMeshView::~DlgSettingsMeshView()
-{
-    // no need to delete child widgets, Qt does it all for us
-}
+DlgSettingsMeshView::~DlgSettingsMeshView() = default;
 
 void DlgSettingsMeshView::saveSettings()
 {

--- a/src/Mod/Mesh/Gui/DlgSmoothing.cpp
+++ b/src/Mod/Mesh/Gui/DlgSmoothing.cpp
@@ -140,9 +140,7 @@ SmoothingDialog::SmoothingDialog(QWidget* parent, Qt::WindowFlags fl)
     hboxLayout->addWidget(buttonBox);
 }
 
-SmoothingDialog::~SmoothingDialog()
-{
-}
+SmoothingDialog::~SmoothingDialog() = default;
 
 // ---------------------------------------
 
@@ -166,11 +164,6 @@ TaskSmoothing::TaskSmoothing()
 
     connect(widget, &DlgSmoothing::toggledSelection,
             tasksel, &QWidget::setVisible);
-}
-
-TaskSmoothing::~TaskSmoothing()
-{
-    // automatically deleted in the sub-class
 }
 
 bool TaskSmoothing::accept()

--- a/src/Mod/Mesh/Gui/DlgSmoothing.h
+++ b/src/Mod/Mesh/Gui/DlgSmoothing.h
@@ -104,7 +104,6 @@ class TaskSmoothing : public Gui::TaskView::TaskDialog
 
 public:
     TaskSmoothing();
-    ~TaskSmoothing() override;
 
 public:
     bool accept() override;

--- a/src/Mod/Mesh/Gui/MeshEditor.h
+++ b/src/Mod/Mesh/Gui/MeshEditor.h
@@ -105,12 +105,12 @@ private:
 class MeshGuiExport MeshHoleFiller
 {
 public:
-    MeshHoleFiller()
-    {
-    }
-    virtual ~MeshHoleFiller()
-    {
-    }
+    MeshHoleFiller() = default;
+    virtual ~MeshHoleFiller() = default;
+    MeshHoleFiller(const MeshHoleFiller&) = delete;
+    MeshHoleFiller(MeshHoleFiller&&) = delete;
+    MeshHoleFiller& operator = (const MeshHoleFiller&) = delete;
+    MeshHoleFiller& operator = (MeshHoleFiller&&) = delete;
     virtual bool fillHoles(Mesh::MeshObject&, const std::list<std::vector<Mesh::PointIndex> >&,
                            Mesh::PointIndex, Mesh::PointIndex)
     {

--- a/src/Mod/Mesh/Gui/RemeshGmsh.cpp
+++ b/src/Mod/Mesh/Gui/RemeshGmsh.cpp
@@ -295,9 +295,7 @@ RemeshGmsh::RemeshGmsh(Mesh::Feature* mesh, QWidget* parent, Qt::WindowFlags fl)
     d->geoFile = App::Application::getTempFileName() + "mesh.geo";
 }
 
-RemeshGmsh::~RemeshGmsh()
-{
-}
+RemeshGmsh::~RemeshGmsh() = default;
 
 bool RemeshGmsh::writeProject(QString& inpFile, QString& outFile)
 {
@@ -400,11 +398,6 @@ TaskRemeshGmsh::TaskRemeshGmsh(Mesh::Feature* mesh)
         QPixmap(), widget->windowTitle(), false, nullptr);
     taskbox->groupLayout()->addWidget(widget);
     Content.push_back(taskbox);
-}
-
-TaskRemeshGmsh::~TaskRemeshGmsh()
-{
-    // automatically deleted in the sub-class
 }
 
 void TaskRemeshGmsh::clicked(int id)

--- a/src/Mod/Mesh/Gui/RemeshGmsh.h
+++ b/src/Mod/Mesh/Gui/RemeshGmsh.h
@@ -111,7 +111,6 @@ class TaskRemeshGmsh : public Gui::TaskView::TaskDialog
 
 public:
     explicit TaskRemeshGmsh(Mesh::Feature* mesh);
-    ~TaskRemeshGmsh() override;
 
 public:
     void clicked(int) override;

--- a/src/Mod/Mesh/Gui/RemoveComponents.cpp
+++ b/src/Mod/Mesh/Gui/RemoveComponents.cpp
@@ -211,9 +211,7 @@ RemoveComponentsDialog::RemoveComponentsDialog(QWidget* parent, Qt::WindowFlags 
     hboxLayout->addWidget(buttonBox);
 }
 
-RemoveComponentsDialog::~RemoveComponentsDialog()
-{
-}
+RemoveComponentsDialog::~RemoveComponentsDialog() = default;
 
 void RemoveComponentsDialog::reject()
 {
@@ -247,11 +245,6 @@ TaskRemoveComponents::TaskRemoveComponents()
         QPixmap(), widget->windowTitle(), false, nullptr);
     taskbox->groupLayout()->addWidget(widget);
     Content.push_back(taskbox);
-}
-
-TaskRemoveComponents::~TaskRemoveComponents()
-{
-    // automatically deleted in the sub-class
 }
 
 void TaskRemoveComponents::modifyStandardButtons(QDialogButtonBox* box)

--- a/src/Mod/Mesh/Gui/RemoveComponents.h
+++ b/src/Mod/Mesh/Gui/RemoveComponents.h
@@ -102,7 +102,6 @@ class TaskRemoveComponents : public Gui::TaskView::TaskDialog
 
 public:
     TaskRemoveComponents();
-    ~TaskRemoveComponents() override;
 
 public:
     bool accept() override;

--- a/src/Mod/Mesh/Gui/Segmentation.cpp
+++ b/src/Mod/Mesh/Gui/Segmentation.cpp
@@ -151,11 +151,6 @@ TaskSegmentation::TaskSegmentation(Mesh::Feature* mesh)
     Content.push_back(taskbox);
 }
 
-TaskSegmentation::~TaskSegmentation()
-{
-    // automatically deleted in the sub-class
-}
-
 bool TaskSegmentation::accept()
 {
     widget->accept();

--- a/src/Mod/Mesh/Gui/Segmentation.h
+++ b/src/Mod/Mesh/Gui/Segmentation.h
@@ -60,7 +60,6 @@ class TaskSegmentation : public Gui::TaskView::TaskDialog
 {
 public:
     explicit TaskSegmentation(Mesh::Feature* mesh);
-    ~TaskSegmentation() override;
 
 public:
     bool accept() override;

--- a/src/Mod/Mesh/Gui/SegmentationBestFit.cpp
+++ b/src/Mod/Mesh/Gui/SegmentationBestFit.cpp
@@ -50,8 +50,8 @@ namespace MeshGui {
 class PlaneFitParameter : public FitParameter
 {
 public:
-    PlaneFitParameter() {}
-    ~PlaneFitParameter() override {}
+    PlaneFitParameter() = default;
+    ~PlaneFitParameter() override = default;
     std::vector<float> getParameter(FitParameter::Points pts) const override {
         std::vector<float> values;
         MeshCore::PlaneFit fit;
@@ -73,8 +73,8 @@ public:
 class CylinderFitParameter : public FitParameter
 {
 public:
-    CylinderFitParameter() {}
-    ~CylinderFitParameter() override {}
+    CylinderFitParameter() = default;
+    ~CylinderFitParameter() override = default;
     std::vector<float> getParameter(FitParameter::Points pts) const override {
         std::vector<float> values;
         MeshCore::CylinderFit fit;
@@ -128,8 +128,8 @@ public:
 class SphereFitParameter : public FitParameter
 {
 public:
-    SphereFitParameter() {}
-    ~SphereFitParameter() override {}
+    SphereFitParameter() = default;
+    ~SphereFitParameter() override = default;
     std::vector<float> getParameter(FitParameter::Points pts) const override {
         std::vector<float> values;
         MeshCore::SphereFit fit;
@@ -522,11 +522,6 @@ TaskSegmentationBestFit::TaskSegmentationBestFit(Mesh::Feature* mesh)
         QPixmap(), widget->windowTitle(), false, nullptr);
     taskbox->groupLayout()->addWidget(widget);
     Content.push_back(taskbox);
-}
-
-TaskSegmentationBestFit::~TaskSegmentationBestFit()
-{
-    // automatically deleted in the sub-class
 }
 
 bool TaskSegmentationBestFit::accept()

--- a/src/Mod/Mesh/Gui/SegmentationBestFit.h
+++ b/src/Mod/Mesh/Gui/SegmentationBestFit.h
@@ -48,7 +48,7 @@ public:
         std::vector<Base::Vector3f> points;
         std::vector<Base::Vector3f> normals;
     };
-    virtual ~FitParameter() {}
+    virtual ~FitParameter() = default;
     virtual std::vector<float> getParameter(Points) const = 0;
 };
 
@@ -114,7 +114,6 @@ class TaskSegmentationBestFit : public Gui::TaskView::TaskDialog
 {
 public:
     explicit TaskSegmentationBestFit(Mesh::Feature* mesh);
-    ~TaskSegmentationBestFit() override;
 
 public:
     bool accept() override;

--- a/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.cpp
+++ b/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.cpp
@@ -102,9 +102,7 @@ MeshRenderer::Private::Private()
 {
 }
 
-MeshRenderer::Private::~Private()
-{
-}
+MeshRenderer::Private::~Private() = default;
 
 bool MeshRenderer::Private::canRenderGLArray(SoGLRenderAction *action) const
 {
@@ -435,9 +433,7 @@ SoFCMaterialEngine::SoFCMaterialEngine()
     SO_ENGINE_ADD_OUTPUT(trigger, SoSFBool);
 }
 
-SoFCMaterialEngine::~SoFCMaterialEngine()
-{
-}
+SoFCMaterialEngine::~SoFCMaterialEngine() = default;
 
 void SoFCMaterialEngine::initClass()
 {

--- a/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.h
+++ b/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.h
@@ -108,7 +108,7 @@ public:
 
 protected:
     // Force using the reference count mechanism.
-    ~SoFCIndexedFaceSet() override {}
+    ~SoFCIndexedFaceSet() override = default;
     void GLRender(SoGLRenderAction *action) override;
     void drawFaces(SoGLRenderAction *action);
     void drawCoords(const SoGLCoordinateElement * const vertexlist,

--- a/src/Mod/Mesh/Gui/SoFCMeshObject.cpp
+++ b/src/Mod/Mesh/Gui/SoFCMeshObject.cpp
@@ -160,9 +160,7 @@ public:
     {
         this->rdbuf(&buf);
     }
-    ~SoInputStream() override
-    {
-    }
+    ~SoInputStream() override = default;
 
 private:
     SoInputStreambuf buf;
@@ -300,9 +298,7 @@ void SoFCMeshObjectElement::init(SoState * state)
     this->mesh = nullptr;
 }
 
-SoFCMeshObjectElement::~SoFCMeshObjectElement()
-{
-}
+SoFCMeshObjectElement::~SoFCMeshObjectElement() = default;
 
 void SoFCMeshObjectElement::set(SoState * const state, SoNode * const node, const Mesh::MeshObject * const mesh)
 {
@@ -419,9 +415,7 @@ SoFCMeshGridNode::SoFCMeshGridNode()
 /*!
   Destructor.
 */
-SoFCMeshGridNode::~SoFCMeshGridNode()
-{
-}
+SoFCMeshGridNode::~SoFCMeshGridNode() = default;
 
 // Doc from superclass.
 void SoFCMeshGridNode::initClass()
@@ -504,9 +498,7 @@ SoFCMeshObjectNode::SoFCMeshObjectNode()
 /*!
   Destructor.
 */
-SoFCMeshObjectNode::~SoFCMeshObjectNode()
-{
-}
+SoFCMeshObjectNode::~SoFCMeshObjectNode() = default;
 
 // Doc from superclass.
 void SoFCMeshObjectNode::initClass()
@@ -600,9 +592,7 @@ SoFCMeshObjectShape::SoFCMeshObjectShape()
     setName(SoFCMeshObjectShape::getClassTypeId().getName());
 }
 
-SoFCMeshObjectShape::~SoFCMeshObjectShape()
-{
-}
+SoFCMeshObjectShape::~SoFCMeshObjectShape() = default;
 
 void SoFCMeshObjectShape::notify(SoNotList * node)
 {

--- a/src/Mod/Mesh/Gui/SoFCMeshObject.h
+++ b/src/Mod/Mesh/Gui/SoFCMeshObject.h
@@ -183,6 +183,8 @@ protected:
                                             const SoPrimitiveVertex * v2,
                                             const SoPrimitiveVertex * v3,
                                             SoPickedPoint * pp) override;
+    // Force using the reference count mechanism.
+    ~SoFCMeshObjectShape() override;
 
 private:
     enum Binding {
@@ -193,8 +195,6 @@ private:
     };
 
 private:
-    // Force using the reference count mechanism.
-    ~SoFCMeshObjectShape() override;
     void notify(SoNotList * list) override;
     Binding findMaterialBinding(SoState * const state) const;
     // Draw faces
@@ -238,6 +238,8 @@ protected:
     void computeBBox(SoAction *action, SbBox3f &box, SbVec3f &center) override;
     void getPrimitiveCount(SoGetPrimitiveCountAction * action) override;
     void generatePrimitives(SoAction *action) override;
+    // Force using the reference count mechanism.
+    ~SoFCMeshSegmentShape() override = default;
 
 private:
     enum Binding {
@@ -248,8 +250,6 @@ private:
     };
 
 private:
-    // Force using the reference count mechanism.
-    ~SoFCMeshSegmentShape() override {}
     Binding findMaterialBinding(SoState * const state) const;
     // Draw faces
     void drawFaces(const Mesh::MeshObject *, SoMaterialBundle* mb, Binding bind,
@@ -271,9 +271,10 @@ protected:
     void computeBBox(SoAction *action, SbBox3f &box, SbVec3f &center) override;
     void getPrimitiveCount(SoGetPrimitiveCountAction * action) override;
     void generatePrimitives(SoAction *action) override;
-private:
     // Force using the reference count mechanism.
-    ~SoFCMeshObjectBoundary() override {}
+    ~SoFCMeshObjectBoundary() override = default;
+
+private:
     void drawLines(const Mesh::MeshObject *) const ;
 };
 

--- a/src/Mod/Mesh/Gui/SoPolygon.h
+++ b/src/Mod/Mesh/Gui/SoPolygon.h
@@ -49,7 +49,7 @@ public:
     SoSFBool  render;
 
 protected:
-    ~SoPolygon() override {}
+    ~SoPolygon() override = default;
     void GLRender(SoGLRenderAction *action) override;
     void computeBBox(SoAction *action, SbBox3f &box, SbVec3f &center) override;
     void rayPick (SoRayPickAction *action) override;

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -160,13 +160,9 @@ void ViewProviderMeshBuilder::createMesh(const MeshCore::MeshKernel& kernel, SoC
 
 PROPERTY_SOURCE(MeshGui::ViewProviderExport, Gui::ViewProviderDocumentObject)
 
-ViewProviderExport::ViewProviderExport()
-{
-}
+ViewProviderExport::ViewProviderExport() = default;
 
-ViewProviderExport::~ViewProviderExport()
-{
-}
+ViewProviderExport::~ViewProviderExport() = default;
 
 std::vector<std::string> ViewProviderExport::getDisplayModes() const
 {
@@ -912,9 +908,6 @@ public:
         , poly(poly)
         , proj(proj)
     {
-
-    }
-    ~MeshSplit() {
 
     }
     void cutMesh() {
@@ -2305,9 +2298,7 @@ ViewProviderIndexedFaceSet::ViewProviderIndexedFaceSet()
     pcMeshFaces = nullptr;
 }
 
-ViewProviderIndexedFaceSet::~ViewProviderIndexedFaceSet()
-{
-}
+ViewProviderIndexedFaceSet::~ViewProviderIndexedFaceSet() = default;
 
 /**
  * Extracts the mesh data from the feature \a pcFeature and creates
@@ -2396,9 +2387,7 @@ ViewProviderMeshObject::ViewProviderMeshObject()
     pcMeshShape = nullptr;
 }
 
-ViewProviderMeshObject::~ViewProviderMeshObject()
-{
-}
+ViewProviderMeshObject::~ViewProviderMeshObject() = default;
 
 void ViewProviderMeshObject::attach(App::DocumentObject *pcFeat)
 {

--- a/src/Mod/Mesh/Gui/ViewProvider.h
+++ b/src/Mod/Mesh/Gui/ViewProvider.h
@@ -80,8 +80,7 @@ class SoFCMeshObjectShape;
 class MeshGuiExport ViewProviderMeshBuilder : public Gui::ViewProviderBuilder
 {
 public:
-    ViewProviderMeshBuilder(){}
-    ~ViewProviderMeshBuilder() override{}
+    ViewProviderMeshBuilder() = default;
     void buildNodes(const App::Property*, std::vector<SoNode*>&) const override;
     void createMesh(const App::Property*, SoCoordinate3*, SoIndexedFaceSet*) const;
     void createMesh(const MeshCore::MeshKernel&, SoCoordinate3*, SoIndexedFaceSet*) const;

--- a/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
@@ -425,9 +425,6 @@ public:
         : vp(vp), s(s), p(p), n(n)
     {
     }
-    ~Annotation()
-    {
-    }
 
     static void run(void * data, SoSensor * sensor)
     {

--- a/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.h
+++ b/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.h
@@ -36,6 +36,7 @@ class SoIndexedFaceSet;
 class SoFaceSet;
 class SoPath;
 class SoLocateHighlight;
+class SbRotation;
 class SoTrackballDragger;
 class SoTransformerManip;
 

--- a/src/Mod/Mesh/Gui/Workbench.cpp
+++ b/src/Mod/Mesh/Gui/Workbench.cpp
@@ -55,13 +55,7 @@ using namespace MeshGui;
 /// @namespace MeshGui @class Workbench
 TYPESYSTEM_SOURCE(MeshGui::Workbench, Gui::StdWorkbench)
 
-Workbench::Workbench()
-{
-}
-
-Workbench::~Workbench()
-{
-}
+Workbench::Workbench() = default;
 
 class MeshInfoWatcher : public Gui::TaskView::TaskWatcher, public Gui::SelectionObserver
 {

--- a/src/Mod/Mesh/Gui/Workbench.h
+++ b/src/Mod/Mesh/Gui/Workbench.h
@@ -40,7 +40,6 @@ class MeshGuiExport Workbench : public Gui::StdWorkbench
 
 public:
   Workbench();
-  ~Workbench() override;
 
   void activated() override;
   void deactivated() override;


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html
This PR affects the code of the Mesh module.