### PR TITLE
Base: fix segfault in InventorBuilder constructor

### DIFF
--- a/src/Base/Builder3D.cpp
+++ b/src/Base/Builder3D.cpp
@@ -915,7 +915,13 @@ void TransformItem::write(InventorOutput& out) const
 InventorBuilder::InventorBuilder(std::ostream& output)
   : result(output)
 {
-    result << "#Inventor V2.1 ascii \n\n";
+    /* We must not access variable "output" here in the constructor!
+     * When this constructor is called from the constructor of the
+     * derived class Builder3D::Builder3D() then output is a reference
+     * to Builder3D's member variable which is not yet valid because
+     * this base class is constructed before the derived class.
+    */
+    firstLineWritten = false;
 }
 
 InventorBuilder:: ~InventorBuilder() = default;
@@ -930,14 +936,24 @@ void InventorBuilder::decreaseIndent()
     indent.decreaseIndent();
 }
 
+void InventorBuilder::ensureFirstLineWriten()
+{
+    if (!firstLineWritten) {
+        result << "#Inventor V2.1 ascii \n\n";
+        firstLineWritten = true;
+    }
+}
+
 void InventorBuilder::addNode(const NodeItem& node)
 {
+    ensureFirstLineWriten();
     InventorOutput out(result, indent);
     node.write(out);
 }
 
 void InventorBuilder::beginSeparator()
 {
+    ensureFirstLineWriten();
     result << indent << "Separator { \n";
     increaseIndent();
 }

--- a/src/Base/Builder3D.h
+++ b/src/Base/Builder3D.h
@@ -613,6 +613,7 @@ public:
 private:
     void increaseIndent();
     void decreaseIndent();
+    void ensureFirstLineWriten();
 
 public:
     InventorBuilder (const InventorBuilder&) = delete;
@@ -621,6 +622,7 @@ public:
 private:
     std::ostream& result;
     Indentation indent;
+    bool firstLineWritten;
 };
 
 /** A Builder class for 3D representations on App level


### PR DESCRIPTION
As described in issue #10462, the `mesh.unite(...)` command causes a crash with the error "segmentation fault".
I could also reproduce the crash by executing the single line `import Mesh; mesh = Mesh.Mesh(); mesh.unite(mesh)` in the FreeCAD GUI Python console. The problem is not only in v0.21.0 but also in master.

As far as I have found out, the problem boils down to this:
In the constructor of a derived class the initializer of the base class is called and given a reference to the derived class's member variable. Then, in the constructor of the base class, the referenced variable is accessed, but that variable was not yet constructed because it will be constructed in the derived class AFTER the base class was fully constructed.

The following code is a stand-alone example to demonstrate the problem
```
#include <iostream>
#include <sstream>

class InventorBuilder
{
public:
    explicit InventorBuilder(std::ostream& str);

private:
    std::ostream& result2;
};

InventorBuilder::InventorBuilder(std::ostream& output)
  : result2(output)
{
    result2 << "#Inventor V2.1 ascii \n\n";
}



class Builder3D : public InventorBuilder
{
public:
    Builder3D();

private:
    std::stringstream result;
};

Builder3D::Builder3D()
  : InventorBuilder(result)
{
}



int main()
{
    std::cout << "creating an object of only the base class" << std::endl;
    std::stringstream result;
    InventorBuilder aa(result);
    std::cout << "... worked normally!" << std::endl;

    std::cout << "creating an object of the derived class" << std::endl;
    Builder3D bb;
    std::cout << "... does not work -- segmentation fault" << std::endl;
    return 0;
}
```
See [here on stackoverflow](https://stackoverflow.com/questions/71679698/initialization-of-a-base-class-reference-from-a-derived-class-member) for further explanations.

To solve the problem, I changed the base class to not access the referenced variable in the constructor. Instead, the initialization will be done at the beginning of other member functions that access that referenced variable.


I will also create a backport for 0.21 after this PR is merged.