### PR TITLE
[stylesheets]Fix for Qcombobox in Qstyle Fusion 

### DIFF
--- a/src/Gui/Stylesheets/Dark-modern.qss
+++ b/src/Gui/Stylesheets/Dark-modern.qss
@@ -16,11 +16,9 @@ INSTALLATION WHEN NECESSARY
     LINUX = /home/[YOUR_USER_NAME]/.FreeCAD/Gui/Stylesheets/
 
 ============================================================================================================
-TO MODIFY USE THESE COLORS:
- @ThemeAccentColor1
- @ThemeAccentColor2
-
-
+FOLLOWING CODES ARE CHANGED IN THE SETTINGS:
+  @ThemeAccentColor1
+  @ThemeAccentColor2
 See Qt documentation:
 
   - https://doc.qt.io/qt-5/stylesheet.html
@@ -1419,6 +1417,10 @@ QComboBox QAbstractItemView:alternate {
   background: #3c3c3c;
 }
 
+QComboBox:checked {
+  color: #ffffff;
+}
+
 QComboBox:disabled {
   background-color: #2b2b2b;
   color: #353535;
@@ -1438,17 +1440,14 @@ QComboBox:on {
 }
 
 QComboBox::indicator {
-  border: none;
-  border-radius: 0px;
+  padding-left: 8px;
   background-color: transparent;
-  selection-background-color: transparent;
-  color: transparent;
-  selection-color: @ThemeAccentColor1;
-  /* Needed to remove indicator - fix #132 */
 }
 
-QComboBox::indicator:alternate {
-  background: #696968;
+QComboBox::indicator:checked {
+  width: 12px;
+  height: 12px;
+  image: url(qss:images_dark-light/check_light.svg);
 }
 
 QComboBox::item {
@@ -1462,9 +1461,16 @@ QComboBox::item {
         }
         */
 }
+/* Background color of popup-list.*/
 
+/* Needed to complete the rule set. */
 QComboBox::item:alternate {
   background: #3c3c3c;
+}
+/* Color of the selected list item. */
+QComboBox::item:selected {
+  border: 1px solid @ThemeAccentColor2;
+  background: @ThemeAccentColor2;
 }
 
 QComboBox::drop-down {

--- a/src/Gui/Stylesheets/Dark.qss
+++ b/src/Gui/Stylesheets/Dark.qss
@@ -669,7 +669,7 @@ QScrollBar:horizontal {
   height: 16px;
   margin: 2px 8px 2px 8px;
   border: 0px solid #696968;
-  border-radius: 1.9px;
+  border-radius: 4px;
   background-color: #7F7F7F;
 }
 
@@ -678,7 +678,7 @@ QScrollBar:vertical {
   width: 16px;
   margin: 8px 2px 8px 2px;
   border: 0px solid #696968;
-  border-radius: 1.9px;
+  border-radius: 4px;
 }
 
 QScrollBar::handle:horizontal {
@@ -1380,6 +1380,7 @@ QComboBox {
   /* changed to 4px to fix #239 */
   /* Fixes #103, #111 */
   min-height: 1.5em;
+  margin: 0px -1px 0px 0px; /* hack for Mac... try it on Windows and Linux */
   /* padding-top: 2px;     removed to fix #132 */
   /* padding-bottom: 2px;  removed to fix #132 */
   /* min-width: 75px;      removed to fix #109 */
@@ -1409,6 +1410,10 @@ QComboBox QAbstractItemView:alternate {
   background: #3c3c3c;
 }
 
+QComboBox:checked {
+  color: #ffffff;
+}
+
 QComboBox:disabled {
   background-color: #7F7F7F;
   color: #353535;
@@ -1428,17 +1433,14 @@ QComboBox:on {
 }
 
 QComboBox::indicator {
-  border: none;
-  border-radius: 0px;
+  padding-left: 8px;
   background-color: transparent;
-  selection-background-color: transparent;
-  color: transparent;
-  selection-color: @ThemeAccentColor1;
-  /* Needed to remove indicator - fix #132 */
 }
 
-QComboBox::indicator:alternate {
-  background: #696968;
+QComboBox::indicator:checked {
+  width: 12px;
+  height: 12px;
+  image: url(qss:images_dark-light/check_light.svg);
 }
 
 QComboBox::item {
@@ -1452,9 +1454,16 @@ QComboBox::item {
         }
         */
 }
+/* Background color of popup-list.*/
 
+/* Needed to complete the rule set. */
 QComboBox::item:alternate {
   background: #3c3c3c;
+}
+/* Color of the selected list item. */
+QComboBox::item:selected {
+  border: 1px solid @ThemeAccentColor2;
+  background: @ThemeAccentColor2;
 }
 
 QComboBox::drop-down {

--- a/src/Gui/Stylesheets/Darker.qss
+++ b/src/Gui/Stylesheets/Darker.qss
@@ -16,11 +16,9 @@ INSTALLATION WHEN NECESSARY
     LINUX = /home/[YOUR_USER_NAME]/.FreeCAD/Gui/Stylesheets/
 
 ============================================================================================================
-TO MODIFY USE THESE COLORS:
- @ThemeAccentColor1
- @ThemeAccentColor2
-
-
+FOLLOWING CODES ARE CHANGED IN THE SETTINGS:
+  @ThemeAccentColor1
+  @ThemeAccentColor2
 See Qt documentation:
 
   - https://doc.qt.io/qt-5/stylesheet.html
@@ -778,6 +776,7 @@ QScrollBar::sub-line:vertical {
 }
 
 QScrollBar::sub-line:vertical:hover, QScrollBar::sub-line:vertical:on {
+  background-color: @ThemeAccentColor1;
   border-image: url(qss:images_dark-light/up_arrow_lighter.svg);
   height: 5px;
   width: 9px;
@@ -1381,6 +1380,7 @@ QComboBox {
   /* changed to 4px to fix #239 */
   /* Fixes #103, #111 */
   min-height: 1.5em;
+  margin: 0px -1px 0px 0px; /* hack for Mac... try it on Windows and Linux */
   /* padding-top: 2px;     removed to fix #132 */
   /* padding-bottom: 2px;  removed to fix #132 */
   /* min-width: 75px;      removed to fix #109 */
@@ -1407,7 +1407,11 @@ QComboBox QAbstractItemView:selected {
 }
 
 QComboBox QAbstractItemView:alternate {
-  background: #3c3c3c;
+  background: #1c1b22;
+}
+
+QComboBox:checked {
+  color: #ffffff;
 }
 
 QComboBox:disabled {
@@ -1429,17 +1433,14 @@ QComboBox:on {
 }
 
 QComboBox::indicator {
-  border: none;
-  border-radius: 0px;
+  padding-left: 8px;
   background-color: transparent;
-  selection-background-color: transparent;
-  color: transparent;
-  selection-color: @ThemeAccentColor1;
-  /* Needed to remove indicator - fix #132 */
 }
 
-QComboBox::indicator:alternate {
-  background: #696968;
+QComboBox::indicator:checked {
+  width: 12px;
+  height: 12px;
+  image: url(qss:images_dark-light/check_light.svg);
 }
 
 QComboBox::item {
@@ -1453,9 +1454,16 @@ QComboBox::item {
         }
         */
 }
+/* Background color of popup-list.*/
 
+/* Needed to complete the rule set. */
 QComboBox::item:alternate {
   background: #3c3c3c;
+}
+/* Color of the selected list item. */
+QComboBox::item:selected {
+  border: 1px solid @ThemeAccentColor2;
+  background: @ThemeAccentColor2;
 }
 
 QComboBox::drop-down {

--- a/src/Gui/Stylesheets/Light-modern.qss
+++ b/src/Gui/Stylesheets/Light-modern.qss
@@ -16,11 +16,9 @@ INSTALLATION WHEN NECESSARY
     LINUX = /home/[YOUR_USER_NAME]/.FreeCAD/Gui/Stylesheets/
 
 ============================================================================================================
-TO MODIFY USE THESE COLORS:
- @ThemeAccentColor1
- @ThemeAccentColor2
-
-
+FOLLOWING CODES ARE CHANGED IN THE SETTINGS:
+  @ThemeAccentColor1
+  @ThemeAccentColor2
 See Qt documentation:
 
   - https://doc.qt.io/qt-5/stylesheet.html
@@ -51,6 +49,7 @@ QToolBar * {
 }
 
 /*hacks */
+
 Gui--PropertyEditor--PropertyEditor QLineEdit:read-only,
 Gui--PropertyEditor--PropertyEditor QLineEdit:disabled,
 Gui--PropertyEditor--PropertyEditor QAbstractSpinBox:read-only,
@@ -1395,6 +1394,7 @@ QComboBox {
   /* changed to 4px to fix #239 */
   /* Fixes #103, #111 */
   min-height: 1.5em;
+  margin: 0px -1px 0px 0px; /* hack for Mac... try it on Windows and Linux */
   /* padding-top: 2px;     removed to fix #132 */
   /* padding-bottom: 2px;  removed to fix #132 */
   /* min-width: 75px;      removed to fix #109 */
@@ -1424,6 +1424,10 @@ QComboBox QAbstractItemView:alternate {
   background: #f5f5f5;
 }
 
+QComboBox:checked {
+  color: black;
+}
+
 QComboBox:disabled {
   background-color: #cccccc;
   color: #515151;
@@ -1443,17 +1447,14 @@ QComboBox:on {
 }
 
 QComboBox::indicator {
-  border: none;
-  border-radius: 0px;
+  padding-left: 8px;
   background-color: transparent;
-  selection-background-color: transparent;
-  color: transparent;
-  selection-color: @ThemeAccentColor1;
-  /* Needed to remove indicator - fix #132 */
 }
 
-QComboBox::indicator:alternate {
-  background: #cccccc;
+QComboBox::indicator:checked {
+  width: 12px;
+  height: 12px;
+  image:url(qss:images_dark-light/check_dark.svg);
 }
 
 QComboBox::item {
@@ -1467,9 +1468,17 @@ QComboBox::item {
         }
         */
 }
+/* Background color of popup-list.*/
 
+/* Needed to complete the rule set. */
 QComboBox::item:alternate {
   background: #f5f5f5;
+}
+
+/* Color of the selected list item. */
+QComboBox::item:selected {
+  border: 1px solid @ThemeAccentColor2;
+  background: @ThemeAccentColor2;
 }
 
 QComboBox::drop-down {

--- a/src/Gui/Stylesheets/Light.qss
+++ b/src/Gui/Stylesheets/Light.qss
@@ -16,11 +16,9 @@ INSTALLATION WHEN NECESSARY
     LINUX = /home/[YOUR_USER_NAME]/.FreeCAD/Gui/Stylesheets/
 
 ============================================================================================================
-TO MODIFY USE THESE COLORS:
- @ThemeAccentColor1
- @ThemeAccentColor2
-
-
+FOLLOWING CODES ARE CHANGED IN THE SETTINGS:
+  @ThemeAccentColor1
+  @ThemeAccentColor2
 See Qt documentation:
 
   - https://doc.qt.io/qt-5/stylesheet.html
@@ -1382,6 +1380,7 @@ QComboBox {
   /* changed to 4px to fix #239 */
   /* Fixes #103, #111 */
   min-height: 1.5em;
+  margin: 0px -1px 0px 0px; /* hack for Mac... try it on Windows and Linux */
   /* padding-top: 2px;     removed to fix #132 */
   /* padding-bottom: 2px;  removed to fix #132 */
   /* min-width: 75px;      removed to fix #109 */
@@ -1411,6 +1410,10 @@ QComboBox QAbstractItemView:alternate {
   background: #f6f6f6;
 }
 
+QComboBox:checked {
+  color: black;
+}
+
 QComboBox:disabled {
   background-color: #F6F6F6;
   color: #BABABA;
@@ -1430,17 +1433,14 @@ QComboBox:on {
 }
 
 QComboBox::indicator {
-  border: none;
-  border-radius: 0px;
+  padding-left: 8px;
   background-color: transparent;
-  selection-background-color: transparent;
-  color: transparent;
-  selection-color: @ThemeAccentColor1;
-  /* Needed to remove indicator - fix #132 */
 }
 
-QComboBox::indicator:alternate {
-  background: #f6f6f6;
+QComboBox::indicator:checked {
+  width: 12px;
+  height: 12px;
+  image:url(qss:images_dark-light/check_dark.svg);
 }
 
 QComboBox::item {
@@ -1454,9 +1454,17 @@ QComboBox::item {
         }
         */
 }
+/* Background color of popup-list.*/
 
+/* Needed to complete the rule set. */
 QComboBox::item:alternate {
   background: #f6f6f6;
+}
+
+/* Color of the selected list item. */
+QComboBox::item:selected {
+  border: 1px solid @ThemeAccentColor2;
+  background: @ThemeAccentColor2;
 }
 
 QComboBox::drop-down {


### PR DESCRIPTION
I finally figured out how to do this PR properly. So I made a new PR.

There was an empty placeholder spot in the Qcombobox in Fusion/Linux style in the stylesheets.
I tried to remove the spot, noticed it was caused by Qcombobox:indicator and I ended up fixing the indicator.
It can be debated if this indicator is useful, as it isn't shown in the no-stylesheet option.
I personally found it looks pretty good and is useful. I'd suggest try it out in main, and we can always remove it afterwards. 
Before:
![image](https://github.com/FreeCAD/FreeCAD/assets/29804962/ba4e3d82-613b-4416-a869-eab34699e26e)
After:
![image](https://github.com/FreeCAD/FreeCAD/assets/29804962/a8f23ab4-2e5d-4172-8597-046e449fe84a)
![image](https://github.com/FreeCAD/FreeCAD/assets/29804962/9fe3eb33-778f-4e5a-ab37-23575029ec7c)
