### PR TITLE
Sketcher_Dimension : Implement selection->tool workflow

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -2297,6 +2297,7 @@ CmdSketcherDimension::CmdSketcherDimension()
 void CmdSketcherDimension::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+    App::AutoTransaction::setEnable(false);
 
     // get the selection
     std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1078,7 +1078,7 @@ public:
 class DrawSketchHandlerDimension : public DrawSketchHandler
 {
 public:
-    DrawSketchHandlerDimension()
+    DrawSketchHandlerDimension(std::vector<std::string>& SubNames)
         : specialConstraint(SpecialConstraint::None)
         , availableConstraint(AvailableConstraint::FIRST)
         , previousOnSketchPos(Base::Vector2d(0.f, 0.f))
@@ -1086,6 +1086,7 @@ public:
         , selLine({})
         , selCircleArc({})
         , selEllipseAndCo({})
+        , initialSelection(SubNames)
         , numberOfConstraintsCreated(0)
     {
     }
@@ -1110,8 +1111,6 @@ public:
 
     void activated() override
     {
-        Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Dimension"));
-
         Obj = sketchgui->getSketchObject();
 
         // Constrain icon size in px
@@ -1138,6 +1137,8 @@ public:
             hotY *= pixelRatio;
         }
         setCursor(cursorPixmap, hotX, hotY, false);
+
+        handleInitialSelection();
     }
 
     void deactivated() override
@@ -1208,7 +1209,6 @@ public:
     bool releaseButton(Base::Vector2d onSketchPos) override
     {
         Q_UNUSED(onSketchPos);
-
         availableConstraint = AvailableConstraint::FIRST;
         SelIdPair selIdPair;
         selIdPair.GeoId = GeoEnum::GeoUndef;
@@ -1294,9 +1294,50 @@ protected:
     std::vector<SelIdPair> selCircleArc;
     std::vector<SelIdPair> selEllipseAndCo;
 
+    std::vector<std::string> initialSelection;
+
     int numberOfConstraintsCreated;
 
     Sketcher::SketchObject* Obj;
+
+    void handleInitialSelection()
+    {
+        if (initialSelection.size() == 0) {
+            return;
+        }
+
+        availableConstraint = AvailableConstraint::FIRST;
+
+        // Add the selected elements to their corresponding selection vectors
+        for (auto& selElement : initialSelection) {
+            SelIdPair selIdPair;
+            getIdsFromName(selElement, Obj, selIdPair.GeoId, selIdPair.PosId);
+
+            Base::Type newselGeoType = Base::Type::badType();
+            if (isEdge(selIdPair.GeoId, selIdPair.PosId)) {
+                const Part::Geometry* geo = Obj->getGeometry(selIdPair.GeoId);
+                newselGeoType = geo->getTypeId();
+            }
+            else if (isVertex(selIdPair.GeoId, selIdPair.PosId)) {
+                newselGeoType = Part::GeomPoint::getClassTypeId();
+            }
+
+            std::vector<SelIdPair>& selVector = getSelectionVector(newselGeoType);
+
+            //add the geometry to its type vector. Temporarily if not selAllowed
+            selVector.push_back(selIdPair);
+        }
+
+        // See if the selection is valid
+        bool selAllowed = makeAppropriateConstraint(Base::Vector2d(0.,0.));
+
+        if (!selAllowed) {
+            selPoints.clear();
+            selLine.clear();
+            selCircleArc.clear();
+            selEllipseAndCo.clear();
+        }
+    }
 
     void finalizeCommand()
     {
@@ -2256,8 +2297,17 @@ CmdSketcherDimension::CmdSketcherDimension()
 void CmdSketcherDimension::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    ActivateHandler(getActiveGuiDocument(), new DrawSketchHandlerDimension());
-    getSelection().clearSelection();
+
+    // get the selection
+    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    std::vector<std::string> SubNames = {};
+
+    // only one sketch with its subelements are allowed to be selected
+    if (selection.size() == 1 && selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
+        SubNames = selection[0].getSubNames();
+    }
+
+    ActivateHandler(getActiveGuiDocument(), new DrawSketchHandlerDimension(SubNames));
 }
 
 void CmdSketcherDimension::updateAction(int mode)


### PR DESCRIPTION
Edit: It is now working and solves https://github.com/FreeCAD/FreeCAD/issues/10443


Initial text:

> Try to solve https://github.com/FreeCAD/FreeCAD/issues/10443
> However there is an interesting issue.
> I handle the initial selection in the DSH activated function.
> 
> ```
> class DrawSketchHandlerDimension : public DrawSketchHandler
> {
>     void activated() override
>     {
>         ....
>         handleInitialSelection();
>     }
> ```
> 
> It works, you can select a line, trigger the tool, then it creates the correct constraint.
> 
> However it appears that in this case the opened transation is commited immediately after.
> 
> Having a closer look, it does not come from my code. I think the open transaction is automatically closed after the command activated function is finished : 
> 
> ```
> void CmdSketcherDimension::activated(int iMsg)
> {
>     ...
>     ActivateHandler(getActiveGuiDocument(), new DrawSketchHandlerDimension(SubNames));
> }
> ```
> So it seems that I open a transaction in ActivateHandler. Then something is closing the transaction after CmdSketcherDimension::activated finishes its execution.
> 
> I also see that the selection is cleared automatically.
> 
> @wwmayer do you know what is happening here?
