### PR TITLE
App: fixes #10460: App::PropertyPythonObject is not saving data

### DIFF
--- a/src/App/PropertyPythonObject.cpp
+++ b/src/App/PropertyPythonObject.cpp
@@ -87,9 +87,9 @@ std::string PropertyPythonObject::toString() const
             throw Py::Exception();
         Py::Callable method(pickle.getAttr(std::string("dumps")));
         Py::Object dump;
-        if (this->object.hasAttr("__getstate__")) {
+        if (this->object.hasAttr("dumps")) {
             Py::Tuple args;
-            Py::Callable state(this->object.getAttr("__getstate__"));
+            Py::Callable state(this->object.getAttr("dumps"));
             dump = state.apply(args);
         }
         else if (this->object.hasAttr("__dict__")) {
@@ -129,10 +129,10 @@ void PropertyPythonObject::fromString(const std::string& repr)
         args.setItem(0, Py::String(repr));
         Py::Object res = method.apply(args);
 
-        if (this->object.hasAttr("__setstate__")) {
+        if (this->object.hasAttr("loads")) {
             Py::Tuple args(1);
             args.setItem(0, res);
-            Py::Callable state(this->object.getAttr("__setstate__"));
+            Py::Callable state(this->object.getAttr("loads"));
             state.apply(args);
         }
         else if (this->object.hasAttr("__dict__")) {

--- a/src/Mod/Arch/ArchAxis.py
+++ b/src/Mod/Arch/ArchAxis.py
@@ -180,11 +180,11 @@ class _Axis:
         if prop in ["Angles","Distances","Placement"]:
             obj.touch()
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 
@@ -658,11 +658,11 @@ class _ViewProviderAxis:
     def transform(self):
         FreeCADGui.ActiveDocument.setEdit(self.Object, 1)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 

--- a/src/Mod/Arch/ArchAxisSystem.py
+++ b/src/Mod/Arch/ArchAxisSystem.py
@@ -136,11 +136,11 @@ class _AxisSystem:
                 for o in obj.Axes:
                     o.Placement = delta.multiply(o.Placement)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 
@@ -259,11 +259,11 @@ class _ViewProviderAxisSystem:
     def edit(self):
         FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 

--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -356,11 +356,11 @@ class BuildingPart(ArchIFC.IfcProduct):
 
         self.setProperties(obj)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 
@@ -1054,10 +1054,10 @@ class ViewProviderBuildingPart:
                     no.LongName = no.CloneOf.LongName
             FreeCAD.ActiveDocument.recompute()
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def writeInventor(self,obj):

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -267,13 +267,13 @@ class Component(ArchIFC.IfcProduct):
                 shape = self.processSubShapes(obj,shape)
             obj.Shape = shape
 
-    def __getstate__(self):
+    def dumps(self):
         # for compatibility with 0.17
         if hasattr(self,"Type"):
             return self.Type
         return "Component"
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def onBeforeChange(self,obj,prop):
@@ -1408,11 +1408,11 @@ class ViewProviderComponent:
                 return "Flat Lines"
         return mode
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 

--- a/src/Mod/Arch/ArchFence.py
+++ b/src/Mod/Arch/ArchFence.py
@@ -81,13 +81,13 @@ class _Fence(ArchComponent.Component):
 
         self.Type = "Fence"
 
-    def __getstate__(self):
+    def dumps(self):
         if hasattr(self, 'sectionFaceNumbers'):
             return self.sectionFaceNumbers
 
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         if state is not None and isinstance(state, tuple):
             self.sectionFaceNumbers = state[0]
 

--- a/src/Mod/Arch/ArchFloor.py
+++ b/src/Mod/Arch/ArchFloor.py
@@ -218,11 +218,11 @@ class _Floor(ArchIFC.IfcProduct):
 
         _Floor.setProperties(self,obj)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 
@@ -372,11 +372,11 @@ class _ViewProviderFloor:
                 return self.Object.Group
         return []
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 

--- a/src/Mod/Arch/ArchGrid.py
+++ b/src/Mod/Arch/ArchGrid.py
@@ -279,11 +279,11 @@ class ArchGrid:
         else:
             return [f.CenterOfMass for f in obj.Shape.Faces]
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 
@@ -330,11 +330,11 @@ class ViewProviderArchGrid:
     def edit(self):
         FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 

--- a/src/Mod/Arch/ArchIFCView.py
+++ b/src/Mod/Arch/ArchIFCView.py
@@ -80,10 +80,10 @@ class IfcContextView:
     def transform(self):
         FreeCADGui.ActiveDocument.setEdit(self.Object, 1)
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 

--- a/src/Mod/Arch/ArchMaterial.py
+++ b/src/Mod/Arch/ArchMaterial.py
@@ -186,11 +186,11 @@ class _ArchMaterialContainer:
     def execute(self,obj):
         return
 
-    def __getstate__(self):
+    def dumps(self):
         if hasattr(self,"Type"):
             return self.Type
 
-    def __setstate__(self,state):
+    def loads(self,state):
         if state:
             self.Type = state
 
@@ -266,10 +266,10 @@ class _ViewProviderArchMaterialContainer:
                 self.Object.Group = g
                 FreeCAD.ActiveDocument.recompute()
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 
@@ -410,11 +410,11 @@ class _ArchMaterial:
                                 p.ViewObject.ShapeColor = c
         return
 
-    def __getstate__(self):
+    def dumps(self):
         if hasattr(self,"Type"):
             return self.Type
 
-    def __setstate__(self,state):
+    def loads(self,state):
         if state:
             self.Type = state
 
@@ -510,10 +510,10 @@ class _ViewProviderArchMaterial:
                     elif hasattr(widget,"setValue"):
                         widget.setText(value)
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):
@@ -744,11 +744,11 @@ class _ArchMultiMaterial:
         obj.addProperty("App::PropertyLinkList","Materials","Arch",QT_TRANSLATE_NOOP("App::Property","The list of layer materials"))
         obj.addProperty("App::PropertyFloatList","Thicknesses","Arch",QT_TRANSLATE_NOOP("App::Property","The list of layer thicknesses"))
 
-    def __getstate__(self):
+    def dumps(self):
         if hasattr(self,"Type"):
             return self.Type
 
-    def __setstate__(self,state):
+    def loads(self,state):
         if state:
             self.Type = state
 
@@ -794,10 +794,10 @@ class _ViewProviderArchMultiMaterial:
     def edit(self):
         FreeCADGui.ActiveDocument.setEdit(self.Object, 0)
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def isShow(self):

--- a/src/Mod/Arch/ArchProfile.py
+++ b/src/Mod/Arch/ArchProfile.py
@@ -238,11 +238,11 @@ class _Profile(Draft._DraftObject):
         self.Profile = profile
         Draft._DraftObject.__init__(self,obj,"Profile")
 
-    def __getstate__(self):
+    def dumps(self):
         if hasattr(self,"Profile"):
             return self.Profile
 
-    def __setstate__(self,state):
+    def loads(self,state):
         if isinstance(state,list):
             self.Profile = state
         self.Type = "Profile"

--- a/src/Mod/Arch/ArchReference.py
+++ b/src/Mod/Arch/ArchReference.py
@@ -113,11 +113,11 @@ class ArchReference:
             if obj.ViewObject and obj.ViewObject.Proxy:
                 obj.ViewObject.Proxy.loadInventor(obj)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 
@@ -395,11 +395,11 @@ class ViewProviderArchReference:
         s = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetInt("ReferenceCheckInterval",60)
         self.timer.start(1000*s)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 

--- a/src/Mod/Arch/ArchSchedule.py
+++ b/src/Mod/Arch/ArchSchedule.py
@@ -401,11 +401,11 @@ class _ArchSchedule:
                             print("TOTAL:"+34*" "+v)
         self.setSpreadsheetData(obj)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return self.Type
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         if state:
             self.Type = state
@@ -477,10 +477,10 @@ class _ViewProviderArchSchedule:
         if hasattr(self,"Object"):
             return [self.Object.Proxy.getSpreadSheet(self.Object)]
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def getDisplayModes(self,vobj):

--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -902,11 +902,11 @@ class _SectionPlane:
 
         return obj.Shape.Faces[0].normalAt(0,0)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 
@@ -1152,11 +1152,11 @@ class _ViewProviderSectionPlane:
                 self.txtfont.size = vobj.FontSize.Value
         return
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -818,11 +818,11 @@ class _Site(ArchIFC.IfcProduct):
             g.append(child)
             obj.Group = g
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 
@@ -1223,11 +1223,11 @@ class _ViewProviderSite:
             return
         self.compass.scale(vobj.Object.ProjectedArea)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 

--- a/src/Mod/Arch/ifc_objects.py
+++ b/src/Mod/Arch/ifc_objects.py
@@ -27,7 +27,7 @@ class ifc_object:
     def onDocumentRestored(self, obj):
         obj.Type = [obj.IfcType]
         obj.Type = obj.IfcType
-    def __getstate__(self):
+    def dumps(self):
         return None
-    def __setstate__(self, state):
+    def loads(self, state):
         return None

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -409,13 +409,13 @@ class ViewProviderJoint:
 
         return ":/icons/Assembly_CreateJoint.svg"
 
-    def __getstate__(self):
+    def dumps(self):
         """When saving the document this object gets stored using Python's json module.\
                 Since we have some un-serializable parts here -- the Coin stuff -- we must define this method\
                 to return a tuple of all serializable objects or None."""
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         """When restoring the serialized object from document we have the chance to set some internals here.\
                 Since no data were serialized nothing needs to be done here."""
         return None

--- a/src/Mod/Draft/draftobjects/base.py
+++ b/src/Mod/Draft/draftobjects/base.py
@@ -85,7 +85,7 @@ class DraftObject(object):
         # Object properties are updated when the document is opened.
         self.props_changed_clear()
 
-    def __getstate__(self):
+    def dumps(self):
         """Return a tuple of all serializable objects or None.
 
         When saving the document this object gets stored
@@ -102,7 +102,7 @@ class DraftObject(object):
         """
         return self.Type
 
-    def __setstate__(self, state):
+    def loads(self, state):
         """Set some internal properties for all restored objects.
 
         When a document is restored this method is used to set some properties

--- a/src/Mod/Draft/draftobjects/draft_annotation.py
+++ b/src/Mod/Draft/draftobjects/draft_annotation.py
@@ -82,11 +82,11 @@ class DraftAnnotation(object):
         if multiplier is not None:
             vobj.ScaleMultiplier = multiplier
 
-    def __getstate__(self):
+    def dumps(self):
 
         return
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return
 

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -64,17 +64,17 @@ class DraftLink(DraftObject):
         if obj:
             self.attach(obj)
 
-    def __getstate__(self):
+    def dumps(self):
         """Return a tuple of all serializable objects or None."""
         return self.__dict__
 
-    def __setstate__(self, state):
+    def loads(self, state):
         """Set some internal properties for all restored objects."""
         if isinstance(state, dict):
             self.__dict__ = state
         else:
             self.use_link = False
-            super(DraftLink, self).__setstate__(state)
+            super(DraftLink, self).loads(state)
 
     def attach(self, obj):
         """Set up the properties when the object is attached."""

--- a/src/Mod/Draft/draftobjects/hatch.py
+++ b/src/Mod/Draft/draftobjects/hatch.py
@@ -67,11 +67,11 @@ class Hatch(DraftObject):
 
         self.setProperties(obj)
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
 
         return None
 

--- a/src/Mod/Draft/draftobjects/layer.py
+++ b/src/Mod/Draft/draftobjects/layer.py
@@ -80,11 +80,11 @@ class Layer:
         _wrn("v0.19, " + obj.Label + ", "
              + translate("draft", "added missing view properties"))
 
-    def __getstate__(self):
+    def dumps(self):
         """Return a tuple of objects to save or None."""
         return self.Type
 
-    def __setstate__(self, state):
+    def loads(self, state):
         """Set the internal properties from the restored state."""
         if state:
             self.Type = state
@@ -126,12 +126,12 @@ class LayerContainer:
         group.sort(key=lambda layer: layer.Label)
         obj.Group = group
 
-    def __getstate__(self):
+    def dumps(self):
         """Return a tuple of objects to save or None."""
         if hasattr(self, "Type"):
             return self.Type
 
-    def __setstate__(self, state):
+    def loads(self, state):
         """Set the internal properties from the restored state."""
         if state:
             self.Type = state

--- a/src/Mod/Draft/draftobjects/text.py
+++ b/src/Mod/Draft/draftobjects/text.py
@@ -76,7 +76,7 @@ class Text(DraftAnnotation):
         """Execute code when the document is restored."""
         super().onDocumentRestored(obj)
 
-        # See __setstate__: self.Type is None for new objects.
+        # See loads: self.Type is None for new objects.
         if self.Type is not None \
                 and hasattr(obj, "ViewObject") \
                 and obj.ViewObject:
@@ -93,7 +93,7 @@ class Text(DraftAnnotation):
         _wrn("v0.21, " + obj.Label + ", "
              + translate("draft", "renamed 'DisplayMode' options to 'World/Screen'"))
 
-    def __setstate__(self,state):
+    def loads(self,state):
         # Before update_properties_0v21 the self.Type value was stored.
         # We use this to identify older objects that need to be updated.
         self.Type = state

--- a/src/Mod/Draft/draftobjects/wpproxy.py
+++ b/src/Mod/Draft/draftobjects/wpproxy.py
@@ -70,10 +70,10 @@ class WorkingPlaneProxy:
     def getNormal(self,obj):
         return obj.Shape.Faces[0].normalAt(0,0)
 
-    def __getstate__(self):
+    def dumps(self):
         return self.Type
 
-    def __setstate__(self,state):
+    def loads(self,state):
         if state:
             self.Type = state
 

--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -118,7 +118,7 @@ class ViewProviderDraft(object):
                                                "Defines the size of the SVG pattern."))
             vobj.PatternSize = utils.get_param("HatchPatternSize", 1)
 
-    def __getstate__(self):
+    def dumps(self):
         """Return a tuple of all serializable objects or None.
 
         When saving the document this view provider object gets stored
@@ -138,7 +138,7 @@ class ViewProviderDraft(object):
         """
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         """Set some internal properties for all restored objects.
 
         When a document is restored this method is used to set some properties
@@ -147,7 +147,7 @@ class ViewProviderDraft(object):
         Override this method to define the properties to change for the
         restored serialized objects.
 
-        By default no objects were serialized with `__getstate__`,
+        By default no objects were serialized with `dumps`,
         so nothing needs to be done here, and it returns `None`.
 
         Parameters

--- a/src/Mod/Draft/draftviewproviders/view_clone.py
+++ b/src/Mod/Draft/draftviewproviders/view_clone.py
@@ -38,10 +38,10 @@ class ViewProviderClone:
     def getIcon(self):
         return ":/icons/Draft_Clone.svg"
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def getDisplayModes(self, vobj):

--- a/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
+++ b/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
@@ -162,11 +162,11 @@ class ViewProviderDraftAnnotation(object):
                              "Graphics",
                              _tip)
 
-    def __getstate__(self):
+    def dumps(self):
         """Return a tuple of objects to save or None."""
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         """Set the internal properties from the restored state."""
         return None
 

--- a/src/Mod/Draft/draftviewproviders/view_hatch.py
+++ b/src/Mod/Draft/draftviewproviders/view_hatch.py
@@ -41,11 +41,11 @@ class ViewProviderDraftHatch:
 
         return ":/icons/Draft_Hatch.svg"
 
-    def __getstate__(self):
+    def dumps(self):
 
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
 
         return None
 

--- a/src/Mod/Draft/draftviewproviders/view_layer.py
+++ b/src/Mod/Draft/draftviewproviders/view_layer.py
@@ -204,11 +204,11 @@ class ViewProviderLayer:
         """Return the saved display mode."""
         return mode
 
-    def __getstate__(self):
+    def dumps(self):
         """Return a tuple of objects to save or None."""
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         """Set the internal properties from the restored state."""
         return None
 
@@ -574,11 +574,11 @@ class ViewProviderLayerContainer:
         doc.recompute()
         doc.commitTransaction()
 
-    def __getstate__(self):
+    def dumps(self):
         """Return a tuple of objects to save or None."""
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         """Set the internal properties from the restored state."""
         return None
 

--- a/src/Mod/Draft/draftviewproviders/view_wpproxy.py
+++ b/src/Mod/Draft/draftviewproviders/view_wpproxy.py
@@ -227,10 +227,10 @@ class ViewProviderWorkingPlaneProxy:
             self.drawstyle.lineWidth = vobj.LineWidth
         return
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 ## @}

--- a/src/Mod/Fem/femobjects/base_fempythonobject.py
+++ b/src/Mod/Fem/femobjects/base_fempythonobject.py
@@ -42,8 +42,8 @@ class BaseFemPythonObject(object):
     # they are needed, see:
     # https://forum.freecad.org/viewtopic.php?f=18&t=44021
     # https://forum.freecad.org/viewtopic.php?f=18&t=44009
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None

--- a/src/Mod/Fem/femviewprovider/view_base_femobject.py
+++ b/src/Mod/Fem/femviewprovider/view_base_femobject.py
@@ -114,8 +114,8 @@ class VPBaseFemObject(object):
     # they are needed, see:
     # https://forum.freecad.org/viewtopic.php?f=18&t=44021
     # https://forum.freecad.org/viewtopic.php?f=18&t=44009
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None

--- a/src/Mod/Fem/femviewprovider/view_mesh_gmsh.py
+++ b/src/Mod/Fem/femviewprovider/view_mesh_gmsh.py
@@ -189,10 +189,10 @@ class VPMeshGmsh:
             FreeCAD.Console.PrintError(message + "\n")
         return True
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def claimChildren(self):

--- a/src/Mod/OpenSCAD/OpenSCADFeatures.py
+++ b/src/Mod/OpenSCAD/OpenSCADFeatures.py
@@ -57,11 +57,11 @@ class ViewProviderTree:
     def onChanged(self, vp, prop):
         return
 
-    def __getstate__(self):
+    def dumps(self):
 #        return {'ObjectName' : self.Object.Name}
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         if state is not None:
             import FreeCAD
             doc = FreeCAD.ActiveDocument #crap
@@ -210,10 +210,10 @@ class Resize:
         mat.A33 = self.Vector[2]
         fp.Shape = self.Target.Shape.transformGeometry(mat)
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -18,12 +18,12 @@ Sub-elements such as vertices, edges or faces are accessible as:
 * Edge#, where # is in range(1, number of edges)
 * Face#, where # is in range(1, number of faces)</UserDocu>
     </Documentation>
-    <Methode Name="__getstate__" Const="true">
+    <Methode Name="dumps" Const="true">
       <Documentation>
         <UserDocu>Serialize the content of this shape to a string in BREP format.</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="__setstate__">
+    <Methode Name="loads">
       <Documentation>
         <UserDocu>Deserialize the content of this shape from a string in BREP format.</UserDocu>
       </Documentation>

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -559,12 +559,12 @@ PyObject*  TopoShapePy::importBrepFromString(PyObject *args)
     Py_Return;
 }
 
-PyObject*  TopoShapePy::__getstate__(PyObject *args) {
+PyObject*  TopoShapePy::dumps(PyObject *args) {
     return exportBrepToString(args);
 }
 
 
-PyObject*  TopoShapePy::__setstate__(PyObject *args) {
+PyObject*  TopoShapePy::loads(PyObject *args) {
     if (! getTopoShapePtr()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError,"no c++ object");
         return nullptr;

--- a/src/Mod/Part/BOPTools/JoinFeatures.py
+++ b/src/Mod/Part/BOPTools/JoinFeatures.py
@@ -145,10 +145,10 @@ class ViewProviderConnect:
         self.ViewObject = vobj
         self.Object = vobj.Object
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):
@@ -256,10 +256,10 @@ class ViewProviderEmbed:
         self.ViewObject = vobj
         self.Object = vobj.Object
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):
@@ -350,10 +350,10 @@ class ViewProviderCutout:
         self.ViewObject = vobj
         self.Object = vobj.Object
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):

--- a/src/Mod/Part/BOPTools/SplitFeatures.py
+++ b/src/Mod/Part/BOPTools/SplitFeatures.py
@@ -100,10 +100,10 @@ class ViewProviderBooleanFragments:
         self.ViewObject = vobj
         self.Object = vobj.Object
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):
@@ -258,10 +258,10 @@ class ViewProviderSlice:
         self.ViewObject = vobj
         self.Object = vobj.Object
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):
@@ -438,10 +438,10 @@ class ViewProviderXOR:
         self.ViewObject = vobj
         self.Object = vobj.Object
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
     def claimChildren(self):

--- a/src/Mod/Part/BasicShapes/ViewProviderShapes.py
+++ b/src/Mod/Part/BasicShapes/ViewProviderShapes.py
@@ -68,10 +68,10 @@ class ViewProviderTube:
     def getIcon(self):
         return ":/icons/parametric/Part_Tube_Parametric.svg"
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 

--- a/src/Mod/Part/CompoundTools/CompoundFilter.py
+++ b/src/Mod/Part/CompoundTools/CompoundFilter.py
@@ -224,10 +224,10 @@ class _ViewProviderCompoundFilter:
         self.ViewObject = vobj
         self.Object = vobj.Object
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def claimChildren(self):

--- a/src/Mod/Part/JoinFeatures.py
+++ b/src/Mod/Part/JoinFeatures.py
@@ -142,10 +142,10 @@ class _ViewProviderPartJoinFeature:
     def unsetEdit(self, vobj, mode):
         return
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def claimChildren(self):

--- a/src/Mod/PartDesign/InvoluteGearFeature.py
+++ b/src/Mod/PartDesign/InvoluteGearFeature.py
@@ -163,10 +163,10 @@ class _ViewProviderInvoluteGear:
         FreeCADGui.Control.closeDialog()
         return
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 

--- a/src/Mod/PartDesign/SprocketFeature.py
+++ b/src/Mod/PartDesign/SprocketFeature.py
@@ -172,10 +172,10 @@ class ViewProviderSprocket:
         FreeCADGui.Control.closeDialog()
         return
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self,state):
+    def loads(self,state):
         return None
 
 

--- a/src/Mod/Path/Path/Base/Gui/IconViewProvider.py
+++ b/src/Mod/Path/Path/Base/Gui/IconViewProvider.py
@@ -55,14 +55,14 @@ class ViewProvider(object):
         self.vobj = vobj
         self.obj = vobj.Object
 
-    def __getstate__(self):
+    def dumps(self):
         attrs = {"icon": self.icon}
         if hasattr(self, "editModule"):
             attrs["editModule"] = self.editModule
             attrs["editCallback"] = self.editCallback
         return attrs
 
-    def __setstate__(self, state):
+    def loads(self, state):
         self.icon = state["icon"]
         if state.get("editModule", None):
             self.editModule = state["editModule"]

--- a/src/Mod/Path/Path/Base/Gui/PropertyBag.py
+++ b/src/Mod/Path/Path/Base/Gui/PropertyBag.py
@@ -65,10 +65,10 @@ class ViewProvider(object):
     def getIcon(self):
         return ":/icons/Path-SetupSheet.svg"
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def getDisplayMode(self, mode):

--- a/src/Mod/Path/Path/Base/Gui/SetupSheet.py
+++ b/src/Mod/Path/Path/Base/Gui/SetupSheet.py
@@ -67,10 +67,10 @@ class ViewProvider:
     def getIcon(self):
         return ":/icons/Path_SetupSheet.svg"
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def getDisplayMode(self, mode):

--- a/src/Mod/Path/Path/Base/PropertyBag.py
+++ b/src/Mod/Path/Path/Base/PropertyBag.py
@@ -76,10 +76,10 @@ class PropertyBag(object):
         )
         self.onDocumentRestored(obj)
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def __sanitizePropertyName(self, name):

--- a/src/Mod/Path/Path/Base/SetupSheet.py
+++ b/src/Mod/Path/Path/Base/SetupSheet.py
@@ -222,10 +222,10 @@ class SetupSheet:
 
         obj.Proxy = self
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         for obj in FreeCAD.ActiveDocument.Objects:
             if hasattr(obj, "Proxy") and obj.Proxy == self:
                 self.obj = obj

--- a/src/Mod/Path/Path/Dressup/Boundary.py
+++ b/src/Mod/Path/Path/Dressup/Boundary.py
@@ -78,10 +78,10 @@ class DressupPathBoundary(object):
         self.safeHeight = None
         self.clearanceHeight = None
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def onDocumentRestored(self, obj):

--- a/src/Mod/Path/Path/Dressup/DogboneII.py
+++ b/src/Mod/Path/Path/Dressup/DogboneII.py
@@ -264,10 +264,10 @@ class Proxy(object):
         self.obj = obj
         obj.setEditorMode("BoneBlacklist", 2)  # hide
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def toolRadius(self, obj):

--- a/src/Mod/Path/Path/Dressup/Gui/AxisMap.py
+++ b/src/Mod/Path/Path/Dressup/Gui/AxisMap.py
@@ -69,10 +69,10 @@ class ObjectDressup:
         obj.AxisMap = "Y->A"
         obj.Proxy = self
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def _linear2angular(self, radius, length):
@@ -239,10 +239,10 @@ class ViewProviderDressup:
     def claimChildren(self):
         return [self.obj.Base]
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def onDelete(self, arg1=None, arg2=None):

--- a/src/Mod/Path/Path/Dressup/Gui/Boundary.py
+++ b/src/Mod/Path/Path/Dressup/Gui/Boundary.py
@@ -207,10 +207,10 @@ class DressupPathBoundaryViewProvider(object):
     def __init__(self, vobj):
         self.attach(vobj)
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def attach(self, vobj):

--- a/src/Mod/Path/Path/Dressup/Gui/Dogbone.py
+++ b/src/Mod/Path/Path/Dressup/Gui/Dogbone.py
@@ -478,10 +478,10 @@ class ObjectDressup(object):
     def onDocumentRestored(self, obj):
         obj.setEditorMode("BoneBlacklist", 2)  # hide this one
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def theOtherSideOf(self, side):
@@ -1320,10 +1320,10 @@ class ViewProviderDressup(object):
         panel.setupUi()
         return True
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def onDelete(self, arg1=None, arg2=None):

--- a/src/Mod/Path/Path/Dressup/Gui/DogboneII.py
+++ b/src/Mod/Path/Path/Dressup/Gui/DogboneII.py
@@ -290,10 +290,10 @@ class ViewProviderDressup(object):
         panel.setupUi()
         return True
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def onDelete(self, arg1=None, arg2=None):

--- a/src/Mod/Path/Path/Dressup/Gui/Dragknife.py
+++ b/src/Mod/Path/Path/Dressup/Gui/Dragknife.py
@@ -83,10 +83,10 @@ class ObjectDressup:
 
         obj.Proxy = self
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def shortcut(self, queue):
@@ -578,10 +578,10 @@ class ViewProviderDressup:
     def claimChildren(self):
         return [self.Object.Base]
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def onDelete(self, arg1=None, arg2=None):

--- a/src/Mod/Path/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/Path/Path/Dressup/Gui/LeadInOut.py
@@ -137,10 +137,10 @@ class ObjectDressup:
         self.wire = None
         self.rapids = None
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def setup(self, obj):
@@ -660,10 +660,10 @@ class ViewProviderDressup:
             arg1.Object.Base = None
         return True
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def clearTaskPanel(self):

--- a/src/Mod/Path/Path/Dressup/Gui/RampEntry.py
+++ b/src/Mod/Path/Path/Dressup/Gui/RampEntry.py
@@ -164,10 +164,10 @@ class ObjectDressup:
 
         return data
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def onChanged(self, obj, prop):
@@ -884,10 +884,10 @@ class ViewProviderDressup:
             arg1.Object.Base = None
         return True
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
 

--- a/src/Mod/Path/Path/Dressup/Gui/Tags.py
+++ b/src/Mod/Path/Path/Dressup/Gui/Tags.py
@@ -384,10 +384,10 @@ class PathDressupTagViewProvider:
         #    return True
         return False
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def setupColors(self):

--- a/src/Mod/Path/Path/Dressup/Gui/ZCorrect.py
+++ b/src/Mod/Path/Path/Dressup/Gui/ZCorrect.py
@@ -91,10 +91,10 @@ class ObjectDressup:
         obj.ArcInterpolate = 0.1
         obj.SegInterpolate = 1.0
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def onChanged(self, fp, prop):
@@ -325,10 +325,10 @@ class ViewProviderDressup:
         panel.setupUi()
         return True
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def onDelete(self, arg1=None, arg2=None):

--- a/src/Mod/Path/Path/Dressup/Tags.py
+++ b/src/Mod/Path/Path/Dressup/Tags.py
@@ -998,10 +998,10 @@ class ObjectTagDressup:
         obj.Proxy = self
         obj.Base = base
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         self.obj = state
         self.solids = []
         self.tags = []

--- a/src/Mod/Path/Path/Main/Gui/Fixture.py
+++ b/src/Mod/Path/Path/Main/Gui/Fixture.py
@@ -112,10 +112,10 @@ class _ViewProviderFixture:
         vobj.setEditorMode("Transparency", mode)
         vobj.setEditorMode("Visibility", mode)
 
-    def __getstate__(self):  # mandatory
+    def dumps(self):  # mandatory
         return None
 
-    def __setstate__(self, state):  # mandatory
+    def loads(self, state):  # mandatory
         return None
 
     def getIcon(self):  # optional

--- a/src/Mod/Path/Path/Main/Gui/Job.py
+++ b/src/Mod/Path/Path/Main/Gui/Job.py
@@ -149,10 +149,10 @@ class ViewProvider:
         sw = coin.SO_SWITCH_ALL if yes else coin.SO_SWITCH_NONE
         self.switch.whichChild = sw
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def deleteObjectsOnReject(self):

--- a/src/Mod/Path/Path/Main/Job.py
+++ b/src/Mod/Path/Path/Main/Job.py
@@ -655,10 +655,10 @@ class ObjectJob:
             attrs[JobTemplate.Description] = obj.Description
         return attrs
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         for obj in FreeCAD.ActiveDocument.Objects:
             if hasattr(obj, "Proxy") and obj.Proxy == self:
                 self.obj = obj

--- a/src/Mod/Path/Path/Main/Stock.py
+++ b/src/Mod/Path/Path/Main/Stock.py
@@ -194,10 +194,10 @@ class StockFromBase(Stock):
         self.width = None
         self.height = None
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def execute(self, obj):
@@ -260,10 +260,10 @@ class StockCreateBox(Stock):
 
         obj.Proxy = self
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def execute(self, obj):
@@ -305,10 +305,10 @@ class StockCreateCylinder(Stock):
 
         obj.Proxy = self
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def execute(self, obj):

--- a/src/Mod/Path/Path/Op/Base.py
+++ b/src/Mod/Path/Path/Op/Base.py
@@ -466,12 +466,12 @@ class ObjectOp(object):
         self.setEditorModes(obj, features)
         self.opOnDocumentRestored(obj)
 
-    def __getstate__(self):
+    def dumps(self):
         """__getstat__(self) ... called when receiver is saved.
         Can safely be overwritten by subclasses."""
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         """__getstat__(self) ... called when receiver is restored.
         Can safely be overwritten by subclasses."""
         return None

--- a/src/Mod/Path/Path/Op/Gui/Array.py
+++ b/src/Mod/Path/Path/Op/Gui/Array.py
@@ -148,10 +148,10 @@ class ObjectArray:
         self.setEditorModes(obj)
         obj.Proxy = self
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def setEditorModes(self, obj):
@@ -431,10 +431,10 @@ class ViewProviderArray:
         self.Object = vobj.Object
         return
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def claimChildren(self):

--- a/src/Mod/Path/Path/Op/Gui/Base.py
+++ b/src/Mod/Path/Path/Op/Gui/Base.py
@@ -135,8 +135,8 @@ class ViewProvider(object):
         if self.panel:
             self.panel.reject(False)
 
-    def __getstate__(self):
-        """__getstate__() ... callback before receiver is saved to a file.
+    def dumps(self):
+        """dumps() ... callback before receiver is saved to a file.
         Returns a dictionary with the receiver's resources as strings."""
         Path.Log.track()
         state = {}
@@ -146,9 +146,9 @@ class ViewProvider(object):
         state["OpPageClass"] = self.OpPageClass
         return state
 
-    def __setstate__(self, state):
-        """__setstate__(state) ... callback on restoring a saved instance, pendant to __getstate__()
-        state is the dictionary returned by __getstate__()."""
+    def loads(self, state):
+        """loads(state) ... callback on restoring a saved instance, pendant to dumps()
+        state is the dictionary returned by dumps()."""
         self.OpName = state["OpName"]
         self.OpIcon = state["OpIcon"]
         self.OpPageModule = state["OpPageModule"]

--- a/src/Mod/Path/Path/Op/Gui/Comment.py
+++ b/src/Mod/Path/Path/Op/Gui/Comment.py
@@ -44,10 +44,10 @@ class Comment:
         mode = 2
         obj.setEditorMode("Placement", mode)
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def onChanged(self, obj, prop):
@@ -74,10 +74,10 @@ class _ViewProviderComment:
         vobj.setEditorMode("Transparency", mode)
         vobj.setEditorMode("Visibility", mode)
 
-    def __getstate__(self):  # mandatory
+    def dumps(self):  # mandatory
         return None
 
-    def __setstate__(self, state):  # mandatory
+    def loads(self, state):  # mandatory
         return None
 
     def getIcon(self):  # optional

--- a/src/Mod/Path/Path/Op/Gui/Copy.py
+++ b/src/Mod/Path/Path/Op/Gui/Copy.py
@@ -51,10 +51,10 @@ class ObjectPathCopy:
         )
         obj.Proxy = self
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def execute(self, obj):
@@ -79,10 +79,10 @@ class ViewProviderPathCopy:
     def getIcon(self):
         return ":/icons/Path_Copy.svg"
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
 

--- a/src/Mod/Path/Path/Op/Gui/Hop.py
+++ b/src/Mod/Path/Path/Op/Gui/Hop.py
@@ -46,10 +46,10 @@ class ObjectHop:
         )
         obj.Proxy = self
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def execute(self, obj):
@@ -87,10 +87,10 @@ class ViewProviderPathHop:
     def getIcon(self):
         return ":/icons/Path_Hop.svg"
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
 

--- a/src/Mod/Path/Path/Op/Gui/Stop.py
+++ b/src/Mod/Path/Path/Op/Gui/Stop.py
@@ -46,10 +46,10 @@ class Stop:
         mode = 2
         obj.setEditorMode("Placement", mode)
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def onChanged(self, obj, prop):
@@ -81,10 +81,10 @@ class _ViewProviderStop:
         vobj.setEditorMode("Transparency", mode)
         vobj.setEditorMode("Visibility", mode)
 
-    def __getstate__(self):  # mandatory
+    def dumps(self):  # mandatory
         return None
 
-    def __setstate__(self, state):  # mandatory
+    def loads(self, state):  # mandatory
         return None
 
     def getIcon(self):  # optional

--- a/src/Mod/Path/Path/Tool/Bit.py
+++ b/src/Mod/Path/Path/Tool/Bit.py
@@ -183,10 +183,10 @@ class ToolBit(object):
             self._setupBitShape(obj)
         self.onDocumentRestored(obj)
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         for obj in FreeCAD.ActiveDocument.Objects:
             if hasattr(obj, "Proxy") and obj.Proxy == self:
                 self.obj = obj

--- a/src/Mod/Path/Path/Tool/Gui/Bit.py
+++ b/src/Mod/Path/Path/Tool/Gui/Bit.py
@@ -70,10 +70,10 @@ class ViewProvider(object):
             return QtGui.QIcon(pixmap)
         return ":/icons/Path_ToolBit.svg"
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def onDelete(self, vobj, arg2=None):

--- a/src/Mod/Path/Path/Tool/Gui/Controller.py
+++ b/src/Mod/Path/Path/Tool/Gui/Controller.py
@@ -64,10 +64,10 @@ class ViewProvider:
         vobj.setEditorMode("Visibility", mode)
         self.vobj = vobj
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         return None
 
     def getIcon(self):

--- a/src/Mod/Show/mTempoVis.py
+++ b/src/Mod/Show/mTempoVis.py
@@ -574,8 +574,8 @@ class TempoVis(object):
 
         return [obj for obj in doc_obj_or_list if is3DObject(obj)]
 
-    def __getstate__(self):
+    def dumps(self):
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         self._init_attrs()


### PR DESCRIPTION
For serialization of Python features the methods `__getstate__/__setstate__` are used optionally. With Py3.11 these methods have been added to the `object` class so that they exist for each Python class. But this way the class App::PropertyPythonObject will always call these methods when it shouldn't.