### PR TITLE
Gui: Add nullptr check in showRotationCenter

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1298,6 +1298,10 @@ bool View3DInventorViewer::hasAxisCross()
 void View3DInventorViewer::showRotationCenter(bool show)
 {
     SoNode* scene = getSceneGraph();
+    if (!scene) {
+        return;
+    }
+
     auto sep = static_cast<SoSeparator*>(scene);
 
     bool showEnabled = App::GetApplication()


### PR DESCRIPTION
Currently, in `~View3DInventorViewer()`, the scenegraph is freed first and then the `NavigationStyle` is freed. However, with the recently added rotation center indicator combined with refactored navigation animations in #9446, it could happen that `NavigationStyle` tries to access an already freed scenegraph and result in segmentation faults. This happens because the destructor of `NavigationStyle` would (indirectly) stop the animation and after that, try to remove the center indicator in a null scenegraph.

Freeing the `NavigationStyle` before the scenegraph could prevent this. Instead, I added a null check in `View3DInventorViewer::showRotationCenter` to make sure that method never tries to access a null scenegraph.