### PR TITLE
fix: windows build need /utf-8

### DIFF
--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(MSVC)
     add_definitions(-DHAVE_ATANH -DHAVE_ASINH -DHAVE_ACOSH)
+    add_compile_options(/utf-8)
 else(MSVC)
     add_definitions(-DHAVE_LIMITS_H -DHAVE_CONFIG_H)
 endif(MSVC)


### PR DESCRIPTION
FreeCAD\src\Mod\TechDraw\Gui\CommandExtensionDims.cpp(174) has a utf-8 character