### PR TITLE
Bug fix: Allow Draft WB to import in FreeCAD headless docker container

### DIFF
--- a/src/Mod/Draft/draftmake/make_hatch.py
+++ b/src/Mod/Draft/draftmake/make_hatch.py
@@ -24,7 +24,8 @@
 
 import FreeCAD
 from draftobjects.hatch import Hatch
-from draftviewproviders.view_hatch import ViewProviderDraftHatch
+if FreeCAD.GuiUp:
+    from draftviewproviders.view_hatch import ViewProviderDraftHatch
 
 def make_hatch(baseobject, filename, pattern, scale, rotation):
 


### PR DESCRIPTION
# Description

Not able to import  `Draft` workbench in FreeCAD docker image compiled without GUI element.

Here is the dockerfile: [https://github.com/amrit3701/docker-freecad-cli/blob/master/0.21/amd64/Dockerfile](https://github.com/amrit3701/docker-freecad-cli/blob/master/0.21/amd64/Dockerfile)

Image already published: [https://hub.docker.com/r/amrit3701/freecad-cli/tags](https://hub.docker.com/r/amrit3701/freecad-cli/tags)
