### PR TITLE
Gui: Fix rotation center indicator for Gesture styles

### DIFF
--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -489,6 +489,7 @@ public:
     explicit RotateState(my_context ctx):my_base(ctx)
     {
         auto &ns = this->outermost_context().ns;
+        ns.setRotationCenter(ns.getFocalPoint());
         ns.setViewingMode(NavigationStyle::DRAGGING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
         if (ns.logging)
@@ -625,6 +626,7 @@ public:
     explicit TiltState(my_context ctx):my_base(ctx)
     {
         auto &ns = this->outermost_context().ns;
+        ns.setRotationCenter(ns.getFocalPoint());
         ns.setViewingMode(NavigationStyle::DRAGGING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
         if (ns.logging)

--- a/src/Gui/MayaGestureNavigationStyle.cpp
+++ b/src/Gui/MayaGestureNavigationStyle.cpp
@@ -424,6 +424,7 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
 
                     // start DRAGGING mode (orbit)
                     // if not pressing left mouse button then it assumes is right mouse button and starts ZOOMING mode
+                    setRotationCenter(getFocalPoint());
                     setViewingMode(this->button1down ? NavigationStyle::DRAGGING : NavigationStyle::ZOOMING);
                     processed = true;
                 } else {
@@ -452,6 +453,7 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
                     processed = true;
                 } else if (type.isDerivedFrom(SoGesturePinchEvent::getClassTypeId())) {
                     pan(viewer->getSoRenderManager()->getCamera());//set up panning plane
+                    setRotationCenter(getFocalPoint());
                     setViewingMode(NavigationStyle::DRAGGING);
                     processed = true;
                 } //all other gestures - ignore!
@@ -478,6 +480,7 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
                 case SoMouseButtonEvent::BUTTON3: // allows to release button3 into SELECTION mode
                     if(comboAfter & BUTTON1DOWN || comboAfter & BUTTON2DOWN) {
                         //don't leave navigation till all buttons have been released
+                        setRotationCenter(getFocalPoint());
                         setViewingMode((comboAfter & BUTTON1DOWN) ? NavigationStyle::DRAGGING : NavigationStyle::PANNING);
                         processed = true;
                     } else { //all buttons are released


### PR DESCRIPTION
When dragging in the Gesture and MayaGesture navigation styles, the rotation center indicator is not shown because the rotation center is not set. The added lines set the rotation center before dragging.