### PR TITLE
[GUI] Fix memory leak in ViewProviderPlane.cpp

### DIFF
--- a/src/Gui/ViewProviderPlane.cpp
+++ b/src/Gui/ViewProviderPlane.cpp
@@ -82,11 +82,11 @@ void ViewProviderPlane::attach ( App::DocumentObject *obj ) {
 
     auto material = new SoMaterial();
     material->transparency.setValue(0.95f);
-    auto color = new SbColor();
+    SbColor color;
     float alpha = 0.0f;
-    color->setPackedValue(ViewProviderOrigin::defaultColor, alpha);
-    material->ambientColor.setValue(*color);
-    material->diffuseColor.setValue(*color);
+    color.setPackedValue(ViewProviderOrigin::defaultColor, alpha);
+    material->ambientColor.setValue(color);
+    material->diffuseColor.setValue(color);
     faceSeparator->addChild(material);
 
     // disable backface culling and render with two-sided lighting


### PR DESCRIPTION
Correction of #9361. Fixes memory leak.

<details><summary>Here is the fragment of the leak report.</summary>


```cpp

Direct leak of 36 byte(s) in 3 object(s) allocated from:
    #0 0x7f867b612a92 in operator new(unsigned long) ../../../../src/libsanitizer/lsan/lsan_interceptors.cpp:248
    #1 0x7f867a3d921c in Gui::ViewProviderPlane::attach(App::DocumentObject*) /home/xtemp09/Downloads/FreeCAD/src/Gui/ViewProviderPlane.cpp:85
    #2 0x7f867a022d19 in Gui::Document::slotNewObject(App::DocumentObject const&) /home/xtemp09/Downloads/FreeCAD/src/Gui/Document.cpp:693
    #3 0x7f867a03a2fd in void std::__invoke_impl<void, void (Gui::Document::*&)(App::DocumentObject const&), Gui::Document*&, App::DocumentObject const&>(std::__invoke_memfun_deref, void (Gui::Document::*&)(App::DocumentObject const&), Gui::Document*&, App::DocumentObject const&) /usr/include/c++/12/bits/invoke.h:74
    #4 0x7f867a03a31b in std::__invoke_result<void (Gui::Document::*&)(App::DocumentObject const&), Gui::Document*&, App::DocumentObject const&>::type std::__invoke<void (Gui::Document::*&)(App::DocumentObject const&), Gui::Document*&, App::DocumentObject const&>(void (Gui::Document::*&)(App::DocumentObject const&), Gui::Document*&, App::DocumentObject const&) /usr/include/c++/12/bits/invoke.h:96
    #5 0x7f867a03a31b in void std::_Bind<void (Gui::Document::*(Gui::Document*, std::_Placeholder<1>))(App::DocumentObject const&)>::__call<void, App::DocumentObject const&, 0ul, 1ul>(std::tuple<App::DocumentObject const&>&&, std::_Index_tuple<0ul, 1ul>) /usr/include/c++/12/functional:495
    #6 0x7f867a03a31b in void std::_Bind<void (Gui::Document::*(Gui::Document*, std::_Placeholder<1>))(App::DocumentObject const&)>::operator()<App::DocumentObject const&, void>(App::DocumentObject const&) /usr/include/c++/12/functional:580
    #7 0x7f867a03a31b in boost::detail::function::void_function_obj_invoker1<std::_Bind<void (Gui::Document::*(Gui::Document*, std::_Placeholder<1>))(App::DocumentObject const&)>, void, App::DocumentObject const&>::invoke(boost::detail::function::function_buffer&, App::DocumentObject const&) /usr/include/boost/function/function_template.hpp:158
    #8 0x7f867927efda in boost::function1<void, App::DocumentObject const&>::operator()(App::DocumentObject const&) const /usr/include/boost/function/function_template.hpp:763
    #9 0x7f867927f072 in boost::signals2::detail::void_type boost::signals2::detail::call_with_tuple_args<boost::signals2::detail::void_type>::m_invoke<boost::function<void (App::DocumentObject const&)>, 0u, App::DocumentObject const&>(boost::function<void (App::DocumentObject const&)>&, boost::signals2::detail::unsigned_meta_array<0u>, std::tuple<App::DocumentObject const&> const&, boost::enable_if<boost::is_void<boost::function<void (App::DocumentObject const&)>::result_type>, void>::type*) const /usr/include/boost/signals2/detail/variadic_slot_invoker.hpp:105
    #10 0x7f867927f072 in boost::signals2::detail::void_type boost::signals2::detail::call_with_tuple_args<boost::signals2::detail::void_type>::operator()<boost::function<void (App::DocumentObject const&)>, App::DocumentObject const&, 1ul>(boost::function<void (App::DocumentObject const&)>&, std::tuple<App::DocumentObject const&> const&, mpl_::size_t<1ul>) const /usr/include/boost/signals2/detail/variadic_slot_invoker.hpp:90
    #11 0x7f867927f072 in boost::signals2::detail::void_type boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>::operator()<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >(boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > const&) const /usr/include/boost/signals2/detail/variadic_slot_invoker.hpp:133
    #12 0x7f867927f0a6 in boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> >::dereference() const /usr/include/boost/signals2/detail/slot_call_iterator.hpp:110
    #13 0x7f867929114d in boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> >::reference boost::iterators::iterator_core_access::dereference<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >(boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > const&) /usr/include/boost/iterator/iterator_facade.hpp:550
    #14 0x7f867929114d in boost::iterators::detail::iterator_facade_base<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> >, boost::signals2::detail::void_type, boost::iterators::single_pass_traversal_tag, boost::signals2::detail::void_type const&, long, false, false>::operator*() const /usr/include/boost/iterator/iterator_facade.hpp:656
    #15 0x7f867929114d in void boost::signals2::optional_last_value<void>::operator()<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >(boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> >, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> >) const /usr/include/boost/signals2/optional_last_value.hpp:57
    #16 0x7f86792913ba in void boost::signals2::detail::combiner_invoker<void>::operator()<boost::signals2::optional_last_value<void>, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >(boost::signals2::optional_last_value<void>&, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> >, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::DocumentObject const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void (App::DocumentObject const&), boost::function<void (App::DocumentObject const&)> >, boost::signals2::mutex> >) const /usr/include/boost/signals2/detail/result_type_wrapper.hpp:64
    #17 0x7f86792913ba in boost::signals2::detail::signal_impl<void (App::DocumentObject const&), boost::signals2::optional_last_value<void>, int, std::less<int>, boost::function<void (App::DocumentObject const&)>, boost::function<void (boost::signals2::connection const&, App::DocumentObject const&)>, boost::signals2::mutex>::operator()(App::DocumentObject const&) /usr/include/boost/signals2/detail/signal_template.hpp:243
    #18 0x7f8679291475 in boost::signals2::signal<void (App::DocumentObject const&), boost::signals2::optional_last_value<void>, int, std::less<int>, boost::function<void (App::DocumentObject const&)>, boost::function<void (boost::signals2::connection const&, App::DocumentObject const&)>, boost::signals2::mutex>::operator()(App::DocumentObject const&) /usr/include/boost/signals2/detail/signal_template.hpp:722
    #19 0x7f8679235c57 in App::Document::addObject(char const*, char const*, bool, char const*, bool) /home/xtemp09/Downloads/FreeCAD/src/App/Document.cpp:3247
    #20 0x7f8679348090 in App::Origin::setupObject() /home/xtemp09/Downloads/FreeCAD/src/App/Origin.cpp:153
    #21 0x7f8679235bbf in App::Document::addObject(char const*, char const*, bool, char const*, bool) /home/xtemp09/Downloads/FreeCAD/src/App/Document.cpp:3233
    #22 0x7f8679344bc7 in App::OriginGroupExtension::getLocalizedOrigin(App::Document*) /home/xtemp09/Downloads/FreeCAD/src/App/OriginGroupExtension.cpp:133
    #23 0x7f8679344c99 in App::OriginGroupExtension::onExtendedSetupObject() /home/xtemp09/Downloads/FreeCAD/src/App/OriginGroupExtension.cpp:142
    #24 0x7f867929cfe7 in App::DocumentObject::setupObject() /home/xtemp09/Downloads/FreeCAD/src/App/DocumentObject.cpp:1012
    #25 0x7f863d178fdc in PartDesign::Body::setupObject() /home/xtemp09/Downloads/FreeCAD/src/Mod/PartDesign/App/Body.cpp:472
    #26 0x7f8679235bbf in App::Document::addObject(char const*, char const*, bool, char const*, bool) /home/xtemp09/Downloads/FreeCAD/src/App/Document.cpp:3233
    #27 0x7f8679302443 in App::DocumentPy::addObject(_object*, _object*) /home/xtemp09/Downloads/FreeCAD/src/App/DocumentPyImp.cpp:272
    #28 0x7f86793030c7 in App::DocumentPy::staticCallback_addObject(_object*, _object*, _object*) /home/xtemp09/Downloads/FreeCAD/build/src/App/DocumentPy.cpp:1221
    #29 0x7f8678128022  (/lib/x86_64-linux-gnu/libpython3.10.so.1.0+0x128022)


```
</details>
