### PR TITLE
CI: Add yaml-cpp dependency to sub_lint.yml

### DIFF
--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -446,6 +446,7 @@ jobs:
                             libvtk7-dev                                 \
                             libx11-dev                                  \
                             libxerces-c-dev                             \
+                            libyaml-cpp-dev                             \
                             libzipios++-dev                             \
                             netgen                                      \
                             netgen-headers                              \


### PR DESCRIPTION
In anticipation of adding the Material WB in PR #10368.