### PR TITLE
Arch: Added missing ArchSketchObject to cmake file

### DIFF
--- a/src/Mod/Arch/CMakeLists.txt
+++ b/src/Mod/Arch/CMakeLists.txt
@@ -61,6 +61,7 @@ SET(Arch_SRCS
     exportIFCStructuralTools.py
     ifc_objects.py
     ifc_viewproviders.py
+    ArchSketchObject.py
 )
 
 SET(Dice3DS_SRCS


### PR DESCRIPTION
The ArchSketchObject.py module was not in the cmake file and therefore not installed.