### PR TITLE
Sketcher: fix segfault on distance constraints without SecondPos

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -826,12 +826,13 @@ Restart:
                 case DistanceY: {
                     assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                     Base::Vector3d pnt1(0., 0., 0.), pnt2(0., 0., 0.);
-                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(Constr->Second);
                     if (Constr->SecondPos != Sketcher::PointPos::none) {// point to point distance
                         pnt1 = geolistfacade.getPoint(Constr->First, Constr->FirstPos);
                         pnt2 = geolistfacade.getPoint(Constr->Second, Constr->SecondPos);
                     }
                     else if (Constr->Second != GeoEnum::GeoUndef) {
+                        const Part::Geometry* geo =
+                            geolistfacade.getGeometryFromGeoId(Constr->Second);
                         if (geo->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
                             const Part::GeomLineSegment* lineSeg =
                                 static_cast<const Part::GeomLineSegment*>(geo);


### PR DESCRIPTION
As reported in issue #10424 FreeCAD crashes with a segmentation fault when opening/editing a sketch.

The cause was a change in #9559 that evaluated a geometry of the second constraint position before the check if the second constraint position was valid.
The crash then happend because the second position of a DistanceX constraint was `GeoEnum::GeoUndef` (-2000). This value means that the distance point is the origin of the sketch and not a geometry object.

This PR restores the old order, i.e. the geometry will be evaluated and assigned _after_ the check.
For me, the change of the order in #9559 seems to be a mishap -- I cannot grasp the reasoning behind that change.
