### PR TITLE
Surface: modernize C++: use equals default

### DIFF
--- a/src/Mod/Surface/App/AppSurface.cpp
+++ b/src/Mod/Surface/App/AppSurface.cpp
@@ -48,8 +48,6 @@ public:
         initialize("This module is the Surface module.");// register with Python
     }
 
-    ~Module() override {}
-
 private:
 };
 

--- a/src/Mod/Surface/App/FeatureExtend.cpp
+++ b/src/Mod/Surface/App/FeatureExtend.cpp
@@ -72,10 +72,6 @@ Extend::Extend() : lockOnChangeMutex(false)
     SampleV.setConstraints(&SampleRange);
 }
 
-Extend::~Extend()
-{
-}
-
 short Extend::mustExecute() const
 {
     if (Face.isTouched())

--- a/src/Mod/Surface/App/FeatureExtend.h
+++ b/src/Mod/Surface/App/FeatureExtend.h
@@ -37,7 +37,6 @@ class SurfaceExport Extend :  public Part::Spline
 
 public:
     Extend();
-    ~Extend() override;
 
     App::PropertyLinkSub Face;
     App::PropertyFloatConstraint Tolerance;

--- a/src/Mod/Surface/App/FeatureSections.cpp
+++ b/src/Mod/Surface/App/FeatureSections.cpp
@@ -46,10 +46,6 @@ Sections::Sections()
     NSections.setScope(App::LinkScope::Global);
 }
 
-Sections::~Sections()
-{
-}
-
 App::DocumentObjectExecReturn *Sections::execute()
 {
     TColGeom_SequenceOfCurve curveSeq;

--- a/src/Mod/Surface/App/FeatureSections.h
+++ b/src/Mod/Surface/App/FeatureSections.h
@@ -37,7 +37,6 @@ class SurfaceExport Sections :  public Part::Spline
 
 public:
     Sections();
-    ~Sections() override;
 
     App::PropertyLinkSubList NSections;
 

--- a/src/Mod/Surface/Gui/AppSurfaceGui.cpp
+++ b/src/Mod/Surface/Gui/AppSurfaceGui.cpp
@@ -50,8 +50,6 @@ public:
         initialize("This module is the SurfaceGui module.");// register with Python
     }
 
-    ~Module() override {}
-
 private:
 };
 

--- a/src/Mod/Surface/Gui/TaskFilling.cpp
+++ b/src/Mod/Surface/Gui/TaskFilling.cpp
@@ -934,11 +934,6 @@ TaskFilling::TaskFilling(ViewProviderFilling* vp, Surface::Filling* obj)
     taskbox3->hideGroupBox();
 }
 
-TaskFilling::~TaskFilling()
-{
-    // automatically deleted in the sub-class
-}
-
 void TaskFilling::setEditedObject(Surface::Filling* obj)
 {
     widget1->setEditedObject(obj);

--- a/src/Mod/Surface/Gui/TaskFilling.h
+++ b/src/Mod/Surface/Gui/TaskFilling.h
@@ -127,7 +127,6 @@ class TaskFilling : public Gui::TaskView::TaskDialog
 
 public:
     TaskFilling(ViewProviderFilling* vp, Surface::Filling* obj);
-    ~TaskFilling() override;
     void setEditedObject(Surface::Filling* obj);
 
 public:

--- a/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
+++ b/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
@@ -636,11 +636,6 @@ TaskGeomFillSurface::TaskGeomFillSurface(ViewProviderGeomFillSurface* vp, Surfac
     Content.push_back(taskbox);
 }
 
-TaskGeomFillSurface::~TaskGeomFillSurface()
-{
-    // automatically deleted in the sub-class
-}
-
 void TaskGeomFillSurface::setEditedObject(Surface::GeomFillSurface* obj)
 {
     widget->setEditedObject(obj);

--- a/src/Mod/Surface/Gui/TaskGeomFillSurface.h
+++ b/src/Mod/Surface/Gui/TaskGeomFillSurface.h
@@ -117,7 +117,6 @@ class TaskGeomFillSurface : public Gui::TaskView::TaskDialog
 
 public:
     TaskGeomFillSurface(ViewProviderGeomFillSurface* vp, Surface::GeomFillSurface* obj);
-    ~TaskGeomFillSurface() override;
     void setEditedObject(Surface::GeomFillSurface* obj);
 
 public:

--- a/src/Mod/Surface/Gui/TaskSections.cpp
+++ b/src/Mod/Surface/Gui/TaskSections.cpp
@@ -276,9 +276,7 @@ SectionsPanel::SectionsPanel(ViewProviderSections* vp, Surface::Sections* obj) :
 /*
  *  Destroys the object and frees any allocated resources
  */
-SectionsPanel::~SectionsPanel()
-{
-}
+SectionsPanel::~SectionsPanel() = default;
 
 void SectionsPanel::setupConnections()
 {
@@ -588,11 +586,6 @@ TaskSections::TaskSections(ViewProviderSections* vp, Surface::Sections* obj)
         widget1->windowTitle(), true, nullptr);
     taskbox1->groupLayout()->addWidget(widget1);
     Content.push_back(taskbox1);
-}
-
-TaskSections::~TaskSections()
-{
-    // automatically deleted in the sub-class
 }
 
 void TaskSections::setEditedObject(Surface::Sections* obj)

--- a/src/Mod/Surface/Gui/TaskSections.h
+++ b/src/Mod/Surface/Gui/TaskSections.h
@@ -116,7 +116,6 @@ class TaskSections : public Gui::TaskView::TaskDialog
 
 public:
     TaskSections(ViewProviderSections* vp, Surface::Sections* obj);
-    ~TaskSections() override;
     void setEditedObject(Surface::Sections* obj);
 
 public:

--- a/src/Mod/Surface/Gui/Workbench.cpp
+++ b/src/Mod/Surface/Gui/Workbench.cpp
@@ -34,13 +34,9 @@ using namespace SurfaceGui;
 /// @namespace SurfaceGui @class Workbench
 TYPESYSTEM_SOURCE(SurfaceGui::Workbench, Gui::StdWorkbench)
 
-Workbench::Workbench()
-{
-}
+Workbench::Workbench() = default;
 
-Workbench::~Workbench()
-{
-}
+Workbench::~Workbench() = default;
 
 Gui::MenuItem *Workbench::setupMenuBar() const
 {


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html
This PR affects the code of the Surface module.