### PR TITLE
Import: Support DXF text rotation

### DIFF
--- a/src/Mod/Draft/draftmake/make_text.py
+++ b/src/Mod/Draft/draftmake/make_text.py
@@ -41,7 +41,7 @@ if App.GuiUp:
     from draftviewproviders.view_text import ViewProviderText
 
 
-def make_text(string, placement=None, screen=False):
+def make_text(string, placement=None, screen=False, height=None):
     """Create a Text object containing the given list of strings.
 
     The current color and text height and font specified in preferences
@@ -65,6 +65,9 @@ def make_text(string, placement=None, screen=False):
         by the default the XY plane.
         If it is `True`, the text will always face perpendicularly
         to the camera direction, that is, it will be flat on the screen.
+
+    height: float, optional
+        A height value for the text, in mm
 
     Returns
     -------
@@ -122,15 +125,16 @@ def make_text(string, placement=None, screen=False):
     if App.GuiUp:
         ViewProviderText(new_obj.ViewObject)
 
-        h = utils.get_param("textheight", 2)
+        if not height:  # zero or None
+            height = utils.get_param("textheight", 2)
 
         new_obj.ViewObject.DisplayMode = "World"
         if screen:
             _msg("screen: {}".format(screen))
             new_obj.ViewObject.DisplayMode = "Screen"
-            h = h * 10
+            height *= 10
 
-        new_obj.ViewObject.FontSize = h
+        new_obj.ViewObject.FontSize = height
         new_obj.ViewObject.FontName = utils.get_param("textfont", "")
         new_obj.ViewObject.LineSpacing = 1
 

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -316,17 +316,24 @@ void ImpExpDxfRead::OnReadEllipse(const double* c,
 }
 
 
-void ImpExpDxfRead::OnReadText(const double* point, const double /*height*/, const char* text)
+void ImpExpDxfRead::OnReadText(const double* point,
+                               const double height,
+                               const char* text,
+                               const double rotation)
 {
     if (optionImportAnnotations) {
-        Base::Vector3d pt(point[0] * optionScaling,
-                          point[1] * optionScaling,
-                          point[2] * optionScaling);
         if (LayerName().substr(0, 6) != "BLOCKS") {
-            App::Annotation* pcFeature =
-                static_cast<App::Annotation*>(document->addObject("App::Annotation", "Text"));
-            pcFeature->LabelText.setValue(Deformat(text));
-            pcFeature->Position.setValue(pt);
+            Base::Interpreter().runString("import Draft");
+            Base::Interpreter().runStringArg("p=FreeCAD.Vector(%f,%f,%f)",
+                                             point[0] * optionScaling,
+                                             point[1] * optionScaling,
+                                             point[2] * optionScaling);
+            Base::Interpreter().runString("a=FreeCAD.Vector(0,0,1)");
+            Base::Interpreter().runStringArg("pl=FreeCAD.Placement(p,a,%f)",
+                                            rotation);
+            Base::Interpreter().runStringArg("Draft.make_text(\"%s\",pl, height=%f)",
+                                             text,
+                                             height);
         }
         // else std::cout << "skipped text in block: " << LayerName() << std::endl;
     }

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -43,7 +43,10 @@ public:
     // CDxfRead's virtual functions
     void OnReadLine(const double* s, const double* e, bool hidden) override;
     void OnReadPoint(const double* s) override;
-    void OnReadText(const double* point, const double height, const char* text) override;
+    void OnReadText(const double* point,
+                    const double height,
+                    const char* text,
+                    const double rotation) override;
     void
     OnReadArc(const double* s, const double* e, const double* c, bool dir, bool hidden) override;
     void OnReadCircle(const double* s, const double* c, bool dir, bool hidden) override;

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -393,8 +393,10 @@ public:
     {}
     ImportExport virtual void OnReadPoint(const double* /*s*/)
     {}
-    ImportExport virtual void
-    OnReadText(const double* /*point*/, const double /*height*/, const char* /*text*/)
+    ImportExport virtual void OnReadText(const double* /*point*/,
+                                         const double /*height*/,
+                                         const char* /*text*/,
+                                         const double /*rotation*/)
     {}
     ImportExport virtual void OnReadArc(const double* /*s*/,
                                         const double* /*e*/,


### PR DESCRIPTION
- Reads and supports text rotation in builtin DXF import
- Makes the builtin DXF import produce Draft texts instead of App::Annotations
- Extends the arguments of Draft make_text()

Fixes #10882