### PR TITLE
Gui: Enable the thumbnail size widget by default

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -379,9 +379,6 @@ automatically run a file recovery when it is started.</string>
         </item>
         <item>
          <widget class="Gui::PrefSpinBox" name="prefThumbnailSize">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
           <property name="toolTip">
            <string>Sets the size of the thumbnail that is stored in the document.
 Common sizes are 128, 256 and 512</string>


### PR DESCRIPTION
With PR #10016 the saving of thumbnails is on by default but the spin box to set the size is still disabled. This results into an inconsistency and one has to click the Save thumbnails check box twice to enable the size widget.