### PR TITLE
Path: fix LeadInOutDressup incorrectly treating missing axis words as…

### DIFF
--- a/src/Mod/Path/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/Path/Path/Dressup/Gui/LeadInOut.py
@@ -559,7 +559,10 @@ class ObjectDressup:
                     queue = []
 
                 # Save all move commands
-                queue.append(curCommand)
+                # getLeadStart and getLeadEnd incorrectly treat missing axis words as being 0.
+                currXYZ = { k: currLocation[k] for k in "XYZ" if k in currLocation }
+                tmp = Path.Command(curCommand.Name, currXYZ | curCommand.Parameters)
+                queue.append(tmp)
 
             currLocation.update(curCommand.Parameters)
             prevCmd = curCommand


### PR DESCRIPTION
… being 0

This PR fixes issue  #10858.

To fix the issue all missing axis words are inserted when splitting the g-code of the base operation into "layers". When those operations are later used in "getLeadStart" and "getLeadEnd" all axis words are available and the dressup produces the expected result.