### PR TITLE
[TD]fix keyboard zoomIn/zoomOut for Touchpad mode

### DIFF
--- a/src/Mod/TechDraw/Gui/QGVNavStyle.cpp
+++ b/src/Mod/TechDraw/Gui/QGVNavStyle.cpp
@@ -109,20 +109,21 @@ void QGVNavStyle::handleFocusOutEvent(QFocusEvent* event)
 
 void QGVNavStyle::handleKeyPressEvent(QKeyEvent* event)
 {
+//    Base::Console().Message("QGNS::handleKeyPressEvent(%d)\n", event->key());
     if (event->modifiers().testFlag(Qt::ControlModifier)) {
         switch (event->key()) {
             case Qt::Key_Plus: {
-                zoom(1.0 + zoomStep);
+                zoomIn();
                 event->accept();
-                break;
+                return;
             }
             case Qt::Key_Minus: {
-                zoom(1.0 - zoomStep);
+                zoomOut();
                 event->accept();
-                break;
+                return;
             }
             default: {
-                break;
+                return;
             }
         }
     }
@@ -132,35 +133,35 @@ void QGVNavStyle::handleKeyPressEvent(QKeyEvent* event)
             case Qt::Key_Left: {
                 getViewer()->kbPanScroll(1, 0);
                 event->accept();
-                break;
+                return;
             }
             case Qt::Key_Up: {
                 getViewer()->kbPanScroll(0, 1);
                 event->accept();
-                break;
+                return;
             }
             case Qt::Key_Right: {
                 getViewer()->kbPanScroll(-1, 0);
                 event->accept();
-                break;
+                return;
             }
             case Qt::Key_Down: {
                 getViewer()->kbPanScroll(0, -1);
                 event->accept();
-                break;
+                return;
             }
             case Qt::Key_Escape: {
                 getViewer()->cancelBalloonPlacing();
                 event->accept();
-                break;
+                return;
             }
             case Qt::Key_Shift: {
                 this->shiftdown = true;
                 event->accept();
-                break;
+                return;
             }
             default: {
-                break;
+                return;
             }
         }
     }
@@ -335,6 +336,16 @@ double QGVNavStyle::mouseZoomFactor(QPoint p)
     double factor = 1.0 + (direction * zoomStep);
     zoomOrigin = p;
     return factor;
+}
+
+void QGVNavStyle::zoomIn()
+{
+    zoom(1.0 + zoomStep);
+}
+
+void QGVNavStyle::zoomOut()
+{
+    zoom(1.0 - zoomStep);
 }
 
 void QGVNavStyle::startPan(QPoint p)

--- a/src/Mod/TechDraw/Gui/QGVNavStyle.h
+++ b/src/Mod/TechDraw/Gui/QGVNavStyle.h
@@ -85,6 +85,8 @@ public:
     virtual void zoom(double factor);
     virtual void stopZoom();
     virtual double mouseZoomFactor(QPoint p);
+    virtual void zoomIn();
+    virtual void zoomOut();
 
     virtual void startPan(QPoint p);
     virtual void pan(QPoint p);

--- a/src/Mod/TechDraw/Gui/QGVNavStyleTouchpad.cpp
+++ b/src/Mod/TechDraw/Gui/QGVNavStyleTouchpad.cpp
@@ -48,16 +48,18 @@ void QGVNavStyleTouchpad::handleKeyPressEvent(QKeyEvent *event)
 {
 //    Q_UNUSED(event)
     if (event->key() == Qt::Key_PageUp) {
-        zoom(1.0 + zoomStep);
+        zoomIn();
         event->accept();
         return;
     }
 
     if (event->key() == Qt::Key_PageDown) {
-        zoom(1.0 - zoomStep);
+        zoomOut();
         event->accept();
         return;
     }
+
+    QGVNavStyle::handleKeyPressEvent(event);
 }
 
 void QGVNavStyleTouchpad::handleKeyReleaseEvent(QKeyEvent *event)
@@ -94,6 +96,7 @@ void QGVNavStyleTouchpad::handleMouseMoveEvent(QMouseEvent *event)
             startPan(event->pos());
         }
         event->accept();
+        return;
     }
 
     if (QGuiApplication::keyboardModifiers().testFlag(Qt::ControlModifier) &&
@@ -105,7 +108,13 @@ void QGVNavStyleTouchpad::handleMouseMoveEvent(QMouseEvent *event)
             startZoom(event->pos());
         }
         event->accept();
+        return;
     }
+
+    // if the mouse moves, but we are not zooming or panning, then we should make
+    // sure that zoom and pan are turned off.
+    stopPan();
+    stopZoom();
 }
 
 void QGVNavStyleTouchpad::setAnchor()


### PR DESCRIPTION
This PR implements a partial fix for #10406.  It adds ctl++ and ctl+- zooming in Touchpad mode.

Zooming from the View menu remains to be fixed.