### PR TITLE
labels.yml: Add Assembly workbench auto-tag back in

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -16,6 +16,9 @@ Addon Manager:
 WB Arch:
 - 'src/Mod/Arch/**/*'
 
+WB Assembly:
+- `src/Mod/Assembly/**/*
+
 WB Draft:
 - 'src/Mod/Draft/**/*'
 


### PR DESCRIPTION
In lieu of #10427 which kickstarted Assembly development, we can add auto-tag assembly wb PRs back in again. Note: I've also re-activated the WB Assembly tag. 

[skip ci]