### PR TITLE
Sketcher: Fix check in carbonCopy's python interface

### DIFF
--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -517,16 +517,15 @@ PyObject* SketchObjectPy::carbonCopy(PyObject* args)
         PyErr_SetString(PyExc_ValueError, str.str().c_str());
         return nullptr;
     }
-    // check if this type of external geometry is allowed
-    if (!skObj->isExternalAllowed(Obj->getDocument(), Obj)
-        && (Obj->getTypeId() != Sketcher::SketchObject::getClassTypeId())) {
+
+    bool xinv = false, yinv = false;
+    if (!skObj->isCarbonCopyAllowed(Obj->getDocument(), Obj, xinv, yinv)) {
         std::stringstream str;
         str << ObjectName << " is not allowed for a carbon copy operation in this sketch";
         PyErr_SetString(PyExc_ValueError, str.str().c_str());
         return nullptr;
     }
 
-    // add the external
     if (skObj->carbonCopy(Obj, Base::asBoolean(construction)) < 0) {
         std::stringstream str;
         str << "Not able to add the requested geometry";
@@ -565,7 +564,7 @@ PyObject* SketchObjectPy::addExternal(PyObject* args)
     // add the external
     if (skObj->addExternal(Obj, SubName) < 0) {
         std::stringstream str;
-        str << "Not able to add external shape element";
+        str << "Not able to add external shape element " << SubName;
         PyErr_SetString(PyExc_ValueError, str.str().c_str());
         return nullptr;
     }


### PR DESCRIPTION
Presumably due to a copy/paste error, carbonCopy used to verify the referenced object via `isExternalAllowed` (just like addExternal). Now using `isCarbonCopyAllowed`, the resulting error message is the expected one for wrong objects, not a generic one after the operation failed.