### PR TITLE
clang-format: disable sorting of includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -50,6 +50,7 @@ ObjCSpaceBeforeProtocolList: true
 PackConstructorInitializers: Never
 PointerAlignment: Left
 ReflowComments: true
+SortIncludes: Never
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false


### PR DESCRIPTION
Sorting the included headers regularly leads to build failures. Especially when PCH is enabled the PreCompiled.h must be the very first include