### PR TITLE
Sketcher_Dimension Replace SubNames by std::move(SubNames)

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1149,7 +1149,7 @@ public:
 class DrawSketchHandlerDimension : public DrawSketchHandler
 {
 public:
-    DrawSketchHandlerDimension(std::vector<std::string>& SubNames)
+    DrawSketchHandlerDimension(std::vector<std::string> SubNames)
         : specialConstraint(SpecialConstraint::None)
         , availableConstraint(AvailableConstraint::FIRST)
         , previousOnSketchPos(Base::Vector2d(0.f, 0.f))
@@ -1157,7 +1157,7 @@ public:
         , selLine({})
         , selCircleArc({})
         , selEllipseAndCo({})
-        , initialSelection(SubNames)
+        , initialSelection(std::move(SubNames))
         , numberOfConstraintsCreated(0)
     {
     }


### PR DESCRIPTION
Small fix, @wwmayer 