### PR TITLE
StartPage: purge unnecessary tempfolders (issue #10221)

### DIFF
--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -26,6 +26,7 @@
 
 import sys
 import os
+import shutil
 import tempfile
 import time
 import zipfile
@@ -329,10 +330,18 @@ def handle():
     import Start
     if hasattr(Start,"iconbank"):
         iconbank = Start.iconbank
-    if hasattr(Start,"tempfolder"):
+    if hasattr(Start,"tempfolder") and os.path.exists(Start.tempfolder):
         tempfolder = Start.tempfolder
     else:
         tempfolder = tempfile.mkdtemp(prefix="FreeCADStartThumbnails")
+
+    # purge old tempfolders
+
+    for entry in os.scandir(tempfile.gettempdir()):
+        if entry.is_dir():
+            if entry.name.startswith("FreeCADStartThumbnails"):
+                if entry.path != tempfolder:
+                    shutil.rmtree(entry.path)
 
     # build the html page skeleton
 


### PR DESCRIPTION
Fix for https://github.com/FreeCAD/FreeCAD/issues/10221

Works pretty well and shouldn't have any performance issues. But one very specific problem I've noticed:
- Launch FreeCAD
- Launch another instance of FreeCAD
- The second instance removes the tempfolder that the first instance uses
- Error warnings show when the StartPage of the first instance is refreshed because it can't access it's thumbnail files

One idea I have to fix this is making it so that the folders are not purged if there is another currently running instance of FreeCAD. But this would require looping over the user's processes, I'm not sure if that's considered fine or not (or if it's cross platform). Would be glad to hear suggestions on how this could be fixed