### PR TITLE
Core: fix a compiler warning

### DIFF
--- a/src/App/ExtensionContainer.h
+++ b/src/App/ExtensionContainer.h
@@ -185,7 +185,7 @@ public:
 
     void Save(Base::Writer& writer) const override;
     void Restore(Base::XMLReader& reader) override;
-    void Restore(Base::DocumentReader& reader,XERCES_CPP_NAMESPACE_QUALIFIER DOMElement *containerEl);
+    void Restore(Base::DocumentReader& reader,XERCES_CPP_NAMESPACE_QUALIFIER DOMElement *containerEl) override;
 
     //those methods save/restore the dynamic extensions without handling properties, which is something
     //done by the default Save/Restore methods.


### PR DESCRIPTION
```
src/App/ExtensionContainer.h:188:10: warning: 'Restore' overrides a member function but is not marked 'override' [-Winconsistent-missing-override] void Restore(Base::DocumentReader& reader,XERCES_CPP_NAMESPACE_QUALIFIER DOMElement *containerEl);
         ^
src/App/PropertyContainer.h:233:8: note: overridden virtual function is here void Restore(Base::DocumentReader &reader, XERCES_CPP_NAMESPACE_QUALIFIER DOMElement *containerEl) override;
       ^
1 warning generated.
```