### PR TITLE
Arch: SoGui removal

### DIFF
--- a/src/Mod/Arch/OfflineRenderingUtils.py
+++ b/src/Mod/Arch/OfflineRenderingUtils.py
@@ -478,9 +478,8 @@ def viewer(scene=None,background=(1.0,1.0,1.0),lightdir=None):
     # Create a Qt widget, which will be our window.
     win = quarter.QuarterWidget()
 
-    win = sogui.SoGui.init()
     if win is None:
-        print("Unable to create a SoGui window")
+        print("Unable to create a Quarter window")
         return
 
     win.setBackgroundColor(coin.SbColor(background[0],background[1],background[2]))

--- a/src/Mod/Arch/OfflineRenderingUtils.py
+++ b/src/Mod/Arch/OfflineRenderingUtils.py
@@ -471,7 +471,12 @@ def viewer(scene=None,background=(1.0,1.0,1.0),lightdir=None):
 
     # Initialize Coin. This returns a main window to use
     from pivy import coin
-    from pivy import sogui
+    from pivy import quarter
+    from PySide2 import QtWidgets
+
+    app = QtWidgets.QApplication([])
+    # Create a Qt widget, which will be our window.
+    win = quarter.QuarterWidget()
 
     win = sogui.SoGui.init()
     if win is None:
@@ -495,17 +500,14 @@ def viewer(scene=None,background=(1.0,1.0,1.0),lightdir=None):
     # ref the scene so it doesn't get garbage-collected
     scene.ref()
 
-    # Create a viewer in which to see our scene graph
-    viewer = sogui.SoGuiExaminerViewer(win)
-
     # Put our scene into viewer, change the title
-    viewer.setSceneGraph(scene)
-    viewer.setTitle("Coin viewer")
-    viewer.show()
+    win.setSceneGraph(scene)
+    win.setWindowTitle("Coin viewer")
 
-    sogui.SoGui.show(win) # Display main window
-    sogui.SoGui.mainLoop()     # Main Coin event loop
-
+    # IMPORTANT!!!!! Windows are hidden by default.
+    win.show()
+    # Start the event loop.
+    app.exec_()
 
 
 def embedLight(scene,lightdir):


### PR DESCRIPTION
Removes the use of SoGui module in Arch/OfflineReneringUtils module, used Quarter instead