### PR TITLE
[Preferences] Exclude 8514oem from Monospace fonts

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsEditor.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.cpp
@@ -26,8 +26,6 @@
 # include <QFontDatabase>
 #endif
 
-#include <boost/algorithm/string.hpp>
-
 #include <App/Color.h>
 #include <Gui/PythonEditor.h>
 #include <Gui/Tools.h>
@@ -303,8 +301,7 @@ void DlgSettingsEditor::loadSettings()
     QStringList fixedFamilyNames;
     for (const auto &name : familyNames) {
         if (QFontDatabase().isFixedPitch(name)) {
-            std::string utf8_name = name.toUtf8().constData();
-            if (boost::iequals(utf8_name, "8514oem")) {
+            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0) {
                 fixedFamilyNames.append(name);
             }
         }
@@ -314,8 +311,7 @@ void DlgSettingsEditor::loadSettings()
     QStringList fixedFamilyNames;
     for (const auto &name : familyNames) {
         if (QFontDatabase::isFixedPitch(name)) {
-            std::string utf8_name = name.toUtf8().constData();
-            if (boost::iequals(utf8_name, "8514oem")) {
+            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0) {
                 fixedFamilyNames.append(name);
             }
         }

--- a/src/Gui/PreferencePages/DlgSettingsEditor.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.cpp
@@ -26,6 +26,8 @@
 # include <QFontDatabase>
 #endif
 
+#include <boost/algorithm/string.hpp>
+
 #include <App/Color.h>
 #include <Gui/PythonEditor.h>
 #include <Gui/Tools.h>
@@ -301,7 +303,10 @@ void DlgSettingsEditor::loadSettings()
     QStringList fixedFamilyNames;
     for (const auto &name : familyNames) {
         if (QFontDatabase().isFixedPitch(name)) {
-            fixedFamilyNames.append(name);
+            std::string utf8_name = name.toUtf8().constData();
+            if (boost::iequals(utf8_name, "8514oem")) {
+                fixedFamilyNames.append(name);
+            }
         }
     }
 #else
@@ -309,7 +314,10 @@ void DlgSettingsEditor::loadSettings()
     QStringList fixedFamilyNames;
     for (const auto &name : familyNames) {
         if (QFontDatabase::isFixedPitch(name)) {
-            fixedFamilyNames.append(name);
+            std::string utf8_name = name.toUtf8().constData();
+            if (boost::iequals(utf8_name, "8514oem")) {
+                fixedFamilyNames.append(name);
+            }
         }
     }
 #endif


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/10122

The 8514oem font is added when Windows users change DPI to for example 125% see https://answers.microsoft.com/en-us/windows/forum/all/windows-add-font-8514oem-when-i-change-windows-dpi/2ec32e81-52d9-40a0-ab35-07a8ef9051b8
which in turn results in a warning in the Report View which makes little sense to the user.