### PR TITLE
Path: fix LeadInOutDressup throwing an exception due to floating poin…

### DIFF
--- a/src/Mod/Path/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/Path/Path/Dressup/Gui/LeadInOut.py
@@ -546,7 +546,7 @@ class ObjectDressup:
                     queue = []
                 if (
                     obj.IncludeLayers
-                    and curCommand.z < currLocation["Z"]
+                    and curCommand.z < currLocation["Z"] and not Path.Geom.isRoughly(curCommand.z, currLocation["Z"])
                     and prevCmd.Name in movecommands
                 ):
                     # Layer change within move cmds


### PR DESCRIPTION
…t inaccuracy when comparing z-positions

This PR fixes issue #10791.

"Path.Geom.isRoughly" is used to make sure the current command moves down by more than the floating point inaccuracy and only considers "curCommand" to be a layer change if that is the case. This prevents single element "queue"s to be added to "layers" in the case demonstrated in the attached file in the issue.