### PR TITLE
Gui: fix possible memory leak if inappropriate view provider is created

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -673,10 +673,11 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
             }
             else if (cName!=Obj.getViewProviderName() && !pcProvider->allowOverride(Obj)) {
                 FC_WARN("View provider type '" << cName << "' does not support " << Obj.getFullName());
+                delete pcProvider;
                 pcProvider = nullptr;
                 cName = Obj.getViewProviderName();
             }
-             else {
+            else {
                 break;
             }
         }


### PR DESCRIPTION
Example code:
```
doc = App.newDocument()
doc.addObject(type = "Part::Feature", viewType = "MeshGui::ViewProviderMesh")
```