### PR TITLE
[Path] Fix bug where ramp dressup makes big circles

### DIFF
--- a/src/Mod/Path/Path/Dressup/Gui/RampEntry.py
+++ b/src/Mod/Path/Path/Dressup/Gui/RampEntry.py
@@ -479,9 +479,9 @@ class ObjectDressup:
         ):
             return Part.makeLine(startPoint, endPoint)
         elif type(originalEdge.Curve) == Part.Circle:
-            arcMid = originalEdge.valueAt(
-                (originalEdge.FirstParameter + originalEdge.LastParameter) / 2
-            )
+            firstParameter = originalEdge.Curve.parameter(startPoint)
+            lastParameter = originalEdge.Curve.parameter(endPoint)
+            arcMid = originalEdge.valueAt((firstParameter + lastParameter) / 2)
             arcMid.z = (startPoint.z + endPoint.z) / 2
             return Part.Arc(startPoint, arcMid, endPoint).toShape()
         else:


### PR DESCRIPTION
Fixes #10317 

Most of the time, creatRampEdge is invoked on an arc with the arc's start and end points as parameters (either matching its argument names or swapped). In this case, the existing computation of arcMid is a correct computation of the arc midpoint, and results in returning the correct arc.

However, in createRampMethod1 (and maybe other places? I haven't checked), this method can be invoked on a subsection of an arc (see lines 554, 559, 566) . In this case, the existing computation of arcMid produces the midpoint of the original arc, not the subsection of the arc. The computed point may lie on the outside of the intended arc, producing instead the arc that goes the other way around the circle from start to end.

My fix is to compute the parameters of the provided startPoint and endPoint in the computation of arcMid instead of the arc boundary parameters. If the provided start and end points are the arc boundary points, nothing should change up to floating point precision. If the points are not end points, existing behavior was buggy and this fixes the behavior.