### PR TITLE
Tests: move Sketcher test target to appropriate CMakeLists.txt file

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(Tests_run)
 add_executable(Mesh_tests_run)
 add_executable(Part_tests_run)
 add_executable(Points_tests_run)
+add_executable(Sketcher_tests_run)
 add_subdirectory(lib)
 add_subdirectory(src)
 target_include_directories(Tests_run PUBLIC
@@ -82,16 +83,3 @@ target_link_libraries(Tests_run
     FreeCADApp
 )
 
-add_executable(Sketcher_tests_run)
-add_subdirectory(src/Mod/Sketcher)
-target_include_directories(Sketcher_tests_run PUBLIC
-    ${EIGEN3_INCLUDE_DIR}
-    ${OCC_INCLUDE_DIR}
-    ${Python3_INCLUDE_DIRS}
-    ${XercesC_INCLUDE_DIRS}
-)
-target_link_libraries(Sketcher_tests_run
-    gtest_main
-    ${Google_Tests_LIBS}
-    Sketcher
-)

--- a/tests/src/Mod/CMakeLists.txt
+++ b/tests/src/Mod/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Mesh)
 add_subdirectory(Part)
 add_subdirectory(Points)
+add_subdirectory(Sketcher)

--- a/tests/src/Mod/Sketcher/CMakeLists.txt
+++ b/tests/src/Mod/Sketcher/CMakeLists.txt
@@ -1,1 +1,15 @@
+
+target_include_directories(Sketcher_tests_run PUBLIC
+    ${EIGEN3_INCLUDE_DIR}
+    ${OCC_INCLUDE_DIR}
+    ${Python3_INCLUDE_DIRS}
+    ${XercesC_INCLUDE_DIRS}
+)
+
+target_link_libraries(Sketcher_tests_run
+    gtest_main
+    ${Google_Tests_LIBS}
+    Sketcher
+)
+
 add_subdirectory(App)


### PR DESCRIPTION
This is to keep clean the top-level CMakeLists.txt file of the tests directory.