### PR TITLE
[Gui] Prefer Dark-Outline as default overlay stylesheet - #7888

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1264,7 +1264,7 @@ void MainWindow::onWindowActivated(QMdiSubWindow* w)
         d->activeView = view;
         Application::Instance->viewActivated(view);
     }
-    
+
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
     bool saveWB = hGrp->GetBool("SaveWBbyTab", false);
     if (saveWB) {

--- a/src/Gui/OverlayManager.h
+++ b/src/Gui/OverlayManager.h
@@ -21,7 +21,7 @@
  ****************************************************************************/
 
 #ifndef FC_OVERLAYMANAGER_H
-#define FC_OVERLAYMANAGER_H 
+#define FC_OVERLAYMANAGER_H
 
 #include <QObject>
 
@@ -61,7 +61,7 @@ public:
         ReloadResume = 2,
     };
     /** Set reload mode
-     * 
+     *
      * An internal timer is used to batch handle all relevant parameter
      * changes. The function is provided to let other code temporarily disable
      * the timer before changing the parameter, and then resume it after done.

--- a/src/Gui/OverlayParams.cpp
+++ b/src/Gui/OverlayParams.cpp
@@ -146,7 +146,7 @@ public:
         if(it == funcs.end())
             return;
         it->second(this);
-        
+
     }
 
 

--- a/src/Gui/OverlayWidgets.h
+++ b/src/Gui/OverlayWidgets.h
@@ -21,7 +21,7 @@
  ****************************************************************************/
 
 #ifndef FC_OVERLAYWIDGETS_H
-#define FC_OVERLAYWIDGETS_H 
+#define FC_OVERLAYWIDGETS_H
 
 #include <QTabWidget>
 #include <QTimer>
@@ -149,7 +149,7 @@ public:
     /// Get the geometry of this tab widget
     const QRect &getRect();
 
-    /// Overlay query option 
+    /// Overlay query option
     enum class QueryOption {
         /// Report the current overlay status
         QueryOverlay,
@@ -170,7 +170,7 @@ public:
      * hide in non 3D view.
      */
     bool checkAutoHide() const;
-    /** Obtain geometry of auto hiding tab widget 
+    /** Obtain geometry of auto hiding tab widget
      * @param rect: output geometry of the tab widget
      * @return Return true if the tab widget should be auto hiding
      */
@@ -522,7 +522,7 @@ public:
 };
 
 /** Class for handling visual hint for bringing back hidden overlay dock widget
- * 
+ *
  * The proxy widget is transparent except a customizable rectangle area with a
  * selectable color shown as the visual hint. The hint is normally hidden, and
  * is shown only if the mouse hovers within the widget. When the hint area is
@@ -614,7 +614,7 @@ public:
     inline QColor color() const { return _color; }
 
     inline bool enabled() const {return _enabled;}
-    inline void setEnabled(bool enabled) 
+    inline void setEnabled(bool enabled)
         { if(_enabled!=enabled) {_enabled = enabled; updateBoundingRect();} }
 
 private:

--- a/src/Gui/PreferencePages/DlgSettingsTheme.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsTheme.cpp
@@ -166,7 +166,7 @@ void DlgSettingsTheme::attachObserver()
     auto handler = handlers.addDelayedHandler("BaseApp/Preferences/MainWindow",
                                {"StyleSheet", "TiledBackground"},
                                applyStyleSheet);
-    handlers.addHandler("BaseApp/Preferences/Themes", 
+    handlers.addHandler("BaseApp/Preferences/Themes",
                         {"ThemeAccentColor1", "ThemeAccentColor2", "ThemeAccentColor2"},
                         handler);
 }

--- a/src/Gui/Stylesheets/CMakeLists.txt
+++ b/src/Gui/Stylesheets/CMakeLists.txt
@@ -33,12 +33,12 @@ FILE(GLOB Images_Files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
 SOURCE_GROUP("images_dark-light" FILES ${Images_Files})
 
 ADD_CUSTOM_TARGET(Stylesheets_data ALL
-    SOURCES ${Stylesheets_Files} ${Images_Files} ${Overlay_Stylesheets_Files} 
+    SOURCES ${Stylesheets_Files} ${Images_Files} ${Overlay_Stylesheets_Files}
 )
 
 fc_copy_sources(Stylesheets_data "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Gui/Stylesheets"
-                                  ${Stylesheets_Files} 
-                                  ${Images_Files} 
+                                  ${Stylesheets_Files}
+                                  ${Images_Files}
                                   ${Overlay_Stylesheets_Files})
 
 INSTALL(

--- a/src/Gui/TreeParams.py
+++ b/src/Gui/TreeParams.py
@@ -66,7 +66,7 @@ Params = [
     ParamInt('FontSize', 0, on_change=True),
     ParamInt('ItemSpacing', 0, on_change=True),
     ParamHex('ItemBackground', 0, on_change=True, title='Item background color', proxy=ParamColor(),
-        doc = "Tree view item background. Only effecitve in overlay."),
+        doc = "Tree view item background. Only effective in overlay."),
     ParamInt('ItemBackgroundPadding', 0, on_change=True, title="Item background padding", proxy=ParamSpinBox(0, 100, 1),
         doc = "Tree view item background padding."),
     ParamBool('HideColumn', True, on_change=True, title="Hide extra column",


### PR DESCRIPTION
As mentioned in https://github.com/FreeCAD/FreeCAD/pull/7888#issuecomment-1752017743

This PR fixes white space problems and changes how stylesheet detection works.

FreeCAD 3D View is often somewhat dark even if the UI is in light colors. So if user has not speficially applied "Light" stylesheet we should prefer to use "Dark-Outline" stylesheet which provides proper and fully transparent overlay panels.