### PR TITLE
Start: Improve "Switch workbench after loading" tooltip

### DIFF
--- a/src/Mod/Start/Gui/DlgStartPreferences.ui
+++ b/src/Mod/Start/Gui/DlgStartPreferences.ui
@@ -30,7 +30,7 @@
       <item row="0" column="1">
        <widget class="QComboBox" name="AutoloadModuleCombo">
         <property name="toolTip">
-         <string>Choose which workbench to switch to after the program launches</string>
+         <string>Workbench to switch to after loading a file from the Start page, only used if Start is the start up workbench</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Make it clearer that this property is different from the "Start up workbench".

See #10580.