### PR TITLE
Assembly: Fix joint icons

### DIFF
--- a/src/Mod/Assembly/Gui/Resources/icons/Assembly_CreateJointBall.svg
+++ b/src/Mod/Assembly/Gui/Resources/icons/Assembly_CreateJointBall.svg
@@ -7,7 +7,7 @@
    id="svg2784"
    sodipodi:version="0.32"
    inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
-   sodipodi:docname="Joint_Ball.svg"
+   sodipodi:docname="Assembly_CreateJointBall.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -110,9 +110,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="9.0727665"
-     inkscape:cx="46.788375"
-     inkscape:cy="12.620186"
+     inkscape:zoom="12.830829"
+     inkscape:cx="35.344558"
+     inkscape:cy="26.225896"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:document-units="px"
@@ -184,7 +184,7 @@
     <g
        id="g1"
        inkscape:label="Part"
-       transform="matrix(0.83333332,0,0,0.83333332,5.3333339,5.3333339)">
+       transform="matrix(0.93353917,0,0,0.93353917,3.1649726,2.1267463)">
       <circle
          style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3808);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:1.80564;marker:none;enable-background:accumulate"
          id="path2826"
@@ -209,7 +209,7 @@
     </g>
     <g
        id="g3894"
-       transform="matrix(0.59756098,0,0,0.59756098,6.2756094,12.367563)">
+       transform="matrix(0.6694159,0,0,0.6694159,4.2205539,10.00682)">
       <path
          id="path3034"
          style="fill:#cc0000;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"

--- a/src/Mod/Assembly/Gui/Resources/icons/Assembly_CreateJointCylindrical.svg
+++ b/src/Mod/Assembly/Gui/Resources/icons/Assembly_CreateJointCylindrical.svg
@@ -5,7 +5,7 @@
    id="svg2821"
    sodipodi:version="0.32"
    inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
-   sodipodi:docname="Joint_Clyndrical_Alt.svg"
+   sodipodi:docname="Assembly_CreateJointCylindrical.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -197,8 +197,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="8.0000004"
-     inkscape:cx="53.687497"
-     inkscape:cy="22.562499"
+     inkscape:cx="36.437498"
+     inkscape:cy="44.062498"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:document-units="px"
@@ -361,45 +361,45 @@
       </g>
     </g>
     <g
-       id="g11"
+       id="g13"
        inkscape:label="Arrows"
        transform="rotate(-120,32.120361,31.864491)">
       <path
          style="fill:#cc0000;stroke:#280000;stroke-width:1.44624;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
          d="m 20.034237,35.554615 0.06786,-5.078769 8.949114,8.324918 -9.169637,8.181082 0.06786,-5.07877 C 13.046383,41.667788 5.7140243,37.951748 5.7140244,34.806973 l 1e-7,-6.297666 c 0,0 2.6499197,7.030509 14.3202125,7.045308 z"
-         id="path1"
+         id="path6"
          sodipodi:nodetypes="cccccccc" />
       <path
          style="display:inline;mix-blend-mode:normal;fill:none;stroke:#ef2929;stroke-width:1.44624;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 21.39105,43.663017 5.518848,-4.879253 -5.391624,-4.987514 -0.03817,3.041133 C 11.304161,37.057072 7.1410319,32.755043 7.1410319,32.755043 l 4.5e-6,2.0746 c 0,0 1.038585,5.595611 14.2881836,5.816818 z"
-         id="path2"
+         id="path7"
          sodipodi:nodetypes="cccccccc" />
       <g
-         id="g4"
+         id="g9"
          transform="matrix(0.82357963,-0.00653796,-0.00848163,-0.63484615,25.744689,50.319336)">
         <path
            style="fill:#cc0000;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
            d="m 22,23 v 8 L 11,18 22,5 v 8 c 8.384675,0.284272 17.347043,6.045424 17.398052,10.998501 l 0.10215,9.918935 C 39.500202,33.917436 36.168943,22.877393 22,23 Z"
-           id="path3"
+           id="path8"
            sodipodi:nodetypes="cccccccc" />
         <path
            style="display:inline;mix-blend-mode:normal;fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            d="M 20,10.5 13.6,18 20,25.5 V 21 c 12.350879,-0.473246 17.471895,5.944927 17.471895,5.944927 l 0.02131,-3.001231 c 0,0 -2.314076,-8.79997 -17.493209,-8.943696 z"
-           id="path4"
+           id="path9"
            sodipodi:nodetypes="cccccccc"
            sodipodi:insensitive="true" />
       </g>
       <g
-         id="g10"
-         transform="matrix(0,0.70000239,-0.70000239,0,54.300069,11.122614)"
+         id="g12"
+         transform="matrix(0,0.70000239,-0.70000239,0,54.300069,4.2920858)"
          style="display:inline">
         <path
-           id="path5"
+           id="path11"
            d="M 15,27 V 19 L 0.87149136,31.999999 15,45 v -8 h 14.714369 c 0,2.2e-5 0,0 0,0 V 27 Z"
            style="fill:#cc0000;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
            sodipodi:nodetypes="ccccccccc" />
         <path
-           id="path10"
+           id="path12"
            d="m 13.066964,29 0.02232,-5.529467 -9.1754064,8.529466 9.2200494,8.574111 V 35.089285 L 27.762035,35 v -6 0 z"
            style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            sodipodi:nodetypes="ccccccccc" />

--- a/src/Mod/Assembly/Gui/Resources/icons/Assembly_CreateJointParallel.svg
+++ b/src/Mod/Assembly/Gui/Resources/icons/Assembly_CreateJointParallel.svg
@@ -7,7 +7,7 @@
    id="svg2821"
    sodipodi:version="0.32"
    inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
-   sodipodi:docname="Joint_Parallel_Alt.svg"
+   sodipodi:docname="Assembly_CreateJointParallel.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
    xml:space="preserve"
@@ -172,10 +172,10 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="11.313708"
-     inkscape:cx="29.565902"
-     inkscape:cy="26.295533"
-     inkscape:current-layer="g7"
+     inkscape:zoom="7.9999996"
+     inkscape:cx="33.562501"
+     inkscape:cy="26.812501"
+     inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:document-units="px"
      inkscape:grid-bbox="true"
@@ -206,7 +206,7 @@
      inkscape:groupmode="layer"><g
        id="g8"
        inkscape:label="Main"
-       transform="translate(-0.08400268,-0.27617774)"><g
+       transform="matrix(1.0899303,0,0,1.0899303,-2.9693267,-3.1787843)"><g
          id="g6"
          inkscape:label="Plane"
          transform="matrix(0.90708807,-0.79900391,0,1.0698986,-19.299267,34.058528)"><rect

--- a/src/Mod/Assembly/Gui/Resources/icons/Assembly_CreateJointPlanar.svg
+++ b/src/Mod/Assembly/Gui/Resources/icons/Assembly_CreateJointPlanar.svg
@@ -7,7 +7,7 @@
    id="svg2821"
    sodipodi:version="0.32"
    inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
-   sodipodi:docname="Joint_Planar.svg"
+   sodipodi:docname="Assembly_CreateJointPlanar.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -158,9 +158,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="16"
-     inkscape:cx="37.09375"
-     inkscape:cy="32.09375"
+     inkscape:zoom="11.313708"
+     inkscape:cx="26.825864"
+     inkscape:cy="27.356194"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:document-units="px"
@@ -229,7 +229,7 @@
     <g
        id="g6"
        inkscape:label="Plane"
-       transform="matrix(0.90708807,0,0,0.90708807,2.9731817,2.9731817)">
+       transform="matrix(1.0798517,0,0,1.0798517,-2.5552547,-2.5552547)">
       <rect
          style="fill:url(#linearGradient6);fill-opacity:1;stroke:#302b00;stroke-width:1.5;stroke-dasharray:none;stroke-opacity:1"
          id="rect3"
@@ -247,7 +247,7 @@
     </g>
     <g
        id="g1"
-       transform="translate(0.14066863,-5.5382098e-4)"
+       transform="matrix(1.1586625,0,0,1.1586625,-4.9142154,-5.0778445)"
        inkscape:label="Arrows">
       <g
          id="g3894-3"

--- a/src/Mod/Assembly/Gui/Resources/icons/Assembly_CreateJointTangent.svg
+++ b/src/Mod/Assembly/Gui/Resources/icons/Assembly_CreateJointTangent.svg
@@ -7,7 +7,7 @@
    id="svg2784"
    sodipodi:version="0.32"
    inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
-   sodipodi:docname="Joint_Tangent_Alt.svg"
+   sodipodi:docname="Assembly_CreateJointTangent.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -131,9 +131,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="9.0727662"
-     inkscape:cx="25.185263"
-     inkscape:cy="26.507902"
+     inkscape:zoom="12.830829"
+     inkscape:cx="33.006441"
+     inkscape:cy="32.071194"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:document-units="px"
@@ -205,7 +205,7 @@
     <g
        id="g5"
        inkscape:label="Main"
-       transform="matrix(1.1300601,0,0,1.1300601,-21.405472,8.2622063)"
+       transform="matrix(1.1443561,0,0,1.1443561,-21.742282,8.049438)"
        style="stroke-width:0.944312">
       <g
          id="g1"
@@ -290,52 +290,52 @@
            x="9.8358345"
            y="9.8358364" />
       </g>
-    </g>
-    <g
-       id="layer1-6"
-       transform="matrix(0.45227982,0,0,0.45227982,21.800894,9.3107694)">
       <g
-         id="g3063"
-         transform="translate(1,-0.99999976)">
-        <path
-           transform="translate(-4,6)"
-           d="M 11.000001,18 C 29.225397,18 44,32.774603 44,51"
-           id="path3025"
-           style="fill:none;stroke:#280000;stroke-width:12.16061331;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           transform="translate(-4,6)"
-           d="M 11.000001,18 C 29.225397,18 44,32.774603 44,51"
-           id="path3025-3"
-           style="fill:none;stroke:#ef2929;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" />
-        <path
-           transform="translate(-4,6)"
-           d="M 11.000001,18 C 29.225397,18 44,32.774603 44,51"
-           id="path3025-3-6"
-           style="fill:none;stroke:#cc0000;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" />
-      </g>
-      <g
-         id="g3071-2"
-         transform="matrix(-0.70710678,-0.70710678,-0.70710678,0.70710678,139.73516,72.918789)">
-        <rect
-           transform="matrix(0.99999974,7.1938714e-4,-7.1838503e-4,0.99999974,0,0)"
-           ry="0"
-           rx="0"
-           y="33.032074"
-           x="78.283699"
-           height="9.8608322"
-           width="53.747211"
-           id="rect3770-9"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cc0000;fill-opacity:1;fill-rule:nonzero;stroke:#280000;stroke-width:3.31653091;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-        <rect
-           transform="matrix(0.99999989,4.636052e-4,-0.00111473,0.99999938,0,0)"
-           ry="0"
-           rx="0"
-           y="35.020126"
-           x="80.300385"
-           height="5.9074764"
-           width="49.745319"
-           id="rect3770-3-1"
-           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+         id="layer1-6"
+         transform="matrix(0.40022634,0,0,0.40022634,38.233689,0.9278826)">
+        <g
+           id="g3063"
+           transform="translate(1,-0.99999976)">
+          <path
+             transform="translate(-4,6)"
+             d="M 11.000001,18 C 29.225397,18 44,32.774603 44,51"
+             id="path3025"
+             style="fill:none;stroke:#280000;stroke-width:12.1606;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             transform="translate(-4,6)"
+             d="M 11.000001,18 C 29.225397,18 44,32.774603 44,51"
+             id="path3025-3"
+             style="fill:none;stroke:#ef2929;stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             transform="translate(-4,6)"
+             d="M 11.000001,18 C 29.225397,18 44,32.774603 44,51"
+             id="path3025-3-6"
+             style="fill:none;stroke:#cc0000;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           id="g3071-2"
+           transform="matrix(-0.70710678,-0.70710678,-0.70710678,0.70710678,139.73516,72.918789)">
+          <rect
+             transform="matrix(0.99999974,7.1938714e-4,-7.1838503e-4,0.99999974,0,0)"
+             ry="0"
+             rx="0"
+             y="33.032074"
+             x="78.283699"
+             height="9.8608322"
+             width="53.747211"
+             id="rect3770-9"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#cc0000;fill-opacity:1;fill-rule:nonzero;stroke:#280000;stroke-width:3.31653;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+          <rect
+             transform="matrix(0.99999989,4.636052e-4,-0.00111473,0.99999938,0,0)"
+             ry="0"
+             rx="0"
+             y="35.020126"
+             x="80.300385"
+             height="5.9074764"
+             width="49.745319"
+             id="rect3770-3-1"
+             style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+        </g>
       </g>
     </g>
   </g>

--- a/src/Mod/Assembly/Gui/Resources/icons/Assembly_Joint.svg
+++ b/src/Mod/Assembly/Gui/Resources/icons/Assembly_Joint.svg
@@ -7,7 +7,7 @@
    id="svg2821"
    sodipodi:version="0.32"
    inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
-   sodipodi:docname="Assembly_CreateJointFixed.svg"
+   sodipodi:docname="Assembly_Joint.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -184,14 +184,14 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="10.193662"
-     inkscape:cx="30.950604"
-     inkscape:cy="29.184801"
+     inkscape:cx="34.482211"
+     inkscape:cy="20.993437"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:document-units="px"
      inkscape:grid-bbox="true"
      inkscape:window-width="2560"
-     inkscape:window-height="1355"
+     inkscape:window-height="1356"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -285,22 +285,33 @@
            rx="24"
            ry="7.9999995" />
       </g>
+      <path
+         d="m 44.724484,42.214865 0,8.096549 c 0,0 -1.084323,3.922162 -12.564831,3.922162 -11.480508,0 -11.750143,-3.922162 -11.750143,-3.922162 l 0,-7.8593"
+         style="fill:#729fcf;fill-opacity:1;stroke:#fce94f;stroke-width:2.08333;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dashoffset:20.4;stroke-opacity:1"
+         id="path1-5"
+         transform="matrix(0.96000015,0,0,0.96000015,1.2799944,2.2388113)"
+         sodipodi:nodetypes="cczcc" />
+      <path
+         d="m 42.423915,37.93471 v 11.605108 c 0,0 0.105469,2.899307 -10.224895,2.899307 -10.330364,0 -9.561926,-2.899307 -9.561926,-2.899307 V 38.110087"
+         style="fill:#729fcf;fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dashoffset:20.4;stroke-opacity:1"
+         id="path1-6"
+         sodipodi:nodetypes="ccscc" />
       <g
          id="g3"
          inkscape:label="Part 2"
          transform="translate(3.6192085e-6,-20.496033)">
         <path
            style="fill:#729fcf;fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dashoffset:20.4;stroke-opacity:1"
-           d="m 56.000001,52.8038 c 0,4.418278 -10.745166,8 -24,8 -13.254833,0 -23.9999985,-3.581722 -23.9999985,-8 l -2e-6,-18.217405 H 56 Z"
+           d="m 56.000001,52.8038 c 0,3.292855 -5.968324,6.121052 -14.495801,7.348199 v 9.235537 c 0,0 0.0958,2.307316 -9.287334,2.307316 -9.383131,0 -8.685155,-2.307316 -8.685155,-2.307316 V 60.291568 C 14.4556,59.150481 8.0000025,56.228438 8.0000025,52.8038 l -2e-6,-18.217405 H 56 Z"
            id="path1"
            inkscape:connector-curvature="0"
-           sodipodi:nodetypes="sscccs" />
+           sodipodi:nodetypes="scczcccccs" />
         <path
            style="fill:url(#linearGradient3);fill-opacity:1;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dashoffset:20.4;stroke-opacity:1"
-           d="m 54,51.531073 c 0,4.016616 -9.84973,7.272727 -22,7.272727 -12.150264,0 -21.999999,-3.256111 -21.999999,-7.272727 l -1.5e-6,-15.950307 H 54 Z"
+           d="m 54,51.531073 c 0,3.178678 -6.168743,5.881062 -14.764615,6.870253 v 10.060365 c 0,0 -3.395389,0.831669 -6.594726,0.824042 -3.199337,-0.0076 -6.53823,-0.824042 -6.53823,-0.824042 V 58.539526 C 16.816059,57.687388 10.000001,54.872367 10.000001,51.531073 l -1.5e-6,-15.950307 H 54 Z"
            id="path2"
            inkscape:connector-curvature="0"
-           sodipodi:nodetypes="sscccs" />
+           sodipodi:nodetypes="scczcccccs" />
         <path
            style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dashoffset:20.4;stroke-opacity:1"
            d="m 54,38.835626 c -2,3.272727 -9.84973,5.272727 -22,5.272727 -12.150264,0 -19,-2 -21.999999,-5.272727"
@@ -314,51 +325,6 @@
            cy="34.381172"
            rx="24"
            ry="7.9999995" />
-      </g>
-      <g
-         transform="matrix(0.55958744,0,0,1.0254139,7.7599462,8.7187646)"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:54.2152px;font-family:Arial;-inkscape-font-specification:Arial;display:inline;overflow:visible;visibility:visible;fill:#ff2600;fill-opacity:1;fill-rule:nonzero;stroke:#731200;stroke-width:2.19132;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         id="text3796"
-         inkscape:label="Lock">
-        <g
-           transform="matrix(0.26232603,0,0,0.14315619,-698.74089,-70.421371)"
-           id="g2385"
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:54.2152px;font-family:Arial;-inkscape-font-specification:Arial;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3844);fill-opacity:1;fill-rule:nonzero;stroke:#042a2a;stroke-width:10.3206;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate">
-          <path
-             style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3045);fill-opacity:1;fill-rule:evenodd;stroke:#280000;stroke-width:10.3206;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-             d="m 2751.3603,595.12568 v 0 0 l -2e-4,46.44262 h 30.9618 l -0.2475,-47.17448 h -0.05 c 0.2977,-25.0696 20.9388,-45.71077 46.7403,-45.71077 25.8014,0 46.4426,20.64117 46.4421,46.44263 v 0 46.44262 h 30.9618 v -46.44262 0 c 5e-4,-41.28234 -25.801,-77.40438 -77.4039,-77.40438 -51.6029,0 -77.4044,36.12204 -77.4044,77.40438 z"
-             id="path2387" />
-          <rect
-             style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3880);fill-opacity:1;fill-rule:evenodd;stroke:#280000;stroke-width:10.3206;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-             id="rect2389"
-             width="196.09097"
-             height="154.80875"
-             x="2730.7192"
-             y="641.5683" />
-          <rect
-             style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ef2929;stroke-width:10.3206;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-             id="rect2389-0"
-             width="175.44977"
-             height="134.16759"
-             x="2741.0398"
-             y="651.88885" />
-        </g>
-        <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:54.2152px;font-family:Arial;-inkscape-font-specification:Arial;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="M 25.719895,26.594196 H 60.915549"
-           id="path3777-7" />
-        <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:54.2152px;font-family:Arial;-inkscape-font-specification:Arial;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="M 25.719921,32.504016 H 60.915574"
-           id="path3777-3-5" />
-        <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:54.2152px;font-family:Arial;-inkscape-font-specification:Arial;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="M 25.719921,38.413838 H 60.915574"
-           id="path3777-6-3" />
-        <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:54.2152px;font-family:Arial;-inkscape-font-specification:Arial;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-           d="m 25.719879,20.684376 v -6.648549 c 1.2e-5,-3.69364 5.414701,-8.8647326 17.597824,-8.8647334 12.183122,-7e-7 17.597835,5.1710934 17.597825,8.8647334 v 6.648549"
-           id="path3828" />
       </g>
     </g>
   </g>


### PR DESCRIPTION
The newly added assembly joint icons (https://github.com/FreeCAD/FreeCAD/pull/10677) had some spacing issues that made certain ones look small on the toolbar, fixed those. 

Also @PaddleStroke I added a generic joint icon that can be used as the icon for the "Joints" group under the Assembly. It isn't perfect but it should look fine in the tree view.