### PR TITLE
Sketcher: Fix segfault when activating a tool in a different view

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -280,14 +280,20 @@ void DrawSketchHandler::activate(ViewProviderSketch* vp)
     sketchgui = vp;
 
     // save the cursor at the time the DSH is activated
-    Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
-    Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
-    oldCursor = viewer->getWidget()->cursor();
+    auto* view = dynamic_cast<Gui::View3DInventor*>(Gui::getMainWindow()->activeWindow());
 
-    updateCursor();
+    if (view) {
+        Gui::View3DInventorViewer* viewer = dynamic_cast<Gui::View3DInventor*>(view)->getViewer();
+        oldCursor = viewer->getWidget()->cursor();
 
-    this->preActivated();
-    this->activated();
+        updateCursor();
+
+        this->preActivated();
+        this->activated();
+    }
+    else {
+        sketchgui->purgeHandler();
+    }
 }
 
 void DrawSketchHandler::deactivate()

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -562,10 +562,13 @@ void ViewProviderSketch::purgeHandler()
     Gui::Selection().clearSelection();
 
     // ensure that we are in sketch only selection mode
-    Gui::MDIView* mdi = Gui::Application::Instance->editDocument()->getActiveView();
-    Gui::View3DInventorViewer* viewer;
-    viewer = static_cast<Gui::View3DInventor*>(mdi)->getViewer();
-    viewer->setSelectionEnabled(false);
+    auto* view = dynamic_cast<Gui::View3DInventor*>(Gui::Application::Instance->editDocument()->getActiveView());
+
+    if(view) {
+        Gui::View3DInventorViewer* viewer;
+        viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
+        viewer->setSelectionEnabled(false);
+    }
 }
 
 void ViewProviderSketch::setAxisPickStyle(bool on)


### PR DESCRIPTION
When in Sketcher edit mode, a tool button is activated, while the view has been changing to view of a different type, it segfaults.

This commit checks the pointer of the view to ensure correct type before activation, and refusing to activate if not of the correct type.

fixes #10809