### PR TITLE
Gui: Initial save of a document doesn't have the expected thumbnail

### DIFF
--- a/src/Gui/Thumbnail.cpp
+++ b/src/Gui/Thumbnail.cpp
@@ -86,15 +86,13 @@ void Thumbnail::SaveDocFile (Base::Writer &writer) const
     if (!this->viewer)
         return;
     QImage img;
-    if (this->viewer->isActiveWindow()) {
-        if (this->viewer->thread() != QThread::currentThread()) {
-            qWarning("Cannot create a thumbnail from non-GUI thread");
-            return;
-        }
-
-        QColor invalid;
-        this->viewer->imageFromFramebuffer(this->size, this->size, 4, invalid, img);
+    if (this->viewer->thread() != QThread::currentThread()) {
+        qWarning("Cannot create a thumbnail from non-GUI thread");
+        return;
     }
+
+    QColor invalid;
+    this->viewer->imageFromFramebuffer(this->size, this->size, 4, invalid, img);
 
     // Get app icon and resize to half size to insert in topbottom position over the current view snapshot
     QPixmap appIcon = Gui::BitmapFactory().pixmap(App::Application::Config()["AppIcon"].c_str());


### PR DESCRIPTION
When saving the thumbnail there is a check if the 3D window is the active window. This check fails if a document is saved for the first time because the appearing file dialog causes the 3D window to not be active any more. Thus, no snapshot of the 3D window will be created and the program logo will be saved instead. A workaround is to save the document twice.

This PR removes the check for the active window so that the snapshot can be created. The issue might be related to #10937.