### PR TITLE
Core: escape filepath characters in FreeCAD.loadFile

### DIFF
--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -210,12 +210,22 @@ PyObject* Application::sLoadFile(PyObject * /*self*/, PyObject *args)
             }
         }
 
+        // path could contain characters that need escaping, such as quote signs
+        // therefore use its representation in the Python code string
+        PyObject *pathObj = PyUnicode_FromString(path);
+        PyObject *pathReprObj = PyObject_Repr(pathObj);
+        const char *pathRepr = PyUnicode_AsUTF8(pathReprObj);
+
         std::stringstream str;
         str << "import " << module << std::endl;
         if (fi.hasExtension("FCStd"))
-            str << module << ".openDocument('" << path << "')" << std::endl;
+            str << module << ".openDocument(" << pathRepr << ")" << std::endl;
         else
-            str << module << ".insert('" << path << "','" << doc << "')" << std::endl;
+            str << module << ".insert(" << pathRepr << ",'" << doc << "')" << std::endl;
+
+        Py_DECREF(pathObj);
+        Py_DECREF(pathReprObj);
+
         Base::Interpreter().runString(str.str().c_str());
         Py_Return;
     }


### PR DESCRIPTION
backport of #10278 
----
Currently, executing the Python command `FreeCAD.loadFile("/tmp/let's go.FCStd")` will fail because of the single quote sign in the path.

This pull request fixes the problem by properly escaping the special characters in the string.

The error was described in #10264 as happening when "opening from recent history". The root cause lies in function `FreeCAD.loadFile` and therefore the error also happens on FreeCAD version 0.20.2 when calling that function directly instead of via the history action.