### PR TITLE
Pref: wb: Add contextual menu to sort alphabetically.

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -234,6 +234,16 @@ DlgSettingsWorkbenchesImp::DlgSettingsWorkbenchesImp( QWidget* parent )
     ui->wbList->setDragEnabled(true);
     ui->wbList->setDefaultDropAction(Qt::MoveAction);
 
+    QAction* sortAction = new QAction(tr("Sort alphabetically"), this);
+    connect(sortAction, &QAction::triggered, this, &DlgSettingsWorkbenchesImp::sortEnabledWorkbenches);
+
+    QMenu* contextMenu = new QMenu(ui->wbList);
+    contextMenu->addAction(sortAction);
+    ui->wbList->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(ui->wbList, &QListWidget::customContextMenuRequested, this, [this, contextMenu](const QPoint& pos) {
+        contextMenu->exec(ui->wbList->mapToGlobal(pos));
+    });
+
     connect(ui->wbList->model(), &QAbstractItemModel::rowsMoved, this, &DlgSettingsWorkbenchesImp::wbItemMoved);
     connect(ui->AutoloadModuleCombo, qOverload<int>(&QComboBox::activated), this, &DlgSettingsWorkbenchesImp::onStartWbChanged);
     connect(ui->WorkbenchSelectorPosition, qOverload<int>(&QComboBox::activated), this, &DlgSettingsWorkbenchesImp::onWbSelectorChanged);
@@ -344,6 +354,8 @@ Build the list of unloaded workbenches.
 void DlgSettingsWorkbenchesImp::buildWorkbenchList()
 {
     QSignalBlocker sigblk(ui->wbList);
+
+    ui->wbList->clear();
 
     QStringList enabledWbs = getEnabledWorkbenches();
     QStringList disabledWbs = getDisabledWorkbenches();
@@ -584,5 +596,14 @@ void DlgSettingsWorkbenchesImp::onWbByTabToggled(bool val)
     requireRestart();
 }
 
+void DlgSettingsWorkbenchesImp::sortEnabledWorkbenches()
+{
+    ParameterGrp::handle hGrp;
+
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
+    hGrp->SetASCII("Ordered", "");
+
+    buildWorkbenchList();
+}
 #include "moc_DlgSettingsWorkbenchesImp.cpp"
 #include "DlgSettingsWorkbenchesImp.moc"

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -24,9 +24,11 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
+#include <QAction>
 #include <QCheckBox>
-#include <QPushButton>
 #include <QLabel>
+#include <QMenu>
+#include <QPushButton>
 #include <sstream>
 #endif
 

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.h
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.h
@@ -64,6 +64,7 @@ protected:
 
 private:
     void addWorkbench(const QString& it, bool enabled);
+    void sortEnabledWorkbenches();
 
     void setStartWorkbenchComboItems();
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/10351

The ability to sort alphabetically the workbench list in preferences has been lost and needs to be reimplemented.+

This PR adds a contextual menu to the workbench list in preferences. By right clicking on the list you have the option to sort alphabetically.