### PR TITLE
Arch: avoid intersecting solids in windows and doors with openings

### DIFF
--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -821,6 +821,8 @@ class _Window(ArchComponent.Component):
                             pass
                         elif omode == 10: # -sliding
                             pass
+                exv = FreeCAD.Vector()
+                zov = FreeCAD.Vector()
                 V = 0
                 thk = obj.WindowParts[(i*5)+3]
                 if "+V" in thk:
@@ -844,12 +846,19 @@ class _Window(ArchComponent.Component):
                     if zof:
                         zov = DraftVecUtils.scaleTo(norm,zof)
                         shape.translate(zov)
-                        for symb in ssymbols:
-                            symb.translate(zov)
-                        for symb in vsymbols:
-                            symb.translate(zov)
-                        if rotdata and hinge and omode:
-                            rotdata[0] = rotdata[0].add(zov)
+                if hinge and omode and 0 < omode < 9:
+                    if DraftVecUtils.angle(chord, norm, enorm) < 0:
+                        if omode%2 == 0:
+                            zov = zov.add(exv)
+                    else:
+                        if omode%2 == 1:
+                            zov = zov.add(exv)
+                    for symb in ssymbols:
+                        symb.translate(zov)
+                    for symb in vsymbols:
+                        symb.translate(zov)
+                    if rotdata:
+                        rotdata[0] = rotdata[0].add(zov)
                 if obj.WindowParts[(i*5)+1] == "Louvre":
                     if hasattr(obj,"LouvreWidth"):
                         if obj.LouvreWidth and obj.LouvreSpacing:


### PR DESCRIPTION
With the current code, if you place a simple door and change its Opening property to 50, the door leaf and the frame intersect. This PR fixes that issue.
