### PR TITLE
[TD]allow cosmetic deletion via DEL

### DIFF
--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -69,6 +69,7 @@
 #include "GeometryObject.h"
 #include "LineGroup.h"
 #include "Preferences.h"
+#include "DrawViewPart.h"
 
 
 using namespace TechDraw;
@@ -1625,6 +1626,27 @@ std::string DrawUtil::translateArbitrary(std::string context, std::string baseNa
     return ssTranslated + suffix;
 }
 
+// true if owner->element is a cosmetic vertex
+bool DrawUtil::isCosmeticVertex(App::DocumentObject* owner, std::string element)
+{
+    auto ownerView = static_cast<TechDraw::DrawViewPart*>(owner);
+    auto vertex = ownerView->getVertex(element);
+    if (vertex) {
+        return vertex->getCosmetic();
+    }
+    return false;
+}
+
+// true if owner->element is a cosmetic edge
+bool DrawUtil::isCosmeticEdge(App::DocumentObject* owner, std::string element)
+{
+    auto ownerView = static_cast<TechDraw::DrawViewPart*>(owner);
+    auto edge = ownerView->getEdge(element);
+    if (edge) {
+        return edge->getCosmetic();
+    }
+    return false;
+}
 
 //============================
 // various debugging routines.

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -255,6 +255,8 @@ public:
 
     static std::string translateArbitrary(std::string context, std::string baseName, std::string uniqueName);
 
+    static bool isCosmeticVertex(App::DocumentObject* owner, std::string element);
+    static bool isCosmeticEdge(App::DocumentObject* owner, std::string element);
 
     //debugging routines
     static void dumpVertexes(const char* text, const TopoDS_Shape& s);

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -47,6 +47,7 @@
 #include <Mod/TechDraw/App/DrawViewDimension.h>
 #include <Mod/TechDraw/App/DrawViewMulti.h>
 #include <Mod/TechDraw/App/LineGroup.h>
+#include <Mod/TechDraw/App/Cosmetic.h>
 
 #include "PreferencesGui.h"
 #include "QGIView.h"
@@ -59,6 +60,7 @@
 
 using namespace TechDrawGui;
 using namespace TechDraw;
+using DU = DrawUtil;
 
 PROPERTY_SOURCE(TechDrawGui::ViewProviderViewPart, TechDrawGui::ViewProviderDrawingView)
 
@@ -304,10 +306,20 @@ void ViewProviderViewPart::handleChangedPropertyType(Base::XMLReader &reader, co
     }
 }
 
-bool ViewProviderViewPart::onDelete(const std::vector<std::string> &)
+bool ViewProviderViewPart::onDelete(const std::vector<std::string> & subNames)
 {
-    // we cannot delete if the view has a section or detail view
+//    Base::Console().Message("VPVP::onDelete() - subs: %d\n", subNames.size());
+    // if a cosmetic subelement is in the list of selected subNames then we treat this
+    // as a delete of the subelement and not a delete of the DVP
+    std::vector<std::string> removables = getSelectedCosmetics(subNames);
+    if (!removables.empty()) {
+        // we have cosmetics, so remove them and tell Std_Delete not to remove the DVP
+        deleteCosmeticElements(removables);
+        getViewObject()->recomputeFeature();
+        return false;
+    }
 
+    // we cannot delete if the view has a section or detail view
     QString bodyMessage;
     QTextStream bodyMessageStream(&bodyMessage);
 
@@ -323,17 +335,56 @@ bool ViewProviderViewPart::onDelete(const std::vector<std::string> &)
             QMessageBox::Ok);
         return false;
     }
-    else {
-        return true;
-    }
+    return true;
 }
 
 bool ViewProviderViewPart::canDelete(App::DocumentObject *obj) const
 {
+//    Base::Console().Message("VPVP::canDelete()\n");
     // deletions of part objects (detail view, View etc.) are valid
     // that it cannot be deleted if it has a child view is handled in the onDelete() function
     Q_UNUSED(obj)
     return true;
+}
+
+//! extract the names of cosmetic subelements from the list of all selected elements
+std::vector<std::string> ViewProviderViewPart::getSelectedCosmetics(std::vector<std::string> subNames)
+{
+//    Base::Console().Message("VPVP::getSelectedCosmetics(%d removables)\n", subNames.size());
+
+    std::vector<std::string> result;
+    // pick out any cosmetic vertices or edges in the selection
+    for (auto& sub : subNames) {
+        if (DU::getGeomTypeFromName(sub) == "Vertex") {
+            if (DU::isCosmeticVertex(getViewObject(), sub)) {
+                result.emplace_back(sub);
+            }
+        } else if (DU::getGeomTypeFromName(sub) == "Edge") {
+            if (DU::isCosmeticEdge(getViewObject(), sub)) {
+                result.emplace_back(sub);
+            }
+        }
+    }
+    return result;
+}
+
+//! delete cosmetic elements for a list of subelement names
+void ViewProviderViewPart::deleteCosmeticElements(std::vector<std::string> removables)
+{
+//    Base::Console().Message("VPVP::deleteCosmeticElements(%d removables)\n", removables.size());
+    for (auto& name : removables) {
+        if (DU::getGeomTypeFromName(name) == "Vertex") {
+            CosmeticVertex* vert = getViewObject()->getCosmeticVertexBySelection(name);
+            getViewObject()->removeCosmeticVertex(vert->getTagAsString());
+            continue;
+        }
+        if (DU::getGeomTypeFromName(name) == "Edge") {
+            CosmeticEdge* edge = getViewObject()->getCosmeticEdgeBySelection(name);
+            // if not edge, something has gone very wrong!
+            getViewObject()->removeCosmeticEdge(edge->getTagAsString());
+            continue;
+        }
+    }
 }
 
 App::Color ViewProviderViewPart::prefSectionColor()

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
@@ -78,6 +78,9 @@ public:
     std::vector<App::DocumentObject*> claimChildren(void) const override;
     void fixSceneDependencies();
 
+    std::vector<std::string> getSelectedCosmetics(std::vector<std::string> subNames);
+    void deleteCosmeticElements(std::vector<std::string> removables);
+
     TechDraw::DrawViewPart* getViewObject() const override;
     TechDraw::DrawViewPart* getViewPart() const;
 };


### PR DESCRIPTION
This PR implements a solution to a long standing problem where users press the delete key instead of using the CosmeticEraser command.  This deletes the entire view instead of the selected cosmetic element.