### PR TITLE
Gui: fix crash with the move to the new-style of class SelectionFilterPy

### DIFF
--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -2303,7 +2303,7 @@ PyObject *SelectionSingleton::sAddSelectionGate(PyObject * /*self*/, PyObject *a
     if (PyArg_ParseTuple(args, "O!|i",SelectionFilterPy::type_object(),&filterPy,resolve)) {
         PY_TRY {
             Selection().addSelectionGate(new SelectionFilterGatePython(
-                        static_cast<SelectionFilterPy*>(filterPy)), toEnum(resolve));
+                        SelectionFilterPy::cast(filterPy)), toEnum(resolve));
             Py_Return;
         }
         PY_CATCH;

--- a/src/Gui/SelectionFilterPy.h
+++ b/src/Gui/SelectionFilterPy.h
@@ -45,6 +45,10 @@ public:
 
 public:
     static void init_type();    // announce properties and methods
+    static SelectionFilterPy* cast(PyObject* py) {
+        using SelectionFilterClass = Py::PythonClassObject<SelectionFilterPy>;
+        return SelectionFilterClass(py).getCxxObject();
+    }
 
     SelectionFilterPy(Py::PythonClassInstance* self, Py::Tuple& args, Py::Dict& kdws);
 


### PR DESCRIPTION
When setting the selection filter below and hovering over an object causes a segmentation fault: filter = Gui.Selection.Filter('SELECT Part::Feature') Gui.Selection.addSelectionGate(filter)