### PR TITLE
Draft: use master version of dxf libraries

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -46,9 +46,9 @@ lines, polylines, lwpolylines, circles, arcs,
 texts, colors,layers (from groups)
 """
 # scaling factor between autocad font sizes and coin font sizes
-# the minimum version of the dxfLibrary needed to run
 TEXTSCALING = 1.35
-CURRENTDXFLIB = 1.41
+# the minimum version of the dxfLibrary needed to run - OBSOLETE - not used anymore
+# CURRENTDXFLIB = 1.41
 
 import sys
 import os
@@ -118,7 +118,8 @@ def errorDXFLib(gui):
 
         _weburl = 'https://raw.githubusercontent.com/yorikvanhavre/'
         _weburl += 'Draft-dxf-importer/'
-        baseurl = _weburl + '{0:.2f}'.format(CURRENTDXFLIB) + "/"
+        # baseurl = _weburl + '{0:.2f}'.format(CURRENTDXFLIB) + "/"
+        baseurl = _weburl + "master/"
         import ArchCommands
         from FreeCAD import Base
         progressbar = Base.ProgressIndicator()


### PR DESCRIPTION
There is no more reason to have FreeCAD use a specific branch of the dxf importer libraries (at some point FreeCAD master and stable release needed different versions because of py2/py3). Better switch to use the master branch.
 
Fixes issue yorikvanhavre/Draft-dxf-importer#26

I left the system in place in case this is needed again in some future