### PR TITLE
[Start] Fix Python 3.11 Unicode Errors

### DIFF
--- a/src/App/PropertyPythonObject.cpp
+++ b/src/App/PropertyPythonObject.cpp
@@ -87,6 +87,7 @@ std::string PropertyPythonObject::toString() const
             throw Py::Exception();
         Py::Callable method(pickle.getAttr(std::string("dumps")));
         Py::Object dump;
+#if PY_VERSION_HEX < 0x03b0000
         if (this->object.hasAttr("__getstate__")) {
             Py::Tuple args;
             Py::Callable state(this->object.getAttr("__getstate__"));
@@ -98,6 +99,9 @@ std::string PropertyPythonObject::toString() const
         else {
             dump = this->object;
         }
+#else
+        dump = this->object;
+#endif
 
         Py::Tuple args(1);
         args.setItem(0, dump);

--- a/src/App/PropertyPythonObject.cpp
+++ b/src/App/PropertyPythonObject.cpp
@@ -87,7 +87,6 @@ std::string PropertyPythonObject::toString() const
             throw Py::Exception();
         Py::Callable method(pickle.getAttr(std::string("dumps")));
         Py::Object dump;
-#if PY_VERSION_HEX < 0x03b0000
         if (this->object.hasAttr("__getstate__")) {
             Py::Tuple args;
             Py::Callable state(this->object.getAttr("__getstate__"));
@@ -99,9 +98,6 @@ std::string PropertyPythonObject::toString() const
         else {
             dump = this->object;
         }
-#else
-        dump = this->object;
-#endif
 
         Py::Tuple args(1);
         args.setItem(0, dump);

--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -425,7 +425,7 @@ def handle():
                             "<!--QSS-->", '<style type="text/css">' + ALTCSS + "</style>"
                         )
                 else:
-                    with codecs.open(path, encoding='utf-8') as f:
+                    with codecs.open(path, encoding="utf-8") as f:
                         ALTCSS = f.read()
                         HTML = HTML.replace(
                             "<!--QSS-->", '<style type="text/css">' + ALTCSS + "</style>"

--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -32,6 +32,7 @@ import zipfile
 import re
 import FreeCAD
 import FreeCADGui
+import codecs
 import urllib.parse
 from . import TranslationTexts
 from PySide import QtCore, QtGui
@@ -424,7 +425,7 @@ def handle():
                             "<!--QSS-->", '<style type="text/css">' + ALTCSS + "</style>"
                         )
                 else:
-                    with open(path, "r") as f:
+                    with codecs.open(path, encoding='utf-8') as f:
                         ALTCSS = f.read()
                         HTML = HTML.replace(
                             "<!--QSS-->", '<style type="text/css">' + ALTCSS + "</style>"
@@ -789,9 +790,13 @@ def exportTestFile():
 
     "Allow to check if everything is Ok"
 
-    f = open(os.path.expanduser("~") + os.sep + "freecad-startpage.html", "w")
-    f.write(handle())
-    f.close()
+    with codecs.open(
+        os.path.expanduser("~") + os.sep + "freecad-startpage.html",
+        encoding="utf-8",
+        mode="w",
+    ) as f:
+        f.write(handle())
+        f.close()
 
 
 def postStart(switch_wb=True):


### PR DESCRIPTION
On Python 3.11 (tested using Debian 12) UnicodeDecodeErrors are raised when running All Tests, this PR addresses those errors.

Example Error :
```
  File "/home/john/freecad-daily-build/Mod/Start/StartPage/StartPage.py", line 422, in handle
    ALTCSS = f.read()
             ^^^^^^^^
  File "/usr/lib/python3.11/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 421: ordinal not in range(128)
```