### PR TITLE
Python: Support METH_NOARGS methods

### DIFF
--- a/src/Base/MatrixPy.xml
+++ b/src/Base/MatrixPy.xml
@@ -97,28 +97,28 @@ if it's not a scale matrix.
 tol : float</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="nullify">
+    <Methode Name="nullify" NoArgs="true">
       <Documentation>
         <UserDocu>nullify() -> None
 
 Make this the null matrix.</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="isNull" Const="true">
+    <Methode Name="isNull" Const="true" NoArgs="true">
       <Documentation>
         <UserDocu>isNull() -> bool
 
 Check if this is the null matrix.</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="unity">
+    <Methode Name="unity" NoArgs="true">
       <Documentation>
         <UserDocu>unity() -> None
 
 Make this matrix to unity (4D identity matrix).</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="isUnity" Const="true">
+    <Methode Name="isUnity" Const="true" NoArgs="true">
       <Documentation>
         <UserDocu>isUnity() -> bool
 
@@ -185,7 +185,7 @@ index : int
 vector : Base.Vector</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="diagonal" Const="true">
+    <Methode Name="diagonal" Const="true" NoArgs="true">
       <Documentation>
         <UserDocu>diagonal() -> Base.Vector
 
@@ -252,34 +252,34 @@ Compute the transformed vector using the matrix.
 vector : Base.Vector</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="invert">
+    <Methode Name="invert" NoArgs="true">
       <Documentation>
         <UserDocu>invert() -> None
 
 Compute the inverse matrix in-place, if possible.</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="inverse" Const="true">
+    <Methode Name="inverse" Const="true" NoArgs="true">
       <Documentation><UserDocu>inverse() -> Base.Matrix
 
 Compute the inverse matrix, if possible.</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="transpose">
+    <Methode Name="transpose" NoArgs="true">
       <Documentation>
         <UserDocu>transpose() -> None
 
 Transpose the matrix in-place.</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="transposed" Const="true">
+    <Methode Name="transposed" Const="true" NoArgs="true">
       <Documentation>
         <UserDocu>transposed() -> Base.Matrix
 
 Returns a transposed copy of this matrix.</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="determinant" Const="true">
+    <Methode Name="determinant" Const="true" NoArgs="true">
       <Documentation>
         <UserDocu>determinant() -> float
 
@@ -309,7 +309,7 @@ dim : int
     Dimension parameter must be in the range [1,4].</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="analyze" Const="true">
+    <Methode Name="analyze" Const="true" NoArgs="true">
       <Documentation>
         <UserDocu>analyze() -> str
 

--- a/src/Base/MatrixPyImp.cpp
+++ b/src/Base/MatrixPyImp.cpp
@@ -352,11 +352,8 @@ PyObject* MatrixPy::hasScale(PyObject * args)
     return Py::new_reference_to(mod.callMemberFunction("ScaleType", Py::TupleN(Py::Int(static_cast<int>(type)))));
 }
 
-PyObject* MatrixPy::nullify(PyObject * args)
+PyObject* MatrixPy::nullify()
 {
-    if (!PyArg_ParseTuple(args, ""))
-      return nullptr;
-
     PY_TRY {
         getMatrixPtr()->nullify();
         Py_Return;
@@ -364,11 +361,8 @@ PyObject* MatrixPy::nullify(PyObject * args)
     PY_CATCH;
 }
 
-PyObject* MatrixPy::isNull(PyObject * args)
+PyObject* MatrixPy::isNull()
 {
-    if (!PyArg_ParseTuple(args, ""))
-      return nullptr;
-
     PY_TRY {
         bool ok = getMatrixPtr()->isNull();
         return Py::new_reference_to(Py::Boolean(ok));
@@ -376,11 +370,8 @@ PyObject* MatrixPy::isNull(PyObject * args)
     PY_CATCH;
 }
 
-PyObject* MatrixPy::unity(PyObject * args)
+PyObject* MatrixPy::unity()
 {
-    if (!PyArg_ParseTuple(args, ""))
-      return nullptr;
-
     PY_TRY {
         getMatrixPtr()->setToUnity();
         Py_Return;
@@ -388,11 +379,8 @@ PyObject* MatrixPy::unity(PyObject * args)
     PY_CATCH;
 }
 
-PyObject* MatrixPy::isUnity(PyObject * args)
+PyObject* MatrixPy::isUnity()
 {
-    if (!PyArg_ParseTuple(args, ""))
-      return nullptr;
-
     PY_TRY {
         bool ok = getMatrixPtr()->isUnity();
         return Py::new_reference_to(Py::Boolean(ok));
@@ -487,11 +475,8 @@ PyObject* MatrixPy::setRow(PyObject * args)
     Py_Return;
 }
 
-PyObject* MatrixPy::diagonal(PyObject * args)
+PyObject* MatrixPy::diagonal()
 {
-    if (!PyArg_ParseTuple(args, ""))
-        return nullptr;
-
     Matrix4D* mat = getMatrixPtr();
     Base::Vector3d v = mat->diagonal();
     return Py::new_reference_to(Py::Vector(v));
@@ -628,11 +613,8 @@ PyObject* MatrixPy::multVec(PyObject * args)
     return new VectorPy(new Vector3d(vec));
 }
 
-PyObject* MatrixPy::invert(PyObject * args)
+PyObject* MatrixPy::invert()
 {
-    if (!PyArg_ParseTuple(args, ""))
-        return nullptr;
-
     PY_TRY {
         if (fabs(getMatrixPtr()->determinant()) > DBL_EPSILON) {
             getMatrixPtr()->inverseGauss();
@@ -646,11 +628,8 @@ PyObject* MatrixPy::invert(PyObject * args)
     PY_CATCH;
 }
 
-PyObject* MatrixPy::inverse(PyObject * args)
+PyObject* MatrixPy::inverse()
 {
-    if (!PyArg_ParseTuple(args, ""))
-        return nullptr;
-
     PY_TRY {
         if (fabs(getMatrixPtr()->determinant()) > DBL_EPSILON) {
             Base::Matrix4D m = *getMatrixPtr();
@@ -665,11 +644,8 @@ PyObject* MatrixPy::inverse(PyObject * args)
     PY_CATCH;
 }
 
-PyObject* MatrixPy::determinant(PyObject * args)
+PyObject* MatrixPy::determinant()
 {
-    if (!PyArg_ParseTuple(args, ""))
-        return nullptr;
-
     return PyFloat_FromDouble(getMatrixPtr()->determinant());
 }
 
@@ -741,11 +717,8 @@ PyObject* MatrixPy::isOrthogonal(PyObject * args)
     return Py::new_reference_to(Py::Float(ok ? mult : 0.0));
 }
 
-PyObject* MatrixPy::transposed(PyObject * args)
+PyObject* MatrixPy::transposed()
 {
-    if (!PyArg_ParseTuple(args, ""))
-        return nullptr;
-
     PY_TRY {
         Base::Matrix4D m = *getMatrixPtr();
         m.transpose();
@@ -754,11 +727,8 @@ PyObject* MatrixPy::transposed(PyObject * args)
     PY_CATCH;
 }
 
-PyObject* MatrixPy::transpose(PyObject * args)
+PyObject* MatrixPy::transpose()
 {
-    if (!PyArg_ParseTuple(args, ""))
-        return nullptr;
-
     PY_TRY {
         getMatrixPtr()->transpose();
         Py_Return;
@@ -766,11 +736,8 @@ PyObject* MatrixPy::transpose(PyObject * args)
     PY_CATCH;
 }
 
-PyObject* MatrixPy::analyze(PyObject * args)
+PyObject* MatrixPy::analyze()
 {
-    if (!PyArg_ParseTuple(args, ""))
-        return nullptr;
-
     PY_TRY {
         std::string type = getMatrixPtr()->analyse();
         return PyUnicode_FromString(type.c_str());

--- a/src/Tools/generateBase/generateMetaModel_Module.xsd
+++ b/src/Tools/generateBase/generateMetaModel_Module.xsd
@@ -18,6 +18,7 @@
 									<xs:attribute name="Name" type="xs:string" use="required"/>
 									<xs:attribute name="Const" type="xs:boolean" use="optional"/>
 									<xs:attribute name="Keyword" type="xs:boolean" use="optional" default="false"/>
+									<xs:attribute name="NoArgs" type="xs:boolean" use="optional" default="false"/>
 									<xs:attribute name="Class" type="xs:boolean" use="optional" default="false"/>
 									<xs:attribute name="Static" type="xs:boolean" use="optional" default="false"/>
 								</xs:complexType>

--- a/src/Tools/generateBase/generateModel_Module.py
+++ b/src/Tools/generateBase/generateModel_Module.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Generated Fri Mar 31 16:59:53 2023 by generateDS.py.
+# Generated Wed Sep 27 11:00:46 2023 by generateDS.py.
 # Update it with: python generateDS.py -o generateModel_Module.py generateMetaModel_Module.xsd
 #
 # WARNING! All changes made in this file will be lost!
@@ -789,6 +789,7 @@ class Methode:
         Name="",
         Const=0,
         Keyword=0,
+        NoArgs=0,
         Class=0,
         Static=0,
         Documentation=None,
@@ -797,6 +798,7 @@ class Methode:
         self.Name = Name
         self.Const = Const
         self.Keyword = Keyword
+        self.NoArgs = NoArgs
         self.Class = Class
         self.Static = Static
         self.Documentation = Documentation
@@ -849,6 +851,12 @@ class Methode:
     def setKeyword(self, Keyword):
         self.Keyword = Keyword
 
+    def getNoargs(self):
+        return self.NoArgs
+
+    def setNoargs(self, NoArgs):
+        self.NoArgs = NoArgs
+
     def getClass(self):
         return self.Class
 
@@ -876,6 +884,8 @@ class Methode:
             outfile.write(' Const="%s"' % (self.getConst(),))
         if self.getKeyword() is not None:
             outfile.write(' Keyword="%s"' % (self.getKeyword(),))
+        if self.getNoargs() is not None:
+            outfile.write(' NoArgs="%s"' % (self.getNoargs(),))
         if self.getClass() is not None:
             outfile.write(' Class="%s"' % (self.getClass(),))
         if self.getStatic() is not None:
@@ -899,6 +909,8 @@ class Methode:
         outfile.write('Const = "%s",\n' % (self.getConst(),))
         showIndent(outfile, level)
         outfile.write('Keyword = "%s",\n' % (self.getKeyword(),))
+        showIndent(outfile, level)
+        outfile.write('NoArgs = "%s",\n' % (self.getNoargs(),))
         showIndent(outfile, level)
         outfile.write('Class = "%s",\n' % (self.getClass(),))
         showIndent(outfile, level)
@@ -948,6 +960,13 @@ class Methode:
                 self.Keyword = 0
             else:
                 raise ValueError("Bad boolean attribute (Keyword)")
+        if attrs.get("NoArgs"):
+            if attrs.get("NoArgs").value in ("true", "1"):
+                self.NoArgs = 1
+            elif attrs.get("NoArgs").value in ("false", "0"):
+                self.NoArgs = 0
+            else:
+                raise ValueError("Bad boolean attribute (NoArgs)")
         if attrs.get("Class"):
             if attrs.get("Class").value in ("true", "1"):
                 self.Class = 1
@@ -1549,12 +1568,7 @@ class Content:
     subclass = None
 
     def __init__(
-        self,
-        Property=None,
-        Feature=None,
-        DocObject=None,
-        GuiCommand=None,
-        PreferencesPage=None,
+        self, Property=None, Feature=None, DocObject=None, GuiCommand=None, PreferencesPage=None
     ):
         if Property is None:
             self.Property = []
@@ -2694,6 +2708,16 @@ class SaxGeneratemodelHandler(handler.ContentHandler):
                     self.reportError(
                         '"Keyword" attribute must be boolean ("true", "1", "false", "0")'
                     )
+            val = attrs.get("NoArgs", None)
+            if val is not None:
+                if val in ("true", "1"):
+                    obj.setNoargs(1)
+                elif val in ("false", "0"):
+                    obj.setNoargs(0)
+                else:
+                    self.reportError(
+                        '"NoArgs" attribute must be boolean ("true", "1", "false", "0")'
+                    )
             val = attrs.get("Class", None)
             if val is not None:
                 if val in ("true", "1"):
@@ -3062,11 +3086,7 @@ class SaxGeneratemodelHandler(handler.ContentHandler):
         locator = self.locator
         sys.stderr.write(
             "Doc: %s  Line: %d  Column: %d\n"
-            % (
-                locator.getSystemId(),
-                locator.getLineNumber(),
-                locator.getColumnNumber() + 1,
-            )
+            % (locator.getSystemId(), locator.getLineNumber(), locator.getColumnNumber() + 1)
         )
         sys.stderr.write(mesg)
         sys.stderr.write("\n")

--- a/src/Tools/generateTemplates/templateClassPyExport.py
+++ b/src/Tools/generateTemplates/templateClassPyExport.py
@@ -121,6 +121,19 @@ public:
     /// implementer for the @i.Name@() method
     PyObject*  @i.Name@(PyObject *args, PyObject *kwd);
 -
+= elif i.NoArgs:
+    /// callback for the @i.Name@() method
+    static PyObject * staticCallback_@i.Name@ (PyObject *self, PyObject *args);
++ if i.Static:
+    /// implementer for the @i.Name@() method
+    static PyObject*  @i.Name@();
+= elif i.Class:
+    /// implementer for the @i.Name@() method
+    static PyObject*  @i.Name@(PyObject *self);
+= else:
+    /// implementer for the @i.Name@() method
+    PyObject*  @i.Name@();
+-
 = else:
     /// callback for the @i.Name@() method
     static PyObject * staticCallback_@i.Name@ (PyObject *self, PyObject *args);
@@ -389,6 +402,17 @@ PyMethodDef @self.export.Name@::Methods[] = {
         reinterpret_cast<PyCFunction>(reinterpret_cast<void (*) ()>( staticCallback_@i.Name@ )),
         METH_VARARGS|METH_KEYWORDS,
 -
+= elif i.NoArgs:
++ if i.Class:
+        reinterpret_cast<PyCFunction>(reinterpret_cast<void (*) ()>( staticCallback_@i.Name@ )),
+        METH_NOARGS|METH_CLASS,
+= elif i.Static:
+        reinterpret_cast<PyCFunction>(reinterpret_cast<void (*) ()>( staticCallback_@i.Name@ )),
+        METH_NOARGS|METH_STATIC,
+= else:
+        reinterpret_cast<PyCFunction>( staticCallback_@i.Name@ ),
+        METH_NOARGS,
+-
 = elif i.Class:
         reinterpret_cast<PyCFunction>(reinterpret_cast<void (*) ()>( staticCallback_@i.Name@ )),
         METH_VARARGS|METH_CLASS,
@@ -532,6 +556,8 @@ PyGetSetDef @self.export.Name@::GetterSetter[] = {
 // has to be implemented in @self.export.Name@Imp.cpp
 + if i.Keyword:
 PyObject * @self.export.Name@::staticCallback_@i.Name@ (PyObject *self, PyObject *args, PyObject * kwd)
+= elif i.NoArgs:
+PyObject * @self.export.Name@::staticCallback_@i.Name@ (PyObject *self, PyObject * Py_UNUSED(args))
 = else:
 PyObject * @self.export.Name@::staticCallback_@i.Name@ (PyObject *self, PyObject *args)
 -
@@ -567,6 +593,15 @@ PyObject * @self.export.Name@::staticCallback_@i.Name@ (PyObject *self, PyObject
         PyObject* ret = @self.export.Name@::@i.Name@(self, args, kwd);
 = else:
         PyObject* ret = static_cast<@self.export.Name@*>(self)->@i.Name@(args, kwd);
+-
+= elif i.NoArgs:
++ if i.Static:
+        (void)self;
+        PyObject* ret = @self.export.Name@::@i.Name@();
+= elif i.Class:
+        PyObject* ret = @self.export.Name@::@i.Name@(self);
+= else:
+        PyObject* ret = static_cast<@self.export.Name@*>(self)->@i.Name@();
 -
 = else:
 + if i.Static:
@@ -880,6 +915,12 @@ std::string @self.export.Name@::representation() const
 PyObject* @self.export.Name@::@i.Name@(PyObject *self, PyObject *args, PyObject *kwds)
 = else:
 PyObject* @self.export.Name@::@i.Name@(PyObject *args, PyObject *kwds)
+-
+= elif i.NoArgs:
++ if i.Class:
+PyObject* @self.export.Name@::@i.Name@(PyObject *self)
+= else:
+PyObject* @self.export.Name@::@i.Name@()
 -
 = else:
 + if i.Class:
@@ -1221,6 +1262,12 @@ int @self.export.Name@::finalization()
 PyObject* @self.export.Name@::@i.Name@(PyObject * /*self*/, PyObject * /*args*/, PyObject * /*kwds*/)
 = else:
 PyObject* @self.export.Name@::@i.Name@(PyObject * /*args*/, PyObject * /*kwds*/)
+-
+= elif i.NoArgs:
++ if i.Class:
+PyObject* @self.export.Name@::@i.Name@(PyObject * /*self*/)
+= else:
+PyObject* @self.export.Name@::@i.Name@()
 -
 = else:
 + if i.Class:


### PR DESCRIPTION
This is to remove superfluous calls of
```
    if (!PyArg_ParseTuple(args, ""))
        return nullptr;
```
from many Python functions.