### PR TITLE
Gui: fixes OverlayManager issues

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1263,7 +1263,7 @@ void MainWindow::onWindowActivated(QMdiSubWindow* w)
         d->activeView = view;
         Application::Instance->viewActivated(view);
     }
-    
+
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
     bool saveWB = hGrp->GetBool("SaveWBbyTab", false);
     if (saveWB) {

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1771,10 +1771,7 @@ void MainWindow::saveWindowSettings(bool canDelay)
     config.endGroup();
 #else
     // We are migrating from saving qt main window layout state in QSettings to
-    // FreeCAD parameters, for more control. The old settings is explicitly
-    // remove from old QSettings conf to allow easier complete reset of
-    // application state by just removing FC user.cfg file.
-    config.remove(qtver);
+    // FreeCAD parameters, for more control.
 #endif
 
     Base::ConnectionBlocker block(d->connParam);

--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -889,11 +889,9 @@ public:
         } else if (!checked) {
             if (sizes[index] > 0 && sizes.size() > 1) {
                 int newtotal = 0;
-                int total = 0;
                 auto newsizes = sizes;
                 newsizes[index] = 0;
                 for (int i=0; i<sizes.size(); ++i) {
-                    total += sizes[i];
                     if (i != index) {
                         auto d = tabWidget->dockWidget(i);
                         auto it = tabWidget->_sizemap.find(d);
@@ -1908,10 +1906,15 @@ void OverlayManager::Private::interceptEvent(QWidget *widget, QEvent *ev)
     }
     case QEvent::Wheel: {
         auto we = static_cast<QWheelEvent*>(ev);
-        lastIntercept = getChildAt(widget, we->globalPos());
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
+        QPoint globalPos = we->globalPos();
+#else
+        QPoint globalPos = we->globalPosition().toPoint();
+#endif
+        lastIntercept = getChildAt(widget, globalPos);
 #if QT_VERSION >= QT_VERSION_CHECK(5,12,0)
-        QWheelEvent wheelEvent(lastIntercept->mapFromGlobal(we->globalPos()),
-                               we->globalPos(),
+        QWheelEvent wheelEvent(lastIntercept->mapFromGlobal(globalPos),
+                               globalPos,
                                we->pixelDelta(),
                                we->angleDelta(),
                                we->buttons(),
@@ -1920,8 +1923,8 @@ void OverlayManager::Private::interceptEvent(QWidget *widget, QEvent *ev)
                                we->inverted(),
                                we->source());
 #else
-        QWheelEvent wheelEvent(lastIntercept->mapFromGlobal(we->globalPos()),
-                               we->globalPos(),
+        QWheelEvent wheelEvent(lastIntercept->mapFromGlobal(globalPos),
+                               globalPos,
                                we->pixelDelta(),
                                we->angleDelta(),
                                0,

--- a/src/Gui/OverlayManager.h
+++ b/src/Gui/OverlayManager.h
@@ -24,6 +24,7 @@
 #define FC_OVERLAYMANAGER_H 
 
 #include <QObject>
+#include <FCGlobal.h>
 
 class QAction;
 class QDockWidget;
@@ -177,6 +178,8 @@ private:
     void onTaskViewUpdate();
     void onFocusChanged(QWidget *, QWidget *);
     void onAction();
+
+private Q_SLOTS:
     void raiseAll();
 
 private:

--- a/src/Gui/OverlayParams.cpp
+++ b/src/Gui/OverlayParams.cpp
@@ -146,7 +146,6 @@ public:
         if(it == funcs.end())
             return;
         it->second(this);
-        
     }
 
 

--- a/src/Gui/OverlayWidgets.h
+++ b/src/Gui/OverlayWidgets.h
@@ -21,7 +21,7 @@
  ****************************************************************************/
 
 #ifndef FC_OVERLAYWIDGETS_H
-#define FC_OVERLAYWIDGETS_H 
+#define FC_OVERLAYWIDGETS_H
 
 #include <QTabWidget>
 #include <QTimer>
@@ -149,7 +149,7 @@ public:
     /// Get the geometry of this tab widget
     const QRect &getRect();
 
-    /// Overlay query option 
+    /// Overlay query option
     enum class QueryOption {
         /// Report the current overlay status
         QueryOverlay,
@@ -170,7 +170,7 @@ public:
      * hide in non 3D view.
      */
     bool checkAutoHide() const;
-    /** Obtain geometry of auto hiding tab widget 
+    /** Obtain geometry of auto hiding tab widget
      * @param rect: output geometry of the tab widget
      * @return Return true if the tab widget should be auto hiding
      */
@@ -522,7 +522,7 @@ public:
 };
 
 /** Class for handling visual hint for bringing back hidden overlay dock widget
- * 
+ *
  * The proxy widget is transparent except a customizable rectangle area with a
  * selectable color shown as the visual hint. The hint is normally hidden, and
  * is shown only if the mouse hovers within the widget. When the hint area is
@@ -614,7 +614,7 @@ public:
     inline QColor color() const { return _color; }
 
     inline bool enabled() const {return _enabled;}
-    inline void setEnabled(bool enabled) 
+    inline void setEnabled(bool enabled)
         { if(_enabled!=enabled) {_enabled = enabled; updateBoundingRect();} }
 
 private:

--- a/src/Gui/PreferencePages/DlgSettingsTheme.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsTheme.cpp
@@ -166,7 +166,7 @@ void DlgSettingsTheme::attachObserver()
     auto handler = handlers.addDelayedHandler("BaseApp/Preferences/MainWindow",
                                {"StyleSheet", "TiledBackground"},
                                applyStyleSheet);
-    handlers.addHandler("BaseApp/Preferences/Themes", 
+    handlers.addHandler("BaseApp/Preferences/Themes",
                         {"ThemeAccentColor1", "ThemeAccentColor2", "ThemeAccentColor2"},
                         handler);
 }

--- a/src/Gui/PreferencePages/DlgSettingsTheme.ui
+++ b/src/Gui/PreferencePages/DlgSettingsTheme.ui
@@ -28,38 +28,8 @@
     <layout class="QGridLayout">
      <item row="0" column="0">
       <layout class="QGridLayout">
-       <item row="3" column="1">
-        <widget class="Gui::PrefComboBox" name="StyleSheets">
-         <property name="toolTip">
-          <string>Style sheet how user interface will look like</string>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>MainWindow</cstring>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>StyleSheet</cstring>
-         </property>
-         <property name="prefType" stdset="0">
-          <cstring></cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Accent color 2</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Accent color 3</string>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="0">
-        <widget class="QLabel" name="label">
+        <widget class="QLabel" name="label1">
          <property name="text">
           <string>Accent color 1</string>
          </property>
@@ -91,10 +61,10 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="styleSheetLabel">
+       <item row="1" column="0">
+        <widget class="QLabel" name="label2">
          <property name="text">
-          <string>Style sheet (advanced):</string>
+          <string>Accent color 2</string>
          </property>
         </widget>
        </item>
@@ -124,6 +94,13 @@
          </property>
         </widget>
        </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label3">
+         <property name="text">
+          <string>Accent color 3</string>
+         </property>
+        </widget>
+       </item>
        <item row="2" column="1">
         <widget class="Gui::PrefColorButton" name="ThemeAccentColor3">
          <property name="sizePolicy">
@@ -147,6 +124,29 @@
          </property>
          <property name="prefPath" stdset="0">
           <cstring>Themes</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="styleSheetLabel">
+         <property name="text">
+          <string>Style sheet (advanced):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="Gui::PrefComboBox" name="StyleSheets">
+         <property name="toolTip">
+          <string>Style sheet how user interface will look like</string>
+         </property>
+         <property name="prefPath" stdset="0">
+          <cstring>MainWindow</cstring>
+         </property>
+         <property name="prefEntry" stdset="0">
+          <cstring>StyleSheet</cstring>
+         </property>
+         <property name="prefType" stdset="0">
+          <cstring></cstring>
          </property>
         </widget>
        </item>

--- a/src/Gui/Stylesheets/CMakeLists.txt
+++ b/src/Gui/Stylesheets/CMakeLists.txt
@@ -33,12 +33,12 @@ FILE(GLOB Images_Files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
 SOURCE_GROUP("images_dark-light" FILES ${Images_Files})
 
 ADD_CUSTOM_TARGET(Stylesheets_data ALL
-    SOURCES ${Stylesheets_Files} ${Images_Files} ${Overlay_Stylesheets_Files} 
+    SOURCES ${Stylesheets_Files} ${Images_Files} ${Overlay_Stylesheets_Files}
 )
 
 fc_copy_sources(Stylesheets_data "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Gui/Stylesheets"
-                                  ${Stylesheets_Files} 
-                                  ${Images_Files} 
+                                  ${Stylesheets_Files}
+                                  ${Images_Files}
                                   ${Overlay_Stylesheets_Files})
 
 INSTALL(


### PR DESCRIPTION
Fixes several issues of https://github.com/FreeCAD/FreeCAD/pull/7888:
* Since Qt5.11 QDesktopWidget is marked as deprecated and has been removed in Qt6. New code has to use QScreen instead.
* QMetaObject::invokeMethod: No such method Gui::OverlayManager::raiseAll()
* 'globalPos' is deprecated: Use globalPosition() [-Wdeprecated-declarations]
