### PR TITLE
Import: fixes #10983: Crash when trying to import a DXF file with Pol…

### DIFF
--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -1809,7 +1809,11 @@ CDxfRead::CDxfRead(const char* filepath)
     memset(m_block_name, '\0', sizeof(m_block_name));
     m_ignore_errors = true;
 
-    m_ifs = new ifstream(filepath);
+    m_version = RUnknown;
+    m_CodePage = nullptr;
+    m_encoding = nullptr;
+
+    m_ifs = new Base::ifstream(Base::FileInfo(filepath));
     if (!(*m_ifs)) {
         m_fail = true;
         printf("DXF file didn't load\n");
@@ -1817,9 +1821,6 @@ CDxfRead::CDxfRead(const char* filepath)
     }
     m_ifs->imbue(std::locale("C"));
 
-    m_version = RUnknown;
-    m_CodePage = nullptr;
-    m_encoding = nullptr;
     stringToUTF8 = &CDxfRead::UTF8ToUTF8;
 }
 


### PR DESCRIPTION
…ish letters in the name

The constructor of CDxfRead isn't correctly implemented because it leaves some class members un-initialized and in the destructor these dangling pointers cause a crash.

UTF-8 decoding wasn't correctly handled when trying to open a C++ file stream.