### PR TITLE
Path: helix toolpath was not allowing Extra Offset values that it should

### DIFF
--- a/src/Mod/Path/Path/Base/Generator/helix.py
+++ b/src/Mod/Path/Path/Base/Generator/helix.py
@@ -71,6 +71,9 @@ def generate(
         )
     )
 
+    # inner_radius contains not a radius but the value from Extra Offset, which is the distance between the hole radius as designed and the hole radius to be cut.
+    # hole_radius contains the designed hole radius - inner_radius.
+
     if type(hole_radius) not in [float, int]:
         raise TypeError("Invalid type for hole radius")
 
@@ -82,13 +85,6 @@ def generate(
 
     if type(tool_diameter) not in [float, int]:
         raise TypeError("tool_diameter must be a float")
-
-    if inner_radius > 0 and hole_radius - inner_radius < tool_diameter:
-        raise ValueError(
-            "hole_radius - inner_radius = {0} is < tool diameter of {1}".format(
-                hole_radius - inner_radius, tool_diameter
-            )
-        )
 
     if not hole_radius * 2 > tool_diameter:
         raise ValueError(

--- a/src/Mod/Path/PathTests/TestPathHelixGenerator.py
+++ b/src/Mod/Path/PathTests/TestPathHelixGenerator.py
@@ -109,17 +109,31 @@ G0 X5.000000 Y5.000000 Z18.000000G0 Z20.000000"
         args["tool_diameter"] = "5"
         self.assertRaises(TypeError, generator.generate, **args)
 
+        # require tool fit 2: hole diameter not greater than tool diam
+        # with zero inner radius
         args = _resetArgs()
-        # require tool fit 1: radius diff less than tool diam
-        args["hole_radius"] = 10.0
-        args["inner_radius"] = 6.0
+        args["hole_radius"] = 2.0
+        args["inner_radius"] = 0.0
         args["tool_diameter"] = 5.0
         self.assertRaises(ValueError, generator.generate, **args)
 
-        # require tool fit 2: hole diameter not greater than tool diam
-        # with zero inner radius
-        args["hole_radius"] = 2.0
-        args["inner_radius"] = 0.0
+        # require tool fit: actual hole diameter after taking Extra Offset into account >= tool diameter
+        # 1. Extra Offset just small enough to leave room for tool should not raise an error
+        args = _resetArgs()
+        designed_hole_diameter = 10.0
+        extra_offset = 2.49
+        args["hole_radius"] = designed_hole_diameter / 2 - extra_offset
+        args["inner_radius"] = extra_offset
+        args["tool_diameter"] = 5.0
+        result = generator.generate(**args)
+        self.assertTrue(result)
+
+        # 2. Extra Offset does not leave room for tool, should raise an error
+        args = _resetArgs()
+        designed_hole_diameter = 10.0
+        extra_offset = 2.50
+        args["hole_radius"] = designed_hole_diameter / 2 - extra_offset
+        args["inner_radius"] = extra_offset
         args["tool_diameter"] = 5.0
         self.assertRaises(ValueError, generator.generate, **args)
 


### PR DESCRIPTION
A check in the helix toolpath generation code was rejecting Extra Offset values, even though there was enough space for the Extra Offset plus the tool inside the designed hole diameter.  

[[Problem] Path: Helix operation positive Extra Offset error](https://github.com/FreeCAD/FreeCAD/issues/10157) (https://github.com/FreeCAD/FreeCAD/issues/10157)
[Helix Extra Offset error in v0.21](https://github.com/FreeCAD/FreeCAD/issues/10336) (https://github.com/FreeCAD/FreeCAD/issues/10336)
 
[Problem with Helix operation](https://forum.freecad.org/viewtopic.php?t=80599)
[Helix Extra Offset error in v0.21](https://forum.freecad.org/viewtopic.php?p=673606)