### PR TITLE
FEM: disable the Constraints without solver submenu - part2

### DIFF
--- a/src/Mod/Fem/Gui/Workbench.cpp
+++ b/src/Mod/Fem/Gui/Workbench.cpp
@@ -326,7 +326,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
         << thermal
         << "Separator"
 //        << nosolver
-        << "Separator"
+//        << "Separator"
         << constants;
 
     Gui::MenuItem* mesh = new Gui::MenuItem;


### PR DESCRIPTION
Temporarily disable the Constraints without Solver submenu from the GUI.
+ a forgotten separator
https://github.com/FreeCAD/FreeCAD/issues/10135

please squash with #10457
Chennes, thank you for guiding me.