### PR TITLE
Sketcher: add TypeId checking helpers

### DIFF
--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -48,6 +48,51 @@ using namespace std;
 using namespace SketcherGui;
 using namespace Sketcher;
 
+bool Sketcher::isCircle(const Part::Geometry& geom)
+{
+    return geom.getTypeId() == Part::GeomCircle::getClassTypeId();
+}
+
+bool Sketcher::isArcOfCircle(const Part::Geometry& geom)
+{
+    return geom.getTypeId() == Part::GeomArcOfCircle::getClassTypeId();
+}
+
+bool Sketcher::isEllipse(const Part::Geometry& geom)
+{
+    return geom.getTypeId() == Part::GeomEllipse::getClassTypeId();
+}
+
+bool Sketcher::isArcOfEllipse(const Part::Geometry& geom)
+{
+    return geom.getTypeId() == Part::GeomArcOfEllipse::getClassTypeId();
+}
+
+bool Sketcher::isLineSegment(const Part::Geometry& geom)
+{
+    return geom.getTypeId() == Part::GeomLineSegment::getClassTypeId();
+}
+
+bool Sketcher::isArcOfHyperbola(const Part::Geometry& geom)
+{
+    return geom.getTypeId() == Part::GeomArcOfHyperbola::getClassTypeId();
+}
+
+bool Sketcher::isArcOfParabola(const Part::Geometry& geom)
+{
+    return geom.getTypeId() == Part::GeomArcOfParabola::getClassTypeId();
+}
+
+bool Sketcher::isBSplineCurve(const Part::Geometry& geom)
+{
+    return geom.getTypeId() == Part::GeomBSplineCurve::getClassTypeId();
+}
+
+bool Sketcher::isPoint(const Part::Geometry& geom)
+{
+    return geom.getTypeId() == Part::GeomPoint::getClassTypeId();
+}
+
 bool SketcherGui::tryAutoRecompute(Sketcher::SketchObject* obj, bool& autoremoveredundants)
 {
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -51,6 +51,17 @@ namespace Sketcher
 {
 enum class PointPos : int;
 class SketchObject;
+
+bool isCircle(const Part::Geometry&);
+bool isArcOfCircle(const Part::Geometry&);
+bool isEllipse(const Part::Geometry&);
+bool isArcOfEllipse(const Part::Geometry&);
+bool isLineSegment(const Part::Geometry&);
+bool isArcOfHyperbola(const Part::Geometry&);
+bool isArcOfParabola(const Part::Geometry&);
+bool isBSplineCurve(const Part::Geometry&);
+bool isPoint(const Part::Geometry&);
+
 }  // namespace Sketcher
 
 namespace SketcherGui


### PR DESCRIPTION
in order to replace
```cpp
geo->getTypeId() == Part::GeomEllipse::getClassTypeId()
```

with
```
Sketcher::isEllipse(*geo)
```