### PR TITLE
RE: modernize C++: use equals default

### DIFF
--- a/src/Mod/ReverseEngineering/App/AppReverseEngineering.cpp
+++ b/src/Mod/ReverseEngineering/App/AppReverseEngineering.cpp
@@ -157,8 +157,6 @@ public:
         initialize("This module is the ReverseEngineering module."); // register with Python
     }
 
-    ~Module() override {}
-
 private:
     Py::Object approxSurface(const Py::Tuple& args, const Py::Dict& kwds)
     {

--- a/src/Mod/ReverseEngineering/App/ApproxSurface.cpp
+++ b/src/Mod/ReverseEngineering/App/ApproxSurface.cpp
@@ -82,9 +82,7 @@ SplineBasisfunction::SplineBasisfunction(TColStd_Array1OfReal& vKnots, int iOrde
     _iOrder = iOrder;
 }
 
-SplineBasisfunction::~SplineBasisfunction()
-{
-}
+SplineBasisfunction::~SplineBasisfunction() = default;
 
 void SplineBasisfunction::SetKnots(TColStd_Array1OfReal& vKnots, int iOrder)
 {
@@ -133,9 +131,7 @@ BSplineBasis::BSplineBasis(TColStd_Array1OfReal& vKnots, int iOrder)
 {
 }
 
-BSplineBasis::~BSplineBasis()
-{
-}
+BSplineBasis::~BSplineBasis() = default;
 
 int BSplineBasis::FindSpan(double fParam)
 {

--- a/src/Mod/ReverseEngineering/App/ApproxSurface.h
+++ b/src/Mod/ReverseEngineering/App/ApproxSurface.h
@@ -375,7 +375,7 @@ public:
                                unsigned usUCtrlpoints=6,          //Qty. of the control points in u-direction
                                unsigned usVCtrlpoints=6);         //Qty. of the control points in v-direction
 
-    ~BSplineParameterCorrection() override{}
+    ~BSplineParameterCorrection() override = default;
 
 protected:
     /**

--- a/src/Mod/ReverseEngineering/Gui/AppReverseEngineeringGui.cpp
+++ b/src/Mod/ReverseEngineering/Gui/AppReverseEngineeringGui.cpp
@@ -51,8 +51,6 @@ public:
         initialize("This module is the ReverseEngineeringGui module."); // register with Python
     }
 
-    ~Module() override {}
-
 private:
 };
 

--- a/src/Mod/ReverseEngineering/Gui/FitBSplineSurface.cpp
+++ b/src/Mod/ReverseEngineering/Gui/FitBSplineSurface.cpp
@@ -48,12 +48,8 @@ class FitBSplineSurfaceWidget::Private
 public:
     Ui_FitBSplineSurface ui;
     App::DocumentObjectT obj;
-    Private()
-    {
-    }
-    ~Private()
-    {
-    }
+    Private() = default;
+    ~Private() = default;
 };
 
 /* TRANSLATOR ReenGui::FitBSplineSurfaceWidget */
@@ -254,10 +250,6 @@ TaskFitBSplineSurface::TaskFitBSplineSurface(const App::DocumentObjectT& obj)
         widget->windowTitle(), true, nullptr);
     taskbox->groupLayout()->addWidget(widget);
     Content.push_back(taskbox);
-}
-
-TaskFitBSplineSurface::~TaskFitBSplineSurface()
-{
 }
 
 void TaskFitBSplineSurface::open()

--- a/src/Mod/ReverseEngineering/Gui/FitBSplineSurface.h
+++ b/src/Mod/ReverseEngineering/Gui/FitBSplineSurface.h
@@ -58,7 +58,6 @@ class TaskFitBSplineSurface : public Gui::TaskView::TaskDialog
 
 public:
     explicit TaskFitBSplineSurface(const App::DocumentObjectT&);
-    ~TaskFitBSplineSurface() override;
 
 public:
     void open() override;

--- a/src/Mod/ReverseEngineering/Gui/Poisson.cpp
+++ b/src/Mod/ReverseEngineering/Gui/Poisson.cpp
@@ -41,12 +41,8 @@ class PoissonWidget::Private
 public:
     Ui_PoissonWidget ui;
     App::DocumentObjectT obj;
-    Private()
-    {
-    }
-    ~Private()
-    {
-    }
+    Private() = default;
+    ~Private() = default;
 };
 
 /* TRANSLATOR ReenGui::PoissonWidget */
@@ -123,9 +119,7 @@ TaskPoisson::TaskPoisson(const App::DocumentObjectT& obj)
     Content.push_back(taskbox);
 }
 
-TaskPoisson::~TaskPoisson()
-{
-}
+TaskPoisson::~TaskPoisson() = default;
 
 void TaskPoisson::open()
 {

--- a/src/Mod/ReverseEngineering/Gui/Segmentation.cpp
+++ b/src/Mod/ReverseEngineering/Gui/Segmentation.cpp
@@ -65,9 +65,7 @@ Segmentation::Segmentation(Mesh::Feature* mesh, QWidget* parent, Qt::WindowFlags
     ui->checkBoxSmooth->setChecked(false);
 }
 
-Segmentation::~Segmentation()
-{
-}
+Segmentation::~Segmentation() = default;
 
 void Segmentation::accept()
 {
@@ -258,11 +256,6 @@ TaskSegmentation::TaskSegmentation(Mesh::Feature* mesh)
         QPixmap(), widget->windowTitle(), false, nullptr);
     taskbox->groupLayout()->addWidget(widget);
     Content.push_back(taskbox);
-}
-
-TaskSegmentation::~TaskSegmentation()
-{
-    // automatically deleted in the sub-class
 }
 
 bool TaskSegmentation::accept()

--- a/src/Mod/ReverseEngineering/Gui/Segmentation.h
+++ b/src/Mod/ReverseEngineering/Gui/Segmentation.h
@@ -61,7 +61,6 @@ class TaskSegmentation : public Gui::TaskView::TaskDialog
 {
 public:
     explicit TaskSegmentation(Mesh::Feature* mesh);
-    ~TaskSegmentation() override;
 
 public:
     bool accept() override;

--- a/src/Mod/ReverseEngineering/Gui/SegmentationManual.cpp
+++ b/src/Mod/ReverseEngineering/Gui/SegmentationManual.cpp
@@ -56,9 +56,7 @@ SegmentationManual::SegmentationManual(QWidget* parent, Qt::WindowFlags fl)
     meshSel.setEnabledViewerSelection(false);
 }
 
-SegmentationManual::~SegmentationManual()
-{
-}
+SegmentationManual::~SegmentationManual() = default;
 
 void SegmentationManual::setupConnections()
 {
@@ -320,11 +318,6 @@ TaskSegmentationManual::TaskSegmentationManual()
         QPixmap(), widget->windowTitle(), false, nullptr);
     taskbox->groupLayout()->addWidget(widget);
     Content.push_back(taskbox);
-}
-
-TaskSegmentationManual::~TaskSegmentationManual()
-{
-    // automatically deleted in the sub-class
 }
 
 void TaskSegmentationManual::modifyStandardButtons(QDialogButtonBox* box)

--- a/src/Mod/ReverseEngineering/Gui/SegmentationManual.h
+++ b/src/Mod/ReverseEngineering/Gui/SegmentationManual.h
@@ -84,7 +84,6 @@ class TaskSegmentationManual : public Gui::TaskView::TaskDialog
 
 public:
     TaskSegmentationManual();
-    ~TaskSegmentationManual() override;
 
 public:
     bool accept() override;

--- a/src/Mod/ReverseEngineering/Gui/Workbench.cpp
+++ b/src/Mod/ReverseEngineering/Gui/Workbench.cpp
@@ -37,13 +37,9 @@ using namespace ReverseEngineeringGui;
 /// @namespace ReverseEngineeringGui @class Workbench
 TYPESYSTEM_SOURCE(ReverseEngineeringGui::Workbench, Gui::StdWorkbench)
 
-Workbench::Workbench()
-{
-}
+Workbench::Workbench() = default;
 
-Workbench::~Workbench()
-{
-}
+Workbench::~Workbench() = default;
 
 Gui::MenuItem* Workbench::setupMenuBar() const
 {


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html
This PR affects the code of the ReverseEngineering module.