### PR TITLE
Update conda development dependencies.

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -81,6 +81,7 @@ dependencies:
 - pivy
 - pkg-config
 - ply
+- pre-commit
 - pybind11
 - pyside2
 - python
@@ -93,6 +94,7 @@ dependencies:
 - swig
 - vtk
 - xerces-c
+- yaml-cpp
 - zlib
 - pip:
   - ptvsd


### PR DESCRIPTION
This commit adds two dependencies to the conda development environment:

- Add `yaml-cpp` to bring the conda development environment back in line with current `HEAD`.
- Add `pre-commit` to support the pre-commit hooks outlined in the Developers Handbook.
