### PR TITLE
Toolbar View and Structure cleaning

### DIFF
--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -206,7 +206,11 @@ StdCmdLinkMake::StdCmdLinkMake()
 {
     sGroup        = "Link";
     sMenuText     = QT_TR_NOOP("Make link");
-    sToolTipText  = QT_TR_NOOP("Create a link to the selected object(s)");
+    sToolTipText  = QT_TR_NOOP("<p>An App::Link is a type of object that references or links"
+        " to another object, in the same document, or in another document. Unlike Clones, Link"
+        " references directly the original Shape, so it is more memory efficient which helps "
+        "with the creation of complex assemblies from smaller subassemblies, and from multiple"
+        " reusable components like screws, nuts, and similar fasteners.</p>");
     sWhatsThis    = "Std_LinkMake";
     sStatusTip    = sToolTipText;
     eType         = AlterDoc;

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -214,7 +214,7 @@ StdCmdLinkMake::StdCmdLinkMake()
 }
 
 bool StdCmdLinkMake::isActive() {
-    return !!App::GetApplication().getActiveDocument();
+    return App::GetApplication().getActiveDocument();
 }
 
 void StdCmdLinkMake::activated(int) {
@@ -878,6 +878,7 @@ public:
         eType         = AlterDoc;
         bCanLog       = false;
 
+        addCommand(new StdCmdLinkMake());
         addCommand(new StdCmdLinkMakeRelative());
         addCommand(new StdCmdLinkReplace());
         addCommand(new StdCmdLinkUnlink());
@@ -898,7 +899,6 @@ namespace Gui {
 void CreateLinkCommands()
 {
     CommandManager &rcCmdMgr = Application::Instance->commandManager();
-    rcCmdMgr.addCommand(new StdCmdLinkMake());
     rcCmdMgr.addCommand(new StdCmdLinkActions());
     rcCmdMgr.addCommand(new StdCmdLinkMakeGroup());
     rcCmdMgr.addCommand(new StdCmdLinkSelectActions());

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -206,11 +206,12 @@ StdCmdLinkMake::StdCmdLinkMake()
 {
     sGroup        = "Link";
     sMenuText     = QT_TR_NOOP("Make link");
-    sToolTipText  = QT_TR_NOOP("<p>An App::Link is a type of object that references or links"
-        " to another object, in the same document, or in another document. Unlike Clones, Link"
-        " references directly the original Shape, so it is more memory efficient which helps "
-        "with the creation of complex assemblies from smaller subassemblies, and from multiple"
-        " reusable components like screws, nuts, and similar fasteners.</p>");
+    static std::string toolTip = std::string("<p>")
+        + QT_TR_NOOP("A Link is an object that references or links to another object in the same "
+        "document, or in another document.Unlike Clones, Links reference the original Shape directly, "
+        " making them more memory efficient which helps with the creation of complex assemblies.")
+        + "</p>";
+    sToolTipText = toolTip.c_str();
     sWhatsThis    = "Std_LinkMake";
     sStatusTip    = sToolTipText;
     eType         = AlterDoc;

--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -49,7 +49,11 @@ StdCmdPart::StdCmdPart()
 {
     sGroup        = "Structure";
     sMenuText     = QT_TR_NOOP("Create part");
-    sToolTipText  = QT_TR_NOOP("Create a new part and make it active");
+    sToolTipText = QT_TR_NOOP("<p>An App::Part is is a general purpose container that keeps together a "
+        "group of objects so that they can be moved together as a unit in the 3D view.\n"
+        "it is meant to arrange objects that have a Part TopoShape, like Part Primitives, PartDesign"
+        " Bodies, and other Part Features. In addition, Std Parts may be nested inside other"
+        " Std Parts to create a big assembly from smaller sub-assemblies.</p>");
     sWhatsThis    = "Std_Part";
     sStatusTip    = sToolTipText;
     sPixmap       = "Geofeaturegroup";

--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -94,7 +94,10 @@ StdCmdGroup::StdCmdGroup()
 {
     sGroup        = "Structure";
     sMenuText     = QT_TR_NOOP("Create group");
-    sToolTipText  = QT_TR_NOOP("Create a new group for ordering objects");
+    sToolTipText = QT_TR_NOOP("<p>Group is a general purpose container that allows you to "
+        "group different types of objects in the Tree view, regardless of their data type. "
+        "It is used as a simple folder to categorize and organize the objects in your model, "
+        "in order to keep a logical structure. Std Groups may be nested inside other Std Groups.</p>");
     sWhatsThis    = "Std_Group";
     sStatusTip    = sToolTipText;
     sPixmap       = "folder";

--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -49,11 +49,13 @@ StdCmdPart::StdCmdPart()
 {
     sGroup        = "Structure";
     sMenuText     = QT_TR_NOOP("Create part");
-    sToolTipText = QT_TR_NOOP("<p>An App::Part is is a general purpose container that keeps together a "
-        "group of objects so that they can be moved together as a unit in the 3D view.\n"
-        "it is meant to arrange objects that have a Part TopoShape, like Part Primitives, PartDesign"
-        " Bodies, and other Part Features. In addition, Std Parts may be nested inside other"
-        " Std Parts to create a big assembly from smaller sub-assemblies.</p>");
+    static std::string toolTip = std::string("<p>")
+        + QT_TR_NOOP("A Part is is a general purpose container to keep together a "
+            "group of objects so that they act as a unit in the 3D view.\n"
+            "It is meant to arrange objects that have a Part TopoShape, like Part Primitives, PartDesign"
+            " Bodies, and other Parts.") 
+        + "</p>";
+    sToolTipText  = toolTip.c_str();
     sWhatsThis    = "Std_Part";
     sStatusTip    = sToolTipText;
     sPixmap       = "Geofeaturegroup";
@@ -94,10 +96,13 @@ StdCmdGroup::StdCmdGroup()
 {
     sGroup        = "Structure";
     sMenuText     = QT_TR_NOOP("Create group");
-    sToolTipText = QT_TR_NOOP("<p>Group is a general purpose container that allows you to "
-        "group different types of objects in the Tree view, regardless of their data type. "
-        "It is used as a simple folder to categorize and organize the objects in your model, "
-        "in order to keep a logical structure. Std Groups may be nested inside other Std Groups.</p>");
+    static std::string toolTip = std::string("<p>")
+        + QT_TR_NOOP("A Group is a general purpose container to group objects in the "
+        "Tree view, regardless of their data type. It is a simple folder to organize "
+        "the objects in a model.")
+        + "</p>";
+    
+    sToolTipText = toolTip.c_str();
     sWhatsThis    = "Std_Group";
     sStatusTip    = sToolTipText;
     sPixmap       = "folder";

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3880,6 +3880,11 @@ public:
 
         addCommand(new StdTreeDrag(),!cmds.empty());
         addCommand(new StdTreeSelection(),!cmds.empty());
+
+        addCommand();
+
+        addCommand(new StdCmdSelBack());
+        addCommand(new StdCmdSelForward());
     }
     const char* className() const override {return "StdCmdTreeViewActions";}
 };

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3577,10 +3577,12 @@ StdCmdSelBack::StdCmdSelBack()
   :Command("Std_SelBack")
 {
   sGroup        = "View";
-  sMenuText     = QT_TR_NOOP("&Back");
-  sToolTipText  = QT_TR_NOOP("Go back to previous selection");
+  sMenuText     = QT_TR_NOOP("Selection Back");
+  sToolTipText  = QT_TR_NOOP("<p>The Std SelBack command restores the previous"
+      " recorded Tree view selection. Note that selections are only recorded if"
+      " Tree RecordSelection mode is switched on.</p>");
   sWhatsThis    = "Std_SelBack";
-  sStatusTip    = QT_TR_NOOP("Go back to previous selection");
+  sStatusTip    = sToolTipText;
   sPixmap       = "sel-back";
   sAccel        = "S, B";
   eType         = AlterSelection;
@@ -3607,10 +3609,12 @@ StdCmdSelForward::StdCmdSelForward()
   :Command("Std_SelForward")
 {
   sGroup        = "View";
-  sMenuText     = QT_TR_NOOP("&Forward");
-  sToolTipText  = QT_TR_NOOP("Repeat the backed selection");
+  sMenuText     = QT_TR_NOOP("Selection Forward");
+  sToolTipText  = QT_TR_NOOP("<p>The Std SelForward command restores the next "
+      "recorded Tree view selection. Note that selections are only recorded if "
+      "Tree RecordSelection mode is switched on.</p>");
   sWhatsThis    = "Std_SelForward";
-  sStatusTip    = QT_TR_NOOP("Repeat the backed selection");
+  sStatusTip    = sToolTipText;
   sPixmap       = "sel-forward";
   sAccel        = "S, F";
   eType         = AlterSelection;

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3578,9 +3578,11 @@ StdCmdSelBack::StdCmdSelBack()
 {
   sGroup        = "View";
   sMenuText     = QT_TR_NOOP("Selection Back");
-  sToolTipText  = QT_TR_NOOP("<p>The Std SelBack command restores the previous"
-      " recorded Tree view selection. Note that selections are only recorded if"
-      " Tree RecordSelection mode is switched on.</p>");
+  static std::string toolTip = std::string("<p>")
+      + QT_TR_NOOP("Restore the previous Tree view selection. "
+      "Only works if Tree RecordSelection mode is switched on.")
+      + "</p>";
+  sToolTipText = toolTip.c_str();
   sWhatsThis    = "Std_SelBack";
   sStatusTip    = sToolTipText;
   sPixmap       = "sel-back";
@@ -3610,9 +3612,11 @@ StdCmdSelForward::StdCmdSelForward()
 {
   sGroup        = "View";
   sMenuText     = QT_TR_NOOP("Selection Forward");
-  sToolTipText  = QT_TR_NOOP("<p>The Std SelForward command restores the next "
-      "recorded Tree view selection. Note that selections are only recorded if "
-      "Tree RecordSelection mode is switched on.</p>");
+  static std::string toolTip = std::string("<p>")
+      + QT_TR_NOOP("Restore the next Tree view selection. "
+      "Only works if Tree RecordSelection mode is switched on.")
+      + "</p>";
+  sToolTipText = toolTip.c_str();
   sWhatsThis    = "Std_SelForward";
   sStatusTip    = sToolTipText;
   sPixmap       = "sel-forward";

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -690,6 +690,7 @@ MenuItem* StdWorkbench::setupMenuBar() const
           << "Std_ToggleNavigation"
           << "Std_SetAppearance" << "Std_RandomColor" << "Separator"
           << "Std_Workbench" << "Std_ToolBarMenu" << "Std_DockViewMenu" << "Separator"
+          << "Std_LinkSelectActions"
           << "Std_TreeViewActions"
           << "Std_ViewStatusBar";
 
@@ -791,11 +792,11 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // View
     auto view = new ToolBarItem( root );
     view->setCommand("View");
-    *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_DrawStyle" << "Std_SelBoundingBox"
-          << "Separator" << "Std_SelectFilter" << "Std_SelBack" << "Std_SelForward"
-          << "Std_LinkSelectActions"<< "Separator" << "Std_TreeViewActions" << "Std_ViewIsometric"
-          << "Std_ViewFront"<< "Std_ViewTop" << "Std_ViewRight" << "Separator" << "Std_ViewRear"
-          << "Separator" << "Std_ViewBottom"<< "Std_ViewLeft"  << "Separator" << "Std_MeasureDistance";
+    *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewIsometric"
+          << "Std_ViewFront"<< "Std_ViewTop" << "Std_ViewRight"
+          << "Std_ViewRear" << "Std_ViewBottom"<< "Std_ViewLeft"
+          << "Separator" << "Std_DrawStyle" << "Std_SelectFilter" << "Std_TreeViewActions"
+          << "Separator" << "Std_MeasureDistance";
 
     // Structure
     auto structure = new ToolBarItem( root );

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -800,7 +800,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // Structure
     auto structure = new ToolBarItem( root );
     structure->setCommand("Structure");
-    *structure << "Std_Part" << "Std_Group" << "Std_LinkMake" << "Std_LinkActions";
+    *structure << "Std_Part" << "Std_Group" << "Std_LinkActions";
 
     // Help
     auto help = new ToolBarItem( root );


### PR DESCRIPTION
This PR does several things : 
- Put Link in the command group
- Give Link a proper tooltip (screenshot outdated: tooltips changed).
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/d2f83367-3c5d-4de1-b0d4-9f7fde1df787)

- Put sel_back and sel_forward in the treeview actions group rather than in root of view toolbar. This way they now appear in the view menu (they weren't before) and they don't appear in the root of view toolbar.
- Give them proper names and tooltips (screenshot outdated: tooltips changed)
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/8bbcd184-fe40-48e8-9b7f-a883b32d836f)

- Remove 'Link Navigation' from the view toolbar
- Put 'Link Navigation' in the view menu where it was missing.
- Remove 'Bouding box' from the view toolbar (its still in view menu)
- Reorder the view toolbar so that the order makes sense.

![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/31967154-0fab-46ac-a146-ec447c856f09)

Lastly it improves the tooltips of std_part and std_group.

Fixes #10755
Fixes #10756
Fixes #10757
Fixes #10758
