### PR TITLE
CI: Add libyaml-cpp-dev to Linux CI

### DIFF
--- a/.github/workflows/sub_buildUbuntu2004.yml
+++ b/.github/workflows/sub_buildUbuntu2004.yml
@@ -111,6 +111,7 @@ jobs:
                             libvtk7-dev                                 \
                             libx11-dev                                  \
                             libxerces-c-dev                             \
+                            libyaml-cpp-dev                             \
                             libzipios++-dev                             \
                             netgen                                      \
                             netgen-headers                              \

--- a/.github/workflows/sub_buildUbuntu2204.yml
+++ b/.github/workflows/sub_buildUbuntu2204.yml
@@ -109,6 +109,7 @@ jobs:
                             libvtk7-dev                                 \
                             libx11-dev                                  \
                             libxerces-c-dev                             \
+                            libyaml-cpp-dev                             \
                             libzipios++-dev                             \
                             netgen                                      \
                             netgen-headers                              \


### PR DESCRIPTION
This is preparatory to the Materials WB, which requires this library. Note that the Windows CI will require a change to the LibPack.