### PR TITLE
StartPage: Visual fixes follow-up

### DIFF
--- a/src/Gui/PreferencePacks/Classic/Classic.cfg
+++ b/src/Gui/PreferencePacks/Classic/Classic.cfg
@@ -37,7 +37,7 @@
           </FCParamGroup>
           <FCParamGroup Name="Start">
             <FCUInt Name="BackgroundColor1" Value="1331197183"/>
-            <FCUInt Name="BackgroundTextColor" Value="4294703103"/>
+            <FCUInt Name="BackgroundTextColor" Value="1600086015"/>
             <FCUInt Name="PageColor" Value="4294967295"/>
             <FCUInt Name="PageTextColor" Value="255"/>
             <FCUInt Name="BoxColor" Value="3722305023"/>

--- a/src/Mod/Start/Gui/DlgStartPreferences.ui
+++ b/src/Mod/Start/Gui/DlgStartPreferences.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>401</width>
-    <height>690</height>
+    <width>548</width>
+    <height>894</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -21,7 +21,7 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="Gui::PrefFileChooser" name="fileChooser_1">
+       <widget class="Gui::PrefFileChooser" name="fileChooser_1" native="true">
         <property name="toolTip">
          <string>An optional HTML template that will be used instead of the default start page.</string>
         </property>
@@ -42,71 +42,6 @@
       <string>Contents</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="4" column="1">
-       <widget class="Gui::PrefCheckBox" name="checkBox_6">
-        <property name="toolTip">
-         <string>Displays help tips in the Start workbench Documents tab</string>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ShowTips</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="Gui::PrefCheckBox" name="checkBox">
-        <property name="toolTip">
-         <string>Shows a notepad next to the file thumbnails, where you can keep notes across sessions</string>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ShowNotes</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_17">
-        <property name="text">
-         <string>Show notepad</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="Gui::PrefFileChooser" name="fileChooser_3">
-        <property name="toolTip">
-         <string>An optional custom folder to be displayed at the bottom of the first page.
-By using &quot;;;&quot; to separate paths, you can add several folders here</string>
-        </property>
-        <property name="mode">
-         <enum>Gui::FileChooser::Directory</enum>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ShowCustomFolder</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
       <item row="4" column="0">
        <widget class="QLabel" name="label_19">
         <property name="text">
@@ -114,36 +49,10 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_14">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_10">
         <property name="text">
-         <string>Show forum</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="Gui::PrefCheckBox" name="checkBox_4">
-        <property name="toolTip">
-         <string>If this is checked, the latest posts from the FreeCAD forum will be displayed on the Activity tab</string>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ShowForum</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Start</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>Show examples folder contents</string>
+         <string>Show additional folder</string>
         </property>
        </widget>
       </item>
@@ -169,10 +78,60 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_10">
+      <item row="3" column="1">
+       <widget class="Gui::PrefCheckBox" name="checkBox_4">
+        <property name="toolTip">
+         <string>If this is checked, the latest posts from the FreeCAD forum will be displayed on the Activity tab</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
         <property name="text">
-         <string>Show additional folder</string>
+         <string/>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowForum</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="Gui::PrefCheckBox" name="showFileThumbnailIconsCheckBox">
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowFileThumbnailIcons</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefCheckBox" name="checkBox">
+        <property name="toolTip">
+         <string>Shows a notepad next to the file thumbnails, where you can keep notes across sessions</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowNotes</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
         </property>
        </widget>
       </item>
@@ -180,6 +139,34 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
        <widget class="QLabel" name="label_20">
         <property name="text">
          <string>Show scrollbars</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_17">
+        <property name="text">
+         <string>Show notepad</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_14">
+        <property name="text">
+         <string>Show forum</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefFileChooser" name="fileChooser_3" native="true">
+        <property name="toolTip">
+         <string>An optional custom folder to be displayed at the bottom of the first page.
+By using &quot;;;&quot; to separate paths, you can add several folders here</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowCustomFolder</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
         </property>
        </widget>
       </item>
@@ -201,6 +188,109 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
          <cstring>Mod/Start</cstring>
         </property>
        </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_18">
+        <property name="text">
+         <string>Show file thumbnails</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Show examples folder contents</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefCheckBox" name="checkBox_6">
+        <property name="toolTip">
+         <string>Displays help tips in the Start workbench Documents tab</string>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowTips</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Start</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_21">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>File thumbnail size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefSpinBox" name="fileThumbnailIconSizeSpinBox">
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>The size of file thumbnail icons in recent files and examples sections</string>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="suffix">
+           <string>px</string>
+          </property>
+          <property name="minimum">
+           <number>32</number>
+          </property>
+          <property name="maximum">
+           <number>128</number>
+          </property>
+          <property name="value">
+           <number>128</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>FileThumbnailIconsSize</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Start</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -255,7 +345,7 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
         <property name="toolTip">
          <string>The background color behind the panels</string>
         </property>
-        <property name="color">
+        <property name="color" stdset="0">
          <color>
           <red>79</red>
           <green>88</green>
@@ -294,7 +384,7 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
         <property name="toolTip">
          <string>The down gradient for the background color (currently unsupported)</string>
         </property>
-        <property name="color">
+        <property name="color" stdset="0">
          <color>
           <red>127</red>
           <green>158</green>
@@ -317,7 +407,7 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
        </widget>
       </item>
       <item row="4" column="1">
-       <widget class="Gui::PrefFileChooser" name="fileChooser_2">
+       <widget class="Gui::PrefFileChooser" name="fileChooser_2" native="true">
         <property name="toolTip">
          <string>An optional image to display as background</string>
         </property>
@@ -347,7 +437,7 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
         <property name="toolTip">
          <string>The color of the version text</string>
         </property>
-        <property name="color">
+        <property name="color" stdset="0">
          <color>
           <red>95</red>
           <green>95</green>
@@ -380,7 +470,7 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
         <property name="toolTip">
          <string>The background of the main start page area</string>
         </property>
-        <property name="color">
+        <property name="color" stdset="0">
          <color>
           <red>255</red>
           <green>255</green>
@@ -413,7 +503,7 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
         <property name="toolTip">
          <string>The color of the text on the main pages</string>
         </property>
-        <property name="color">
+        <property name="color" stdset="0">
          <color>
           <red>0</red>
           <green>0</green>
@@ -446,7 +536,7 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
         <property name="toolTip">
          <string>The background color of the boxes inside the pages</string>
         </property>
-        <property name="color">
+        <property name="color" stdset="0">
          <color>
           <red>221</red>
           <green>221</green>
@@ -479,7 +569,7 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
         <property name="toolTip">
          <string>The color of the links</string>
         </property>
-        <property name="color">
+        <property name="color" stdset="0">
          <color>
           <red>0</red>
           <green>0</green>

--- a/src/Mod/Start/Gui/DlgStartPreferences.ui
+++ b/src/Mod/Start/Gui/DlgStartPreferences.ui
@@ -349,9 +349,9 @@ By using &quot;;;&quot; to separate paths, you can add several folders here</str
         </property>
         <property name="color">
          <color>
-          <red>255</red>
-          <green>251</green>
-          <blue>247</blue>
+          <red>95</red>
+          <green>95</green>
+          <blue>95</blue>
          </color>
         </property>
         <property name="prefEntry" stdset="0">

--- a/src/Mod/Start/Gui/DlgStartPreferencesImp.cpp
+++ b/src/Mod/Start/Gui/DlgStartPreferencesImp.cpp
@@ -111,6 +111,8 @@ void DlgStartPreferencesImp::saveSettings()
     ui->checkBox_7->onSave();
     ui->lineEdit->onSave();
     ui->spinBox->onSave();
+    ui->showFileThumbnailIconsCheckBox->onSave();
+    ui->fileThumbnailIconSizeSpinBox->onSave();
 }
 
 void DlgStartPreferencesImp::loadSettings()
@@ -142,6 +144,8 @@ void DlgStartPreferencesImp::loadSettings()
     ui->checkBox_7->onRestore();
     ui->lineEdit->onRestore();
     ui->spinBox->onRestore();
+    ui->showFileThumbnailIconsCheckBox->onRestore();
+    ui->fileThumbnailIconSizeSpinBox->onRestore();
 }
 
 /**

--- a/src/Mod/Start/StartPage/StartPage.css
+++ b/src/Mod/Start/StartPage/StartPage.css
@@ -150,6 +150,7 @@ ul.tabs li a.active:hover {
 }
 
 .footnote {
+    color: BGTCOLOR;
     text-align: center;
     display: block; /* footnote tips display */
     clear: both;

--- a/src/Mod/Start/StartPage/StartPage.css
+++ b/src/Mod/Start/StartPage/StartPage.css
@@ -1,3 +1,10 @@
+/*
+ * !!! WARNING !!!
+ * DO NOT change lines that have comment labels right beside them
+ * these lines are marked with "don't change this line"
+ * they get replaced by StartPage.py according to the preferences
+*/
+
 /* --- MAIN --- */
 
 html {
@@ -150,9 +157,10 @@ ul.tabs li a.active:hover {
 }
 
 .footnote {
+    /* don't change this line */
+    display: block; /* footnote tips display */
     color: BGTCOLOR;
     text-align: center;
-    display: block; /* footnote tips display */
     clear: both;
     padding-top: 10px;
 }
@@ -189,8 +197,8 @@ ul.icons {
 }
 
 .file-card img {
-    display: block; /* thumb icons display */
     /* don't change this line */
+    display: block; /* thumb icons display */
     margin: auto;
     width: THUMBSIZE;
     height: THUMBSIZE;
@@ -252,8 +260,8 @@ a .caption:visited {
 }
 
 .notes {
-    display: none; /* notes display */
     /* don't change this line */
+    display: none; /* notes display */
     width: 100%;
 }
 
@@ -347,8 +355,8 @@ ul.addonslist {
 }
 
 .forum {
-    display: none; /* forum display */
     /* don't change this line */
+    display: none; /* forum display */
 }
 
 .forum pre {

--- a/src/Mod/Start/StartPage/StartPage.css
+++ b/src/Mod/Start/StartPage/StartPage.css
@@ -174,23 +174,26 @@ ul.icons {
 .file-card {
     list-style: none;
     display: inline;
-    padding: 10px 0px 15px 10px;
-    width: 138px;
-    height: 200px;
+    padding: 10px;
+    width: 130px;
+    height: THUMBCARDSIZE;
     background: BOXCOLOR;
     border-radius: 8px;
     margin: 10px;
     word-wrap: break-word;
+    text-align: center;
 }
 
 .file-card h4 {
-    margin: 3px 0;
-    max-width: 90%;
+    margin: 5px 0;
 }
 
 .file-card img {
-    width: 128px;
-    height: 128px;
+    display: block; /* thumb icons display */
+    /* don't change this line */
+    margin: auto;
+    width: THUMBSIZE;
+    height: THUMBSIZE;
     border-radius: 4px;
 }
 
@@ -239,8 +242,8 @@ a .caption:visited {
 }
 
 .quickstart-button-card img {
-    width: 64px;
-    height: 64px;
+    width: 60px;
+    height: 60px;
     margin-right: 10px;
 }
 

--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -390,6 +390,16 @@ def handle():
                         ALTCSS = f.read()
                         HTML = HTML.replace("<!--QSS-->","<style type=\"text/css\">"+ALTCSS+"</style>")
 
+    # handle file thumbnail icons visiblity and size
+
+    if not FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Start").GetBool("ShowFileThumbnailIcons",True):
+        HTML = HTML.replace("display: block; /* thumb icons display */","display: none; /* thumb icons display */")
+        HTML = HTML.replace("THUMBCARDSIZE","75px")
+
+    thumb_icons_size = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Start").GetInt("FileThumbnailIconsSize", 128)
+    HTML = HTML.replace("THUMBSIZE",str(thumb_icons_size)+"px")
+    HTML = HTML.replace("THUMBCARDSIZE",str(thumb_icons_size + 75)+"px")
+
     # turn tips off if needed
 
     if not FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Start").GetBool("ShowTips",True):

--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -602,7 +602,7 @@ def handle():
     BASECOLOR = gethexcolor(p.GetUnsigned("PageColor",4294967295))
     BOXCOLOR  = gethexcolor(p.GetUnsigned("BoxColor",3722305023))
     TEXTCOLOR = gethexcolor(p.GetUnsigned("PageTextColor",255))
-    BGTCOLOR = gethexcolor(p.GetUnsigned("BackgroundTextColor",4294703103))
+    BGTCOLOR = gethexcolor(p.GetUnsigned("BackgroundTextColor",1600086015))
     OVERFLOW = "" if p.GetBool("ShowScrollBars",True) else "body::-webkit-scrollbar {display: none;}"
     SHADOW = "#888888"
     if QtGui.QColor(BASECOLOR).valueF() < 0.5: # dark page - we need to make darker shadows


### PR DESCRIPTION
This PR is a follow up to https://github.com/FreeCAD/FreeCAD/pull/10391 and https://github.com/FreeCAD/FreeCAD/issues/10381

Changes the default BackgroundTextColor and adds two new preferences for changing the visibility and size of file thumbnail icons