### PR TITLE
Ignore scanning `src/Mod/Import/App/SCL_output` in codespell

### DIFF
--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -129,7 +129,7 @@ on:
         type: string
         required: false
       spellingIgnore:
-        default: ./.git,*.po,*.ts,*.svg,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/
+        default: ./.git,*.po,*.ts,*.svg,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL*,./src/WindowsInstaller,./src/Doc/FreeCAD.uml,./build/
         type: string
         required: false
       codespellFailSilent:


### PR DESCRIPTION
Follow-up to #10644   
`src/Mod/Import/App/SCL_output` is auto-generated and should be skipped by codespell.

ref: https://github.com/FreeCAD/FreeCAD/pull/10644#issuecomment-1713362858