### PR TITLE
Change default file saving preferences

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1895,7 +1895,7 @@ bool Document::saveToFile(const char* filename) const
     signalStartSave(*this, filename);
 
     auto hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document");
-    int compression = hGrp->GetInt("CompressionLevel",3);
+    int compression = hGrp->GetInt("CompressionLevel",7);
     compression = Base::clamp<int>(compression, Z_NO_COMPRESSION, Z_BEST_COMPRESSION);
 
     bool policy = App::GetApplication().GetParameterGroupByPath

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2145,7 +2145,7 @@ void Application::runApplication()
                      &mw, SLOT(processMessages(const QList<QByteArray> &)));
 
     ParameterGrp::handle hDocGrp = WindowParameter::getDefaultParameter()->GetGroup("Document");
-    int timeout = hDocGrp->GetInt("AutoSaveTimeout", 15); // 15 min
+    int timeout = hDocGrp->GetInt("AutoSaveTimeout", 5); // 5 min
     if (!hDocGrp->GetBool("AutoSaveEnabled", true))
         timeout = 0;
     AutoSaver::instance()->setTimeout(timeout * 60000);

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1354,7 +1354,7 @@ void Document::Save (Base::Writer &writer) const
 
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document");
         if (hGrp->GetBool("SaveThumbnail", true)) {
-            int size = hGrp->GetInt("ThumbnailSize", 128);
+            int size = hGrp->GetInt("ThumbnailSize", 256);
             size = Base::clamp<int>(size, 64, 512);
             std::list<MDIView*> mdi = getMDIViews();
             for (const auto & it : mdi) {

--- a/src/Gui/Language/FreeCAD.ts
+++ b/src/Gui/Language/FreeCAD.ts
@@ -3307,7 +3307,7 @@ besides the color bar</source>
     <message>
         <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
         <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/Gui/Language/FreeCAD_af.ts
+++ b/src/Gui/Language/FreeCAD_af.ts
@@ -2810,9 +2810,9 @@ bounding box size of the 3D object that is currently displayed.</translation>
     </message>
     <message>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Kompressievlak vir dokumentstoring
-(0 = geen, 9 = hoogste, 3  = versuimwaarde)</translation>
+(0 = geen, 9 = hoogste, 7 = versuimwaarde)</translation>
     </message>
     <message>
       <source>Create new document at start up</source>

--- a/src/Gui/Language/FreeCAD_ar.ts
+++ b/src/Gui/Language/FreeCAD_ar.ts
@@ -2830,9 +2830,9 @@ bounding box size of the 3D object that is currently displayed.</translation>
     </message>
     <message>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation type="unfinished">Document save compression level
-(0 = none, 9 = highest, 3 = default)</translation>
+(0 = none, 9 = highest, 7 = default)</translation>
     </message>
     <message>
       <source>Create new document at start up</source>

--- a/src/Gui/Language/FreeCAD_be.ts
+++ b/src/Gui/Language/FreeCAD_be.ts
@@ -3335,9 +3335,9 @@ besides the color bar</source>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Узровень сціску захавання дакумента
-(0 = няма, 9 = самы высокі, 3 = першапачатковы)</translation>
+(0 = няма, 9 = самы высокі, 7 = першапачатковы)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_bg.ts
+++ b/src/Gui/Language/FreeCAD_bg.ts
@@ -2804,8 +2804,8 @@ bounding box size of the 3D object that is currently displayed.</source>
     </message>
     <message>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>Документ запазване със степен на компресиране (0 = няма, 9 = най-високата, 3 = по подразбиране) </translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>Документ запазване със степен на компресиране (0 = няма, 9 = най-високата, 7 = по подразбиране)</translation>
     </message>
     <message>
       <source>Create new document at start up</source>

--- a/src/Gui/Language/FreeCAD_ca.ts
+++ b/src/Gui/Language/FreeCAD_ca.ts
@@ -3341,9 +3341,9 @@ a més de la barra de colors</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Nivell de compressió per a desar el document
-(0 = cap, 9 = el més alt, 3 = per defecte)</translation>
+(0 = cap, 9 = el més alt, 7 = per defecte)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_cs.ts
+++ b/src/Gui/Language/FreeCAD_cs.ts
@@ -3345,8 +3345,8 @@ podél barevné škály</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>Úroveň komprese při ukládání dokumentu (0 = žádná, 9 = nejvyšší, 3 = výchozí)</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>Úroveň komprese při ukládání dokumentu (0 = žádná, 9 = nejvyšší, 7 = výchozí)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_de.ts
+++ b/src/Gui/Language/FreeCAD_de.ts
@@ -3340,9 +3340,9 @@ neben dem Farbbalken</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Kompressionsstufe beim Speichern des Dokuments
-(0 = keine, 9 = höchste, 3 = standardmäßige Kompression)</translation>
+(0 = keine, 9 = höchste, 7 = standardmäßige Kompression)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_el.ts
+++ b/src/Gui/Language/FreeCAD_el.ts
@@ -3346,9 +3346,9 @@ besides the color bar</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Βαθμός συμπίεσης αποθηκευόμενων εγγράφων
-(0 = καμία, 9 = ύψιστη, 3 = προεπιλεγμένη)</translation>
+(0 = καμία, 9 = ύψιστη, 7 = προεπιλεγμένη)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_es-AR.ts
+++ b/src/Gui/Language/FreeCAD_es-AR.ts
@@ -3346,9 +3346,9 @@ junto a la barra de color</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Nivel de compresión de guardado de documentos
-(0 = ninguno, 9 = más alto, 3 = por defecto)</translation>
+(0 = ninguno, 9 = más alto, 7 = por defecto)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_es-ES.ts
+++ b/src/Gui/Language/FreeCAD_es-ES.ts
@@ -3348,9 +3348,9 @@ junto a la barra de color</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Nivel de compresión de guardado del documento
-(0 = ninguno, 9 = el más alto, 3 = por defecto)</translation>
+(0 = ninguno, 9 = el más alto, 7 = por defecto)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_eu.ts
+++ b/src/Gui/Language/FreeCAD_eu.ts
@@ -3347,9 +3347,9 @@ kolore-barraz aparte</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Dokumentua gordetzeko konpresio maila
-(0 = zero, 9 = handiena, 3 = lehenetsia)</translation>
+(0 = zero, 9 = handiena, 7 = lehenetsia)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_fi.ts
+++ b/src/Gui/Language/FreeCAD_fi.ts
@@ -3350,8 +3350,8 @@ besides the color bar</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>Asiakirja tallennetaan pakkaustasolla (0 = ei yhtään, 9 = suurin, 3 = oletus)</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>Asiakirja tallennetaan pakkaustasolla (0 = ei yhtään, 9 = suurin, 7 = oletus)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_fil.ts
+++ b/src/Gui/Language/FreeCAD_fil.ts
@@ -3953,9 +3953,9 @@ besides the color bar</translation>
     <message>
       <location filename="../DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Dokumento i-impok ang antas ng compression
-(0 = none, 9 = highest, 3 = default)</translation>
+(0 = none, 9 = highest, 7 = default)</translation>
     </message>
     <message>
       <location filename="../DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_fr.ts
+++ b/src/Gui/Language/FreeCAD_fr.ts
@@ -3338,9 +3338,9 @@ en plus de la barre de couleur</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Niveau de compression pour la sauvegarde de document
-(0 = aucune, 9 = forte, 3 = par défaut)</translation>
+(0 = aucune, 9 = forte, 7 = par défaut)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_gl.ts
+++ b/src/Gui/Language/FreeCAD_gl.ts
@@ -3350,9 +3350,9 @@ besides the color bar</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Nivel de compresión no gardado de documentos
-(0 = ningún, 9 = o máis alto, 3 = por defecto)</translation>
+(0 = ningún, 9 = o máis alto, 7 = por defecto)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_hr.ts
+++ b/src/Gui/Language/FreeCAD_hr.ts
@@ -3360,8 +3360,8 @@ osim trake boja</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>Razina kompresije spremanja dokumenta (0 = ništa, 9 = najviši, 3 = zadana vrijednost)</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>Razina kompresije spremanja dokumenta (0 = ništa, 9 = najviši, 7 = zadana vrijednost)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_hu.ts
+++ b/src/Gui/Language/FreeCAD_hu.ts
@@ -3345,9 +3345,9 @@ a színsáv mellett</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Dokumentum mentésének tömörítési szintje
-(0=nincs, 9=legnagyobb, 3=alapértelmezett)</translation>
+(0=nincs, 9=legnagyobb, 7=alapértelmezett)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_id.ts
+++ b/src/Gui/Language/FreeCAD_id.ts
@@ -3347,8 +3347,8 @@ besides the color bar</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>Dokumen menyimpan tingkat kompresi (0 = none, 9 = tertinggi, 3 = default)</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>Dokumen menyimpan tingkat kompresi (0 = none, 9 = tertinggi, 7 = default)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_it.ts
+++ b/src/Gui/Language/FreeCAD_it.ts
@@ -3346,9 +3346,9 @@ oltre alla barra dei colori</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Livello di compressione di salvataggio del documento
-(0 = nessuno, 9 = massimo, 3 = normale)</translation>
+(0 = nessuno, 9 = massimo, 7 = normale)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_ja.ts
+++ b/src/Gui/Language/FreeCAD_ja.ts
@@ -3329,8 +3329,8 @@ besides the color bar</source>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>ドキュメントの圧縮レベル(0 = 非圧縮、9 = 高圧縮、3 = デフォルト)</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>ドキュメントの圧縮レベル(0 = 非圧縮、9 = 高圧縮、7 = デフォルト)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_ka.ts
+++ b/src/Gui/Language/FreeCAD_ka.ts
@@ -3343,9 +3343,9 @@ besides the color bar</source>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>დოკუმენტის შეკუმშვის დონე შენახვისას
-(0 = არაფერი, 9 = უმაღლესი, 3 = ნაგულისხმევი)</translation>
+(0 = არაფერი, 9 = უმაღლესი, 7 = ნაგულისხმევი)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_kab.ts
+++ b/src/Gui/Language/FreeCAD_kab.ts
@@ -2810,9 +2810,9 @@ bounding box size of the 3D object that is currently displayed.</translation>
     </message>
     <message>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Niveau de compression pour la sauvegarde de document
-(0 = aucune, 9 = forte, 3 = par défaut)</translation>
+(0 = aucune, 9 = forte, 7 = par défaut)</translation>
     </message>
     <message>
       <source>Create new document at start up</source>

--- a/src/Gui/Language/FreeCAD_ko.ts
+++ b/src/Gui/Language/FreeCAD_ko.ts
@@ -3346,9 +3346,9 @@ besides the color bar</source>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>문서 저장 압축 수준
-(0 = 없음, 9 = 최고, 3 = 기본값)</translation>
+(0 = 없음, 9 = 최고, 7 = 기본값)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_lt.ts
+++ b/src/Gui/Language/FreeCAD_lt.ts
@@ -3936,9 +3936,9 @@ besides the color bar</translation>
     <message>
       <location filename="../DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Išsaugomo dokumento suglaudinimo lygis
-(0 = neglaudintas; 9 = labiausiai suglaudintas; 3 = numatytasis)</translation>
+(0 = neglaudintas; 9 = labiausiai suglaudintas; 7 = numatytasis)</translation>
     </message>
     <message>
       <location filename="../DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_nl.ts
+++ b/src/Gui/Language/FreeCAD_nl.ts
@@ -3335,8 +3335,8 @@ besides the color bar</source>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>Document op te slaan compressie-niveau (0=geen, 9=hoogste, 3=standaard)</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>Document op te slaan compressie-niveau (0=geen, 9=hoogste, 7=standaard)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_no.ts
+++ b/src/Gui/Language/FreeCAD_no.ts
@@ -2808,9 +2808,9 @@ bounding box size of the 3D object that is currently displayed.</translation>
     </message>
     <message>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Dokumentetlagring komprimeringsnivå
-(0=ingen, 9=høyest, 3=standard)</translation>
+(0=ingen, 9=høyest, 7=standard)</translation>
     </message>
     <message>
       <source>Create new document at start up</source>

--- a/src/Gui/Language/FreeCAD_pl.ts
+++ b/src/Gui/Language/FreeCAD_pl.ts
@@ -3348,8 +3348,8 @@ oprócz paska kolorów</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>Poziom kompresji podczas zapisu dokumentu (0 = brak, 9 = najwyższy, 3 = domyślny)</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>Poziom kompresji podczas zapisu dokumentu (0 = brak, 9 = najwyższy, 7 = domyślny)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_pt-BR.ts
+++ b/src/Gui/Language/FreeCAD_pt-BR.ts
@@ -3346,8 +3346,8 @@ além da barra de cores</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>Nível de compactação ao salvar documentos (0 = nenhum, 9 = mais alto, 3 = padrão)</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>Nível de compactação ao salvar documentos (0 = nenhum, 9 = mais alto, 7 = padrão)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_pt-PT.ts
+++ b/src/Gui/Language/FreeCAD_pt-PT.ts
@@ -3347,8 +3347,8 @@ besides the color bar</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>Nível de compactação ao guardar documentos (0 = nenhum, 9 = mais alto, 3 = padrão)</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>Nível de compactação ao guardar documentos (0 = nenhum, 9 = mais alto, 7 = padrão)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_ro.ts
+++ b/src/Gui/Language/FreeCAD_ro.ts
@@ -3346,9 +3346,9 @@ pe lângă bara de culori</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>nivelul de comprimare al documentului
-(0=deloc, 9=cel mai mare, 3=implicit)</translation>
+(0=deloc, 9=cel mai mare, 7=implicit)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_ru.ts
+++ b/src/Gui/Language/FreeCAD_ru.ts
@@ -3341,9 +3341,9 @@ besides the color bar</source>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Уровень сжатия сохраняемого документа
-(0 = нет, 9 = наивысший, 3 = по умолчанию)</translation>
+(0 = нет, 9 = наивысший, 7 = по умолчанию)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_sk.ts
+++ b/src/Gui/Language/FreeCAD_sk.ts
@@ -3953,9 +3953,9 @@ besides the color bar</translation>
     <message>
       <location filename="../DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Úroveň kompresie ukladaného súboru
-(0=nie, 9=najvyššia, 3=predvolená)</translation>
+(0=nie, 9=najvyššia, 7=predvolená)</translation>
     </message>
     <message>
       <location filename="../DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_sl.ts
+++ b/src/Gui/Language/FreeCAD_sl.ts
@@ -3350,9 +3350,9 @@ poleg barvne vrstice</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Raven stiskanja pri shranjevanju dokumenta
-(0 = brez, 9 = najvišja, 3 = privzeta)</translation>
+(0 = brez, 9 = najvišja, 7 = privzeta)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_sr-CS.ts
+++ b/src/Gui/Language/FreeCAD_sr-CS.ts
@@ -3348,9 +3348,9 @@ besides the color bar</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Nivo kompresije za čuvanje dokumenta
-(0 = ništa, 9 = najviše, 3 = podrazumevano)</translation>
+(0 = ništa, 9 = najviše, 7 = podrazumevano)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_sr.ts
+++ b/src/Gui/Language/FreeCAD_sr.ts
@@ -3348,9 +3348,9 @@ besides the color bar</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Ниво компресије за чување документа
-(0 = ништа, 9 = највише, 3 = подразумевано)</translation>
+(0 = ништа, 9 = највише, 7 = подразумевано)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_sv-SE.ts
+++ b/src/Gui/Language/FreeCAD_sv-SE.ts
@@ -3350,9 +3350,9 @@ besides the color bar</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Komprimeringsgrad när dokument sparas
-(0 = ingen, 9 = högst, 3 = standard)</translation>
+(0 = ingen, 9 = högst, 7 = standard)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_tr.ts
+++ b/src/Gui/Language/FreeCAD_tr.ts
@@ -3349,9 +3349,9 @@ besides the color bar</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Belge kaydındaki sıkıştırma seviyesi
-(0=hiç,9=en yüksek,3=varsayılan)</translation>
+(0=hiç,9=en yüksek,7=varsayılan)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_uk.ts
+++ b/src/Gui/Language/FreeCAD_uk.ts
@@ -3347,9 +3347,9 @@ besides the color bar</source>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Рівень стиснення документу
-(0 = немає, 9 = високий, 3 = за замовчуванням)</translation>
+(0 = немає, 9 = високий, 7 = за замовчуванням)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_val-ES.ts
+++ b/src/Gui/Language/FreeCAD_val-ES.ts
@@ -3347,8 +3347,8 @@ besides the color bar</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>Nivell de compressió per a guardar el document (0 = cap, 9 = el més alt, 3 = per defecte)</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>Nivell de compressió per a guardar el document (0 = cap, 9 = el més alt, 7 = per defecte)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_vi.ts
+++ b/src/Gui/Language/FreeCAD_vi.ts
@@ -3955,9 +3955,9 @@ besides the color bar</translation>
     <message>
       <location filename="../DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
+(0 = none, 9 = highest, 7 = default)</source>
       <translation>Mức độ nén tài liệu lưu trữ
-(0 = không, 9 = cao nhất, 3 = mặc định)</translation>
+(0 = không, 9 = cao nhất, 7 = mặc định)</translation>
     </message>
     <message>
       <location filename="../DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_zh-CN.ts
+++ b/src/Gui/Language/FreeCAD_zh-CN.ts
@@ -3335,8 +3335,8 @@ besides the color bar</source>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>保存文件的压缩级别(0 = 无，9 = 最高，3 = 默认)</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>保存文件的压缩级别(0 = 无，9 = 最高，7 = 默认)</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/Language/FreeCAD_zh-TW.ts
+++ b/src/Gui/Language/FreeCAD_zh-TW.ts
@@ -3346,8 +3346,8 @@ besides the color bar</translation>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="90"/>
       <source>Document save compression level
-(0 = none, 9 = highest, 3 = default)</source>
-      <translation>儲存文件的壓縮級別（0 =無，9 =最高，3 =預設）</translation>
+(0 = none, 9 = highest, 7 = default)</source>
+      <translation>儲存文件的壓縮級別（0 =無，9 =最高，7 =預設）</translation>
     </message>
     <message>
       <location filename="../PreferencePages/DlgSettingsDocument.ui" line="98"/>

--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -88,7 +88,7 @@
          <widget class="QLabel" name="textLabel1">
           <property name="text">
            <string>Document save compression level
-(0 = none, 9 = highest, 3 = default)</string>
+(0 = none, 9 = highest, 7 = default)</string>
           </property>
          </widget>
         </item>

--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -393,7 +393,7 @@ Common sizes are 128, 256 and 512</string>
            <number>512</number>
           </property>
           <property name="value">
-           <number>128</number>
+           <number>256</number>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>ThumbnailSize</cstring>

--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -302,7 +302,7 @@ automatically run a file recovery when it is started.</string>
            <number>60</number>
           </property>
           <property name="value">
-           <number>15</number>
+           <number>5</number>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>AutoSaveTimeout</cstring>

--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -98,7 +98,7 @@
            <string>Compression level for FCStd files</string>
           </property>
           <property name="value">
-           <number>3</number>
+           <number>7</number>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>CompressionLevel</cstring>


### PR DESCRIPTION
This PR:
 - Increases default compression level from 3 to 7
 - Increases default thumbnail size from 128px to 256px
 - Decreases autosave interval from 15 minutes to 5 minutes

In my testing, increasing compression level didn't significantly increase saving time, even on low-end machines, and compression performance plateaus at 7.
![image](https://github.com/FreeCAD/FreeCAD/assets/140345756/8e752a26-53e3-4fdd-ae23-7e069a3a9284)

Increasing thumbnail resolution significantly increases quality even when displayed at a lower resolution.
![image](https://github.com/FreeCAD/FreeCAD/assets/140345756/137ee81b-919b-48b9-b505-89847a673ebc)
