### PR TITLE
Gui: make GroupCommand more flexible

### DIFF
--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1006,6 +1006,36 @@ GroupCommand::GroupCommand(const char *name)
     :Command(name)
 {}
 
+bool GroupCommand::isCheckable() const
+{
+    return checkable;
+}
+
+void GroupCommand::setCheckable(bool on)
+{
+    checkable = on;
+}
+
+bool GroupCommand::isExclusive() const
+{
+    return exclusive;
+}
+
+void GroupCommand::setExclusive(bool on)
+{
+    exclusive = on;
+}
+
+bool GroupCommand::hasDropDownMenu() const
+{
+    return dropDownMenu;
+}
+
+void GroupCommand::setDropDownMenu(bool on)
+{
+    dropDownMenu = on;
+}
+
 int GroupCommand::addCommand(Command *cmd, bool reg) {
     cmds.emplace_back(cmd,cmds.size());
     if(cmd && reg)
@@ -1030,9 +1060,9 @@ Command *GroupCommand::getCommand(int idx) const
 Action * GroupCommand::createAction() {
     auto* pcAction = new ActionGroup(this, getMainWindow());
     pcAction->setMenuRole(QAction::NoRole);
-    pcAction->setDropDownMenu(true);
-    pcAction->setExclusive(false);
-    pcAction->setCheckable(true);
+    pcAction->setDropDownMenu(hasDropDownMenu());
+    pcAction->setExclusive(isExclusive());
+    pcAction->setCheckable(isCheckable());
     pcAction->setWhatsThis(QString::fromLatin1(sWhatsThis));
 
     for(auto &v : cmds) {

--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -652,6 +652,12 @@ public:
 
     Command *getCommand(int idx) const;
 protected:
+    bool isCheckable() const;
+    void setCheckable(bool);
+    bool isExclusive() const;
+    void setExclusive(bool);
+    bool hasDropDownMenu() const;
+    void setDropDownMenu(bool);
     void activated(int iMsg) override;
     Gui::Action * createAction() override;
     void languageChange() override;
@@ -659,6 +665,9 @@ protected:
     void setup(Action *);
 
 protected:
+    bool checkable = true;
+    bool exclusive = false;
+    bool dropDownMenu = true;
     std::vector<std::pair<Command*,size_t> > cmds;
 };
 


### PR DESCRIPTION
Currently the GroupCommand by default sets the action group as non-exclusive, checkable and having a drop-down menu which isn't always the desired behaviour in sub-classes. Thus, some new methods are added to let a sub-class in its constructor decide how it should behave.