### PR TITLE
Gui: implement option to disable overlay management

### DIFF
--- a/src/Gui/DockWindowManager.h
+++ b/src/Gui/DockWindowManager.h
@@ -97,6 +97,8 @@ public:
     void loadState();
     void retranslate();
 
+    bool isOverlayActivated() const;
+
 private Q_SLOTS:
    /**
     * \internal
@@ -110,6 +112,7 @@ private Q_SLOTS:
 private:
     QDockWidget* findDockWidget(const QList<QDockWidget*>&, const QString&) const;
     void tabifyDockWidgets(DockWindowItems*);
+    void setupOverlayManagement();
 
     DockWindowManager();
     ~DockWindowManager() override;

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -230,6 +230,10 @@ void DlgSettingsGeneral::saveSettings()
     ui->RecentFiles->onSave();
     ui->EnableCursorBlinking->onSave();
     ui->SplashScreen->onSave();
+    ui->ActivateOverlay->onSave();
+    if (property("ActivateOverlay").toBool() != ui->ActivateOverlay->isChecked()) {
+        requireRestart();
+    }
 
     setRecentFileSize();
     bool force = setLanguage();
@@ -297,6 +301,8 @@ void DlgSettingsGeneral::loadSettings()
     ui->RecentFiles->onRestore();
     ui->EnableCursorBlinking->onRestore();
     ui->SplashScreen->onRestore();
+    ui->ActivateOverlay->onRestore();
+    setProperty("ActivateOverlay", ui->ActivateOverlay->isChecked());
 
     // search for the language files
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.ui
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.ui
@@ -360,6 +360,25 @@ display the splash screen</string>
          </property>
         </widget>
        </item>
+       <item row="5" column="1">
+        <widget class="Gui::PrefCheckBox" name="ActivateOverlay">
+         <property name="toolTip">
+          <string>Activate overlay handling of dock windows</string>
+         </property>
+         <property name="text">
+          <string>Activate overlay handling</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <property name="prefEntry" stdset="0">
+          <cstring>ActivateOverlay</cstring>
+         </property>
+         <property name="prefPath" stdset="0">
+          <cstring>DockWindows</cstring>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </item>

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -698,8 +698,16 @@ MenuItem* StdWorkbench::setupMenuBar() const
 #endif
           << "Separator" << visu
           << "Std_ToggleNavigation"
-          << "Std_SetAppearance" << "Std_RandomColor" << "Separator"
-          << "Std_Workbench" << "Std_ToolBarMenu" << "Std_DockViewMenu" << "Std_DockOverlay" << "Separator"
+          << "Std_SetAppearance"
+          << "Std_RandomColor"
+          << "Separator"
+          << "Std_Workbench"
+          << "Std_ToolBarMenu"
+          << "Std_DockViewMenu";
+    if (DockWindowManager::instance()->isOverlayActivated()) {
+        *view << "Std_DockOverlay";
+    }
+    *view << "Separator"
           << "Std_LinkSelectActions"
           << "Std_TreeViewActions"
           << "Std_ViewStatusBar";


### PR DESCRIPTION
Overlay management is not stable yet and causes serious problems to many users. This PR allows to deactivate it entirely.