### PR TITLE
App: the function findLicense() uses the '==' operator to compare two…

### DIFF
--- a/src/App/License.h
+++ b/src/App/License.h
@@ -24,6 +24,7 @@
 #define APP_LICENSE_H
 
 #include <array>
+#include <cstring>
 #include <string>
 
 namespace App
@@ -64,8 +65,11 @@ constexpr std::array<TLicenseArr, countOfLicenses> licenseItems {{
 
 int constexpr findLicense(const char* identifier)
 {
+    if (!identifier || identifier[0] == '\0') {
+        return -1;
+    }
     for (int i = 0; i < countOfLicenses; i++) {
-        if (licenseItems.at(i).at(posnOfIdentifier) == identifier) {
+        if (strcmp(licenseItems.at(i).at(posnOfIdentifier), identifier) == 0) {
             return i;
         }
     }

--- a/tests/src/App/License.cpp
+++ b/tests/src/App/License.cpp
@@ -2,6 +2,16 @@
 
 #include "App/License.h"
 
+TEST(License, isLicenseEmpty)
+{
+    EXPECT_EQ(App::findLicense(""), -1);
+}
+
+TEST(License, isLicenseNull)
+{
+    EXPECT_EQ(App::findLicense(nullptr), -1);
+}
+
 TEST(License, isLicenseYesStr)
 {
     EXPECT_EQ(App::findLicense("CC_BY_40"), 1);
@@ -19,7 +29,9 @@ TEST(License, direct)
     App::TLicenseArr tt {"CC_BY_40",
                          "Creative Commons Attribution 4.0",
                          "https://creativecommons.org/licenses/by/4.0/"};
-    EXPECT_EQ(App::licenseItems.at(posn), tt);
+    EXPECT_STREQ(App::licenseItems.at(posn).at(0), tt.at(0));
+    EXPECT_STREQ(App::licenseItems.at(posn).at(1), tt.at(1));
+    EXPECT_STREQ(App::licenseItems.at(posn).at(2), tt.at(2));
 }
 
 TEST(License, findLicenseByIdent)


### PR DESCRIPTION
… C strings.

This is wrong and leads to failures under Windows.