### PR TITLE
Splits DocumentObject::getNameInDocument() into three methods.

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1215,7 +1215,7 @@ std::set<DocumentObject *> Application::getLinksTo(
     } else {
         std::set<Document*> docs;
         for(auto o : obj->getInList()) {
-            if(o && o->getNameInDocument() && docs.insert(o->getDocument()).second) {
+            if(o && o->isAttachedToDocument() && docs.insert(o->getDocument()).second) {
                 o->getDocument()->getLinksTo(links,obj,options,maxCount);
                 if(maxCount && (int)links.size()>=maxCount)
                     break;

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -262,6 +262,8 @@ public:
      */
     std::vector<DocumentObject *>addObjects(const char* sType, const std::vector<std::string>& objectNames, bool isNew=true);
     /// Remove a feature out of the document
+    void removeObject(const std::string& name);
+    /// Remove a feature out of the document
     void removeObject(const char* sName);
     /** Add an existing feature with sName (ASCII) to this document and set it active.
      * Unicode names are set through the Label property.
@@ -297,13 +299,17 @@ public:
     /// Returns the active Object of this document
     DocumentObject *getActiveObject() const;
     /// Returns a Object of this document
-    DocumentObject *getObject(const char *Name) const;
+    DocumentObject *getObject(const char* Name) const;
+    /// Returns a Object of this document
+    DocumentObject *getObject(const std::string Name) const;
     /// Returns a Object of this document by its id
     DocumentObject *getObjectByID(long id) const;
     /// Returns true if the DocumentObject is contained in this document
     bool isIn(const DocumentObject *pFeat) const;
     /// Returns a Name of an Object or 0
     const char *getObjectName(DocumentObject *pFeat) const;
+    /// Returns a Name of an Object or 0
+    std::string getUniqueObjectName(const std::string& Name) const;
     /// Returns a Name of an Object or 0
     std::string getUniqueObjectName(const char *Name) const;
     /// Returns a name of the form prefix_number. d specifies the number of digits.

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -133,7 +133,9 @@ public:
     ~DocumentObject() override;
 
     /// returns the name which is set in the document for this object (not the name property!)
-    const char *getNameInDocument() const;
+    const char* getDagKey() const;
+    /// returns the name which is set in the document for this object (not the name property!)
+    const std::string& getNameInDocument() const;
     /// Return the object ID that is unique within its owner document
     long getID() const {return _Id;}
     /// returns the name that is safe to be exported to other document

--- a/src/App/DocumentObjectPyImp.cpp
+++ b/src/App/DocumentObjectPyImp.cpp
@@ -52,11 +52,11 @@ std::string DocumentObjectPy::representation() const
 Py::String DocumentObjectPy::getName() const
 {
     DocumentObject* object = this->getDocumentObjectPtr();
-    const char* internal = object->getNameInDocument();
-    if (!internal) {
+    std::string internal = object->getNameInDocument();
+    if (internal.empty()) {
         throw Py::RuntimeError(std::string("This object is currently not part of a document"));
     }
-    return {std::string(internal)};
+    return {internal};
 }
 
 Py::String DocumentObjectPy::getFullName() const
@@ -224,8 +224,8 @@ Py::Object DocumentObjectPy::getViewObject() const
         if(!getDocumentObjectPtr()->getDocument()) {
             throw Py::RuntimeError("Object has no document");
         }
-        const char* internalName = getDocumentObjectPtr()->getNameInDocument();
-        if (!internalName) {
+        std::string internalName = getDocumentObjectPtr()->getNameInDocument();
+        if (internalName.empty()) {
             throw Py::RuntimeError("Object has been removed from document");
         }
 

--- a/src/App/DocumentObserver.cpp
+++ b/src/App/DocumentObserver.cpp
@@ -153,7 +153,7 @@ DocumentObjectT &DocumentObjectT::operator=(DocumentObjectT&& obj)
 
 void DocumentObjectT::operator=(const DocumentObject* obj)
 {
-    if(!obj || !obj->getNameInDocument()) {
+    if(!obj || !obj->isAttachedToDocument()) {
         object.clear();
         label.clear();
         document.clear();

--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -97,7 +97,7 @@ DocumentObject *GeoFeature::resolveElement(DocumentObject *obj, const char *subn
         ElementNameType type, const DocumentObject *filter, 
         const char **_element, GeoFeature **geoFeature)
 {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return nullptr;
     if(!subname)
         subname = "";

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -489,8 +489,8 @@ void GeoFeatureGroupExtension::getInvalidLinkObjects(const DocumentObject* obj, 
 
 bool GeoFeatureGroupExtension::extensionGetSubObjects(std::vector<std::string> &ret, int) const {
     for(auto obj : Group.getValues()) {
-        if(obj && obj->getNameInDocument() && !obj->testStatus(ObjectStatus::GeoExcluded))
-            ret.push_back(std::string(obj->getNameInDocument())+'.');
+        if(obj && obj->isAttachedToDocument() && !obj->testStatus(ObjectStatus::GeoExcluded))
+            ret.push_back(obj->getNameInDocument()+'.');
     }
     return true;
 }

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -158,7 +158,7 @@ void GroupExtension::removeObjectsFromDocument()
 void GroupExtension::removeObjectFromDocument(DocumentObject* obj)
 {
     // check that object is not invalid
-    if (!obj || !obj->getNameInDocument())
+    if (!obj || !obj->isAttachedToDocument())
         return;
 
     // remove all children
@@ -351,7 +351,7 @@ void GroupExtension::extensionOnChanged(const Property* p) {
     if(p == &Group) {
         _Conns.clear();
         for(auto obj : Group.getValue()) {
-            if(obj && obj->getNameInDocument()) {
+            if(obj && obj->isAttachedToDocument()) {
                 //NOLINTBEGIN
                 _Conns[obj] = obj->signalChanged.connect(std::bind(
                             &GroupExtension::slotChildChanged,this,sp::_1, sp::_2));
@@ -398,7 +398,7 @@ bool GroupExtension::extensionGetSubObject(DocumentObject *&ret, const char *sub
 
 bool GroupExtension::extensionGetSubObjects(std::vector<std::string> &ret, int) const {
     for(auto obj : Group.getValues()) {
-        if(obj && obj->getNameInDocument())
+        if(obj && obj->isAttachedToDocument())
             ret.push_back(std::string(obj->getNameInDocument())+'.');
     }
     return true;
@@ -421,7 +421,7 @@ void GroupExtension::getAllChildren(std::vector<App::DocumentObject*> &res,
         std::set<App::DocumentObject*> &rset) const
 {
     for(auto obj : Group.getValues()) {
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         if(!rset.insert(obj).second)
             continue;

--- a/src/App/GroupExtensionPyImp.cpp
+++ b/src/App/GroupExtensionPyImp.cpp
@@ -62,7 +62,7 @@ PyObject*  GroupExtensionPy::addObject(PyObject *args)
         return nullptr;
 
     DocumentObjectPy* docObj = static_cast<DocumentObjectPy*>(object);
-    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->getNameInDocument()) {
+    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot add an invalid object");
         return nullptr;
     }
@@ -174,7 +174,7 @@ PyObject*  GroupExtensionPy::removeObject(PyObject *args)
         return nullptr;
 
     DocumentObjectPy* docObj = static_cast<DocumentObjectPy*>(object);
-    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->getNameInDocument()) {
+    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot remove an invalid object");
         return nullptr;
     }
@@ -262,7 +262,7 @@ PyObject*  GroupExtensionPy::hasObject(PyObject *args)
 
     DocumentObjectPy* docObj = static_cast<DocumentObjectPy*>(object);
     bool recursive = Base::asBoolean(recursivePy);
-    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->getNameInDocument()) {
+    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot check an invalid object");
         return nullptr;
     }

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -468,7 +468,7 @@ void LinkBaseExtension::setOnChangeCopyObject(
         }
     }
 
-    const char *key = flags.testFlag(OnChangeCopyOptions::ApplyAll) ? "*" : parent->getNameInDocument();
+    const char *key = flags.testFlag(OnChangeCopyOptions::ApplyAll) ? "*" : parent->getDagKey();
     if (external)
         prop->setValue(key, exclude ? "" : "+");
     else
@@ -518,7 +518,7 @@ void LinkBaseExtension::syncCopyOnChange()
             // to match the possible new copy later.
             objs = copyOnChangeGroup->ElementList.getValues();
             for (auto obj : objs) {
-                if (!obj->getNameInDocument())
+                if (!obj->isAttachedToDocument())
                     continue;
                 auto prop = Base::freecad_dynamic_cast<PropertyUUID>(
                         obj->getPropertyByName("_SourceUUID"));
@@ -872,7 +872,7 @@ App::DocumentObject *LinkBaseExtension::makeCopyOnChange() {
 
     if (auto prop = getLinkCopyOnChangeGroupProperty()) {
         if (auto obj = prop->getValue()) {
-            if (obj->getNameInDocument() && obj->getDocument())
+            if (obj->isAttachedToDocument() && obj->getDocument())
                 obj->getDocument()->removeObject(obj->getNameInDocument());
         }
         auto group = new LinkGroup;
@@ -1088,7 +1088,7 @@ int LinkBaseExtension::getElementIndex(const char *subname, const char **psubnam
         // pattern, which is the owner object name + "_i" + index
         const char *name = subname[0]=='$'?subname+1:subname;
         auto owner = getContainer();
-        if(owner && owner->getNameInDocument()) {
+        if(owner && owner->isAttachedToDocument()) {
             std::string ownerName(owner->getNameInDocument());
             ownerName += '_';
             if(boost::algorithm::starts_with(name,ownerName.c_str())) {
@@ -1108,7 +1108,7 @@ int LinkBaseExtension::getElementIndex(const char *subname, const char **psubnam
             // Then check for the actual linked object's name or label, and
             // redirect that reference to the first array element
             auto linked = getTrueLinkedObject(false);
-            if(!linked || !linked->getNameInDocument())
+            if(!linked || !linked->isAttachedToDocument())
                 return -1;
             if(subname[0]=='$') {
                 CharRange sub(subname+1, dot);
@@ -1223,7 +1223,7 @@ Base::Matrix4D LinkBaseExtension::getTransform(bool transform) const {
 bool LinkBaseExtension::extensionGetSubObjects(std::vector<std::string> &ret, int reason) const {
     if(!getLinkedObjectProperty() && getElementListProperty()) {
         for(auto obj : getElementListProperty()->getValues()) {
-            if(obj && obj->getNameInDocument()) {
+            if(obj && obj->isAttachedToDocument()) {
                 std::string name(obj->getNameInDocument());
                 name+='.';
                 ret.push_back(name);
@@ -1303,7 +1303,7 @@ bool LinkBaseExtension::extensionGetSubObject(DocumentObject *&ret, const char *
     if(idx>=0) {
         const auto &elements = _getElementListValue();
         if(!elements.empty()) {
-            if(idx>=(int)elements.size() || !elements[idx] || !elements[idx]->getNameInDocument())
+            if(idx>=(int)elements.size() || !elements[idx] || !elements[idx]->isAttachedToDocument())
                 return true;
             ret = elements[idx]->getSubObject(subname,pyObj,mat,true,depth+1);
             // do not resolve the link if this element is the last referenced object
@@ -1415,7 +1415,7 @@ void LinkBaseExtension::onExtendedUnsetupObject() {
         return;
     detachElements();
     if (auto obj = getLinkCopyOnChangeGroupValue()) {
-        if(obj->getNameInDocument() && !obj->isRemoving())
+        if(obj->isAttachedToDocument() && !obj->isRemoving())
             obj->getDocument()->removeObject(obj->getNameInDocument());
     }
 }
@@ -1440,7 +1440,7 @@ DocumentObject *LinkBaseExtension::getTrueLinkedObject(
     }
     if(ret && recurse)
         ret = ret->getLinkedObject(recurse,mat,transform,depth+1);
-    if(ret && !ret->getNameInDocument())
+    if(ret && !ret->isAttachedToDocument())
         return nullptr;
     return ret;
 }
@@ -1514,7 +1514,7 @@ void LinkBaseExtension::updateGroup() {
         groupSet.insert(group->getExtendedObject());
     }else{
         for(auto o : getElementListProperty()->getValues()) {
-            if(!o || !o->getNameInDocument())
+            if(!o || !o->isAttachedToDocument())
                 continue;
             auto ext = o->getExtensionByType<GroupExtension>(true,false);
             if(ext) {
@@ -1636,7 +1636,7 @@ void LinkBaseExtension::update(App::DocumentObject *parent, const Property *prop
                 getScaleListProperty()->setValue(scales);
 
             for(auto obj : objs) {
-                if(obj && obj->getNameInDocument())
+                if(obj && obj->isAttachedToDocument())
                     obj->getDocument()->removeObject(obj->getNameInDocument());
             }
         }
@@ -1734,7 +1734,7 @@ void LinkBaseExtension::update(App::DocumentObject *parent, const Property *prop
                 }
                 getElementListProperty()->setValue(objs);
                 for(auto obj : tmpObjs) {
-                    if(obj && obj->getNameInDocument())
+                    if(obj && obj->isAttachedToDocument())
                         obj->getDocument()->removeObject(obj->getNameInDocument());
                 }
             }
@@ -1859,7 +1859,7 @@ void LinkBaseExtension::cacheChildLabel(int enable) const {
 
     int idx = 0;
     for(auto child : _getElementListValue()) {
-        if(child && child->getNameInDocument())
+        if(child && child->isAttachedToDocument())
             myLabelCache[child->Label.getStrValue()] = idx;
         ++idx;
     }
@@ -2021,7 +2021,7 @@ void LinkBaseExtension::setLink(int index, DocumentObject *obj,
                     objs.push_back(elements[i]);
             }
             getElementListProperty()->setValue(objs);
-        }else if(!obj->getNameInDocument())
+        }else if(!obj->isAttachedToDocument())
             LINK_THROW(Base::ValueError,"Invalid object");
         else{
             if(index>(int)elements.size())
@@ -2075,7 +2075,7 @@ void LinkBaseExtension::setLink(int index, DocumentObject *obj,
 
     auto xlink = freecad_dynamic_cast<PropertyXLink>(linkProp);
     if(obj) {
-        if(!obj->getNameInDocument())
+        if(!obj->isAttachedToDocument())
             LINK_THROW(Base::ValueError,"Invalid document object");
         if(!xlink) {
             if(parent && obj->getDocument()!=parent->getDocument())
@@ -2113,7 +2113,7 @@ void LinkBaseExtension::detachElements()
 }
 
 void LinkBaseExtension::detachElement(DocumentObject *obj) {
-    if(!obj || !obj->getNameInDocument() || obj->isRemoving())
+    if(!obj || !obj->isAttachedToDocument() || obj->isRemoving())
         return;
     auto ext = obj->getExtensionByType<LinkBaseExtension>(true);
     auto owner = getContainer();

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -1421,7 +1421,7 @@ void ObjectIdentifier::setDocumentObjectName(ObjectIdentifier::String &&name, bo
 void ObjectIdentifier::setDocumentObjectName(const App::DocumentObject *obj, bool force,
         ObjectIdentifier::String &&subname, bool checkImport)
 {
-    if(!owner || !obj || !obj->getNameInDocument() || !obj->getDocument())
+    if(!owner || !obj || !obj->isAttachedToDocument() || !obj->getDocument())
         FC_THROWM(Base::RuntimeError,"invalid object");
 
     if(checkImport)
@@ -1930,7 +1930,7 @@ bool ObjectIdentifier::isTouched() const {
 }
 
 void ObjectIdentifier::resolveAmbiguity() {
-    if(!owner || !owner->getNameInDocument() || isLocalProperty() ||
+    if(!owner || !owner->isAttachedToDocument() || isLocalProperty() ||
        (documentObjectNameSet && !documentObjectName.getString().empty() &&
         (documentObjectName.isRealString() || documentObjectName.isForceIdentifier())))
     {

--- a/src/App/OriginGroupExtension.cpp
+++ b/src/App/OriginGroupExtension.cpp
@@ -71,7 +71,7 @@ bool OriginGroupExtension::extensionGetSubObject(DocumentObject *&ret, const cha
 {
     App::DocumentObject *originObj = Origin.getValue ();
     const char *dot;
-    if(originObj && originObj->getNameInDocument() &&
+    if(originObj && originObj->isAttachedToDocument() &&
        subname && (dot=strchr(subname,'.')))
     {
         bool found;

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -129,7 +129,7 @@ Property *PropertyExpressionEngine::Copy() const
 void PropertyExpressionEngine::hasSetValue()
 {
     App::DocumentObject *owner = dynamic_cast<App::DocumentObject*>(getContainer());
-    if(!owner || !owner->getNameInDocument() || owner->isRestoring() || testFlag(LinkDetached)) {
+    if(!owner || !owner->isAttachedToDocument() || owner->isRestoring() || testFlag(LinkDetached)) {
         PropertyExpressionContainer::hasSetValue();
         return;
     }

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1485,7 +1485,7 @@ void PropertyString::setValue(const char* newLabel)
     auto obj = dynamic_cast<DocumentObject*>(getContainer());
     bool commit = false;
 
-    if(obj && obj->getNameInDocument() && this==&obj->Label &&
+    if(obj && obj->isAttachedToDocument() && this==&obj->Label &&
        (!obj->getDocument()->testStatus(App::Document::Restoring)||
         obj->getDocument()->testStatus(App::Document::Importing)) &&
        !obj->getDocument()->isPerformingTransaction())
@@ -1534,7 +1534,7 @@ void PropertyString::setValue(const char* newLabel)
                 {
                     // In case the label has the same base name as object's
                     // internal name, use it as the label instead.
-                    const char *objName = obj->getNameInDocument();
+                    const char *objName = obj->getNameInDocument().c_str();
                     const char *c = &objName[lastpos+1];
                     for(;*c;++c) {
                         if(*c<48 || *c>57)
@@ -1626,7 +1626,7 @@ void PropertyString::Save (Base::Writer &writer) const
     auto obj = dynamic_cast<DocumentObject*>(getContainer());
     writer.Stream() << writer.ind() << "<String ";
     bool exported = false;
-    if(obj && obj->getNameInDocument() &&
+    if(obj && obj->isAttachedToDocument() &&
        obj->isExporting() && &obj->Label==this)
     {
         if(obj->allowDuplicateLabel())

--- a/src/App/Transactions.cpp
+++ b/src/App/Transactions.cpp
@@ -65,7 +65,7 @@ Transaction::~Transaction()
     for (const auto & It : index) {
         if (It.second->status == TransactionObject::New) {
             // If an object has been removed from the document the transaction
-            // status is 'New'. The 'pcNameInDocument' member serves as criterion
+            // status is 'New'. The 'isAttachedToDocument()' member serves as criterion
             // to check whether the object is part of the document or not.
             // Note, it's possible that the transaction status is 'New' while the
             // object is (again) part of the document. This usually happens when

--- a/src/Gui/ActiveObjectList.cpp
+++ b/src/Gui/ActiveObjectList.cpp
@@ -46,7 +46,7 @@ App::DocumentObject *ActiveObjectList::getObject(const ObjectInfo &info, bool re
     if (subname)
         *subname = info.subname;
     auto obj = info.obj;
-    if (!obj || !obj->getNameInDocument())
+    if (!obj || !obj->isAttachedToDocument())
         return nullptr;
     if (!info.subname.empty()) {
         obj = obj->getSubObject(info.subname.c_str());
@@ -78,7 +78,7 @@ Gui::ActiveObjectList::ObjectInfo Gui::ActiveObjectList::getObjectInfo(App::Docu
 {
     ObjectInfo info;
     info.obj = nullptr;
-    if (!obj || !obj->getNameInDocument())
+    if (!obj || !obj->isAttachedToDocument())
         return info;
 
     if (subname) {

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -591,9 +591,9 @@ std::string Command::getObjectCmd(const char *Name, const App::Document *doc,
 std::string Command::getObjectCmd(const App::DocumentObject *obj,
         const char *prefix, const char *postfix, bool gui)
 {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return {"None"};
-    return getObjectCmd(obj->getNameInDocument(), obj->getDocument(), prefix, postfix,gui);
+    return getObjectCmd(obj->getNameInDocument().c_str(), obj->getDocument(), prefix, postfix,gui);
 }
 
 void Command::setAppModuleName(const char* s)
@@ -782,7 +782,7 @@ void Command::_copyVisual(const char *file, int line, const char* to, const char
 
 void Command::_copyVisual(const char *file, int line, const App::DocumentObject *to, const char* attr_to, const App::DocumentObject *from, const char *attr_from)
 {
-    if(!from || !from->getNameInDocument() || !to || !to->getNameInDocument())
+    if(!from || !from->isAttachedToDocument() || !to || !to->isAttachedToDocument())
         return;
     static std::map<std::string,std::string> attrMap = {
         {"ShapeColor","ShapeMaterial.DiffuseColor"},

--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -110,7 +110,7 @@
  */
 #define _FCMD_OBJ_CMD(_type,_cmd_type,_obj,_cmd) do{\
     auto __obj = _obj;\
-    if(__obj && __obj->getNameInDocument()) {\
+    if(__obj && __obj->isAttachedToDocument()) {\
         std::ostringstream _str;\
         _str << #_type ".getDocument('" << __obj->getDocument()->getName() \
              << "').getObject('" <<  __obj->getNameInDocument() << "')." << _cmd;\
@@ -178,7 +178,7 @@
  */
 #define FCMD_SET_EDIT(_obj) do{\
     auto __obj = _obj;\
-    if(__obj && __obj->getNameInDocument()) {\
+    if(__obj && __obj->isAttachedToDocument()) {\
         Gui::Command::doCommand(Gui::Command::Gui,\
             "Gui.ActiveDocument.setEdit(App.getDocument('%s').getObject('%s'), %i)",\
             __obj->getDocument()->getName(), __obj->getNameInDocument(), Gui::Application::Instance->getUserEditMode());\

--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -149,9 +149,9 @@
  */
 #define FCMD_OBJ_CMD2(_cmd,_obj,...) do{\
     auto __obj = _obj;\
-    if(__obj && __obj->getNameInDocument()) {\
+    if(__obj && __obj->isAttachedToDocument()) {\
         Gui::Command::doCommand(Gui::Command::Doc,"App.getDocument('%s').getObject('%s')." _cmd,\
-                __obj->getDocument()->getName(),__obj->getNameInDocument(),## __VA_ARGS__);\
+                __obj->getDocument()->getName(),__obj->getNameInDocument().c_str(),## __VA_ARGS__);\
     }\
 }while(0)
 
@@ -162,9 +162,9 @@
  */
 #define FCMD_VOBJ_CMD2(_cmd,_obj,...) do{\
     auto __obj = _obj;\
-    if(__obj && __obj->getNameInDocument()) {\
+    if(__obj && __obj->isAttachedToDocument()) {\
         Gui::Command::doCommand(Gui::Command::Gui,"Gui.getDocument('%s').getObject('%s')." _cmd,\
-                __obj->getDocument()->getName(),__obj->getNameInDocument(),## __VA_ARGS__);\
+                __obj->getDocument()->getName(),__obj->getNameInDocument().c_str(),## __VA_ARGS__);\
     }\
 }while(0)
 
@@ -181,7 +181,7 @@
     if(__obj && __obj->isAttachedToDocument()) {\
         Gui::Command::doCommand(Gui::Command::Gui,\
             "Gui.ActiveDocument.setEdit(App.getDocument('%s').getObject('%s'), %i)",\
-            __obj->getDocument()->getName(), __obj->getNameInDocument(), Gui::Application::Instance->getUserEditMode());\
+            __obj->getDocument()->getName(), __obj->getNameInDocument().c_str(), Gui::Application::Instance->getUserEditMode());\
     }\
 }while(0)
 

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1206,7 +1206,7 @@ void StdCmdDuplicateSelection::activated(int iMsg)
     std::vector<App::DocumentObject*> sel;
     std::set<App::DocumentObject*> objSet;
     for(auto &s : Selection().getCompleteSelection()) {
-        if(s.pObject && s.pObject->getNameInDocument() && objSet.insert(s.pObject).second)
+        if(s.pObject && s.pObject->isAttachedToDocument() && objSet.insert(s.pObject).second)
             sel.push_back(s.pObject);
     }
     if(sel.empty())
@@ -1366,7 +1366,7 @@ void StdCmdDelete::activated(int iMsg)
                             if(parent->getDocument() != obj->getDocument())
                                 label = QLatin1String(parent->getFullName().c_str());
                             else
-                                label = QLatin1String(parent->getNameInDocument());
+                                label = QLatin1String(parent->getNameInDocument().c_str());
                             if(parent->Label.getStrValue() != parent->getNameInDocument())
                                 label += QString::fromLatin1(" (%1)").arg(
                                         QString::fromUtf8(parent->Label.getValue()));

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -152,7 +152,7 @@ void StdCmdSendToPythonConsole::activated(int iMsg)
     if (!obj)
         return;
     QString docname = QString::fromLatin1(obj->getDocument()->getName());
-    QString objname = QString::fromLatin1(obj->getNameInDocument());
+    QString objname = QString::fromLatin1(obj->getNameInDocument().c_str());
     try {
         // clear variables from previous run, if any
         QString cmd = QLatin1String("try:\n    del(doc,lnk,obj,shp,sub,subs)\nexcept Exception:\n    pass\n");

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -129,7 +129,7 @@ void StdCmdLinkMakeGroup::activated(int option) {
     }
 
     for(auto &sel : Selection().getCompleteSelection()) {
-        if(sel.pObject && sel.pObject->getNameInDocument() &&
+        if(sel.pObject && sel.pObject->isAttachedToDocument() &&
            objset.insert(sel.pObject).second)
             objs.push_back(sel.pObject);
     }
@@ -231,7 +231,7 @@ void StdCmdLinkMake::activated(int) {
 
     std::set<App::DocumentObject*> objs;
     for(auto &sel : Selection().getCompleteSelection()) {
-        if(sel.pObject && sel.pObject->getNameInDocument())
+        if(sel.pObject && sel.pObject->isAttachedToDocument())
            objs.insert(sel.pObject);
     }
 
@@ -296,7 +296,7 @@ void StdCmdLinkMakeRelative::activated(int) {
         std::map<std::pair<App::DocumentObject*,std::string>,
                  std::pair<App::DocumentObject*, std::vector<std::string> > > linkInfo;
         for(auto &sel : Selection().getCompleteSelection(ResolveMode::NoResolve)) {
-            if(!sel.pObject || !sel.pObject->getNameInDocument())
+            if(!sel.pObject || !sel.pObject->isAttachedToDocument())
                 continue;
             auto key = std::make_pair(sel.pObject,
                     Data::noElementName(sel.SubName));
@@ -375,7 +375,7 @@ static void linkConvert(bool unlink) {
         info.inited = true;
         if(unlink) {
             auto linked = obj->getLinkedObject(false);
-            if(!linked || !linked->getNameInDocument() || linked == obj) {
+            if(!linked || !linked->isAttachedToDocument() || linked == obj) {
                 FC_WARN("skip non link");
                 continue;
             }
@@ -410,7 +410,7 @@ static void linkConvert(bool unlink) {
             App::DocumentObject *replaceObj;
             if(unlink) {
                 replaceObj = obj->getLinkedObject(false);
-                if(!replaceObj || !replaceObj->getNameInDocument() || replaceObj == obj)
+                if(!replaceObj || !replaceObj->isAttachedToDocument() || replaceObj == obj)
                     continue;
             }else{
                 auto name = doc->getUniqueObjectName("Link");
@@ -555,10 +555,10 @@ static std::map<App::Document*, std::vector<App::DocumentObject*> > getLinkImpor
     std::map<App::Document*, std::vector<App::DocumentObject*> > objMap;
     for(auto &sel : Selection().getCompleteSelection(ResolveMode::NoResolve)) {
         auto obj = sel.pObject->resolve(sel.SubName);
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         for(auto o : obj->getOutList()) {
-            if(o && o->getNameInDocument() && o->getDocument()!=obj->getDocument()) {
+            if(o && o->isAttachedToDocument() && o->getDocument()!=obj->getDocument()) {
                 objMap[obj->getDocument()].push_back(obj);
                 break;
             }
@@ -693,7 +693,7 @@ static App::DocumentObject *getSelectedLink(bool finalLink, std::string *subname
         return nullptr;
 
     auto linked = linkedVp->getObject();
-    if(!linked || !linked->getNameInDocument())
+    if(!linked || !linked->isAttachedToDocument())
         return nullptr;
 
     if(subname && sels[0].pObject!=sobj && sels[0].SubName) {
@@ -753,7 +753,7 @@ void StdCmdLinkSelectLinked::activated(int)
     Selection().selStackPush();
     Selection().clearCompleteSelection();
     if(!subname.empty()) {
-        Selection().addSelection(linked->getDocument()->getName(),linked->getNameInDocument(),subname.c_str());
+        Selection().addSelection(linked->getDocument()->getName(),linked->getNameInDocument().c_str(),subname.c_str());
         auto doc = Application::Instance->getDocument(linked->getDocument());
         if(doc) {
             auto vp = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(linked));

--- a/src/Gui/CommandT.h
+++ b/src/Gui/CommandT.h
@@ -355,7 +355,7 @@ inline void cmdSetEdit(const App::DocumentObject* obj, int mod = 0) {
     if (obj && obj->isAttachedToDocument()) {
         Gui::Command::doCommand(Gui::Command::Gui,
             "Gui.ActiveDocument.setEdit(App.getDocument('%s').getObject('%s'), %d)",
-            obj->getDocument()->getName(), obj->getNameInDocument(), mod);
+            obj->getDocument()->getName(), obj->getNameInDocument().c_str(), mod);
     }
 }
 
@@ -382,7 +382,7 @@ void cmdAppObjectArgs(const App::DocumentObject* obj, const std::string& cmd, Ar
         boost::format fmt(cmd);
         _cmd = FormatString::toStr(fmt, std::forward<Args>(args)...);
         Gui::Command::doCommand(Gui::Command::Doc,"App.getDocument('%s').getObject('%s').%s",
-            obj->getDocument()->getName(), obj->getNameInDocument(), _cmd.c_str());
+            obj->getDocument()->getName(), obj->getNameInDocument().c_str(), _cmd.c_str());
     }
     catch (const std::exception& e) {
         Base::Console().DeveloperError(obj->getFullLabel(),"%s: %s\n", e.what(), cmd.c_str());
@@ -407,7 +407,7 @@ void cmdGuiObjectArgs(const App::DocumentObject* obj, const std::string& cmd, Ar
         boost::format fmt(cmd);
         _cmd = FormatString::toStr(fmt, std::forward<Args>(args)...);
         Gui::Command::doCommand(Gui::Command::Gui,"Gui.getDocument('%s').getObject('%s').%s",
-            obj->getDocument()->getName(), obj->getNameInDocument(), _cmd.c_str());
+            obj->getDocument()->getName(), obj->getNameInDocument().c_str(), _cmd.c_str());
     }
     catch (const std::exception& e) {
         Base::Console().DeveloperError(obj->getFullLabel(),"%s: %s\n", e.what(), cmd.c_str());

--- a/src/Gui/CommandT.h
+++ b/src/Gui/CommandT.h
@@ -301,7 +301,7 @@ inline void cmdGuiDocument(const App::DocumentObject* obj, T&& cmd) {
  */
 template<typename T>
 void _cmdObject(Gui::Command::DoCmd_Type cmdType, const App::DocumentObject* obj, const std::string& mod, T&& cmd) {
-    if (obj && obj->getNameInDocument()) {
+    if (obj && obj->isAttachedToDocument()) {
         std::ostringstream str;
         str << mod << ".getDocument('" << obj->getDocument()->getName() << "')"
                       ".getObject('" << obj->getNameInDocument() << "')."
@@ -352,7 +352,7 @@ inline void cmdAppObjectShow(const App::DocumentObject* obj) {
  * external group.
  */
 inline void cmdSetEdit(const App::DocumentObject* obj, int mod = 0) {
-    if (obj && obj->getNameInDocument()) {
+    if (obj && obj->isAttachedToDocument()) {
         Gui::Command::doCommand(Gui::Command::Gui,
             "Gui.ActiveDocument.setEdit(App.getDocument('%s').getObject('%s'), %d)",
             obj->getDocument()->getName(), obj->getNameInDocument(), mod);

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -923,10 +923,10 @@ void StdCmdToggleSelectability::activated(int iMsg)
             if (pr && pr->isDerivedFrom(ViewProviderGeometryObject::getClassTypeId())){
                 if (static_cast<ViewProviderGeometryObject*>(pr)->Selectable.getValue())
                     doCommand(Gui,"Gui.getDocument(\"%s\").getObject(\"%s\").Selectable=False"
-                                 , doc->getName(), ft->getNameInDocument());
+                                 , doc->getName(), ft->getNameInDocument().c_str());
                 else
                     doCommand(Gui,"Gui.getDocument(\"%s\").getObject(\"%s\").Selectable=True"
-                                 , doc->getName(), ft->getNameInDocument());
+                                 , doc->getName(), ft->getNameInDocument().c_str());
             }
         }
     }
@@ -1064,10 +1064,10 @@ void StdCmdToggleObjects::activated(int iMsg)
     for (const auto & it : obj) {
         if (doc->isShow(it->getNameInDocument().c_str()))
             doCommand(Gui,"Gui.getDocument(\"%s\").getObject(\"%s\").Visibility=False"
-                         , app->getName(), it->getNameInDocument());
+                         , app->getName(), it->getNameInDocument().c_str());
         else
             doCommand(Gui,"Gui.getDocument(\"%s\").getObject(\"%s\").Visibility=True"
-                         , app->getName(), it->getNameInDocument());
+                         , app->getName(), it->getNameInDocument().c_str());
     }
 }
 
@@ -1104,7 +1104,7 @@ void StdCmdShowObjects::activated(int iMsg)
 
     for (const auto & it : obj) {
         doCommand(Gui,"Gui.getDocument(\"%s\").getObject(\"%s\").Visibility=True"
-                     , app->getName(), it->getNameInDocument());
+                     , app->getName(), it->getNameInDocument().c_str());
     }
 }
 
@@ -1141,7 +1141,7 @@ void StdCmdHideObjects::activated(int iMsg)
 
     for (const auto & it : obj) {
         doCommand(Gui,"Gui.getDocument(\"%s\").getObject(\"%s\").Visibility=False"
-                     , app->getName(), it->getNameInDocument());
+                     , app->getName(), it->getNameInDocument().c_str());
     }
 }
 

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -919,7 +919,7 @@ void StdCmdToggleSelectability::activated(int iMsg)
         TransactionView transaction(pcDoc, QT_TRANSLATE_NOOP("Command", "Toggle selectability"));
 
         for (const auto & ft : sel) {
-            ViewProvider *pr = pcDoc->getViewProviderByName(ft->getNameInDocument());
+            ViewProvider *pr = pcDoc->getViewProviderByName(ft->getNameInDocument().c_str());
             if (pr && pr->isDerivedFrom(ViewProviderGeometryObject::getClassTypeId())){
                 if (static_cast<ViewProviderGeometryObject*>(pr)->Selectable.getValue())
                     doCommand(Gui,"Gui.getDocument(\"%s\").getObject(\"%s\").Selectable=False"
@@ -1022,7 +1022,7 @@ void StdCmdSelectVisibleObjects::activated(int iMsg)
     std::vector<App::DocumentObject*> visible;
     visible.reserve(obj.size());
     for (const auto & it : obj) {
-        if (doc->isShow(it->getNameInDocument()))
+        if (doc->isShow(it->getNameInDocument().c_str()))
             visible.push_back(it);
     }
 
@@ -1062,7 +1062,7 @@ void StdCmdToggleObjects::activated(int iMsg)
         (App::DocumentObject::getClassTypeId());
 
     for (const auto & it : obj) {
-        if (doc->isShow(it->getNameInDocument()))
+        if (doc->isShow(it->getNameInDocument().c_str()))
             doCommand(Gui,"Gui.getDocument(\"%s\").getObject(\"%s\").Visibility=False"
                          , app->getName(), it->getNameInDocument());
         else
@@ -2705,7 +2705,7 @@ static std::vector<std::string> getBoxSelection(
 {
     std::vector<std::string> ret;
     auto obj = vp->getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return ret;
 
     // DO NOT check this view object Visibility, let the caller do this. Because
@@ -2872,7 +2872,7 @@ static void doSelect(void* ud, SoEventCallback * cb)
 
             Base::Matrix4D mat;
             for(auto &sub : getBoxSelection(vp,selectionMode,selectElement,proj,polygon,mat))
-                Gui::Selection().addSelection(doc->getName(), obj->getNameInDocument(), sub.c_str());
+                Gui::Selection().addSelection(doc->getName(), obj->getNameInDocument().c_str(), sub.c_str());
         }
     }
 }
@@ -3079,7 +3079,7 @@ bool StdCmdTreeSelectAllInstances::isActive()
     if(sels.empty())
         return false;
     auto obj = sels[0].getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return false;
     return dynamic_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(obj)) != nullptr;
@@ -3092,7 +3092,7 @@ void StdCmdTreeSelectAllInstances::activated(int iMsg)
     if(sels.empty())
         return;
     auto obj = sels[0].getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return;
     auto vpd = dynamic_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(obj));

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -939,16 +939,16 @@ void Model::mousePressEvent(QGraphicsSceneMouseEvent* event)
       if (!rect) continue;
       const GraphLinkRecord &selectionRecord = findRecord(rect, *graphLink);
       Gui::Selection().addSelection(selectionRecord.DObject->getDocument()->getName(),
-                                    selectionRecord.DObject->getNameInDocument());
+                                    selectionRecord.DObject->getNameInDocument().c_str());
     }
   };
 
   auto toggleSelect = [](const App::DocumentObject *dObjectIn, RectItem *rectIn)
   {
     if (rectIn->isSelected())
-      Gui::Selection().rmvSelection(dObjectIn->getDocument()->getName(), dObjectIn->getNameInDocument());
+      Gui::Selection().rmvSelection(dObjectIn->getDocument()->getName(), dObjectIn->getNameInDocument().c_str());
     else
-      Gui::Selection().addSelection(dObjectIn->getDocument()->getName(), dObjectIn->getNameInDocument());
+      Gui::Selection().addSelection(dObjectIn->getDocument()->getName(), dObjectIn->getNameInDocument().c_str());
   };
 
   if (proxy)
@@ -989,7 +989,7 @@ void Model::mousePressEvent(QGraphicsSceneMouseEvent* event)
           else
           {
             Gui::Selection().clearSelection(dObject->getDocument()->getName());
-            Gui::Selection().addSelection(dObject->getDocument()->getName(), dObject->getNameInDocument());
+            Gui::Selection().addSelection(dObject->getDocument()->getName(), dObject->getNameInDocument().c_str());
           }
         }
         if (selectionMode == SelectionMode::Multiple)
@@ -1067,7 +1067,7 @@ void Model::contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
     if (!rect->isSelected())
     {
       Gui::Selection().clearSelection(record.DObject->getDocument()->getName());
-      Gui::Selection().addSelection(record.DObject->getDocument()->getName(), record.DObject->getNameInDocument());
+      Gui::Selection().addSelection(record.DObject->getDocument()->getName(), record.DObject->getNameInDocument().c_str());
       lastPickValid = true;
       lastPick = event->scenePos();
     }

--- a/src/Gui/DlgObjectSelection.cpp
+++ b/src/Gui/DlgObjectSelection.cpp
@@ -544,7 +544,7 @@ QTreeWidgetItem *DlgObjectSelection::createDepItem(QTreeWidget *parent, App::Doc
         item->setFont(0, font);
     }
     item->setText(1, QString::fromUtf8(obj->getDocument()->getName()));
-    item->setText(2, QString::fromUtf8(obj->getNameInDocument()));
+    item->setText(2, QString::fromUtf8(obj->getNameInDocument().c_str()));
     item->setFlags(Qt::ItemIsSelectable|Qt::ItemIsUserCheckable|Qt::ItemIsEnabled);
     auto it = itemMap.find(obj);
     if (it != itemMap.end())

--- a/src/Gui/DlgPropertyLink.cpp
+++ b/src/Gui/DlgPropertyLink.cpp
@@ -143,29 +143,27 @@ QList<App::SubObjectT> DlgPropertyLink::getLinksFromProperty(const App::Property
 
 QString DlgPropertyLink::formatObject(App::Document *ownerDoc, App::DocumentObject *obj, const char *sub)
 {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return QLatin1String("?");
 
-    const char *objName = obj->getNameInDocument();
-    std::string _objName;
+    std::string objName = obj->getNameInDocument();
     if(ownerDoc && ownerDoc!=obj->getDocument()) {
-        _objName = obj->getFullName();
-        objName = _objName.c_str();
+        objName = obj->getFullName();
     }
 
     if(!sub || !sub[0]) {
         if(obj->Label.getStrValue() == obj->getNameInDocument())
-            return QLatin1String(objName);
-        return QString::fromLatin1("%1 (%2)").arg(QLatin1String(objName),
+            return QLatin1String(objName.c_str());
+        return QString::fromLatin1("%1 (%2)").arg(QLatin1String(objName.c_str()),
                                                   QString::fromUtf8(obj->Label.getValue()));
     }
 
     auto sobj = obj->getSubObject(sub);
     if(!sobj || sobj->Label.getStrValue() == sobj->getNameInDocument())
-        return QString::fromLatin1("%1.%2").arg(QLatin1String(objName),
+        return QString::fromLatin1("%1.%2").arg(QLatin1String(objName.c_str()),
                                                 QString::fromUtf8(sub));
 
-    return QString::fromLatin1("%1.%2 (%3)").arg(QLatin1String(objName),
+    return QString::fromLatin1("%1.%2 (%3)").arg(QLatin1String(objName.c_str()),
                                                  QString::fromUtf8(sub),
                                                  QString::fromUtf8(sobj->Label.getValue()));
 }
@@ -241,7 +239,7 @@ void DlgPropertyLink::init(const App::DocumentObjectT &prop, bool tryFilter) {
 
     objProp  = prop;
     auto owner = objProp.getObject();
-    if(!owner || !owner->getNameInDocument())
+    if(!owner || !owner->isAttachedToDocument())
         return;
 
     ui->searchBox->setDocumentObject(owner);
@@ -567,7 +565,7 @@ QTreeWidgetItem *DlgPropertyLink::findItem(
     if(pfound)
         *pfound = false;
 
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return nullptr;
 
     std::vector<App::DocumentObject *> sobjs;
@@ -608,7 +606,7 @@ QTreeWidgetItem *DlgPropertyLink::findItem(
         bool found = false;
         for(int i=0,count=item->childCount();i<count;++i) {
             auto child = item->child(i);
-            if(strcmp(o->getNameInDocument(),
+            if(strcmp(o->getNameInDocument().c_str(),
                         child->data(0, Qt::UserRole).toByteArray().constData())==0)
             {
                 item = child;
@@ -869,10 +867,10 @@ void DlgPropertyLink::itemSearch(const QString &text, bool select) {
             if(!found)
                 return;
             Gui::Selection().addSelection(obj->getDocument()->getName(),
-                    obj->getNameInDocument(),subname);
+                    obj->getNameInDocument().c_str(),subname);
         }else{
             Selection().setPreselect(obj->getDocument()->getName(),
-                    obj->getNameInDocument(), subname, 0, 0, 0,
+                    obj->getNameInDocument().c_str(), subname, 0, 0, 0,
                     Gui::SelectionChanges::MsgSource::TreeView);
             searchItem = item;
             ui->treeWidget->scrollToItem(searchItem);
@@ -887,7 +885,7 @@ void DlgPropertyLink::itemSearch(const QString &text, bool select) {
 QTreeWidgetItem *DlgPropertyLink::createItem(
         App::DocumentObject *obj, QTreeWidgetItem *parent)
 {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return nullptr;
 
     if(inList.find(obj)!=inList.end())
@@ -905,7 +903,7 @@ QTreeWidgetItem *DlgPropertyLink::createItem(
         item = new QTreeWidgetItem(ui->treeWidget);
     item->setIcon(0, vp->getIcon());
     item->setText(0, QString::fromUtf8((obj)->Label.getValue()));
-    item->setData(0, Qt::UserRole, QByteArray(obj->getNameInDocument()));
+    item->setData(0, Qt::UserRole, QByteArray(obj->getNameInDocument().c_str()));
     item->setData(0, Qt::UserRole+1, QByteArray(obj->getDocument()->getName()));
 
     if(allowSubObject) {
@@ -1038,7 +1036,7 @@ void DlgPropertyLink::onItemExpanded(QTreeWidgetItem * item) {
                 itemMap[obj] = newItem;
         }
     } else if(allowSubObject) {
-        auto obj = doc->getObject(objName);
+        auto obj = doc->getObject(std::string(objName));
         if(!obj)
             return;
         std::set<App::DocumentObject*> childSet;

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -305,7 +305,7 @@ bool Document::setEdit(Gui::ViewProvider* p, int ModNum, const char *subname)
     }
 
     auto obj = vp->getObject();
-    if(!obj->getNameInDocument()) {
+    if(!obj->isAttachedToDocument()) {
         FC_ERR("cannot edit detached object");
         return false;
     }
@@ -317,7 +317,7 @@ bool Document::setEdit(Gui::ViewProvider* p, int ModNum, const char *subname)
         auto sels = Gui::Selection().getCompleteSelection(ResolveMode::NoResolve);
         App::DocumentObject *parentObj = nullptr;
         for(auto &sel : sels) {
-            if(!sel.pObject || !sel.pObject->getNameInDocument())
+            if(!sel.pObject || !sel.pObject->isAttachedToDocument())
                 continue;
             if(!parentObj)
                 parentObj = sel.pObject;
@@ -386,7 +386,7 @@ bool Document::setEdit(Gui::ViewProvider* p, int ModNum, const char *subname)
     //     }
     // }
     auto sobj = obj->getSubObject(subname,nullptr,&d->_editingTransform);
-    if(!sobj || !sobj->getNameInDocument()) {
+    if(!sobj || !sobj->isAttachedToDocument()) {
         FC_ERR("Invalid sub object '" << obj->getFullName()
                 << '.' << (subname?subname:"") << "'");
         return false;
@@ -958,7 +958,7 @@ void Document::slotSkipRecompute(const App::Document& doc, const std::vector<App
     }
     if(!obj)
         obj = doc.getActiveObject();
-    if(!obj || !obj->getNameInDocument() || (!objs.empty() && objs.front()!=obj))
+    if(!obj || !obj->isAttachedToDocument() || (!objs.empty() && objs.front()!=obj))
         return;
     obj->recomputeFeature(true);
 }
@@ -2609,7 +2609,7 @@ void Document::handleChildren3D(ViewProvider* viewProvider, bool deleting)
             // add the remaining old children back to toplevel invertor node
             for(auto vpd : oldChildren) {
                 auto obj = vpd->getObject();
-                if(!obj || !obj->getNameInDocument())
+                if(!obj || !obj->isAttachedToDocument())
                     continue;
 
                 for (BaseView* view : d->baseViews) {

--- a/src/Gui/DocumentPyImp.cpp
+++ b/src/Gui/DocumentPyImp.cpp
@@ -138,7 +138,7 @@ PyObject* DocumentPy::setEdit(PyObject *args)
     }
 
     if (!vp) {
-        if (!obj || !obj->getNameInDocument() || !(vp=Application::Instance->getViewProvider(obj))) {
+        if (!obj || !obj->isAttachedToDocument() || !(vp=Application::Instance->getViewProvider(obj))) {
             PyErr_SetString(PyExc_ValueError,"Invalid document object");
             return nullptr;
         }
@@ -467,7 +467,7 @@ Py::Object DocumentPy::getInEditInfo() const {
     std::string subname,subelement;
     int mode = 0;
     getDocumentPtr()->getInEdit(&vp,&subname,&mode,&subelement);
-    if (!vp || !vp->getObject() || !vp->getObject()->getNameInDocument())
+    if (!vp || !vp->getObject() || !vp->getObject()->isAttachedToDocument())
         return Py::None();
 
     return Py::TupleN(Py::Object(vp->getObject()->getPyObject(),true),

--- a/src/Gui/ExpressionBinding.cpp
+++ b/src/Gui/ExpressionBinding.cpp
@@ -201,7 +201,7 @@ bool ExpressionBinding::apply(const std::string & propName)
         }
         Gui::Command::doCommand(Gui::Command::Doc,"App.getDocument('%s').%s.setExpression('%s', u'%s')",
                                 docObj->getDocument()->getName(),
-                                docObj->getNameInDocument(),
+                                docObj->getNameInDocument().c_str(),
                                 path.toEscapedString().c_str(),
                                 getEscapedExpressionString().c_str());
         if(transaction)
@@ -224,7 +224,7 @@ bool ExpressionBinding::apply(const std::string & propName)
                 }
                 Gui::Command::doCommand(Gui::Command::Doc,"App.getDocument('%s').%s.setExpression('%s', None)",
                                         docObj->getDocument()->getName(),
-                                        docObj->getNameInDocument(),
+                                        docObj->getNameInDocument().c_str(),
                                         path.toEscapedString().c_str());
                 if(transaction)
                     App::GetApplication().closeActiveTransaction();

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -381,7 +381,7 @@ public:
                     if (idx & 1)
                         res = QString::fromUtf8(quote(obj->Label.getStrValue()).c_str());
                     else
-                        res = QString::fromLatin1(obj->getNameInDocument());
+                        res = QString::fromLatin1(obj->getNameInDocument().c_str());
                     if (sep && !noProperty)
                         res += QLatin1Char('.');
                 }
@@ -421,7 +421,7 @@ public:
                     if (idx & 1)
                         res = QString::fromUtf8(quote(obj->Label.getStrValue()).c_str());
                     else
-                        res = QString::fromLatin1(obj->getNameInDocument());
+                        res = QString::fromLatin1(obj->getNameInDocument().c_str());
                     if (sep && !noProperty)
                         res += QLatin1Char('.');
                     v->setValue(res);
@@ -673,7 +673,7 @@ void ExpressionCompleter::init() {
 
 void ExpressionCompleter::setDocumentObject(const App::DocumentObject* obj, bool _checkInList)
 {
-    if (!obj || !obj->getNameInDocument())
+    if (!obj || !obj->isAttachedToDocument())
         currentObj = App::DocumentObjectT();
     else
         currentObj = obj;

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1919,7 +1919,7 @@ QMimeData * MainWindow::createMimeDataFromSelection () const
     std::vector<App::DocumentObject*> sel;
     std::set<App::DocumentObject*> objSet;
     for(auto &s : Selection().getCompleteSelection()) {
-        if(s.pObject && s.pObject->getNameInDocument() && objSet.insert(s.pObject).second)
+        if(s.pObject && s.pObject->isAttachedToDocument() && objSet.insert(s.pObject).second)
             sel.push_back(s.pObject);
     }
     if(sel.empty())

--- a/src/Gui/Placement.cpp
+++ b/src/Gui/Placement.cpp
@@ -276,7 +276,7 @@ QString PlacementHandler::getIncrementalPlacement(App::DocumentObject* obj, cons
     return QString::fromLatin1(
         R"(App.getDocument("%1").%2.%3=%4.multiply(App.getDocument("%1").%2.%3))")
         .arg(QString::fromLatin1(obj->getDocument()->getName()),
-             QString::fromLatin1(obj->getNameInDocument()),
+             QString::fromLatin1(obj->getNameInDocument().c_str()),
              QString::fromLatin1(this->propertyName.c_str()),
              data);
 }
@@ -286,7 +286,7 @@ QString PlacementHandler::getSimplePlacement(App::DocumentObject* obj, const QSt
     return QString::fromLatin1(
         "App.getDocument(\"%1\").%2.%3=%4")
         .arg(QString::fromLatin1(obj->getDocument()->getName()),
-             QString::fromLatin1(obj->getNameInDocument()),
+             QString::fromLatin1(obj->getNameInDocument().c_str()),
              QString::fromLatin1(this->propertyName.c_str()),
              data);
 }

--- a/src/Gui/SelectionView.cpp
+++ b/src/Gui/SelectionView.cpp
@@ -287,11 +287,11 @@ void SelectionView::search(const QString& text)
                     QTextStream str(&selObject);
                     QStringList list;
                     list << QString::fromLatin1(doc->getName());
-                    list << QString::fromLatin1(it->getNameInDocument());
+                    list << QString::fromLatin1(it->getNameInDocument().c_str());
                     // build name
                     str << QString::fromUtf8(doc->Label.getValue());
                     str << "#";
-                    str << it->getNameInDocument();
+                    str << it->getNameInDocument().c_str();
                     str << " (";
                     str << label;
                     str << ")";
@@ -311,7 +311,7 @@ void SelectionView::validateSearch()
         if (doc) {
             Gui::Selection().clearSelection();
             for (auto it : searchList) {
-                Gui::Selection().addSelection(doc->getName(),it->getNameInDocument(),nullptr);
+                Gui::Selection().addSelection(doc->getName(),it->getNameInDocument().c_str(),nullptr);
             }
         }
     }

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -419,7 +419,7 @@ public:
 
     void setHighlight(bool set, HighlightMode mode = HighlightMode::LightBlue);
 
-    const char *getName() const;
+    std::string getName() const;
     const char *getTreeName() const;
 
     bool isLink() const;

--- a/src/Gui/Utilities.cpp
+++ b/src/Gui/Utilities.cpp
@@ -136,7 +136,7 @@ public:
     explicit MatchName(const QString& n) : name(n)
     {}
     bool operator() (const App::DocumentObject* obj) {
-        return name == QLatin1String(obj->getNameInDocument());
+        return name == QLatin1String(obj->getNameInDocument().c_str());
     }
 private:
     QString name;

--- a/src/Gui/View3DInventorSelection.cpp
+++ b/src/Gui/View3DInventorSelection.cpp
@@ -108,7 +108,7 @@ void View3DInventorSelection::checkGroupOnTop(const SelectionChanges &Reason)
     if(!getDocument() || !Reason.pDocName || !Reason.pDocName[0] || !Reason.pObjectName)
         return;
     auto obj = getDocument()->getDocument()->getObject(Reason.pObjectName);
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return;
     std::string key(obj->getNameInDocument());
     key += '.';
@@ -155,7 +155,7 @@ void View3DInventorSelection::checkGroupOnTop(const SelectionChanges &Reason)
     auto svp = vp;
     if(subname && *subname) {
         auto sobj = obj->getSubObject(subname);
-        if(!sobj || !sobj->getNameInDocument())
+        if(!sobj || !sobj->isAttachedToDocument())
             return;
         if(sobj!=obj) {
             svp = dynamic_cast<ViewProviderDocumentObject*>(
@@ -206,7 +206,7 @@ void View3DInventorSelection::checkGroupOnTop(const SelectionChanges &Reason)
     std::set<ViewProvider*> visited;
     for(auto childVp=vp;;childVp=grpVp) {
         auto grp = App::GeoFeatureGroupExtension::getGroupOfObject(childVp->getObject());
-        if (!grp || !grp->getNameInDocument()) {
+        if (!grp || !grp->isAttachedToDocument()) {
             break;
         }
 

--- a/src/Gui/ViewProviderAnnotation.cpp
+++ b/src/Gui/ViewProviderAnnotation.cpp
@@ -206,7 +206,7 @@ void ViewProviderAnnotation::attach(App::DocumentObject* f)
     selectionColor.setPackedValue((uint32_t)selection, transparency);
     textsep->colorSelection.setValue(selectionColor);
 
-    textsep->objectName = pcObject->getNameInDocument();
+    textsep->objectName = pcObject->getNameInDocument().c_str();
     textsep->documentName = pcObject->getDocument()->getName();
     textsep->subElementName = "Main";
     textsep->addChild(pTranslation);
@@ -221,7 +221,7 @@ void ViewProviderAnnotation::attach(App::DocumentObject* f)
     textsep3d->colorHighlight.setValue(highlightColor);
     textsep3d->colorSelection.setValue(selectionColor);
 
-    textsep3d->objectName = pcObject->getNameInDocument();
+    textsep3d->objectName = pcObject->getNameInDocument().c_str();
     textsep3d->documentName = pcObject->getDocument()->getName();
     textsep3d->subElementName = "Main";
     textsep3d->addChild(pTranslation);

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -331,7 +331,7 @@ void ViewProviderDocumentObject::attach(App::DocumentObject *pcObj)
     // save Object pointer
     pcObject = pcObj;
 
-    if(pcObj && pcObj->getNameInDocument() &&
+    if(pcObj && pcObj->isAttachedToDocument() &&
        Visibility.getValue()!=pcObj->Visibility.getValue())
         pcObj->Visibility.setValue(Visibility.getValue());
 
@@ -519,14 +519,14 @@ bool ViewProviderDocumentObject::canDropObjectEx(App::DocumentObject* obj, App::
 int ViewProviderDocumentObject::replaceObject(
         App::DocumentObject *oldObj, App::DocumentObject *newObj)
 {
-    if(!oldObj || !oldObj->getNameInDocument()
-            || !newObj || !newObj->getNameInDocument())
+    if(!oldObj || !oldObj->isAttachedToDocument()
+            || !newObj || !newObj->isAttachedToDocument())
     {
         FC_THROWM(Base::RuntimeError,"Invalid object");
     }
 
     auto obj = getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         FC_THROWM(Base::RuntimeError,"View provider not attached");
 
     int res = ViewProvider::replaceObject(oldObj,newObj);
@@ -606,7 +606,7 @@ bool ViewProviderDocumentObject::getElementPicked(const SoPickedPoint *pp, std::
     if(!vp)
         return false;
     auto obj = vp->getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return false;
     std::ostringstream str;
     str << obj->getNameInDocument() << '.';
@@ -635,7 +635,7 @@ bool ViewProviderDocumentObject::getDetailPath(const char *subname, SoFullPath *
     if(!dot)
         return false;
     auto obj = getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return false;
     auto sobj = obj->getSubObject(std::string(subname,dot-subname+1).c_str());
     if(!sobj)
@@ -676,7 +676,7 @@ ViewProviderDocumentObject *ViewProviderDocumentObject::getLinkedViewProvider(
 {
     (void)subname;
     auto self = const_cast<ViewProviderDocumentObject*>(this);
-    if(!pcObject || !pcObject->getNameInDocument())
+    if(!pcObject || !pcObject->isAttachedToDocument())
         return self;
     auto linked = pcObject->getLinkedObject(recursive);
     if(!linked || linked == pcObject)

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
@@ -96,7 +96,7 @@ std::vector<App::DocumentObject*> ViewProviderGeoFeatureGroupExtension::extensio
     // remove the otherwise handled objects, preserving their order so the order in the TreeWidget is correct
     std::vector<App::DocumentObject*> Result;
     for(auto obj : model) {
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         if(outSet.count(obj))
             obj->setStatus(App::ObjectStatus::GeoExcluded,true);

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -64,8 +64,8 @@ void ViewProviderGroupExtension::extensionDragObject(App::DocumentObject* obj) {
 
     Gui::Command::doCommand(Gui::Command::Doc,"App.getDocument(\"%s\").getObject(\"%s\").removeObject("
             "App.getDocument(\"%s\").getObject(\"%s\"))",
-            getExtendedViewProvider()->getObject()->getDocument()->getName(), getExtendedViewProvider()->getObject()->getNameInDocument(),
-            obj->getDocument()->getName(), obj->getNameInDocument() );
+            getExtendedViewProvider()->getObject()->getDocument()->getName(), getExtendedViewProvider()->getObject()->getNameInDocument().c_str(),
+            obj->getDocument()->getName(), obj->getNameInDocument().c_str() );
 }
 
 bool ViewProviderGroupExtension::extensionCanDropObjects() const {
@@ -171,7 +171,7 @@ bool ViewProviderGroupExtension::extensionOnDelete(const std::vector< std::strin
             Gui::Command::doCommand(Gui::Command::Doc,
                     "App.getDocument(\"%s\").getObject(\"%s\").removeObjectsFromDocument()"
                     , getExtendedViewProvider()->getObject()->getDocument()->getName()
-                    , getExtendedViewProvider()->getObject()->getNameInDocument());
+                    , getExtendedViewProvider()->getObject()->getNameInDocument().c_str());
         }
     }
     return true;

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -100,8 +100,8 @@ void ViewProviderGroupExtension::extensionDropObject(App::DocumentObject* obj) {
     cmd = QString::fromLatin1("App.getDocument(\"%1\").getObject(\"%2\").addObject("
                         "App.getDocument(\"%1\").getObject(\"%3\"))")
                         .arg(QString::fromLatin1(doc->getName()),
-                             QString::fromLatin1(grp->getNameInDocument()),
-                             QString::fromLatin1(obj->getNameInDocument()));
+                             QString::fromLatin1(grp->getNameInDocument().c_str()),
+                             QString::fromLatin1(obj->getNameInDocument().c_str()));
 
     Gui::Command::doCommand(Gui::Command::App, cmd.toUtf8());
 }

--- a/src/Gui/ViewProviderInventorObject.cpp
+++ b/src/Gui/ViewProviderInventorObject.cpp
@@ -100,8 +100,8 @@ void ViewProviderInventorObject::updateData(const App::Property* prop)
         SoSeparator * node = SoDB::readAll(&in);
         if (node) {
             const char* doc = this->pcObject->getDocument()->getName();
-            const char* obj = this->pcObject->getNameInDocument();
-            adjustSelectionNodes(node, doc, obj);
+            std::string obj = this->pcObject->getNameInDocument();
+            adjustSelectionNodes(node, doc, obj.c_str());
             pcBuffer->addChild(node);
         }
     }
@@ -118,8 +118,8 @@ void ViewProviderInventorObject::updateData(const App::Property* prop)
             SoSeparator * node = SoDB::readAll(&in);
             if (node) {
                 const char* doc = this->pcObject->getDocument()->getName();
-                const char* obj = this->pcObject->getNameInDocument();
-                adjustSelectionNodes(node, doc, obj);
+                std::string obj = this->pcObject->getNameInDocument();
+                adjustSelectionNodes(node, doc, obj.c_str());
                 pcFile->addChild(node);
             }
         }

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -135,7 +135,7 @@ public:
     std::map<qint64, QIcon> iconMap;
 
     static ViewProviderDocumentObject *getView(App::DocumentObject *obj) {
-        if(obj && obj->getNameInDocument()) {
+        if(obj && obj->isAttachedToDocument()) {
             Document *pDoc = Application::Instance->getDocument(obj->getDocument());
             if(pDoc) {
                 ViewProvider *vp = pDoc->getViewProvider(obj);
@@ -221,11 +221,11 @@ public:
 
     bool isLinked() const {
         return pcLinked && pcLinked->getObject() &&
-           pcLinked->getObject()->getNameInDocument();
+           pcLinked->getObject()->isAttachedToDocument();
     }
 
     const char *getLinkedName() const {
-        return pcLinked->getObject()->getNameInDocument();
+        return pcLinked->getObject()->getDagKey();
     }
 
     const char *getLinkedLabel() const {
@@ -539,7 +539,8 @@ public:
         //     ++subname;
         //     CHECK_NAME(obj->getDocument()->getName(),'*');
         // }
-        CHECK_NAME(obj->getNameInDocument(),'.');
+        std::string objName = obj->getNameInDocument();
+        CHECK_NAME(objName.c_str(),'.');
         return subname;
     }
 
@@ -1777,13 +1778,13 @@ bool ViewProviderLink::setLinkType(App::LinkBaseExtension *ext) {
 }
 
 App::LinkBaseExtension *ViewProviderLink::getLinkExtension() {
-    if(!pcObject || !pcObject->getNameInDocument())
+    if(!pcObject || !pcObject->isAttachedToDocument())
         return nullptr;
     return pcObject->getExtensionByType<App::LinkBaseExtension>(true);
 }
 
 const App::LinkBaseExtension *ViewProviderLink::getLinkExtension() const{
-    if(!pcObject || !pcObject->getNameInDocument())
+    if(!pcObject || !pcObject->isAttachedToDocument())
         return nullptr;
     return const_cast<App::DocumentObject*>(pcObject)->getExtensionByType<App::LinkBaseExtension>(true);
 }

--- a/src/Gui/ViewProviderOrigin.cpp
+++ b/src/Gui/ViewProviderOrigin.cpp
@@ -215,7 +215,7 @@ bool ViewProviderOrigin::onDelete(const std::vector<std::string> &) {
 
     for (auto obj: objs ) {
         Gui::Command::doCommand( Gui::Command::Doc, "App.getDocument(\"%s\").removeObject(\"%s\")",
-                obj->getDocument()->getName(), obj->getNameInDocument() );
+                obj->getDocument()->getName(), obj->getNameInDocument().c_str() );
     }
 
     return true;

--- a/src/Gui/ViewProviderOriginFeature.cpp
+++ b/src/Gui/ViewProviderOriginFeature.cpp
@@ -103,15 +103,15 @@ void ViewProviderOriginFeature::attach(App::DocumentObject* pcObject)
     if ( pcObject->getTypeId() == App::Line::getClassTypeId() ) {
         // keep font size on axes equal to font size on planes
         fontRatio *= ViewProviderOrigin::axesScaling;
-        const char* axisName = pcObject->getNameInDocument();
+        std::string axisName = pcObject->getNameInDocument();
         auto axisRoles = App::Origin::AxisRoles;
-        if ( strncmp(axisName, axisRoles[0], strlen(axisRoles[0]) ) == 0 ) {
+        if ( strncmp(axisName.c_str(), axisRoles[0], strlen(axisRoles[0]) ) == 0 ) {
             // X-axis: red
             ShapeColor.setValue ( 0xFF0000FF );
-        } else if ( strncmp(axisName, axisRoles[1], strlen(axisRoles[1]) ) == 0 ) {
+        } else if ( strncmp(axisName.c_str(), axisRoles[1], strlen(axisRoles[1]) ) == 0 ) {
             // Y-axis: green
             ShapeColor.setValue ( 0x00FF00FF );
-        } else if ( strncmp(axisName, axisRoles[2], strlen(axisRoles[2]) ) == 0 ) {
+        } else if ( strncmp(axisName.c_str(), axisRoles[2], strlen(axisRoles[2]) ) == 0 ) {
             // Z-axis: blue
             ShapeColor.setValue ( 0x0000FFFF );
         }
@@ -125,7 +125,7 @@ void ViewProviderOriginFeature::attach(App::DocumentObject* pcObject)
     if ( !Selectable.getValue() ) {
         highlight->selectionMode = Gui::SoFCSelection::SEL_OFF;
     }
-    highlight->objectName    = getObject()->getNameInDocument();
+    highlight->objectName    = getObject()->getNameInDocument().c_str();
     highlight->documentName  = getObject()->getDocument()->getName();
     highlight->style = SoFCSelection::EMISSIVE_DIFFUSE;
 

--- a/src/Gui/ViewProviderOriginGroupExtension.cpp
+++ b/src/Gui/ViewProviderOriginGroupExtension.cpp
@@ -139,7 +139,7 @@ void ViewProviderOriginGroupExtension::slotChangedObjectGui ( const Gui::ViewPro
 void ViewProviderOriginGroupExtension::updateOriginSize () {
     auto owner = getExtendedViewProvider()->getObject();
 
-    if(!owner->getNameInDocument() ||
+    if(!owner->isAttachedToDocument() ||
        owner->isRemoving() ||
        owner->getDocument()->testStatus(App::Document::Restoring))
         return;

--- a/src/Gui/ViewProviderPart.cpp
+++ b/src/Gui/ViewProviderPart.cpp
@@ -103,7 +103,7 @@ bool ViewProviderPart::doubleClicked()
                 "Gui.ActiveDocument.ActiveView.setActiveObject('%s', App.getDocument('%s').getObject('%s'))",
                 PARTKEY,
                 this->getObject()->getDocument()->getName(),
-                this->getObject()->getNameInDocument());
+                this->getObject()->getNameInDocument().c_str());
     }
 
     return true;

--- a/src/Gui/ViewProviderPythonFeature.cpp
+++ b/src/Gui/ViewProviderPythonFeature.cpp
@@ -1136,8 +1136,8 @@ ViewProviderPythonFeatureImp::ValueT
 ViewProviderPythonFeatureImp::replaceObject(
         App::DocumentObject *oldObj, App::DocumentObject *newObj)
 {
-    if(!oldObj || !oldObj->getNameInDocument()
-            || !newObj || !newObj->getNameInDocument())
+    if(!oldObj || !oldObj->isAttachedToDocument()
+            || !newObj || !newObj->isAttachedToDocument())
         return NotImplemented;
 
     FC_PY_CALL_CHECK(replaceObject);

--- a/src/Gui/ViewProviderVRMLObject.cpp
+++ b/src/Gui/ViewProviderVRMLObject.cpp
@@ -74,7 +74,7 @@ void ViewProviderVRMLObject::attach(App::DocumentObject *pcObj)
 {
     ViewProviderDocumentObject::attach(pcObj);
     addDisplayMaskMode(pcVRML, "VRML");
-    pcVRML->objectName = pcObj->getNameInDocument();
+    pcVRML->objectName = pcObj->getNameInDocument().c_str();
     pcVRML->documentName = pcObj->getDocument()->getName();
     pcVRML->subElementName = "Main";
 }
@@ -219,7 +219,7 @@ void ViewProviderVRMLObject::updateData(const App::Property* prop)
         if (!fn.isEmpty() && file.open(QFile::ReadOnly)) {
             QFileInfo fi(fn);
             QByteArray filepath = fi.absolutePath().toUtf8();
-            QByteArray subpath = filepath + "/" + ivObj->getNameInDocument();
+            QByteArray subpath = filepath + "/" + ivObj->getNameInDocument().c_str();
 
             // Add this to the search path in order to read inline files
             SoInput::addDirectoryFirst(filepath.constData());

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -294,7 +294,7 @@ void PropertyEditor::openEditor(const QModelIndex &index)
             break;
         }
     }
-    if(obj && obj->getNameInDocument())
+    if(obj && obj->isAttachedToDocument())
         str << obj->getNameInDocument() << '.';
     else
         str << tr("property").toUtf8().constData() << ' ';

--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -1047,7 +1047,7 @@ void DefineNodesCallback(void* ud, SoEventCallback* n)
                             set.str().c_str());
     Gui::Command::doCommand(Gui::Command::Doc,
                             "App.activeDocument().%s.addObject(App.activeDocument().NodeSet)",
-                            Analysis->getNameInDocument());
+                            Analysis->getNameInDocument().c_str());
     // Gui::Command::updateActive();
     Gui::Command::commitCommand();
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -632,11 +632,12 @@ void TaskDlgFemConstraintDisplacement::open()
         QString msg = QObject::tr("Displacement boundary condition");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-                .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                ViewProviderFemConstraint::gethideMeshShowPartStr(
+                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                        ->getNameInDocument()
+                                        .c_str())
+                                    .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -632,12 +632,11 @@ void TaskDlgFemConstraintDisplacement::open()
         QString msg = QObject::tr("Displacement boundary condition");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc,
-                                ViewProviderFemConstraint::gethideMeshShowPartStr(
-                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                        ->getNameInDocument()
-                                        .c_str())
-                                    .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            ViewProviderFemConstraint::gethideMeshShowPartStr(
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -635,7 +635,7 @@ void TaskDlgFemConstraintDisplacement::open()
         Gui::Command::doCommand(
             Gui::Command::Doc,
             ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
                 .c_str());  // OvG: Hide meshes and show parts
     }
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
@@ -286,12 +286,11 @@ void TaskDlgFemConstraintFixed::open()
         QString msg = QObject::tr("Fixed boundary condition");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc,
-                                ViewProviderFemConstraint::gethideMeshShowPartStr(
-                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                        ->getNameInDocument()
-                                        .c_str())
-                                    .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            ViewProviderFemConstraint::gethideMeshShowPartStr(
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
@@ -289,7 +289,7 @@ void TaskDlgFemConstraintFixed::open()
         Gui::Command::doCommand(
             Gui::Command::Doc,
             ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
                 .c_str());  // OvG: Hide meshes and show parts
     }
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
@@ -286,11 +286,12 @@ void TaskDlgFemConstraintFixed::open()
         QString msg = QObject::tr("Fixed boundary condition");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-                .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                ViewProviderFemConstraint::gethideMeshShowPartStr(
+                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                        ->getNameInDocument()
+                                        .c_str())
+                                    .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -433,11 +433,12 @@ void TaskDlgFemConstraintForce::open()
         QString msg = QObject::tr("Force load");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-                .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                ViewProviderFemConstraint::gethideMeshShowPartStr(
+                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                        ->getNameInDocument()
+                                        .c_str())
+                                    .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -433,12 +433,11 @@ void TaskDlgFemConstraintForce::open()
         QString msg = QObject::tr("Force load");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc,
-                                ViewProviderFemConstraint::gethideMeshShowPartStr(
-                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                        ->getNameInDocument()
-                                        .c_str())
-                                    .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            ViewProviderFemConstraint::gethideMeshShowPartStr(
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -436,7 +436,7 @@ void TaskDlgFemConstraintForce::open()
         Gui::Command::doCommand(
             Gui::Command::Doc,
             ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
                 .c_str());  // OvG: Hide meshes and show parts
     }
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -438,11 +438,12 @@ void TaskDlgFemConstraintHeatflux::open()
         QString msg = QObject::tr("Heat flux load");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-                .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                ViewProviderFemConstraint::gethideMeshShowPartStr(
+                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                        ->getNameInDocument()
+                                        .c_str())
+                                    .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -438,12 +438,11 @@ void TaskDlgFemConstraintHeatflux::open()
         QString msg = QObject::tr("Heat flux load");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc,
-                                ViewProviderFemConstraint::gethideMeshShowPartStr(
-                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                        ->getNameInDocument()
-                                        .c_str())
-                                    .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            ViewProviderFemConstraint::gethideMeshShowPartStr(
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -441,7 +441,7 @@ void TaskDlgFemConstraintHeatflux::open()
         Gui::Command::doCommand(
             Gui::Command::Doc,
             ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
                 .c_str());  // OvG: Hide meshes and show parts
     }
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
@@ -102,7 +102,7 @@ void TaskDlgFemConstraintInitialTemperature::open()
         Gui::Command::doCommand(
             Gui::Command::Doc,
             ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
                 .c_str());  // OvG: Hide meshes and show parts
     }
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
@@ -99,11 +99,12 @@ void TaskDlgFemConstraintInitialTemperature::open()
         QString msg = QObject::tr("Constraint initial temperature");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-                .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                ViewProviderFemConstraint::gethideMeshShowPartStr(
+                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                        ->getNameInDocument()
+                                        .c_str())
+                                    .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
@@ -99,12 +99,11 @@ void TaskDlgFemConstraintInitialTemperature::open()
         QString msg = QObject::tr("Constraint initial temperature");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc,
-                                ViewProviderFemConstraint::gethideMeshShowPartStr(
-                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                        ->getNameInDocument()
-                                        .c_str())
-                                    .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            ViewProviderFemConstraint::gethideMeshShowPartStr(
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
@@ -315,7 +315,7 @@ void TaskDlgFemConstraintPlaneRotation::open()
         Gui::Command::doCommand(
             Gui::Command::Doc,
             ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
                 .c_str());  // OvG: Hide meshes and show parts
     }
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
@@ -312,11 +312,12 @@ void TaskDlgFemConstraintPlaneRotation::open()
         QString msg = QObject::tr("Plane multi-point constraint");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-                .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                ViewProviderFemConstraint::gethideMeshShowPartStr(
+                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                        ->getNameInDocument()
+                                        .c_str())
+                                    .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
@@ -312,12 +312,11 @@ void TaskDlgFemConstraintPlaneRotation::open()
         QString msg = QObject::tr("Plane multi-point constraint");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc,
-                                ViewProviderFemConstraint::gethideMeshShowPartStr(
-                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                        ->getNameInDocument()
-                                        .c_str())
-                                    .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            ViewProviderFemConstraint::gethideMeshShowPartStr(
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -302,11 +302,12 @@ void TaskDlgFemConstraintPressure::open()
         QString msg = QObject::tr("Pressure load");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-                .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                ViewProviderFemConstraint::gethideMeshShowPartStr(
+                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                        ->getNameInDocument()
+                                        .c_str())
+                                    .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -302,12 +302,11 @@ void TaskDlgFemConstraintPressure::open()
         QString msg = QObject::tr("Pressure load");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc,
-                                ViewProviderFemConstraint::gethideMeshShowPartStr(
-                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                        ->getNameInDocument()
-                                        .c_str())
-                                    .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            ViewProviderFemConstraint::gethideMeshShowPartStr(
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -305,7 +305,7 @@ void TaskDlgFemConstraintPressure::open()
         Gui::Command::doCommand(
             Gui::Command::Doc,
             ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
                 .c_str());  // OvG: Hide meshes and show parts
     }
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
@@ -201,11 +201,12 @@ void TaskDlgFemConstraintPulley::open()
         QString msg = QObject::tr("Constraint pulley");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-                .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                ViewProviderFemConstraint::gethideMeshShowPartStr(
+                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                        ->getNameInDocument()
+                                        .c_str())
+                                    .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
@@ -204,7 +204,7 @@ void TaskDlgFemConstraintPulley::open()
         Gui::Command::doCommand(
             Gui::Command::Doc,
             ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
                 .c_str());  // OvG: Hide meshes and show parts
     }
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
@@ -201,12 +201,11 @@ void TaskDlgFemConstraintPulley::open()
         QString msg = QObject::tr("Constraint pulley");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc,
-                                ViewProviderFemConstraint::gethideMeshShowPartStr(
-                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                        ->getNameInDocument()
-                                        .c_str())
-                                    .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            ViewProviderFemConstraint::gethideMeshShowPartStr(
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
@@ -313,7 +313,7 @@ void TaskDlgFemConstraintSpring::open()
         Gui::Command::doCommand(
             Gui::Command::Doc,
             ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
                 .c_str());  // OvG: Hide meshes and show parts
     }
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
@@ -310,11 +310,12 @@ void TaskDlgFemConstraintSpring::open()
         QString msg = QObject::tr("Constraint spring");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-                .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                ViewProviderFemConstraint::gethideMeshShowPartStr(
+                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                        ->getNameInDocument()
+                                        .c_str())
+                                    .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
@@ -310,12 +310,11 @@ void TaskDlgFemConstraintSpring::open()
         QString msg = QObject::tr("Constraint spring");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc,
-                                ViewProviderFemConstraint::gethideMeshShowPartStr(
-                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                        ->getNameInDocument()
-                                        .c_str())
-                                    .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            ViewProviderFemConstraint::gethideMeshShowPartStr(
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -339,12 +339,11 @@ void TaskDlgFemConstraintTemperature::open()
         QString msg = QObject::tr("Temperature boundary condition");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc,
-                                ViewProviderFemConstraint::gethideMeshShowPartStr(
-                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                        ->getNameInDocument()
-                                        .c_str())
-                                    .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            ViewProviderFemConstraint::gethideMeshShowPartStr(
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -342,7 +342,7 @@ void TaskDlgFemConstraintTemperature::open()
         Gui::Command::doCommand(
             Gui::Command::Doc,
             ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
                 .c_str());  // OvG: Hide meshes and show parts
     }
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -339,11 +339,12 @@ void TaskDlgFemConstraintTemperature::open()
         QString msg = QObject::tr("Temperature boundary condition");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-                .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                ViewProviderFemConstraint::gethideMeshShowPartStr(
+                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                        ->getNameInDocument()
+                                        .c_str())
+                                    .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -127,11 +127,12 @@ TaskFemConstraintTransform::TaskFemConstraintTransform(
     ui->lw_Rect->clear();
 
     // Transformable surfaces
-    Gui::Command::doCommand(
-        Gui::Command::Doc,
-        TaskFemConstraintTransform::getSurfaceReferences(
-            (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-            .c_str());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            TaskFemConstraintTransform::getSurfaceReferences(
+                                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                    ->getNameInDocument()
+                                    .c_str())
+                                .c_str());
     std::vector<App::DocumentObject*> ObjDispl = pcConstraint->RefDispl.getValues();
     std::vector<std::string> SubElemDispl = pcConstraint->RefDispl.getSubValues();
 
@@ -591,11 +592,12 @@ void TaskDlgFemConstraintTransform::open()
         QString msg = QObject::tr("Local coordinate system");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(
-            Gui::Command::Doc,
-            ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
-                .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(Gui::Command::Doc,
+                                ViewProviderFemConstraint::gethideMeshShowPartStr(
+                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
+                                        ->getNameInDocument()
+                                        .c_str())
+                                    .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -127,12 +127,11 @@ TaskFemConstraintTransform::TaskFemConstraintTransform(
     ui->lw_Rect->clear();
 
     // Transformable surfaces
-    Gui::Command::doCommand(Gui::Command::Doc,
-                            TaskFemConstraintTransform::getSurfaceReferences(
-                                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                    ->getNameInDocument()
-                                    .c_str())
-                                .c_str());
+    Gui::Command::doCommand(
+        Gui::Command::Doc,
+        TaskFemConstraintTransform::getSurfaceReferences(
+            (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+            .c_str());
     std::vector<App::DocumentObject*> ObjDispl = pcConstraint->RefDispl.getValues();
     std::vector<std::string> SubElemDispl = pcConstraint->RefDispl.getSubValues();
 
@@ -592,12 +591,11 @@ void TaskDlgFemConstraintTransform::open()
         QString msg = QObject::tr("Local coordinate system");
         Gui::Command::openCommand((const char*)msg.toUtf8());
         ConstraintView->setVisible(true);
-        Gui::Command::doCommand(Gui::Command::Doc,
-                                ViewProviderFemConstraint::gethideMeshShowPartStr(
-                                    (static_cast<Fem::Constraint*>(ConstraintView->getObject()))
-                                        ->getNameInDocument()
-                                        .c_str())
-                                    .c_str());  // OvG: Hide meshes and show parts
+        Gui::Command::doCommand(
+            Gui::Command::Doc,
+            ViewProviderFemConstraint::gethideMeshShowPartStr(
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                .c_str());  // OvG: Hide meshes and show parts
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -130,7 +130,7 @@ TaskFemConstraintTransform::TaskFemConstraintTransform(
     Gui::Command::doCommand(
         Gui::Command::Doc,
         TaskFemConstraintTransform::getSurfaceReferences(
-            (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+            (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
             .c_str());
     std::vector<App::DocumentObject*> ObjDispl = pcConstraint->RefDispl.getValues();
     std::vector<std::string> SubElemDispl = pcConstraint->RefDispl.getSubValues();
@@ -594,7 +594,7 @@ void TaskDlgFemConstraintTransform::open()
         Gui::Command::doCommand(
             Gui::Command::Doc,
             ViewProviderFemConstraint::gethideMeshShowPartStr(
-                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
+                (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument().c_str())
                 .c_str());  // OvG: Hide meshes and show parts
     }
 }

--- a/src/Mod/Fem/Gui/TaskObjectName.cpp
+++ b/src/Mod/Fem/Gui/TaskObjectName.cpp
@@ -58,7 +58,8 @@ TaskObjectName::TaskObjectName(App::DocumentObject* pcObject, QWidget* parent)
         ui->lineEdit_ObjectName->setText(QString::fromUtf8(pcObject->Label.getValue()));
     }
     else {
-        ui->lineEdit_ObjectName->setText(QString::fromLatin1(pcObject->getNameInDocument().c_str()));
+        ui->lineEdit_ObjectName->setText(
+            QString::fromLatin1(pcObject->getNameInDocument().c_str()));
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskObjectName.cpp
+++ b/src/Mod/Fem/Gui/TaskObjectName.cpp
@@ -58,7 +58,7 @@ TaskObjectName::TaskObjectName(App::DocumentObject* pcObject, QWidget* parent)
         ui->lineEdit_ObjectName->setText(QString::fromUtf8(pcObject->Label.getValue()));
     }
     else {
-        ui->lineEdit_ObjectName->setText(QString::fromLatin1(pcObject->getNameInDocument()));
+        ui->lineEdit_ObjectName->setText(QString::fromLatin1(pcObject->getNameInDocument().c_str()));
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskPostBoxes.cpp
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.cpp
@@ -1369,7 +1369,7 @@ void TaskPostClip::collectImplicitFunctions()
                 static_cast<Fem::FemPostFunctionProvider*>(pipeline->Functions.getValue())
                     ->Functions.getValues();
             for (std::size_t i = 0; i < funcs.size(); ++i) {
-                items.push_back(QString::fromLatin1(funcs[i]->getNameInDocument()));
+                items.push_back(QString::fromLatin1(funcs[i]->getNameInDocument().c_str()));
                 if (currentFunction == funcs[i]) {
                     currentItem = i;
                 }
@@ -1659,7 +1659,7 @@ void TaskPostCut::collectImplicitFunctions()
                 static_cast<Fem::FemPostFunctionProvider*>(pipeline->Functions.getValue())
                     ->Functions.getValues();
             for (std::size_t i = 0; i < funcs.size(); ++i) {
-                items.push_back(QString::fromLatin1(funcs[i]->getNameInDocument()));
+                items.push_back(QString::fromLatin1(funcs[i]->getNameInDocument().c_str()));
                 if (currentFunction == funcs[i]) {
                     currentItem = i;
                 }

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -121,7 +121,7 @@ bool ViewProviderFemAnalysis::doubleClicked()
     Gui::Command::addModule(Gui::Command::Gui, "FemGui");
     Gui::Command::doCommand(Gui::Command::Gui,
                             "FemGui.setActiveAnalysis(App.activeDocument().%s)",
-                            this->getObject()->getNameInDocument());
+                            this->getObject()->getNameInDocument().c_str());
     // After activation of the analysis the allowed FEM toolbar buttons should become active.
     // To achieve this we must clear the object selection to trigger the selection observer.
     Gui::Command::doCommand(Gui::Command::Gui, "Gui.Selection.clearSelection()");

--- a/src/Mod/Import/App/ExportOCAF2.cpp
+++ b/src/Mod/Import/App/ExportOCAF2.cpp
@@ -611,7 +611,7 @@ bool ExportOCAF2::canFallback(std::vector<App::DocumentObject*> objs)
 {
     for (size_t i = 0; i < objs.size(); ++i) {
         auto obj = objs[i];
-        if (!obj || !obj->getNameInDocument()) {
+        if (!obj || !obj->isAttachedToDocument()) {
             continue;
         }
         if (obj->getExtensionByType<App::LinkBaseExtension>(true)) {

--- a/src/Mod/Inspection/Gui/VisualInspection.cpp
+++ b/src/Mod/Inspection/Gui/VisualInspection.cpp
@@ -128,13 +128,13 @@ VisualInspection::VisualInspection(QWidget* parent, Qt::WindowFlags fl)
             QIcon px = view->getIcon();
             SingleSelectionItem* item1 = new SingleSelectionItem(ui->treeWidgetActual);
             item1->setText(0, QString::fromUtf8(it->Label.getValue()));
-            item1->setData(0, Qt::UserRole, QString::fromLatin1(it->getNameInDocument()));
+            item1->setData(0, Qt::UserRole, QString::fromLatin1(it->getNameInDocument().c_str()));
             item1->setCheckState(0, Qt::Unchecked);
             item1->setIcon(0, px);
 
             SingleSelectionItem* item2 = new SingleSelectionItem(ui->treeWidgetNominal);
             item2->setText(0, QString::fromUtf8(it->Label.getValue()));
-            item2->setData(0, Qt::UserRole, QString::fromLatin1(it->getNameInDocument()));
+            item2->setData(0, Qt::UserRole, QString::fromLatin1(it->getNameInDocument().c_str()));
             item2->setCheckState(0, Qt::Unchecked);
             item2->setIcon(0, px);
 

--- a/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
@@ -260,7 +260,7 @@ void DlgEvaluateMeshImp::slotCreatedObject(const App::DocumentObject& Obj)
     // add new mesh object to the list
     if (Obj.getTypeId().isDerivedFrom(Mesh::Feature::getClassTypeId())) {
         QString label = QString::fromUtf8(Obj.Label.getValue());
-        QString name = QString::fromLatin1(Obj.getNameInDocument());
+        QString name = QString::fromLatin1(Obj.getNameInDocument().c_str());
         d->ui.meshNameButton->addItem(label, name);
     }
 }
@@ -269,7 +269,7 @@ void DlgEvaluateMeshImp::slotDeletedObject(const App::DocumentObject& Obj)
 {
     // remove mesh objects from the list
     if (Obj.getTypeId().isDerivedFrom(Mesh::Feature::getClassTypeId())) {
-        int index = d->ui.meshNameButton->findData(QString::fromLatin1(Obj.getNameInDocument()));
+        int index = d->ui.meshNameButton->findData(QString::fromLatin1(Obj.getNameInDocument().c_str()));
         if (index > 0) {
             d->ui.meshNameButton->removeItem(index);
             d->ui.meshNameButton->setDisabled(d->ui.meshNameButton->count() < 2);
@@ -301,7 +301,7 @@ void DlgEvaluateMeshImp::slotChangedObject(const App::DocumentObject& Obj,
         if (Prop.getTypeId() == App::PropertyString::getClassTypeId()
             && strcmp(Prop.getName(), "Label") == 0) {
             QString label = QString::fromUtf8(Obj.Label.getValue());
-            QString name = QString::fromLatin1(Obj.getNameInDocument());
+            QString name = QString::fromLatin1(Obj.getNameInDocument().c_str());
             int index = d->ui.meshNameButton->findData(name);
             d->ui.meshNameButton->setItemText(index, label);
         }
@@ -335,7 +335,7 @@ void DlgEvaluateMeshImp::setMesh(Mesh::Feature* m)
     refreshList();
 
     int ct = d->ui.meshNameButton->count();
-    QString objName = QString::fromLatin1(m->getNameInDocument());
+    QString objName = QString::fromLatin1(m->getNameInDocument().c_str());
     for (int i = 1; i < ct; i++) {
         if (d->ui.meshNameButton->itemData(i).toString() == objName) {
             d->ui.meshNameButton->setCurrentIndex(i);
@@ -392,7 +392,7 @@ void DlgEvaluateMeshImp::onMeshNameButtonActivated(int i)
     std::vector<App::DocumentObject*> objs =
         getDocument()->getObjectsOfType(Mesh::Feature::getClassTypeId());
     for (auto obj : objs) {
-        if (item == QLatin1String(obj->getNameInDocument())) {
+        if (item == QLatin1String(obj->getNameInDocument().c_str())) {
             d->meshFeature = static_cast<Mesh::Feature*>(obj);
             break;
         }
@@ -414,7 +414,7 @@ void DlgEvaluateMeshImp::refreshList()
             this->getDocument()->getObjectsOfType(Mesh::Feature::getClassTypeId());
         for (auto obj : objs) {
             items.push_back(qMakePair(QString::fromUtf8(obj->Label.getValue()),
-                                      QString::fromLatin1(obj->getNameInDocument())));
+                                      QString::fromLatin1(obj->getNameInDocument().c_str())));
         }
     }
 
@@ -546,14 +546,14 @@ void DlgEvaluateMeshImp::onRepairOrientationButtonClicked()
 {
     if (d->meshFeature) {
         const char* docName = App::GetApplication().getDocumentName(d->meshFeature->getDocument());
-        const char* objName = d->meshFeature->getNameInDocument();
+        std::string objName = d->meshFeature->getNameInDocument();
         Gui::Document* doc = Gui::Application::Instance->getDocument(docName);
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Harmonize normals"));
         try {
             Gui::Command::doCommand(Gui::Command::App,
                                     R"(App.getDocument("%s").getObject("%s").harmonizeNormals())",
                                     docName,
-                                    objName);
+                                    objName.c_str());
         }
         catch (const Base::Exception& e) {
             QMessageBox::warning(this, tr("Orientation"), QString::fromLatin1(e.what()));
@@ -657,14 +657,14 @@ void DlgEvaluateMeshImp::onRepairNonmanifoldsButtonClicked()
 {
     if (d->meshFeature) {
         const char* docName = App::GetApplication().getDocumentName(d->meshFeature->getDocument());
-        const char* objName = d->meshFeature->getNameInDocument();
+        std::string objName = d->meshFeature->getNameInDocument();
         Gui::Document* doc = Gui::Application::Instance->getDocument(docName);
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Remove non-manifolds"));
         try {
             Gui::Command::doCommand(Gui::Command::App,
                                     R"(App.getDocument("%s").getObject("%s").removeNonManifolds())",
                                     docName,
-                                    objName);
+                                    objName.c_str());
 
             if (d->checkNonManfoldPoints) {
                 Gui::Command::doCommand(
@@ -762,14 +762,14 @@ void DlgEvaluateMeshImp::onRepairIndicesButtonClicked()
 {
     if (d->meshFeature) {
         const char* docName = App::GetApplication().getDocumentName(d->meshFeature->getDocument());
-        const char* objName = d->meshFeature->getNameInDocument();
+        std::string objName = d->meshFeature->getNameInDocument();
         Gui::Document* doc = Gui::Application::Instance->getDocument(docName);
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Fix indices"));
         try {
             Gui::Command::doCommand(Gui::Command::App,
                                     R"(App.getDocument("%s").getObject("%s").fixIndices())",
                                     docName,
-                                    objName);
+                                    objName.c_str());
         }
         catch (const Base::Exception& e) {
             QMessageBox::warning(this, tr("Indices"), QString::fromLatin1(e.what()));
@@ -832,14 +832,14 @@ void DlgEvaluateMeshImp::onRepairDegeneratedButtonClicked()
 {
     if (d->meshFeature) {
         const char* docName = App::GetApplication().getDocumentName(d->meshFeature->getDocument());
-        const char* objName = d->meshFeature->getNameInDocument();
+        std::string objName = d->meshFeature->getNameInDocument();
         Gui::Document* doc = Gui::Application::Instance->getDocument(docName);
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Remove degenerated faces"));
         try {
             Gui::Command::doCommand(Gui::Command::App,
                                     R"(App.getDocument("%s").getObject("%s").fixDegenerations(%f))",
                                     docName,
-                                    objName,
+                                    objName.c_str(),
                                     d->epsilonDegenerated);
         }
         catch (const Base::Exception& e) {
@@ -904,7 +904,7 @@ void DlgEvaluateMeshImp::onRepairDuplicatedFacesButtonClicked()
 {
     if (d->meshFeature) {
         const char* docName = App::GetApplication().getDocumentName(d->meshFeature->getDocument());
-        const char* objName = d->meshFeature->getNameInDocument();
+        std::string objName = d->meshFeature->getNameInDocument();
         Gui::Document* doc = Gui::Application::Instance->getDocument(docName);
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Remove duplicated faces"));
         try {
@@ -912,7 +912,7 @@ void DlgEvaluateMeshImp::onRepairDuplicatedFacesButtonClicked()
                 Gui::Command::App,
                 R"(App.getDocument("%s").getObject("%s").removeDuplicatedFacets())",
                 docName,
-                objName);
+                objName.c_str());
         }
         catch (const Base::Exception& e) {
             QMessageBox::warning(this, tr("Duplicated faces"), QString::fromLatin1(e.what()));
@@ -974,7 +974,7 @@ void DlgEvaluateMeshImp::onRepairDuplicatedPointsButtonClicked()
 {
     if (d->meshFeature) {
         const char* docName = App::GetApplication().getDocumentName(d->meshFeature->getDocument());
-        const char* objName = d->meshFeature->getNameInDocument();
+        std::string objName = d->meshFeature->getNameInDocument();
         Gui::Document* doc = Gui::Application::Instance->getDocument(docName);
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Remove duplicated points"));
         try {
@@ -1138,7 +1138,7 @@ void DlgEvaluateMeshImp::onRepairFoldsButtonClicked()
 {
     if (d->meshFeature) {
         const char* docName = App::GetApplication().getDocumentName(d->meshFeature->getDocument());
-        const char* objName = d->meshFeature->getNameInDocument();
+        std::string objName = d->meshFeature->getNameInDocument();
         Gui::Document* doc = Gui::Application::Instance->getDocument(docName);
         qApp->setOverrideCursor(Qt::WaitCursor);
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Remove folds"));
@@ -1183,7 +1183,7 @@ void DlgEvaluateMeshImp::onRepairAllTogetherClicked()
     if (d->meshFeature) {
         Gui::WaitCursor wc;
         const char* docName = App::GetApplication().getDocumentName(d->meshFeature->getDocument());
-        const char* objName = d->meshFeature->getNameInDocument();
+        std::string objName = d->meshFeature->getNameInDocument();
         Gui::Document* doc = Gui::Application::Instance->getDocument(docName);
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Repair mesh"));
 

--- a/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
@@ -269,7 +269,8 @@ void DlgEvaluateMeshImp::slotDeletedObject(const App::DocumentObject& Obj)
 {
     // remove mesh objects from the list
     if (Obj.getTypeId().isDerivedFrom(Mesh::Feature::getClassTypeId())) {
-        int index = d->ui.meshNameButton->findData(QString::fromLatin1(Obj.getNameInDocument().c_str()));
+        int index =
+            d->ui.meshNameButton->findData(QString::fromLatin1(Obj.getNameInDocument().c_str()));
         if (index > 0) {
             d->ui.meshNameButton->removeItem(index);
             d->ui.meshNameButton->setDisabled(d->ui.meshNameButton->count() < 2);

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -433,7 +433,7 @@ void ViewProviderMesh::attach(App::DocumentObject* pcFeat)
 {
     ViewProviderGeometryObject::attach(pcFeat);
 
-    pcHighlight->objectName = pcFeat->getNameInDocument();
+    pcHighlight->objectName = pcFeat->getNameInDocument().c_str();
     pcHighlight->documentName = pcFeat->getDocument()->getName();
     pcHighlight->subElementName = "Main";
 
@@ -1628,7 +1628,7 @@ void ViewProviderMesh::splitMesh(const MeshCore::MeshKernel& toolMesh,
     removeFacets(indices);
     Mesh::Feature* splitMesh = static_cast<Mesh::Feature*>(
         App::GetApplication().getActiveDocument()->addObject("Mesh::Feature",
-                                                             pcObject->getNameInDocument()));
+                                                             pcObject->getNameInDocument().c_str()));
     // Note: deletes also kernel
     splitMesh->Mesh.setValuePtr(kernel);
     static_cast<Mesh::Feature*>(pcObject)->purgeTouched();

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -1626,9 +1626,10 @@ void ViewProviderMesh::splitMesh(const MeshCore::MeshKernel& toolMesh,
     // Remove the facets from the mesh and create a new one
     Mesh::MeshObject* kernel = meshProp.getValue().meshFromSegment(indices);
     removeFacets(indices);
-    Mesh::Feature* splitMesh = static_cast<Mesh::Feature*>(
-        App::GetApplication().getActiveDocument()->addObject("Mesh::Feature",
-                                                             pcObject->getNameInDocument().c_str()));
+    Mesh::Feature* splitMesh =
+        static_cast<Mesh::Feature*>(App::GetApplication().getActiveDocument()->addObject(
+            "Mesh::Feature",
+            pcObject->getNameInDocument().c_str()));
     // Note: deletes also kernel
     splitMesh->Mesh.setValuePtr(kernel);
     static_cast<Mesh::Feature*>(pcObject)->purgeTouched();

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -455,7 +455,7 @@ QString Tessellation::getStandardParameters(App::DocumentObject* obj) const
         param +=
             QString::fromLatin1(",GroupColors=Gui.getDocument('%1').getObject('%2').DiffuseColor")
                 .arg(QString::fromLatin1(obj->getDocument()->getName()),
-                     QString::fromLatin1(obj->getNameInDocument()));
+                     QString::fromLatin1(obj->getNameInDocument().c_str()));
     }
 
     return param;

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -448,7 +448,7 @@ TopoShape Feature::getTopoShape(const App::DocumentObject *obj, const char *subn
         bool needSubElement, Base::Matrix4D *pmat, App::DocumentObject **powner,
         bool resolveLink, bool transform, bool noElementMap)
 {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return {};
 
     std::vector<App::DocumentObject*> linkStack;

--- a/src/Mod/Part/Gui/BoxSelection.cpp
+++ b/src/Mod/Part/Gui/BoxSelection.cpp
@@ -115,7 +115,7 @@ void BoxSelection::selectionCallback(void * ud, SoEventCallback * cb)
             if (!vp->isVisible())
                 continue;
             const TopoDS_Shape& shape = it->Shape.getValue();
-            self->addShapeToSelection(doc->getName(), it->getNameInDocument(), proj, polygon, shape, self->shapeEnum);
+            self->addShapeToSelection(doc->getName(), it->getNameInDocument().c_str(), proj, polygon, shape, self->shapeEnum);
         }
         view->redraw();
     }

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1135,7 +1135,7 @@ void CmdPartMakeSolid::activated(int iMsg)
                     "__o__.Shape=__s__\n"
                     "del __s__, __o__"
                     )
-                    .arg(QLatin1String(it->getNameInDocument()),
+                    .arg(QLatin1String(it->getNameInDocument().c_str()),
                          QLatin1String(it->Label.getValue()));
             }
             else if (type == TopAbs_SHELL) {
@@ -1147,7 +1147,7 @@ void CmdPartMakeSolid::activated(int iMsg)
                     "__o__.Shape=__s__\n"
                     "del __s__, __o__"
                     )
-                    .arg(QLatin1String(it->getNameInDocument()),
+                    .arg(QLatin1String(it->getNameInDocument().c_str()),
                          QLatin1String(it->Label.getValue()));
             }
             else {
@@ -1210,14 +1210,14 @@ void CmdPartReverseShape::activated(int iMsg)
                 "del __o__"
                 )
                 .arg(QString::fromLatin1(name.c_str()),
-                     QString::fromLatin1(it->getNameInDocument()),
+                     QString::fromLatin1(it->getNameInDocument().c_str()),
                      QString::fromLatin1(it->Label.getValue()));
 
             try {
                 runCommand(Doc, str.toLatin1());
-                copyVisual(name.c_str(), "ShapeColor", it->getNameInDocument());
-                copyVisual(name.c_str(), "LineColor" , it->getNameInDocument());
-                copyVisual(name.c_str(), "PointColor", it->getNameInDocument());
+                copyVisual(name.c_str(), "ShapeColor", it->getNameInDocument().c_str());
+                copyVisual(name.c_str(), "LineColor" , it->getNameInDocument().c_str());
+                copyVisual(name.c_str(), "PointColor", it->getNameInDocument().c_str());
             }
             catch (const Base::Exception& e) {
                 Base::Console().Error("Cannot convert %s because %s.\n",
@@ -1656,9 +1656,9 @@ void CmdPartOffset::activated(int iMsg)
 
     adjustCameraPosition();
 
-    copyVisual(offset.c_str(), "ShapeColor", shape->getNameInDocument());
-    copyVisual(offset.c_str(), "LineColor" , shape->getNameInDocument());
-    copyVisual(offset.c_str(), "PointColor", shape->getNameInDocument());
+    copyVisual(offset.c_str(), "ShapeColor", shape->getNameInDocument().c_str());
+    copyVisual(offset.c_str(), "LineColor" , shape->getNameInDocument().c_str());
+    copyVisual(offset.c_str(), "PointColor", shape->getNameInDocument().c_str());
 }
 
 bool CmdPartOffset::isActive()
@@ -1712,9 +1712,9 @@ void CmdPartOffset2D::activated(int iMsg)
     doCommand(Gui,"Gui.ActiveDocument.setEdit('%s')",offset.c_str());
     adjustCameraPosition();
 
-    copyVisual(offset.c_str(), "ShapeColor", shape->getNameInDocument());
-    copyVisual(offset.c_str(), "LineColor" , shape->getNameInDocument());
-    copyVisual(offset.c_str(), "PointColor", shape->getNameInDocument());
+    copyVisual(offset.c_str(), "ShapeColor", shape->getNameInDocument().c_str());
+    copyVisual(offset.c_str(), "LineColor" , shape->getNameInDocument().c_str());
+    copyVisual(offset.c_str(), "PointColor", shape->getNameInDocument().c_str());
 }
 
 bool CmdPartOffset2D::isActive()
@@ -1896,9 +1896,9 @@ void CmdPartThickness::activated(int iMsg)
     doCommand(Gui,"Gui.ActiveDocument.setEdit('%s')",thick.c_str());
     adjustCameraPosition();
 
-    copyVisual(thick.c_str(), "ShapeColor", obj->getNameInDocument());
-    copyVisual(thick.c_str(), "LineColor" , obj->getNameInDocument());
-    copyVisual(thick.c_str(), "PointColor", obj->getNameInDocument());
+    copyVisual(thick.c_str(), "ShapeColor", obj->getNameInDocument().c_str());
+    copyVisual(thick.c_str(), "LineColor" , obj->getNameInDocument().c_str());
+    copyVisual(thick.c_str(), "PointColor", obj->getNameInDocument().c_str());
 }
 
 bool CmdPartThickness::isActive()

--- a/src/Mod/Part/Gui/CommandParametric.cpp
+++ b/src/Mod/Part/Gui/CommandParametric.cpp
@@ -43,7 +43,7 @@ QString getAutoGroupCommandStr()
 {
     App::Part* activePart = Gui::Application::Instance->activeView()->getActiveObject<App::Part*>("part");
     if (activePart) {
-        QString activePartName = QString::fromLatin1(activePart->getNameInDocument());
+        QString activePartName = QString::fromLatin1(activePart->getNameInDocument().c_str());
         return QString::fromLatin1("App.ActiveDocument.getObject('%1\')."
             "addObject(App.ActiveDocument.ActiveObject)\n")
             .arg(activePartName);

--- a/src/Mod/Part/Gui/CommandSimple.cpp
+++ b/src/Mod/Part/Gui/CommandSimple.cpp
@@ -379,9 +379,9 @@ void CmdPartRefineShape::activated(int iMsg)
                               obj->getNameInDocument(),
                               obj->getNameInDocument());
 
-                copyVisual("ActiveObject", "ShapeColor", obj->getNameInDocument());
-                copyVisual("ActiveObject", "LineColor", obj->getNameInDocument());
-                copyVisual("ActiveObject", "PointColor", obj->getNameInDocument());
+                copyVisual("ActiveObject", "ShapeColor", obj->getNameInDocument().c_str());
+                copyVisual("ActiveObject", "LineColor", obj->getNameInDocument().c_str());
+                copyVisual("ActiveObject", "PointColor", obj->getNameInDocument().c_str());
             }
             catch (const Base::Exception& e) {
                 Base::Console().Warning("%s: %s\n", obj->Label.getValue(), e.what());

--- a/src/Mod/Part/Gui/CrossSections.cpp
+++ b/src/Mod/Part/Gui/CrossSections.cpp
@@ -277,7 +277,7 @@ void CrossSections::apply()
             "wires=list()\n"
             "shape=FreeCAD.getDocument(\"%1\").%2.Shape\n")
             .arg(QLatin1String(doc->getName()),
-                 QLatin1String(it->getNameInDocument())).toLatin1());
+                 QLatin1String(it->getNameInDocument().c_str())).toLatin1());
 
         for (double jt : d) {
             Gui::Command::runCommand(Gui::Command::App, QString::fromLatin1(

--- a/src/Mod/Part/Gui/DlgBooleanOperation.cpp
+++ b/src/Mod/Part/Gui/DlgBooleanOperation.cpp
@@ -141,7 +141,7 @@ void DlgBooleanOperation::slotChangedObject(const App::DocumentObject& obj,
         if (!shape.IsNull()) {
             Gui::Document* activeGui = Gui::Application::Instance->getDocument(obj.getDocument());
             QString label = QString::fromUtf8(obj.Label.getValue());
-            QString name = QString::fromLatin1(obj.getNameInDocument());
+            QString name = QString::fromLatin1(obj.getNameInDocument().c_str());
 
             QTreeWidgetItem* child = new BooleanOperationItem();
             child->setCheckState(0, Qt::Unchecked);
@@ -226,7 +226,7 @@ void DlgBooleanOperation::findShapes()
         const TopoDS_Shape& shape = static_cast<Part::Feature*>(obj)->Shape.getValue();
         if (!shape.IsNull()) {
             QString label = QString::fromUtf8(obj->Label.getValue());
-            QString name = QString::fromLatin1(obj->getNameInDocument());
+            QString name = QString::fromLatin1(obj->getNameInDocument().c_str());
 
             QTreeWidgetItem* child = new BooleanOperationItem();
             child->setCheckState(0, Qt::Unchecked);

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -216,7 +216,7 @@ void DlgExtrusion::onSelectEdgeClicked()
                 if (!obj)
                     continue;
                 features_to_hide.append(QString::fromLatin1("App.ActiveDocument."));
-                features_to_hide.append(QString::fromLatin1(obj->getNameInDocument()));
+                features_to_hide.append(QString::fromLatin1(obj->getNameInDocument().c_str()));
                 features_to_hide.append(QString::fromLatin1(", \n"));
             }
             QByteArray code_2 = code.arg(features_to_hide).toLatin1();
@@ -392,7 +392,7 @@ void DlgExtrusion::findShapes()
         if (canExtrude(shape)) {
             QTreeWidgetItem* item = new QTreeWidgetItem(ui->treeWidget);
             item->setText(0, QString::fromUtf8(obj->Label.getValue()));
-            item->setData(0, Qt::UserRole, QString::fromLatin1(obj->getNameInDocument()));
+            item->setData(0, Qt::UserRole, QString::fromLatin1(obj->getNameInDocument().c_str()));
             Gui::ViewProvider* vp = activeGui->getViewProvider(obj);
             if (vp)
                 item->setIcon(0, vp->getIcon());
@@ -591,9 +591,9 @@ void DlgExtrusion::setAxisLink(const App::PropertyLinkSub& lnk)
         return;
     }
     if (lnk.getSubValues().size() == 1){
-        this->setAxisLink(lnk.getValue()->getNameInDocument(), lnk.getSubValues()[0].c_str());
+        this->setAxisLink(lnk.getValue()->getNameInDocument().c_str(), lnk.getSubValues()[0].c_str());
     } else {
-        this->setAxisLink(lnk.getValue()->getNameInDocument(), "");
+        this->setAxisLink(lnk.getValue()->getNameInDocument().c_str(), "");
     }
 }
 

--- a/src/Mod/Part/Gui/DlgFilletEdges.cpp
+++ b/src/Mod/Part/Gui/DlgFilletEdges.cpp
@@ -471,7 +471,7 @@ void DlgFilletEdges::onSelectEdgesOfFace(const QString& subelement, int type)
                 Gui::SelectionChanges::MsgType msgType = Gui::SelectionChanges::MsgType(type);
                 if (msgType == Gui::SelectionChanges::AddSelection) {
                     Gui::Selection().addSelection(d->object->getDocument()->getName(),
-                        d->object->getNameInDocument(), (const char*)name.toLatin1());
+                        d->object->getNameInDocument().c_str(), (const char*)name.toLatin1());
                 }
             }
         }
@@ -498,7 +498,7 @@ void DlgFilletEdges::onDeleteObject(const App::DocumentObject& obj)
         onShapeObjectActivated(0);
     }
     else {
-        QString shape = QString::fromLatin1(obj.getNameInDocument());
+        QString shape = QString::fromLatin1(obj.getNameInDocument().c_str());
         // start from the second item
         for (int i=1; i<ui->shapeObject->count(); i++) {
             if (ui->shapeObject->itemData(i).toString() == shape) {
@@ -540,13 +540,13 @@ void DlgFilletEdges::toggleCheckState(const QModelIndex& index)
     if (checkState & Qt::Checked) {
         App::Document* doc = d->object->getDocument();
         Gui::Selection().addSelection(doc->getName(),
-            d->object->getNameInDocument(),
+            d->object->getNameInDocument().c_str(),
             (const char*)name.toLatin1());
     }
     else {
         App::Document* doc = d->object->getDocument();
         Gui::Selection().rmvSelection(doc->getName(),
-            d->object->getNameInDocument(),
+            d->object->getNameInDocument().c_str(),
             (const char*)name.toLatin1());
     }
 
@@ -565,7 +565,7 @@ void DlgFilletEdges::findShapes()
     int current_index = 0;
     for (std::vector<App::DocumentObject*>::iterator it = objs.begin(); it!=objs.end(); ++it, ++index) {
         ui->shapeObject->addItem(QString::fromUtf8((*it)->Label.getValue()));
-        ui->shapeObject->setItemData(index, QString::fromLatin1((*it)->getNameInDocument()));
+        ui->shapeObject->setItemData(index, QString::fromLatin1((*it)->getNameInDocument().c_str()));
         if (current_index == 0) {
             if (Gui::Selection().isSelected(*it)) {
                 current_index = index;
@@ -680,7 +680,7 @@ void DlgFilletEdges::setupFillet(const std::vector<App::DocumentObject*>& objs)
 
         if (!subElements.empty()) {
             Gui::Selection().addSelections(doc->getName(),
-                d->object->getNameInDocument(),
+                d->object->getNameInDocument().c_str(),
                 subElements);
         }
     }
@@ -828,7 +828,7 @@ void DlgFilletEdges::onSelectAllButtonClicked()
     if (d->object) {
         App::Document* doc = d->object->getDocument();
         Gui::Selection().addSelections(doc->getName(),
-            d->object->getNameInDocument(),
+            d->object->getNameInDocument().c_str(),
             subElements);
     }
 }
@@ -929,7 +929,7 @@ bool DlgFilletEdges::accept()
     type = QString::fromLatin1("Part::%1").arg(QString::fromLatin1(fillet.c_str()));
 
     if (d->fillet)
-        name = QString::fromLatin1(d->fillet->getNameInDocument());
+        name = QString::fromLatin1(d->fillet->getNameInDocument().c_str());
     else
         name = QString::fromLatin1(activeDoc->getUniqueObjectName(fillet.c_str()).c_str());
 

--- a/src/Mod/Part/Gui/DlgPrimitives.cpp
+++ b/src/Mod/Part/Gui/DlgPrimitives.cpp
@@ -65,7 +65,7 @@ namespace PartGui {
     {
         App::Part* activePart = Gui::Application::Instance->activeView()->getActiveObject<App::Part*>("part");
         if (activePart) {
-            QString activeObjectName = QString::fromLatin1(activePart->getNameInDocument());
+            QString activeObjectName = QString::fromLatin1(activePart->getNameInDocument().c_str());
             return QString::fromLatin1("App.ActiveDocument.getObject('%1\')."
                 "addObject(App.ActiveDocument.getObject('%2\'))\n")
                 .arg(activeObjectName, objectName);
@@ -1945,7 +1945,7 @@ void DlgPrimitives::acceptChanges(const QString& placement)
     App::Document* doc = featurePtr->getDocument();
     QString objectName = QString::fromLatin1("App.getDocument(\"%1\").%2")
                          .arg(QString::fromLatin1(doc->getName()),
-                              QString::fromLatin1(featurePtr->getNameInDocument()));
+                              QString::fromLatin1(featurePtr->getNameInDocument().c_str()));
 
     // read values from the properties
     std::shared_ptr<AbstractPrimitive> primitive = getPrimitive(ui->PrimitiveTypeCB->currentIndex());

--- a/src/Mod/Part/Gui/DlgRevolution.cpp
+++ b/src/Mod/Part/Gui/DlgRevolution.cpp
@@ -220,9 +220,9 @@ void DlgRevolution::setAxisLink(const App::PropertyLinkSub& lnk)
         return;
     }
     if (lnk.getSubValues().size() == 1){
-        this->setAxisLink(lnk.getValue()->getNameInDocument(), lnk.getSubValues()[0].c_str());
+        this->setAxisLink(lnk.getValue()->getNameInDocument().c_str(), lnk.getSubValues()[0].c_str());
     } else {
-        this->setAxisLink(lnk.getValue()->getNameInDocument(), "");
+        this->setAxisLink(lnk.getValue()->getNameInDocument().c_str(), "");
     }
 }
 
@@ -357,7 +357,7 @@ void DlgRevolution::findShapes()
         // So allowed are: vertex, edge, wire, face, shell and compound
         QTreeWidgetItem* item = new QTreeWidgetItem(ui->treeWidget);
         item->setText(0, QString::fromUtf8(obj->Label.getValue()));
-        item->setData(0, Qt::UserRole, QString::fromLatin1(obj->getNameInDocument()));
+        item->setData(0, Qt::UserRole, QString::fromLatin1(obj->getNameInDocument().c_str()));
         Gui::ViewProvider* vp = activeGui->getViewProvider(obj);
         if (vp) item->setIcon(0, vp->getIcon());
     }
@@ -384,7 +384,7 @@ void DlgRevolution::accept()
         QString strAxisLink;
         if (axisLink.getValue()){
             strAxisLink = QString::fromLatin1("(App.ActiveDocument.%1, %2)")
-                    .arg(QString::fromLatin1(axisLink.getValue()->getNameInDocument()),
+                    .arg(QString::fromLatin1(axisLink.getValue()->getNameInDocument().c_str()),
                          axisLink.getSubValues().size() ==  1 ?
                              QString::fromLatin1("\"%1\"").arg(QString::fromLatin1(axisLink.getSubValues()[0].c_str()))
                              : QString() );

--- a/src/Mod/Part/Gui/DlgScale.cpp
+++ b/src/Mod/Part/Gui/DlgScale.cpp
@@ -132,7 +132,7 @@ void DlgScale::findShapes()
         if (canScale(shape)) {
             QTreeWidgetItem* item = new QTreeWidgetItem(ui->treeWidget);
             item->setText(0, QString::fromUtf8(obj->Label.getValue()));
-            item->setData(0, Qt::UserRole, QString::fromLatin1(obj->getNameInDocument()));
+            item->setData(0, Qt::UserRole, QString::fromLatin1(obj->getNameInDocument().c_str()));
             Gui::ViewProvider* vp = activeGui->getViewProvider(obj);
             if (vp)
                 item->setIcon(0, vp->getIcon());

--- a/src/Mod/Part/Gui/Mirroring.cpp
+++ b/src/Mod/Part/Gui/Mirroring.cpp
@@ -106,7 +106,7 @@ void Mirroring::findShapes()
         Part::TopoShape shape = Part::Feature::getTopoShape(obj);
         if (!shape.isNull()) {
             QString label = QString::fromUtf8(obj->Label.getValue());
-            QString name = QString::fromLatin1(obj->getNameInDocument());
+            QString name = QString::fromLatin1(obj->getNameInDocument().c_str());
 
             QTreeWidgetItem* child = new QTreeWidgetItem();
             child->setText(0, label);

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -68,20 +68,20 @@ const QString makeRefString(const App::DocumentObject* obj, const std::string& s
     if (obj->getTypeId().isDerivedFrom(App::OriginFeature::getClassTypeId()) ||
         obj->getTypeId().isDerivedFrom(Part::Datum::getClassTypeId()))
         // App::Plane, Line or Datum feature
-        return QString::fromLatin1(obj->getNameInDocument());
+        return QString::fromLatin1(obj->getNameInDocument().c_str());
 
     if ((sub.size() > 4) && (sub.substr(0,4) == "Face")) {
         int subId = std::atoi(&sub[4]);
-        return QString::fromLatin1(obj->getNameInDocument()) + QString::fromLatin1(":") + QObject::tr("Face") + QString::number(subId);
+        return QString::fromLatin1(obj->getNameInDocument().c_str()) + QString::fromLatin1(":") + QObject::tr("Face") + QString::number(subId);
     } else if ((sub.size() > 4) && (sub.substr(0,4) == "Edge")) {
         int subId = std::atoi(&sub[4]);
-        return QString::fromLatin1(obj->getNameInDocument()) + QString::fromLatin1(":") + QObject::tr("Edge") + QString::number(subId);
+        return QString::fromLatin1(obj->getNameInDocument().c_str()) + QString::fromLatin1(":") + QObject::tr("Edge") + QString::number(subId);
     } else if ((sub.size() > 6) && (sub.substr(0,6) == "Vertex")) {
         int subId = std::atoi(&sub[6]);
-        return QString::fromLatin1(obj->getNameInDocument()) + QString::fromLatin1(":") + QObject::tr("Vertex") + QString::number(subId);
+        return QString::fromLatin1(obj->getNameInDocument().c_str()) + QString::fromLatin1(":") + QObject::tr("Vertex") + QString::number(subId);
     } else {
         //something else that face/edge/vertex. Can be empty string.
-        return QString::fromLatin1(obj->getNameInDocument())
+        return QString::fromLatin1(obj->getNameInDocument().c_str())
                 + (sub.length()>0 ? QString::fromLatin1(":") : QString())
                 + QString::fromLatin1(sub.c_str());
     }
@@ -1003,7 +1003,7 @@ void TaskAttacher::visibilityAutomation(bool opening_not_closing)
             return;
         if (!ViewProvider->getObject())
             return;
-        if (!ViewProvider->getObject()->getNameInDocument())
+        if (!ViewProvider->getObject()->isAttachedToDocument())
             return;
 
         auto editDoc = Gui::Application::Instance->editDocument();

--- a/src/Mod/Part/Gui/TaskFaceColors.cpp
+++ b/src/Mod/Part/Gui/TaskFaceColors.cpp
@@ -185,7 +185,7 @@ public:
                     if (polygon.Contains(Base::Vector2d(pt2d.x, pt2d.y))) {
                         std::stringstream str;
                         str << "Face" << k;
-                        Gui::Selection().addSelection(appdoc->getName(), obj->getNameInDocument(), str.str().c_str());
+                        Gui::Selection().addSelection(appdoc->getName(), obj->getNameInDocument().c_str(), str.str().c_str());
                         break;
                     }
                     xp_vertex.Next();

--- a/src/Mod/Part/Gui/TaskLoft.cpp
+++ b/src/Mod/Part/Gui/TaskLoft.cpp
@@ -140,7 +140,7 @@ void LoftWidget::findShapes()
             shape.ShapeType() == TopAbs_EDGE ||
             shape.ShapeType() == TopAbs_VERTEX) {
             QString label = QString::fromUtf8(obj->Label.getValue());
-            QString name = QString::fromLatin1(obj->getNameInDocument());
+            QString name = QString::fromLatin1(obj->getNameInDocument().c_str());
             QTreeWidgetItem* child = new QTreeWidgetItem();
             child->setText(0, label);
             child->setToolTip(0, label);

--- a/src/Mod/Part/Gui/TaskShapeBuilder.cpp
+++ b/src/Mod/Part/Gui/TaskShapeBuilder.cpp
@@ -434,7 +434,7 @@ void ShapeBuilderWidget::createShellFromFace()
             obj.insert(it.getObject());
         str << "[]";
         for (auto it : obj) {
-            str << "+ App.ActiveDocument." << it->getNameInDocument() << ".Shape.Faces";
+            str << "+ App.ActiveDocument." << it->getNameInDocument().c_str() << ".Shape.Faces";
         }
     }
     else {

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -202,7 +202,7 @@ void SweepWidget::findShapes()
             shape.ShapeType() == TopAbs_EDGE ||
             shape.ShapeType() == TopAbs_VERTEX) {
             QString label = QString::fromUtf8(obj->Label.getValue());
-            QString name = QString::fromLatin1(obj->getNameInDocument());
+            QString name = QString::fromLatin1(obj->getNameInDocument().c_str());
 
             QTreeWidgetItem* child = new QTreeWidgetItem();
             child->setText(0, label);

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -396,11 +396,11 @@ App::DocumentObject* SubShapeBinder::getSubObject(const char* subname, PyObject*
     std::string name(subname, dot - subname);
     for (auto& l : Support.getSubListValues()) {
         auto obj = l.getValue();
-        if (!obj || !obj->getNameInDocument())
+        if (!obj || !obj->isAttachedToDocument())
             continue;
         for (auto& sub : l.getSubValues()) {
             auto sobj = obj->getSubObject(sub.c_str());
-            if (!sobj || !sobj->getNameInDocument())
+            if (!sobj || !sobj->isAttachedToDocument())
                 continue;
             if (subname[0] == '$') {
                 if (sobj->Label.getStrValue() != name.c_str() + 1)
@@ -512,7 +512,7 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
     std::unordered_map<const App::DocumentObject*, Base::Matrix4D> mats;
     for (auto& l : Support.getSubListValues()) {
         auto obj = l.getValue();
-        if (!obj || !obj->getNameInDocument())
+        if (!obj || !obj->isAttachedToDocument())
             continue;
         auto res = mats.emplace(obj, Base::Matrix4D());
         if (parent && res.second) {
@@ -909,7 +909,7 @@ void SubShapeBinder::setLinks(std::map<App::DocumentObject*, std::vector<std::st
     inSet.insert(this);
 
     for (auto& v : values) {
-        if (!v.first || !v.first->getNameInDocument())
+        if (!v.first || !v.first->isAttachedToDocument())
             FC_THROWM(Base::ValueError, "Invalid document object");
         if (inSet.find(v.first) != inSet.end())
             FC_THROWM(Base::ValueError, "Cyclic reference to " << v.first->getFullName());

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -2264,7 +2264,7 @@ void CmdPartDesignMultiTransform::activated(int iMsg)
         }
         Gui::Selection().clearSelection();
         if (prevFeature)
-            Gui::Selection().addSelection(prevFeature->getDocument()->getName(), prevFeature->getNameInDocument());
+            Gui::Selection().addSelection(prevFeature->getDocument()->getName(), prevFeature->getNameInDocument().c_str());
 
         openCommand(QT_TRANSLATE_NOOP("Command", "Convert to MultiTransform feature"));
 
@@ -2299,7 +2299,7 @@ void CmdPartDesignMultiTransform::activated(int iMsg)
         // Restore the insert point
         if (pcActiveBody && oldTip != trFeat) {
             Gui::Selection().clearSelection();
-            Gui::Selection().addSelection(oldTip->getDocument()->getName(), oldTip->getNameInDocument());
+            Gui::Selection().addSelection(oldTip->getDocument()->getName(), oldTip->getNameInDocument().c_str());
             rcCmdMgr.runCommandByName("PartDesign_MoveTip");
             Gui::Selection().clearSelection();
         } // otherwise the insert point remains at the new MultiTransform, which is fine

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -345,10 +345,10 @@ QString getRefStr(const App::DocumentObject* obj, const std::vector<std::string>
     }
 
     if (PartDesign::Feature::isDatum(obj)) {
-        return QString::fromLatin1(obj->getNameInDocument());
+        return QString::fromLatin1(obj->getNameInDocument().c_str());
     }
     else if (!sub.empty()) {
-        return QString::fromLatin1(obj->getNameInDocument()) + QString::fromLatin1(":") +
+        return QString::fromLatin1(obj->getNameInDocument().c_str()) + QString::fromLatin1(":") +
                QString::fromLatin1(sub.front().c_str());
     }
 

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -106,7 +106,7 @@ public:
             if (tip && tip->isDerivedFrom(Part::Feature::getClassTypeId()) && elements.size() == 1) {
                 Gui::SelectionChanges msg;
                 msg.pDocName = faceSelection.getDocName();
-                msg.pObjectName = tip->getNameInDocument();
+                msg.pObjectName = tip->getNameInDocument().c_str();
                 msg.pSubName = elements[0].c_str();
                 msg.pTypeName = tip->getTypeId().getName();
 

--- a/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
@@ -74,7 +74,7 @@ TaskBooleanParameters::TaskBooleanParameters(ViewProviderBoolean *BooleanView,QW
     for (auto body : bodies) {
         QListWidgetItem* item = new QListWidgetItem(ui->listWidgetBodies);
         item->setText(QString::fromUtf8(body->Label.getValue()));
-        item->setData(Qt::UserRole, QString::fromLatin1(body->getNameInDocument()));
+        item->setData(Qt::UserRole, QString::fromLatin1(body->getNameInDocument().c_str()));
     }
 
     // Create context menu
@@ -128,7 +128,7 @@ void TaskBooleanParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 
                 QListWidgetItem* item = new QListWidgetItem(ui->listWidgetBodies);
                 item->setText(QString::fromUtf8(pcBody->Label.getValue()));
-                item->setData(Qt::UserRole, QString::fromLatin1(pcBody->getNameInDocument()));
+                item->setData(Qt::UserRole, QString::fromLatin1(pcBody->getNameInDocument().c_str()));
 
                 pcBoolean->getDocument()->recomputeFeature(pcBoolean);
                 ui->buttonBodyAdd->setChecked(false);
@@ -200,7 +200,7 @@ void TaskBooleanParameters::onButtonBodyAdd(bool checked)
         Gui::Document* doc = BooleanView->getDocument();
         BooleanView->hide();
         if (pcBoolean->Group.getValues().empty() && pcBoolean->BaseFeature.getValue())
-            doc->setHide(pcBoolean->BaseFeature.getValue()->getNameInDocument());
+            doc->setHide(pcBoolean->BaseFeature.getValue()->getNameInDocument().c_str());
         selectionMode = bodyAdd;
         Gui::Selection().clearSelection();
     } else {
@@ -259,7 +259,7 @@ void TaskBooleanParameters::onBodyDeleted()
     App::DocumentObject* body = bodies[index];
     QString internalName = ui->listWidgetBodies->item(index)->data(Qt::UserRole).toString();
     for (auto it = bodies.begin(); it != bodies.end(); ++it) {
-        if (internalName == QLatin1String((*it)->getNameInDocument())) {
+        if (internalName == QLatin1String((*it)->getNameInDocument().c_str())) {
             body = *it;
             bodies.erase(it);
             break;
@@ -302,7 +302,7 @@ void TaskBooleanParameters::exitSelectionMode()
     selectionMode = none;
     Gui::Document* doc = Gui::Application::Instance->activeDocument();
     if (doc)
-        doc->setShow(BooleanView->getObject()->getNameInDocument());
+        doc->setShow(BooleanView->getObject()->getNameInDocument().c_str());
 }
 
 //**************************************************************************
@@ -337,7 +337,7 @@ void TaskDlgBooleanParameters::clicked(int)
 bool TaskDlgBooleanParameters::accept()
 {
     auto obj = BooleanView->getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return false;
     BooleanView->Visibility.setValue(true);
 
@@ -376,10 +376,10 @@ bool TaskDlgBooleanParameters::reject()
     Gui::Document* doc = Gui::Application::Instance->activeDocument();
     if (doc) {
         if (obj->BaseFeature.getValue()) {
-            doc->setShow(obj->BaseFeature.getValue()->getNameInDocument());
+            doc->setShow(obj->BaseFeature.getValue()->getNameInDocument().c_str());
             std::vector<App::DocumentObject*> bodies = obj->Group.getValues();
             for (auto body : bodies) {
-                doc->setShow(body->getNameInDocument());
+                doc->setShow(body->getNameInDocument().c_str());
             }
         }
     }

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -117,9 +117,7 @@ void TaskDressUpParameters::referenceSelected(const Gui::SelectionChanges& msg, 
     PartDesign::DressUp* pcDressUp = static_cast<PartDesign::DressUp*>(DressUpView->getObject());
     App::DocumentObject* base = this->getBase();
 
-    // TODO: Must we make a copy here instead of assigning to const char* ?
-    const char* fname = base->getNameInDocument();
-    if (strcmp(msg.pObjectName, fname) != 0)
+    if (base->getNameInDocument() != msg.pObjectName)
         return;
 
     std::string subName(msg.pSubName);

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -145,14 +145,14 @@ void TaskExtrudeParameters::setupDialog()
     // Set object labels
     if (obj && PartDesign::Feature::isDatum(obj)) {
         ui->lineFaceName->setText(QString::fromUtf8(obj->Label.getValue()));
-        ui->lineFaceName->setProperty("FeatureName", QByteArray(obj->getNameInDocument()));
+        ui->lineFaceName->setProperty("FeatureName", QByteArray(obj->getNameInDocument().c_str()));
     }
     else if (obj && faceId >= 0) {
         ui->lineFaceName->setText(QString::fromLatin1("%1:%2%3")
                                   .arg(QString::fromUtf8(obj->Label.getValue()),
                                        tr("Face"),
                                        QString::number(faceId)));
-        ui->lineFaceName->setProperty("FeatureName", QByteArray(obj->getNameInDocument()));
+        ui->lineFaceName->setProperty("FeatureName", QByteArray(obj->getNameInDocument().c_str()));
     }
     else {
         ui->lineFaceName->clear();

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -116,7 +116,7 @@ TaskFeaturePick::TaskFeaturePick(std::vector<App::DocumentObject*>& objects,
                          getFeatureStatusString(*statusIt)
                 )
         );
-        item->setData(Qt::UserRole, QString::fromLatin1((*objIt)->getNameInDocument()));
+        item->setData(Qt::UserRole, QString::fromLatin1((*objIt)->getNameInDocument().c_str()));
         ui->listWidget->addItem(item);
 
         App::Document* pDoc = (*objIt)->getDocument();

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -623,7 +623,7 @@ void TaskHelixParameters::startReferenceSelection(App::DocumentObject* profile, 
     if (pcHelix && showPreview(pcHelix)) {
         Gui::Document* doc = vp->getDocument();
         if (doc) {
-            doc->setHide(profile->getNameInDocument());
+            doc->setHide(profile->getNameInDocument().c_str());
         }
     }
     else {
@@ -637,7 +637,7 @@ void TaskHelixParameters::finishReferenceSelection(App::DocumentObject* profile,
     if (pcHelix && showPreview(pcHelix)) {
         Gui::Document* doc = vp->getDocument();
         if (doc) {
-            doc->setShow(profile->getNameInDocument());
+            doc->setShow(profile->getNameInDocument().c_str());
         }
     }
     else {

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -150,7 +150,7 @@ void TaskLinearPatternParameters::setupUI()
         if (obj) {
             QListWidgetItem* item = new QListWidgetItem();
             item->setText(QString::fromUtf8(obj->Label.getValue()));
-            item->setData(Qt::UserRole, QString::fromLatin1(obj->getNameInDocument()));
+            item->setData(Qt::UserRole, QString::fromLatin1(obj->getNameInDocument().c_str()));
             ui->listWidgetFeatures->addItem(item);
         }
     }
@@ -258,7 +258,7 @@ void TaskLinearPatternParameters::kickUpdateViewTimer() const
 void TaskLinearPatternParameters::addObject(App::DocumentObject* obj)
 {
     QString label = QString::fromUtf8(obj->Label.getValue());
-    QString objectName = QString::fromLatin1(obj->getNameInDocument());
+    QString objectName = QString::fromLatin1(obj->getNameInDocument().c_str());
 
     QListWidgetItem* item = new QListWidgetItem();
     item->setText(label);

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -177,8 +177,7 @@ bool TaskLoftParameters::referenceSelected(const Gui::SelectionChanges& msg) con
             return false;
 
         // not allowed to reference ourself
-        const char* fname = vp->getObject()->getNameInDocument();
-        if (strcmp(msg.pObjectName, fname) == 0)
+        if (vp->getObject()->getNameInDocument() == msg.pObjectName)
             return false;
 
         //every selection needs to be a profile in itself, hence currently only full objects are
@@ -237,7 +236,7 @@ void TaskLoftParameters::onDeleteSection()
     int row = ui->listWidgetReferences->currentRow();
     QListWidgetItem* item = ui->listWidgetReferences->takeItem(row);
     if (item) {
-        QByteArray data(item->data(Qt::UserRole).value<App::PropertyLinkSubList::SubSet>().first->getNameInDocument());
+        QByteArray data(item->data(Qt::UserRole).value<App::PropertyLinkSubList::SubSet>().first->getNameInDocument().c_str());
         delete item;
 
         // search inside the list of sections

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -124,7 +124,7 @@ void TaskMirroredParameters::setupUI()
         if (obj) {
             QListWidgetItem* item = new QListWidgetItem();
             item->setText(QString::fromUtf8(obj->Label.getValue()));
-            item->setData(Qt::UserRole, QString::fromLatin1(obj->getNameInDocument()));
+            item->setData(Qt::UserRole, QString::fromLatin1(obj->getNameInDocument().c_str()));
             ui->listWidgetFeatures->addItem(item);
         }
     }
@@ -177,7 +177,7 @@ void TaskMirroredParameters::updateUI()
 void TaskMirroredParameters::addObject(App::DocumentObject* obj)
 {
     QString label = QString::fromUtf8(obj->Label.getValue());
-    QString objectName = QString::fromLatin1(obj->getNameInDocument());
+    QString objectName = QString::fromLatin1(obj->getNameInDocument().c_str());
 
     QListWidgetItem* item = new QListWidgetItem();
     item->setText(label);

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -153,7 +153,7 @@ TaskMultiTransformParameters::TaskMultiTransformParameters(ViewProviderTransform
         if (obj) {
             QListWidgetItem* item = new QListWidgetItem();
             item->setText(QString::fromUtf8(obj->Label.getValue()));
-            item->setData(Qt::UserRole, QString::fromLatin1(obj->getNameInDocument()));
+            item->setData(Qt::UserRole, QString::fromLatin1(obj->getNameInDocument().c_str()));
             ui->listWidgetFeatures->addItem(item);
         }
     }
@@ -163,7 +163,7 @@ TaskMultiTransformParameters::TaskMultiTransformParameters(ViewProviderTransform
 void TaskMultiTransformParameters::addObject(App::DocumentObject* obj)
 {
     QString label = QString::fromUtf8(obj->Label.getValue());
-    QString objectName = QString::fromLatin1(obj->getNameInDocument());
+    QString objectName = QString::fromLatin1(obj->getNameInDocument().c_str());
 
     QListWidgetItem* item = new QListWidgetItem();
     item->setText(label);

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -587,7 +587,7 @@ bool TaskDlgMultiTransformParameters::accept()
 //    {
 //        if ((*it) != NULL)
 //            Gui::Command::doCommand(
-//                Gui::Command::Doc,"App.ActiveDocument.removeObject(\"%s\")", (*it)->getNameInDocument());
+//                Gui::Command::Doc,"App.ActiveDocument.removeObject(\"%s\")", (*it)->getNameInDocument().c_str());
 //    }
 //
 //    return TaskDlgTransformedParameters::reject();

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -297,8 +297,7 @@ bool TaskPipeParameters::referenceSelected(const SelectionChanges& msg) const
             return false;
 
         // not allowed to reference ourself
-        const char* fname = vp->getObject()->getNameInDocument();
-        if (strcmp(msg.pObjectName, fname) == 0)
+        if (vp->getObject()->getNameInDocument() == msg.pObjectName)
             return false;
 
         switch (selectionMode) {
@@ -714,8 +713,7 @@ bool TaskPipeOrientation::referenceSelected(const SelectionChanges& msg) const
             return false;
 
         // not allowed to reference ourself
-        const char* fname = vp->getObject()->getNameInDocument();
-        if (strcmp(msg.pObjectName, fname) == 0)
+        if (vp->getObject()->getNameInDocument() == msg.pObjectName)
             return false;
 
         //change the references
@@ -941,8 +939,7 @@ bool TaskPipeScaling::referenceSelected(const SelectionChanges& msg) const
             return false;
 
         // not allowed to reference ourself
-        const char* fname = vp->getObject()->getNameInDocument();
-        if (strcmp(msg.pObjectName, fname) == 0)
+        if (vp->getObject()->getNameInDocument() == msg.pObjectName)
             return false;
 
         //every selection needs to be a profile in itself, hence currently only full objects are
@@ -993,7 +990,7 @@ void TaskPipeScaling::onDeleteSection()
     int row = ui->listWidgetReferences->currentRow();
     QListWidgetItem* item = ui->listWidgetReferences->takeItem(row);
     if (item) {
-        QByteArray data(item->data(Qt::UserRole).value<App::PropertyLinkSubList::SubSet>().first->getNameInDocument());
+        QByteArray data(item->data(Qt::UserRole).value<App::PropertyLinkSubList::SubSet>().first->getNameInDocument().c_str());
         delete item;
 
         // search inside the list of sections

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -156,7 +156,7 @@ void TaskPolarPatternParameters::setupUI()
         if (obj) {
             QListWidgetItem* item = new QListWidgetItem();
             item->setText(QString::fromUtf8(obj->Label.getValue()));
-            item->setData(Qt::UserRole, QString::fromLatin1(obj->getNameInDocument()));
+            item->setData(Qt::UserRole, QString::fromLatin1(obj->getNameInDocument().c_str()));
             ui->listWidgetFeatures->addItem(item);
         }
     }
@@ -257,7 +257,7 @@ void TaskPolarPatternParameters::adaptVisibilityToMode()
 void TaskPolarPatternParameters::addObject(App::DocumentObject* obj)
 {
     QString label = QString::fromUtf8(obj->Label.getValue());
-    QString objectName = QString::fromLatin1(obj->getNameInDocument());
+    QString objectName = QString::fromLatin1(obj->getNameInDocument().c_str());
 
     QListWidgetItem* item = new QListWidgetItem();
     item->setText(label);

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
@@ -115,7 +115,7 @@ void TaskScaledParameters::setupUI()
         if (obj) {
             QListWidgetItem* item = new QListWidgetItem();
             item->setText(QString::fromUtf8(obj->Label.getValue()));
-            item->setData(Qt::UserRole, QString::fromLatin1(obj->getNameInDocument()));
+            item->setData(Qt::UserRole, QString::fromLatin1(obj->getNameInDocument().c_str()));
             ui->listWidgetFeatures->addItem(item);
         }
     }

--- a/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
@@ -283,8 +283,7 @@ bool TaskShapeBinder::referenceSelected(const SelectionChanges& msg) const
             return false;
 
         // not allowed to reference ourself
-        const char* fname = vp->getObject()->getNameInDocument();
-        if (strcmp(msg.pObjectName, fname) == 0)
+        if (vp->getObject()->getNameInDocument() == msg.pObjectName)
             return false;
 
         //change the references
@@ -313,7 +312,7 @@ bool TaskShapeBinder::referenceSelected(const SelectionChanges& msg) const
 
         if (selectionMode != refObjAdd) {
             // ensure the new selected subref belongs to the same object
-            if (strcmp(msg.pObjectName, obj->getNameInDocument()) != 0)
+            if (obj->getNameInDocument() != msg.pObjectName)
                 return false;
 
             std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), subName);

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -71,10 +71,10 @@ const QString TaskSketchBasedParameters::onAddSelection(const Gui::SelectionChan
     // Remove subname for planes and datum features
     if (PartDesign::Feature::isDatum(selObj)) {
         subname = "";
-        refStr = QString::fromLatin1(selObj->getNameInDocument());
+        refStr = QString::fromLatin1(selObj->getNameInDocument().c_str());
     } else if (subname.size() > 4) {
         int faceId = std::atoi(&subname[4]);
-        refStr = QString::fromLatin1(selObj->getNameInDocument()) + QString::fromLatin1(":") + QObject::tr("Face") + QString::number(faceId);
+        refStr = QString::fromLatin1(selObj->getNameInDocument().c_str()) + QString::fromLatin1(":") + QObject::tr("Face") + QString::number(faceId);
     }
 
     std::vector<std::string> upToFaces(1,subname);
@@ -88,9 +88,9 @@ void TaskSketchBasedParameters::startReferenceSelection(App::DocumentObject* pro
 {
     Gui::Document* doc = vp->getDocument();
     if (doc) {
-        doc->setHide(profile->getNameInDocument());
+        doc->setHide(profile->getNameInDocument().c_str());
         if (base)
-            doc->setShow(base->getNameInDocument());
+            doc->setShow(base->getNameInDocument().c_str());
     }
 }
 
@@ -98,9 +98,9 @@ void TaskSketchBasedParameters::finishReferenceSelection(App::DocumentObject* pr
 {
     Gui::Document* doc = vp->getDocument();
     if (doc) {
-        doc->setShow(profile->getNameInDocument());
+        doc->setShow(profile->getNameInDocument().c_str());
         if (base)
-            doc->setHide(base->getNameInDocument());
+            doc->setHide(base->getNameInDocument().c_str());
     }
 }
 
@@ -187,7 +187,7 @@ QVariant TaskSketchBasedParameters::objectNameByLabel(const QString& label,
     if (suggest.isValid()) {
         App::DocumentObject* obj = doc->getObject(suggest.toByteArray());
         if (obj && QString::fromUtf8(obj->Label.getValue()) == label) {
-            return QVariant(QByteArray(obj->getNameInDocument()));
+            return QVariant(QByteArray(obj->getNameInDocument().c_str()));
         }
     }
 
@@ -196,7 +196,7 @@ QVariant TaskSketchBasedParameters::objectNameByLabel(const QString& label,
     std::vector<App::DocumentObject*> objs = doc->getObjects();
     for (auto obj : objs) {
         if (name == obj->Label.getValue()) {
-            return QVariant(QByteArray(obj->getNameInDocument()));
+            return QVariant(QByteArray(obj->getNameInDocument().c_str()));
         }
     }
 

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -73,7 +73,7 @@ App::DocumentObject* getParent(App::DocumentObject* obj, std::string& subname)
 }
 
 bool setEdit(App::DocumentObject *obj, PartDesign::Body *body) {
-    if (!obj || !obj->getNameInDocument()) {
+    if (!obj || !obj->isAttachedToDocument()) {
         FC_ERR("invalid object");
         return false;
     }

--- a/src/Mod/PartDesign/Gui/ViewProviderDressUp.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDressUp.cpp
@@ -74,7 +74,7 @@ bool ViewProviderDressUp::setEdit(int ModNum) {
             QMessageBox::warning ( nullptr, QObject::tr("Feature error"),
                     QObject::tr("%1 misses a base feature.\n"
                            "This feature is broken and can't be edited.")
-                        .arg( QString::fromLatin1(dressUp->getNameInDocument()) )
+                        .arg( QString::fromLatin1(dressUp->getNameInDocument().c_str()) )
                 );
             return false;
         }

--- a/src/Mod/PartDesign/Gui/ViewProviderMultiTransform.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderMultiTransform.cpp
@@ -69,7 +69,7 @@ bool ViewProviderMultiTransform::onDelete(const std::vector<std::string> &svec) 
         if (it) {
             Gui::Command::doCommand(
                 Gui::Command::Doc,"App.getDocument('%s').removeObject(\"%s\")", \
-                    it->getDocument()->getName(), it->getNameInDocument());
+                    it->getDocument()->getName(), it->getNameInDocument().c_str());
         }
     }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -324,15 +324,15 @@ bool ViewProviderSubShapeBinder::setEdit(int ModNum) {
         Gui::Selection().clearSelection();
         for (auto& link : self->Support.getSubListValues()) {
             auto obj = link.getValue();
-            if (!obj || !obj->getNameInDocument())
+            if (!obj || !obj->isAttachedToDocument())
                 continue;
             const auto& subs = link.getSubValues();
             if (!subs.empty())
                 Gui::Selection().addSelections(obj->getDocument()->getName(),
-                    obj->getNameInDocument(), subs);
+                    obj->getNameInDocument().c_str(), subs);
             else
                 Gui::Selection().addSelection(obj->getDocument()->getName(),
-                    obj->getNameInDocument());
+                    obj->getNameInDocument().c_str());
         }
         Gui::Selection().selStackPush();
         break;

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -160,7 +160,7 @@ void Workbench::slotNewObject(const App::DocumentObject& obj)
         // Add the new object to the active Body
         // Note: Will this break Undo? But how else can we catch Edit->Duplicate selection?
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",
-                                ActivePartObject->getNameInDocument(), obj.getNameInDocument());
+                                ActivePartObject->getNameInDocument().c_str(), obj.getNameInDocument().c_str());
     }
 }
 */

--- a/src/Mod/Path/App/FeaturePathCompoundPyImp.cpp
+++ b/src/Mod/Path/App/FeaturePathCompoundPyImp.cpp
@@ -43,7 +43,7 @@ PyObject*  FeaturePathCompoundPy::addObject(PyObject *args)
         return nullptr;
 
     DocumentObjectPy* docObj = static_cast<DocumentObjectPy*>(object);
-    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->getNameInDocument()) {
+    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot add an invalid object");
         return nullptr;
     }
@@ -88,7 +88,7 @@ PyObject*  FeaturePathCompoundPy::removeObject(PyObject *args)
         return nullptr;
 
     DocumentObjectPy* docObj = static_cast<DocumentObjectPy*>(object);
-    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->getNameInDocument()) {
+    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot remove an invalid object");
         return nullptr;
     }

--- a/src/Mod/Path/Gui/TaskDlgPathCompound.cpp
+++ b/src/Mod/Path/Gui/TaskDlgPathCompound.cpp
@@ -59,7 +59,7 @@ TaskWidgetPathCompound::TaskWidgetPathCompound(ViewProviderPathCompound *Compoun
     Path::FeatureCompound* pcCompound = static_cast<Path::FeatureCompound*>(CompoundView->getObject());
     const std::vector<App::DocumentObject*> &Paths = pcCompound->Group.getValues();
     for (std::vector<App::DocumentObject*>::const_iterator it= Paths.begin();it!=Paths.end();++it) {
-        QString name = QString::fromLatin1((*it)->getNameInDocument());
+        QString name = QString::fromLatin1((*it)->getNameInDocument().c_str());
         name += QString::fromLatin1(" (");
         name += QString::fromUtf8((*it)->Label.getValue());
         name += QString::fromLatin1(")");

--- a/src/Mod/Points/Gui/ViewProvider.cpp
+++ b/src/Mod/Points/Gui/ViewProvider.cpp
@@ -383,7 +383,7 @@ void ViewProviderScattered::attach(App::DocumentObject* pcObj)
     // call parent's attach to define display modes
     ViewProviderGeometryObject::attach(pcObj);
 
-    pcHighlight->objectName = pcObj->getNameInDocument();
+    pcHighlight->objectName = pcObj->getNameInDocument().c_str();
     pcHighlight->documentName = pcObj->getDocument()->getName();
     pcHighlight->subElementName = "Main";
 
@@ -555,7 +555,7 @@ void ViewProviderStructured::attach(App::DocumentObject* pcObj)
     // call parent's attach to define display modes
     ViewProviderGeometryObject::attach(pcObj);
 
-    pcHighlight->objectName = pcObj->getNameInDocument();
+    pcHighlight->objectName = pcObj->getNameInDocument().c_str();
     pcHighlight->documentName = pcObj->getDocument()->getName();
     pcHighlight->subElementName = "Main";
 

--- a/src/Mod/Robot/Gui/ViewProviderRobotObject.cpp
+++ b/src/Mod/Robot/Gui/ViewProviderRobotObject.cpp
@@ -114,13 +114,13 @@ void ViewProviderRobotObject::attach(App::DocumentObject* pcObj)
     ViewProviderGeometryObject::attach(pcObj);
 
     addDisplayMaskMode(pcRobotRoot, "VRML");
-    pcRobotRoot->objectName = pcObj->getNameInDocument();
+    pcRobotRoot->objectName = pcObj->getNameInDocument().c_str();
     pcRobotRoot->documentName = pcObj->getDocument()->getName();
     pcRobotRoot->subElementName = "Main";
     pcRobotRoot->addChild(pcTcpRoot);
 
     addDisplayMaskMode(pcSimpleRoot, "Simple");
-    pcSimpleRoot->objectName = pcObj->getNameInDocument();
+    pcSimpleRoot->objectName = pcObj->getNameInDocument().c_str();
     pcSimpleRoot->documentName = pcObj->getDocument()->getName();
     pcSimpleRoot->subElementName = "Main";
     pcSimpleRoot->addChild(pcTcpRoot);

--- a/src/Mod/Robot/Gui/ViewProviderTrajectory.cpp
+++ b/src/Mod/Robot/Gui/ViewProviderTrajectory.cpp
@@ -103,7 +103,7 @@ void ViewProviderTrajectory::attach(App::DocumentObject* pcObj)
     pcTrajectoryRoot->addChild(linesep);
 
     addDisplayMaskMode(pcTrajectoryRoot, "Waypoints");
-    pcTrajectoryRoot->objectName = pcObj->getNameInDocument();
+    pcTrajectoryRoot->objectName = pcObj->getNameInDocument().c_str();
     pcTrajectoryRoot->documentName = pcObj->getDocument()->getName();
     pcTrajectoryRoot->subElementName = "Main";
 }

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1033,7 +1033,7 @@ public:
             // If mouse is released on something allowed, select it and move forward
             selSeq.push_back(selIdPair);
             Gui::Selection().addSelection(sketchgui->getSketchObject()->getDocument()->getName(),
-                                          sketchgui->getSketchObject()->getNameInDocument(),
+                                          sketchgui->getSketchObject()->getNameInDocument().c_str(),
                                           ss.str().c_str(),
                                           onSketchPos.x,
                                           onSketchPos.y,
@@ -1466,7 +1466,7 @@ public:
             if (selAllowed) {
                 // If mouse is released on something allowed, select it
                 Gui::Selection().addSelection(Obj->getDocument()->getName(),
-                    Obj->getNameInDocument(),
+                    Obj->getNameInDocument().c_str(),
                     ss.str().c_str(), onSketchPos.x, onSketchPos.y, 0.f);
                 sketchgui->draw(false, false); // Redraw
             }
@@ -1485,7 +1485,7 @@ public:
             }
 
             Gui::Selection().rmvSelection(Obj->getDocument()->getName(),
-                Obj->getNameInDocument(),
+                Obj->getNameInDocument().c_str(),
                 ss.str().c_str());
             sketchgui->draw(false, false); // Redraw
         }
@@ -3685,7 +3685,7 @@ public:
             GeoId1 = GeoId_temp;
             PosId1 = PosId_temp;
             Gui::Selection().addSelection(sketchgui->getSketchObject()->getDocument()->getName(),
-                                          sketchgui->getSketchObject()->getNameInDocument(),
+                                          sketchgui->getSketchObject()->getNameInDocument().c_str(),
                                           ss.str().c_str(),
                                           onSketchPos.x,
                                           onSketchPos.y,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
@@ -215,7 +215,7 @@ public:
                     ss << "Edge" << firstCurve + 1;
                     Gui::Selection().addSelection(
                         sketchgui->getSketchObject()->getDocument()->getName(),
-                        sketchgui->getSketchObject()->getNameInDocument(),
+                        sketchgui->getSketchObject()->getNameInDocument().c_str(),
                         ss.str().c_str(),
                         onSketchPos.x,
                         onSketchPos.y,

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1351,7 +1351,7 @@ void TaskSketcherConstraints::onSelectionChanged(const Gui::SelectionChanges& ms
         bool select = (msg.Type == Gui::SelectionChanges::AddSelection);
         // is it this object??
         if (strcmp(msg.pDocName, sketchView->getSketchObject()->getDocument()->getName()) == 0
-            && strcmp(msg.pObjectName, sketchView->getSketchObject()->getNameInDocument()) == 0) {
+            && sketchView->getSketchObject()->getNameInDocument() == msg.pObjectName) {
             if (msg.pSubName) {
                 QRegularExpression rx(QString::fromLatin1("^Constraint(\\d+)$"));
                 QRegularExpressionMatch match;

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -1218,7 +1218,7 @@ void TaskSketcherElements::onSelectionChanged(const Gui::SelectionChanges& msg)
         bool select = (msg.Type == Gui::SelectionChanges::AddSelection);
         // is it this object??
         if (strcmp(msg.pDocName, sketchView->getSketchObject()->getDocument()->getName()) == 0
-            && strcmp(msg.pObjectName, sketchView->getSketchObject()->getNameInDocument()) == 0) {
+            && sketchView->getSketchObject()->getNameInDocument() == msg.pObjectName) {
             if (msg.pSubName) {
                 QString expr = QString::fromLatin1(msg.pSubName);
                 std::string shapetype(msg.pSubName);
@@ -1707,7 +1707,7 @@ void TaskSketcherElements::slotElementsChanged()
             if (isNamingBoxChecked) {
                 if (size_t(j - 3) < linkobjs.size() && size_t(j - 3) < linksubs.size()) {
                     linkname = IdInformation(true)
-                        + QString::fromUtf8(linkobjs[j - 3]->getNameInDocument())
+                        + QString::fromUtf8(linkobjs[j - 3]->getNameInDocument().c_str())
                         + QString::fromLatin1(".") + QString::fromUtf8(linksubs[j - 3].c_str())
                         + QString::fromLatin1(")");
                 }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1914,7 +1914,7 @@ void ViewProviderSketch::onSelectionChanged(const Gui::SelectionChanges& msg)
         else if (msg.Type == Gui::SelectionChanges::AddSelection) {
             // is it this object??
             if (strcmp(msg.pDocName, getSketchObject()->getDocument()->getName()) == 0
-                && strcmp(msg.pObjectName, getSketchObject()->getNameInDocument()) == 0) {
+                && getSketchObject()->getNameInDocument() == msg.pObjectName) {
                 if (msg.pSubName) {
                     std::string shapetype(msg.pSubName);
                     if (shapetype.size() > 4 && shapetype.substr(0, 4) == "Edge") {
@@ -1961,7 +1961,7 @@ void ViewProviderSketch::onSelectionChanged(const Gui::SelectionChanges& msg)
                 || !selection.SelConstraintSet.empty()) {
                 // is it this object??
                 if (strcmp(msg.pDocName, getSketchObject()->getDocument()->getName()) == 0
-                    && strcmp(msg.pObjectName, getSketchObject()->getNameInDocument()) == 0) {
+                    && getSketchObject()->getNameInDocument() == msg.pObjectName) {
                     if (msg.pSubName) {
                         std::string shapetype(msg.pSubName);
                         if (shapetype.size() > 4 && shapetype.substr(0, 4) == "Edge") {
@@ -2025,7 +2025,7 @@ void ViewProviderSketch::onSelectionChanged(const Gui::SelectionChanges& msg)
         }
         else if (msg.Type == Gui::SelectionChanges::SetPreselect) {
             if (strcmp(msg.pDocName, getSketchObject()->getDocument()->getName()) == 0
-                && strcmp(msg.pObjectName, getSketchObject()->getNameInDocument()) == 0) {
+                && getSketchObject()->getNameInDocument() == msg.pObjectName) {
                 if (msg.pSubName) {
                     std::string shapetype(msg.pSubName);
                     if (shapetype.size() > 4 && shapetype.substr(0, 4) == "Edge") {
@@ -3226,7 +3226,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
                     "del(tv)\n"
                     "del(ActiveSketch)\n")
                     .arg(QString::fromLatin1(getDocument()->getDocument()->getName()),
-                         QString::fromLatin1(getSketchObject()->getNameInDocument()),
+                         QString::fromLatin1(getSketchObject()->getNameInDocument().c_str()),
                          QString::fromLatin1(Gui::Command::getObjectCmd(editObj).c_str()),
                          QString::fromLatin1(editSubName.c_str()));
             QByteArray cmdstr_bytearray = cmdstr.toLatin1();
@@ -3481,7 +3481,7 @@ void ViewProviderSketch::unsetEdit(int ModNum)
                                 "del(tv)\n"
                                 "del(ActiveSketch)\n")
                 .arg(QString::fromLatin1(getDocument()->getDocument()->getName()),
-                     QString::fromLatin1(getSketchObject()->getNameInDocument()));
+                     QString::fromLatin1(getSketchObject()->getNameInDocument().c_str()));
         QByteArray cmdstr_bytearray = cmdstr.toLatin1();
         Gui::Command::runCommand(Gui::Command::Gui, cmdstr_bytearray);
     }
@@ -3508,7 +3508,7 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
                     "    "
                     "ActiveSketch.ViewObject.Document.ActiveView.setCameraType('Orthographic')\n")
                     .arg(QString::fromLatin1(getDocument()->getDocument()->getName()),
-                         QString::fromLatin1(getSketchObject()->getNameInDocument()));
+                         QString::fromLatin1(getSketchObject()->getNameInDocument().c_str()));
             QByteArray cmdstr_bytearray = cmdstr.toLatin1();
             Gui::Command::runCommand(Gui::Command::Gui, cmdstr_bytearray);
         }

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -1668,7 +1668,7 @@ void PropertySheet::recomputeDependencies(CellAddress key)
 
 void PropertySheet::hasSetValue()
 {
-    if (updateCount == 0 || !owner || !owner->getNameInDocument() || owner->isRestoring()
+    if (updateCount == 0 || !owner || !owner->isAttachedToDocument() || owner->isRestoring()
         || this != &owner->cells || testFlag(LinkDetached)) {
         PropertyExpressionContainer::hasSetValue();
         return;

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -1123,7 +1123,7 @@ DocumentObjectExecReturn* Sheet::execute()
             catch (std::exception&) {  // TODO: evaluate using a more specific exception (not_a_dag)
                 // Cycle detected; flag all with errors
                 Base::Console().Error("Cyclic dependency detected in spreadsheet : %s\n",
-                                      *pcNameInDocument);
+                                      getNameInDocument());
                 std::ostringstream ss;
                 ss << "Cyclic dependency";
                 int count = 0;

--- a/src/Mod/Spreadsheet/Gui/Command.cpp
+++ b/src/Mod/Spreadsheet/Gui/Command.cpp
@@ -84,7 +84,7 @@ void CmdSpreadsheetMergeCells::activated(int iMsg)
                     if (i->size() > 1) {
                         Gui::Command::doCommand(Gui::Command::Doc,
                                                 "App.ActiveDocument.%s.mergeCells('%s')",
-                                                sheet->getNameInDocument(),
+                                                sheet->getNameInDocument().c_str(),
                                                 i->rangeString().c_str());
                     }
                 }
@@ -142,7 +142,7 @@ void CmdSpreadsheetSplitCell::activated(int iMsg)
                 Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Split cell"));
                 Gui::Command::doCommand(Gui::Command::Doc,
                                         "App.ActiveDocument.%s.splitCell('%s')",
-                                        sheet->getNameInDocument(),
+                                        sheet->getNameInDocument().c_str(),
                                         address.c_str());
                 Gui::Command::commitCommand();
                 Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
@@ -323,7 +323,7 @@ void CmdSpreadsheetAlignLeft::activated(int iMsg)
                     Gui::Command::doCommand(
                         Gui::Command::Doc,
                         "App.ActiveDocument.%s.setAlignment('%s', 'left', 'keep')",
-                        sheet->getNameInDocument(),
+                        sheet->getNameInDocument().c_str(),
                         i->rangeString().c_str());
                 }
                 Gui::Command::commitCommand();
@@ -380,7 +380,7 @@ void CmdSpreadsheetAlignCenter::activated(int iMsg)
                     Gui::Command::doCommand(
                         Gui::Command::Doc,
                         "App.ActiveDocument.%s.setAlignment('%s', 'center', 'keep')",
-                        sheet->getNameInDocument(),
+                        sheet->getNameInDocument().c_str(),
                         i->rangeString().c_str());
                 }
                 Gui::Command::commitCommand();
@@ -437,7 +437,7 @@ void CmdSpreadsheetAlignRight::activated(int iMsg)
                     Gui::Command::doCommand(
                         Gui::Command::Doc,
                         "App.ActiveDocument.%s.setAlignment('%s', 'right', 'keep')",
-                        sheet->getNameInDocument(),
+                        sheet->getNameInDocument().c_str(),
                         i->rangeString().c_str());
                 }
                 Gui::Command::commitCommand();
@@ -494,7 +494,7 @@ void CmdSpreadsheetAlignTop::activated(int iMsg)
                     Gui::Command::doCommand(
                         Gui::Command::Doc,
                         "App.ActiveDocument.%s.setAlignment('%s', 'top', 'keep')",
-                        sheet->getNameInDocument(),
+                        sheet->getNameInDocument().c_str(),
                         i->rangeString().c_str());
                 }
                 Gui::Command::commitCommand();
@@ -551,7 +551,7 @@ void CmdSpreadsheetAlignBottom::activated(int iMsg)
                     Gui::Command::doCommand(
                         Gui::Command::Doc,
                         "App.ActiveDocument.%s.setAlignment('%s', 'bottom', 'keep')",
-                        sheet->getNameInDocument(),
+                        sheet->getNameInDocument().c_str(),
                         i->rangeString().c_str());
                 }
                 Gui::Command::commitCommand();
@@ -608,7 +608,7 @@ void CmdSpreadsheetAlignVCenter::activated(int iMsg)
                     Gui::Command::doCommand(
                         Gui::Command::Doc,
                         "App.ActiveDocument.%s.setAlignment('%s', 'vcenter', 'keep')",
-                        sheet->getNameInDocument(),
+                        sheet->getNameInDocument().c_str(),
                         i->rangeString().c_str());
                 }
                 Gui::Command::commitCommand();
@@ -683,14 +683,14 @@ void CmdSpreadsheetStyleBold::activated(int iMsg)
                         Gui::Command::doCommand(
                             Gui::Command::Doc,
                             "App.ActiveDocument.%s.setStyle('%s', 'bold', 'add')",
-                            sheet->getNameInDocument(),
+                            sheet->getNameInDocument().c_str(),
                             i->rangeString().c_str());
                     }
                     else {
                         Gui::Command::doCommand(
                             Gui::Command::Doc,
                             "App.ActiveDocument.%s.setStyle('%s', 'bold', 'remove')",
-                            sheet->getNameInDocument(),
+                            sheet->getNameInDocument().c_str(),
                             i->rangeString().c_str());
                     }
                 }
@@ -766,14 +766,14 @@ void CmdSpreadsheetStyleItalic::activated(int iMsg)
                         Gui::Command::doCommand(
                             Gui::Command::Doc,
                             "App.ActiveDocument.%s.setStyle('%s', 'italic', 'add')",
-                            sheet->getNameInDocument(),
+                            sheet->getNameInDocument().c_str(),
                             i->rangeString().c_str());
                     }
                     else {
                         Gui::Command::doCommand(
                             Gui::Command::Doc,
                             "App.ActiveDocument.%s.setStyle('%s', 'italic', 'remove')",
-                            sheet->getNameInDocument(),
+                            sheet->getNameInDocument().c_str(),
                             i->rangeString().c_str());
                     }
                 }
@@ -849,14 +849,14 @@ void CmdSpreadsheetStyleUnderline::activated(int iMsg)
                         Gui::Command::doCommand(
                             Gui::Command::Doc,
                             "App.ActiveDocument.%s.setStyle('%s', 'underline', 'add')",
-                            sheet->getNameInDocument(),
+                            sheet->getNameInDocument().c_str(),
                             i->rangeString().c_str());
                     }
                     else {
                         Gui::Command::doCommand(
                             Gui::Command::Doc,
                             "App.ActiveDocument.%s.setStyle('%s', 'underline', 'remove')",
-                            sheet->getNameInDocument(),
+                            sheet->getNameInDocument().c_str(),
                             i->rangeString().c_str());
                     }
                 }

--- a/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
@@ -111,13 +111,13 @@ DlgBindSheet::DlgBindSheet(Sheet* sheet, const std::vector<Range>& ranges, QWidg
         QString label;
         if (obj->Label.getStrValue() != obj->getNameInDocument()) {
             label =
-                QString::fromLatin1("%1 (%2)").arg(QString::fromLatin1(obj->getNameInDocument()),
+                QString::fromLatin1("%1 (%2)").arg(QString::fromLatin1(obj->getNameInDocument().c_str()),
                                                    QString::fromUtf8(obj->Label.getValue()));
         }
         else {
-            label = QLatin1String(obj->getNameInDocument());
+            label = QLatin1String(obj->getNameInDocument().c_str());
         }
-        ui->comboBox->addItem(label, QByteArray(obj->getNameInDocument()));
+        ui->comboBox->addItem(label, QByteArray(obj->getNameInDocument().c_str()));
         if (obj == target) {
             ui->comboBox->setCurrentIndex(ui->comboBox->count() - 1);
         }

--- a/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgBindSheet.cpp
@@ -110,9 +110,9 @@ DlgBindSheet::DlgBindSheet(Sheet* sheet, const std::vector<Range>& ranges, QWidg
         }
         QString label;
         if (obj->Label.getStrValue() != obj->getNameInDocument()) {
-            label =
-                QString::fromLatin1("%1 (%2)").arg(QString::fromLatin1(obj->getNameInDocument().c_str()),
-                                                   QString::fromUtf8(obj->Label.getValue()));
+            label = QString::fromLatin1("%1 (%2)").arg(
+                QString::fromLatin1(obj->getNameInDocument().c_str()),
+                QString::fromUtf8(obj->Label.getValue()));
         }
         else {
             label = QLatin1String(obj->getNameInDocument().c_str());

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -679,7 +679,7 @@ void SheetTableView::deleteSelection()
         for (; i != ranges.end(); ++i) {
             Gui::Command::doCommand(Gui::Command::Doc,
                                     "App.ActiveDocument.%s.clear('%s')",
-                                    sheet->getNameInDocument(),
+                                    sheet->getNameInDocument().c_str(),
                                     i->rangeString().c_str());
         }
         Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");

--- a/src/Mod/Spreadsheet/Gui/Workbench.cpp
+++ b/src/Mod/Spreadsheet/Gui/Workbench.cpp
@@ -144,7 +144,7 @@ void WorkbenchHelper::setForegroundColor(const QColor& color)
                 for (; i != ranges.end(); ++i) {
                     Gui::Command::doCommand(Gui::Command::Doc,
                                             "App.ActiveDocument.%s.setForeground('%s', (%f,%f,%f))",
-                                            sheet->getNameInDocument(),
+                                            sheet->getNameInDocument().c_str(),
                                             i->rangeString().c_str(),
                                             color.redF(),
                                             color.greenF(),
@@ -178,7 +178,7 @@ void WorkbenchHelper::setBackgroundColor(const QColor& color)
                 for (; i != ranges.end(); ++i) {
                     Gui::Command::doCommand(Gui::Command::Doc,
                                             "App.ActiveDocument.%s.setBackground('%s', (%f,%f,%f))",
-                                            sheet->getNameInDocument(),
+                                            sheet->getNameInDocument().c_str(),
                                             i->rangeString().c_str(),
                                             color.redF(),
                                             color.greenF(),

--- a/src/Mod/Surface/Gui/TaskFilling.cpp
+++ b/src/Mod/Surface/Gui/TaskFilling.cpp
@@ -387,7 +387,7 @@ void FillingPanel::setEditedObject(Surface::Filling* fea)
         // 5. the continuity as int
         QList<QVariant> data;
         data << QByteArray(doc->getName());
-        data << QByteArray(obj->getNameInDocument());
+        data << QByteArray(obj->getNameInDocument().c_str());
         data << QByteArray(edge.c_str());
         data << QByteArray(face.c_str());
         data << static_cast<int>(conts[i]);

--- a/src/Mod/Surface/Gui/TaskFillingEdge.cpp
+++ b/src/Mod/Surface/Gui/TaskFillingEdge.cpp
@@ -226,7 +226,7 @@ void FillingEdgePanel::setEditedObject(Surface::Filling* fea)
         // 5. the continuity as int
         QList<QVariant> data;
         data << QByteArray(doc->getName());
-        data << QByteArray(obj->getNameInDocument());
+        data << QByteArray(obj->getNameInDocument().c_str());
         data << QByteArray(edge.c_str());
         data << QByteArray(face.c_str());
         data << static_cast<int>(conts[i]);

--- a/src/Mod/Surface/Gui/TaskFillingVertex.cpp
+++ b/src/Mod/Surface/Gui/TaskFillingVertex.cpp
@@ -181,7 +181,7 @@ void FillingVertexPanel::setEditedObject(Surface::Filling* obj)
 
         QList<QVariant> data;
         data << QByteArray(doc->getName());
-        data << QByteArray((*it)->getNameInDocument());
+        data << QByteArray((*it)->getNameInDocument().c_str());
         data << QByteArray(jt->c_str());
         item->setData(Qt::UserRole, data);
     }

--- a/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
+++ b/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
@@ -313,7 +313,7 @@ void GeomFillSurface::setEditedObject(Surface::GeomFillSurface* obj)
 
         QList<QVariant> data;
         data << QByteArray(doc->getName());
-        data << QByteArray((*it)->getNameInDocument());
+        data << QByteArray((*it)->getNameInDocument().c_str());
         data << QByteArray(jt->c_str());
         item->setData(Qt::UserRole, data);
     }

--- a/src/Mod/Surface/Gui/TaskSections.cpp
+++ b/src/Mod/Surface/Gui/TaskSections.cpp
@@ -332,7 +332,7 @@ void SectionsPanel::setEditedObject(Surface::Sections* fea)
         // 3. sub-element name of the edge
         QList<QVariant> data;
         data << QByteArray(doc->getName());
-        data << QByteArray(obj->getNameInDocument());
+        data << QByteArray(obj->getNameInDocument().c_str());
         data << QByteArray(edge.c_str());
         item->setData(Qt::UserRole, data);
     }

--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -279,8 +279,7 @@ int DrawPage::removeView(App::DocumentObject* docObj)
         return -1;
     }
 
-    const char* name = docObj->getNameInDocument();
-    if (!name) {
+    if (!docObj->isAttachedToDocument()) {
         return -1;
     }
     const std::vector<App::DocumentObject*> currViews = Views.getValues();
@@ -292,8 +291,8 @@ int DrawPage::removeView(App::DocumentObject* docObj)
             continue;
         }
 
-        std::string viewName = name;
-        if (viewName.compare((*it)->getNameInDocument()) != 0) {
+        std::string viewName = docObj->getNameInDocument();
+        if (viewName != (*it)->getNameInDocument()) {
             newViews.push_back((*it));
         }
     }

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -1230,10 +1230,9 @@ void DrawViewPart::unsetupObject()
         std::vector<TechDraw::DrawViewDimension*>::iterator it3 = dims.begin();
         for (; it3 != dims.end(); it3++) {
             page->removeView(*it3);
-            const char* name = (*it3)->getNameInDocument();
-            if (name) {
+            if ((*it3)->isAttachedToDocument()) {
                 Base::Interpreter().runStringArg("App.getDocument(\"%s\").removeObject(\"%s\")",
-                                                 docName.c_str(), name);
+                                                 docName.c_str(), (*it3)->getNameInDocument().c_str());
             }
         }
     }
@@ -1246,10 +1245,9 @@ void DrawViewPart::unsetupObject()
         std::vector<TechDraw::DrawViewBalloon*>::iterator it3 = balloons.begin();
         for (; it3 != balloons.end(); it3++) {
             page->removeView(*it3);
-            const char* name = (*it3)->getNameInDocument();
-            if (name) {
+            if ((*it3)->isAttachedToDocument()) {
                 Base::Interpreter().runStringArg("App.getDocument(\"%s\").removeObject(\"%s\")",
-                                                 docName.c_str(), name);
+                                                 docName.c_str(), (*it3)->getNameInDocument().c_str());
             }
         }
     }

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -110,7 +110,7 @@ MDIViewPage::MDIViewPage(ViewProviderPage* pageVp, Gui::Document* doc, QWidget* 
 
     isSelectionBlocked = false;
 
-    QString tabText = QString::fromUtf8(pageVp->getDrawPage()->getNameInDocument());
+    QString tabText = QString::fromUtf8(pageVp->getDrawPage()->getNameInDocument().c_str());
     tabText += QString::fromUtf8("[*]");
     setWindowTitle(tabText);
 
@@ -178,7 +178,7 @@ void MDIViewPage::onDeleteObject(const App::DocumentObject& obj)
     //if this page has a QView for this obj, delete it.
     blockSceneSelection(true);
     if (obj.isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
-        (void)m_scene->removeQViewByName(obj.getNameInDocument());
+        (void)m_scene->removeQViewByName(obj.getNameInDocument().c_str());
     }
     blockSceneSelection(false);
 }
@@ -604,14 +604,14 @@ void MDIViewPage::preSelectionChanged(const QPoint& pos)
         ss << "Edge" << edge->getProjIndex();
         //bool accepted =
         static_cast<void>(Gui::Selection().setPreselect(viewObj->getDocument()->getName(),
-                                                        viewObj->getNameInDocument(),
+                                                        viewObj->getNameInDocument().c_str(),
                                                         ss.str().c_str(), pos.x(), pos.y(), 0));
     }
     else if (vert) {
         ss << "Vertex" << vert->getProjIndex();
         //bool accepted =
         static_cast<void>(Gui::Selection().setPreselect(viewObj->getDocument()->getName(),
-                                                        viewObj->getNameInDocument(),
+                                                        viewObj->getNameInDocument().c_str(),
                                                         ss.str().c_str(), pos.x(), pos.y(), 0));
     }
     else if (face) {
@@ -619,13 +619,13 @@ void MDIViewPage::preSelectionChanged(const QPoint& pos)
            << face->getProjIndex();//TODO: SectionFaces have ProjIndex = -1. (but aren't selectable?) Problem?
         //bool accepted =
         static_cast<void>(Gui::Selection().setPreselect(viewObj->getDocument()->getName(),
-                                                        viewObj->getNameInDocument(),
+                                                        viewObj->getNameInDocument().c_str(),
                                                         ss.str().c_str(), pos.x(), pos.y(), 0));
     }
     else {
         ss << "";
         Gui::Selection().setPreselect(viewObj->getDocument()->getName(),
-                                      viewObj->getNameInDocument(), ss.str().c_str(), pos.x(),
+                                      viewObj->getNameInDocument().c_str(), ss.str().c_str(), pos.x(),
                                       pos.y(), 0);
     }
 }
@@ -809,9 +809,9 @@ void MDIViewPage::setTreeToSceneSelect()
                 ss << "Edge" << edge->getProjIndex();
                 //bool accepted =
                 static_cast<void>(Gui::Selection().addSelection(viewObj->getDocument()->getName(),
-                                                                viewObj->getNameInDocument(),
+                                                                viewObj->getNameInDocument().c_str(),
                                                                 ss.str().c_str()));
-                showStatusMsg(viewObj->getDocument()->getName(), viewObj->getNameInDocument(),
+                showStatusMsg(viewObj->getDocument()->getName(), viewObj->getNameInDocument().c_str(),
                               ss.str().c_str());
                 continue;
             }
@@ -834,9 +834,9 @@ void MDIViewPage::setTreeToSceneSelect()
                 ss << "Vertex" << vert->getProjIndex();
                 //bool accepted =
                 static_cast<void>(Gui::Selection().addSelection(viewObj->getDocument()->getName(),
-                                                                viewObj->getNameInDocument(),
+                                                                viewObj->getNameInDocument().c_str(),
                                                                 ss.str().c_str()));
-                showStatusMsg(viewObj->getDocument()->getName(), viewObj->getNameInDocument(),
+                showStatusMsg(viewObj->getDocument()->getName(), viewObj->getNameInDocument().c_str(),
                               ss.str().c_str());
                 continue;
             }
@@ -859,9 +859,9 @@ void MDIViewPage::setTreeToSceneSelect()
                 ss << "Face" << face->getProjIndex();
                 //bool accepted =
                 static_cast<void>(Gui::Selection().addSelection(viewObj->getDocument()->getName(),
-                                                                viewObj->getNameInDocument(),
+                                                                viewObj->getNameInDocument().c_str(),
                                                                 ss.str().c_str()));
-                showStatusMsg(viewObj->getDocument()->getName(), viewObj->getNameInDocument(),
+                showStatusMsg(viewObj->getDocument()->getName(), viewObj->getNameInDocument().c_str(),
                               ss.str().c_str());
                 continue;
             }
@@ -883,15 +883,14 @@ void MDIViewPage::setTreeToSceneSelect()
                 if (!dimObj) {
                     continue;
                 }
-                const char* name = dimObj->getNameInDocument();
-                if (!name) {//can happen during undo/redo if Dim is selected???
+                if (!dimObj->isAttachedToDocument()) {//can happen during undo/redo if Dim is selected???
                     //Base::Console().Log("INFO - MDIVP::sceneSelectionChanged - dimObj name is null!\n");
                     continue;
                 }
 
                 //bool accepted =
                 static_cast<void>(Gui::Selection().addSelection(dimObj->getDocument()->getName(),
-                                                                dimObj->getNameInDocument()));
+                                                                dimObj->getNameInDocument().c_str()));
             }
 
             QGMText* mText = dynamic_cast<QGMText*>(*it);
@@ -911,14 +910,13 @@ void MDIViewPage::setTreeToSceneSelect()
                 if (!parentFeat) {
                     continue;
                 }
-                const char* name = parentFeat->getNameInDocument();
-                if (!name) {//can happen during undo/redo if Dim is selected???
+                if (!parentFeat->isAttachedToDocument()) {//can happen during undo/redo if Dim is selected???
                     continue;
                 }
 
                 //bool accepted =
                 static_cast<void>(Gui::Selection().addSelection(
-                    parentFeat->getDocument()->getName(), parentFeat->getNameInDocument()));
+                    parentFeat->getDocument()->getName(), parentFeat->getNameInDocument().c_str()));
             }
         }
         else {

--- a/src/Mod/TechDraw/Gui/PagePrinter.cpp
+++ b/src/Mod/TechDraw/Gui/PagePrinter.cpp
@@ -277,7 +277,7 @@ void PagePrinter::printBannerPage(QPrinter* printer, QPainter& painter, QPageLay
     verticalPos += 2 * verticalSpacing * fontSizePx;
     for (auto& obj : docObjs) {
         //print a line for each page
-        QString pageLine = QString::fromUtf8(obj->getNameInDocument()) + QString::fromUtf8(" / ")
+        QString pageLine = QString::fromUtf8(obj->getNameInDocument().c_str()) + QString::fromUtf8(" / ")
             + QString::fromUtf8(obj->Label.getValue());
         painter.drawText(leftMargin, verticalPos, pageLine);
         verticalPos += verticalSpacing * fontSizePx;

--- a/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
@@ -181,7 +181,7 @@ QGIView * QGIProjGroup::getAnchorQItem() const
 
     for (QList<QGraphicsItem*>::iterator it = list.begin(); it != list.end(); ++it) {
         QGIView *view = dynamic_cast<QGIView *>(*it);
-        if(view && strcmp(view->getViewName(), anchorView->getNameInDocument()) == 0) {
+        if(view && anchorView->getNameInDocument() == view->getViewName()) {
               return view;
         }
     }

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -373,7 +373,7 @@ void QGIView::setViewFeature(TechDraw::DrawView *obj)
 
     //mark the actual QGraphicsItem so we can check what's in the scene later
     setData(0, QString::fromUtf8("QGIV"));
-    setData(1, QString::fromUtf8(obj->getNameInDocument()));
+    setData(1, QString::fromUtf8(obj->getNameInDocument().c_str()));
 }
 
 void QGIView::toggleCache(bool state)

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -477,18 +477,18 @@ void QGIViewBalloon::balloonLabelDragFinished()
     double x = Rez::appX(balloonLabel->X() / scale), y = Rez::appX(balloonLabel->Y() / scale);
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Drag Balloon"));
     Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.X = %f",
-                            dvb->getNameInDocument(), x);
+                            dvb->getNameInDocument().c_str(), x);
     Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Y = %f",
-                            dvb->getNameInDocument(), -y);
+                            dvb->getNameInDocument().c_str(), -y);
 
     // for the case that origin was also dragged, calc new origin and update feature
     if (m_originDragged) {
         Base::Vector3d pos(x, -y, 0.0);
         Base::Vector3d newOrg = pos - m_saveOffset;
         Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.OriginX = %f",
-                                dvb->getNameInDocument(), newOrg.x);
+                                dvb->getNameInDocument().c_str(), newOrg.x);
         Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.OriginY = %f",
-                                dvb->getNameInDocument(), newOrg.y);
+                                dvb->getNameInDocument().c_str(), newOrg.y);
     }
 
     Gui::Command::commitCommand();

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -685,9 +685,9 @@ void QGIViewDimension::datumLabelDragFinished()
     double x = Rez::appX(datumLabel->X()), y = Rez::appX(datumLabel->Y());
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Drag Dimension"));
     Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.X = %f",
-                            dim->getNameInDocument(), x);
+                            dim->getNameInDocument().c_str(), x);
     Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.%s.Y = %f",
-                            dim->getNameInDocument(), -y);
+                            dim->getNameInDocument().c_str(), -y);
     Gui::Command::commitCommand();
 }
 

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -745,7 +745,7 @@ QGIView* QGSPage::findQViewForDocObj(App::DocumentObject* obj) const
     if (obj) {
         const std::vector<QGIView*> qviews = getViews();
         for (std::vector<QGIView*>::const_iterator it = qviews.begin(); it != qviews.end(); ++it) {
-            if (strcmp(obj->getNameInDocument(), (*it)->getViewName()) == 0)
+            if (obj->getNameInDocument() == (*it)->getViewName())
                 return *it;
         }
     }
@@ -787,7 +787,7 @@ QGIView* QGSPage::findParent(QGIView* view) const
             // Attach the dimension to the first object's group
             for (std::vector<QGIView*>::const_iterator it = qviews.begin(); it != qviews.end();
                  ++it) {
-                if (strcmp((*it)->getViewName(), objs.at(0)->getNameInDocument()) == 0) {
+                if (objs.at(0)->getNameInDocument() == (*it)->getViewName()) {
                     return *it;
                 }
             }
@@ -805,7 +805,7 @@ QGIView* QGSPage::findParent(QGIView* view) const
             // Attach the Balloon to the first object's group
             for (std::vector<QGIView*>::const_iterator it = qviews.begin(); it != qviews.end();
                  ++it) {
-                if (strcmp((*it)->getViewName(), obj->getNameInDocument()) == 0) {
+                if (obj->getNameInDocument() == (*it)->getViewName()) {
                     return *it;
                 }
             }
@@ -855,7 +855,7 @@ QGIView* QGSPage::findParent(QGIView* view) const
                 std::vector<App::DocumentObject*> objs = collection->Views.getValues();
                 for (std::vector<App::DocumentObject*>::iterator it = objs.begin();
                      it != objs.end(); ++it) {
-                    if (strcmp(myFeat->getNameInDocument(), (*it)->getNameInDocument()) == 0)
+                    if (myFeat->getNameInDocument() == (*it)->getNameInDocument())
 
                         return grp;
                 }
@@ -873,7 +873,7 @@ bool QGSPage::hasQView(App::DocumentObject* obj)
 
     while (qview != views.end()) {
         // Unsure if we can compare pointers so rely on name
-        if (strcmp((*qview)->getViewName(), obj->getNameInDocument()) == 0) {
+        if (obj->getNameInDocument() == (*qview)->getViewName()) {
             return true;
         }
         qview++;
@@ -940,7 +940,7 @@ void QGSPage::fixOrphans(bool force)
     // if we ever have collections of collections, we'll need to revisit this
     TechDraw::DrawPage* thisPage = m_vpPage->getDrawPage();
 
-    if (!thisPage->getNameInDocument())
+    if (!thisPage->isAttachedToDocument())
         return;
 
     std::vector<App::DocumentObject*> pChildren = thisPage->getAllViews();
@@ -1023,7 +1023,7 @@ bool QGSPage::orphanExists(const char* viewName, const std::vector<App::Document
         }
 
         // Unsure if we can compare pointers so rely on name
-        if (strcmp(viewName, (*it)->getNameInDocument()) == 0) {
+        if ((*it)->getNameInDocument() == viewName) {
             return true;
         }
     }
@@ -1093,7 +1093,7 @@ void QGSPage::saveSvg(QString filename)
     TechDraw::DrawPage* page(m_vpPage->getDrawPage());
 
     const QString docName(QString::fromUtf8(page->getDocument()->getName()));
-    const QString pageName(QString::fromUtf8(page->getNameInDocument()));
+    const QString pageName(QString::fromUtf8(page->getNameInDocument().c_str()));
     QString svgDescription = QString::fromUtf8("Drawing page: ") + pageName
         + QString::fromUtf8(" exported from FreeCAD document: ") + docName;
 

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -170,8 +170,8 @@ QGVPage::QGVPage(ViewProviderPage* vpPage, QGSPage* scenePage, QWidget* parent)
 {
     assert(vpPage);
     m_vpPage = vpPage;
-    const char* name = vpPage->getDrawPage()->getNameInDocument();
-    setObjectName(QString::fromLocal8Bit(name));
+    std::string name = vpPage->getDrawPage()->getNameInDocument();
+    setObjectName(QString::fromLocal8Bit(name.c_str()));
 
     setScene(scenePage);
     setMouseTracking(true);

--- a/src/Mod/TechDraw/Gui/TaskDetail.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDetail.cpp
@@ -248,7 +248,7 @@ void TaskDetail::setUiFromFeat()
     Base::Vector3d anchor;
 
     TechDraw::DrawViewDetail* detailFeat = getDetailFeat();
-    QString detailDisplay = QString::fromUtf8(detailFeat->getNameInDocument()) +
+    QString detailDisplay = QString::fromUtf8(detailFeat->getNameInDocument().c_str()) +
                             QString::fromUtf8(" / ") +
                             QString::fromUtf8(detailFeat->Label.getValue());
     ui->leDetailView->setText(detailDisplay);

--- a/src/Mod/TechDraw/Gui/TaskDimRepair.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimRepair.cpp
@@ -116,7 +116,7 @@ void TaskDimRepair::slotUseSelection()
         //validators happy
         //bool accepted =
         static_cast<void>(Gui::Selection().addSelection(m_dim->getDocument()->getName(),
-                                                        m_dim->getNameInDocument()));
+                                                        m_dim->getNameInDocument().c_str()));
     }
     ReferenceVector references2d;
     ReferenceVector references3d;

--- a/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLeaderLine.cpp
@@ -435,9 +435,9 @@ void TaskLeaderLine::removeFeature()
         try {
             std::string PageName = m_basePage->getNameInDocument();
             Gui::Command::doCommand(Gui::Command::Gui, "App.activeDocument().%s.removeView(App.activeDocument().%s)",
-                                    PageName.c_str(), m_lineFeat->getNameInDocument());
+                                    PageName.c_str(), m_lineFeat->getNameInDocument().c_str());
             Gui::Command::doCommand(Gui::Command::Gui, "App.activeDocument().removeObject('%s')",
-                                        m_lineFeat->getNameInDocument());
+                                        m_lineFeat->getNameInDocument().c_str());
         }
         catch (...) {
             Base::Console().Message("TTL::removeFeature - failed to delete feature\n");

--- a/src/Mod/TechDraw/Gui/TaskLinkDim.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLinkDim.cpp
@@ -118,7 +118,7 @@ void TaskLinkDim::loadAvailDims()
 void TaskLinkDim::loadToTree(const TechDraw::DrawViewDimension* dim, const bool selected, Gui::Document* guiDoc)
 {
     QString label = QString::fromUtf8(dim->Label.getValue());
-    QString name = QString::fromUtf8(dim->getNameInDocument());
+    QString name = QString::fromUtf8(dim->getNameInDocument().c_str());
     QString tooltip = label + QString::fromUtf8(" / ") + name;
 
     QTreeWidgetItem* child = new QTreeWidgetItem();

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -184,7 +184,7 @@ void TaskProjGroup::viewToggled(bool toggle)
     if ( toggle && !multiView->hasProjection( viewNameCStr ) ) {
         Gui::Command::doCommand(Gui::Command::Doc,
                                 "App.activeDocument().%s.addProjection('%s')",
-                                multiView->getNameInDocument(), viewNameCStr);
+                                multiView->getNameInDocument().c_str(), viewNameCStr);
         changed = true;
     } else if ( !toggle && multiView->hasProjection( viewNameCStr ) ) {
         if (multiView->canDelete(viewNameCStr)) {
@@ -404,7 +404,7 @@ void TaskProjGroup::scaleManuallyChanged(int unused)
 
     double scale = (double) a / (double) b;
 
-    Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().%s.Scale = %f", multiView->getNameInDocument()
+    Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().%s.Scale = %f", multiView->getNameInDocument().c_str()
                                                                                      , scale);
     multiView->recomputeFeature();
 }

--- a/src/Mod/TechDraw/Gui/TaskProjection.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjection.cpp
@@ -81,13 +81,13 @@ bool TaskProjection::accept()
     Gui::Command::openCommand("Project shape");
     Gui::Command::addModule(Gui::Command::Doc, "TechDraw");
     for (std::vector<Part::Feature*>::iterator it = shapes.begin(); it != shapes.end(); ++it) {
-        const char* object = (*it)->getNameInDocument();
+        std::string object = (*it)->getNameInDocument();
         Gui::Command::doCommand(Gui::Command::Doc,
-            "FreeCAD.ActiveDocument.addObject('TechDraw::FeatureProjection', '%s_proj')", object);
+            "FreeCAD.ActiveDocument.addObject('TechDraw::FeatureProjection', '%s_proj')", object.c_str());
         Gui::Command::doCommand(Gui::Command::Doc,
             "FreeCAD.ActiveDocument.ActiveObject.Direction=FreeCAD.Vector(%f, %f, %f)", x, y,z);
         Gui::Command::doCommand(Gui::Command::Doc,
-            "FreeCAD.ActiveDocument.ActiveObject.Source=FreeCAD.ActiveDocument.%s", object);
+            "FreeCAD.ActiveDocument.ActiveObject.Source=FreeCAD.ActiveDocument.%s", object.c_str());
         Gui::Command::doCommand(Gui::Command::Doc,
             "FreeCAD.ActiveDocument.ActiveObject.VCompound=%s", (ui->cbVisSharp->isChecked() ? "True" : "False"));
         Gui::Command::doCommand(Gui::Command::Doc,

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -381,9 +381,9 @@ void TaskRichAnno::removeFeature()
             // this doesn't remove the QGMText item??
             std::string PageName = m_basePage->getNameInDocument();
             Gui::Command::doCommand(Gui::Command::Gui, "App.activeDocument().%s.removeView(App.activeDocument().%s)",
-                                    PageName.c_str(), m_annoFeat->getNameInDocument());
+                                    PageName.c_str(), m_annoFeat->getNameInDocument().c_str());
             Gui::Command::doCommand(Gui::Command::Gui, "App.activeDocument().removeObject('%s')",
-                                        m_annoFeat->getNameInDocument());
+                                        m_annoFeat->getNameInDocument().c_str());
         }
         catch (...) {
             Base::Console().Warning("TRA::removeFeature - failed to delete feature\n");

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -85,11 +85,10 @@ void ViewProviderDrawingView::attach(App::DocumentObject *pcFeat)
     //NOLINTEND
     auto feature = getViewObject();
     if (feature) {
-        const char* temp = feature->getNameInDocument();
-        if (temp) {
+        if (feature->isAttachedToDocument()) {
             // it could happen that feature is not completely in the document yet and getNameInDocument returns
             // nullptr, so we only update m_myName if we got a valid string.
-            m_myName = temp;
+            m_myName = feature->getNameInDocument();
         }
         connectGuiRepaint = feature->signalGuiPaint.connect(bnd);
         connectProgressMessage = feature->signalProgressMessage.connect(bndProgressMessage);

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -120,11 +120,10 @@ void ViewProviderPage::attach(App::DocumentObject* pcFeat)
     TechDraw::DrawPage* feature = dynamic_cast<TechDraw::DrawPage*>(pcFeat);
     if (feature) {
         connectGuiRepaint = feature->signalGuiPaint.connect(bnd);
-        const char* temp = feature->getNameInDocument();
-        if (temp) {
+        if (feature->isAttachedToDocument()) {
             // it could happen that feature is not completely in the document yet and getNameInDocument returns
             // nullptr, so we only update m_myName if we got a valid string.
-            m_pageName = temp;
+            m_pageName = feature->getNameInDocument();
         }
         m_graphicsScene->setObjectName(QString::fromLocal8Bit(m_pageName.c_str()));
     }

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -252,7 +252,7 @@ bool ViewProviderViewPart::setEdit(int ModNum)
         Gui::Control().showDialog(new TaskDlgDetail(dvd));
         Gui::Selection().clearSelection();
         Gui::Selection().addSelection(dvd->getDocument()->getName(),
-                                        dvd->getNameInDocument());
+                                        dvd->getNameInDocument().c_str());
     }
 
     return true;


### PR DESCRIPTION
This passed:
```
$ bin/FreeCAD --run-test 0
$ bin/FreeCADCmd --run-test 0
```

In FreeCAD, DocumentObject pcNameInDocument has three different uses:
  1. It is the name the object has when it belongs to a document.
  2. It indicates if this object belongs to a document or not.
  3. It provides a CAG key for each object. Some sort of UUID.

The most serious issue is that the method might return a nullptr, but this is hardly ever checked.  In most parts of FreeCAD the developer simply assumed this method provides a valid `const char*`.
This has the potential to cause a crash, as reported here:
https://github.com/FreeCAD/FreeCAD/issues/10130

Therefore, this method was divided into three methods:
  1. Always returns a valid string: const std::string& getNameInDocument().
  2. bool isAttachedToDocument().
  3. const char* getCagKey().

Unfortunately, the string returned by getNameInDocument() ends up being converted to `const char*` most of the time.
This is because in FreeCAD, for dealing with strings, we have:
  1. const char*
  2. std::string
  3. QString from utf8
  4. QString from Latin1 (?!?!?!?!)
  5. QByteArray
  6. Coin library's string object.

Making getNameInDocument() return a `std::string` was important to make the compiler point out in what places a `const char*` was expected. Unfortunately, because FreeCAD does not use std::string in a consistent way, there were lots of "false positive", where `.c_str()` ended up being required. I hope most of those `c_str()` get removed soon. :-)