### PR TITLE
[Macro Execute Dialog] add file name and file content filtering

### DIFF
--- a/src/Gui/DlgMacroExecute.ui
+++ b/src/Gui/DlgMacroExecute.ui
@@ -77,7 +77,39 @@
           </property>
          </widget>
         </item>
-       <item row="1" column="0">
+        <item row="1" column="0">
+         <layout class="QHBoxLayout">
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Find file:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="LineEditFind">
+            <property name="toolTip">
+             <string>Case-insensitive search for filenames, regular expressions supported</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Find in files:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="LineEditFindInFiles">
+            <property name="toolTip">
+             <string>Filter by case-insensitive file content, regular expressions supported</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="2" column="0">
          <widget class="QTabWidget" name="tabMacroWidget">
           <property name="tabPosition">
            <enum>QTabWidget::North</enum>
@@ -137,7 +169,7 @@
           </widget>
          </widget>
         </item>
-        </layout>
+       </layout>
       </widget>
      </item>
      <item row="0" column="1">
@@ -281,7 +313,7 @@
        </item>
       </layout>
      </item>
-    <item row="1" column="0">
+     <item row="1" column="0">
       <widget class="QGroupBox" name="DestinationGroup">
        <property name="title">
         <string>User macros location:</string>
@@ -307,15 +339,12 @@
           <property name="focusPolicy">
            <enum>Qt::StrongFocus</enum>
           </property>
-          <property name="mode">
-           <enum>Gui::FileChooser::Directory</enum>
-          </property>
          </widget>
         </item>
        </layout>
       </widget>
      </item>
-     </layout>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/Gui/DlgMacroExecuteImp.h
+++ b/src/Gui/DlgMacroExecuteImp.h
@@ -64,9 +64,12 @@ private:
     void onUserMacroListBoxCurrentItemChanged(QTreeWidgetItem*);
     void onSystemMacroListBoxCurrentItemChanged(QTreeWidgetItem*);
     void onTabMacroWidgetCurrentChanged(int index);
+    void onLineEditFindTextChanged(const QString&);
+    void onLineEditFindInFilesTextChanged(const QString&);
 
 protected:
     void fillUpList();
+    QStringList filterFiles(const QString&);
 
 protected:
     QString macroPath;


### PR DESCRIPTION
This adds 2 labels and 2 line edits above the macro files list box:

Find file: [LineEditFile] Find in files: [LineEditFindInFiles]
[macro file names list box]

LineEditFile text is used to search the filenames for matches to the filter the user has entered.  Example: if the user types in "a" (without the quotes) then only files with "a" in the filename get listed in the list box.  Regular expressions are supported.  A check is done if the text entered is a valid regex expression.  If it is not valid, then we use a simpler text search with QString::contains().

LineEditFindInFiles text is used to further filter the results of the first filter to only include files containing text entered in LineEditFindInFiles.  This is also a regular expression search unless it's an invalid regex expression, in which case QString::contains() is used instead.

In the filtering process we skip as many loops as possible.  For example, if there is no content filter then we don't bother loading and reading the files to search for matches to the empty string.  If there is no filename filter, then we just apply the content filter to the unfiltered filenames.

All searches are case-insensitive.
![Snip macro screenshot-4e5b33](https://github.com/FreeCAD/FreeCAD/assets/39143564/8e45cbff-c7ec-491d-9640-bb88f760ba42)

Notice in the screenshot, the regular expression calls for file names with an _ followed by a capital letter, and yet the results contain lower case matches.  I considered adding a checkbox for case-sensitive, but I don't want to clutter up the dialog.


