### PR TITLE
Proposal: Support TextSignature in PyExport.xml files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ files: |
     )
 exclude: |
     (?x)^(
+        src/Tools/generateBase/generateModel_Module.py|
         .*vcproj.*|
         .*vcxproj.*
     )

--- a/src/Tools/generateBase/generateMetaModel_Module.xsd
+++ b/src/Tools/generateBase/generateMetaModel_Module.xsd
@@ -16,6 +16,15 @@
 										<xs:element ref="Parameter" minOccurs="0" maxOccurs="unbounded"/>
 									</xs:sequence>
 									<xs:attribute name="Name" type="xs:string" use="required"/>
+									<xs:attribute name="TextSignature" type="xs:string" use="optional">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Specifies the __text__signature__ for the method.
+                                                This is similar to Argument Clinic's @text_signature,
+                                                see https://docs.python.org/3/howto/clinic.html#how-to-override-the-generated-signature
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
 									<xs:attribute name="Const" type="xs:boolean" use="optional"/>
 									<xs:attribute name="Keyword" type="xs:boolean" use="optional" default="false"/>
 									<xs:attribute name="Class" type="xs:boolean" use="optional" default="false"/>

--- a/src/Tools/generateBase/generateModel_Module.py
+++ b/src/Tools/generateBase/generateModel_Module.py
@@ -32,31 +32,28 @@ from xml.dom import Node
 # Support/utility functions.
 #
 
-
 def showIndent(outfile, level):
     for idx in range(level):
-        outfile.write("    ")
-
+        outfile.write('    ')
 
 def quote_xml(inStr):
     s1 = inStr
-    s1 = s1.replace("&", "&amp;")
-    s1 = s1.replace("<", "&lt;")
-    s1 = s1.replace('"', "&quot;")
+    s1 = s1.replace('&', '&amp;')
+    s1 = s1.replace('<', '&lt;')
+    s1 = s1.replace('"', '&quot;')
     return s1
-
 
 def quote_python(inStr):
     s1 = inStr
     if s1.find("'") == -1:
-        if s1.find("\n") == -1:
+        if s1.find('\n') == -1:
             return "'%s'" % s1
         else:
             return "'''%s'''" % s1
     else:
         if s1.find('"') != -1:
             s1 = s1.replace('"', '\\"')
-        if s1.find("\n") == -1:
+        if s1.find('\n') == -1:
             return '"%s"' % s1
         else:
             return '"""%s"""' % s1
@@ -77,85 +74,61 @@ class MixedContainer:
     TypeDecimal = 5
     TypeDouble = 6
     TypeBoolean = 7
-
     def __init__(self, category, content_type, name, value):
         self.category = category
         self.content_type = content_type
         self.name = name
         self.value = value
-
     def getCategory(self):
         return self.category
-
     def getContenttype(self, content_type):
         return self.content_type
-
     def getValue(self):
         return self.value
-
     def getName(self):
         return self.name
-
     def export(self, outfile, level, name):
         if self.category == MixedContainer.CategoryText:
             outfile.write(self.value)
         elif self.category == MixedContainer.CategorySimple:
             self.exportSimple(outfile, level, name)
-        else:  # category == MixedContainer.CategoryComplex
+        else:    # category == MixedContainer.CategoryComplex
             self.value.export(outfile, level, name)
-
     def exportSimple(self, outfile, level, name):
         if self.content_type == MixedContainer.TypeString:
-            outfile.write("<%s>%s</%s>" % (self.name, self.value, self.name))
-        elif (
-            self.content_type == MixedContainer.TypeInteger
-            or self.content_type == MixedContainer.TypeBoolean
-        ):
-            outfile.write("<%s>%d</%s>" % (self.name, self.value, self.name))
-        elif (
-            self.content_type == MixedContainer.TypeFloat
-            or self.content_type == MixedContainer.TypeDecimal
-        ):
-            outfile.write("<%s>%f</%s>" % (self.name, self.value, self.name))
+            outfile.write('<%s>%s</%s>' % (self.name, self.value, self.name))
+        elif self.content_type == MixedContainer.TypeInteger or \
+                self.content_type == MixedContainer.TypeBoolean:
+            outfile.write('<%s>%d</%s>' % (self.name, self.value, self.name))
+        elif self.content_type == MixedContainer.TypeFloat or \
+                self.content_type == MixedContainer.TypeDecimal:
+            outfile.write('<%s>%f</%s>' % (self.name, self.value, self.name))
         elif self.content_type == MixedContainer.TypeDouble:
-            outfile.write("<%s>%g</%s>" % (self.name, self.value, self.name))
-
+            outfile.write('<%s>%g</%s>' % (self.name, self.value, self.name))
     def exportLiteral(self, outfile, level, name):
         if self.category == MixedContainer.CategoryText:
             showIndent(outfile, level)
-            outfile.write(
-                'MixedContainer(%d, %d, "%s", "%s"),\n'
-                % (self.category, self.content_type, self.name, self.value)
-            )
+            outfile.write('MixedContainer(%d, %d, "%s", "%s"),\n' % \
+                (self.category, self.content_type, self.name, self.value))
         elif self.category == MixedContainer.CategorySimple:
             showIndent(outfile, level)
-            outfile.write(
-                'MixedContainer(%d, %d, "%s", "%s"),\n'
-                % (self.category, self.content_type, self.name, self.value)
-            )
-        else:  # category == MixedContainer.CategoryComplex
+            outfile.write('MixedContainer(%d, %d, "%s", "%s"),\n' % \
+                (self.category, self.content_type, self.name, self.value))
+        else:    # category == MixedContainer.CategoryComplex
             showIndent(outfile, level)
-            outfile.write(
-                'MixedContainer(%d, %d, "%s",\n'
-                % (
-                    self.category,
-                    self.content_type,
-                    self.name,
-                )
-            )
+            outfile.write('MixedContainer(%d, %d, "%s",\n' % \
+                (self.category, self.content_type, self.name,))
             self.value.exportLiteral(outfile, level + 1)
             showIndent(outfile, level)
-            outfile.write(")\n")
+            outfile.write(')\n')
 
 
 #
 # Data representation classes.
 #
 
-
 class GenerateModel:
     subclass = None
-
     def __init__(self, Module=None, PythonExport=None):
         if Module is None:
             self.Module = []
@@ -165,144 +138,89 @@ class GenerateModel:
             self.PythonExport = []
         else:
             self.PythonExport = PythonExport
-
     def factory(*args_, **kwargs_):
         if GenerateModel.subclass:
             return GenerateModel.subclass(*args_, **kwargs_)
         else:
             return GenerateModel(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getModule(self):
-        return self.Module
-
-    def setModule(self, Module):
-        self.Module = Module
-
-    def addModule(self, value):
-        self.Module.append(value)
-
-    def insertModule(self, index, value):
-        self.Module[index] = value
-
-    def getPythonexport(self):
-        return self.PythonExport
-
-    def setPythonexport(self, PythonExport):
-        self.PythonExport = PythonExport
-
-    def addPythonexport(self, value):
-        self.PythonExport.append(value)
-
-    def insertPythonexport(self, index, value):
-        self.PythonExport[index] = value
-
-    def export(self, outfile, level, name_="GenerateModel"):
+    def getModule(self): return self.Module
+    def setModule(self, Module): self.Module = Module
+    def addModule(self, value): self.Module.append(value)
+    def insertModule(self, index, value): self.Module[index] = value
+    def getPythonexport(self): return self.PythonExport
+    def setPythonexport(self, PythonExport): self.PythonExport = PythonExport
+    def addPythonexport(self, value): self.PythonExport.append(value)
+    def insertPythonexport(self, index, value): self.PythonExport[index] = value
+    def export(self, outfile, level, name_='GenerateModel'):
         showIndent(outfile, level)
-        outfile.write("<%s>\n" % name_)
+        outfile.write('<%s>\n' % name_)
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="GenerateModel"):
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='GenerateModel'):
         pass
-
-    def exportChildren(self, outfile, level, name_="GenerateModel"):
+    def exportChildren(self, outfile, level, name_='GenerateModel'):
         for Module_ in self.getModule():
             Module_.export(outfile, level)
         for PythonExport_ in self.getPythonexport():
             PythonExport_.export(outfile, level)
-
-    def exportLiteral(self, outfile, level, name_="GenerateModel"):
+    def exportLiteral(self, outfile, level, name_='GenerateModel'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         pass
-
     def exportLiteralChildren(self, outfile, level, name_):
         showIndent(outfile, level)
-        outfile.write("Module=[\n")
+        outfile.write('Module=[\n')
         level += 1
         for Module in self.Module:
             showIndent(outfile, level)
-            outfile.write("Module(\n")
+            outfile.write('Module(\n')
             Module.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
+        outfile.write('],\n')
         showIndent(outfile, level)
-        outfile.write("PythonExport=[\n")
+        outfile.write('PythonExport=[\n')
         level += 1
         for PythonExport in self.PythonExport:
             showIndent(outfile, level)
-            outfile.write("PythonExport(\n")
+            outfile.write('PythonExport(\n')
             PythonExport.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
-
+        outfile.write('],\n')
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
         pass
-
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Module":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Module':
             obj_ = Module.factory()
             obj_.build(child_)
             self.Module.append(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "PythonExport":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'PythonExport':
             obj_ = PythonExport.factory()
             obj_.build(child_)
             self.PythonExport.append(obj_)
-
-
 # end class GenerateModel
 
 
 class PythonExport:
     subclass = None
-
-    def __init__(
-        self,
-        Name="",
-        PythonName="",
-        Include="",
-        Father="",
-        Twin="",
-        Namespace="",
-        FatherInclude="",
-        FatherNamespace="",
-        Constructor=0,
-        NumberProtocol=0,
-        RichCompare=0,
-        TwinPointer="",
-        Delete=0,
-        Reference=0,
-        Initialization=0,
-        DisableNotify=0,
-        DescriptorGetter=0,
-        DescriptorSetter=0,
-        Documentation=None,
-        Methode=None,
-        Attribute=None,
-        Sequence=None,
-        CustomAttributes="",
-        ClassDeclarations="",
-        ForwardDeclarations="",
-    ):
+    def __init__(self, Name='', PythonName='', Include='', Father='', Twin='', Namespace='', FatherInclude='', FatherNamespace='', Constructor=0, NumberProtocol=0, RichCompare=0, TwinPointer='', Delete=0, Reference=0, Initialization=0, DisableNotify=0, DescriptorGetter=0, DescriptorSetter=0, Documentation=None, Methode=None, Attribute=None, Sequence=None, CustomAttributes='', ClassDeclarations='', ForwardDeclarations=''):
         self.Name = Name
         self.PythonName = PythonName
         self.Include = Include
@@ -334,217 +252,104 @@ class PythonExport:
         self.CustomAttributes = CustomAttributes
         self.ClassDeclarations = ClassDeclarations
         self.ForwardDeclarations = ForwardDeclarations
-
     def factory(*args_, **kwargs_):
         if PythonExport.subclass:
             return PythonExport.subclass(*args_, **kwargs_)
         else:
             return PythonExport(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getDocumentation(self):
-        return self.Documentation
-
-    def setDocumentation(self, Documentation):
-        self.Documentation = Documentation
-
-    def getMethode(self):
-        return self.Methode
-
-    def setMethode(self, Methode):
-        self.Methode = Methode
-
-    def addMethode(self, value):
-        self.Methode.append(value)
-
-    def insertMethode(self, index, value):
-        self.Methode[index] = value
-
-    def getAttribute(self):
-        return self.Attribute
-
-    def setAttribute(self, Attribute):
-        self.Attribute = Attribute
-
-    def addAttribute(self, value):
-        self.Attribute.append(value)
-
-    def insertAttribute(self, index, value):
-        self.Attribute[index] = value
-
-    def getSequence(self):
-        return self.Sequence
-
-    def setSequence(self, Sequence):
-        self.Sequence = Sequence
-
-    def getCustomattributes(self):
-        return self.CustomAttributes
-
-    def setCustomattributes(self, CustomAttributes):
-        self.CustomAttributes = CustomAttributes
-
-    def getClassdeclarations(self):
-        return self.ClassDeclarations
-
-    def setClassdeclarations(self, ClassDeclarations):
-        self.ClassDeclarations = ClassDeclarations
-
-    def getForwarddeclarations(self):
-        return self.ForwardDeclarations
-
-    def setForwarddeclarations(self, ForwardDeclarations):
-        self.ForwardDeclarations = ForwardDeclarations
-
-    def getName(self):
-        return self.Name
-
-    def setName(self, Name):
-        self.Name = Name
-
-    def getPythonname(self):
-        return self.PythonName
-
-    def setPythonname(self, PythonName):
-        self.PythonName = PythonName
-
-    def getInclude(self):
-        return self.Include
-
-    def setInclude(self, Include):
-        self.Include = Include
-
-    def getFather(self):
-        return self.Father
-
-    def setFather(self, Father):
-        self.Father = Father
-
-    def getTwin(self):
-        return self.Twin
-
-    def setTwin(self, Twin):
-        self.Twin = Twin
-
-    def getNamespace(self):
-        return self.Namespace
-
-    def setNamespace(self, Namespace):
-        self.Namespace = Namespace
-
-    def getFatherinclude(self):
-        return self.FatherInclude
-
-    def setFatherinclude(self, FatherInclude):
-        self.FatherInclude = FatherInclude
-
-    def getFathernamespace(self):
-        return self.FatherNamespace
-
-    def setFathernamespace(self, FatherNamespace):
-        self.FatherNamespace = FatherNamespace
-
-    def getConstructor(self):
-        return self.Constructor
-
-    def setConstructor(self, Constructor):
-        self.Constructor = Constructor
-
-    def getNumberprotocol(self):
-        return self.NumberProtocol
-
-    def setNumberprotocol(self, NumberProtocol):
-        self.NumberProtocol = NumberProtocol
-
-    def getRichcompare(self):
-        return self.RichCompare
-
-    def setRichcompare(self, RichCompare):
-        self.RichCompare = RichCompare
-
-    def getTwinpointer(self):
-        return self.TwinPointer
-
-    def setTwinpointer(self, TwinPointer):
-        self.TwinPointer = TwinPointer
-
-    def getDelete(self):
-        return self.Delete
-
-    def setDelete(self, Delete):
-        self.Delete = Delete
-
-    def getReference(self):
-        return self.Reference
-
-    def setReference(self, Reference):
-        self.Reference = Reference
-
-    def getInitialization(self):
-        return self.Initialization
-
-    def setInitialization(self, Initialization):
-        self.Initialization = Initialization
-
-    def getDisablenotify(self):
-        return self.DisableNotify
-
-    def setDisablenotify(self, DisableNotify):
-        self.DisableNotify = DisableNotify
-
-    def getDescriptorgetter(self):
-        return self.DescriptorGetter
-
-    def setDescriptorgetter(self, DescriptorGetter):
-        self.DescriptorGetter = DescriptorGetter
-
-    def getDescriptorsetter(self):
-        return self.DescriptorSetter
-
-    def setDescriptorsetter(self, DescriptorSetter):
-        self.DescriptorSetter = DescriptorSetter
-
-    def export(self, outfile, level, name_="PythonExport"):
+    def getDocumentation(self): return self.Documentation
+    def setDocumentation(self, Documentation): self.Documentation = Documentation
+    def getMethode(self): return self.Methode
+    def setMethode(self, Methode): self.Methode = Methode
+    def addMethode(self, value): self.Methode.append(value)
+    def insertMethode(self, index, value): self.Methode[index] = value
+    def getAttribute(self): return self.Attribute
+    def setAttribute(self, Attribute): self.Attribute = Attribute
+    def addAttribute(self, value): self.Attribute.append(value)
+    def insertAttribute(self, index, value): self.Attribute[index] = value
+    def getSequence(self): return self.Sequence
+    def setSequence(self, Sequence): self.Sequence = Sequence
+    def getCustomattributes(self): return self.CustomAttributes
+    def setCustomattributes(self, CustomAttributes): self.CustomAttributes = CustomAttributes
+    def getClassdeclarations(self): return self.ClassDeclarations
+    def setClassdeclarations(self, ClassDeclarations): self.ClassDeclarations = ClassDeclarations
+    def getForwarddeclarations(self): return self.ForwardDeclarations
+    def setForwarddeclarations(self, ForwardDeclarations): self.ForwardDeclarations = ForwardDeclarations
+    def getName(self): return self.Name
+    def setName(self, Name): self.Name = Name
+    def getPythonname(self): return self.PythonName
+    def setPythonname(self, PythonName): self.PythonName = PythonName
+    def getInclude(self): return self.Include
+    def setInclude(self, Include): self.Include = Include
+    def getFather(self): return self.Father
+    def setFather(self, Father): self.Father = Father
+    def getTwin(self): return self.Twin
+    def setTwin(self, Twin): self.Twin = Twin
+    def getNamespace(self): return self.Namespace
+    def setNamespace(self, Namespace): self.Namespace = Namespace
+    def getFatherinclude(self): return self.FatherInclude
+    def setFatherinclude(self, FatherInclude): self.FatherInclude = FatherInclude
+    def getFathernamespace(self): return self.FatherNamespace
+    def setFathernamespace(self, FatherNamespace): self.FatherNamespace = FatherNamespace
+    def getConstructor(self): return self.Constructor
+    def setConstructor(self, Constructor): self.Constructor = Constructor
+    def getNumberprotocol(self): return self.NumberProtocol
+    def setNumberprotocol(self, NumberProtocol): self.NumberProtocol = NumberProtocol
+    def getRichcompare(self): return self.RichCompare
+    def setRichcompare(self, RichCompare): self.RichCompare = RichCompare
+    def getTwinpointer(self): return self.TwinPointer
+    def setTwinpointer(self, TwinPointer): self.TwinPointer = TwinPointer
+    def getDelete(self): return self.Delete
+    def setDelete(self, Delete): self.Delete = Delete
+    def getReference(self): return self.Reference
+    def setReference(self, Reference): self.Reference = Reference
+    def getInitialization(self): return self.Initialization
+    def setInitialization(self, Initialization): self.Initialization = Initialization
+    def getDisablenotify(self): return self.DisableNotify
+    def setDisablenotify(self, DisableNotify): self.DisableNotify = DisableNotify
+    def getDescriptorgetter(self): return self.DescriptorGetter
+    def setDescriptorgetter(self, DescriptorGetter): self.DescriptorGetter = DescriptorGetter
+    def getDescriptorsetter(self): return self.DescriptorSetter
+    def setDescriptorsetter(self, DescriptorSetter): self.DescriptorSetter = DescriptorSetter
+    def export(self, outfile, level, name_='PythonExport'):
         showIndent(outfile, level)
-        outfile.write("<%s" % (name_,))
-        self.exportAttributes(outfile, level, name_="PythonExport")
-        outfile.write(">\n")
+        outfile.write('<%s' % (name_, ))
+        self.exportAttributes(outfile, level, name_='PythonExport')
+        outfile.write('>\n')
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="PythonExport"):
-        outfile.write(' Name="%s"' % (self.getName(),))
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='PythonExport'):
+        outfile.write(' Name="%s"' % (self.getName(), ))
         if self.getPythonname() is not None:
-            outfile.write(' PythonName="%s"' % (self.getPythonname(),))
-        outfile.write(' Include="%s"' % (self.getInclude(),))
-        outfile.write(' Father="%s"' % (self.getFather(),))
-        outfile.write(' Twin="%s"' % (self.getTwin(),))
-        outfile.write(' Namespace="%s"' % (self.getNamespace(),))
-        outfile.write(' FatherInclude="%s"' % (self.getFatherinclude(),))
-        outfile.write(' FatherNamespace="%s"' % (self.getFathernamespace(),))
+            outfile.write(' PythonName="%s"' % (self.getPythonname(), ))
+        outfile.write(' Include="%s"' % (self.getInclude(), ))
+        outfile.write(' Father="%s"' % (self.getFather(), ))
+        outfile.write(' Twin="%s"' % (self.getTwin(), ))
+        outfile.write(' Namespace="%s"' % (self.getNamespace(), ))
+        outfile.write(' FatherInclude="%s"' % (self.getFatherinclude(), ))
+        outfile.write(' FatherNamespace="%s"' % (self.getFathernamespace(), ))
         if self.getConstructor() is not None:
-            outfile.write(' Constructor="%s"' % (self.getConstructor(),))
+            outfile.write(' Constructor="%s"' % (self.getConstructor(), ))
         if self.getNumberprotocol() is not None:
-            outfile.write(' NumberProtocol="%s"' % (self.getNumberprotocol(),))
+            outfile.write(' NumberProtocol="%s"' % (self.getNumberprotocol(), ))
         if self.getRichcompare() is not None:
-            outfile.write(' RichCompare="%s"' % (self.getRichcompare(),))
-        outfile.write(' TwinPointer="%s"' % (self.getTwinpointer(),))
+            outfile.write(' RichCompare="%s"' % (self.getRichcompare(), ))
+        outfile.write(' TwinPointer="%s"' % (self.getTwinpointer(), ))
         if self.getDelete() is not None:
-            outfile.write(' Delete="%s"' % (self.getDelete(),))
+            outfile.write(' Delete="%s"' % (self.getDelete(), ))
         if self.getReference() is not None:
-            outfile.write(' Reference="%s"' % (self.getReference(),))
+            outfile.write(' Reference="%s"' % (self.getReference(), ))
         if self.getInitialization() is not None:
-            outfile.write(' Initialization="%s"' % (self.getInitialization(),))
+            outfile.write(' Initialization="%s"' % (self.getInitialization(), ))
         if self.getDisablenotify() is not None:
-            outfile.write(' DisableNotify="%s"' % (self.getDisablenotify(),))
+            outfile.write(' DisableNotify="%s"' % (self.getDisablenotify(), ))
         if self.getDescriptorgetter() is not None:
-            outfile.write(' DescriptorGetter="%s"' % (self.getDescriptorgetter(),))
+            outfile.write(' DescriptorGetter="%s"' % (self.getDescriptorgetter(), ))
         if self.getDescriptorsetter() is not None:
-            outfile.write(' DescriptorSetter="%s"' % (self.getDescriptorsetter(),))
-
-    def exportChildren(self, outfile, level, name_="PythonExport"):
+            outfile.write(' DescriptorSetter="%s"' % (self.getDescriptorsetter(), ))
+    def exportChildren(self, outfile, level, name_='PythonExport'):
         if self.Documentation:
             self.Documentation.export(outfile, level)
         for Methode_ in self.getMethode():
@@ -554,24 +359,15 @@ class PythonExport:
         if self.Sequence:
             self.Sequence.export(outfile, level)
         showIndent(outfile, level)
-        outfile.write(
-            "<CustomAttributes>%s</CustomAttributes>\n" % quote_xml(self.getCustomattributes())
-        )
+        outfile.write('<CustomAttributes>%s</CustomAttributes>\n' % quote_xml(self.getCustomattributes()))
         showIndent(outfile, level)
-        outfile.write(
-            "<ClassDeclarations>%s</ClassDeclarations>\n" % quote_xml(self.getClassdeclarations())
-        )
+        outfile.write('<ClassDeclarations>%s</ClassDeclarations>\n' % quote_xml(self.getClassdeclarations()))
         showIndent(outfile, level)
-        outfile.write(
-            "<ForwardDeclarations>%s</ForwardDeclarations>\n"
-            % quote_xml(self.getForwarddeclarations())
-        )
-
-    def exportLiteral(self, outfile, level, name_="PythonExport"):
+        outfile.write('<ForwardDeclarations>%s</ForwardDeclarations>\n' % quote_xml(self.getForwarddeclarations()))
+    def exportLiteral(self, outfile, level, name_='PythonExport'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('Name = "%s",\n' % (self.getName(),))
@@ -609,191 +405,182 @@ class PythonExport:
         outfile.write('DescriptorGetter = "%s",\n' % (self.getDescriptorgetter(),))
         showIndent(outfile, level)
         outfile.write('DescriptorSetter = "%s",\n' % (self.getDescriptorsetter(),))
-
     def exportLiteralChildren(self, outfile, level, name_):
         if self.Documentation:
             showIndent(outfile, level)
-            outfile.write("Documentation=Documentation(\n")
+            outfile.write('Documentation=Documentation(\n')
             self.Documentation.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         showIndent(outfile, level)
-        outfile.write("Methode=[\n")
+        outfile.write('Methode=[\n')
         level += 1
         for Methode in self.Methode:
             showIndent(outfile, level)
-            outfile.write("Methode(\n")
+            outfile.write('Methode(\n')
             Methode.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
+        outfile.write('],\n')
         showIndent(outfile, level)
-        outfile.write("Attribute=[\n")
+        outfile.write('Attribute=[\n')
         level += 1
         for Attribute in self.Attribute:
             showIndent(outfile, level)
-            outfile.write("Attribute(\n")
+            outfile.write('Attribute(\n')
             Attribute.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
+        outfile.write('],\n')
         if self.Sequence:
             showIndent(outfile, level)
-            outfile.write("Sequence=Sequence(\n")
+            outfile.write('Sequence=Sequence(\n')
             self.Sequence.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         showIndent(outfile, level)
-        outfile.write("CustomAttributes=%s,\n" % quote_python(self.getCustomattributes()))
+        outfile.write('CustomAttributes=%s,\n' % quote_python(self.getCustomattributes()))
         showIndent(outfile, level)
-        outfile.write("ClassDeclarations=%s,\n" % quote_python(self.getClassdeclarations()))
+        outfile.write('ClassDeclarations=%s,\n' % quote_python(self.getClassdeclarations()))
         showIndent(outfile, level)
-        outfile.write("ForwardDeclarations=%s,\n" % quote_python(self.getForwarddeclarations()))
-
+        outfile.write('ForwardDeclarations=%s,\n' % quote_python(self.getForwarddeclarations()))
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
-        if attrs.get("Name"):
-            self.Name = attrs.get("Name").value
-        if attrs.get("PythonName"):
-            self.PythonName = attrs.get("PythonName").value
-        if attrs.get("Include"):
-            self.Include = attrs.get("Include").value
-        if attrs.get("Father"):
-            self.Father = attrs.get("Father").value
-        if attrs.get("Twin"):
-            self.Twin = attrs.get("Twin").value
-        if attrs.get("Namespace"):
-            self.Namespace = attrs.get("Namespace").value
-        if attrs.get("FatherInclude"):
-            self.FatherInclude = attrs.get("FatherInclude").value
-        if attrs.get("FatherNamespace"):
-            self.FatherNamespace = attrs.get("FatherNamespace").value
-        if attrs.get("Constructor"):
-            if attrs.get("Constructor").value in ("true", "1"):
+        if attrs.get('Name'):
+            self.Name = attrs.get('Name').value
+        if attrs.get('PythonName'):
+            self.PythonName = attrs.get('PythonName').value
+        if attrs.get('Include'):
+            self.Include = attrs.get('Include').value
+        if attrs.get('Father'):
+            self.Father = attrs.get('Father').value
+        if attrs.get('Twin'):
+            self.Twin = attrs.get('Twin').value
+        if attrs.get('Namespace'):
+            self.Namespace = attrs.get('Namespace').value
+        if attrs.get('FatherInclude'):
+            self.FatherInclude = attrs.get('FatherInclude').value
+        if attrs.get('FatherNamespace'):
+            self.FatherNamespace = attrs.get('FatherNamespace').value
+        if attrs.get('Constructor'):
+            if attrs.get('Constructor').value in ('true', '1'):
                 self.Constructor = 1
-            elif attrs.get("Constructor").value in ("false", "0"):
+            elif attrs.get('Constructor').value in ('false', '0'):
                 self.Constructor = 0
             else:
-                raise ValueError("Bad boolean attribute (Constructor)")
-        if attrs.get("NumberProtocol"):
-            if attrs.get("NumberProtocol").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (Constructor)')
+        if attrs.get('NumberProtocol'):
+            if attrs.get('NumberProtocol').value in ('true', '1'):
                 self.NumberProtocol = 1
-            elif attrs.get("NumberProtocol").value in ("false", "0"):
+            elif attrs.get('NumberProtocol').value in ('false', '0'):
                 self.NumberProtocol = 0
             else:
-                raise ValueError("Bad boolean attribute (NumberProtocol)")
-        if attrs.get("RichCompare"):
-            if attrs.get("RichCompare").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (NumberProtocol)')
+        if attrs.get('RichCompare'):
+            if attrs.get('RichCompare').value in ('true', '1'):
                 self.RichCompare = 1
-            elif attrs.get("RichCompare").value in ("false", "0"):
+            elif attrs.get('RichCompare').value in ('false', '0'):
                 self.RichCompare = 0
             else:
-                raise ValueError("Bad boolean attribute (RichCompare)")
-        if attrs.get("TwinPointer"):
-            self.TwinPointer = attrs.get("TwinPointer").value
-        if attrs.get("Delete"):
-            if attrs.get("Delete").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (RichCompare)')
+        if attrs.get('TwinPointer'):
+            self.TwinPointer = attrs.get('TwinPointer').value
+        if attrs.get('Delete'):
+            if attrs.get('Delete').value in ('true', '1'):
                 self.Delete = 1
-            elif attrs.get("Delete").value in ("false", "0"):
+            elif attrs.get('Delete').value in ('false', '0'):
                 self.Delete = 0
             else:
-                raise ValueError("Bad boolean attribute (Delete)")
-        if attrs.get("Reference"):
-            if attrs.get("Reference").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (Delete)')
+        if attrs.get('Reference'):
+            if attrs.get('Reference').value in ('true', '1'):
                 self.Reference = 1
-            elif attrs.get("Reference").value in ("false", "0"):
+            elif attrs.get('Reference').value in ('false', '0'):
                 self.Reference = 0
             else:
-                raise ValueError("Bad boolean attribute (Reference)")
-        if attrs.get("Initialization"):
-            if attrs.get("Initialization").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (Reference)')
+        if attrs.get('Initialization'):
+            if attrs.get('Initialization').value in ('true', '1'):
                 self.Initialization = 1
-            elif attrs.get("Initialization").value in ("false", "0"):
+            elif attrs.get('Initialization').value in ('false', '0'):
                 self.Initialization = 0
             else:
-                raise ValueError("Bad boolean attribute (Initialization)")
-        if attrs.get("DisableNotify"):
-            if attrs.get("DisableNotify").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (Initialization)')
+        if attrs.get('DisableNotify'):
+            if attrs.get('DisableNotify').value in ('true', '1'):
                 self.DisableNotify = 1
-            elif attrs.get("DisableNotify").value in ("false", "0"):
+            elif attrs.get('DisableNotify').value in ('false', '0'):
                 self.DisableNotify = 0
             else:
-                raise ValueError("Bad boolean attribute (DisableNotify)")
-        if attrs.get("DescriptorGetter"):
-            if attrs.get("DescriptorGetter").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (DisableNotify)')
+        if attrs.get('DescriptorGetter'):
+            if attrs.get('DescriptorGetter').value in ('true', '1'):
                 self.DescriptorGetter = 1
-            elif attrs.get("DescriptorGetter").value in ("false", "0"):
+            elif attrs.get('DescriptorGetter').value in ('false', '0'):
                 self.DescriptorGetter = 0
             else:
-                raise ValueError("Bad boolean attribute (DescriptorGetter)")
-        if attrs.get("DescriptorSetter"):
-            if attrs.get("DescriptorSetter").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (DescriptorGetter)')
+        if attrs.get('DescriptorSetter'):
+            if attrs.get('DescriptorSetter').value in ('true', '1'):
                 self.DescriptorSetter = 1
-            elif attrs.get("DescriptorSetter").value in ("false", "0"):
+            elif attrs.get('DescriptorSetter').value in ('false', '0'):
                 self.DescriptorSetter = 0
             else:
-                raise ValueError("Bad boolean attribute (DescriptorSetter)")
-
+                raise ValueError('Bad boolean attribute (DescriptorSetter)')
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Documentation":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Documentation':
             obj_ = Documentation.factory()
             obj_.build(child_)
             self.setDocumentation(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Methode":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Methode':
             obj_ = Methode.factory()
             obj_.build(child_)
             self.Methode.append(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Attribute":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Attribute':
             obj_ = Attribute.factory()
             obj_.build(child_)
             self.Attribute.append(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Sequence":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Sequence':
             obj_ = Sequence.factory()
             obj_.build(child_)
             self.setSequence(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "CustomAttributes":
-            CustomAttributes_ = ""
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'CustomAttributes':
+            CustomAttributes_ = ''
             for text__content_ in child_.childNodes:
                 CustomAttributes_ += text__content_.nodeValue
             self.CustomAttributes = CustomAttributes_
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "ClassDeclarations":
-            ClassDeclarations_ = ""
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'ClassDeclarations':
+            ClassDeclarations_ = ''
             for text__content_ in child_.childNodes:
                 ClassDeclarations_ += text__content_.nodeValue
             self.ClassDeclarations = ClassDeclarations_
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "ForwardDeclarations":
-            ForwardDeclarations_ = ""
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'ForwardDeclarations':
+            ForwardDeclarations_ = ''
             for text__content_ in child_.childNodes:
                 ForwardDeclarations_ += text__content_.nodeValue
             self.ForwardDeclarations = ForwardDeclarations_
-
-
 # end class PythonExport
 
 
 class Methode:
     subclass = None
-
-    def __init__(
-        self,
-        Name="",
-        Const=0,
-        Keyword=0,
-        Class=0,
-        Static=0,
-        Documentation=None,
-        Parameter=None,
-    ):
+    def __init__(self, Name='', Const=0, Keyword=0, Class=0, Static=0, Documentation=None, Parameter=None):
         self.Name = Name
         self.Const = Const
         self.Keyword = Keyword
@@ -804,94 +591,55 @@ class Methode:
             self.Parameter = []
         else:
             self.Parameter = Parameter
-
     def factory(*args_, **kwargs_):
         if Methode.subclass:
             return Methode.subclass(*args_, **kwargs_)
         else:
             return Methode(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getDocumentation(self):
-        return self.Documentation
-
-    def setDocumentation(self, Documentation):
-        self.Documentation = Documentation
-
-    def getParameter(self):
-        return self.Parameter
-
-    def setParameter(self, Parameter):
-        self.Parameter = Parameter
-
-    def addParameter(self, value):
-        self.Parameter.append(value)
-
-    def insertParameter(self, index, value):
-        self.Parameter[index] = value
-
-    def getName(self):
-        return self.Name
-
-    def setName(self, Name):
-        self.Name = Name
-
-    def getConst(self):
-        return self.Const
-
-    def setConst(self, Const):
-        self.Const = Const
-
-    def getKeyword(self):
-        return self.Keyword
-
-    def setKeyword(self, Keyword):
-        self.Keyword = Keyword
-
-    def getClass(self):
-        return self.Class
-
-    def setClass(self, Class):
-        self.Class = Class
-
-    def getStatic(self):
-        return self.Static
-
-    def setStatic(self, Static):
-        self.Static = Static
-
-    def export(self, outfile, level, name_="Methode"):
+    def getDocumentation(self): return self.Documentation
+    def setDocumentation(self, Documentation): self.Documentation = Documentation
+    def getParameter(self): return self.Parameter
+    def setParameter(self, Parameter): self.Parameter = Parameter
+    def addParameter(self, value): self.Parameter.append(value)
+    def insertParameter(self, index, value): self.Parameter[index] = value
+    def getName(self): return self.Name
+    def setName(self, Name): self.Name = Name
+    def getConst(self): return self.Const
+    def setConst(self, Const): self.Const = Const
+    def getKeyword(self): return self.Keyword
+    def setKeyword(self, Keyword): self.Keyword = Keyword
+    def getClass(self): return self.Class
+    def setClass(self, Class): self.Class = Class
+    def getStatic(self): return self.Static
+    def setStatic(self, Static): self.Static = Static
+    def export(self, outfile, level, name_='Methode'):
         showIndent(outfile, level)
-        outfile.write("<%s" % (name_,))
-        self.exportAttributes(outfile, level, name_="Methode")
-        outfile.write(">\n")
+        outfile.write('<%s' % (name_, ))
+        self.exportAttributes(outfile, level, name_='Methode')
+        outfile.write('>\n')
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="Methode"):
-        outfile.write(' Name="%s"' % (self.getName(),))
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='Methode'):
+        outfile.write(' Name="%s"' % (self.getName(), ))
         if self.getConst() is not None:
-            outfile.write(' Const="%s"' % (self.getConst(),))
+            outfile.write(' Const="%s"' % (self.getConst(), ))
         if self.getKeyword() is not None:
-            outfile.write(' Keyword="%s"' % (self.getKeyword(),))
+            outfile.write(' Keyword="%s"' % (self.getKeyword(), ))
         if self.getClass() is not None:
-            outfile.write(' Class="%s"' % (self.getClass(),))
+            outfile.write(' Class="%s"' % (self.getClass(), ))
         if self.getStatic() is not None:
-            outfile.write(' Static="%s"' % (self.getStatic(),))
-
-    def exportChildren(self, outfile, level, name_="Methode"):
+            outfile.write(' Static="%s"' % (self.getStatic(), ))
+    def exportChildren(self, outfile, level, name_='Methode'):
         if self.Documentation:
             self.Documentation.export(outfile, level)
         for Parameter_ in self.getParameter():
             Parameter_.export(outfile, level)
-
-    def exportLiteral(self, outfile, level, name_="Methode"):
+    def exportLiteral(self, outfile, level, name_='Methode'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('Name = "%s",\n' % (self.getName(),))
@@ -903,214 +651,168 @@ class Methode:
         outfile.write('Class = "%s",\n' % (self.getClass(),))
         showIndent(outfile, level)
         outfile.write('Static = "%s",\n' % (self.getStatic(),))
-
     def exportLiteralChildren(self, outfile, level, name_):
         if self.Documentation:
             showIndent(outfile, level)
-            outfile.write("Documentation=Documentation(\n")
+            outfile.write('Documentation=Documentation(\n')
             self.Documentation.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         showIndent(outfile, level)
-        outfile.write("Parameter=[\n")
+        outfile.write('Parameter=[\n')
         level += 1
         for Parameter in self.Parameter:
             showIndent(outfile, level)
-            outfile.write("Parameter(\n")
+            outfile.write('Parameter(\n')
             Parameter.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
-
+        outfile.write('],\n')
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
-        if attrs.get("Name"):
-            self.Name = attrs.get("Name").value
-        if attrs.get("Const"):
-            if attrs.get("Const").value in ("true", "1"):
+        if attrs.get('Name'):
+            self.Name = attrs.get('Name').value
+        if attrs.get('Const'):
+            if attrs.get('Const').value in ('true', '1'):
                 self.Const = 1
-            elif attrs.get("Const").value in ("false", "0"):
+            elif attrs.get('Const').value in ('false', '0'):
                 self.Const = 0
             else:
-                raise ValueError("Bad boolean attribute (Const)")
-        if attrs.get("Keyword"):
-            if attrs.get("Keyword").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (Const)')
+        if attrs.get('Keyword'):
+            if attrs.get('Keyword').value in ('true', '1'):
                 self.Keyword = 1
-            elif attrs.get("Keyword").value in ("false", "0"):
+            elif attrs.get('Keyword').value in ('false', '0'):
                 self.Keyword = 0
             else:
-                raise ValueError("Bad boolean attribute (Keyword)")
-        if attrs.get("Class"):
-            if attrs.get("Class").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (Keyword)')
+        if attrs.get('Class'):
+            if attrs.get('Class').value in ('true', '1'):
                 self.Class = 1
-            elif attrs.get("Class").value in ("false", "0"):
+            elif attrs.get('Class').value in ('false', '0'):
                 self.Class = 0
             else:
-                raise ValueError("Bad boolean attribute (Class)")
-        if attrs.get("Static"):
-            if attrs.get("Static").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (Class)')
+        if attrs.get('Static'):
+            if attrs.get('Static').value in ('true', '1'):
                 self.Static = 1
-            elif attrs.get("Static").value in ("false", "0"):
+            elif attrs.get('Static').value in ('false', '0'):
                 self.Static = 0
             else:
-                raise ValueError("Bad boolean attribute (Static)")
-
+                raise ValueError('Bad boolean attribute (Static)')
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Documentation":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Documentation':
             obj_ = Documentation.factory()
             obj_.build(child_)
             self.setDocumentation(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Parameter":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Parameter':
             obj_ = Parameter.factory()
             obj_.build(child_)
             self.Parameter.append(obj_)
-
-
 # end class Methode
 
 
 class Attribute:
     subclass = None
-
-    def __init__(self, Name="", ReadOnly=0, Documentation=None, Parameter=None):
+    def __init__(self, Name='', ReadOnly=0, Documentation=None, Parameter=None):
         self.Name = Name
         self.ReadOnly = ReadOnly
         self.Documentation = Documentation
         self.Parameter = Parameter
-
     def factory(*args_, **kwargs_):
         if Attribute.subclass:
             return Attribute.subclass(*args_, **kwargs_)
         else:
             return Attribute(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getDocumentation(self):
-        return self.Documentation
-
-    def setDocumentation(self, Documentation):
-        self.Documentation = Documentation
-
-    def getParameter(self):
-        return self.Parameter
-
-    def setParameter(self, Parameter):
-        self.Parameter = Parameter
-
-    def getName(self):
-        return self.Name
-
-    def setName(self, Name):
-        self.Name = Name
-
-    def getReadonly(self):
-        return self.ReadOnly
-
-    def setReadonly(self, ReadOnly):
-        self.ReadOnly = ReadOnly
-
-    def export(self, outfile, level, name_="Attribute"):
+    def getDocumentation(self): return self.Documentation
+    def setDocumentation(self, Documentation): self.Documentation = Documentation
+    def getParameter(self): return self.Parameter
+    def setParameter(self, Parameter): self.Parameter = Parameter
+    def getName(self): return self.Name
+    def setName(self, Name): self.Name = Name
+    def getReadonly(self): return self.ReadOnly
+    def setReadonly(self, ReadOnly): self.ReadOnly = ReadOnly
+    def export(self, outfile, level, name_='Attribute'):
         showIndent(outfile, level)
-        outfile.write("<%s" % (name_,))
-        self.exportAttributes(outfile, level, name_="Attribute")
-        outfile.write(">\n")
+        outfile.write('<%s' % (name_, ))
+        self.exportAttributes(outfile, level, name_='Attribute')
+        outfile.write('>\n')
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="Attribute"):
-        outfile.write(' Name="%s"' % (self.getName(),))
-        outfile.write(' ReadOnly="%s"' % (self.getReadonly(),))
-
-    def exportChildren(self, outfile, level, name_="Attribute"):
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='Attribute'):
+        outfile.write(' Name="%s"' % (self.getName(), ))
+        outfile.write(' ReadOnly="%s"' % (self.getReadonly(), ))
+    def exportChildren(self, outfile, level, name_='Attribute'):
         if self.Documentation:
             self.Documentation.export(outfile, level)
         if self.Parameter:
             self.Parameter.export(outfile, level)
-
-    def exportLiteral(self, outfile, level, name_="Attribute"):
+    def exportLiteral(self, outfile, level, name_='Attribute'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('Name = "%s",\n' % (self.getName(),))
         showIndent(outfile, level)
         outfile.write('ReadOnly = "%s",\n' % (self.getReadonly(),))
-
     def exportLiteralChildren(self, outfile, level, name_):
         if self.Documentation:
             showIndent(outfile, level)
-            outfile.write("Documentation=Documentation(\n")
+            outfile.write('Documentation=Documentation(\n')
             self.Documentation.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         if self.Parameter:
             showIndent(outfile, level)
-            outfile.write("Parameter=Parameter(\n")
+            outfile.write('Parameter=Parameter(\n')
             self.Parameter.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
-
+            outfile.write('),\n')
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
-        if attrs.get("Name"):
-            self.Name = attrs.get("Name").value
-        if attrs.get("ReadOnly"):
-            if attrs.get("ReadOnly").value in ("true", "1"):
+        if attrs.get('Name'):
+            self.Name = attrs.get('Name').value
+        if attrs.get('ReadOnly'):
+            if attrs.get('ReadOnly').value in ('true', '1'):
                 self.ReadOnly = 1
-            elif attrs.get("ReadOnly").value in ("false", "0"):
+            elif attrs.get('ReadOnly').value in ('false', '0'):
                 self.ReadOnly = 0
             else:
-                raise ValueError("Bad boolean attribute (ReadOnly)")
-
+                raise ValueError('Bad boolean attribute (ReadOnly)')
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Documentation":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Documentation':
             obj_ = Documentation.factory()
             obj_.build(child_)
             self.setDocumentation(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Parameter":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Parameter':
             obj_ = Parameter.factory()
             obj_.build(child_)
             self.setParameter(obj_)
-
-
 # end class Attribute
 
 
 class Sequence:
     subclass = None
-
-    def __init__(
-        self,
-        sq_length=0,
-        sq_concat=0,
-        sq_repeat=0,
-        sq_item=0,
-        mp_subscript=0,
-        sq_ass_item=0,
-        mp_ass_subscript=0,
-        sq_contains=0,
-        sq_inplace_concat=0,
-        sq_inplace_repeat=0,
-        valueOf_="",
-    ):
+    def __init__(self, sq_length=0, sq_concat=0, sq_repeat=0, sq_item=0, mp_subscript=0, sq_ass_item=0, mp_ass_subscript=0, sq_contains=0, sq_inplace_concat=0, sq_inplace_repeat=0, valueOf_=''):
         self.sq_length = sq_length
         self.sq_concat = sq_concat
         self.sq_repeat = sq_repeat
@@ -1122,110 +824,59 @@ class Sequence:
         self.sq_inplace_concat = sq_inplace_concat
         self.sq_inplace_repeat = sq_inplace_repeat
         self.valueOf_ = valueOf_
-
     def factory(*args_, **kwargs_):
         if Sequence.subclass:
             return Sequence.subclass(*args_, **kwargs_)
         else:
             return Sequence(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getSq_length(self):
-        return self.sq_length
-
-    def setSq_length(self, sq_length):
-        self.sq_length = sq_length
-
-    def getSq_concat(self):
-        return self.sq_concat
-
-    def setSq_concat(self, sq_concat):
-        self.sq_concat = sq_concat
-
-    def getSq_repeat(self):
-        return self.sq_repeat
-
-    def setSq_repeat(self, sq_repeat):
-        self.sq_repeat = sq_repeat
-
-    def getSq_item(self):
-        return self.sq_item
-
-    def setSq_item(self, sq_item):
-        self.sq_item = sq_item
-
-    def getMp_subscript(self):
-        return self.mp_subscript
-
-    def setMp_subscript(self, mp_subscript):
-        self.mp_subscript = mp_subscript
-
-    def getSq_ass_item(self):
-        return self.sq_ass_item
-
-    def setSq_ass_item(self, sq_ass_item):
-        self.sq_ass_item = sq_ass_item
-
-    def getMp_ass_subscript(self):
-        return self.mp_ass_subscript
-
-    def setMp_ass_subscript(self, mp_ass_subscript):
-        self.mp_ass_subscript = mp_ass_subscript
-
-    def getSq_contains(self):
-        return self.sq_contains
-
-    def setSq_contains(self, sq_contains):
-        self.sq_contains = sq_contains
-
-    def getSq_inplace_concat(self):
-        return self.sq_inplace_concat
-
-    def setSq_inplace_concat(self, sq_inplace_concat):
-        self.sq_inplace_concat = sq_inplace_concat
-
-    def getSq_inplace_repeat(self):
-        return self.sq_inplace_repeat
-
-    def setSq_inplace_repeat(self, sq_inplace_repeat):
-        self.sq_inplace_repeat = sq_inplace_repeat
-
-    def getValueOf_(self):
-        return self.valueOf_
-
-    def setValueOf_(self, valueOf_):
-        self.valueOf_ = valueOf_
-
-    def export(self, outfile, level, name_="Sequence"):
+    def getSq_length(self): return self.sq_length
+    def setSq_length(self, sq_length): self.sq_length = sq_length
+    def getSq_concat(self): return self.sq_concat
+    def setSq_concat(self, sq_concat): self.sq_concat = sq_concat
+    def getSq_repeat(self): return self.sq_repeat
+    def setSq_repeat(self, sq_repeat): self.sq_repeat = sq_repeat
+    def getSq_item(self): return self.sq_item
+    def setSq_item(self, sq_item): self.sq_item = sq_item
+    def getMp_subscript(self): return self.mp_subscript
+    def setMp_subscript(self, mp_subscript): self.mp_subscript = mp_subscript
+    def getSq_ass_item(self): return self.sq_ass_item
+    def setSq_ass_item(self, sq_ass_item): self.sq_ass_item = sq_ass_item
+    def getMp_ass_subscript(self): return self.mp_ass_subscript
+    def setMp_ass_subscript(self, mp_ass_subscript): self.mp_ass_subscript = mp_ass_subscript
+    def getSq_contains(self): return self.sq_contains
+    def setSq_contains(self, sq_contains): self.sq_contains = sq_contains
+    def getSq_inplace_concat(self): return self.sq_inplace_concat
+    def setSq_inplace_concat(self, sq_inplace_concat): self.sq_inplace_concat = sq_inplace_concat
+    def getSq_inplace_repeat(self): return self.sq_inplace_repeat
+    def setSq_inplace_repeat(self, sq_inplace_repeat): self.sq_inplace_repeat = sq_inplace_repeat
+    def getValueOf_(self): return self.valueOf_
+    def setValueOf_(self, valueOf_): self.valueOf_ = valueOf_
+    def export(self, outfile, level, name_='Sequence'):
         showIndent(outfile, level)
-        outfile.write("<%s" % (name_,))
-        self.exportAttributes(outfile, level, name_="Sequence")
-        outfile.write(">\n")
+        outfile.write('<%s' % (name_, ))
+        self.exportAttributes(outfile, level, name_='Sequence')
+        outfile.write('>\n')
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="Sequence"):
-        outfile.write(' sq_length="%s"' % (self.getSq_length(),))
-        outfile.write(' sq_concat="%s"' % (self.getSq_concat(),))
-        outfile.write(' sq_repeat="%s"' % (self.getSq_repeat(),))
-        outfile.write(' sq_item="%s"' % (self.getSq_item(),))
-        outfile.write(' mp_subscript="%s"' % (self.getMp_subscript(),))
-        outfile.write(' sq_ass_item="%s"' % (self.getSq_ass_item(),))
-        outfile.write(' mp_ass_subscript="%s"' % (self.getMp_ass_subscript(),))
-        outfile.write(' sq_contains="%s"' % (self.getSq_contains(),))
-        outfile.write(' sq_inplace_concat="%s"' % (self.getSq_inplace_concat(),))
-        outfile.write(' sq_inplace_repeat="%s"' % (self.getSq_inplace_repeat(),))
-
-    def exportChildren(self, outfile, level, name_="Sequence"):
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='Sequence'):
+        outfile.write(' sq_length="%s"' % (self.getSq_length(), ))
+        outfile.write(' sq_concat="%s"' % (self.getSq_concat(), ))
+        outfile.write(' sq_repeat="%s"' % (self.getSq_repeat(), ))
+        outfile.write(' sq_item="%s"' % (self.getSq_item(), ))
+        outfile.write(' mp_subscript="%s"' % (self.getMp_subscript(), ))
+        outfile.write(' sq_ass_item="%s"' % (self.getSq_ass_item(), ))
+        outfile.write(' mp_ass_subscript="%s"' % (self.getMp_ass_subscript(), ))
+        outfile.write(' sq_contains="%s"' % (self.getSq_contains(), ))
+        outfile.write(' sq_inplace_concat="%s"' % (self.getSq_inplace_concat(), ))
+        outfile.write(' sq_inplace_repeat="%s"' % (self.getSq_inplace_repeat(), ))
+    def exportChildren(self, outfile, level, name_='Sequence'):
         outfile.write(self.valueOf_)
-
-    def exportLiteral(self, outfile, level, name_="Sequence"):
+    def exportLiteral(self, outfile, level, name_='Sequence'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('sq_length = "%s",\n' % (self.getSq_length(),))
@@ -1247,315 +898,253 @@ class Sequence:
         outfile.write('sq_inplace_concat = "%s",\n' % (self.getSq_inplace_concat(),))
         showIndent(outfile, level)
         outfile.write('sq_inplace_repeat = "%s",\n' % (self.getSq_inplace_repeat(),))
-
     def exportLiteralChildren(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('valueOf_ = "%s",\n' % (self.valueOf_,))
-
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
-        if attrs.get("sq_length"):
-            if attrs.get("sq_length").value in ("true", "1"):
+        if attrs.get('sq_length'):
+            if attrs.get('sq_length').value in ('true', '1'):
                 self.sq_length = 1
-            elif attrs.get("sq_length").value in ("false", "0"):
+            elif attrs.get('sq_length').value in ('false', '0'):
                 self.sq_length = 0
             else:
-                raise ValueError("Bad boolean attribute (sq_length)")
-        if attrs.get("sq_concat"):
-            if attrs.get("sq_concat").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (sq_length)')
+        if attrs.get('sq_concat'):
+            if attrs.get('sq_concat').value in ('true', '1'):
                 self.sq_concat = 1
-            elif attrs.get("sq_concat").value in ("false", "0"):
+            elif attrs.get('sq_concat').value in ('false', '0'):
                 self.sq_concat = 0
             else:
-                raise ValueError("Bad boolean attribute (sq_concat)")
-        if attrs.get("sq_repeat"):
-            if attrs.get("sq_repeat").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (sq_concat)')
+        if attrs.get('sq_repeat'):
+            if attrs.get('sq_repeat').value in ('true', '1'):
                 self.sq_repeat = 1
-            elif attrs.get("sq_repeat").value in ("false", "0"):
+            elif attrs.get('sq_repeat').value in ('false', '0'):
                 self.sq_repeat = 0
             else:
-                raise ValueError("Bad boolean attribute (sq_repeat)")
-        if attrs.get("sq_item"):
-            if attrs.get("sq_item").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (sq_repeat)')
+        if attrs.get('sq_item'):
+            if attrs.get('sq_item').value in ('true', '1'):
                 self.sq_item = 1
-            elif attrs.get("sq_item").value in ("false", "0"):
+            elif attrs.get('sq_item').value in ('false', '0'):
                 self.sq_item = 0
             else:
-                raise ValueError("Bad boolean attribute (sq_item)")
-        if attrs.get("mp_subscript"):
-            if attrs.get("mp_subscript").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (sq_item)')
+        if attrs.get('mp_subscript'):
+            if attrs.get('mp_subscript').value in ('true', '1'):
                 self.mp_subscript = 1
-            elif attrs.get("mp_subscript").value in ("false", "0"):
+            elif attrs.get('mp_subscript').value in ('false', '0'):
                 self.mp_subscript = 0
             else:
-                raise ValueError("Bad boolean attribute (mp_subscript)")
-        if attrs.get("sq_ass_item"):
-            if attrs.get("sq_ass_item").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (mp_subscript)')
+        if attrs.get('sq_ass_item'):
+            if attrs.get('sq_ass_item').value in ('true', '1'):
                 self.sq_ass_item = 1
-            elif attrs.get("sq_ass_item").value in ("false", "0"):
+            elif attrs.get('sq_ass_item').value in ('false', '0'):
                 self.sq_ass_item = 0
             else:
-                raise ValueError("Bad boolean attribute (sq_ass_item)")
-        if attrs.get("mp_ass_subscript"):
-            if attrs.get("mp_ass_subscript").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (sq_ass_item)')
+        if attrs.get('mp_ass_subscript'):
+            if attrs.get('mp_ass_subscript').value in ('true', '1'):
                 self.mp_ass_subscript = 1
-            elif attrs.get("mp_ass_subscript").value in ("false", "0"):
+            elif attrs.get('mp_ass_subscript').value in ('false', '0'):
                 self.mp_ass_subscript = 0
             else:
-                raise ValueError("Bad boolean attribute (mp_ass_subscript)")
-        if attrs.get("sq_contains"):
-            if attrs.get("sq_contains").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (mp_ass_subscript)')
+        if attrs.get('sq_contains'):
+            if attrs.get('sq_contains').value in ('true', '1'):
                 self.sq_contains = 1
-            elif attrs.get("sq_contains").value in ("false", "0"):
+            elif attrs.get('sq_contains').value in ('false', '0'):
                 self.sq_contains = 0
             else:
-                raise ValueError("Bad boolean attribute (sq_contains)")
-        if attrs.get("sq_inplace_concat"):
-            if attrs.get("sq_inplace_concat").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (sq_contains)')
+        if attrs.get('sq_inplace_concat'):
+            if attrs.get('sq_inplace_concat').value in ('true', '1'):
                 self.sq_inplace_concat = 1
-            elif attrs.get("sq_inplace_concat").value in ("false", "0"):
+            elif attrs.get('sq_inplace_concat').value in ('false', '0'):
                 self.sq_inplace_concat = 0
             else:
-                raise ValueError("Bad boolean attribute (sq_inplace_concat)")
-        if attrs.get("sq_inplace_repeat"):
-            if attrs.get("sq_inplace_repeat").value in ("true", "1"):
+                raise ValueError('Bad boolean attribute (sq_inplace_concat)')
+        if attrs.get('sq_inplace_repeat'):
+            if attrs.get('sq_inplace_repeat').value in ('true', '1'):
                 self.sq_inplace_repeat = 1
-            elif attrs.get("sq_inplace_repeat").value in ("false", "0"):
+            elif attrs.get('sq_inplace_repeat').value in ('false', '0'):
                 self.sq_inplace_repeat = 0
             else:
-                raise ValueError("Bad boolean attribute (sq_inplace_repeat)")
-
+                raise ValueError('Bad boolean attribute (sq_inplace_repeat)')
     def buildChildren(self, child_, nodeName_):
-        self.valueOf_ = ""
+        self.valueOf_ = ''
         for child in child_.childNodes:
             if child.nodeType == Node.TEXT_NODE:
                 self.valueOf_ += child.nodeValue
-
-
 # end class Sequence
 
 
 class Module:
     subclass = None
-
-    def __init__(self, Name="", Documentation=None, Dependencies=None, Content=None):
+    def __init__(self, Name='', Documentation=None, Dependencies=None, Content=None):
         self.Name = Name
         self.Documentation = Documentation
         self.Dependencies = Dependencies
         self.Content = Content
-
     def factory(*args_, **kwargs_):
         if Module.subclass:
             return Module.subclass(*args_, **kwargs_)
         else:
             return Module(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getDocumentation(self):
-        return self.Documentation
-
-    def setDocumentation(self, Documentation):
-        self.Documentation = Documentation
-
-    def getDependencies(self):
-        return self.Dependencies
-
-    def setDependencies(self, Dependencies):
-        self.Dependencies = Dependencies
-
-    def getContent(self):
-        return self.Content
-
-    def setContent(self, Content):
-        self.Content = Content
-
-    def getName(self):
-        return self.Name
-
-    def setName(self, Name):
-        self.Name = Name
-
-    def export(self, outfile, level, name_="Module"):
+    def getDocumentation(self): return self.Documentation
+    def setDocumentation(self, Documentation): self.Documentation = Documentation
+    def getDependencies(self): return self.Dependencies
+    def setDependencies(self, Dependencies): self.Dependencies = Dependencies
+    def getContent(self): return self.Content
+    def setContent(self, Content): self.Content = Content
+    def getName(self): return self.Name
+    def setName(self, Name): self.Name = Name
+    def export(self, outfile, level, name_='Module'):
         showIndent(outfile, level)
-        outfile.write("<%s" % (name_,))
-        self.exportAttributes(outfile, level, name_="Module")
-        outfile.write(">\n")
+        outfile.write('<%s' % (name_, ))
+        self.exportAttributes(outfile, level, name_='Module')
+        outfile.write('>\n')
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="Module"):
-        outfile.write(' Name="%s"' % (self.getName(),))
-
-    def exportChildren(self, outfile, level, name_="Module"):
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='Module'):
+        outfile.write(' Name="%s"' % (self.getName(), ))
+    def exportChildren(self, outfile, level, name_='Module'):
         if self.Documentation:
             self.Documentation.export(outfile, level)
         if self.Dependencies:
             self.Dependencies.export(outfile, level)
         if self.Content:
             self.Content.export(outfile, level)
-
-    def exportLiteral(self, outfile, level, name_="Module"):
+    def exportLiteral(self, outfile, level, name_='Module'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('Name = "%s",\n' % (self.getName(),))
-
     def exportLiteralChildren(self, outfile, level, name_):
         if self.Documentation:
             showIndent(outfile, level)
-            outfile.write("Documentation=Documentation(\n")
+            outfile.write('Documentation=Documentation(\n')
             self.Documentation.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         if self.Dependencies:
             showIndent(outfile, level)
-            outfile.write("Dependencies=Dependencies(\n")
+            outfile.write('Dependencies=Dependencies(\n')
             self.Dependencies.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         if self.Content:
             showIndent(outfile, level)
-            outfile.write("Content=Content(\n")
+            outfile.write('Content=Content(\n')
             self.Content.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
-
+            outfile.write('),\n')
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
-        if attrs.get("Name"):
-            self.Name = attrs.get("Name").value
-
+        if attrs.get('Name'):
+            self.Name = attrs.get('Name').value
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Documentation":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Documentation':
             obj_ = Documentation.factory()
             obj_.build(child_)
             self.setDocumentation(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Dependencies":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Dependencies':
             obj_ = Dependencies.factory()
             obj_.build(child_)
             self.setDependencies(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Content":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Content':
             obj_ = Content.factory()
             obj_.build(child_)
             self.setContent(obj_)
-
-
 # end class Module
 
 
 class Dependencies:
     subclass = None
-
     def __init__(self, Module=None):
         if Module is None:
             self.Module = []
         else:
             self.Module = Module
-
     def factory(*args_, **kwargs_):
         if Dependencies.subclass:
             return Dependencies.subclass(*args_, **kwargs_)
         else:
             return Dependencies(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getModule(self):
-        return self.Module
-
-    def setModule(self, Module):
-        self.Module = Module
-
-    def addModule(self, value):
-        self.Module.append(value)
-
-    def insertModule(self, index, value):
-        self.Module[index] = value
-
-    def export(self, outfile, level, name_="Dependencies"):
+    def getModule(self): return self.Module
+    def setModule(self, Module): self.Module = Module
+    def addModule(self, value): self.Module.append(value)
+    def insertModule(self, index, value): self.Module[index] = value
+    def export(self, outfile, level, name_='Dependencies'):
         showIndent(outfile, level)
-        outfile.write("<%s>\n" % name_)
+        outfile.write('<%s>\n' % name_)
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="Dependencies"):
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='Dependencies'):
         pass
-
-    def exportChildren(self, outfile, level, name_="Dependencies"):
+    def exportChildren(self, outfile, level, name_='Dependencies'):
         for Module_ in self.getModule():
             Module_.export(outfile, level)
-
-    def exportLiteral(self, outfile, level, name_="Dependencies"):
+    def exportLiteral(self, outfile, level, name_='Dependencies'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         pass
-
     def exportLiteralChildren(self, outfile, level, name_):
         showIndent(outfile, level)
-        outfile.write("Module=[\n")
+        outfile.write('Module=[\n')
         level += 1
         for Module in self.Module:
             showIndent(outfile, level)
-            outfile.write("Module(\n")
+            outfile.write('Module(\n')
             Module.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
-
+        outfile.write('],\n')
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
         pass
-
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Module":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Module':
             obj_ = Module.factory()
             obj_.build(child_)
             self.Module.append(obj_)
-
-
 # end class Dependencies
 
 
 class Content:
     subclass = None
-
-    def __init__(
-        self,
-        Property=None,
-        Feature=None,
-        DocObject=None,
-        GuiCommand=None,
-        PreferencesPage=None,
-    ):
+    def __init__(self, Property=None, Feature=None, DocObject=None, GuiCommand=None, PreferencesPage=None):
         if Property is None:
             self.Property = []
         else:
@@ -1576,86 +1165,41 @@ class Content:
             self.PreferencesPage = []
         else:
             self.PreferencesPage = PreferencesPage
-
     def factory(*args_, **kwargs_):
         if Content.subclass:
             return Content.subclass(*args_, **kwargs_)
         else:
             return Content(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getProperty(self):
-        return self.Property
-
-    def setProperty(self, Property):
-        self.Property = Property
-
-    def addProperty(self, value):
-        self.Property.append(value)
-
-    def insertProperty(self, index, value):
-        self.Property[index] = value
-
-    def getFeature(self):
-        return self.Feature
-
-    def setFeature(self, Feature):
-        self.Feature = Feature
-
-    def addFeature(self, value):
-        self.Feature.append(value)
-
-    def insertFeature(self, index, value):
-        self.Feature[index] = value
-
-    def getDocobject(self):
-        return self.DocObject
-
-    def setDocobject(self, DocObject):
-        self.DocObject = DocObject
-
-    def addDocobject(self, value):
-        self.DocObject.append(value)
-
-    def insertDocobject(self, index, value):
-        self.DocObject[index] = value
-
-    def getGuicommand(self):
-        return self.GuiCommand
-
-    def setGuicommand(self, GuiCommand):
-        self.GuiCommand = GuiCommand
-
-    def addGuicommand(self, value):
-        self.GuiCommand.append(value)
-
-    def insertGuicommand(self, index, value):
-        self.GuiCommand[index] = value
-
-    def getPreferencespage(self):
-        return self.PreferencesPage
-
-    def setPreferencespage(self, PreferencesPage):
-        self.PreferencesPage = PreferencesPage
-
-    def addPreferencespage(self, value):
-        self.PreferencesPage.append(value)
-
-    def insertPreferencespage(self, index, value):
-        self.PreferencesPage[index] = value
-
-    def export(self, outfile, level, name_="Content"):
+    def getProperty(self): return self.Property
+    def setProperty(self, Property): self.Property = Property
+    def addProperty(self, value): self.Property.append(value)
+    def insertProperty(self, index, value): self.Property[index] = value
+    def getFeature(self): return self.Feature
+    def setFeature(self, Feature): self.Feature = Feature
+    def addFeature(self, value): self.Feature.append(value)
+    def insertFeature(self, index, value): self.Feature[index] = value
+    def getDocobject(self): return self.DocObject
+    def setDocobject(self, DocObject): self.DocObject = DocObject
+    def addDocobject(self, value): self.DocObject.append(value)
+    def insertDocobject(self, index, value): self.DocObject[index] = value
+    def getGuicommand(self): return self.GuiCommand
+    def setGuicommand(self, GuiCommand): self.GuiCommand = GuiCommand
+    def addGuicommand(self, value): self.GuiCommand.append(value)
+    def insertGuicommand(self, index, value): self.GuiCommand[index] = value
+    def getPreferencespage(self): return self.PreferencesPage
+    def setPreferencespage(self, PreferencesPage): self.PreferencesPage = PreferencesPage
+    def addPreferencespage(self, value): self.PreferencesPage.append(value)
+    def insertPreferencespage(self, index, value): self.PreferencesPage[index] = value
+    def export(self, outfile, level, name_='Content'):
         showIndent(outfile, level)
-        outfile.write("<%s>\n" % name_)
+        outfile.write('<%s>\n' % name_)
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="Content"):
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='Content'):
         pass
-
-    def exportChildren(self, outfile, level, name_="Content"):
+    def exportChildren(self, outfile, level, name_='Content'):
         for Property_ in self.getProperty():
             Property_.export(outfile, level)
         for Feature_ in self.getFeature():
@@ -1664,117 +1208,113 @@ class Content:
             DocObject_.export(outfile, level)
         for GuiCommand_ in self.getGuicommand():
             showIndent(outfile, level)
-            outfile.write("<GuiCommand>%s</GuiCommand>\n" % quote_xml(GuiCommand_))
+            outfile.write('<GuiCommand>%s</GuiCommand>\n' % quote_xml(GuiCommand_))
         for PreferencesPage_ in self.getPreferencespage():
             showIndent(outfile, level)
-            outfile.write("<PreferencesPage>%s</PreferencesPage>\n" % quote_xml(PreferencesPage_))
-
-    def exportLiteral(self, outfile, level, name_="Content"):
+            outfile.write('<PreferencesPage>%s</PreferencesPage>\n' % quote_xml(PreferencesPage_))
+    def exportLiteral(self, outfile, level, name_='Content'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         pass
-
     def exportLiteralChildren(self, outfile, level, name_):
         showIndent(outfile, level)
-        outfile.write("Property=[\n")
+        outfile.write('Property=[\n')
         level += 1
         for Property in self.Property:
             showIndent(outfile, level)
-            outfile.write("Property(\n")
+            outfile.write('Property(\n')
             Property.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
+        outfile.write('],\n')
         showIndent(outfile, level)
-        outfile.write("Feature=[\n")
+        outfile.write('Feature=[\n')
         level += 1
         for Feature in self.Feature:
             showIndent(outfile, level)
-            outfile.write("Feature(\n")
+            outfile.write('Feature(\n')
             Feature.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
+        outfile.write('],\n')
         showIndent(outfile, level)
-        outfile.write("DocObject=[\n")
+        outfile.write('DocObject=[\n')
         level += 1
         for DocObject in self.DocObject:
             showIndent(outfile, level)
-            outfile.write("DocObject(\n")
+            outfile.write('DocObject(\n')
             DocObject.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
+        outfile.write('],\n')
         showIndent(outfile, level)
-        outfile.write("GuiCommand=[\n")
+        outfile.write('GuiCommand=[\n')
         level += 1
         for GuiCommand in self.GuiCommand:
             showIndent(outfile, level)
-            outfile.write("%s,\n" % quote_python(GuiCommand))
+            outfile.write('%s,\n' % quote_python(GuiCommand))
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
+        outfile.write('],\n')
         showIndent(outfile, level)
-        outfile.write("PreferencesPage=[\n")
+        outfile.write('PreferencesPage=[\n')
         level += 1
         for PreferencesPage in self.PreferencesPage:
             showIndent(outfile, level)
-            outfile.write("%s,\n" % quote_python(PreferencesPage))
+            outfile.write('%s,\n' % quote_python(PreferencesPage))
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
-
+        outfile.write('],\n')
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
         pass
-
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Property":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Property':
             obj_ = Property.factory()
             obj_.build(child_)
             self.Property.append(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Feature":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Feature':
             obj_ = Feature.factory()
             obj_.build(child_)
             self.Feature.append(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "DocObject":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'DocObject':
             obj_ = DocObject.factory()
             obj_.build(child_)
             self.DocObject.append(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "GuiCommand":
-            GuiCommand_ = ""
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'GuiCommand':
+            GuiCommand_ = ''
             for text__content_ in child_.childNodes:
                 GuiCommand_ += text__content_.nodeValue
             self.GuiCommand.append(GuiCommand_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "PreferencesPage":
-            PreferencesPage_ = ""
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'PreferencesPage':
+            PreferencesPage_ = ''
             for text__content_ in child_.childNodes:
                 PreferencesPage_ += text__content_.nodeValue
             self.PreferencesPage.append(PreferencesPage_)
-
-
 # end class Content
 
 
 class Feature:
     subclass = None
-
-    def __init__(self, Name="", Documentation=None, Property=None, ViewProvider=None):
+    def __init__(self, Name='', Documentation=None, Property=None, ViewProvider=None):
         self.Name = Name
         self.Documentation = Documentation
         if Property is None:
@@ -1782,309 +1322,227 @@ class Feature:
         else:
             self.Property = Property
         self.ViewProvider = ViewProvider
-
     def factory(*args_, **kwargs_):
         if Feature.subclass:
             return Feature.subclass(*args_, **kwargs_)
         else:
             return Feature(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getDocumentation(self):
-        return self.Documentation
-
-    def setDocumentation(self, Documentation):
-        self.Documentation = Documentation
-
-    def getProperty(self):
-        return self.Property
-
-    def setProperty(self, Property):
-        self.Property = Property
-
-    def addProperty(self, value):
-        self.Property.append(value)
-
-    def insertProperty(self, index, value):
-        self.Property[index] = value
-
-    def getViewprovider(self):
-        return self.ViewProvider
-
-    def setViewprovider(self, ViewProvider):
-        self.ViewProvider = ViewProvider
-
-    def getName(self):
-        return self.Name
-
-    def setName(self, Name):
-        self.Name = Name
-
-    def export(self, outfile, level, name_="Feature"):
+    def getDocumentation(self): return self.Documentation
+    def setDocumentation(self, Documentation): self.Documentation = Documentation
+    def getProperty(self): return self.Property
+    def setProperty(self, Property): self.Property = Property
+    def addProperty(self, value): self.Property.append(value)
+    def insertProperty(self, index, value): self.Property[index] = value
+    def getViewprovider(self): return self.ViewProvider
+    def setViewprovider(self, ViewProvider): self.ViewProvider = ViewProvider
+    def getName(self): return self.Name
+    def setName(self, Name): self.Name = Name
+    def export(self, outfile, level, name_='Feature'):
         showIndent(outfile, level)
-        outfile.write("<%s" % (name_,))
-        self.exportAttributes(outfile, level, name_="Feature")
-        outfile.write(">\n")
+        outfile.write('<%s' % (name_, ))
+        self.exportAttributes(outfile, level, name_='Feature')
+        outfile.write('>\n')
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="Feature"):
-        outfile.write(' Name="%s"' % (self.getName(),))
-
-    def exportChildren(self, outfile, level, name_="Feature"):
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='Feature'):
+        outfile.write(' Name="%s"' % (self.getName(), ))
+    def exportChildren(self, outfile, level, name_='Feature'):
         if self.Documentation:
             self.Documentation.export(outfile, level)
         for Property_ in self.getProperty():
             Property_.export(outfile, level)
         if self.ViewProvider:
             self.ViewProvider.export(outfile, level)
-
-    def exportLiteral(self, outfile, level, name_="Feature"):
+    def exportLiteral(self, outfile, level, name_='Feature'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('Name = "%s",\n' % (self.getName(),))
-
     def exportLiteralChildren(self, outfile, level, name_):
         if self.Documentation:
             showIndent(outfile, level)
-            outfile.write("Documentation=Documentation(\n")
+            outfile.write('Documentation=Documentation(\n')
             self.Documentation.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         showIndent(outfile, level)
-        outfile.write("Property=[\n")
+        outfile.write('Property=[\n')
         level += 1
         for Property in self.Property:
             showIndent(outfile, level)
-            outfile.write("Property(\n")
+            outfile.write('Property(\n')
             Property.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
+        outfile.write('],\n')
         if self.ViewProvider:
             showIndent(outfile, level)
-            outfile.write("ViewProvider=ViewProvider(\n")
+            outfile.write('ViewProvider=ViewProvider(\n')
             self.ViewProvider.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
-
+            outfile.write('),\n')
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
-        if attrs.get("Name"):
-            self.Name = attrs.get("Name").value
-
+        if attrs.get('Name'):
+            self.Name = attrs.get('Name').value
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Documentation":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Documentation':
             obj_ = Documentation.factory()
             obj_.build(child_)
             self.setDocumentation(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Property":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Property':
             obj_ = Property.factory()
             obj_.build(child_)
             self.Property.append(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "ViewProvider":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'ViewProvider':
             obj_ = ViewProvider.factory()
             obj_.build(child_)
             self.setViewprovider(obj_)
-
-
 # end class Feature
 
 
 class DocObject:
     subclass = None
-
-    def __init__(self, Name="", Documentation=None, Property=None):
+    def __init__(self, Name='', Documentation=None, Property=None):
         self.Name = Name
         self.Documentation = Documentation
         if Property is None:
             self.Property = []
         else:
             self.Property = Property
-
     def factory(*args_, **kwargs_):
         if DocObject.subclass:
             return DocObject.subclass(*args_, **kwargs_)
         else:
             return DocObject(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getDocumentation(self):
-        return self.Documentation
-
-    def setDocumentation(self, Documentation):
-        self.Documentation = Documentation
-
-    def getProperty(self):
-        return self.Property
-
-    def setProperty(self, Property):
-        self.Property = Property
-
-    def addProperty(self, value):
-        self.Property.append(value)
-
-    def insertProperty(self, index, value):
-        self.Property[index] = value
-
-    def getName(self):
-        return self.Name
-
-    def setName(self, Name):
-        self.Name = Name
-
-    def export(self, outfile, level, name_="DocObject"):
+    def getDocumentation(self): return self.Documentation
+    def setDocumentation(self, Documentation): self.Documentation = Documentation
+    def getProperty(self): return self.Property
+    def setProperty(self, Property): self.Property = Property
+    def addProperty(self, value): self.Property.append(value)
+    def insertProperty(self, index, value): self.Property[index] = value
+    def getName(self): return self.Name
+    def setName(self, Name): self.Name = Name
+    def export(self, outfile, level, name_='DocObject'):
         showIndent(outfile, level)
-        outfile.write("<%s" % (name_,))
-        self.exportAttributes(outfile, level, name_="DocObject")
-        outfile.write(">\n")
+        outfile.write('<%s' % (name_, ))
+        self.exportAttributes(outfile, level, name_='DocObject')
+        outfile.write('>\n')
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="DocObject"):
-        outfile.write(' Name="%s"' % (self.getName(),))
-
-    def exportChildren(self, outfile, level, name_="DocObject"):
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='DocObject'):
+        outfile.write(' Name="%s"' % (self.getName(), ))
+    def exportChildren(self, outfile, level, name_='DocObject'):
         if self.Documentation:
             self.Documentation.export(outfile, level)
         for Property_ in self.getProperty():
             Property_.export(outfile, level)
-
-    def exportLiteral(self, outfile, level, name_="DocObject"):
+    def exportLiteral(self, outfile, level, name_='DocObject'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('Name = "%s",\n' % (self.getName(),))
-
     def exportLiteralChildren(self, outfile, level, name_):
         if self.Documentation:
             showIndent(outfile, level)
-            outfile.write("Documentation=Documentation(\n")
+            outfile.write('Documentation=Documentation(\n')
             self.Documentation.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         showIndent(outfile, level)
-        outfile.write("Property=[\n")
+        outfile.write('Property=[\n')
         level += 1
         for Property in self.Property:
             showIndent(outfile, level)
-            outfile.write("Property(\n")
+            outfile.write('Property(\n')
             Property.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
-
+        outfile.write('],\n')
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
-        if attrs.get("Name"):
-            self.Name = attrs.get("Name").value
-
+        if attrs.get('Name'):
+            self.Name = attrs.get('Name').value
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Documentation":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Documentation':
             obj_ = Documentation.factory()
             obj_.build(child_)
             self.setDocumentation(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Property":
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Property':
             obj_ = Property.factory()
             obj_.build(child_)
             self.Property.append(obj_)
-
-
 # end class DocObject
 
 
 class Property:
     subclass = None
-
-    def __init__(self, Name="", Type="", StartValue="", Documentation=None):
+    def __init__(self, Name='', Type='', StartValue='', Documentation=None):
         self.Name = Name
         self.Type = Type
         self.StartValue = StartValue
         self.Documentation = Documentation
-
     def factory(*args_, **kwargs_):
         if Property.subclass:
             return Property.subclass(*args_, **kwargs_)
         else:
             return Property(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getDocumentation(self):
-        return self.Documentation
-
-    def setDocumentation(self, Documentation):
-        self.Documentation = Documentation
-
-    def getName(self):
-        return self.Name
-
-    def setName(self, Name):
-        self.Name = Name
-
-    def getType(self):
-        return self.Type
-
-    def setType(self, Type):
-        self.Type = Type
-
-    def getStartvalue(self):
-        return self.StartValue
-
-    def setStartvalue(self, StartValue):
-        self.StartValue = StartValue
-
-    def export(self, outfile, level, name_="Property"):
+    def getDocumentation(self): return self.Documentation
+    def setDocumentation(self, Documentation): self.Documentation = Documentation
+    def getName(self): return self.Name
+    def setName(self, Name): self.Name = Name
+    def getType(self): return self.Type
+    def setType(self, Type): self.Type = Type
+    def getStartvalue(self): return self.StartValue
+    def setStartvalue(self, StartValue): self.StartValue = StartValue
+    def export(self, outfile, level, name_='Property'):
         showIndent(outfile, level)
-        outfile.write("<%s" % (name_,))
-        self.exportAttributes(outfile, level, name_="Property")
-        outfile.write(">\n")
+        outfile.write('<%s' % (name_, ))
+        self.exportAttributes(outfile, level, name_='Property')
+        outfile.write('>\n')
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="Property"):
-        outfile.write(' Name="%s"' % (self.getName(),))
-        outfile.write(' Type="%s"' % (self.getType(),))
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='Property'):
+        outfile.write(' Name="%s"' % (self.getName(), ))
+        outfile.write(' Type="%s"' % (self.getType(), ))
         if self.getStartvalue() is not None:
-            outfile.write(' StartValue="%s"' % (self.getStartvalue(),))
-
-    def exportChildren(self, outfile, level, name_="Property"):
+            outfile.write(' StartValue="%s"' % (self.getStartvalue(), ))
+    def exportChildren(self, outfile, level, name_='Property'):
         if self.Documentation:
             self.Documentation.export(outfile, level)
-
-    def exportLiteral(self, outfile, level, name_="Property"):
+    def exportLiteral(self, outfile, level, name_='Property'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('Name = "%s",\n' % (self.getName(),))
@@ -2092,206 +1550,154 @@ class Property:
         outfile.write('Type = "%s",\n' % (self.getType(),))
         showIndent(outfile, level)
         outfile.write('StartValue = "%s",\n' % (self.getStartvalue(),))
-
     def exportLiteralChildren(self, outfile, level, name_):
         if self.Documentation:
             showIndent(outfile, level)
-            outfile.write("Documentation=Documentation(\n")
+            outfile.write('Documentation=Documentation(\n')
             self.Documentation.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
-
+            outfile.write('),\n')
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
-        if attrs.get("Name"):
-            self.Name = attrs.get("Name").value
-        if attrs.get("Type"):
-            self.Type = attrs.get("Type").value
-        if attrs.get("StartValue"):
-            self.StartValue = attrs.get("StartValue").value
-
+        if attrs.get('Name'):
+            self.Name = attrs.get('Name').value
+        if attrs.get('Type'):
+            self.Type = attrs.get('Type').value
+        if attrs.get('StartValue'):
+            self.StartValue = attrs.get('StartValue').value
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Documentation":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Documentation':
             obj_ = Documentation.factory()
             obj_.build(child_)
             self.setDocumentation(obj_)
-
-
 # end class Property
 
 
 class Documentation:
     subclass = None
-
-    def __init__(self, Author=None, DeveloperDocu="", UserDocu=""):
+    def __init__(self, Author=None, DeveloperDocu='', UserDocu=''):
         self.Author = Author
         self.DeveloperDocu = DeveloperDocu
         self.UserDocu = UserDocu
-
     def factory(*args_, **kwargs_):
         if Documentation.subclass:
             return Documentation.subclass(*args_, **kwargs_)
         else:
             return Documentation(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getAuthor(self):
-        return self.Author
-
-    def setAuthor(self, Author):
-        self.Author = Author
-
-    def getDeveloperdocu(self):
-        return self.DeveloperDocu
-
-    def setDeveloperdocu(self, DeveloperDocu):
-        self.DeveloperDocu = DeveloperDocu
-
-    def getUserdocu(self):
-        return self.UserDocu
-
-    def setUserdocu(self, UserDocu):
-        self.UserDocu = UserDocu
-
-    def export(self, outfile, level, name_="Documentation"):
+    def getAuthor(self): return self.Author
+    def setAuthor(self, Author): self.Author = Author
+    def getDeveloperdocu(self): return self.DeveloperDocu
+    def setDeveloperdocu(self, DeveloperDocu): self.DeveloperDocu = DeveloperDocu
+    def getUserdocu(self): return self.UserDocu
+    def setUserdocu(self, UserDocu): self.UserDocu = UserDocu
+    def export(self, outfile, level, name_='Documentation'):
         showIndent(outfile, level)
-        outfile.write("<%s>\n" % name_)
+        outfile.write('<%s>\n' % name_)
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="Documentation"):
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='Documentation'):
         pass
-
-    def exportChildren(self, outfile, level, name_="Documentation"):
+    def exportChildren(self, outfile, level, name_='Documentation'):
         if self.Author:
             self.Author.export(outfile, level)
         showIndent(outfile, level)
-        outfile.write("<DeveloperDocu>%s</DeveloperDocu>\n" % quote_xml(self.getDeveloperdocu()))
+        outfile.write('<DeveloperDocu>%s</DeveloperDocu>\n' % quote_xml(self.getDeveloperdocu()))
         showIndent(outfile, level)
-        outfile.write("<UserDocu>%s</UserDocu>\n" % quote_xml(self.getUserdocu()))
-
-    def exportLiteral(self, outfile, level, name_="Documentation"):
+        outfile.write('<UserDocu>%s</UserDocu>\n' % quote_xml(self.getUserdocu()))
+    def exportLiteral(self, outfile, level, name_='Documentation'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         pass
-
     def exportLiteralChildren(self, outfile, level, name_):
         if self.Author:
             showIndent(outfile, level)
-            outfile.write("Author=Author(\n")
+            outfile.write('Author=Author(\n')
             self.Author.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         showIndent(outfile, level)
-        outfile.write("DeveloperDocu=%s,\n" % quote_python(self.getDeveloperdocu()))
+        outfile.write('DeveloperDocu=%s,\n' % quote_python(self.getDeveloperdocu()))
         showIndent(outfile, level)
-        outfile.write("UserDocu=%s,\n" % quote_python(self.getUserdocu()))
-
+        outfile.write('UserDocu=%s,\n' % quote_python(self.getUserdocu()))
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
         pass
-
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Author":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Author':
             obj_ = Author.factory()
             obj_.build(child_)
             self.setAuthor(obj_)
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "DeveloperDocu":
-            DeveloperDocu_ = ""
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'DeveloperDocu':
+            DeveloperDocu_ = ''
             for text__content_ in child_.childNodes:
                 DeveloperDocu_ += text__content_.nodeValue
             self.DeveloperDocu = DeveloperDocu_
-        elif child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "UserDocu":
-            UserDocu_ = ""
+        elif child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'UserDocu':
+            UserDocu_ = ''
             for text__content_ in child_.childNodes:
                 UserDocu_ += text__content_.nodeValue
             self.UserDocu = UserDocu_
-
-
 # end class Documentation
 
 
 class Author:
     subclass = None
-
-    def __init__(self, Name="", EMail="", Licence="", valueOf_=""):
+    def __init__(self, Name='', EMail='', Licence='', valueOf_=''):
         self.Name = Name
         self.EMail = EMail
         self.Licence = Licence
         self.valueOf_ = valueOf_
-
     def factory(*args_, **kwargs_):
         if Author.subclass:
             return Author.subclass(*args_, **kwargs_)
         else:
             return Author(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getName(self):
-        return self.Name
-
-    def setName(self, Name):
-        self.Name = Name
-
-    def getEmail(self):
-        return self.EMail
-
-    def setEmail(self, EMail):
-        self.EMail = EMail
-
-    def getLicence(self):
-        return self.Licence
-
-    def setLicence(self, Licence):
-        self.Licence = Licence
-
-    def getValueOf_(self):
-        return self.valueOf_
-
-    def setValueOf_(self, valueOf_):
-        self.valueOf_ = valueOf_
-
-    def export(self, outfile, level, name_="Author"):
+    def getName(self): return self.Name
+    def setName(self, Name): self.Name = Name
+    def getEmail(self): return self.EMail
+    def setEmail(self, EMail): self.EMail = EMail
+    def getLicence(self): return self.Licence
+    def setLicence(self, Licence): self.Licence = Licence
+    def getValueOf_(self): return self.valueOf_
+    def setValueOf_(self, valueOf_): self.valueOf_ = valueOf_
+    def export(self, outfile, level, name_='Author'):
         showIndent(outfile, level)
-        outfile.write("<%s" % (name_,))
-        self.exportAttributes(outfile, level, name_="Author")
-        outfile.write(">\n")
+        outfile.write('<%s' % (name_, ))
+        self.exportAttributes(outfile, level, name_='Author')
+        outfile.write('>\n')
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="Author"):
-        outfile.write(' Name="%s"' % (self.getName(),))
-        outfile.write(' EMail="%s"' % (self.getEmail(),))
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='Author'):
+        outfile.write(' Name="%s"' % (self.getName(), ))
+        outfile.write(' EMail="%s"' % (self.getEmail(), ))
         if self.getLicence() is not None:
-            outfile.write(' Licence="%s"' % (self.getLicence(),))
-
-    def exportChildren(self, outfile, level, name_="Author"):
+            outfile.write(' Licence="%s"' % (self.getLicence(), ))
+    def exportChildren(self, outfile, level, name_='Author'):
         outfile.write(self.valueOf_)
-
-    def exportLiteral(self, outfile, level, name_="Author"):
+    def exportLiteral(self, outfile, level, name_='Author'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('Name = "%s",\n' % (self.getName(),))
@@ -2299,218 +1705,163 @@ class Author:
         outfile.write('EMail = "%s",\n' % (self.getEmail(),))
         showIndent(outfile, level)
         outfile.write('Licence = "%s",\n' % (self.getLicence(),))
-
     def exportLiteralChildren(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('valueOf_ = "%s",\n' % (self.valueOf_,))
-
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
-        if attrs.get("Name"):
-            self.Name = attrs.get("Name").value
-        if attrs.get("EMail"):
-            self.EMail = attrs.get("EMail").value
-        if attrs.get("Licence"):
-            self.Licence = attrs.get("Licence").value
-
+        if attrs.get('Name'):
+            self.Name = attrs.get('Name').value
+        if attrs.get('EMail'):
+            self.EMail = attrs.get('EMail').value
+        if attrs.get('Licence'):
+            self.Licence = attrs.get('Licence').value
     def buildChildren(self, child_, nodeName_):
-        self.valueOf_ = ""
+        self.valueOf_ = ''
         for child in child_.childNodes:
             if child.nodeType == Node.TEXT_NODE:
                 self.valueOf_ += child.nodeValue
-
-
 # end class Author
 
 
 class ViewProvider:
     subclass = None
-
     def __init__(self, Property=None):
         if Property is None:
             self.Property = []
         else:
             self.Property = Property
-
     def factory(*args_, **kwargs_):
         if ViewProvider.subclass:
             return ViewProvider.subclass(*args_, **kwargs_)
         else:
             return ViewProvider(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getProperty(self):
-        return self.Property
-
-    def setProperty(self, Property):
-        self.Property = Property
-
-    def addProperty(self, value):
-        self.Property.append(value)
-
-    def insertProperty(self, index, value):
-        self.Property[index] = value
-
-    def export(self, outfile, level, name_="ViewProvider"):
+    def getProperty(self): return self.Property
+    def setProperty(self, Property): self.Property = Property
+    def addProperty(self, value): self.Property.append(value)
+    def insertProperty(self, index, value): self.Property[index] = value
+    def export(self, outfile, level, name_='ViewProvider'):
         showIndent(outfile, level)
-        outfile.write("<%s>\n" % name_)
+        outfile.write('<%s>\n' % name_)
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="ViewProvider"):
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='ViewProvider'):
         pass
-
-    def exportChildren(self, outfile, level, name_="ViewProvider"):
+    def exportChildren(self, outfile, level, name_='ViewProvider'):
         for Property_ in self.getProperty():
             Property_.export(outfile, level)
-
-    def exportLiteral(self, outfile, level, name_="ViewProvider"):
+    def exportLiteral(self, outfile, level, name_='ViewProvider'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         pass
-
     def exportLiteralChildren(self, outfile, level, name_):
         showIndent(outfile, level)
-        outfile.write("Property=[\n")
+        outfile.write('Property=[\n')
         level += 1
         for Property in self.Property:
             showIndent(outfile, level)
-            outfile.write("Property(\n")
+            outfile.write('Property(\n')
             Property.exportLiteral(outfile, level)
             showIndent(outfile, level)
-            outfile.write("),\n")
+            outfile.write('),\n')
         level -= 1
         showIndent(outfile, level)
-        outfile.write("],\n")
-
+        outfile.write('],\n')
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
         pass
-
     def buildChildren(self, child_, nodeName_):
-        if child_.nodeType == Node.ELEMENT_NODE and nodeName_ == "Property":
+        if child_.nodeType == Node.ELEMENT_NODE and \
+            nodeName_ == 'Property':
             obj_ = Property.factory()
             obj_.build(child_)
             self.Property.append(obj_)
-
-
 # end class ViewProvider
 
 
 class Parameter:
     subclass = None
-
-    def __init__(self, Name="", Type="", valueOf_=""):
+    def __init__(self, Name='', Type='', valueOf_=''):
         self.Name = Name
         self.Type = Type
         self.valueOf_ = valueOf_
-
     def factory(*args_, **kwargs_):
         if Parameter.subclass:
             return Parameter.subclass(*args_, **kwargs_)
         else:
             return Parameter(*args_, **kwargs_)
-
     factory = staticmethod(factory)
-
-    def getName(self):
-        return self.Name
-
-    def setName(self, Name):
-        self.Name = Name
-
-    def getType(self):
-        return self.Type
-
-    def setType(self, Type):
-        self.Type = Type
-
-    def getValueOf_(self):
-        return self.valueOf_
-
-    def setValueOf_(self, valueOf_):
-        self.valueOf_ = valueOf_
-
-    def export(self, outfile, level, name_="Parameter"):
+    def getName(self): return self.Name
+    def setName(self, Name): self.Name = Name
+    def getType(self): return self.Type
+    def setType(self, Type): self.Type = Type
+    def getValueOf_(self): return self.valueOf_
+    def setValueOf_(self, valueOf_): self.valueOf_ = valueOf_
+    def export(self, outfile, level, name_='Parameter'):
         showIndent(outfile, level)
-        outfile.write("<%s" % (name_,))
-        self.exportAttributes(outfile, level, name_="Parameter")
-        outfile.write(">\n")
+        outfile.write('<%s' % (name_, ))
+        self.exportAttributes(outfile, level, name_='Parameter')
+        outfile.write('>\n')
         self.exportChildren(outfile, level + 1, name_)
         showIndent(outfile, level)
-        outfile.write("</%s>\n" % name_)
-
-    def exportAttributes(self, outfile, level, name_="Parameter"):
-        outfile.write(' Name="%s"' % (self.getName(),))
-        outfile.write(' Type="%s"' % (self.getType(),))
-
-    def exportChildren(self, outfile, level, name_="Parameter"):
+        outfile.write('</%s>\n' % name_)
+    def exportAttributes(self, outfile, level, name_='Parameter'):
+        outfile.write(' Name="%s"' % (self.getName(), ))
+        outfile.write(' Type="%s"' % (self.getType(), ))
+    def exportChildren(self, outfile, level, name_='Parameter'):
         outfile.write(self.valueOf_)
-
-    def exportLiteral(self, outfile, level, name_="Parameter"):
+    def exportLiteral(self, outfile, level, name_='Parameter'):
         level += 1
         self.exportLiteralAttributes(outfile, level, name_)
         self.exportLiteralChildren(outfile, level, name_)
-
     def exportLiteralAttributes(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('Name = "%s",\n' % (self.getName(),))
         showIndent(outfile, level)
         outfile.write('Type = "%s",\n' % (self.getType(),))
-
     def exportLiteralChildren(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('valueOf_ = "%s",\n' % (self.valueOf_,))
-
     def build(self, node_):
         attrs = node_.attributes
         self.buildAttributes(attrs)
         for child_ in node_.childNodes:
-            nodeName_ = child_.nodeName.split(":")[-1]
+            nodeName_ = child_.nodeName.split(':')[-1]
             self.buildChildren(child_, nodeName_)
-
     def buildAttributes(self, attrs):
-        if attrs.get("Name"):
-            self.Name = attrs.get("Name").value
-        if attrs.get("Type"):
-            self.Type = attrs.get("Type").value
-
+        if attrs.get('Name'):
+            self.Name = attrs.get('Name').value
+        if attrs.get('Type'):
+            self.Type = attrs.get('Type').value
     def buildChildren(self, child_, nodeName_):
-        self.valueOf_ = ""
+        self.valueOf_ = ''
         for child in child_.childNodes:
             if child.nodeType == Node.TEXT_NODE:
                 self.valueOf_ += child.nodeValue
-
-
 # end class Parameter
 
 
 from xml.sax import handler, make_parser
 
-
 class SaxStackElement:
-    def __init__(self, name="", obj=None):
+    def __init__(self, name='', obj=None):
         self.name = name
         self.obj = obj
-        self.content = ""
-
+        self.content = ''
 
 #
 # SAX handler
@@ -2527,406 +1878,358 @@ class SaxGeneratemodelHandler(handler.ContentHandler):
         self.locator = locator
 
     def showError(self, msg):
-        print("*** (showError):", msg)
+        print('*** (showError):', msg)
         sys.exit(-1)
 
     def startElement(self, name, attrs):
         done = 0
-        if name == "GenerateModel":
+        if name == 'GenerateModel':
             obj = GenerateModel.factory()
-            stackObj = SaxStackElement("GenerateModel", obj)
+            stackObj = SaxStackElement('GenerateModel', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "Module":
+        elif name == 'Module':
             obj = Module.factory()
-            stackObj = SaxStackElement("Module", obj)
+            stackObj = SaxStackElement('Module', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "PythonExport":
+        elif name == 'PythonExport':
             obj = PythonExport.factory()
-            val = attrs.get("Name", None)
+            val = attrs.get('Name', None)
             if val is not None:
                 obj.setName(val)
-            val = attrs.get("PythonName", None)
+            val = attrs.get('PythonName', None)
             if val is not None:
                 obj.setPythonname(val)
-            val = attrs.get("Include", None)
+            val = attrs.get('Include', None)
             if val is not None:
                 obj.setInclude(val)
-            val = attrs.get("Father", None)
+            val = attrs.get('Father', None)
             if val is not None:
                 obj.setFather(val)
-            val = attrs.get("Twin", None)
+            val = attrs.get('Twin', None)
             if val is not None:
                 obj.setTwin(val)
-            val = attrs.get("Namespace", None)
+            val = attrs.get('Namespace', None)
             if val is not None:
                 obj.setNamespace(val)
-            val = attrs.get("FatherInclude", None)
+            val = attrs.get('FatherInclude', None)
             if val is not None:
                 obj.setFatherinclude(val)
-            val = attrs.get("FatherNamespace", None)
+            val = attrs.get('FatherNamespace', None)
             if val is not None:
                 obj.setFathernamespace(val)
-            val = attrs.get("Constructor", None)
+            val = attrs.get('Constructor', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setConstructor(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setConstructor(0)
                 else:
-                    self.reportError(
-                        '"Constructor" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("NumberProtocol", None)
+                    self.reportError('"Constructor" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('NumberProtocol', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setNumberprotocol(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setNumberprotocol(0)
                 else:
-                    self.reportError(
-                        '"NumberProtocol" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("RichCompare", None)
+                    self.reportError('"NumberProtocol" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('RichCompare', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setRichcompare(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setRichcompare(0)
                 else:
-                    self.reportError(
-                        '"RichCompare" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("TwinPointer", None)
+                    self.reportError('"RichCompare" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('TwinPointer', None)
             if val is not None:
                 obj.setTwinpointer(val)
-            val = attrs.get("Delete", None)
+            val = attrs.get('Delete', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setDelete(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setDelete(0)
                 else:
-                    self.reportError(
-                        '"Delete" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("Reference", None)
+                    self.reportError('"Delete" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('Reference', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setReference(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setReference(0)
                 else:
-                    self.reportError(
-                        '"Reference" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("Initialization", None)
+                    self.reportError('"Reference" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('Initialization', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setInitialization(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setInitialization(0)
                 else:
-                    self.reportError(
-                        '"Initialization" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("DisableNotify", None)
+                    self.reportError('"Initialization" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('DisableNotify', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setDisablenotify(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setDisablenotify(0)
                 else:
-                    self.reportError(
-                        '"DisableNotify" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("DescriptorGetter", None)
+                    self.reportError('"DisableNotify" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('DescriptorGetter', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setDescriptorgetter(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setDescriptorgetter(0)
                 else:
-                    self.reportError(
-                        '"DescriptorGetter" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("DescriptorSetter", None)
+                    self.reportError('"DescriptorGetter" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('DescriptorSetter', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setDescriptorsetter(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setDescriptorsetter(0)
                 else:
-                    self.reportError(
-                        '"DescriptorSetter" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            stackObj = SaxStackElement("PythonExport", obj)
+                    self.reportError('"DescriptorSetter" attribute must be boolean ("true", "1", "false", "0")')
+            stackObj = SaxStackElement('PythonExport', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "Documentation":
+        elif name == 'Documentation':
             obj = Documentation.factory()
-            stackObj = SaxStackElement("Documentation", obj)
+            stackObj = SaxStackElement('Documentation', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "Methode":
+        elif name == 'Methode':
             obj = Methode.factory()
-            val = attrs.get("Name", None)
+            val = attrs.get('Name', None)
             if val is not None:
                 obj.setName(val)
-            val = attrs.get("Const", None)
+            val = attrs.get('Const', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setConst(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setConst(0)
                 else:
-                    self.reportError(
-                        '"Const" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("Keyword", None)
+                    self.reportError('"Const" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('Keyword', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setKeyword(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setKeyword(0)
                 else:
-                    self.reportError(
-                        '"Keyword" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("Class", None)
+                    self.reportError('"Keyword" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('Class', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setClass(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setClass(0)
                 else:
-                    self.reportError(
-                        '"Class" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("Static", None)
+                    self.reportError('"Class" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('Static', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setStatic(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setStatic(0)
                 else:
-                    self.reportError(
-                        '"Static" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            stackObj = SaxStackElement("Methode", obj)
+                    self.reportError('"Static" attribute must be boolean ("true", "1", "false", "0")')
+            stackObj = SaxStackElement('Methode', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "Parameter":
+        elif name == 'Parameter':
             obj = Parameter.factory()
-            val = attrs.get("Name", None)
+            val = attrs.get('Name', None)
             if val is not None:
                 obj.setName(val)
-            val = attrs.get("Type", None)
+            val = attrs.get('Type', None)
             if val is not None:
                 obj.setType(val)
-            stackObj = SaxStackElement("Parameter", obj)
+            stackObj = SaxStackElement('Parameter', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "Attribute":
+        elif name == 'Attribute':
             obj = Attribute.factory()
-            val = attrs.get("Name", None)
+            val = attrs.get('Name', None)
             if val is not None:
                 obj.setName(val)
-            val = attrs.get("ReadOnly", None)
+            val = attrs.get('ReadOnly', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setReadonly(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setReadonly(0)
                 else:
-                    self.reportError(
-                        '"ReadOnly" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            stackObj = SaxStackElement("Attribute", obj)
+                    self.reportError('"ReadOnly" attribute must be boolean ("true", "1", "false", "0")')
+            stackObj = SaxStackElement('Attribute', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "Sequence":
+        elif name == 'Sequence':
             obj = Sequence.factory()
-            val = attrs.get("sq_length", None)
+            val = attrs.get('sq_length', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setSq_length(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setSq_length(0)
                 else:
-                    self.reportError(
-                        '"sq_length" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("sq_concat", None)
+                    self.reportError('"sq_length" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('sq_concat', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setSq_concat(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setSq_concat(0)
                 else:
-                    self.reportError(
-                        '"sq_concat" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("sq_repeat", None)
+                    self.reportError('"sq_concat" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('sq_repeat', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setSq_repeat(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setSq_repeat(0)
                 else:
-                    self.reportError(
-                        '"sq_repeat" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("sq_item", None)
+                    self.reportError('"sq_repeat" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('sq_item', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setSq_item(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setSq_item(0)
                 else:
-                    self.reportError(
-                        '"sq_item" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("mp_subscript", None)
+                    self.reportError('"sq_item" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('mp_subscript', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setMp_subscript(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setMp_subscript(0)
                 else:
-                    self.reportError(
-                        '"mp_subscript" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("sq_ass_item", None)
+                    self.reportError('"mp_subscript" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('sq_ass_item', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setSq_ass_item(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setSq_ass_item(0)
                 else:
-                    self.reportError(
-                        '"sq_ass_item" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("mp_ass_subscript", None)
+                    self.reportError('"sq_ass_item" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('mp_ass_subscript', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setMp_ass_subscript(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setMp_ass_subscript(0)
                 else:
-                    self.reportError(
-                        '"mp_ass_subscript" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("sq_contains", None)
+                    self.reportError('"mp_ass_subscript" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('sq_contains', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setSq_contains(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setSq_contains(0)
                 else:
-                    self.reportError(
-                        '"sq_contains" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("sq_inplace_concat", None)
+                    self.reportError('"sq_contains" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('sq_inplace_concat', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setSq_inplace_concat(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setSq_inplace_concat(0)
                 else:
-                    self.reportError(
-                        '"sq_inplace_concat" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            val = attrs.get("sq_inplace_repeat", None)
+                    self.reportError('"sq_inplace_concat" attribute must be boolean ("true", "1", "false", "0")')
+            val = attrs.get('sq_inplace_repeat', None)
             if val is not None:
-                if val in ("true", "1"):
+                if val in ('true', '1'):
                     obj.setSq_inplace_repeat(1)
-                elif val in ("false", "0"):
+                elif val in ('false', '0'):
                     obj.setSq_inplace_repeat(0)
                 else:
-                    self.reportError(
-                        '"sq_inplace_repeat" attribute must be boolean ("true", "1", "false", "0")'
-                    )
-            stackObj = SaxStackElement("Sequence", obj)
+                    self.reportError('"sq_inplace_repeat" attribute must be boolean ("true", "1", "false", "0")')
+            stackObj = SaxStackElement('Sequence', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "CustomAttributes":
-            stackObj = SaxStackElement("CustomAttributes", None)
+        elif name == 'CustomAttributes':
+            stackObj = SaxStackElement('CustomAttributes', None)
             self.stack.append(stackObj)
             done = 1
-        elif name == "ClassDeclarations":
-            stackObj = SaxStackElement("ClassDeclarations", None)
+        elif name == 'ClassDeclarations':
+            stackObj = SaxStackElement('ClassDeclarations', None)
             self.stack.append(stackObj)
             done = 1
-        elif name == "ForwardDeclarations":
-            stackObj = SaxStackElement("ForwardDeclarations", None)
+        elif name == 'ForwardDeclarations':
+            stackObj = SaxStackElement('ForwardDeclarations', None)
             self.stack.append(stackObj)
             done = 1
-        elif name == "Dependencies":
+        elif name == 'Dependencies':
             obj = Dependencies.factory()
-            stackObj = SaxStackElement("Dependencies", obj)
+            stackObj = SaxStackElement('Dependencies', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "Content":
+        elif name == 'Content':
             obj = Content.factory()
-            stackObj = SaxStackElement("Content", obj)
+            stackObj = SaxStackElement('Content', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "Property":
+        elif name == 'Property':
             obj = Property.factory()
-            stackObj = SaxStackElement("Property", obj)
+            stackObj = SaxStackElement('Property', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "Feature":
+        elif name == 'Feature':
             obj = Feature.factory()
-            val = attrs.get("Name", None)
+            val = attrs.get('Name', None)
             if val is not None:
                 obj.setName(val)
-            stackObj = SaxStackElement("Feature", obj)
+            stackObj = SaxStackElement('Feature', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "ViewProvider":
+        elif name == 'ViewProvider':
             obj = ViewProvider.factory()
-            stackObj = SaxStackElement("ViewProvider", obj)
+            stackObj = SaxStackElement('ViewProvider', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "DocObject":
+        elif name == 'DocObject':
             obj = DocObject.factory()
-            val = attrs.get("Name", None)
+            val = attrs.get('Name', None)
             if val is not None:
                 obj.setName(val)
-            stackObj = SaxStackElement("DocObject", obj)
+            stackObj = SaxStackElement('DocObject', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "GuiCommand":
-            stackObj = SaxStackElement("GuiCommand", None)
+        elif name == 'GuiCommand':
+            stackObj = SaxStackElement('GuiCommand', None)
             self.stack.append(stackObj)
             done = 1
-        elif name == "PreferencesPage":
-            stackObj = SaxStackElement("PreferencesPage", None)
+        elif name == 'PreferencesPage':
+            stackObj = SaxStackElement('PreferencesPage', None)
             self.stack.append(stackObj)
             done = 1
-        elif name == "Author":
+        elif name == 'Author':
             obj = Author.factory()
-            val = attrs.get("Name", None)
+            val = attrs.get('Name', None)
             if val is not None:
                 obj.setName(val)
-            val = attrs.get("EMail", None)
+            val = attrs.get('EMail', None)
             if val is not None:
                 obj.setEmail(val)
-            val = attrs.get("Licence", None)
+            val = attrs.get('Licence', None)
             if val is not None:
                 obj.setLicence(val)
-            stackObj = SaxStackElement("Author", obj)
+            stackObj = SaxStackElement('Author', obj)
             self.stack.append(stackObj)
             done = 1
-        elif name == "DeveloperDocu":
-            stackObj = SaxStackElement("DeveloperDocu", None)
+        elif name == 'DeveloperDocu':
+            stackObj = SaxStackElement('DeveloperDocu', None)
             self.stack.append(stackObj)
             done = 1
-        elif name == "UserDocu":
-            stackObj = SaxStackElement("UserDocu", None)
+        elif name == 'UserDocu':
+            stackObj = SaxStackElement('UserDocu', None)
             self.stack.append(stackObj)
             done = 1
         if not done:
@@ -2934,118 +2237,118 @@ class SaxGeneratemodelHandler(handler.ContentHandler):
 
     def endElement(self, name):
         done = 0
-        if name == "GenerateModel":
+        if name == 'GenerateModel':
             if len(self.stack) == 1:
                 self.root = self.stack[-1].obj
                 self.stack.pop()
                 done = 1
-        elif name == "Module":
+        elif name == 'Module':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.addModule(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "PythonExport":
+        elif name == 'PythonExport':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.addPythonexport(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "Documentation":
+        elif name == 'Documentation':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.setDocumentation(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "Methode":
+        elif name == 'Methode':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.addMethode(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "Parameter":
+        elif name == 'Parameter':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.addParameter(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "Attribute":
+        elif name == 'Attribute':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.addAttribute(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "Sequence":
+        elif name == 'Sequence':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.setSequence(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "CustomAttributes":
+        elif name == 'CustomAttributes':
             if len(self.stack) >= 2:
                 content = self.stack[-1].content
                 self.stack[-2].obj.setCustomattributes(content)
                 self.stack.pop()
                 done = 1
-        elif name == "ClassDeclarations":
+        elif name == 'ClassDeclarations':
             if len(self.stack) >= 2:
                 content = self.stack[-1].content
                 self.stack[-2].obj.setClassdeclarations(content)
                 self.stack.pop()
                 done = 1
-        elif name == "ForwardDeclarations":
+        elif name == 'ForwardDeclarations':
             if len(self.stack) >= 2:
                 content = self.stack[-1].content
                 self.stack[-2].obj.setForwarddeclarations(content)
                 self.stack.pop()
                 done = 1
-        elif name == "Dependencies":
+        elif name == 'Dependencies':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.setDependencies(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "Content":
+        elif name == 'Content':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.setContent(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "Property":
+        elif name == 'Property':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.addProperty(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "Feature":
+        elif name == 'Feature':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.addFeature(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "ViewProvider":
+        elif name == 'ViewProvider':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.setViewprovider(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "DocObject":
+        elif name == 'DocObject':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.addDocobject(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "GuiCommand":
+        elif name == 'GuiCommand':
             if len(self.stack) >= 2:
                 content = self.stack[-1].content
                 self.stack[-2].obj.addGuicommand(content)
                 self.stack.pop()
                 done = 1
-        elif name == "PreferencesPage":
+        elif name == 'PreferencesPage':
             if len(self.stack) >= 2:
                 content = self.stack[-1].content
                 self.stack[-2].obj.addPreferencespage(content)
                 self.stack.pop()
                 done = 1
-        elif name == "Author":
+        elif name == 'Author':
             if len(self.stack) >= 2:
                 self.stack[-2].obj.setAuthor(self.stack[-1].obj)
                 self.stack.pop()
                 done = 1
-        elif name == "DeveloperDocu":
+        elif name == 'DeveloperDocu':
             if len(self.stack) >= 2:
                 content = self.stack[-1].content
                 self.stack[-2].obj.setDeveloperdocu(content)
                 self.stack.pop()
                 done = 1
-        elif name == "UserDocu":
+        elif name == 'UserDocu':
             if len(self.stack) >= 2:
                 content = self.stack[-1].content
                 self.stack[-2].obj.setUserdocu(content)
@@ -3060,26 +2363,19 @@ class SaxGeneratemodelHandler(handler.ContentHandler):
 
     def reportError(self, mesg):
         locator = self.locator
-        sys.stderr.write(
-            "Doc: %s  Line: %d  Column: %d\n"
-            % (
-                locator.getSystemId(),
-                locator.getLineNumber(),
-                locator.getColumnNumber() + 1,
-            )
-        )
+        sys.stderr.write('Doc: %s  Line: %d  Column: %d\n' % \
+            (locator.getSystemId(), locator.getLineNumber(),
+            locator.getColumnNumber() + 1))
         sys.stderr.write(mesg)
-        sys.stderr.write("\n")
+        sys.stderr.write('\n')
         sys.exit(-1)
-        # raise RuntimeError
-
+        #raise RuntimeError
 
 USAGE_TEXT = """
 Usage: python <Parser>.py [ -s ] <in_xml_file>
 Options:
     -s        Use the SAX parser, not the minidom parser.
 """
-
 
 def usage():
     print(USAGE_TEXT)
@@ -3092,17 +2388,15 @@ def usage():
 class SaxSelectorHandler(handler.ContentHandler):
     def __init__(self):
         self.topElementName = None
-
     def getTopElementName(self):
         return self.topElementName
-
     def startElement(self, name, attrs):
         self.topElementName = name
         raise StopIteration
 
 
 def parseSelect(inFileName):
-    infile = open(inFileName, "r")
+    infile = open(inFileName, 'r')
     topElementName = None
     parser = make_parser()
     documentHandler = SaxSelectorHandler()
@@ -3113,10 +2407,10 @@ def parseSelect(inFileName):
         except StopIteration:
             topElementName = documentHandler.getTopElementName()
         if topElementName is None:
-            raise RuntimeError("no top level element")
-        topElementName = topElementName.replace("-", "_").replace(":", "_")
+            raise RuntimeError('no top level element')
+        topElementName = topElementName.replace('-', '_').replace(':', '_')
         if topElementName not in globals():
-            raise RuntimeError("no class for top element: %s" % topElementName)
+            raise RuntimeError('no class for top element: %s' % topElementName)
         topElement = globals()[topElementName]
         infile.seek(0)
         doc = minidom.parse(infile)
@@ -3136,7 +2430,7 @@ def saxParse(inFileName):
     parser = make_parser()
     documentHandler = SaxGeneratemodelHandler()
     parser.setDocumentHandler(documentHandler)
-    parser.parse("file:%s" % inFileName)
+    parser.parse('file:%s' % inFileName)
     root = documentHandler.getRoot()
     sys.stdout.write('<?xml version="1.0" ?>\n')
     root.export(sys.stdout, 0)
@@ -3150,8 +2444,8 @@ def saxParseString(inString):
     parser.feed(inString)
     parser.close()
     rootObj = documentHandler.getRoot()
-    # sys.stdout.write('<?xml version="1.0" ?>\n')
-    # rootObj.export(sys.stdout, 0)
+    #sys.stdout.write('<?xml version="1.0" ?>\n')
+    #rootObj.export(sys.stdout, 0)
     return rootObj
 
 
@@ -3186,16 +2480,16 @@ def parseLiteral(inFileName):
     rootObj.build(rootNode)
     # Enable Python to collect the space used by the DOM.
     doc = None
-    sys.stdout.write("from generateModel_Module import *\n\n")
-    sys.stdout.write("rootObj = GenerateModel(\n")
+    sys.stdout.write('from generateModel_Module import *\n\n')
+    sys.stdout.write('rootObj = GenerateModel(\n')
     rootObj.exportLiteral(sys.stdout, 0, name_="GenerateModel")
-    sys.stdout.write(")\n")
+    sys.stdout.write(')\n')
     return rootObj
 
 
 def main():
     args = sys.argv[1:]
-    if len(args) == 2 and args[0] == "-s":
+    if len(args) == 2 and args[0] == '-s':
         saxParse(args[1])
     elif len(args) == 1:
         parse(args[0])
@@ -3203,7 +2497,8 @@ def main():
         usage()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()
-    # import pdb
-    # pdb.run('main()')
+    #import pdb
+    #pdb.run('main()')
+

--- a/src/Tools/generateBase/generateModel_Module.py
+++ b/src/Tools/generateBase/generateModel_Module.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Generated Fri Mar 31 16:59:53 2023 by generateDS.py.
+# Generated Tue Sep  5 00:13:06 2023 by generateDS.py.
 # Update it with: python generateDS.py -o generateModel_Module.py generateMetaModel_Module.xsd
 #
 # WARNING! All changes made in this file will be lost!
@@ -580,8 +580,9 @@ class PythonExport:
 
 class Methode:
     subclass = None
-    def __init__(self, Name='', Const=0, Keyword=0, Class=0, Static=0, Documentation=None, Parameter=None):
+    def __init__(self, Name='', TextSignature='', Const=0, Keyword=0, Class=0, Static=0, Documentation=None, Parameter=None):
         self.Name = Name
+        self.TextSignature = TextSignature
         self.Const = Const
         self.Keyword = Keyword
         self.Class = Class
@@ -605,6 +606,8 @@ class Methode:
     def insertParameter(self, index, value): self.Parameter[index] = value
     def getName(self): return self.Name
     def setName(self, Name): self.Name = Name
+    def getTextsignature(self): return self.TextSignature
+    def setTextsignature(self, TextSignature): self.TextSignature = TextSignature
     def getConst(self): return self.Const
     def setConst(self, Const): self.Const = Const
     def getKeyword(self): return self.Keyword
@@ -623,6 +626,8 @@ class Methode:
         outfile.write('</%s>\n' % name_)
     def exportAttributes(self, outfile, level, name_='Methode'):
         outfile.write(' Name="%s"' % (self.getName(), ))
+        if self.getTextsignature() is not None:
+            outfile.write(' TextSignature="%s"' % (self.getTextsignature(), ))
         if self.getConst() is not None:
             outfile.write(' Const="%s"' % (self.getConst(), ))
         if self.getKeyword() is not None:
@@ -643,6 +648,8 @@ class Methode:
     def exportLiteralAttributes(self, outfile, level, name_):
         showIndent(outfile, level)
         outfile.write('Name = "%s",\n' % (self.getName(),))
+        showIndent(outfile, level)
+        outfile.write('TextSignature = "%s",\n' % (self.getTextsignature(),))
         showIndent(outfile, level)
         outfile.write('Const = "%s",\n' % (self.getConst(),))
         showIndent(outfile, level)
@@ -679,6 +686,8 @@ class Methode:
     def buildAttributes(self, attrs):
         if attrs.get('Name'):
             self.Name = attrs.get('Name').value
+        if attrs.get('TextSignature'):
+            self.TextSignature = attrs.get('TextSignature').value
         if attrs.get('Const'):
             if attrs.get('Const').value in ('true', '1'):
                 self.Const = 1
@@ -2007,6 +2016,9 @@ class SaxGeneratemodelHandler(handler.ContentHandler):
             val = attrs.get('Name', None)
             if val is not None:
                 obj.setName(val)
+            val = attrs.get('TextSignature', None)
+            if val is not None:
+                obj.setTextsignature(val)
             val = attrs.get('Const', None)
             if val is not None:
                 if val in ('true', '1'):

--- a/src/Tools/generateTemplates/templateClassPyExport.py
+++ b/src/Tools/generateTemplates/templateClassPyExport.py
@@ -399,6 +399,9 @@ PyMethodDef @self.export.Name@::Methods[] = {
         reinterpret_cast<PyCFunction>( staticCallback_@i.Name@ ),
         METH_VARARGS,
 -
++ if i.TextSignature:
+        "@escapeString(i.Name + i.TextSignature, indent=8)@\\n--\\n\\n"
+-
         "@escapeString(i.Documentation.UserDocu, indent=8)@"
     },
 -


### PR DESCRIPTION
The new optional attribute "TextSignature" allows to specify a signature for build-in methods. The signature is stored in the `__text_signature__` property and thus enables introspection via the `inspect.signature` module on build-in methods, too.
This is used e.g. by the `help()` function to display the signature instead of just "(...)".
The format has to follow [Python's "Argument Clinic"](https://docs.python.org/3/howto/clinic.html#how-to-override-the-generated-signature), e.g.
```xml
   <Methode Name="carbonCopy" TextSignature="($self, srcObjName, asConstruction=True)">
```
The value has to be a valid python signature and does not support return type annotations (as of now, i.e. Python-3.11).

Also note that I'm not sure if `__text__signature__` and the support for this "some_method(...)\n--\n\n" docstring prefix is "public API" or just support for Argument Clinic (which is explicitly declared internal-only for CPython). It has been around since Python-3.4 though, so for quite some time.

What are your thoughts about this? Is this worth perusing? Should we better discuss this in the forum?