### PR TITLE
[MacroExecuteDialog] set keyboard focus to LineEditFind

### DIFF
--- a/src/Gui/DlgMacroExecuteImp.cpp
+++ b/src/Gui/DlgMacroExecuteImp.cpp
@@ -102,6 +102,7 @@ DlgMacroExecuteImp::DlgMacroExecuteImp( QWidget* parent, Qt::WindowFlags fl )
     ui->systemMacroListBox->setHeaderLabels(labels);
     ui->systemMacroListBox->header()->hide();
     fillUpList();
+    ui->LineEditFind->setFocus();
 }
 
 /**


### PR DESCRIPTION
Sets the focus on the Find: line edit.  Saves the user the necessity of clicking on the line edit in order to filter by file name.  The only other widget in this dialog that accepts keyboard input is the Find in files: line edit, but I think this one is the more commonly used one.