### PR TITLE
Draft: ShapeString: improve ObliqueAngle

### DIFF
--- a/src/Mod/Draft/draftobjects/shapestring.py
+++ b/src/Mod/Draft/draftobjects/shapestring.py
@@ -164,11 +164,6 @@ class ShapeString(DraftObject):
                 if obj.ScaleToSize:
                     ss_shape.scale(obj.Size / cap_height)
                     cap_height = obj.Size
-                just_vec = self.justification_vector(ss_shape,
-                                                     cap_height,
-                                                     obj.Justification,
-                                                     obj.JustificationReference,
-                                                     obj.KeepLeftMargin)
                 if obj.ObliqueAngle:
                     if -80 <= obj.ObliqueAngle <= 80:
                         mtx = App.Matrix()
@@ -177,6 +172,11 @@ class ShapeString(DraftObject):
                     else:
                         wrn = translate("draft", "ShapeString: oblique angle must be in the -80 to +80 degree range") + "\n"
                         App.Console.PrintWarning(wrn)
+                just_vec = self.justification_vector(ss_shape,
+                                                     cap_height,
+                                                     obj.Justification,
+                                                     obj.JustificationReference,
+                                                     obj.KeepLeftMargin)
                 shapes = ss_shape.SubShapes
                 for shape in shapes:
                     shape.translate(just_vec)
@@ -194,7 +194,7 @@ class ShapeString(DraftObject):
         self.props_changed_store(prop)
 
     def justification_vector(self, ss_shape, cap_height, just, just_ref, keep_left_margin): # ss_shape is a compound
-        box = ss_shape.BoundBox
+        box = ss_shape.optimalBoundingBox()
         if keep_left_margin is True and "Left" in just:
             vec = App.Vector(0, 0, 0)
         else:


### PR DESCRIPTION
Calculation of the justification vector required the use of `optimalBoundingBox` and should happen after applying the oblique angle.
