### PR TITLE
[Release 0.21] pre-commit: Avoid automatic commits for backport fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,15 +4,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 files: |
     (?x)^(
-        src/Mod/AddonManager|
-        src/Tools|
-        tests/src|
-        src/Mod/Sketcher
+        tests/src
     )
 exclude: |
     (?x)^(
         .*vcproj.*|
-        .*vcxproj.*
+        .*vcxproj.*|
+        src|
+        tests/src
     )
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
For backport fixes the automatic changes by pre-commit should be avoided as this leads to hundreds of modified files.