### PR TITLE
Add nullptr check to prevent segfault

### DIFF
--- a/src/Gui/NavigationAnimation.cpp
+++ b/src/Gui/NavigationAnimation.cpp
@@ -88,6 +88,10 @@ void FixedTimeAnimation::initialize()
  */
 void FixedTimeAnimation::update(const QVariant& value)
 {
+    if (!navigation->getCamera()) {
+        return;
+    }
+
     float angle = value.toFloat() * angularVelocity;
     SbVec3f translation = value.toFloat() * linearVelocity;
 
@@ -129,6 +133,10 @@ void SpinningAnimation::initialize()
  */
 void SpinningAnimation::update(const QVariant& value)
 {
+    if (!navigation->getCamera()) {
+        return;
+    }
+
     SbRotation deltaRotation = SbRotation(rotationAxis, value.toFloat() - prevAngle);
     navigation->reorientCamera(navigation->getCamera(), deltaRotation);
 


### PR DESCRIPTION
Attempt to fix the segfault during test caused by #9446. Adding a nullptr check appeared to prevent the segfault when I ran the actions locally using act.

