### PR TITLE
Clang-tidy: enable check google-explicit-constructor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
 Checks:          'clang-diagnostic-*,clang-analyzer-*,boost-*,bugprone-*,
-performance-*,readability-*,portability-*,modernize-*,cppcoreguidelines-*,
+performance-*,readability-*,portability-*,modernize-*,cppcoreguidelines-*,google-explicit-constructor,
 concurrency-*,-modernize-use-trailing-return-type, -modernize-use-nodiscard,
 -readability-redundant-access-specifiers,-readability-qualified-auto'
 WarningsAsErrors: ''


### PR DESCRIPTION
Currently this check isn't enabled but when pushing a PR then the lint checker warns about non-explicit constructors which is a bit annoying because the PR must be updated to fix the warning or in most cases it won't be fixed at all.

By enabling this check the developer already sees the warning before pushing a PR.