### PR TITLE
libkdtree++: fix deprecation warning

### DIFF
--- a/src/3rdParty/libkdtree/kdtree++/iterator.hpp
+++ b/src/3rdParty/libkdtree/kdtree++/iterator.hpp
@@ -54,8 +54,8 @@ namespace KDTree
 
     inline _Base_iterator(_Base_const_ptr const __N = NULL)
       : _M_node(__N) {}
-    inline _Base_iterator(_Base_iterator const& __THAT)
-      : _M_node(__THAT._M_node) {}
+    //inline _Base_iterator(_Base_iterator const& __THAT)
+    //  : _M_node(__THAT._M_node) {}
 
     inline void
     _M_increment()


### PR DESCRIPTION
definition of implicit copy assignment operator for '_Base_iterator' is deprecated because it has a user-provided copy constructor [-Wdeprecated-copy-with-user-provided-copy]