### PR TITLE
Fix possible issues in selection node

### DIFF
--- a/src/Gui/SoFCSelectionContext.cpp
+++ b/src/Gui/SoFCSelectionContext.cpp
@@ -181,12 +181,7 @@ int SoFCSelectionContextEx::merge(int status, SoFCSelectionContextBasePtr &outpu
         SoFCSelectionContextBasePtr input, SoNode *node)
 {
     auto ctx = std::dynamic_pointer_cast<SoFCSelectionContextEx>(input);
-    SoFCSelectionRoot* selectionNode;
-    if (node == nullptr) {
-        selectionNode = nullptr;
-    } else {
-        selectionNode = dynamic_cast<SoFCSelectionRoot*>(node);
-    }
+    SoFCSelectionRoot* selectionNode = dynamic_cast<SoFCSelectionRoot*>(node);
 
     if(!ctx) {
         if(selectionNode && selectionNode->hasColorOverride()) {

--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -1124,9 +1124,14 @@ SoFCSelectionContextBasePtr
 SoFCSelectionRoot::getNodeContext2(Stack &stack, SoNode *node, SoFCSelectionContextBase::MergeFunc *merge)
 {
     SoFCSelectionContextBasePtr ret;
-    auto *back = dynamic_cast<SoFCSelectionRoot*>(stack.back());
-    if(stack.empty() || back == nullptr || back->contextMap2.empty())
+    if (stack.empty()) {
         return ret;
+    }
+
+    auto *back = dynamic_cast<SoFCSelectionRoot*>(stack.back());
+    if (back == nullptr || back->contextMap2.empty()) {
+        return ret;
+    }
 
     int status = 0;
     auto &map = back->contextMap2;


### PR DESCRIPTION
Fixes some issues added with PR #9285:
* no need to check for nullptr when using dynamic_cast
* do not call back() on an empty container