### PR TITLE
Fem: Remove callback added by filters task box and rework marker classes

### DIFF
--- a/src/Mod/Fem/Gui/TaskPostBoxes.h
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.h
@@ -50,6 +50,11 @@ class SoIndexedLineSet;
 class SoEventCallback;
 class SoMarkerSet;
 
+namespace Fem
+{
+class FemPostDataAlongLineFilter;
+class FemPostDataAtPointFilter;
+}  // namespace Fem
 
 namespace FemGui
 {
@@ -62,25 +67,27 @@ class PointMarker: public QObject
     Q_OBJECT
 
 public:
-    PointMarker(Gui::View3DInventorViewer* view, std::string ObjName);
+    PointMarker(Gui::View3DInventorViewer* view, App::DocumentObject* obj);
     ~PointMarker() override;
 
     void addPoint(const SbVec3f&);
-    int countPoints() const;
     void clearPoints() const;
-
-Q_SIGNALS:
-    void PointsChanged(double x1, double y1, double z1, double x2, double y2, double z2);
+    int countPoints() const;
+    SbVec3f getPoint(int idx) const;
+    void setPoint(int idx, const SbVec3f& pt) const;
+    Gui::View3DInventorViewer* getView() const;
+    App::DocumentObject* getObject() const;
+    QMetaObject::Connection connSelectPoint;
 
 protected:
-    void customEvent(QEvent* e) override;
+    std::string ObjectInvisible();
 
 private:
     Gui::View3DInventorViewer* view;
+    App::DocumentObject* obj;
     ViewProviderPointMarker* vp;
-    std::string m_name;
-    std::string ObjectInvisible();
 };
+
 
 class FemGuiExport ViewProviderPointMarker: public Gui::ViewProviderDocumentObject
 {
@@ -92,51 +99,42 @@ public:
 
 protected:
     SoCoordinate3* pCoords;
+    SoMarkerSet* pMarker;
     friend class PointMarker;
 };
 
 
 // ***************************************************************************
-// data marker
-class ViewProviderDataMarker;
-class DataMarker: public QObject
+// DataAlongLine markers
+class DataAlongLineMarker: public PointMarker
 {
     Q_OBJECT
 
 public:
-    DataMarker(Gui::View3DInventorViewer* view, std::string ObjName);
-    ~DataMarker() override;
+    DataAlongLineMarker(Gui::View3DInventorViewer* view, Fem::FemPostDataAlongLineFilter* obj);
 
-    void addPoint(const SbVec3f&);
-    int countPoints() const;
-    void setPoint(int idx, const SbVec3f& pt) const;
+Q_SIGNALS:
+    void PointsChanged(double x1, double y1, double z1, double x2, double y2, double z2);
+
+protected:
+    void customEvent(QEvent* e) override;
+};
+
+
+// ***************************************************************************
+// DataAtPoint markers
+class DataAtPointMarker: public PointMarker
+{
+    Q_OBJECT
+
+public:
+    DataAtPointMarker(Gui::View3DInventorViewer* view, Fem::FemPostDataAtPointFilter* obj);
 
 Q_SIGNALS:
     void PointsChanged(double x, double y, double z);
 
 protected:
     void customEvent(QEvent* e) override;
-
-private:
-    Gui::View3DInventorViewer* view;
-    ViewProviderDataMarker* vp;
-    std::string m_name;
-    std::string ObjectInvisible();
-};
-
-
-class FemGuiExport ViewProviderDataMarker: public Gui::ViewProviderDocumentObject
-{
-    PROPERTY_HEADER_WITH_OVERRIDE(FemGui::ViewProviderDataMarker);
-
-public:
-    ViewProviderDataMarker();
-    ~ViewProviderDataMarker() override;
-
-protected:
-    SoCoordinate3* pCoords;
-    SoMarkerSet* pMarker;
-    friend class DataMarker;
 };
 
 
@@ -318,7 +316,7 @@ private:
     std::string ObjectVisible();
     QWidget* proxy;
     std::unique_ptr<Ui_TaskPostDataAlongLine> ui;
-    PointMarker* marker;
+    DataAlongLineMarker* marker;
 };
 
 
@@ -348,7 +346,7 @@ private:
     std::string ObjectVisible();
     QWidget* proxy;
     std::unique_ptr<Ui_TaskPostDataAtPoint> ui;
-    DataMarker* marker;
+    DataAtPointMarker* marker;
 };
 
 


### PR DESCRIPTION
Currently the callback functions and the connection used to pick the points in the `TaskPostDataAtPoint` and `TaskPostDataAlongLine` functions are not removed properly. So this lead in a crash if, for example, click the `Select Point` button and close the dialog without end the  points selection process since the markers are destroyed but the callback remains active. In fact, each time the button is pressed, a callback and a connection are established.

Additionally, there is some rework in the point marker classes to avoid code duplication and to use pointers to initialize the objects.
The `TaskPostDataAlongLine` and `TaskPostDataAtPoint` boxes are created using pointers to their specific view provider objects.

These changes fix the problem without changing the current code structure too much, but the TaskPostBoxes files could need some rework in general.