### PR TITLE
Sketcher: Fix wrong format string in PyArg_ParseTuple

### DIFF
--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -504,7 +504,7 @@ PyObject* SketchObjectPy::carbonCopy(PyObject* args)
 {
     char* ObjectName;
     PyObject* construction = Py_True;
-    if (!PyArg_ParseTuple(args, "s|O!:Give an object", &ObjectName, &PyBool_Type, &construction)) {
+    if (!PyArg_ParseTuple(args, "s|O!", &ObjectName, &PyBool_Type, &construction)) {
         return nullptr;
     }
 
@@ -541,7 +541,7 @@ PyObject* SketchObjectPy::addExternal(PyObject* args)
 {
     char* ObjectName;
     char* SubName;
-    if (!PyArg_ParseTuple(args, "ss:Give an object and subelement name", &ObjectName, &SubName)) {
+    if (!PyArg_ParseTuple(args, "ss", &ObjectName, &SubName)) {
         return nullptr;
     }
 


### PR DESCRIPTION
While working on the python docs for SketchObject, I noticed two wrong usages of the `PyArg_ParseTuple` format strings, resulting in strange error messages.

The part behind the column represents the function name itself, not an error message. So previously, an argument error looked like this: ("Give an object" is not the method name)
```
>>> obj.carbonCopy()
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: Give an object() takes at least 1 argument (0 given)
>>> obj.carbonCopy(123)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: Give an object() argument 1 must be str, not int
```

While the format string also supports a text for the complete error message (using a semicolon instead), I decided against this: Pythons standard text is more precise than this:
(the type error here is not "Give an object")
```
>>> obj.carbonCopy()
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: Give an object
>>> obj.carbonCopy(123)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: Give an object
```