### PR TITLE
Core: Rename Std_Part to Std_Assembly

### DIFF
--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -42,28 +42,31 @@ using namespace Gui;
 //===========================================================================
 // Std_Part
 //===========================================================================
-DEF_STD_CMD_A(StdCmdPart)
+DEF_STD_CMD_A(StdCmdAssembly)
 
-StdCmdPart::StdCmdPart()
-  : Command("Std_Part")
+StdCmdAssembly::StdCmdAssembly()
+  : Command("Std_Assembly")
 {
     sGroup        = "Structure";
-    sMenuText     = QT_TR_NOOP("Create part");
-    sToolTipText  = QT_TR_NOOP("Create a new part and make it active");
+    sMenuText     = QT_TR_NOOP("Create assembly");
+    sToolTipText = QT_TR_NOOP("Create a new assembly and make it active.\n"
+        "An assembly is meant to arrange objects like Part Primitives,\n"
+        "PartDesign Bodies, and other Assemblies. It provides an Origin object,\n"
+        "that can be used as reference to position the contained objects.");
     sWhatsThis    = "Std_Part";
     sStatusTip    = sToolTipText;
     sPixmap       = "Geofeaturegroup";
 }
 
-void StdCmdPart::activated(int iMsg)
+void StdCmdAssembly::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    openCommand(QT_TRANSLATE_NOOP("Command", "Add a part"));
-    std::string FeatName = getUniqueObjectName("Part");
+    openCommand(QT_TRANSLATE_NOOP("Command", "Add an assembly"));
+    std::string FeatName = getUniqueObjectName("Assembly");
 
     std::string PartName;
-    PartName = getUniqueObjectName("Part");
+    PartName = getUniqueObjectName("Assembly");
     doCommand(Doc,"App.activeDocument().Tip = App.activeDocument().addObject('App::Part','%s')",PartName.c_str());
     // TODO We really must set label ourselves? (2015-08-17, Fat-Zer)
     doCommand(Doc,"App.activeDocument().%s.Label = '%s'", PartName.c_str(),
@@ -75,7 +78,7 @@ void StdCmdPart::activated(int iMsg)
     updateActive();
 }
 
-bool StdCmdPart::isActive()
+bool StdCmdAssembly::isActive()
 {
     return hasActiveDocument();
 }
@@ -128,7 +131,7 @@ void CreateStructureCommands()
 {
     CommandManager &rcCmdMgr = Application::Instance->commandManager();
 
-    rcCmdMgr.addCommand(new StdCmdPart());
+    rcCmdMgr.addCommand(new StdCmdAssembly());
     rcCmdMgr.addCommand(new StdCmdGroup());
 }
 

--- a/src/Gui/Icons/Geofeaturegroup.svg
+++ b/src/Gui/Icons/Geofeaturegroup.svg
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    version="1.1"
    viewBox="0 0 64 64"
    id="svg96"
    sodipodi:docname="Geofeaturegroup.svg"
-   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+   inkscape:version="1.1-beta1 (77e7b44db3, 2021-03-28)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -24,17 +24,18 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1066"
-     inkscape:window-height="791"
+     inkscape:window-width="1384"
+     inkscape:window-height="997"
      id="namedview98"
      showgrid="false"
-     inkscape:zoom="5"
-     inkscape:cx="32"
-     inkscape:cy="28"
-     inkscape:window-x="67"
-     inkscape:window-y="23"
+     inkscape:zoom="2.5"
+     inkscape:cx="71.4"
+     inkscape:cy="61.4"
+     inkscape:window-x="1480"
+     inkscape:window-y="277"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg96" />
+     inkscape:current-layer="svg96"
+     inkscape:pagecheckerboard="0" />
   <defs
      id="defs26">
     <linearGradient
@@ -131,7 +132,7 @@
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient69056"
+       xlink:href="#linearGradient4383"
        id="linearGradient920"
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(-1.2435,-2.5881)"
@@ -141,7 +142,7 @@
        y2="27.587999" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient73208"
+       xlink:href="#linearGradient4383"
        id="linearGradient69042-3"
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(-12.714351,-17.585786)"
@@ -149,18 +150,6 @@
        y1="45.585785"
        x2="46.714352"
        y2="35.585785" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient73208">
-      <stop
-         style="stop-color:#c4a000;stop-opacity:1"
-         offset="0"
-         id="stop73210" />
-      <stop
-         style="stop-color:#edd400;stop-opacity:1"
-         offset="1"
-         id="stop73212" />
-    </linearGradient>
   </defs>
   <metadata
      id="metadata28">
@@ -170,7 +159,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
         <dc:title>Path-Stock</dc:title>
         <dc:date>2015-07-04</dc:date>
         <dc:relation>http://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
@@ -277,15 +265,15 @@
   <path
      d="M 9,35 V 21 l 14,5 v 14 z"
      id="path912"
-     style="fill:url(#linearGradient920);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linejoin:round"
+     style="fill:url(#linearGradient920);fill-opacity:1.0;stroke:#172a04;stroke-width:2;stroke-linejoin:round"
      inkscape:connector-curvature="0" />
   <path
      d="M 9,21 28.585,5.209 42,10.0001 l -19,16 z"
      id="path914"
      inkscape:connector-curvature="0"
-     style="fill:#fce94f;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linejoin:round;stroke-opacity:1" />
+     style="fill:#729fcf;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linejoin:round;stroke-opacity:1" />
   <path
-     style="fill:none;stroke:#fce94f;stroke-width:2;stroke-opacity:1"
+     style="fill:none;stroke:#729fcf;stroke-width:2;stroke-opacity:1"
      inkscape:connector-curvature="0"
      id="path52"
      d="m 10.951,33.746 0.08695,-9.9796 9.9568,3.5229 -0.02105,9.9613 z" />
@@ -294,11 +282,11 @@
      inkscape:connector-curvature="0"
      id="path69040"
      d="M 23,40 V 26 L 42,10 v 13 z"
-     style="fill:url(#linearGradient69042-3);fill-opacity:1;fill-rule:nonzero;stroke:#302b00;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+     style="fill:url(#linearGradient69042-3);fill-opacity:1.0;fill-rule:nonzero;stroke:#302b00;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
   <path
      sodipodi:nodetypes="ccccc"
      inkscape:connector-curvature="0"
      id="path69044-6"
      d="M 25,36 V 27 L 40,14 v 8 z"
-     style="fill:none;stroke:#edd400;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none" />
+     style="fill:none;stroke:#5a8ec7;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/src/Gui/PreferencePackTemplates/Shortcuts.cfg
+++ b/src/Gui/PreferencePackTemplates/Shortcuts.cfg
@@ -681,7 +681,7 @@
           <FCText Name="Std_OnlineHelpWebsite"></FCText>
           <FCText Name="Std_Open">Ctrl+O</FCText>
           <FCText Name="Std_OrthographicCamera">V, O</FCText>
-          <FCText Name="Std_Part"></FCText>
+          <FCText Name="Std_Assembly"></FCText>
           <FCText Name="Std_Paste">Ctrl+V</FCText>
           <FCText Name="Std_PerspectiveCamera">V, P</FCText>
           <FCText Name="Std_Placement"></FCText>

--- a/src/Gui/ViewProviderPart.cpp
+++ b/src/Gui/ViewProviderPart.cpp
@@ -113,7 +113,7 @@ QIcon ViewProviderPart::getIcon() const
 {
     // the original Part object for this ViewProviderPart
     auto part = static_cast<App::Part*>(this->getObject());
-    // the normal case for Std_Part
+    // the normal case for Std_Assembly
     const char* pixmap = sPixmap;
     // if it's flagged as an Assembly in its Type, it gets another icon
     if (part->Type.getStrValue() == "Assembly") { pixmap = aPixmap; }

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -799,7 +799,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // Structure
     auto structure = new ToolBarItem( root );
     structure->setCommand("Structure");
-    *structure << "Std_Part" << "Std_Group" << "Std_LinkMake" << "Std_LinkActions";
+    *structure << "Std_Assembly" << "Std_Group" << "Std_LinkMake" << "Std_LinkActions";
 
     // Help
     auto help = new ToolBarItem( root );

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -61,7 +61,7 @@ App::Part* assertActivePart () {
 
     if ( !rv ) {
         Gui::CommandManager &rcCmdMgr = Gui::Application::Instance->commandManager();
-        rcCmdMgr.runCommandByName("Std_Part");
+        rcCmdMgr.runCommandByName("Std_Assembly");
         rv = Gui::Application::Instance->activeView()->getActiveObject<App::Part *> ( PARTKEY );
         if ( !rv ) {
             QMessageBox::critical ( nullptr, QObject::tr( "Part creation failed" ),


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/10338
Provides a proper tooltip.
And paves the way for the integrated Assembly workbench.

Here is how it looks : 
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/42ff2c05-6a7c-49aa-a517-9aa4d547c2fb)

Details : 
- The command Std_Part has been renamed Std_Assembly. 
- The cpp class StdCmdPart is renamed StdCmdAssembly
- The object name in the tree is now Assembly.
- The icon is modified to make it clearer that it's 2 separate solids in the icon.

Note : 
- It does not changes the internal "App::Part" name. I think it would be best if we rename this as well, but I fear that this is going to break a lot of things. Thoughts ?

People who might want to weight in : @adrianinsaval @chennes @Zolko-123 @sliptonic