### PR TITLE
[Stylesheets] Replaced more static colors with the accent colors.

### DIFF
--- a/src/Gui/Stylesheets/Behave-dark.qss
+++ b/src/Gui/Stylesheets/Behave-dark.qss
@@ -51,7 +51,7 @@ If you would like to change the overall look/style of the theme, just find and r
     SELECTION (darker to lighter)
         #1b3774
         #2053c0
-         @ThemeAccentColor2
+         @ThemeAccentColor3 text color
          @ThemeAccentColor2 = main selection color
         #6f9efa = used to build QSpinBox up and down buttons, it's used as color in the middle
         #7cabf9
@@ -106,7 +106,7 @@ Reset elements
     border-image: none;
     outline: 0;
     /*font-size: 20px;*/
-    color:  @ThemeAccentColor2; /* Default color for labels and different text elements that usually use dark colors */
+    color:  @ThemeAccentColor3; /* Default color for labels and different text elements that usually use dark colors */
 }
 
 /* specific reset for elements inside QToolBar */
@@ -845,7 +845,7 @@ Gui--PropertyEditor--PropertyEditor QAbstractSpinBox:disabled {
 
 /* hack to hide weird redundant information inside cells with links and no editable data (but editable via "..." button) */
 Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel {
-    color:  @ThemeAccentColor2;
+    color:  @ThemeAccentColor3;
     background-color: #2C333D;/*was CBD8E6*/
 }
 
@@ -1240,7 +1240,7 @@ QDateTimeEdit {
 
 /* more contrast for QTexEdits */
 QTextEdit {
-    color:  @ThemeAccentColor2;
+    color:  @ThemeAccentColor3;
 }
 
 /* shifts text/number editable field to the left to make space for the up/down or drop-down buttons */
@@ -1270,7 +1270,7 @@ QTextEdit:focus,
 QTimeEdit:focus,
 QDateEdit:focus,
 QDateTimeEdit:focus {
-    color:  @ThemeAccentColor2;
+    color:  @ThemeAccentColor3;
     border-color: #7cabf9;
     border-right-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0  @ThemeAccentColor2, stop:1 #7cabf9); /* same as up/down or drop-down button color */
     background-color: #2C333D;/*was CBD8E6*/
@@ -1595,7 +1595,7 @@ Tool button inside QDialogs that works as QPushButtons
 ==================================================================================================*/
 /* found under Tools -> Customize -> Macros -> Pixmap "..." button */
 QDialog QToolButton {
-    color:  @ThemeAccentColor2;
+    color:  @ThemeAccentColor3;
     text-align: center;
     background-color: qlineargradient(spread:pad, x1:0, y1:0.3, x2:0, y2:1, stop:0 #232932, stop:1 #646464);
     border: 1px solid #232932;
@@ -1630,7 +1630,7 @@ Tool button inside Task Panel content that works as QPushButtons
 ==================================================================================================*/
 /* found inside Part Design Workbench and "make a draft on a face" Task panel options */
 QSint--ActionGroup QFrame[class="content"] QToolButton {
-    color:  @ThemeAccentColor2;
+    color:  @ThemeAccentColor3;
     text-align: center;
     background-color: qlineargradient(spread:pad, x1:0, y1:0.3, x2:0, y2:1, stop:0 #232932, stop:1 #646464);
     border: 1px solid #232932;
@@ -1702,7 +1702,7 @@ QRadioButton::indicator:checked {
 
 QRadioButton,
 QRadioButton:disabled {
-    color:  @ThemeAccentColor2;
+    color:  @ThemeAccentColor3;
     padding: 3px;
     outline: none;
     background-color: transparent;
@@ -1719,7 +1719,7 @@ QRadioButton::indicator:pressed {
 }
 
 QRadioButton::indicator:disabled {
-    color:  @ThemeAccentColor2;
+    color:  @ThemeAccentColor3;
     background-color: transparent;
     border: 1px solid  @ThemeAccentColor2;
 }
@@ -1734,7 +1734,7 @@ Checkbox
 ==================================================================================================*/
 QCheckBox,
 QCheckBox:disabled {
-    color:  @ThemeAccentColor2;
+    color:  @ThemeAccentColor3;
     padding: 3px;
     outline: none;
     background-color: transparent;
@@ -2176,7 +2176,7 @@ QTableView > QWidget > QTextEdit,
 QTableView > QWidget > QTimeEdit,
 QTableView > QWidget > QDateEdit,
 QTableView > QWidget > QDateTimeEdit {
-    color:  @ThemeAccentColor2;
+    color:  @ThemeAccentColor3;
     background-color: transparent;
     border-color: transparent;
 }
@@ -2237,7 +2237,7 @@ QTableView > QWidget > QTextEdit:read-only,
 QTableView > QWidget > QTimeEdit:read-only,
 QTableView > QWidget > QDateEdit:read-only,
 QTableView > QWidget > QDateTimeEdit:read-only {
-    color:  @ThemeAccentColor2;
+    color:  @ThemeAccentColor3;
     background-color: transparent;
     border-color: transparent;
 }

--- a/src/Gui/Stylesheets/Behave-dark.qss
+++ b/src/Gui/Stylesheets/Behave-dark.qss
@@ -30,7 +30,7 @@ If you would like to change the overall look/style of the theme, just find and r
 ! If you find not matching or unreadable sections in FreeCAD please tell Chrismettal or open up a PR yourself !
 
     BACKGROUND (darker to lighter)
-        #65A2E5
+         @ThemeAccentColor2
         #1e1e1e
         #3c3c3c
         #434D5B
@@ -45,14 +45,14 @@ If you would like to change the overall look/style of the theme, just find and r
         #232932 = console color
         #d2d2d2
         #588AC1 = top menu item
-        #588AC2
+         @ThemeAccentColor3
         white
 
     SELECTION (darker to lighter)
         #1b3774
         #2053c0
-        #65A2E5
-        #65A2E5 = main selection color
+         @ThemeAccentColor2
+         @ThemeAccentColor2 = main selection color
         #6f9efa = used to build QSpinBox up and down buttons, it's used as color in the middle
         #7cabf9
         #adc5ed
@@ -106,7 +106,7 @@ Reset elements
     border-image: none;
     outline: 0;
     /*font-size: 20px;*/
-    color: #65A2E5; /* Default color for labels and different text elements that usually use dark colors */
+    color:  @ThemeAccentColor2; /* Default color for labels and different text elements that usually use dark colors */
 }
 
 /* specific reset for elements inside QToolBar */
@@ -202,8 +202,8 @@ QMenu::icon {
 }
 
 QMenu::icon:checked { /* appearance of a 'checked' icon */
-    background: #61D29D;
-    border: 2px #61D29D;
+    background:  @ThemeAccentColor1;
+    border: 2px  @ThemeAccentColor1;
     position: absolute;
     border-radius: 2px;
 }
@@ -235,19 +235,19 @@ QMenu QToolButton:pressed,
 QMenu QPushButton:selected,
 QMenu QToolButton:selected {
     color: white;
-    background-color: #65A2E5; /* same as QMenu::item:selected and QMenu::item:pressed */
+    background-color:  @ThemeAccentColor2; /* same as QMenu::item:selected and QMenu::item:pressed */
 }
 
 QMenu QRadioButton:disabled,
 QMenu QCheckBox:disabled {
-    color: #588AC2;
+    color:  @ThemeAccentColor3;
 }
 
 QMenu QRadioButton::indicator:disabled,
 QMenu QCheckBox::indicator:disabled {
-    color: #588AC2;
+    color:  @ThemeAccentColor3;
     background-color: transparent;
-    border: 1px solid #588AC2;
+    border: 1px solid  @ThemeAccentColor3;
 }
 
 
@@ -401,7 +401,7 @@ QProgressBar:horizontal {
 }
 QProgressBar::chunk,
 QProgressBar::chunk:horizontal {
-    background-color: qlineargradient(spread:pad, x1:1, y1:0.545, x2:1, y2:0, stop:0 #65A2E5, stop:1 #65A2E5);
+    background-color: qlineargradient(spread:pad, x1:1, y1:0.545, x2:1, y2:0, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
     border-radius: 3px;
 }
 
@@ -616,22 +616,22 @@ QTabBar::tab:selected {
 }
 
 QTabBar::tab:top:selected {
-    border-top: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5); /* selection color */
+    border-top: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2); /* selection color */
     border-bottom-color: #2C333D; /* same as tab content background color */
 }
 
 QTabBar::tab:bottom:selected {
-    border-bottom: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5); /* selection color */
+    border-bottom: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2); /* selection color */
     border-top-color: #2C333D; /* same as tab content background color */
 }
 
 QTabBar::tab:right:selected {
-    border-left: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0 #65A2E5, stop:1 #65A2E5); /* selection color */
+    border-left: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2); /* selection color */
     border-right-color: #2C333D; /* same as tab content background color */
 }
 
 QTabBar::tab:left:selected {
-    border-right: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0 #65A2E5, stop:1 #65A2E5); /* selection color */
+    border-right: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2); /* selection color */
     border-left-color: #2C333D; /* same as tab content background color */
 }
 
@@ -682,7 +682,7 @@ QDialog#Gui__Dialog__DlgPreferences > QListView::item:hover {
 
 QDialog#Gui__Dialog__DlgPreferences > QListView::item:selected {
     color: #232932;
-    background-color: #61D29D;
+    background-color:  @ThemeAccentColor1;
 }
 
 
@@ -845,7 +845,7 @@ Gui--PropertyEditor--PropertyEditor QAbstractSpinBox:disabled {
 
 /* hack to hide weird redundant information inside cells with links and no editable data (but editable via "..." button) */
 Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QLabel {
-    color: #65A2E5;
+    color:  @ThemeAccentColor2;
     background-color: #2C333D;/*was CBD8E6*/
 }
 
@@ -940,7 +940,7 @@ Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QWidget {
 Header of tree and list views
 ==================================================================================================*/
 QHeaderView {
-    color: #61D29D;
+    color:  @ThemeAccentColor1;
     background-color: #434D5B;
     border-top-left-radius: 2px; /* 1px less than its container */
     border-top-right-radius: 2px; /* 1px less than its container */
@@ -993,7 +993,7 @@ QHeaderView::down-arrow:hover {
 
 /* Group header inside Property Editor (FreeCAD custom widget) */
 Gui--PropertyEditor--PropertyEditor {
-    qproperty-groupTextColor: #61D29D;
+    qproperty-groupTextColor:  @ThemeAccentColor1;
     qproperty-groupBackground: #2C333D;
 }
 
@@ -1127,7 +1127,7 @@ QSint--ActionGroup QFrame[class="header"] {
 }
 
 QSint--ActionGroup QFrame[class="header"]:hover {
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
 }
 
 QSint--ActionGroup QToolButton[class="header"] {
@@ -1209,7 +1209,7 @@ QSint--ActionGroup QFrame[class="content"] > QWidget > QPushButton {
 /* QSint--ActionGroup QFrame[class="content"] QTreeView,
 QSint--ActionGroup QFrame[class="content"] QListView,
 QSint--ActionGroup QFrame[class="content"] QTableView {
-    color: #588AC2;
+    color:  @ThemeAccentColor3;
     background-color: #787878;
 } */
 
@@ -1230,7 +1230,7 @@ QDateTimeEdit {
     color: #bebebe;
     background-color: #1E2226;
     selection-color: white;
-    selection-background-color: #65A2E5;
+    selection-background-color:  @ThemeAccentColor2;
     border: 1px solid #1E2226;
     border-radius: 3px;
     min-width: 50px; /* it ensures the default value is correctly displayed */
@@ -1240,7 +1240,7 @@ QDateTimeEdit {
 
 /* more contrast for QTexEdits */
 QTextEdit {
-    color: #65A2E5;
+    color:  @ThemeAccentColor2;
 }
 
 /* shifts text/number editable field to the left to make space for the up/down or drop-down buttons */
@@ -1270,9 +1270,9 @@ QTextEdit:focus,
 QTimeEdit:focus,
 QDateEdit:focus,
 QDateTimeEdit:focus {
-    color: #65A2E5;
+    color:  @ThemeAccentColor2;
     border-color: #7cabf9;
-    border-right-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #65A2E5, stop:1 #7cabf9); /* same as up/down or drop-down button color */
+    border-right-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0  @ThemeAccentColor2, stop:1 #7cabf9); /* same as up/down or drop-down button color */
     background-color: #2C333D;/*was CBD8E6*/
 }
 
@@ -1342,7 +1342,7 @@ QDoubleSpinBox:down-button:focus,
 QTimeEdit:down-button:focus,
 QDateEdit:down-button:focus,
 QDateTimeEdit:down-button:focus {
-    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #65A2E5, stop:1 #6f9efa);
+    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0  @ThemeAccentColor2, stop:1 #6f9efa);
 }
 
 QAbstractSpinBox:up-button:disabled,
@@ -1447,7 +1447,7 @@ QComboBox::drop-down {
 
 QComboBox::drop-down:on,
 QComboBox::drop-down:focus {
-    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #65A2E5, stop:1 #7cabf9);
+    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0  @ThemeAccentColor2, stop:1 #7cabf9);
 }
 
 QComboBox::down-arrow {
@@ -1467,14 +1467,14 @@ QComboBox::down-arrow:disabled {
 /* ComboBox menu */
 QComboBox {
     selection-color: white;
-    selection-background-color: #65A2E5;
+    selection-background-color:  @ThemeAccentColor2;
 }
 
 QComboBox QAbstractItemView {
     color: #bebebe; /* same as regular QComboBox color */
     background-color: transparent;
     selection-color: white;
-    selection-background-color: #65A2E5;
+    selection-background-color:  @ThemeAccentColor2;
     border-width: 5px 0px 5px 0px;
     border-style: solid;
     border-color: transparent;
@@ -1500,8 +1500,8 @@ QPushButton {
 QPushButton:hover,
 QPushButton:focus {
     color: white;
-    border-color: #65A2E5;
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5);
+    border-color:  @ThemeAccentColor2;
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
 }
 
 QPushButton:disabled,
@@ -1512,12 +1512,12 @@ QPushButton:disabled:checked {
 }
 
 QPushButton:pressed {
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
 }
 
 QPushButton:checked {
-    background-color: #65A2E5;
-    border-color: #65A2E5;
+    background-color:  @ThemeAccentColor2;
+    border-color:  @ThemeAccentColor2;
 }
 
 /* Color Buttons */
@@ -1540,12 +1540,12 @@ Gui--ColorButton:disabled {
 
 Gui--ColorButton:hover,
 Gui--ColorButton:focus {
-    border-color: #65A2E5;
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5);
+    border-color:  @ThemeAccentColor2;
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
 }
 
 Gui--ColorButton:pressed {
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
 }
 
 /* Pushbutton style for "..." inside Placement cell which launches Placement tool */
@@ -1573,8 +1573,8 @@ Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QWidget > QWidget > QF
 }
 
 QPushButton:checked {
-    background-color: #65A2E5;
-    border-color: #65A2E5;
+    background-color:  @ThemeAccentColor2;
+    border-color:  @ThemeAccentColor2;
 }
 
 /*==================================================================================================
@@ -1595,7 +1595,7 @@ Tool button inside QDialogs that works as QPushButtons
 ==================================================================================================*/
 /* found under Tools -> Customize -> Macros -> Pixmap "..." button */
 QDialog QToolButton {
-    color: #65A2E5;
+    color:  @ThemeAccentColor2;
     text-align: center;
     background-color: qlineargradient(spread:pad, x1:0, y1:0.3, x2:0, y2:1, stop:0 #232932, stop:1 #646464);
     border: 1px solid #232932;
@@ -1609,8 +1609,8 @@ QDialog QToolButton {
 QDialog QToolButton:hover,
 QDialog QToolButton:focus {
     color: white;
-    border-color: #65A2E5;
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5);
+    border-color:  @ThemeAccentColor2;
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
 }
 
 QDialog QToolButton:disabled,
@@ -1621,7 +1621,7 @@ QDialog QToolButton:disabled:checked {
 }
 
 QDialog QToolButton:pressed {
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
 }
 
 
@@ -1630,7 +1630,7 @@ Tool button inside Task Panel content that works as QPushButtons
 ==================================================================================================*/
 /* found inside Part Design Workbench and "make a draft on a face" Task panel options */
 QSint--ActionGroup QFrame[class="content"] QToolButton {
-    color: #65A2E5;
+    color:  @ThemeAccentColor2;
     text-align: center;
     background-color: qlineargradient(spread:pad, x1:0, y1:0.3, x2:0, y2:1, stop:0 #232932, stop:1 #646464);
     border: 1px solid #232932;
@@ -1644,8 +1644,8 @@ QSint--ActionGroup QFrame[class="content"] QToolButton {
 QSint--ActionGroup QFrame[class="content"] QToolButton:hover,
 QSint--ActionGroup QFrame[class="content"] QToolButton:focus {
     color: white;
-    border-color: #65A2E5;
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5);
+    border-color:  @ThemeAccentColor2;
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:disabled,
@@ -1656,7 +1656,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:disabled:checked {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #65A2E5, stop:1 #65A2E5);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor2);
 }
 
 /* QToolButtons with a menu found in Sketcher task panel*/
@@ -1689,20 +1689,20 @@ QSint--ActionGroup QToolButton#filterButton QListWidget {
 Radio button
 ==================================================================================================*/
 QRadioButton::indicator:unchecked{
-    color: #61D29D;
+    color:  @ThemeAccentColor1;
     background-color: rgba(255,255,255,20);
     border: 1px solid #232932;
 }
 
 QRadioButton::indicator:checked {
-    background-color: #61D29D; /* QCheckBox has the same color */
-    border: 1px solid #61D29D; /* QCheckBox has the same color */
+    background-color:  @ThemeAccentColor1; /* QCheckBox has the same color */
+    border: 1px solid  @ThemeAccentColor1; /* QCheckBox has the same color */
     image:url(qss:images_dark-light/radiobutton_light.svg);
 }
 
 QRadioButton,
 QRadioButton:disabled {
-    color: #65A2E5;
+    color:  @ThemeAccentColor2;
     padding: 3px;
     outline: none;
     background-color: transparent;
@@ -1719,9 +1719,9 @@ QRadioButton::indicator:pressed {
 }
 
 QRadioButton::indicator:disabled {
-    color: #65A2E5;
+    color:  @ThemeAccentColor2;
     background-color: transparent;
-    border: 1px solid #65A2E5;
+    border: 1px solid  @ThemeAccentColor2;
 }
 
 QRadioButton:focus {
@@ -1734,7 +1734,7 @@ Checkbox
 ==================================================================================================*/
 QCheckBox,
 QCheckBox:disabled {
-    color: #65A2E5;
+    color:  @ThemeAccentColor2;
     padding: 3px;
     outline: none;
     background-color: transparent;
@@ -1742,7 +1742,7 @@ QCheckBox:disabled {
 
 QCheckBox::indicator,
 QGroupBox::indicator {
-    color: #61D29D;
+    color:  @ThemeAccentColor1;
     background-color: rgba(255,255,255,20);
     border: 1px solid #232932;
     width: 11px;
@@ -1763,8 +1763,8 @@ QGroupBox::indicator:checked:pressed {
 
 QCheckBox::indicator:checked,
 QGroupBox::indicator:checked {
-    background-color: #61D29D; /* QRadioButton has the same color */
-    border: 1px solid #61D29D; /* QRadioButton has the same color */
+    background-color:  @ThemeAccentColor1; /* QRadioButton has the same color */
+    border: 1px solid  @ThemeAccentColor1; /* QRadioButton has the same color */
     image:url(qss:images_dark-light/checkbox_light.svg);
 }
 
@@ -1781,8 +1781,8 @@ QGroupBox::indicator:disabled {
 
 QCheckBox::indicator:indeterminate,
 QGroupBox::indicator:indeterminate {
-    background-color: #61D29D;
-    border: 1px solid #61D29D;
+    background-color:  @ThemeAccentColor1;
+    border: 1px solid  @ThemeAccentColor1;
     image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
@@ -1835,8 +1835,8 @@ QTreeView::indicator:checked:pressed {
 
 QListWidget::indicator:checked,
 QTreeView::indicator:checked {
-    background-color: #65A2E5; /* QRadioButton has the same color */
-    border: 1px solid #65A2E5; /* QRadioButton has the same color */
+    background-color:  @ThemeAccentColor2; /* QRadioButton has the same color */
+    border: 1px solid  @ThemeAccentColor2; /* QRadioButton has the same color */
     image:url(qss:images_dark-light/checkbox_light.svg);
 }
 
@@ -1848,8 +1848,8 @@ QTreeView::indicator:disabled {
 
 QListWidget::indicator:indeterminate,
 QTreeView::indicator:indeterminate {
-    background-color: #65A2E5;
-    border: 1px solid #65A2E5;
+    background-color:  @ThemeAccentColor2;
+    border: 1px solid  @ThemeAccentColor2;
     image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
@@ -2055,7 +2055,7 @@ QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
 QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:hover,
 QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
 QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:open {
-    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #65A2E5, stop:1 #7cabf9);
+    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0  @ThemeAccentColor2, stop:1 #7cabf9);
 }
 
 QToolBar > QToolButton::menu-arrow {
@@ -2176,7 +2176,7 @@ QTableView > QWidget > QTextEdit,
 QTableView > QWidget > QTimeEdit,
 QTableView > QWidget > QDateEdit,
 QTableView > QWidget > QDateTimeEdit {
-    color: #65A2E5;
+    color:  @ThemeAccentColor2;
     background-color: transparent;
     border-color: transparent;
 }
@@ -2209,7 +2209,7 @@ QTableView > QWidget > QDateEdit:focus,
 QTableView > QWidget > QDateTimeEdit:focus {
     color: #D2D8E1;
     selection-color: white;
-    selection-background-color: #65A2E5;
+    selection-background-color:  @ThemeAccentColor2;
     border-color: #2C333D;/*was CBD8E6*/
     background-color: #2C333D;/*was CBD8E6*/
 }
@@ -2237,7 +2237,7 @@ QTableView > QWidget > QTextEdit:read-only,
 QTableView > QWidget > QTimeEdit:read-only,
 QTableView > QWidget > QDateEdit:read-only,
 QTableView > QWidget > QDateTimeEdit:read-only {
-    color: #65A2E5;
+    color:  @ThemeAccentColor2;
     background-color: transparent;
     border-color: transparent;
 }

--- a/src/Gui/Stylesheets/Dark-contrast.qss
+++ b/src/Gui/Stylesheets/Dark-contrast.qss
@@ -45,10 +45,10 @@ If you would like to change the overall look/style of the theme, just find and r
         white
 
     SELECTION (darker to lighter)
-        #1b3774
-        #2053c0
-        #3874f2
-        #5e90fa = main selection color
+        @ThemeAccentColor3
+         @ThemeAccentColor1
+         @ThemeAccentColor3
+         @ThemeAccentColor2 = main selection color
         #6f9efa = used to build QSpinBox up and down buttons, it's used as color in the middle
         #7cabf9
         #adc5ed
@@ -133,7 +133,7 @@ QMenuBar::item:pressed,
 QMenu::item:selected,
 QMenu::item:pressed {
     color: #ffffff;
-    background-color: #2053c0;
+    background-color:  @ThemeAccentColor1;
 }
 
 QMenu::right-arrow {
@@ -158,8 +158,8 @@ QMenu::icon {
 }
 
 QMenu::icon:checked { /* appearance of a 'checked' icon */
-    background: #2053c0;
-    border: 2px #2053c0;
+    background:  @ThemeAccentColor1;
+    border: 2px  @ThemeAccentColor1;
     position: absolute;
     border-radius: 2px;
 }
@@ -191,7 +191,7 @@ QMenu QToolButton:pressed,
 QMenu QPushButton:selected,
 QMenu QToolButton:selected {
     color: white;
-    background-color: #2053c0; /* same as QMenu::item:selected and QMenu::item:pressed */
+    background-color:  @ThemeAccentColor1; /* same as QMenu::item:selected and QMenu::item:pressed */
 }
 
 QMenu QRadioButton:disabled,
@@ -356,7 +356,7 @@ QProgressBar:horizontal {
 }
 QProgressBar::chunk,
 QProgressBar::chunk:horizontal {
-    background-color: qlineargradient(spread:pad, x1:1, y1:0.545, x2:1, y2:0, stop:0 #3874f2, stop:1 #5e90fa);
+    background-color: qlineargradient(spread:pad, x1:1, y1:0.545, x2:1, y2:0, stop:0  @ThemeAccentColor3, stop:1  @ThemeAccentColor2);
     border-radius: 3px;
 }
 
@@ -571,22 +571,22 @@ QTabBar::tab:selected {
 }
 
 QTabBar::tab:top:selected {
-    border-top: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #5e90fa, stop:1 #3874f2); /* selection color */
+    border-top: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor3); /* selection color */
     border-bottom-color: #444444; /* same as tab content background color */
 }
 
 QTabBar::tab:bottom:selected {
-    border-bottom: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #5e90fa, stop:1 #3874f2); /* selection color */
+    border-bottom: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor3); /* selection color */
     border-top-color: #444444; /* same as tab content background color */
 }
 
 QTabBar::tab:right:selected {
-    border-left: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0 #5e90fa, stop:1 #3874f2); /* selection color */
+    border-left: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor3); /* selection color */
     border-right-color: #444444; /* same as tab content background color */
 }
 
 QTabBar::tab:left:selected {
-    border-right: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0 #5e90fa, stop:1 #3874f2); /* selection color */
+    border-right: 4px solid qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0, stop:0  @ThemeAccentColor2, stop:1  @ThemeAccentColor3); /* selection color */
     border-left-color: #444444; /* same as tab content background color */
 }
 
@@ -637,7 +637,7 @@ QDialog#Gui__Dialog__DlgPreferences > QListView::item:hover {
 
 QDialog#Gui__Dialog__DlgPreferences > QListView::item:selected {
     color: white;
-    background-color: #2053c0;
+    background-color:  @ThemeAccentColor1;
 }
 
 
@@ -749,7 +749,7 @@ QTableView {
     alternate-background-color: #1f1f1f; /* related with QListView background  */
     border: 1px solid #333333;
     selection-color: #ffffff;
-    selection-background-color: #2053c0; /* should be similar to QListView::item selected background-color */
+    selection-background-color:  @ThemeAccentColor1; /* should be similar to QListView::item selected background-color */
     show-decoration-selected: 1; /* make the selection span the entire width of the view */
     border-radius: 3px;
 }
@@ -762,7 +762,7 @@ QTreeView::item:hover  {
 QListView::item:selected,
 QTreeView::item:selected  {
     color: #ffffff; /* should be similar to QListView selection-color */
-    background-color: #2053c0; /* should be similar to QListView selection-background-color */
+    background-color:  @ThemeAccentColor1; /* should be similar to QListView selection-background-color */
     show-decoration-selected: 1; /* make the selection span the entire width of the view */
 }
 
@@ -773,7 +773,7 @@ Gui--PropertyEditor--PropertyEditor {
 
 /* fix for column items background when a link is present */
 Gui--PropertyEditor--PropertyEditor > QWidget > QFrame:focus {
-    background-color: #2053c0; /* same as focused background color */
+    background-color:  @ThemeAccentColor1; /* same as focused background color */
 }
 
 /* hack to hide weird redundant information inside the value of a Placement cell */
@@ -1040,7 +1040,7 @@ QPlainTextEdit,
 QPlainTextEdit:focus {
     background-color: black;
     selection-color: #cbd8e6;
-    selection-background-color: #2053c0;
+    selection-background-color:  @ThemeAccentColor1;
     border: 1px solid #333333;
     border-radius: 3px;
     margin: 4px;
@@ -1083,7 +1083,7 @@ QSint--ActionGroup QFrame[class="header"] {
 }
 
 QSint--ActionGroup QFrame[class="header"]:hover {
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #1b3774, stop:1 #1b3774);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor3, stop:1 @ThemeAccentColor3);
 }
 
 QSint--ActionGroup QToolButton[class="header"] {
@@ -1186,7 +1186,7 @@ QDateTimeEdit {
     color: #bebebe;
     background-color: black;
     selection-color: white;
-    selection-background-color: #1b3774 ;
+    selection-background-color: @ThemeAccentColor3 ;
     border: 1px solid black;
     border-radius: 3px;
     min-width: 50px; /* it ensures the default value is correctly displayed */
@@ -1227,9 +1227,9 @@ QTimeEdit:focus,
 QDateEdit:focus,
 QDateTimeEdit:focus {
     color: #fafafa;
-    border-color: #1b3774;
-    border-right-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #1b3774, stop:1 #1b3774); /* same as up/down or drop-down button color */
-    background-color: #2053c0;
+    border-color: @ThemeAccentColor3;
+    border-right-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 @ThemeAccentColor3, stop:1 @ThemeAccentColor3); /* same as up/down or drop-down button color */
+    background-color:  @ThemeAccentColor1;
 }
 
 QComboBox:disabled,
@@ -1289,7 +1289,7 @@ QDoubleSpinBox:up-button:focus,
 QTimeEdit:up-button:focus,
 QDateEdit:up-button:focus,
 QDateTimeEdit:up-button:focus {
-    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #1b3774, stop:1 #1b3774);
+    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 @ThemeAccentColor3, stop:1 @ThemeAccentColor3);
 }
 
 QAbstractSpinBox:down-button:focus,
@@ -1298,7 +1298,7 @@ QDoubleSpinBox:down-button:focus,
 QTimeEdit:down-button:focus,
 QDateEdit:down-button:focus,
 QDateTimeEdit:down-button:focus {
-    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #1b3774, stop:1 #1b3774);
+    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 @ThemeAccentColor3, stop:1 @ThemeAccentColor3);
 }
 
 QAbstractSpinBox:up-button:disabled,
@@ -1403,7 +1403,7 @@ QComboBox::drop-down {
 
 QComboBox::drop-down:on,
 QComboBox::drop-down:focus {
-    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #1b3774, stop:1 #1b3774);
+    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 @ThemeAccentColor3, stop:1 @ThemeAccentColor3);
 }
 
 QComboBox::down-arrow {
@@ -1423,14 +1423,14 @@ QComboBox::down-arrow:disabled {
 /* ComboBox menu */
 QComboBox {
     selection-color: #fafafa;
-    selection-background-color: #2053c0;
+    selection-background-color:  @ThemeAccentColor1;
 }
 
 QComboBox QAbstractItemView {
     color: #bebebe; /* same as regular QComboBox color */
     background-color: transparent;
     selection-color: #fafafa;
-    selection-background-color: #2053c0;
+    selection-background-color:  @ThemeAccentColor1;
     border-width: 5px 0px 5px 0px;
     border-style: solid;
     border-color: transparent;
@@ -1456,8 +1456,8 @@ QPushButton {
 QPushButton:hover,
 QPushButton:focus {
     color: #cbd8e6;
-    border-color: #1b3774;
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #2053c0, stop:1 #1b3774);
+    border-color: @ThemeAccentColor3;
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QPushButton:disabled,
@@ -1468,12 +1468,12 @@ QPushButton:disabled:checked {
 }
 
 QPushButton:pressed {
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #1b3774, stop:1 #2053c0);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor3, stop:1  @ThemeAccentColor1);
 }
 
 QPushButton:checked {
-    background-color: #2053c0;
-    border-color: #1b3774;
+    background-color:  @ThemeAccentColor1;
+    border-color: @ThemeAccentColor3;
 }
 
 /* Color Buttons */
@@ -1496,12 +1496,12 @@ Gui--ColorButton:disabled {
 
 Gui--ColorButton:hover,
 Gui--ColorButton:focus {
-    border-color: #1b3774;
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #2053c0, stop:1 #1b3774);
+    border-color: @ThemeAccentColor3;
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 Gui--ColorButton:pressed {
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #1b3774, stop:1 #2053c0);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor3, stop:1  @ThemeAccentColor1);
 }
 
 /* Pushbutton style for "..." inside Placement cell which launches Placement tool */
@@ -1529,8 +1529,8 @@ Gui--PropertyEditor--PropertyEditor > QWidget > QWidget > QWidget > QWidget > QF
 }
 
 QPushButton:checked {
-    background-color: #2053c0;
-    border-color: #2053c0;
+    background-color:  @ThemeAccentColor1;
+    border-color:  @ThemeAccentColor1;
 }
 
 /*==================================================================================================
@@ -1565,8 +1565,8 @@ QDialog QToolButton {
 QDialog QToolButton:hover,
 QDialog QToolButton:focus {
     color: #cbd8e6;
-    border-color: #1b3774;
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #2053c0, stop:1 #1b3774);
+    border-color: @ThemeAccentColor3;
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QDialog QToolButton:disabled,
@@ -1577,7 +1577,7 @@ QDialog QToolButton:disabled:checked {
 }
 
 QDialog QToolButton:pressed {
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #1b3774, stop:1 #2053c0);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor3, stop:1  @ThemeAccentColor1);
 }
 
 
@@ -1600,8 +1600,8 @@ QSint--ActionGroup QFrame[class="content"] QToolButton {
 QSint--ActionGroup QFrame[class="content"] QToolButton:hover,
 QSint--ActionGroup QFrame[class="content"] QToolButton:focus {
     color: white;
-    border-color: #1b3774;
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #2053c0, stop:1 #1b3774);
+    border-color: @ThemeAccentColor3;
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:disabled,
@@ -1612,7 +1612,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:disabled:checked {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #1b3774, stop:1 #2053c0);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor3, stop:1  @ThemeAccentColor1);
 }
 
 /* QToolButtons with a menu found in Sketcher task panel*/
@@ -1667,8 +1667,8 @@ QRadioButton::indicator:unchecked{
 }
 
 QRadioButton::indicator:checked {
-    background-color: #2053c0; /* QCheckBox has the same color */
-    border: 1px solid #2053c0; /* QCheckBox has the same color */
+    background-color:  @ThemeAccentColor1; /* QCheckBox has the same color */
+    border: 1px solid  @ThemeAccentColor1; /* QCheckBox has the same color */
     image:url(qss:images_dark-light/radiobutton_light.svg);
 }
 
@@ -1740,8 +1740,8 @@ QGroupBox::indicator:checked:pressed {
 
 QCheckBox::indicator:checked,
 QGroupBox::indicator:checked {
-    background-color: #2053c0; /* QRadioButton has the same color */
-    border: 1px solid #2053c0; /* QRadioButton has the same color */
+    background-color:  @ThemeAccentColor1; /* QRadioButton has the same color */
+    border: 1px solid  @ThemeAccentColor1; /* QRadioButton has the same color */
     image:url(qss:images_dark-light/checkbox_light.svg);
 }
 
@@ -1758,8 +1758,8 @@ QGroupBox::indicator:disabled {
 
 QCheckBox::indicator:indeterminate,
 QGroupBox::indicator:indeterminate {
-    background-color: #2053c0;
-    border: 1px solid #2053c0;
+    background-color:  @ThemeAccentColor1;
+    border: 1px solid  @ThemeAccentColor1;
     image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
@@ -1795,8 +1795,8 @@ QListWidget::indicator:checked:selected,
 QListWidget::indicator:indeterminate:selected,
 QTreeView::indicator:checked:selected,
 QTreeView::indicator:indeterminate:selected {
-    background-color: #2053c0; /* slightly lighter than default */
-    border-color: #2053c0; /* slightly darker than default */
+    background-color:  @ThemeAccentColor1; /* slightly lighter than default */
+    border-color:  @ThemeAccentColor1; /* slightly darker than default */
 }
 
 QListWidget::indicator:pressed,
@@ -1812,8 +1812,8 @@ QTreeView::indicator:checked:pressed {
 
 QListWidget::indicator:checked,
 QTreeView::indicator:checked {
-    background-color: #2053c0; /* QRadioButton has the same color */
-    border: 1px solid #2053c0; /* QRadioButton has the same color */
+    background-color:  @ThemeAccentColor1; /* QRadioButton has the same color */
+    border: 1px solid  @ThemeAccentColor1; /* QRadioButton has the same color */
     image:url(qss:images_dark-light/checkbox_light.svg);
 }
 
@@ -1825,8 +1825,8 @@ QTreeView::indicator:disabled {
 
 QListWidget::indicator:indeterminate,
 QTreeView::indicator:indeterminate {
-    background-color: #2053c0;
-    border: 1px solid #2053c0;
+    background-color:  @ThemeAccentColor1;
+    border: 1px solid  @ThemeAccentColor1;
     image: url(qss:images_dark-light/checkbox_indeterminate_light.svg);
 }
 
@@ -1892,7 +1892,7 @@ QSlider::handle:vertical:hover,
 QSlider::handle:horizontal:pressed,
 QSlider::handle:vertical:pressed {
     border-color: #adc5ed;
-    background-color: #2053c0;
+    background-color:  @ThemeAccentColor1;
 }
 
 QSlider::handle:horizontal:disabled,
@@ -1941,7 +1941,7 @@ QToolBar > QPushButton {
 
 QToolBar > QPushButton:checked {
     border: 1px solid #7cabf9;
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #2053c0, stop:1 #2053c0);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor1, stop:1  @ThemeAccentColor1);
 }
 
 QToolBar > QPushButton:!checked {
@@ -1961,7 +1961,7 @@ QToolBar > QPushButton:!checked:hover {
 }
 
 QToolBar > QPushButton:checked:pressed {
-    background-color: #2053c0;
+    background-color:  @ThemeAccentColor1;
 }
 
 QToolBar > QPushButton:!checked:pressed {
@@ -2014,7 +2014,7 @@ QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
 QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:hover,
 QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
 QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:open {
-    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #2053c0, stop:1 #7cabf9);
+    background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0  @ThemeAccentColor1, stop:1 #7cabf9);
 }
 
 QToolBar > QToolButton::menu-arrow {
@@ -2073,7 +2073,7 @@ Tables (spreadsheets)
 ==================================================================================================*/
 QTableView {
     gridline-color: #a0a0a0;
-    selection-color: #1b3774;
+    selection-color: @ThemeAccentColor3;
     selection-background-color: #adc5ed;
 }
 
@@ -2086,7 +2086,7 @@ QTableView::item:disabled  {
 }
 
 QTableView::item:selected  {
-    color: #1b3774;
+    color: @ThemeAccentColor3;
     border-color: #cbd8e6; /* same as focused background color */
     border-bottom-color: #7cabf9; /* same as focused border color */
 }
@@ -2158,9 +2158,9 @@ QTableView > QWidget > QTextEdit:focus,
 QTableView > QWidget > QTimeEdit:focus,
 QTableView > QWidget > QDateEdit:focus,
 QTableView > QWidget > QDateTimeEdit:focus {
-    color: #1b3774;
+    color: @ThemeAccentColor3;
     selection-color: white;
-    selection-background-color: #2053c0;
+    selection-background-color:  @ThemeAccentColor1;
     border-color: #cbd8e6;
     background-color: #cbd8e6;
 }

--- a/src/Gui/Stylesheets/Dark-modern.qss
+++ b/src/Gui/Stylesheets/Dark-modern.qss
@@ -1185,12 +1185,12 @@ QPushButton:checked:selected {
 }
 
 QPushButton:hover {
-  background-color: @ThemeAccentColor1;
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
   color: White;
 }
 
 QPushButton:pressed {
-  background-color: @ThemeAccentColor1;
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QPushButton:selected {
@@ -1475,7 +1475,7 @@ QComboBox::drop-down {
   border-left: 1px solid #696968;
 }
 QComboBox::drop-down:hover {
-  background-color: @ThemeAccentColor1;
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QComboBox::down-arrow {
@@ -1535,7 +1535,7 @@ padding: 0px;
 }
 
 QSint--ActionGroup QFrame[class="header"]:hover {
-background-color: @ThemeAccentColor1;
+background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QSint--ActionGroup QToolButton[class="header"] {
@@ -1637,8 +1637,8 @@ QSint--ActionGroup QFrame[class="content"] QToolButton {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:hover{
-  background: @ThemeAccentColor1;
-  border: 1px solid @ThemeAccentColor1;
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
+
 }
 QSint--ActionGroup QFrame[class="content"] QToolButton:focus {
   border: 1px solid @ThemeAccentColor2;
@@ -1651,8 +1651,8 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:disabled:checked {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
-  background: @ThemeAccentColor1;
-  border: 1px solid @ThemeAccentColor1;
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
+
 }
 
 /* QSlider ----------------------------------------------------------------

--- a/src/Gui/Stylesheets/Dark.qss
+++ b/src/Gui/Stylesheets/Dark.qss
@@ -1176,12 +1176,12 @@ QPushButton:checked:selected {
 }
 
 QPushButton:hover {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
   color: White;
 }
 
 QPushButton:pressed {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor2, stop:1 @ThemeAccentColor1);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QPushButton:selected {
@@ -1465,7 +1465,7 @@ QComboBox::drop-down {
   border-left: 1px solid transparent;
 }
 QComboBox::drop-down:hover {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QComboBox::down-arrow {
@@ -1525,7 +1525,7 @@ padding: 0px;
 }
 
 QSint--ActionGroup QFrame[class="header"]:hover {
-background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QSint--ActionGroup QToolButton[class="header"] {
@@ -1627,7 +1627,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:hover{
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 
 }
 QSint--ActionGroup QFrame[class="content"] QToolButton:focus {
@@ -1641,7 +1641,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:disabled:checked {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 
 }
 
@@ -1796,11 +1796,6 @@ QTabWidget::pane {
 
 QTabWidget::pane:selected {
   background-color: @ThemeAccentColor1;
-  border: 1px solid #346792;
-}
-
-QTabWidget::pane:selected {
-  background-color: #557bb6;
   border: 1px solid #346792;
 }
 
@@ -2494,7 +2489,7 @@ QSplitter::handle:vertical {
 }
 QSplitter::handle:vertical:hover {
   background-image: url(qss:images_dark-light/splitter_horizontal_light.svg);
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,stop:0.2 transparent,stop:0.5 #2053c0, stop:0.8 transparent);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,stop:0.2 transparent,stop:0.5 @ThemeAccentColor1, stop:0.8 transparent);
   background-position: center center;
   background-repeat: none;
   }
@@ -2503,7 +2498,7 @@ QSplitter::handle:vertical:hover {
   background-image: url(qss:images_dark-light/splitter_horizontal_light.svg);
   background-position: center center;
   background-repeat: none;
-  background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,stop:0.2 transparent,stop:0.5 #2053c0, stop:0.8 transparent);
+  background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,stop:0.2 transparent,stop:0.5 @ThemeAccentColor1, stop:0.8 transparent);
 }
 
 /* QDateEdit, QDateTimeEdit -----------------------------------------------

--- a/src/Gui/Stylesheets/Darker.qss
+++ b/src/Gui/Stylesheets/Darker.qss
@@ -1177,12 +1177,12 @@ QPushButton:checked:selected {
 }
 
 QPushButton:hover {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
   color: White;
 }
 
 QPushButton:pressed {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor2, stop:1 @ThemeAccentColor1);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QPushButton:selected {
@@ -1466,7 +1466,7 @@ QComboBox::drop-down {
   border-left: 1px solid transparent;
 }
 QComboBox::drop-down:hover {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QComboBox::down-arrow {
@@ -1526,7 +1526,7 @@ padding: 0px;
 }
 
 QSint--ActionGroup QFrame[class="header"]:hover {
-background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QSint--ActionGroup QToolButton[class="header"] {
@@ -1628,7 +1628,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:hover{
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 
 }
 QSint--ActionGroup QFrame[class="content"] QToolButton:focus {
@@ -1642,7 +1642,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:disabled:checked {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 
 }
 

--- a/src/Gui/Stylesheets/Light-modern.qss
+++ b/src/Gui/Stylesheets/Light-modern.qss
@@ -1191,12 +1191,12 @@ QPushButton:checked:selected {
 }
 
 QPushButton:hover {
-  background-color: @ThemeAccentColor1;
-  color: black;
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
+  color: White;
 }
 
 QPushButton:pressed {
-  background-color: @ThemeAccentColor1;
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QPushButton:selected {
@@ -1480,7 +1480,7 @@ QComboBox::drop-down {
   border-left: 1px solid #cccccc;
 }
 QComboBox::drop-down:hover {
-  background-color: @ThemeAccentColor1;
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QComboBox::down-arrow {
@@ -1540,7 +1540,7 @@ padding: 0px;
 }
 
 QSint--ActionGroup QFrame[class="header"]:hover {
-background-color: @ThemeAccentColor1;
+background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QSint--ActionGroup QToolButton[class="header"] {
@@ -1642,8 +1642,8 @@ QSint--ActionGroup QFrame[class="content"] QToolButton {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:hover{
-    background: @ThemeAccentColor1;
-    border: 1px solid @ThemeAccentColor1;
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
+
 }
 QSint--ActionGroup QFrame[class="content"] QToolButton:focus {
   border: 1px solid @ThemeAccentColor2;
@@ -1656,8 +1656,8 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:disabled:checked {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
-  background: @ThemeAccentColor1;
-  border: 1px solid @ThemeAccentColor1;
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
+
 }
 
 /* QSlider ----------------------------------------------------------------

--- a/src/Gui/Stylesheets/Light.qss
+++ b/src/Gui/Stylesheets/Light.qss
@@ -1178,12 +1178,12 @@ QPushButton:checked:selected {
 }
 
 QPushButton:hover {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
-  color: black;
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
+  color: White;
 }
 
 QPushButton:pressed {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor2, stop:1 @ThemeAccentColor1);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QPushButton:selected {
@@ -1467,7 +1467,7 @@ QComboBox::drop-down {
   border-left: 1px solid transparent;
 }
 QComboBox::drop-down:hover {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QComboBox::down-arrow {
@@ -1527,7 +1527,7 @@ padding: 0px;
 }
 
 QSint--ActionGroup QFrame[class="header"]:hover {
-background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 }
 
 QSint--ActionGroup QToolButton[class="header"] {
@@ -1629,7 +1629,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:hover{
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 
 }
 QSint--ActionGroup QFrame[class="content"] QToolButton:focus {
@@ -1644,7 +1644,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:disabled:checked {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
-  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor2);
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 @ThemeAccentColor1, stop:1 @ThemeAccentColor3);
 
 }
 

--- a/src/Gui/Stylesheets/ProDark.qss
+++ b/src/Gui/Stylesheets/ProDark.qss
@@ -46,11 +46,11 @@ THESE COLOURS WERE USED AS TEMP SCRATCHPAD FOR DESIGNING. PLEASE DISREGARD!
         white
 
     SELECTION (darker to lighter)
-        #557BB6
+         @ThemeAccentColor1
         #696969
         #3874f2
-        #557BB6 = main selection color
-        #557BB6 = used to build QSpinBox up and down buttons, it's used as color in the middle
+         @ThemeAccentColor1 = main selection color
+         @ThemeAccentColor1 = used to build QSpinBox up and down buttons, it's used as color in the middle
         #adc5ed
         #cbd8e6
 */
@@ -137,7 +137,7 @@ QToolBox::tab
 
 QToolBox::tab:hover
 {
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
     border: 1px solid #6492d7;
         border-radius: 1px
 }
@@ -176,7 +176,7 @@ QMenuBar::item:pressed,
 QMenu::item:selected,
 QMenu::item:pressed {
     color: #ffffff;
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QMenu::right-arrow {
@@ -201,8 +201,8 @@ QMenu::icon {
 }
 
 QMenu::icon:checked { /* appearance of a 'checked' icon */
-    background: #557BB6;
-    border: 2px #557BB6;
+    background:  @ThemeAccentColor1;
+    border: 2px  @ThemeAccentColor1;
     position: absolute;
     border-radius: 2px;
 }
@@ -234,7 +234,7 @@ QMenu QToolButton:pressed,
 QMenu QPushButton:selected,
 QMenu QToolButton:selected {
     color: white;
-    background-color: #557bb6; /* same as QMenu::item:selected and QMenu::item:pressed */
+    background-color:  @ThemeAccentColor1; /* same as QMenu::item:selected and QMenu::item:pressed */
 }
 
 QMenu QRadioButton:disabled,
@@ -371,13 +371,13 @@ QDockWidget::float-button {
 
 QDockWidget::close-button:hover,
 QDockWidget::float-button:hover {
-    background-color: #557bb6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QDockWidget::close-button:pressed,
 QDockWidget::float-button:pressed {
-    background-color: #42608d;
-    border: 2px solid #76acfd
+    background-color:  @ThemeAccentColor2;
+    border: 2px solid  @ThemeAccentColor3;
 }
 
 /* fix for Python Console (probably there is a smarter way to arrive to it) */
@@ -402,7 +402,7 @@ QProgressBar:horizontal {
 }
 QProgressBar::chunk,
 QProgressBar::chunk:horizontal {
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
     border-radius: 1px;
 }
 
@@ -433,7 +433,7 @@ QScrollBar::handle:horizontal {
 
 QScrollBar::handle:vertical:hover,
 QScrollBar::handle:horizontal:hover {
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QScrollBar::handle:horizontal {
@@ -463,13 +463,13 @@ QScrollBar::add-line:horizontal {
 QScrollBar::sub-line:horizontal:hover,
 QScrollBar::sub-line:horizontal:on {
     border-image: url(qss:images_dark-light/left_arrow_lighter.svg);
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QScrollBar::add-line:horizontal:hover,
 QScrollBar::add-line:horizontal:on {
     border-image: url(qss:images_dark-light/right_arrow_lighter.svg);
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QScrollBar::up-arrow:horizontal,
@@ -515,13 +515,13 @@ QScrollBar::add-line:vertical {
 QScrollBar::sub-line:vertical:hover,
 QScrollBar::sub-line:vertical:on {
     border-image: url(qss:images_dark-light/up_arrow_lighter.svg);
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QScrollBar::add-line:vertical:hover,
 QScrollBar::add-line:vertical:on {
     border-image: url(qss:images_dark-light/down_arrow_lighter.svg);
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QScrollBar::up-arrow:vertical,
@@ -621,23 +621,23 @@ QTabBar::tab:selected {
 }
 
 QTabBar::tab:top:selected {
-    border-top: 4px solid #557BB6; /* selection color */
+    border-top: 4px solid  @ThemeAccentColor1; /* selection color */
     border-bottom-color: #333333; /* same as tab content background color */
     border-radius: 2px;
 }
 
 QTabBar::tab:bottom:selected {
-    border-bottom: 4px solid #557BB6; /* selection color */
+    border-bottom: 4px solid  @ThemeAccentColor1; /* selection color */
     border-top-color: #333333; /* same as tab content background color */
 }
 
 QTabBar::tab:right:selected {
-    border-left: 4px solid #557BB6; /* selection color */
+    border-left: 4px solid  @ThemeAccentColor1; /* selection color */
     border-right-color: #333333; /* same as tab content background color */
 }
 
 QTabBar::tab:left:selected {
-    border-right: 4px solid #557BB6; /* selection color */
+    border-right: 4px solid  @ThemeAccentColor1; /* selection color */
     border-left-color: #333333; /* same as tab content background color */
 }
 
@@ -647,7 +647,7 @@ QTabBar::tab:!selected {
 
 QTabBar::tab:!selected:hover {
     color: rgba(255,255,255,180);
-    background-color: #557BB6; /* Hack for Undocked inactive tabs - can also change to #696969 */ /* was rgba(255,255,255,20) */
+    background-color:  @ThemeAccentColor1; /* Hack for Undocked inactive tabs - can also change to #696969 */ /* was rgba(255,255,255,20) */
 }
 
 QTabBar::tab:first:selected {
@@ -684,12 +684,12 @@ QDialog#Gui__Dialog__DlgPreferences > QListView::item {
 }
 
 QDialog#Gui__Dialog__DlgPreferences > QListView::item:hover { /* Preference left icons*/
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QDialog#Gui__Dialog__DlgPreferences > QListView::item:selected { /* Preference left icons*/
     color: white;
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 
@@ -801,7 +801,7 @@ QTableView {
     alternate-background-color: #333333; /* related with QListView background  */
     border: 1px solid #333333;
     selection-color: #ffffff;
-    selection-background-color: #557BB6; /* should be similar to QListView::item selected background-color */
+    selection-background-color:  @ThemeAccentColor1; /* should be similar to QListView::item selected background-color */
     show-decoration-selected: 1; /* make the selection span the entire width of the view */
     border-radius: 1px;
 }
@@ -814,7 +814,7 @@ QTreeView::item:hover  {
 QListView::item:selected,
 QTreeView::item:selected  {
     color: #ffffff; /* should be similar to QListView selection-color */
-    background-color: #557BB6; /* should be similar to QListView selection-background-color */
+    background-color:  @ThemeAccentColor1; /* should be similar to QListView selection-background-color */
     show-decoration-selected: 1; /* make the selection span the entire width of the view */
 }
 
@@ -1092,7 +1092,7 @@ QPlainTextEdit,
 QPlainTextEdit:focus {
     background-color: #3c3c3c; /* Python Console */
     selection-color: #f5f5f5;
-    selection-background-color: #557BB6;
+    selection-background-color:  @ThemeAccentColor1;
     border: 6px solid #333333;
     border-radius: 0px;
     margin: 0px;
@@ -1136,7 +1136,7 @@ QSint--ActionGroup QFrame[class="header"] {
 }
 
 QSint--ActionGroup QFrame[class="header"]:hover {
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QSint--ActionGroup QToolButton[class="header"] {
@@ -1242,7 +1242,7 @@ QToolBar > Gui--WorkbenchComboBox  {
 QToolBar > Gui--WorkbenchComboBox:!editable {
     color: #f5f5f5;
     font-weight: bold;
-    background-color: #557bb6;  /* workbench disabled color */
+    background-color:  @ThemeAccentColor1;  /* workbench disabled color */
 }
 
 QComboBox,
@@ -1257,7 +1257,7 @@ QDateTimeEdit {
     color: #f5f5f5;
     background-color: #494949;  /* lineedits and drop-downs */
     selection-color: #ffffff;
-    selection-background-color: #557bb6;
+    selection-background-color:  @ThemeAccentColor1;
     border: 0px solid #2a2a2a;
     border-radius: 1px;
     min-width: 50px; /* it ensures the default value is correctly displayed */
@@ -1305,7 +1305,7 @@ QDateTimeEdit:focus {
     color: #f5f5f5;
     border-color: #333333;
     border: 1px;
-    border-right-color: #557BB6; /* same as up/down or drop-down button color */
+    border-right-color:  @ThemeAccentColor1; /* same as up/down or drop-down button color */
     background-color: #494949;
 }
 
@@ -1500,14 +1500,14 @@ QComboBox::down-arrow:disabled {
 /* ComboBox menu */
 QComboBox {
     selection-color: #f5f5f5;
-    selection-background-color: #557BB6;
+    selection-background-color:  @ThemeAccentColor1;
 }
 
 QComboBox QAbstractItemView {
     color: #bebebe; /* same as regular QComboBox color */
     background-color: transparent; /* was transparent */
     selection-color: #f5f5f5;
-    selection-background-color: #557BB6;
+    selection-background-color:  @ThemeAccentColor1;
     border-width: 5px 0px 5px 0px;
     border-style: solid;
     border-color: transparent;
@@ -1531,7 +1531,7 @@ QPushButton {
 QPushButton:hover,
 QPushButton:focus {
     color: #ffffff;
-    background-color: #557bb6;
+    background-color:  @ThemeAccentColor1;
     border: 1px solid #f5f5f5;
 }
 
@@ -1544,13 +1544,13 @@ QPushButton:disabled:checked {
 
 QPushButton:pressed {
     color: #ffffff;
-    background-color: #48699a;
+    background-color: #@ThemeAccentColor2;
     border: 1px solid #3c3c3c;
 }
 
 QPushButton:checked {
-    background-color: #557BB6;
-    border: 1px solid #557BB6;
+    background-color:  @ThemeAccentColor1;
+    border: 1px solid  @ThemeAccentColor1;
 }
 
 /* Inspect Widgets Addon */
@@ -1564,15 +1564,15 @@ QDockWidget#InspectWidgets QPushButton {
 
 QDockWidget#InspectWidgets QPushButton:hover {
     color: #ffffff;
-    background-color: #557bb6;
+    background-color:  @ThemeAccentColor1;
     border: 1px solid #f5f5f5;
     border-bottom: 1px solid #f5f5f5;
 }
 
 QDockWidget#InspectWidgets QPushButton:checked,
 QDockWidget#InspectWidgets QPushButton:pressed {
-    background-color: #557bb6;
-    border: 1px solid #557bb6;
+    background-color:  @ThemeAccentColor1;
+    border: 1px solid  @ThemeAccentColor1;
 }
 
 /* CAD Navigation Style */
@@ -1580,7 +1580,7 @@ QMenu::item#NavigationIndicator {
     image: url(qss:images_dark-light/NavigationBlender_light.svg);
 }
 QPushButton#NavigationIndicator {
-    background-color: #557bb6;
+    background-color:  @ThemeAccentColor1;
     padding: 2px;
     margin: 0px;
     border: 1px solid #333333;
@@ -1596,8 +1596,8 @@ QPushButton:hover#NavigationIndicator {
 
 QPushButton:pressed#NavigationIndicator {
     color: #ffffff;
-    background-color: #557bb6;
-    border: 1px solid #557bb6;
+    background-color:  @ThemeAccentColor1;
+    border: 1px solid  @ThemeAccentColor1;
 }
 
 /* BIM Views Manager */
@@ -1616,12 +1616,12 @@ QWidget#Form QPushButton {
 
 QWidget#Form QPushButton:hover {
     border: 1px solid #f5f5f5;
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QWidget#Form QPushButton:pressed {
-    border: 1px solid #557bb6;
-    background-color: #557BB6;
+    border: 1px solid  @ThemeAccentColor1;
+    background-color:  @ThemeAccentColor1;
 }
 
 /* Addon Manager */
@@ -1635,7 +1635,7 @@ QDialog#Dialog QPushButton {
 QDialog#Dialog QPushButton:hover {
     color: #ffffff;
     border: 1px solid #3c3c3c;
-    background-color: #48699a;
+    background-color: #@ThemeAccentColor2;
 }
 
 QPushButton#buttonUninstall {
@@ -1678,12 +1678,12 @@ Gui--ColorButton:disabled {
 
 Gui--ColorButton:hover,
 Gui--ColorButton:focus {
-    border-color: #557BB6;
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #557BB6, stop:1 #557BB6);
+    border-color:  @ThemeAccentColor1;
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor1, stop:1  @ThemeAccentColor1);
 }
 
 Gui--ColorButton:pressed {
-    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 #557BB6, stop:1 #557BB6);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0  @ThemeAccentColor1, stop:1  @ThemeAccentColor1);
 
 }
 
@@ -1726,7 +1726,7 @@ QFileDialog#QFileDialog QToolButton {
 QFileDialog#QFileDialog QToolButton:hover,
 QFileDialog#QFileDialog QToolButton:focus {
     color: #ffffff;
-    background-color: #557bb6;
+    background-color:  @ThemeAccentColor1;
     border: 1px solid #f5f5f5;
 }
 
@@ -1749,7 +1749,7 @@ QDialog QToolButton {
 QDialog QToolButton:hover,
 QDialog QToolButton:focus {
     color: #ffffff;
-    background-color: #557bb6;
+    background-color:  @ThemeAccentColor1;
     border: 1px solid #f5f5f5;
 }
 
@@ -1762,7 +1762,7 @@ QDialog QToolButton:disabled:checked {
 
 QDialog QToolButton:pressed {
     color: #ffffff;
-    background-color: #48699a;
+    background-color: #@ThemeAccentColor2;
     border: 1px solid #3c3c3c;
 }
 
@@ -1787,7 +1787,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:hover,
 QSint--ActionGroup QFrame[class="content"] QToolButton:focus {
     color: white;
     border-color: solid #f5f5f5;
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:disabled,
@@ -1798,7 +1798,7 @@ QSint--ActionGroup QFrame[class="content"] QToolButton:disabled:checked {
 }
 
 QSint--ActionGroup QFrame[class="content"] QToolButton:pressed {
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 /* QToolButtons with a menu found in Sketcher task panel*/
@@ -1852,7 +1852,7 @@ QRadioButton::indicator:unchecked{
 }
 
 QRadioButton::indicator:checked {
-    background-color: #557BB6; /* QCheckBox has the same color */
+    background-color:  @ThemeAccentColor1; /* QCheckBox has the same color */
     border: 1px solid #2a2a2a; /* QCheckBox has the same color */
     image:url(qss:images_dark-light/radiobutton_light.svg);
 }
@@ -1925,7 +1925,7 @@ QGroupBox::indicator:checked:pressed {
 
 QCheckBox::indicator:checked,
 QGroupBox::indicator:checked {
-    background-color: #557BB6; /* QRadioButton has the same color */
+    background-color:  @ThemeAccentColor1; /* QRadioButton has the same color */
     border: 1px solid #2a2a2a; /* QRadioButton has the same color */
     image:url(qss:images_dark-light/checkbox_light.svg);
 }
@@ -2077,13 +2077,13 @@ QSlider::handle:vertical:hover,
 QSlider::handle:horizontal:pressed,
 QSlider::handle:vertical:pressed {
     border-color: #adc5ed;
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QSlider::handle:horizontal:disabled,
 QSlider::handle:vertical:disabled {
     border-color: #2a2a2a;
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 
@@ -2126,7 +2126,7 @@ QToolBar > QPushButton {
 
 QToolBar > QPushButton:checked {
     border: 1px solid #3c3c3c;
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 /* Hack to avoid QPushButton text partially hidden under menu-indicator */
@@ -2148,18 +2148,18 @@ QToolBar > QPushButton:checked:hover {
 
 QToolBar > QPushButton:!checked:hover {
     color: #ffffff;
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
     border: 1px solid #f5f5f5;
 }
 
 QToolBar > QPushButton:checked:pressed {
-    border: 1px solid #557bb6;
-    background-color: solid #557BB6;
+    border: 1px solid  @ThemeAccentColor1;
+    background-color: solid  @ThemeAccentColor1;
 }
 
 QToolBar > QPushButton:!checked:pressed {
-    border: 1px solid #557bb6;
-    background-color: #557BB6;
+    border: 1px solid  @ThemeAccentColor1;
+    background-color:  @ThemeAccentColor1;
 }
 
 QToolBar > QPushButton:checked:disabled,
@@ -2176,13 +2176,13 @@ QToolBar > QToolButton {
 }
 
 QToolBar > QToolButton:hover {
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
     border: 1px solid #f5f5f5;
 }
 
 QToolBar > QToolButton:pressed {
-    background-color: #557BB6;
-    border: 1px solid #557bb6;
+    background-color:  @ThemeAccentColor1;
+    border: 1px solid  @ThemeAccentColor1;
 }
 
 /* ToolBar menu buttons (buttons with drop-down menu) */
@@ -2206,26 +2206,26 @@ QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:hover {
     border-top: 1px solid #f5f5f5;
     border-bottom: 1px solid #f5f5f5;
     border-right: 1px solid #f5f5f5;
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
 }
 
 QToolBar > QToolButton#qt_toolbutton_menubutton:pressed,
 QToolBar > QToolButton#qt_toolbutton_menubutton:open {
-    background-color: #557BB6;
-    border: 1px solid #557BB6;
+    background-color:  @ThemeAccentColor1;
+    border: 1px solid  @ThemeAccentColor1;
 }
 
 QToolBar > QToolButton#qt_toolbutton_menubutton:hover {
-    background-color: #557BB6;
+    background-color:  @ThemeAccentColor1;
     border: 1px solid #f5f5f5;
 }
 
 QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
 QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:open {
-    border-top: 1px solid #557bb6;
-    border-bottom: 1px solid #557bb6;
-    border-right: 1px solid #557bb6;
-    background-color: #557BB6;
+    border-top: 1px solid  @ThemeAccentColor1;
+    border-bottom: 1px solid  @ThemeAccentColor1;
+    border-right: 1px solid  @ThemeAccentColor1;
+    background-color:  @ThemeAccentColor1;
 }
 
 QToolBar > QToolButton::menu-arrow {
@@ -2247,13 +2247,13 @@ QToolBar > QToolButton::menu-arrow:open {
 
 /* when QToolButton is checked: */
 QToolBar > QToolButton:checked {
-    border: 1px solid #557BB6;
-    background-color: #557BB6; /* transparency for #557BB6 color */
+    border: 1px solid  @ThemeAccentColor1;
+    background-color:  @ThemeAccentColor1; /* transparency for  @ThemeAccentColor1 color */
 }
 
 QToolBar > QToolButton:checked:hover {
-    border: 1px solid #557BB6;
-    background-color: #557BB6; /* transparency for #557BB6 color */
+    border: 1px solid  @ThemeAccentColor1;
+    background-color:  @ThemeAccentColor1; /* transparency for  @ThemeAccentColor1 color */
 }
 
 /*The "show more" button  (it can also be stylable with "QToolBarExtension" */
@@ -2288,7 +2288,7 @@ QMdiArea > QWidget > QMdiSubWindow > SpreadsheetGui--SheetView > QWidget > Sprea
 QTableView {
     gridline-color: #a8a8a8;
     selection-color: #ffffff;
-    selection-background-color: #557bb6; /* Default Spreadsheet cell selection background color */
+    selection-background-color:  @ThemeAccentColor1; /* Default Spreadsheet cell selection background color */
 }
 
 QTableView::item:disabled  {
@@ -2298,8 +2298,8 @@ QTableView::item:disabled  {
 QTableView::item:selected  {
     color: #ffffff;
     border-color: #cecece; /* same as focused background color */
-    border-bottom-color: #557BB6; /* same as focused border color */
-    background-color: #557BB6; /* cell background color */
+    border-bottom-color:  @ThemeAccentColor1; /* same as focused border color */
+    background-color:  @ThemeAccentColor1; /* cell background color */
 }
 
 /* fix for elements inside the cells */
@@ -2371,7 +2371,7 @@ QTableView > QWidget > QDateEdit:focus,
 QTableView > QWidget > QDateTimeEdit:focus {
     color: #000000;
     selection-color: #f5f5f5;
-    selection-background-color: #557BB6;
+    selection-background-color:  @ThemeAccentColor1;
     border-color: #3c3c3c;
     background-color: #cecece;
 }


### PR DESCRIPTION
As the title says I replaced some static colors with the accent colors, also for ProDark and Behave-Dark and Dark-contrast.
I also added gradient to the modern styles, as you can now manually disable gradients by making the 2 colors the same.

We might need to look into some "reset to default" option for the theme's.

![afbeelding](https://github.com/FreeCAD/FreeCAD/assets/29804962/9b4f1ba3-a4bd-41db-811c-30dbad21f97b)
![afbeelding](https://github.com/FreeCAD/FreeCAD/assets/29804962/366f6654-f91d-4178-a151-798c71da483a)
![afbeelding](https://github.com/FreeCAD/FreeCAD/assets/29804962/bb6e57ea-3ee3-43bf-81ee-f2a1bcaf24d1)
![afbeelding](https://github.com/FreeCAD/FreeCAD/assets/29804962/c17da584-f628-4875-942e-1d6ef4042862)
