### PR TITLE
Gui: make layout of Combo, Property and Tree view more flexible

### DIFF
--- a/src/Gui/ComboView.h
+++ b/src/Gui/ComboView.h
@@ -56,7 +56,7 @@ namespace Gui {
 namespace DockWnd {
 
 /** Combo View
-  * is a combination of a tree, property and TaskPanel for
+  * is a combination of a tree and property view for
   * integrated user action.
  */
 class GuiExport ComboView : public Gui::DockWindow
@@ -68,7 +68,7 @@ public:
      * A constructor.
      * A more elaborate description of the constructor.
      */
-    ComboView(bool showModel, Gui::Document*  pcDocument, QWidget *parent=nullptr);
+    ComboView(Gui::Document*  pcDocument, QWidget *parent=nullptr);
 
     /**
      * A destructor.
@@ -76,33 +76,11 @@ public:
     */
     ~ComboView() override;
 
-    Gui::TaskView::TaskView *getTaskPanel(){return taskPanel;}
-    QTabWidget* getTabPanel() const { return tabs;}
-
-
     friend class Gui::ControlSingleton;
 
-    void showTreeView();
-    void showTaskView();
-
-private Q_SLOTS:
-    void onCurrentTabChanged(int index);
-
-protected:
-    void showDialog(Gui::TaskView::TaskDialog *dlg);
-    void closeDialog();
-    void closedDialog();
-    void changeEvent(QEvent *e) override;
-
 private:
-    int oldTabIndex;
-    int modelIndex;
-    int taskIndex;
-    QTabWidget                         * tabs;
     Gui::PropertyView                  * prop;
     Gui::TreePanel                     * tree;
-    Gui::TaskView::TaskView            * taskPanel;
-  //Gui::ProjectWidget                 * projectView;
 };
 
 } // namespace DockWnd

--- a/src/Gui/Control.cpp
+++ b/src/Gui/Control.cpp
@@ -80,7 +80,7 @@ QTabBar* ControlSingleton::findTabBar(QDockWidget* widget) const
     if (count > 1) {
         QList<QTabBar*> bars = getMainWindow()->findChildren<QTabBar*>();
         for (auto it : bars) {
-            if (it->count() == count) {
+            if (it->count() <= count) {
                 for (int i = 0; i < count; i++) {
                     if (it->tabText(i) == widget->windowTitle()) {
                         return it;

--- a/src/Gui/Control.cpp
+++ b/src/Gui/Control.cpp
@@ -37,6 +37,8 @@
 #include <Gui/MainWindow.h>
 
 #include "Control.h"
+#include "BitmapFactory.h"
+#include "Tree.h"
 #include "TaskView/TaskView.h"
 
 
@@ -46,10 +48,10 @@ using namespace std;
 /* TRANSLATOR Gui::ControlSingleton */
 
 ControlSingleton* ControlSingleton::_pcSingleton = nullptr;
-static QPointer<Gui::TaskView::TaskView> _taskPanel = nullptr;
 
 ControlSingleton::ControlSingleton()
   : ActiveDialog(nullptr)
+  , oldTabIndex(-1)
 {
 
 }
@@ -58,37 +60,86 @@ ControlSingleton::~ControlSingleton() = default;
 
 Gui::TaskView::TaskView* ControlSingleton::taskPanel() const
 {
-    auto pcComboView = qobject_cast<Gui::DockWnd::ComboView*>
-        (Gui::DockWindowManager::instance()->getDockWindow("Combo View"));
-    // should return the pointer to combo view
-    if (pcComboView)
-        return pcComboView->getTaskPanel();
-    // not all workbenches have the combo view enabled
-    else if (_taskPanel)
-        return _taskPanel;
-    // no task panel available
-    else
-        return nullptr;
+    auto taskView = qobject_cast<Gui::TaskView::TaskView*>
+        (Gui::DockWindowManager::instance()->getDockWindow("Tasks"));
+    return taskView;
+}
+
+void ControlSingleton::showDockWidget(QWidget* widget)
+{
+    QWidget* parent = widget->parentWidget();
+    if (parent) {
+        parent->show();
+        parent->raise();
+    }
+}
+
+QTabBar* ControlSingleton::findTabBar(QDockWidget* widget) const
+{
+    int count = getMainWindow()->tabifiedDockWidgets(widget).size() + 1;
+    if (count > 1) {
+        QList<QTabBar*> bars = getMainWindow()->findChildren<QTabBar*>();
+        for (auto it : bars) {
+            if (it->count() == count) {
+                for (int i = 0; i < count; i++) {
+                    if (it->tabText(i) == widget->windowTitle()) {
+                        return it;
+                    }
+                }
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+void ControlSingleton::aboutToShowDialog(QDockWidget* widget)
+{
+    static QIcon icon = Gui::BitmapFactory().pixmap("edit-edit.svg");
+    QTabBar* bar = findTabBar(widget);
+    if (bar) {
+        oldTabIndex = bar->currentIndex();
+        for (int i = 0; i < bar->count(); i++) {
+            if (bar->tabText(i) == widget->windowTitle()) {
+                bar->setTabIcon(i, icon);
+                break;
+            }
+        }
+    }
+
+    widget->show();
+    widget->raise();
+}
+
+void ControlSingleton::aboutToHideDialog(QDockWidget* widget)
+{
+    QTabBar* bar = findTabBar(widget);
+    if (bar) {
+        bar->setCurrentIndex(oldTabIndex);
+        for (int i = 0; i < bar->count(); i++) {
+            if (bar->tabText(i) == widget->windowTitle()) {
+                bar->setTabIcon(i, QIcon());
+                break;
+            }
+        }
+    }
 }
 
 void ControlSingleton::showTaskView()
 {
-    auto pcComboView = qobject_cast<Gui::DockWnd::ComboView*>
-        (Gui::DockWindowManager::instance()->getDockWindow("Combo View"));
-    if (pcComboView)
-        pcComboView->showTaskView();
-    else if (_taskPanel)
-        _taskPanel->raise();
+    Gui::TaskView::TaskView* taskView = taskPanel();
+    if (taskView) {
+        showDockWidget(taskView);
+    }
 }
 
 void ControlSingleton::showModelView()
 {
-    auto pcComboView = qobject_cast<Gui::DockWnd::ComboView*>
-        (Gui::DockWindowManager::instance()->getDockWindow("Combo View"));
-    if (pcComboView)
-        pcComboView->showTreeView();
-    else if (_taskPanel)
-        _taskPanel->raise();
+    auto treeView = qobject_cast<Gui::TreeDockWidget*>
+        (Gui::DockWindowManager::instance()->getDockWindow("Tree view"));
+    if (treeView) {
+        showDockWidget(treeView);
+    }
 }
 
 void ControlSingleton::showDialog(Gui::TaskView::TaskDialog *dlg)
@@ -113,14 +164,15 @@ void ControlSingleton::showDialog(Gui::TaskView::TaskDialog *dlg)
     // which may open a transaction but fails when auto transaction is still active.
     App::AutoTransaction::setEnable(false);
 
-    auto pcComboView = qobject_cast<Gui::DockWnd::ComboView*>
-        (Gui::DockWindowManager::instance()->getDockWindow("Combo View"));
+    Gui::TaskView::TaskView* taskView = taskPanel();
     // should return the pointer to combo view
-    if (pcComboView) {
-        pcComboView->showDialog(dlg);
+    if (taskView) {
+        taskView->showDialog(dlg);
+
         // make sure that the combo view is shown
-        auto dw = qobject_cast<QDockWidget*>(pcComboView->parentWidget());
+        auto dw = qobject_cast<QDockWidget*>(taskView->parentWidget());
         if (dw) {
+            aboutToShowDialog(dw);
             dw->setVisible(true);
             dw->toggleViewAction()->setVisible(true);
             dw->setFeatures(QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable);
@@ -132,37 +184,6 @@ void ControlSingleton::showDialog(Gui::TaskView::TaskDialog *dlg)
         connect(dlg, &TaskView::TaskDialog::aboutToBeDestroyed,
                 this, &ControlSingleton::closedDialog);
     }
-    // not all workbenches have the combo view enabled
-    else if (!_taskPanel) {
-        auto dw = new QDockWidget();
-        dw->setWindowTitle(tr("Task panel"));
-        dw->setFeatures(QDockWidget::DockWidgetMovable);
-        _taskPanel = new Gui::TaskView::TaskView(dw);
-        dw->setWidget(_taskPanel);
-        _taskPanel->showDialog(dlg);
-        getMainWindow()->addDockWidget(Qt::LeftDockWidgetArea, dw);
-        connect(dlg, &TaskView::TaskDialog::destroyed, dw, &ControlSingleton::deleteLater);
-
-        // if we have the normal tree view available then just tabify with it
-        QWidget* treeView = Gui::DockWindowManager::instance()->getDockWindow("Tree view");
-        QDockWidget* par = treeView ? qobject_cast<QDockWidget*>(treeView->parent()) : 0;
-        if (par && par->isVisible()) {
-            getMainWindow()->tabifyDockWidget(par, dw);
-            qApp->processEvents(); // make sure that the task panel is tabified now
-            dw->show();
-            dw->raise();
-        }
-    }
-}
-
-QTabWidget* ControlSingleton::tabPanel() const
-{
-    Gui::DockWnd::ComboView* pcComboView = qobject_cast<Gui::DockWnd::ComboView*>
-        (Gui::DockWindowManager::instance()->getDockWindow("Combo View"));
-    // should return the pointer to combo view
-    if (pcComboView)
-        return pcComboView->getTabPanel();
-    return nullptr;
 }
 
 Gui::TaskView::TaskDialog* ControlSingleton::activeDialog() const
@@ -170,22 +191,11 @@ Gui::TaskView::TaskDialog* ControlSingleton::activeDialog() const
     return ActiveDialog;
 }
 
-Gui::TaskView::TaskView* ControlSingleton::getTaskPanel()
-{
-    // should return the pointer to combo view
-    auto pcComboView = qobject_cast<Gui::DockWnd::ComboView*>
-        (Gui::DockWindowManager::instance()->getDockWindow("Combo View"));
-    if (pcComboView)
-        return pcComboView->getTaskPanel();
-    else
-        return _taskPanel;
-}
-
 void ControlSingleton::accept()
 {
-    Gui::TaskView::TaskView* taskPanel = getTaskPanel();
-    if (taskPanel) {
-        taskPanel->accept();
+    Gui::TaskView::TaskView* taskView = taskPanel();
+    if (taskView) {
+        taskView->accept();
         qApp->processEvents(QEventLoop::ExcludeUserInputEvents |
                             QEventLoop::ExcludeSocketNotifiers);
     }
@@ -193,9 +203,9 @@ void ControlSingleton::accept()
 
 void ControlSingleton::reject()
 {
-    Gui::TaskView::TaskView* taskPanel = getTaskPanel();
-    if (taskPanel) {
-        taskPanel->reject();
+    Gui::TaskView::TaskView* taskView = taskPanel();
+    if (taskView) {
+        taskView->reject();
         qApp->processEvents(QEventLoop::ExcludeUserInputEvents |
                             QEventLoop::ExcludeSocketNotifiers);
     }
@@ -203,29 +213,25 @@ void ControlSingleton::reject()
 
 void ControlSingleton::closeDialog()
 {
-    auto pcComboView = qobject_cast<Gui::DockWnd::ComboView*>
-        (Gui::DockWindowManager::instance()->getDockWindow("Combo View"));
-    // should return the pointer to combo view
-    if (pcComboView)
-        pcComboView->closeDialog();
-    else if (_taskPanel)
-        _taskPanel->removeDialog();
+    Gui::TaskView::TaskView* taskView = taskPanel();
+    if (taskView)
+        taskView->removeDialog();
 }
 
 void ControlSingleton::closedDialog()
 {
     ActiveDialog = nullptr;
-    auto pcComboView = qobject_cast<Gui::DockWnd::ComboView*>
-        (Gui::DockWindowManager::instance()->getDockWindow("Combo View"));
-    // should return the pointer to combo view
-    assert(pcComboView);
-    pcComboView->closedDialog();
+    Gui::TaskView::TaskView* taskView = taskPanel();
+    assert(taskView);
+
     // make sure that the combo view is shown
-    auto dw = qobject_cast<QDockWidget*>(pcComboView->parentWidget());
-    if (dw)
+    auto dw = qobject_cast<QDockWidget*>(taskView->parentWidget());
+    if (dw) {
+        aboutToHideDialog(dw);
         dw->setFeatures(QDockWidget::DockWidgetClosable
                         | QDockWidget::DockWidgetMovable
                         | QDockWidget::DockWidgetFloatable);
+    }
 }
 
 bool ControlSingleton::isAllowedAlterDocument() const

--- a/src/Gui/Control.h
+++ b/src/Gui/Control.h
@@ -32,7 +32,8 @@
 
 #include <Gui/TaskView/TaskDialog.h>
 
-class QTabWidget;
+class QDockWidget;
+class QTabBar;
 
 namespace App
 {
@@ -75,8 +76,6 @@ public:
     Gui::TaskView::TaskView* taskPanel() const;
     /// raising the model view
     void showModelView();
-    /// get the tab panel
-    QTabWidget* tabPanel() const;
     //@}
 
     /*!
@@ -107,9 +106,6 @@ private Q_SLOTS:
     void closedDialog();
 
 private:
-    Gui::TaskView::TaskView *getTaskPanel();
-
-private:
     struct status {
         std::bitset<32> StatusBits;
     } CurrentStatus;
@@ -117,12 +113,17 @@ private:
     std::stack<status> StatusStack;
 
     Gui::TaskView::TaskDialog *ActiveDialog;
+    int oldTabIndex;
 
 private:
     /// Construction
     ControlSingleton();
     /// Destruction
     ~ControlSingleton() override;
+    void showDockWidget(QWidget*);
+    QTabBar* findTabBar(QDockWidget*) const;
+    void aboutToShowDialog(QDockWidget* widget);
+    void aboutToHideDialog(QDockWidget* widget);
 
     static ControlSingleton* _pcSingleton;
 };

--- a/src/Gui/DockWindowManager.cpp
+++ b/src/Gui/DockWindowManager.cpp
@@ -176,6 +176,20 @@ QWidget* DockWindowManager::getDockWindow(const char* name) const
 }
 
 /**
+ * Returns the dock widget by name.
+ * If it does not exist 0 is returned.
+ */
+QDockWidget* DockWindowManager::getDockContainer(const char* name) const
+{
+    for (QList<QDockWidget*>::Iterator it = d->_dockedWindows.begin(); it != d->_dockedWindows.end(); ++it) {
+        if ((*it)->objectName() == QLatin1String(name))
+            return (*it);
+    }
+
+    return nullptr;
+}
+
+/**
  * Returns a list of all widgets inside the dock windows.
  */
 QList<QWidget*> DockWindowManager::getDockWindows() const

--- a/src/Gui/DockWindowManager.h
+++ b/src/Gui/DockWindowManager.h
@@ -86,6 +86,8 @@ public:
     /// returned from @ref addDockWindow. If you want to access the QDockWidget
     /// you get it with parentWidget() of the returned widget.
     QWidget* getDockWindow(const char* name) const;
+    /// Returns the QDockWidget container
+    QDockWidget* getDockContainer(const char* name) const;
     /// Returns a list of all widgets which set to a QDockWidget.
     QList<QWidget*> getDockWindows() const;
     /// If the corresponding dock widget isn't visible then activate it

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -469,11 +469,11 @@ void MainWindow::setupDockWindows()
     if (ht != config.end())
         hiddenDockWindows = ht->second;
 
-    bool treeView = setupTreeView(hiddenDockWindows);
-    bool propertyView = setupPropertyView(hiddenDockWindows);
+    setupTreeView(hiddenDockWindows);
+    setupPropertyView(hiddenDockWindows);
     setupTaskView(hiddenDockWindows);
     setupSelectionView(hiddenDockWindows);
-    setupComboView(hiddenDockWindows, !treeView || !propertyView);
+    setupComboView(hiddenDockWindows);
 
     // Report view must be created before PythonConsole!
     setupReportView(hiddenDockWindows);
@@ -492,7 +492,7 @@ bool MainWindow::setupTreeView(const std::string& hiddenDockWindows)
         bool enabled = group->GetBool("Enabled", true);
         if (enabled != group->GetBool("Enabled", false)) {
             enabled = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
-                            ->GetGroup("MainWindow")->GetGroup("DockWindows")->GetBool("Std_TreeView",false);
+                            ->GetGroup("MainWindow")->GetGroup("DockWindows")->GetBool("Std_TreeView", true);
         }
         group->SetBool("Enabled", enabled); //ensure entry exists.
         if (enabled) {
@@ -537,7 +537,7 @@ bool MainWindow::setupPropertyView(const std::string& hiddenDockWindows)
         bool enabled = group->GetBool("Enabled", true);
         if (enabled != group->GetBool("Enabled", false)) {
             enabled = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
-                            ->GetGroup("MainWindow")->GetGroup("DockWindows")->GetBool("Std_PropertyView",false);
+                            ->GetGroup("MainWindow")->GetGroup("DockWindows")->GetBool("Std_PropertyView", true);
         }
         group->SetBool("Enabled", enabled); //ensure entry exists.
         if (enabled) {
@@ -572,23 +572,23 @@ bool MainWindow::setupSelectionView(const std::string& hiddenDockWindows)
     return false;
 }
 
-bool MainWindow::setupComboView(const std::string& hiddenDockWindows, bool enable)
+bool MainWindow::setupComboView(const std::string& hiddenDockWindows)
 {
     // Combo view
     if (hiddenDockWindows.find("Std_ComboView") == std::string::npos) {
-        if (!enable) {
-            ParameterGrp::handle group = App::GetApplication().GetUserParameter().
-                    GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("DockWindows")->GetGroup("ComboView");
-            enable = group->GetBool("Enabled", true);
+        ParameterGrp::handle group = App::GetApplication().GetUserParameter().
+                GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("DockWindows")->GetGroup("ComboView");
+        bool enable = group->GetBool("Enabled", false);
+
+        if (enable) {
+            auto pcComboView = new ComboView(nullptr, this);
+            pcComboView->setObjectName(QString::fromLatin1(QT_TRANSLATE_NOOP("QDockWidget", "Model")));
+            pcComboView->setMinimumWidth(150);
+
+            DockWindowManager* pDockMgr = DockWindowManager::instance();
+            pDockMgr->registerDockWindow("Std_ComboView", pcComboView);
+            return true;
         }
-
-        auto pcComboView = new ComboView(nullptr, this);
-        pcComboView->setObjectName(QString::fromLatin1(QT_TRANSLATE_NOOP("QDockWidget", "Model")));
-        pcComboView->setMinimumWidth(150);
-
-        DockWindowManager* pDockMgr = DockWindowManager::instance();
-        pDockMgr->registerDockWindow("Std_ComboView", pcComboView);
-        return true;
     }
 
     return false;

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -479,6 +479,8 @@ void MainWindow::setupDockWindows()
     setupReportView(hiddenDockWindows);
     setupPythonConsole(hiddenDockWindows);
     setupDAGView(hiddenDockWindows);
+
+    this->setTabPosition(Qt::LeftDockWidgetArea, QTabWidget::North);
 }
 
 bool MainWindow::setupTreeView(const std::string& hiddenDockWindows)
@@ -580,8 +582,8 @@ bool MainWindow::setupComboView(const std::string& hiddenDockWindows, bool enabl
             enable = group->GetBool("Enabled", true);
         }
 
-        auto pcComboView = new ComboView(enable, nullptr, this);
-        pcComboView->setObjectName(QString::fromLatin1(QT_TRANSLATE_NOOP("QDockWidget","Combo View")));
+        auto pcComboView = new ComboView(nullptr, this);
+        pcComboView->setObjectName(QString::fromLatin1(QT_TRANSLATE_NOOP("QDockWidget", "Model")));
         pcComboView->setMinimumWidth(150);
 
         DockWindowManager* pDockMgr = DockWindowManager::instance();

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -471,6 +471,7 @@ void MainWindow::setupDockWindows()
 
     bool treeView = setupTreeView(hiddenDockWindows);
     bool propertyView = setupPropertyView(hiddenDockWindows);
+    setupTaskView(hiddenDockWindows);
     setupSelectionView(hiddenDockWindows);
     setupComboView(hiddenDockWindows, !treeView || !propertyView);
 
@@ -502,6 +503,23 @@ bool MainWindow::setupTreeView(const std::string& hiddenDockWindows)
             pDockMgr->registerDockWindow("Std_TreeView", tree);
             return true;
         }
+    }
+
+    return false;
+}
+
+bool MainWindow::setupTaskView(const std::string& hiddenDockWindows)
+{
+    // Task view
+    if (hiddenDockWindows.find("Std_TaskView") == std::string::npos) {
+        auto taskView = new Gui::TaskView::TaskView(this);
+        taskView->setObjectName
+            (QString::fromLatin1(QT_TRANSLATE_NOOP("QDockWidget","Tasks")));
+        taskView->setMinimumWidth(210);
+
+        DockWindowManager* pDockMgr = DockWindowManager::instance();
+        pDockMgr->registerDockWindow("Std_TaskView", taskView);
+        return true;
     }
 
     return false;

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -287,7 +287,7 @@ private:
     bool setupTaskView(const std::string&);
     bool setupPropertyView(const std::string&);
     bool setupSelectionView(const std::string&);
-    bool setupComboView(const std::string&, bool enable);
+    bool setupComboView(const std::string&);
     bool setupDAGView(const std::string&);
     bool setupReportView(const std::string&);
     bool setupPythonConsole(const std::string&);

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -284,6 +284,7 @@ protected:
 private:
     void setupDockWindows();
     bool setupTreeView(const std::string&);
+    bool setupTaskView(const std::string&);
     bool setupPropertyView(const std::string&);
     bool setupSelectionView(const std::string&);
     bool setupComboView(const std::string&, bool enable);

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -226,23 +226,7 @@ void DlgSettingsGeneral::saveSettings()
     int blinkTime{hGrp->GetBool("EnableCursorBlinking", true) ? -1 : 0};
     qApp->setCursorFlashTime(blinkTime);
 
-    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/DockWindows");
-    bool treeView=false;
-    bool propertyView=false;
-    bool comboView=true;
-    switch(ui->treeMode->currentIndex()) {
-    case 1:
-        treeView = propertyView = true;
-        comboView = false;
-        break;
-    case 2:
-        comboView = true;
-        treeView = propertyView = true;
-        break;
-    }
-    hGrp->GetGroup("ComboView")->SetBool("Enabled",comboView);
-    hGrp->GetGroup("TreeView")->SetBool("Enabled",treeView);
-    hGrp->GetGroup("PropertyView")->SetBool("Enabled",propertyView);
+    saveDockWindowVisibility();
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow");
     hGrp->SetBool("TiledBackground", ui->tiledBackground->isChecked());
@@ -330,20 +314,7 @@ void DlgSettingsGeneral::loadSettings()
     ui->toolbarIconSize->setCurrentIndex(index);
 
     //TreeMode combobox setup.
-    ui->treeMode->clear();
-    ui->treeMode->addItem(tr("Combo View"));
-    ui->treeMode->addItem(tr("TreeView and PropertyView"));
-    ui->treeMode->addItem(tr("Both"));
-
-    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/DockWindows");
-    bool propertyView = hGrp->GetGroup("PropertyView")->GetBool("Enabled",false);
-    bool treeView = hGrp->GetGroup("TreeView")->GetBool("Enabled",false);
-    bool comboView = hGrp->GetGroup("ComboView")->GetBool("Enabled",true);
-    index = 0;
-    if(propertyView || treeView) {
-        index = comboView?2:1;
-    }
-    ui->treeMode->setCurrentIndex(index);
+    loadDockWindowVisibility();
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow");
     ui->tiledBackground->setChecked(hGrp->GetBool("TiledBackground", false));
@@ -425,6 +396,48 @@ void DlgSettingsGeneral::changeEvent(QEvent *event)
     else {
         QWidget::changeEvent(event);
     }
+}
+
+void DlgSettingsGeneral::saveDockWindowVisibility()
+{
+    auto hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/DockWindows");
+    bool treeView = hGrp->GetGroup("TreeView")->GetBool("Enabled", true);
+    bool propertyView = hGrp->GetGroup("PropertyView")->GetBool("Enabled", true);
+    bool comboView = hGrp->GetGroup("ComboView")->GetBool("Enabled", false);
+    switch (ui->treeMode->currentIndex()) {
+    case 0:
+        comboView = true;
+        treeView = propertyView = false;
+        break;
+    case 1:
+        treeView = propertyView = true;
+        comboView = false;
+        break;
+    }
+
+    hGrp->GetGroup("ComboView")->SetBool("Enabled", comboView);
+    hGrp->GetGroup("TreeView")->SetBool("Enabled", treeView);
+    hGrp->GetGroup("PropertyView")->SetBool("Enabled", propertyView);
+}
+
+void DlgSettingsGeneral::loadDockWindowVisibility()
+{
+    ui->treeMode->clear();
+    ui->treeMode->addItem(tr("Combo View"));
+    ui->treeMode->addItem(tr("TreeView and PropertyView"));
+
+    auto hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/DockWindows");
+    bool propertyView = hGrp->GetGroup("PropertyView")->GetBool("Enabled", true);
+    bool treeView = hGrp->GetGroup("TreeView")->GetBool("Enabled", true);
+    bool comboView = hGrp->GetGroup("ComboView")->GetBool("Enabled", false);
+    int index = -1;
+    if (propertyView || treeView) {
+        index = 1;
+    }
+    else if (comboView) {
+        index = 0;
+    }
+    ui->treeMode->setCurrentIndex(index);
 }
 
 void DlgSettingsGeneral::recreatePreferencePackMenu()

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.h
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.h
@@ -72,6 +72,8 @@ public Q_SLOTS:
     void onUnitSystemIndexChanged(int index);
 
 private:
+    void saveDockWindowVisibility();
+    void loadDockWindowVisibility();
     void setRecentFileSize();
     void saveAsNewPreferencePack();
     void revertToSavedConfig();

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -837,6 +837,7 @@ DockWindowItems* StdWorkbench::setupDockWindows() const
     //root->addDockWidget("Std_HelpView", Qt::RightDockWidgetArea, true, false);
     root->addDockWidget("Std_TreeView", Qt::LeftDockWidgetArea, true, false);
     root->addDockWidget("Std_PropertyView", Qt::LeftDockWidgetArea, true, false);
+    root->addDockWidget("Std_TaskView", Qt::LeftDockWidgetArea, true, true);
     root->addDockWidget("Std_SelectionView", Qt::LeftDockWidgetArea, false, false);
     root->addDockWidget("Std_ComboView", Qt::LeftDockWidgetArea, false, false);
     root->addDockWidget("Std_ReportView", Qt::BottomDockWidgetArea, true, true);


### PR DESCRIPTION
Rework the current behaviour of the ComboView to make it more flexible. It moves the Task view out of the ComboView and makes it a stand-alone dock widget. 

See https://forum.freecad.org/viewtopic.php?p=626732#p626732 and https://forum.freecad.org/viewtopic.php?t=79950