### PR TITLE
TechDraw: Implements projected Length dimension

### DIFF
--- a/src/Mod/TechDraw/App/DimensionGeometry.cpp
+++ b/src/Mod/TechDraw/App/DimensionGeometry.cpp
@@ -41,6 +41,14 @@ pointPair::pointPair(const pointPair& pp)
 {
     first(pp.first());
     second(pp.second());
+    overrideFirst(pp.extensionLineFirst());
+    overrideSecond(pp.extensionLineSecond());
+}
+
+// set extension line points from argument base points
+void pointPair::setExtensionLine(const pointPair& pp){
+    overrideFirst(pp.first());
+    overrideSecond(pp.second());
 }
 
 //move the points by offset
@@ -48,6 +56,8 @@ void pointPair::move(const Base::Vector3d& offset)
 {
     m_first = m_first - offset;
     m_second = m_second - offset;
+    m_overrideFirst = m_overrideFirst - offset;
+    m_overrideSecond = m_overrideSecond - offset;
 }
 
 // project the points onto the dvp's paper plane.
@@ -55,6 +65,8 @@ void pointPair::project(const DrawViewPart* dvp)
 {
     m_first = dvp->projectPoint(m_first) * dvp->getScale();
     m_second = dvp->projectPoint(m_second) * dvp->getScale();
+    m_overrideFirst = dvp->projectPoint(m_overrideFirst) * dvp->getScale();
+    m_overrideSecond = dvp->projectPoint(m_overrideSecond) * dvp->getScale();
 }
 
 // map the points onto the dvp's XY coordinate system

--- a/src/Mod/TechDraw/App/DimensionGeometry.h
+++ b/src/Mod/TechDraw/App/DimensionGeometry.h
@@ -38,12 +38,26 @@ class TechDrawExport pointPair
 {
 public:
     pointPair() = default;
-    pointPair(const Base::Vector3d& point0, const Base::Vector3d& point1) { m_first = point0; m_second = point1; }
+    pointPair(const Base::Vector3d& point0, const Base::Vector3d& point1)
+        : m_first(point0)
+        , m_second(point1){};
+
+    pointPair(const Base::Vector3d& point0, const Base::Vector3d& point1,
+              const Base::Vector3d& extensionPoint0, const Base::Vector3d& extensionPoint1)
+        : m_first(point0)
+        , m_second(point1)
+        , m_useOverrideFirst(true)
+        , m_overrideFirst(extensionPoint0)
+        , m_useOverrideSecond(true)
+        , m_overrideSecond(extensionPoint1){};
+
     pointPair(const pointPair& pp);
 
     pointPair& operator=(const pointPair& pp) {
         m_first = pp.first();
         m_second = pp.second();
+        overrideFirst(pp.extensionLineFirst());
+        overrideSecond(pp.extensionLineSecond());
         return *this;
     }
 
@@ -51,6 +65,12 @@ public:
     void first(Base::Vector3d newFirst) { m_first = newFirst; }
     Base::Vector3d second() const { return m_second; }
     void second(Base::Vector3d newSecond) { m_second = newSecond; }
+    // extension line specific points
+    Base::Vector3d extensionLineFirst() const { return m_useOverrideFirst ? m_overrideFirst : m_first; }
+    void overrideFirst(Base::Vector3d newFirst) { m_useOverrideFirst = true;  m_overrideFirst = newFirst; }
+    Base::Vector3d extensionLineSecond() const { return m_useOverrideSecond ? m_overrideSecond : m_second; }
+    void overrideSecond(Base::Vector3d newSecond) { m_useOverrideSecond = true;  m_overrideSecond = newSecond; }
+    void setExtensionLine(const pointPair& pp);
 
     void move(const Base::Vector3d& offset);
     void project(const DrawViewPart* dvp);
@@ -61,6 +81,11 @@ public:
 private:
     Base::Vector3d m_first;
     Base::Vector3d m_second;
+    // extension line specific points
+    bool m_useOverrideFirst = false;
+    Base::Vector3d m_overrideFirst;
+    bool m_useOverrideSecond = false;
+    Base::Vector3d m_overrideSecond;
 };
 
 //a convenient container for angular dimension points

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -42,6 +42,10 @@
 # include <gp_Circ.hxx>
 # include <gp_Elips.hxx>
 # include <gp_Pnt.hxx>
+# include <gp_Pnt2d.hxx>
+# include <Geom_Plane.hxx>
+# include <Geom2d_Curve.hxx>
+# include <Geom2dAPI_ProjectPointOnCurve.hxx>
 # include <TopExp.hxx>
 # include <TopExp_Explorer.hxx>
 # include <TopoDS_Edge.hxx>
@@ -751,7 +755,29 @@ pointPair DrawViewDimension::getPointsEdgeVert(ReferenceVector references)
         if (!vertex || !edge) {
             throw Base::RuntimeError("Missing geometry for dimension (4)");
         }
-        return closestPoints(edge->getOCCEdge(), vertex->getOCCVertex());
+
+        //get curve from edge
+        double start, end; // curve parameters
+        const Handle(Geom_Surface) hplane = new Geom_Plane(gp_Ax3());
+        auto const occCurve = BRep_Tool::CurveOnPlane(edge->getOCCEdge()
+                                                      , hplane
+                                                      , TopLoc_Location()
+                                                      , start
+                                                      , end);
+        auto const occPoint = gp_Pnt2d(vertex->x(), vertex->y());
+        //project point on curve
+        auto projector = Geom2dAPI_ProjectPointOnCurve(occPoint, occCurve);
+        if (projector.NbPoints() > 0) {
+                auto p1 = Base::Vector3d(vertex->x(), vertex->y(), 0.0);
+                auto p2 = Base::Vector3d(projector.NearestPoint().X()
+                                         , projector.NearestPoint().Y()
+                                         , 0.0);
+                return pointPair(p1, p2);
+        }
+        else {
+                // unable to project
+                return closestPoints(edge->getOCCEdge(), vertex->getOCCVertex());
+        }
     }
 
     //this is a 3d object

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -772,7 +772,9 @@ pointPair DrawViewDimension::getPointsEdgeVert(ReferenceVector references)
                 auto p2 = Base::Vector3d(projector.NearestPoint().X()
                                          , projector.NearestPoint().Y()
                                          , 0.0);
-                return pointPair(p1, p2);
+                pointPair result = pointPair(p1, p2);
+                result.setExtensionLine(closestPoints(edge->getOCCEdge(), vertex->getOCCVertex()));
+                return result;
         }
         else {
                 // unable to project

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -2112,7 +2112,7 @@ void QGIViewDimension::drawDistance(TechDraw::DrawViewDimension* dimension,
                              dimension->ExtensionAngle.getValue() * M_PI / 180.0);
     }
     else {
-        drawDistanceExecutive(fromQtApp(linePoints.first()), fromQtApp(linePoints.second()),
+        drawDistanceExecutive(fromQtApp(linePoints.extensionLineFirst()), fromQtApp(linePoints.extensionLineSecond()),
                               lineAngle, labelRectangle, standardStyle, renderExtent, flipArrows);
     }
 }


### PR DESCRIPTION
When a line and a vertex are selected, the Length dimension currently use closest points of the finite edge. It's not the mathematical definition of the distance which require the projection of the point on the infinite line.

When selecting the upper right vertex and the bottom line:
Left the current implementation, Right the true length given by this PR
![image](https://github.com/FreeCAD/FreeCAD/assets/10371513/26b0ad68-e240-4e7b-b4bf-56d35cdfb6ac)


https://forum.freecad.org/viewtopic.php?t=81561

EDIT: update screenshot with corrected extension line
