### PR TITLE
Draft: Allow to set a custom feet separator for dimensions

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
@@ -538,7 +538,7 @@ such as &quot;Arial:Bold&quot;</string>
         <item>
          <widget class="Gui::PrefLineEdit" name="lineEdit_2">
           <property name="toolTip">
-           <string>Here you can set an optional, customized separator to apear between the feet and inches values on dimensions</string>
+           <string>Optional string to appear between the feet and inches values in dimensions</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>FeetSeparator</cstring>

--- a/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>537</width>
-    <height>605</height>
+    <width>555</width>
+    <height>797</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
     <number>9</number>
    </property>
    <item>
@@ -45,9 +54,9 @@
           </property>
           <property name="toolTip">
            <string>This is the default font name for all Draft texts and dimensions.
-It can be a font name such as "Arial", a default style such as "sans", "serif"
-or "mono", or a family such as "Arial,Helvetica,sans" or a name with a style
-such as "Arial:Bold"</string>
+It can be a font name such as &quot;Arial&quot;, a default style such as &quot;sans&quot;, &quot;serif&quot;
+or &quot;mono&quot;, or a family such as &quot;Arial,Helvetica,sans&quot; or a name with a style
+such as &quot;Arial:Bold&quot;</string>
           </property>
           <property name="text">
            <string/>
@@ -496,6 +505,43 @@ such as "Arial:Bold"</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>overrideUnit</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Feet separator</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefLineEdit" name="lineEdit_2">
+          <property name="toolTip">
+           <string>Here you can set an optional, customized separator to apear between the feet and inches values on dimensions</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>FeetSeparator</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/Draft</cstring>

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -572,9 +572,18 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
         # Special representation if we use 'Building US' scheme
         u_params = App.ParamGet("User parameter:BaseApp/Preferences/Units")
         if u_params.GetInt("UserSchema", 0) == 5:
-            s = App.Units.Quantity(length, App.Units.Length).UserString
-            self.string = s.replace("' ", "'- ")  # feet
-            self.string = s.replace("+", " ")
+            self.string = App.Units.Quantity(length, App.Units.Length).UserString
+            if self.string.count('"') > 1:
+                # multiple inch tokens
+                self.string = self.string.replace('"',"",self.string.count('"')-1)
+            d_params = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+            sep = d_params.GetString("FeetSeparator","")
+            if sep:
+                # use a custom separator
+                self.string = self.string.replace("' ", "'" + sep + " ")
+            self.string = self.string.replace("+", " ")
+            self.string = self.string.replace("   ", " ")
+            self.string = self.string.replace("  ", " ")
         elif hasattr(vobj, "Decimals"):
             self.string = units.display_external(length,
                                                  vobj.Decimals,

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -577,10 +577,9 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
                 # multiple inch tokens
                 self.string = self.string.replace('"',"",self.string.count('"')-1)
             d_params = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-            sep = d_params.GetString("FeetSeparator","")
-            if sep:
-                # use a custom separator
-                self.string = self.string.replace("' ", "'" + sep + " ")
+            sep = d_params.GetString("FeetSeparator"," ")
+            # use a custom separator
+            self.string = self.string.replace("' ", "'" + sep)
             self.string = self.string.replace("+", " ")
             self.string = self.string.replace("   ", " ")
             self.string = self.string.replace("  ", " ")


### PR DESCRIPTION
Currently the Draft dimensions, when set to display measurement in Building US units, simply removes the + symbol. With 0.21, Building US add an additional " symbol to overcome ambiguity. So 1' 2 3/4" is represented internally as 1' + 2" 3/4". Currently, this is rendered in Draft ad 1' 2" 3/4"

This PR:
1) removes the intermediary " so 1' +  2" 3/4" is rendered as 1' 2 3/4"
2) adds a preference setting under Draft -> Text settings to specify a custom feet separator. So for ex. by specifying a long dash ( — ), the measurement is rendered as 1' — 2 3/4"

TODO: Update https://wiki.freecad.org/Draft_Dimension