### PR TITLE
Core, Gui: allow breakpoints in Init.py and InitGui.py of mods

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -178,8 +178,8 @@ def InitApplications():
         InstallFile = os.path.join(Dir,"Init.py")
         if (os.path.exists(InstallFile)):
             try:
-                with open(file=InstallFile, encoding="utf-8") as f:
-                    exec(f.read())
+                with open(InstallFile, 'rt', encoding='utf-8') as f:
+                    exec(compile(f.read(), InstallFile, 'exec'))
             except Exception as inst:
                 Log('Init:      Initializing ' + Dir + '... failed\n')
                 Log('-'*100+'\n')

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -132,8 +132,8 @@ def InitApplications():
         InstallFile = os.path.join(Dir,"InitGui.py")
         if os.path.exists(InstallFile):
             try:
-                with open(file=InstallFile, encoding="utf-8") as f:
-                    exec(f.read())
+                with open(InstallFile, 'rt', encoding='utf-8') as f:
+                    exec(compile(f.read(), InstallFile, 'exec'))
             except Exception as inst:
                 Log('Init:      Initializing ' + Dir + '... failed\n')
                 Log('-'*100+'\n')


### PR DESCRIPTION
The changes make it possible to set breakpoints directly in the Python init scripts of mods, such as `Mod/Draft/Init.py` and `Mod/Draft/InitGui.py`. Currently, the python code is executed from a string without the Python interpreter/debugger knowing the source file path.