### PR TITLE
Add G43 tool height compensation to centroid post

### DIFF
--- a/src/Mod/Path/Path/Post/scripts/centroid_post.py
+++ b/src/Mod/Path/Path/Post/scripts/centroid_post.py
@@ -51,6 +51,7 @@ Arguments for centroid:
     --feed-precision=1               ... number of digits of precision for feed rate.  Default=1
     --axis-precision=4               ... number of digits of precision for axis moves.  Default=4
     --inches                         ... Convert output for US imperial mode (G20)
+    --no-tlo                         ... Suppress tool length offset (G43) following tool changes
 """
 
 # These globals set common customization preferences
@@ -62,6 +63,7 @@ if FreeCAD.GuiUp:
 else:
     SHOW_EDITOR = False
 MODAL = False  # if true commands are suppressed if the same as previous line.
+USE_TLO = True  # if true G43 will be output following tool changes
 
 COMMAND_SPACE = " "
 LINENR = 100  # line number starting value
@@ -139,6 +141,7 @@ def processArguments(argstring):
     global UNIT_SPEED_FORMAT
     global UNIT_FORMAT
     global UNITS
+    global USE_TLO
 
     for arg in argstring.split():
         if arg == "--header":
@@ -165,6 +168,8 @@ def processArguments(argstring):
             UNITS = "G20"
             UNIT_SPEED_FORMAT = "in/min"
             UNIT_FORMAT = "in"
+        elif arg == "--no-tlo":
+            USE_TLO = False
 
 
 def export(objectslist, filename, argstring):
@@ -342,6 +347,8 @@ def parse(pathobj):
                 #     out += linenumber() + "(begin toolchange)\n"
                 for line in TOOL_CHANGE.splitlines(True):
                     out += linenumber() + line
+                if USE_TLO:
+                    out += linenumber() + "G43 H" + str(int(c.Parameters["T"])) + "\n"
 
             # if command == "message":
             #     if OUTPUT_COMMENTS is False:

--- a/src/Mod/Path/PathTests/TestCentroidPost.py
+++ b/src/Mod/Path/PathTests/TestCentroidPost.py
@@ -277,16 +277,15 @@ M99
 
         args = "--no-header --no-show-editor"
         gcode = postprocessor.export(postables, "gcode.tmp", args)
-        self.assertEqual(gcode.splitlines()[5], "M6 T2")
-        self.assertEqual(gcode.splitlines()[6], "M3 S3000")
+        self.assertEqual(gcode.splitlines()[5], "G43 H2")
+        self.assertEqual(gcode.splitlines()[6], "M6 T2")
+        self.assertEqual(gcode.splitlines()[7], "M3 S3000")
 
         # suppress TLO
         #
-        # The original centroid postprocessor does not have an
-        # --no-tlo option.  We end up with the original gcode.
-        #
         args = "--no-header --no-tlo --no-show-editor"
         gcode = postprocessor.export(postables, "gcode.tmp", args)
+        self.assertEqual(gcode.splitlines()[5], "G43 H2")
         self.assertEqual(gcode.splitlines()[6], "M3 S3000")
 
     def test090(self):


### PR DESCRIPTION
This adds G43 tool height compensation to the centroid CAM post-processor using a similar approach to the G43 support in the MACH3 post.

Specifically, G43 is emitted at every tool change by default and a new `--no-tlo` post argument can restore the old behaviour of no height compensation being emitted. These both match how the MACH3 post does it.