### PR TITLE
Gui: Fix rotation center indicator for OpenCascade style

### DIFF
--- a/src/Gui/OpenCascadeNavigationStyle.cpp
+++ b/src/Gui/OpenCascadeNavigationStyle.cpp
@@ -251,6 +251,9 @@ SbBool OpenCascadeNavigationStyle::processSoEvent(const SoEvent * const ev)
         newmode = NavigationStyle::PANNING;
         break;
     case CTRLDOWN|BUTTON2DOWN:
+        if (newmode != NavigationStyle::DRAGGING) {
+            saveCursorPosition(ev);
+        }
         newmode = NavigationStyle::DRAGGING;
         break;
     case BUTTON2DOWN:


### PR DESCRIPTION
When dragging in OpenCascade navigation style, the rotation center indicator is not shown because the rotation center is not found. The added lines make sure the rotation center is found.