### PR TITLE
PD: modernize C++: use equals default

### DIFF
--- a/src/Mod/PartDesign/App/AppPartDesignPy.cpp
+++ b/src/Mod/PartDesign/App/AppPartDesignPy.cpp
@@ -40,8 +40,6 @@ public:
         initialize("This module is the PartDesign module."); // register with Python
     }
 
-    ~Module() override {}
-
 private:
     Py::Object makeFilletArc(const Py::Tuple& args)
     {

--- a/src/Mod/PartDesign/App/DatumCS.cpp
+++ b/src/Mod/PartDesign/App/DatumCS.cpp
@@ -52,9 +52,7 @@ CoordinateSystem::CoordinateSystem()
     Shape.setValue(builder.Shape());
 }
 
-CoordinateSystem::~CoordinateSystem()
-{
-}
+CoordinateSystem::~CoordinateSystem() = default;
 
 Base::Vector3d CoordinateSystem::getXAxis()
 {

--- a/src/Mod/PartDesign/App/DatumLine.cpp
+++ b/src/Mod/PartDesign/App/DatumLine.cpp
@@ -65,9 +65,7 @@ Line::Line()
     Support.touch();
 }
 
-Line::~Line()
-{
-}
+Line::~Line() = default;
 
 Base::Vector3d Line::getDirection() const
 {

--- a/src/Mod/PartDesign/App/DatumPlane.cpp
+++ b/src/Mod/PartDesign/App/DatumPlane.cpp
@@ -66,9 +66,7 @@ Plane::Plane()
     Shape.setValue(myShape);
 }
 
-Plane::~Plane()
-{
-}
+Plane::~Plane() = default;
 
 Base::Vector3d Plane::getNormal()
 {

--- a/src/Mod/PartDesign/App/DatumPoint.cpp
+++ b/src/Mod/PartDesign/App/DatumPoint.cpp
@@ -43,9 +43,7 @@ Point::Point()
     this->makeShape();
 }
 
-Point::~Point()
-{
-}
+Point::~Point() = default;
 
 void Point::onChanged(const App::Property* prop)
 {

--- a/src/Mod/PartDesign/App/FeatureAddSub.cpp
+++ b/src/Mod/PartDesign/App/FeatureAddSub.cpp
@@ -123,9 +123,7 @@ FeatureAdditivePython::FeatureAdditivePython()
     addSubType = Additive;
 }
 
-FeatureAdditivePython::~FeatureAdditivePython()
-{
-}
+FeatureAdditivePython::~FeatureAdditivePython() = default;
 
 
 PROPERTY_SOURCE(PartDesign::FeatureSubtractivePython, PartDesign::FeatureAddSubPython)
@@ -135,8 +133,6 @@ FeatureSubtractivePython::FeatureSubtractivePython()
     addSubType = Subtractive;
 }
 
-FeatureSubtractivePython::~FeatureSubtractivePython()
-{
-}
+FeatureSubtractivePython::~FeatureSubtractivePython() = default;
 
 }

--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -49,9 +49,7 @@ App::PropertyQuantityConstraint::Constraints FeatureExtrude::signedLengthConstra
 double FeatureExtrude::maxAngle = 90 - Base::toDegrees<double>(Precision::Angular());
 App::PropertyAngle::Constraints FeatureExtrude::floatAngle = { -maxAngle, maxAngle, 1.0 };
 
-FeatureExtrude::FeatureExtrude()
-{
-}
+FeatureExtrude::FeatureExtrude() = default;
 
 short FeatureExtrude::mustExecute() const
 {

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -197,7 +197,7 @@ private:
         std::string thread_type;
         std::string cut_name;
     public:
-        CutDimensionKey() {}
+        CutDimensionKey() = default;
         CutDimensionKey(const std::string &t, const std::string &c);
         bool operator<(const CutDimensionKey &b) const;
     };

--- a/src/Mod/PartDesign/App/FeatureSolid.cpp
+++ b/src/Mod/PartDesign/App/FeatureSolid.cpp
@@ -31,9 +31,7 @@ namespace PartDesign {
 
 PROPERTY_SOURCE(PartDesign::Solid,PartDesign::Feature)
 
-Solid::Solid()
-{
-}
+Solid::Solid() = default;
 
 
 

--- a/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
+++ b/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
@@ -85,8 +85,6 @@ public:
         initialize("This module is the PartDesignGui module."); // register with Python
     }
 
-    ~Module() override {}
-
 private:
 };
 

--- a/src/Mod/PartDesign/Gui/DlgActiveBody.cpp
+++ b/src/Mod/PartDesign/Gui/DlgActiveBody.cpp
@@ -84,9 +84,7 @@ DlgActiveBody::DlgActiveBody(QWidget *parent, App::Document*& doc, const QString
     }
 }
 
-DlgActiveBody::~DlgActiveBody()
-{
-}
+DlgActiveBody::~DlgActiveBody() = default;
 
 void DlgActiveBody::accept()
 {

--- a/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
@@ -284,9 +284,7 @@ void TaskBooleanParameters::onBodyDeleted()
     }
 }
 
-TaskBooleanParameters::~TaskBooleanParameters()
-{
-}
+TaskBooleanParameters::~TaskBooleanParameters() = default;
 
 void TaskBooleanParameters::changeEvent(QEvent *e)
 {
@@ -321,10 +319,7 @@ TaskDlgBooleanParameters::TaskDlgBooleanParameters(ViewProviderBoolean *BooleanV
     Content.push_back(parameter);
 }
 
-TaskDlgBooleanParameters::~TaskDlgBooleanParameters()
-{
-
-}
+TaskDlgBooleanParameters::~TaskDlgBooleanParameters() = default;
 
 //==== calls from the TaskView ===============================================================
 

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -336,10 +336,7 @@ TaskDlgChamferParameters::TaskDlgChamferParameters(ViewProviderChamfer *DressUpV
     Content.push_back(parameter);
 }
 
-TaskDlgChamferParameters::~TaskDlgChamferParameters()
-{
-
-}
+TaskDlgChamferParameters::~TaskDlgChamferParameters() = default;
 
 //==== calls from the TaskView ===============================================================
 

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -80,10 +80,7 @@ TaskDlgDatumParameters::TaskDlgDatumParameters(ViewProviderDatum *ViewProvider)
     Content.push_back(parameter);
 }
 
-TaskDlgDatumParameters::~TaskDlgDatumParameters()
-{
-
-}
+TaskDlgDatumParameters::~TaskDlgDatumParameters() = default;
 
 bool TaskDlgDatumParameters::reject() {
 

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
@@ -296,10 +296,7 @@ TaskDlgDraftParameters::TaskDlgDraftParameters(ViewProviderDraft *DressUpView)
     Content.push_back(parameter);
 }
 
-TaskDlgDraftParameters::~TaskDlgDraftParameters()
-{
-
-}
+TaskDlgDraftParameters::~TaskDlgDraftParameters() = default;
 
 //==== calls from the TaskView ===============================================================
 

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -411,10 +411,7 @@ TaskDlgDressUpParameters::TaskDlgDressUpParameters(ViewProviderDressUp *DressUpV
     assert(DressUpView);
 }
 
-TaskDlgDressUpParameters::~TaskDlgDressUpParameters()
-{
-
-}
+TaskDlgDressUpParameters::~TaskDlgDressUpParameters() = default;
 
 //==== calls from the TaskView ===============================================================
 

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -59,9 +59,7 @@ TaskExtrudeParameters::TaskExtrudeParameters(ViewProviderSketchBased *SketchBase
     this->groupLayout()->addWidget(proxy);
 }
 
-TaskExtrudeParameters::~TaskExtrudeParameters()
-{
-}
+TaskExtrudeParameters::~TaskExtrudeParameters() = default;
 
 void TaskExtrudeParameters::setupDialog()
 {

--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.cpp
@@ -83,10 +83,7 @@ TaskDlgFeatureParameters::TaskDlgFeatureParameters(PartDesignGui::ViewProvider *
     assert(vp);
 }
 
-TaskDlgFeatureParameters::~TaskDlgFeatureParameters()
-{
-
-}
+TaskDlgFeatureParameters::~TaskDlgFeatureParameters() = default;
 
 bool TaskDlgFeatureParameters::accept() {
     App::DocumentObject* feature = vp->getObject();

--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
@@ -41,7 +41,7 @@ class TaskFeatureParameters : public Gui::TaskView::TaskBox,
 public:
     TaskFeatureParameters(PartDesignGui::ViewProvider* vp, QWidget *parent,
                               const std::string& pixmapname, const QString& parname);
-    ~TaskFeatureParameters() override {}
+    ~TaskFeatureParameters() override = default;
 
     /// save field history
     virtual void saveHistory() {}

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -206,10 +206,7 @@ TaskDlgFilletParameters::TaskDlgFilletParameters(ViewProviderFillet *DressUpView
     Content.push_back(parameter);
 }
 
-TaskDlgFilletParameters::~TaskDlgFilletParameters()
-{
-
-}
+TaskDlgFilletParameters::~TaskDlgFilletParameters() = default;
 
 //==== calls from the TaskView ===============================================================
 

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -258,9 +258,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
     this->groupLayout()->addWidget(proxy);
 }
 
-TaskHoleParameters::~TaskHoleParameters()
-{
-}
+TaskHoleParameters::~TaskHoleParameters() = default;
 
 void TaskHoleParameters::threadedChanged()
 {
@@ -1189,10 +1187,7 @@ TaskDlgHoleParameters::TaskDlgHoleParameters(ViewProviderHole* HoleView)
     Content.push_back(parameter);
 }
 
-TaskDlgHoleParameters::~TaskDlgHoleParameters()
-{
-
-}
+TaskDlgHoleParameters::~TaskDlgHoleParameters() = default;
 
 #include "moc_TaskHoleParameters.cpp"
 

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -96,7 +96,7 @@ class TaskDlgLinearPatternParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgLinearPatternParameters(ViewProviderLinearPattern *LinearPatternView);
-    ~TaskDlgLinearPatternParameters() override {}
+    ~TaskDlgLinearPatternParameters() override = default;
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -122,9 +122,7 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft *LoftView, bool /*newObj
     updateUI();
 }
 
-TaskLoftParameters::~TaskLoftParameters()
-{
-}
+TaskLoftParameters::~TaskLoftParameters() = default;
 
 void TaskLoftParameters::updateUI()
 {
@@ -373,9 +371,7 @@ TaskDlgLoftParameters::TaskDlgLoftParameters(ViewProviderLoft *LoftView,bool new
     Content.push_back(parameter);
 }
 
-TaskDlgLoftParameters::~TaskDlgLoftParameters()
-{
-}
+TaskDlgLoftParameters::~TaskDlgLoftParameters() = default;
 
 bool TaskDlgLoftParameters::accept()
 {

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
@@ -86,7 +86,7 @@ class TaskDlgMirroredParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgMirroredParameters(ViewProviderMirrored *MirroredView);
-    ~TaskDlgMirroredParameters() override {}
+    ~TaskDlgMirroredParameters() override = default;
 
 public:
     /// is called by the framework if the dialog is accepted (Ok)

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
@@ -113,7 +113,7 @@ class TaskDlgMultiTransformParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgMultiTransformParameters(ViewProviderMultiTransform *MultiTransformView);
-    ~TaskDlgMultiTransformParameters() override {}
+    ~TaskDlgMultiTransformParameters() override = default;
 
 public:
     /// is called by the framework if the dialog is accepted (Ok)

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -62,9 +62,7 @@ TaskPadParameters::TaskPadParameters(ViewProviderPad *PadView, QWidget *parent, 
     }
 }
 
-TaskPadParameters::~TaskPadParameters()
-{
-}
+TaskPadParameters::~TaskPadParameters() = default;
 
 void TaskPadParameters::translateModeList(int index)
 {

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.h
@@ -62,7 +62,7 @@ public:
 
 public:
     StateHandlerTaskPipe() {selectionMode = SelectionModes::none;}
-    ~StateHandlerTaskPipe() {}
+    ~StateHandlerTaskPipe() = default;
 
     // only keeping getter because task boxes shouldn't need to change this
     // and task dialog is already friend

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
@@ -63,9 +63,7 @@ TaskPocketParameters::TaskPocketParameters(ViewProviderPocket *PocketView,QWidge
     }
 }
 
-TaskPocketParameters::~TaskPocketParameters()
-{
-}
+TaskPocketParameters::~TaskPocketParameters() = default;
 
 void TaskPocketParameters::translateModeList(int index)
 {

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -98,7 +98,7 @@ class TaskDlgPolarPatternParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgPolarPatternParameters(ViewProviderPolarPattern *PolarPatternView);
-    ~TaskDlgPolarPatternParameters() override {}
+    ~TaskDlgPolarPatternParameters() override = default;
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -936,10 +936,7 @@ TaskPrimitiveParameters::TaskPrimitiveParameters(ViewProviderPrimitive* Primitiv
     Content.push_back(parameter);
 }
 
-TaskPrimitiveParameters::~TaskPrimitiveParameters()
-{
-
-}
+TaskPrimitiveParameters::~TaskPrimitiveParameters() = default;
 
 bool TaskPrimitiveParameters::accept()
 {

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.h
@@ -83,7 +83,7 @@ class TaskDlgScaledParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgScaledParameters(ViewProviderScaled *ScaledView);
-    ~TaskDlgScaledParameters() override {}
+    ~TaskDlgScaledParameters() override = default;
 
 public:
     /// is called by the framework if the dialog is accepted (Ok)

--- a/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
@@ -76,9 +76,7 @@ TaskShapeBinder::TaskShapeBinder(ViewProviderShapeBinder* view, bool newObj, QWi
     updateUI();
 }
 
-TaskShapeBinder::~TaskShapeBinder()
-{
-}
+TaskShapeBinder::~TaskShapeBinder() = default;
 
 void TaskShapeBinder::updateUI()
 {
@@ -391,10 +389,7 @@ TaskDlgShapeBinder::TaskDlgShapeBinder(ViewProviderShapeBinder* view, bool newOb
     Content.push_back(parameter);
 }
 
-TaskDlgShapeBinder::~TaskDlgShapeBinder()
-{
-
-}
+TaskDlgShapeBinder::~TaskDlgShapeBinder() = default;
 
 bool TaskDlgShapeBinder::accept()
 {

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -246,10 +246,7 @@ TaskDlgSketchBasedParameters::TaskDlgSketchBasedParameters(PartDesignGui::ViewPr
 {
 }
 
-TaskDlgSketchBasedParameters::~TaskDlgSketchBasedParameters()
-{
-
-}
+TaskDlgSketchBasedParameters::~TaskDlgSketchBasedParameters() = default;
 
 //==== calls from the TaskView ===============================================================
 

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -261,10 +261,7 @@ TaskDlgThicknessParameters::TaskDlgThicknessParameters(ViewProviderThickness *Dr
     Content.push_back(parameter);
 }
 
-TaskDlgThicknessParameters::~TaskDlgThicknessParameters()
-{
-
-}
+TaskDlgThicknessParameters::~TaskDlgThicknessParameters() = default;
 
 //==== calls from the TaskView ===============================================================
 

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -242,7 +242,7 @@ class TaskDlgTransformedParameters : public PartDesignGui::TaskDlgFeatureParamet
 
 public:
     explicit TaskDlgTransformedParameters(ViewProviderTransformed *TransformedView);
-    ~TaskDlgTransformedParameters() override {}
+    ~TaskDlgTransformedParameters() override = default;
 
     ViewProviderTransformed* getTransformedView() const
     { return static_cast<ViewProviderTransformed*>(vp); }

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -55,9 +55,7 @@ ViewProvider::ViewProvider()
     PartGui::ViewProviderAttachExtension::initExtension(this);
 }
 
-ViewProvider::~ViewProvider()
-{
-}
+ViewProvider::~ViewProvider() = default;
 
 bool ViewProvider::doubleClicked()
 {

--- a/src/Mod/PartDesign/Gui/ViewProviderBase.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBase.cpp
@@ -39,10 +39,7 @@ ViewProviderBase::ViewProviderBase()
     sPixmap = "PartDesign_BaseFeature.svg";
 }
 
-ViewProviderBase::~ViewProviderBase()
-{
-
-}
+ViewProviderBase::~ViewProviderBase() = default;
 
 bool ViewProviderBase::doubleClicked()
 {

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
@@ -54,9 +54,7 @@ ViewProviderBoolean::ViewProviderBoolean()
     Display.setEnums(DisplayEnum);
 }
 
-ViewProviderBoolean::~ViewProviderBoolean()
-{
-}
+ViewProviderBoolean::~ViewProviderBoolean() = default;
 
 
 void ViewProviderBoolean::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)

--- a/src/Mod/PartDesign/Gui/ViewProviderDatumPoint.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatumPoint.cpp
@@ -49,9 +49,7 @@ ViewProviderDatumPoint::ViewProviderDatumPoint()
     Transparency.setStatus(App::Property::Hidden, true); //< make transparency hidden
 }
 
-ViewProviderDatumPoint::~ViewProviderDatumPoint()
-{
-}
+ViewProviderDatumPoint::~ViewProviderDatumPoint() = default;
 
 void ViewProviderDatumPoint::attach ( App::DocumentObject *obj ) {
     ViewProviderDatum::attach ( obj );

--- a/src/Mod/PartDesign/Gui/ViewProviderDressUp.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderDressUp.h
@@ -38,11 +38,9 @@ class PartDesignGuiExport ViewProviderDressUp : public ViewProvider
 
 public:
     /// constructor
-    ViewProviderDressUp()
-        {}
+    ViewProviderDressUp()  = default;
     /// destructor
-    ~ViewProviderDressUp() override
-        {}
+    ~ViewProviderDressUp() override         = default;
 
     /// grouping handling
     void setupContextMenu(QMenu*, QObject*, const char*) override;

--- a/src/Mod/PartDesign/Gui/ViewProviderGroove.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderGroove.cpp
@@ -39,9 +39,7 @@ ViewProviderGroove::ViewProviderGroove()
     sPixmap = "PartDesign_Groove.svg";
 }
 
-ViewProviderGroove::~ViewProviderGroove()
-{
-}
+ViewProviderGroove::~ViewProviderGroove() = default;
 
 void ViewProviderGroove::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {

--- a/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
@@ -42,13 +42,9 @@ using namespace PartDesignGui;
 PROPERTY_SOURCE(PartDesignGui::ViewProviderHelix,PartDesignGui::ViewProvider)
 
 
-ViewProviderHelix::ViewProviderHelix()
-{
-}
+ViewProviderHelix::ViewProviderHelix() = default;
 
-ViewProviderHelix::~ViewProviderHelix()
-{
-}
+ViewProviderHelix::~ViewProviderHelix() = default;
 
 void ViewProviderHelix::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {

--- a/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
@@ -46,9 +46,7 @@ ViewProviderHole::ViewProviderHole()
     sPixmap = "PartDesign_Hole.svg";
 }
 
-ViewProviderHole::~ViewProviderHole()
-{
-}
+ViewProviderHole::~ViewProviderHole() = default;
 
 std::vector<App::DocumentObject*> ViewProviderHole::claimChildren()const
 {

--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
@@ -39,13 +39,9 @@ using namespace PartDesignGui;
 
 PROPERTY_SOURCE(PartDesignGui::ViewProviderLoft,PartDesignGui::ViewProvider)
 
-ViewProviderLoft::ViewProviderLoft()
-{
-}
+ViewProviderLoft::ViewProviderLoft() = default;
 
-ViewProviderLoft::~ViewProviderLoft()
-{
-}
+ViewProviderLoft::~ViewProviderLoft() = default;
 
 std::vector<App::DocumentObject*> ViewProviderLoft::claimChildren()const
 {

--- a/src/Mod/PartDesign/Gui/ViewProviderPad.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPad.cpp
@@ -39,9 +39,7 @@ ViewProviderPad::ViewProviderPad()
     sPixmap = "Tree_PartDesign_Pad.svg";
 }
 
-ViewProviderPad::~ViewProviderPad()
-{
-}
+ViewProviderPad::~ViewProviderPad() = default;
 
 void ViewProviderPad::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
@@ -39,13 +39,9 @@ using namespace PartDesignGui;
 
 PROPERTY_SOURCE(PartDesignGui::ViewProviderPipe,PartDesignGui::ViewProvider)
 
-ViewProviderPipe::ViewProviderPipe()
-{
-}
+ViewProviderPipe::ViewProviderPipe() = default;
 
-ViewProviderPipe::~ViewProviderPipe()
-{
-}
+ViewProviderPipe::~ViewProviderPipe() = default;
 
 std::vector<App::DocumentObject*> ViewProviderPipe::claimChildren()const
 {

--- a/src/Mod/PartDesign/Gui/ViewProviderPocket.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPocket.cpp
@@ -40,9 +40,7 @@ ViewProviderPocket::ViewProviderPocket()
     sPixmap = "PartDesign_Pocket.svg";
 }
 
-ViewProviderPocket::~ViewProviderPocket()
-{
-}
+ViewProviderPocket::~ViewProviderPocket() = default;
 
 
 void ViewProviderPocket::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)

--- a/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
@@ -41,14 +41,9 @@ using namespace PartDesignGui;
 
 PROPERTY_SOURCE(PartDesignGui::ViewProviderPrimitive,PartDesignGui::ViewProvider)
 
-ViewProviderPrimitive::ViewProviderPrimitive()
-{
-}
+ViewProviderPrimitive::ViewProviderPrimitive() = default;
 
-ViewProviderPrimitive::~ViewProviderPrimitive()
-{
-
-}
+ViewProviderPrimitive::~ViewProviderPrimitive() = default;
 
 void ViewProviderPrimitive::attach(App::DocumentObject* obj) {
     ViewProviderAddSub::attach(obj);

--- a/src/Mod/PartDesign/Gui/ViewProviderRevolution.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderRevolution.cpp
@@ -39,9 +39,7 @@ ViewProviderRevolution::ViewProviderRevolution()
     sPixmap = "Tree_PartDesign_Revolution.svg";
 }
 
-ViewProviderRevolution::~ViewProviderRevolution()
-{
-}
+ViewProviderRevolution::~ViewProviderRevolution() = default;
 
 void ViewProviderRevolution::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -79,10 +79,7 @@ ViewProviderShapeBinder::ViewProviderShapeBinder()
     LineWidth.setValue(1);
 }
 
-ViewProviderShapeBinder::~ViewProviderShapeBinder()
-{
-
-}
+ViewProviderShapeBinder::~ViewProviderShapeBinder() = default;
 
 bool ViewProviderShapeBinder::setEdit(int ModNum) {
     // TODO Share code with other view providers (2015-09-11, Fat-Zer)

--- a/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
@@ -35,14 +35,9 @@ using namespace PartDesignGui;
 PROPERTY_SOURCE(PartDesignGui::ViewProviderSketchBased, PartDesignGui::ViewProvider)
 
 
-ViewProviderSketchBased::ViewProviderSketchBased()
-{
-}
+ViewProviderSketchBased::ViewProviderSketchBased() = default;
 
-
-ViewProviderSketchBased::~ViewProviderSketchBased()
-{
-}
+ViewProviderSketchBased::~ViewProviderSketchBased() = default;
 
 
 std::vector<App::DocumentObject*> ViewProviderSketchBased::claimChildren() const {

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.h
@@ -39,8 +39,7 @@ public:
     ViewProviderTransformed()
         : pcRejectedRoot(nullptr) {}
     /// destructor
-    ~ViewProviderTransformed() override
-        {}
+    ~ViewProviderTransformed() override  = default;
 
     // The feature name of the subclass
     virtual const std::string & featureName() const;


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html
This PR affects the code of the PartDesign module.