### PR TITLE
Improve Pad/Pocket Task Dialog

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -431,7 +431,7 @@ void TaskExtrudeParameters::setCheckboxes(Modes mode, Type type)
     bool isMidplaneEnabled = false;
     bool isMidplaneVisible = false;
     bool isReversedEnabled = false;
-    bool isFaceEditEnabled = false;
+    bool isFaceEditVisible = false;
     bool isTaperEditVisible = false;
     bool isTaperEdit2Visible = false;
 
@@ -463,7 +463,7 @@ void TaskExtrudeParameters::setCheckboxes(Modes mode, Type type)
     else if (mode == Modes::ToFace) {
         isOffsetEditVisible = true;
         isReversedEnabled = true;
-        isFaceEditEnabled = true;
+        isFaceEditVisible = true;
         QMetaObject::invokeMethod(ui->lineFaceName, "setFocus", Qt::QueuedConnection);
         // Go into reference selection mode if no face has been selected yet
         if (ui->lineFaceName->property("FeatureName").isNull())
@@ -503,9 +503,9 @@ void TaskExtrudeParameters::setCheckboxes(Modes mode, Type type)
 
     ui->checkBoxReversed->setEnabled(isReversedEnabled);
 
-    ui->buttonFace->setEnabled(isFaceEditEnabled);
-    ui->lineFaceName->setEnabled(isFaceEditEnabled);
-    if (!isFaceEditEnabled) {
+    ui->buttonFace->setVisible(isFaceEditVisible);
+    ui->lineFaceName->setVisible(isFaceEditVisible);
+    if (!isFaceEditVisible) {
         ui->buttonFace->setChecked(false);
     }
 }

--- a/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
@@ -16,10 +16,46 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="textLabel1">
+       <property name="text">
+        <string>Type</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="changeMode">
+       <item>
+        <property name="text">
+         <string>Dimension</string>
+        </property>
+       </item>
+      </widget>
+     </item>
      <item row="1" column="0">
       <widget class="QLabel" name="labelLength">
        <property name="text">
         <string>Length</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelLength2">
+       <property name="text">
+        <string>2nd length</string>
        </property>
       </widget>
      </item>
@@ -40,29 +76,6 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="labelLength2">
-       <property name="text">
-        <string>2nd length</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="changeMode">
-       <item>
-        <property name="text">
-         <string>Dimension</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="textLabel1">
-       <property name="text">
-        <string>Type</string>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="1">
       <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit">
        <property name="keyboardTracking">
@@ -70,19 +83,6 @@
        </property>
        <property name="unit" stdset="0">
         <string notr="true">mm</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit">
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="unit" stdset="0">
-        <string notr="true">mm</string>
-       </property>
-       <property name="minimum">
-        <double>0.000000000000000</double>
        </property>
       </widget>
      </item>

--- a/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
@@ -16,10 +16,34 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="textLabel1">
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelLength">
        <property name="text">
-        <string>Type</string>
+        <string>Length</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit2">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelOffset">
+       <property name="text">
+        <string>Offset to face</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelLength2">
+       <property name="text">
+        <string>2nd length</string>
        </property>
       </widget>
      </item>
@@ -32,10 +56,20 @@
        </item>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="labelLength">
+     <item row="0" column="0">
+      <widget class="QLabel" name="textLabel1">
        <property name="text">
-        <string>Length</string>
+        <string>Type</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
        </property>
       </widget>
      </item>
@@ -52,24 +86,54 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="labelOffset">
+    </layout>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_5">
+     <item row="0" column="0">
+      <widget class="QToolButton" name="buttonFace">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
        <property name="text">
-        <string>Offset to face</string>
+        <string>Select face</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="Gui::PrefQuantitySpinBox" name="offsetEdit">
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="unit" stdset="0">
-        <string notr="true">mm</string>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="lineFaceName">
+       <property name="readOnly">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxMidplane">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Applies length symmetrically to sketch plane</string>
+     </property>
+     <property name="text">
+      <string>Symmetric to plane</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxReversed">
+     <property name="text">
+      <string>Reversed</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="groupBox">
@@ -245,26 +309,6 @@ measured along the specified direction</string>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBoxMidplane">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="toolTip">
-      <string>Applies length symmetrically to sketch plane</string>
-     </property>
-     <property name="text">
-      <string>Symmetric to plane</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkBoxReversed">
-     <property name="text">
-      <string>Reversed</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_5">
      <item>
       <widget class="QLabel" name="labelTaperAngle">
@@ -289,27 +333,6 @@ measured along the specified direction</string>
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QLabel" name="labelLength2">
-       <property name="text">
-        <string>2nd length</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="Gui::PrefQuantitySpinBox" name="lengthEdit2">
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="unit" stdset="0">
-        <string notr="true">mm</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_6">
      <item>
       <widget class="QLabel" name="labelTaperAngle2">
@@ -328,33 +351,6 @@ measured along the specified direction</string>
        </property>
        <property name="unit" stdset="0">
         <string notr="true">deg</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="gridLayout_5">
-     <item row="0" column="0">
-      <widget class="QToolButton" name="buttonFace">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Select face</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="lineFaceName">
-       <property name="readOnly">
-        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -399,20 +395,20 @@ measured along the specified direction</string>
  <tabstops>
   <tabstop>changeMode</tabstop>
   <tabstop>lengthEdit</tabstop>
+  <tabstop>lengthEdit2</tabstop>
   <tabstop>offsetEdit</tabstop>
+  <tabstop>buttonFace</tabstop>
+  <tabstop>lineFaceName</tabstop>
+  <tabstop>checkBoxMidplane</tabstop>
+  <tabstop>checkBoxReversed</tabstop>
   <tabstop>directionCB</tabstop>
   <tabstop>checkBoxDirection</tabstop>
   <tabstop>XDirectionEdit</tabstop>
   <tabstop>YDirectionEdit</tabstop>
   <tabstop>ZDirectionEdit</tabstop>
   <tabstop>checkBoxAlongDirection</tabstop>
-  <tabstop>checkBoxMidplane</tabstop>
-  <tabstop>checkBoxReversed</tabstop>
   <tabstop>taperEdit</tabstop>
-  <tabstop>lengthEdit2</tabstop>
   <tabstop>taperEdit2</tabstop>
-  <tabstop>buttonFace</tabstop>
-  <tabstop>lineFaceName</tabstop>
   <tabstop>checkBoxUpdateView</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
Based on the discussion here https://forum.freecad.org/viewtopic.php?t=80413 I made the following changes to the Pad/Pocket task dialog:
- reorder UI elements
- hide "Select Face" if not necessary
- improve tab stop order
