### PR TITLE
Part: Fix a missing argument for HLR projector

### DIFF
--- a/src/Mod/Part/App/HLRBRep/HLRBRep_AlgoPyImp.cpp
+++ b/src/Mod/Part/App/HLRBRep/HLRBRep_AlgoPyImp.cpp
@@ -114,7 +114,7 @@ PyObject* HLRBRep_AlgoPy::setProjector(PyObject *args, PyObject *kwds)
     PyObject* xd = nullptr;
     double focus = std::numeric_limits<double>::quiet_NaN();
 
-    static const std::array<const char *, 4> kwlist {"Origin", "ZDir", "XDir", nullptr};
+    static const std::array<const char *, 5> kwlist {"Origin", "ZDir", "XDir", "focus", nullptr};
     if (Base::Wrapped_ParseTupleAndKeywords(args, kwds, "|O!O!O!d", kwlist,
                                             &Base::VectorPy::Type, &ps,
                                             &Base::VectorPy::Type, &zd,


### PR DESCRIPTION
As discussed in #10726, this small pull request fixes it.

The following listing works as opposed in the issue

``` python
>>> origin = App.Vector(0, 0, 0)
>>> direction = App.Vector(0, 1, 0)
>>> xDirection = App.Vector(1, 0, 0)
>>> algo = Part.HLRBRep.Algo()
>>> algo.setProjector(origin, direction, xDirection)
>>> algo.setProjector(origin, direction, xDirection, 1.0)
```