### PR TITLE
Support different mode of file path resolve in App::PropertyXLink

### DIFF
--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -164,8 +164,15 @@ public:
     void setActiveDocument(const char *Name);
     /// close all documents (without saving)
     void closeAllDocuments();
-    /// Add pending document to open together with the current opening document
-    int addPendingDocument(const char *FileName, const char *objName, bool allowPartial);
+    /** Add pending document to open together with the current opening document
+     *
+     * @param FileName: file path to the document
+     * @param objName: linked object name in the document
+     * @param allowPartial: whether the link supports partial loading.
+     *
+     * @return Returns true if the document is already opened of can be opened right away, else return nullptr.
+     */
+    App::Document *addPendingDocument(const char *FileName, const char *objName, bool allowPartial);
     /// Indicate whether the application is opening (restoring) some document
     bool isRestoring() const;
     /// Indicate the application is closing all document

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -1145,6 +1145,27 @@ public:
 
     void setSyncSubObject(bool enable);
 
+    /// Defines the ways linked file path are resolves
+    enum class PathResolveMode {
+        Dynamic = 0,
+        Relative = 1,
+        RelativeCanonical = 2,
+        Absolute = 3,
+        Canonical = 4,
+    };
+    PathResolveMode getPathResolveMode() const;
+    const char *getPathResolveModeName() const;
+    void setPathResolveMode(PathResolveMode mode);
+    void setPathResolveMode(const char *mode);
+    std::string getFilePath(PathResolveMode mode) const;
+
+    struct PathResolveModeDoc {
+        const char *name = "";
+        const char *doc = "";
+    };
+    using PathResolveModeMap = std::map<PathResolveMode, PathResolveModeDoc>;
+    static const PathResolveModeMap &getPathResolveModeDocs();
+
 protected:
     void unlink();
     void detach();
@@ -1165,6 +1186,7 @@ protected:
     std::string docName;
     std::string objectName;
     std::string stamp;
+    PathResolveMode resolveMode = PathResolveMode::Dynamic;
     std::vector<std::string> _SubList;
     std::vector<ShadowSub> _ShadowSubList;
     std::vector<int> _mapped;

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -69,6 +69,10 @@ void _class_::init(void) { \
     (void)new Gui::PropertyEditor::PropertyItemProducer<_class_>(#_class_); \
 }
 
+namespace App {
+class PropertyXLink;
+}
+
 namespace Gui {
 
 namespace Dialog { 
@@ -143,6 +147,10 @@ public:
     virtual QVariant editorData(QWidget *editor) const;
     virtual bool isSeparator() const { return false; }
 
+    virtual QWidget* createChildEditor(const PropertyItem *child, QWidget* parent, const QObject* receiver, const char* method) const;
+    virtual void setChildEditorData(const PropertyItem *child, QWidget *editor, const QVariant& data) const;
+    virtual QVariant childEditorData(const PropertyItem *child, QWidget *editor) const;
+
     QWidget* createExpressionEditor(QWidget* parent, const QObject* receiver, const char* method) const;
     void setExpressionEditorData(QWidget *editor, const QVariant& data) const;
     QVariant expressionEditorData(QWidget *editor) const;
@@ -183,6 +191,7 @@ public:
     void setPropertyName(QString name, QString realName=QString());
     void setPropertyValue(const QString&);
     virtual QVariant data(int column, int role) const;
+    virtual QVariant childData(const PropertyItem *child, int column, int role) const;
     bool setData (const QVariant& value);
     Qt::ItemFlags flags(int column) const;
     virtual int row() const;
@@ -1170,11 +1179,18 @@ private:
 class GuiExport PropertyLinkItem: public PropertyItem
 {
     Q_OBJECT
+    Q_PROPERTY(QString File READ getFile WRITE setFile DESIGNABLE true USER true) // clazy:exclude=qproperty-without-notify
+    Q_PROPERTY(QByteArray PathResolveMode READ getPathResolveMode WRITE setPathResolveMode DESIGNABLE true USER true) // clazy:exclude=qproperty-without-notify
     PROPERTYITEM_HEADER
 
     QWidget* createEditor(QWidget* parent, const QObject* receiver, const char* method) const override;
     void setEditorData(QWidget *editor, const QVariant& data) const override;
     QVariant editorData(QWidget *editor) const override;
+
+    QString getFile() const;
+    void setFile(const QString &);
+    QByteArray getPathResolveMode() const;
+    void setPathResolveMode(const QByteArray &);
 
 protected:
     QVariant toString(const QVariant&) const override;
@@ -1182,8 +1198,20 @@ protected:
     void setValue(const QVariant&) override;
     QVariant data(int column, int role) const override;
 
+    QVariant childData(const PropertyItem *child, int column, int role) const override;
+    QWidget* createChildEditor(const PropertyItem *child, QWidget* parent, const QObject* receiver, const char* method) const  override;
+    void setChildEditorData(const PropertyItem *child, QWidget *editor, const QVariant& data) const  override;
+    QVariant childEditorData(const PropertyItem *child, QWidget *editor) const  override;
+    void initialize() override;
+
+    App::PropertyXLink *getXLink() const;
+
 protected:
     PropertyLinkItem();
+
+protected:
+    PropertyItem *m_file = nullptr;
+    PropertyItem *m_resolveMode = nullptr;
 };
 
 /**


### PR DESCRIPTION
Default to `Dynamic` resolving of relative path which can solve issue raised in #7596.

User can select different mode through property editor

![Screenshot from 2023-10-14 18-09-27](https://github.com/FreeCAD/FreeCAD/assets/1207888/30aba61d-bb36-42d5-b724-60649a9ab5dd)
