### PR TITLE
TechDraw: Expose two functions for SVG export

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -180,6 +180,13 @@ public:
             "string = removeSvgTags(string) -- Removes the opening and closing svg tags\n"
             "and other metatags from a svg code, making it embeddable"
         );
+        add_varargs_method("exportSVGEdges", &Module::exportSVGEdges,
+            "string = exportSVGEdges(TopoShape) -- export an SVG string of the shape\n"
+        );
+        add_varargs_method("build3dCurves", &Module::build3dCurves,
+            "TopoShape = build3dCurves(TopoShape) -- convert the edges to a 3D curve\n"
+	    "which is useful for shapes obtained Part.HLRBRep.Algo"
+        );
         initialize("This is a module for making drawings"); // register with Python
     }
     ~Module() override {}
@@ -1224,6 +1231,35 @@ private:
         return result;
     }
 
+    Py::Object exportSVGEdges(const Py::Tuple& args)
+    {
+        PyObject *pcObjShape(nullptr);
+
+        if (!PyArg_ParseTuple(args.ptr(), "O!",
+			      &(TopoShapePy::Type), &pcObjShape))
+            throw Py::Exception();
+
+        TopoShapePy* pShape = static_cast<TopoShapePy*>(pcObjShape);
+	SVGOutput output;
+	Py::String result(output.exportEdges(pShape->getTopoShapePtr()->getShape()));
+
+	return result;
+    }
+
+    Py::Object build3dCurves(const Py::Tuple& args)
+    {
+        PyObject *pcObjShape(nullptr);
+
+        if (!PyArg_ParseTuple(args.ptr(), "O!",
+			      &(TopoShapePy::Type), &pcObjShape))
+            throw Py::Exception();
+
+        TopoShapePy* pShape = static_cast<TopoShapePy*>(pcObjShape);
+	const TopoShape& nShape =
+	    TechDraw::build3dCurves(pShape->getTopoShapePtr()->getShape());
+	
+	return Py::Object(new TopoShapePy(new TopoShape(nShape)));
+    }
  };
 
  PyObject* initModule()

--- a/src/Mod/TechDraw/App/ProjectionAlgos.cpp
+++ b/src/Mod/TechDraw/App/ProjectionAlgos.cpp
@@ -50,6 +50,18 @@ using namespace std;
 // ProjectionAlgos
 //===========================================================================
 
+namespace TechDraw {
+  //added by tanderson. aka blobfish.
+  //projection algorithms build a 2d curve(pcurve) but no 3d curve.
+  //this causes problems with meshing algorithms after save and load.
+  const TopoDS_Shape& build3dCurves(const TopoDS_Shape &shape)
+  {
+    TopExp_Explorer it;
+    for (it.Init(shape, TopAbs_EDGE); it.More(); it.Next())
+      BRepLib::BuildCurve3d(TopoDS::Edge(it.Current()));
+    return shape;
+  }
+}
 
 ProjectionAlgos::ProjectionAlgos(const TopoDS_Shape &Input, const Base::Vector3d &Dir)
   : Input(Input), Direction(Dir)
@@ -61,16 +73,6 @@ ProjectionAlgos::~ProjectionAlgos()
 {
 }
 
-//added by tanderson. aka blobfish.
-//projection algorithms build a 2d curve(pcurve) but no 3d curve.
-//this causes problems with meshing algorithms after save and load.
-static const TopoDS_Shape& build3dCurves(const TopoDS_Shape &shape)
-{
-  TopExp_Explorer it;
-  for (it.Init(shape, TopAbs_EDGE); it.More(); it.Next())
-    BRepLib::BuildCurve3d(TopoDS::Edge(it.Current()));
-  return shape;
-}
 
 void ProjectionAlgos::execute()
 {

--- a/src/Mod/TechDraw/App/ProjectionAlgos.h
+++ b/src/Mod/TechDraw/App/ProjectionAlgos.h
@@ -38,6 +38,8 @@ class BRepAdaptor_Curve;
 namespace TechDraw
 {
 
+  const TopoDS_Shape& build3dCurves(const TopoDS_Shape& shape);
+  
 /** Algo class for projecting shapes and creating SVG output of it
  */
 class TechDrawExport ProjectionAlgos


### PR DESCRIPTION
This pull requests exposes two functions to Python that allows Python code and workbenches to generate SVG images. See #10733.

This pull request exposes `TechDraw.build3dCurves()` and `TechDraw.exportSVGEdges()` and it is a convenient addition for workbenches that want more control over SVG export, possibly in relation to Part HLR, see for example #10726.

This pull request is independent of but related to #10726. In order to test the code below with the Part HLR module, it is necessary to have the changes from #10727. With that code in place, the following is possible creating an SVG from Python like so:

``` python
# create object
doc = App.ActiveDocument
doc.addObject("Part::Box","Box")
obj = doc.ActiveObject
obj.Label = "Cube"
doc.recompute()
shape = obj.Shape

# find camera position
view = Gui.ActiveDocument.ActiveView
view.viewIsometric()
direction = view.getViewDirection()
xDirection = App.Vector(0.7, 0.7, 0)
origin = App.Vector(0, 0, 0)

# perform HLR
algo = Part.HLRBRep.Algo()
algo.add(shape)
algo.setProjector(origin, direction, xDirection)
algo.update()
algo.hide()
projShapes = Part.HLRBRep.HLRToShape(algo)

# create the SVG with help from TechDraw
import TechDraw as td
v = td.build3dCurves(projShapes.vCompound(shape))
edges = td.exportSVGEdges(v)
bb = v.BoundBox

with open('hlr.svg', 'w') as f:
    f.write("<svg\n")
    f.write(f"       width=\"{bb.XLength}\"\n")
    f.write(f"       height=\"{bb.YLength}\"\n")
    f.write(f"       viewBox=\"0 0 {bb.XLength} {bb.YLength}\"\n")
    f.write("	xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\"\n")
    f.write("	xmlns:freecad=\"http://www.freecadweb.org/wiki/index.php")
    f.write("?title=Svg_Namespace\">\n")
    f.write('<g stroke=\"#000000\"\n')
    f.write('   stroke-width=\"0.4px\"\n')
    f.write('   stroke-linecap=\"round\"\n')
    f.write('   stroke-linejoin=\"round\"\n')
    f.write('   fill=\"none\"\n')
    f.write(f'   transform=\"matrix(1, 0, 0, -1, {-bb.XMin}, {bb.YMax})\">\n')
    f.write(edges)
    f.write("\n</g>")
    f.write("\n</svg>")
```