### PR TITLE
CI: Fix syntax in labeler

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -17,7 +17,7 @@ WB Arch:
 - 'src/Mod/Arch/**/*'
 
 WB Assembly:
-- `src/Mod/Assembly/**/*
+- 'src/Mod/Assembly/**/*'
 
 WB Draft:
 - 'src/Mod/Draft/**/*'


### PR DESCRIPTION
Syntax error in GitHub YAML file.