### PR TITLE
[Macro toolbar] Remove stop from toolbar and menu

### DIFF
--- a/src/Gui/CommandMacro.cpp
+++ b/src/Gui/CommandMacro.cpp
@@ -21,9 +21,14 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
+#ifndef _PreComp_
+# include <QApplication>
+#endif
 
 #include "Command.h"
+#include "Action.h"
 #include "Application.h"
+#include "BitmapFactory.h"
 #include "DlgMacroExecuteImp.h"
 #include "DlgMacroRecordImp.h"
 #include "Macro.h"
@@ -54,13 +59,27 @@ StdCmdDlgMacroRecord::StdCmdDlgMacroRecord()
 void StdCmdDlgMacroRecord::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    Gui::Dialog::DlgMacroRecordImp cDlg(getMainWindow());
-    cDlg.exec();
+    if (!getGuiApplication()->macroManager()->isOpen()){
+        Gui::Dialog::DlgMacroRecordImp cDlg(getMainWindow());
+        if (cDlg.exec() && getAction()) {
+            getAction()->setIcon(Gui::BitmapFactory().iconFromTheme("media-playback-stop"));
+            getAction()->setText(QCoreApplication::translate("StdCmdDlgMacroRecord", "S&top macro recording"));
+            getAction()->setToolTip(QCoreApplication::translate("StdCmdDlgMacroRecord", "Stop the macro recording session"));
+        }
+    }
+    else {
+        getGuiApplication()->macroManager()->commit();
+        if (getAction()) {
+            getAction()->setIcon(Gui::BitmapFactory().iconFromTheme("media-record"));
+            getAction()->setText(QString::fromLatin1(sMenuText));
+            getAction()->setToolTip(QString::fromLatin1(sToolTipText));
+        }
+    }
 }
 
 bool StdCmdDlgMacroRecord::isActive()
 {
-    return ! (getGuiApplication()->macroManager()->isOpen());
+    return true;
 }
 
 //===========================================================================

--- a/src/Gui/CommandMacro.cpp
+++ b/src/Gui/CommandMacro.cpp
@@ -83,34 +83,6 @@ bool StdCmdDlgMacroRecord::isActive()
 }
 
 //===========================================================================
-// Std_MacroStopRecord
-//===========================================================================
-DEF_STD_CMD_A(StdCmdMacroStopRecord)
-
-StdCmdMacroStopRecord::StdCmdMacroStopRecord()
-  : Command("Std_MacroStopRecord")
-{
-    sGroup        = "Macro";
-    sMenuText     = QT_TR_NOOP("S&top macro recording");
-    sToolTipText  = QT_TR_NOOP("Stop the macro recording session");
-    sWhatsThis    = "Std_MacroStopRecord";
-    sStatusTip    = QT_TR_NOOP("Stop the macro recording session");
-    sPixmap       = "media-playback-stop";
-    eType         = 0;
-}
-
-void StdCmdMacroStopRecord::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-    getGuiApplication()->macroManager()->commit();
-}
-
-bool StdCmdMacroStopRecord::isActive()
-{
-    return getGuiApplication()->macroManager()->isOpen();
-}
-
-//===========================================================================
 // Std_DlgMacroExecute
 //===========================================================================
 DEF_STD_CMD_A(StdCmdDlgMacroExecute)
@@ -336,7 +308,6 @@ void CreateMacroCommands()
 {
     CommandManager &rcCmdMgr = Application::Instance->commandManager();
     rcCmdMgr.addCommand(new StdCmdDlgMacroRecord());
-    rcCmdMgr.addCommand(new StdCmdMacroStopRecord());
     rcCmdMgr.addCommand(new StdCmdDlgMacroExecute());
     rcCmdMgr.addCommand(new StdCmdDlgMacroExecuteDirect());
     rcCmdMgr.addCommand(new StdCmdMacroAttachDebugger());

--- a/src/Gui/PreferencePackTemplates/Shortcuts.cfg
+++ b/src/Gui/PreferencePackTemplates/Shortcuts.cfg
@@ -677,7 +677,6 @@
           <FCText Name="Std_MacroStepInto">F11</FCText>
           <FCText Name="Std_MacroStepOver">F10</FCText>
           <FCText Name="Std_MacroStopDebug">Shift+F6</FCText>
-          <FCText Name="Std_MacroStopRecord"></FCText>
           <FCText Name="Std_MainFullscreen">Alt+F11</FCText>
           <FCText Name="Std_MeasureDistance"></FCText>
           <FCText Name="Std_MergeProjects"></FCText>

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -722,7 +722,6 @@ MenuItem* StdWorkbench::setupMenuBar() const
     auto macro = new MenuItem( menuBar );
     macro->setCommand("&Macro");
     *macro << "Std_DlgMacroRecord"
-           << "Std_MacroStopRecord"
            << "Std_DlgMacroExecute"
            << "Std_RecentMacros"
            << "Separator"
@@ -786,7 +785,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // Macro
     auto macro = new ToolBarItem( root );
     macro->setCommand("Macro");
-    *macro << "Std_DlgMacroRecord" << "Std_MacroStopRecord" << "Std_DlgMacroExecute"
+    *macro << "Std_DlgMacroRecord" << "Std_DlgMacroExecute"
            << "Std_DlgMacroExecuteDirect";
 
     // View
@@ -825,7 +824,7 @@ ToolBarItem* StdWorkbench::setupCommandBars() const
     // Special Ops
     auto macro = new ToolBarItem( root );
     macro->setCommand("Special Ops");
-    *macro << "Std_DlgParameter" << "Std_DlgPreferences" << "Std_DlgMacroRecord" << "Std_MacroStopRecord"
+    *macro << "Std_DlgParameter" << "Std_DlgPreferences" << "Std_DlgMacroRecord"
            << "Std_DlgMacroExecute" << "Std_DlgCustomize";
 
     return root;

--- a/src/Mod/Web/Gui/Workbench.cpp
+++ b/src/Mod/Web/Gui/Workbench.cpp
@@ -138,7 +138,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     //    Gui::MenuItem* tool = new Gui::MenuItem( menuBar );
     //    tool->setCommand("&Tools");
     //    *tool << "Std_CommandLine" << "Std_DlgParameter" << "Separator" << "Std_DlgMacroRecord"
-    //          << "Std_MacroStopRecord" << "Std_DlgMacroExecute" << "Std_DlgMacroExecuteDirect"
+    //          << "Std_DlgMacroExecute" << "Std_DlgMacroExecuteDirect"
     //          << "Separator" << "Std_ViewScreenShot" << "Separator" << "Std_DlgCustomize";
     //
     //    // Mesh


### PR DESCRIPTION
And adds the stop functionality to the Std_DlgMacroRecord command. ie if you start recording, the button becomes a stop button.
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/34003a3c-9352-4280-9297-65d33b95bb49)

There might be some usecases where the user stops the recording by another mean than the command (in python for example?) and in this case the command wouldn't update. But I don't know if there are actually such usecases.

Fixes https://github.com/FreeCAD/FreeCAD/issues/10834