### PR TITLE
Sketcher: Fix Visual toolbox visibility

### DIFF
--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -164,7 +164,7 @@ inline const QStringList editModeToolbarNames()
                         QString::fromLatin1("Sketcher constraints"),
                         QString::fromLatin1("Sketcher tools"),
                         QString::fromLatin1("Sketcher B-spline tools"),
-                        QString::fromLatin1("Sketcher virtual space"),
+                        QString::fromLatin1("Sketcher visual"),
                         QString::fromLatin1("Sketcher edit tools")};
 }
 


### PR DESCRIPTION
Fix #10310 The Sketcher Visual toolbox can't be displayed as it doesn't appear in the context menu.