### PR TITLE
Workbench list in settings, small UI fix.

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -124,7 +124,8 @@ wbListItem::wbListItem(const QString& wbName, bool enabled, bool startupWb, bool
     subLayout->setAlignment(Qt::AlignLeft);
     subLayout->setContentsMargins(5, 0, 0, 5);
     subWidget->setMinimumSize(250, 0);
-
+    subWidget->setAttribute(Qt::WA_TranslucentBackground);
+   
     // 5: Autoloaded checkBox.
     autoloadCheckBox = new QCheckBox(this);
     autoloadCheckBox->setText(tr("Auto-load"));


### PR DESCRIPTION
This fixes an issue with the workbench list where the workbench name has a Qwidget background, while the list has a Qlist background.
Also the Qwidget background was in front of the Qlist hover background color.
 
Before:
![freecad_GroeuWxbpF](https://github.com/FreeCAD/FreeCAD/assets/29804962/3030e46f-13ce-4989-91a4-e0c07a5f96d0)
After:
![FreeCAD_8YrQJNyAd5](https://github.com/FreeCAD/FreeCAD/assets/29804962/48f6916d-e0df-4065-9e20-f22690f1ba27)
