### PR TITLE
Gui: Register overlay search path from preference packs

### DIFF
--- a/src/Gui/PreferencePackManager.cpp
+++ b/src/Gui/PreferencePackManager.cpp
@@ -58,12 +58,15 @@ PreferencePack::PreferencePack(const fs::path& path, const App::Metadata& metada
 
     auto qssPaths = QDir::searchPaths(QString::fromUtf8("qss"));
     auto cssPaths = QDir::searchPaths(QString::fromUtf8("css"));
+    auto overlayPaths = QDir::searchPaths(QString::fromUtf8("overlay"));
 
     qssPaths.append(QString::fromStdString(_path.string()));
     cssPaths.append(QString::fromStdString(_path.string()));
+    overlayPaths.append(QString::fromStdString(_path.string() + "/overlay"));
 
     QDir::setSearchPaths(QString::fromUtf8("qss"), qssPaths);
     QDir::setSearchPaths(QString::fromUtf8("css"), cssPaths);
+    QDir::setSearchPaths(QString::fromUtf8("overlay"), overlayPaths);
 }
 
 std::string PreferencePack::name() const


### PR DESCRIPTION
This PR adds `"<mod>/overlay"` path to search paths of "overlay" prefix. This allows preference packs to register custom overlay stylesheets.

I think that we should think about better ways of doing that kind of stuff. Package metadata could include elements like 
```
<searchpath prefix="qss" path="." />
<searchpath prefix="overlay" path="./overlay" />
```
which should enable package developers to have better control over the search paths. This should however be done in another request and issue.

Fixes: #11023