### PR TITLE
Sketcher: minor fix of c++ source docs for solve(..)

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -237,8 +237,12 @@ public:
        sketch and updates all dependent features When a solve only is necessary (e.g. DoF changed),
        solve() solves the sketch and updates the geometry (if updateGeoAfterSolving==true), but does
        not trigger any recompute.
-        @return 0 if no error, if error, the following codes in this order of priority: -4 if
-       overconstrained, -3 if conflicting, -1 if solver error, -2 if redundant constraints
+       @return 0 if no error, if error, the following codes in this order of priority:
+       -4 if overconstrained,
+       -3 if conflicting constraints,
+       -5 if malformed constraints,
+       -1 if solver error,
+       -2 if redundant constraints
     */
     int solve(bool updateGeoAfterSolving = true);
     /// set the datum of a Distance or Angle constraint and solve


### PR DESCRIPTION
While working on the python docs for SketchObject, I stumbled upon this little outdated c++ comment.
Since the docstring was initially written, an additional error code was added.
Just following the boy-scout rule here...