### PR TITLE
Main: Fix for Windows with Py3.10

### DIFF
--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -97,8 +97,9 @@ private:
 
 int main( int argc, char ** argv )
 {
-    setlocale(LC_ALL, ""); // use native environment settings
 #if defined (FC_OS_LINUX) || defined(FC_OS_BSD)
+    setlocale(LC_ALL, ""); // use native environment settings
+
     // Make sure to setup the Qt locale system before setting LANG and LC_ALL to C.
     // which is needed to use the system locale settings.
     (void)QLocale::system();


### PR DESCRIPTION
The fix for https://forum.freecad.org/viewtopic.php?t=79192 may have caused a regression with Py3.10 on Windows as reported here https://forum.freecad.org/viewtopic.php?t=80659

This PR activates the previous fix for Linux & UNIX systems only