### PR TITLE
Gui: Target proper widget when passing wheel event

### DIFF
--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -1947,6 +1947,13 @@ void OverlayManager::Private::interceptEvent(QWidget *widget, QEvent *ev)
         QPoint globalPos = we->globalPosition().toPoint();
 #endif
         lastIntercept = getChildAt(widget, globalPos);
+
+        for (auto parent = lastIntercept->parentWidget(); parent; parent = parent->parentWidget()) {
+            if (qobject_cast<QGraphicsView*>(parent)) {
+                lastIntercept = parent;
+            }
+        }
+
 #if QT_VERSION >= QT_VERSION_CHECK(5,12,0)
         QWheelEvent wheelEvent(lastIntercept->mapFromGlobal(globalPos),
                                globalPos,


### PR DESCRIPTION
As mentioned by @realthunder in https://github.com/FreeCAD/FreeCAD/issues/11015#issuecomment-1762922058 the https://github.com/realthunder/FreeCAD/commit/bdf7af1380c932371f4d01dab243c832dd2c68ec commit broke wheel event passing in overlay widgets. Reverting one block fixes the issue, I did not revert the other change as this function is used also in other places which seems to work fine.

Fixes: #11015