### PR TITLE
Gui: Remove CornerNaviCube from OverlayParams and use directly in OverlayManager

### DIFF
--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -663,8 +663,11 @@ public:
             h -= tabbar->height();
 
         int naviCubeSize = NaviCube::getNaviCubeSize();
-        int naviCorner = OverlayParams::getDockOverlayCheckNaviCube() ?
-            OverlayParams::getCornerNaviCube() : -1;
+        int naviCorner = OverlayParams::getDockOverlayCheckNaviCube()
+            ? App::GetApplication()
+                  .GetParameterGroupByPath("User parameter:BaseApp/Preferences/NaviCube")
+                  ->GetInt("CornerNaviCube", 1)
+            : -1;
 
         QRect rect;
         QRect rectBottom(0,0,0,0);

--- a/src/Gui/OverlayParams.cpp
+++ b/src/Gui/OverlayParams.cpp
@@ -28,21 +28,20 @@ import OverlayParams
 OverlayParams.define()
 ]]]*/
 
-// Auto generated code (Tools/params_utils.py:166)
+// Auto generated code (Tools/params_utils.py:196)
 #include <unordered_map>
 #include <App/Application.h>
 #include <App/DynamicProperty.h>
 #include "OverlayParams.h"
 using namespace Gui;
 
-// Auto generated code (Tools/params_utils.py:175)
+// Auto generated code (Tools/params_utils.py:207)
 namespace {
 class OverlayParamsP: public ParameterGrp::ObserverType {
 public:
     ParameterGrp::handle handle;
     std::unordered_map<const char *,void(*)(OverlayParamsP*),App::CStringHasher,App::CStringHasher> funcs;
 
-    long CornerNaviCube;
     bool DockOverlayAutoView;
     long DockOverlayDelay;
     long DockOverlayRevealDelay;
@@ -71,13 +70,11 @@ public:
     bool DockOverlayHidePropertyViewScrollBar;
     long DockOverlayMinimumSize;
 
-    // Auto generated code (Tools/params_utils.py:203)
+    // Auto generated code (Tools/params_utils.py:245)
     OverlayParamsP() {
         handle = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
         handle->Attach(this);
 
-        CornerNaviCube = handle->GetInt("CornerNaviCube", 1);
-        funcs["CornerNaviCube"] = &OverlayParamsP::updateCornerNaviCube;
         DockOverlayAutoView = handle->GetBool("DockOverlayAutoView", true);
         funcs["DockOverlayAutoView"] = &OverlayParamsP::updateDockOverlayAutoView;
         DockOverlayDelay = handle->GetInt("DockOverlayDelay", 200);
@@ -134,11 +131,11 @@ public:
         funcs["DockOverlayMinimumSize"] = &OverlayParamsP::updateDockOverlayMinimumSize;
     }
 
-    // Auto generated code (Tools/params_utils.py:217)
+    // Auto generated code (Tools/params_utils.py:263)
     ~OverlayParamsP() {
     }
 
-    // Auto generated code (Tools/params_utils.py:222)
+    // Auto generated code (Tools/params_utils.py:270)
     void OnChange(Base::Subject<const char*> &, const char* sReason) {
         if(!sReason)
             return;
@@ -149,15 +146,7 @@ public:
     }
 
 
-    // Auto generated code (Tools/params_utils.py:244)
-    static void updateCornerNaviCube(OverlayParamsP *self) {
-        auto v = self->handle->GetInt("CornerNaviCube", 1);
-        if (self->CornerNaviCube != v) {
-            self->CornerNaviCube = v;
-            OverlayParams::onCornerNaviCubeChanged();
-        }
-    }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateDockOverlayAutoView(OverlayParamsP *self) {
         auto v = self->handle->GetBool("DockOverlayAutoView", true);
         if (self->DockOverlayAutoView != v) {
@@ -165,39 +154,39 @@ public:
             OverlayParams::onDockOverlayAutoViewChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayDelay(OverlayParamsP *self) {
         self->DockOverlayDelay = self->handle->GetInt("DockOverlayDelay", 200);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayRevealDelay(OverlayParamsP *self) {
         self->DockOverlayRevealDelay = self->handle->GetInt("DockOverlayRevealDelay", 2000);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlaySplitterHandleTimeout(OverlayParamsP *self) {
         self->DockOverlaySplitterHandleTimeout = self->handle->GetInt("DockOverlaySplitterHandleTimeout", 0);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayActivateOnHover(OverlayParamsP *self) {
         self->DockOverlayActivateOnHover = self->handle->GetBool("DockOverlayActivateOnHover", true);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayAutoMouseThrough(OverlayParamsP *self) {
         self->DockOverlayAutoMouseThrough = self->handle->GetBool("DockOverlayAutoMouseThrough", true);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayWheelPassThrough(OverlayParamsP *self) {
         self->DockOverlayWheelPassThrough = self->handle->GetBool("DockOverlayWheelPassThrough", true);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayWheelDelay(OverlayParamsP *self) {
         self->DockOverlayWheelDelay = self->handle->GetInt("DockOverlayWheelDelay", 1000);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayAlphaRadius(OverlayParamsP *self) {
         self->DockOverlayAlphaRadius = self->handle->GetInt("DockOverlayAlphaRadius", 2);
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateDockOverlayCheckNaviCube(OverlayParamsP *self) {
         auto v = self->handle->GetBool("DockOverlayCheckNaviCube", true);
         if (self->DockOverlayCheckNaviCube != v) {
@@ -205,51 +194,51 @@ public:
             OverlayParams::onDockOverlayCheckNaviCubeChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintTriggerSize(OverlayParamsP *self) {
         self->DockOverlayHintTriggerSize = self->handle->GetInt("DockOverlayHintTriggerSize", 16);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintSize(OverlayParamsP *self) {
         self->DockOverlayHintSize = self->handle->GetInt("DockOverlayHintSize", 8);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintLeftLength(OverlayParamsP *self) {
         self->DockOverlayHintLeftLength = self->handle->GetInt("DockOverlayHintLeftLength", 100);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintRightLength(OverlayParamsP *self) {
         self->DockOverlayHintRightLength = self->handle->GetInt("DockOverlayHintRightLength", 100);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintTopLength(OverlayParamsP *self) {
         self->DockOverlayHintTopLength = self->handle->GetInt("DockOverlayHintTopLength", 100);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintBottomLength(OverlayParamsP *self) {
         self->DockOverlayHintBottomLength = self->handle->GetInt("DockOverlayHintBottomLength", 100);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintLeftOffset(OverlayParamsP *self) {
         self->DockOverlayHintLeftOffset = self->handle->GetInt("DockOverlayHintLeftOffset", 0);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintRightOffset(OverlayParamsP *self) {
         self->DockOverlayHintRightOffset = self->handle->GetInt("DockOverlayHintRightOffset", 0);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintTopOffset(OverlayParamsP *self) {
         self->DockOverlayHintTopOffset = self->handle->GetInt("DockOverlayHintTopOffset", 0);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintBottomOffset(OverlayParamsP *self) {
         self->DockOverlayHintBottomOffset = self->handle->GetInt("DockOverlayHintBottomOffset", 0);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintTabBar(OverlayParamsP *self) {
         self->DockOverlayHintTabBar = self->handle->GetBool("DockOverlayHintTabBar", false);
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateDockOverlayHideTabBar(OverlayParamsP *self) {
         auto v = self->handle->GetBool("DockOverlayHideTabBar", true);
         if (self->DockOverlayHideTabBar != v) {
@@ -257,23 +246,23 @@ public:
             OverlayParams::onDockOverlayHideTabBarChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHintDelay(OverlayParamsP *self) {
         self->DockOverlayHintDelay = self->handle->GetInt("DockOverlayHintDelay", 200);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayAnimationDuration(OverlayParamsP *self) {
         self->DockOverlayAnimationDuration = self->handle->GetInt("DockOverlayAnimationDuration", 200);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayAnimationCurve(OverlayParamsP *self) {
         self->DockOverlayAnimationCurve = self->handle->GetInt("DockOverlayAnimationCurve", 7);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateDockOverlayHidePropertyViewScrollBar(OverlayParamsP *self) {
         self->DockOverlayHidePropertyViewScrollBar = self->handle->GetBool("DockOverlayHidePropertyViewScrollBar", false);
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateDockOverlayMinimumSize(OverlayParamsP *self) {
         auto v = self->handle->GetInt("DockOverlayMinimumSize", 30);
         if (self->DockOverlayMinimumSize != v) {
@@ -283,7 +272,7 @@ public:
     }
 };
 
-// Auto generated code (Tools/params_utils.py:256)
+// Auto generated code (Tools/params_utils.py:310)
 OverlayParamsP *instance() {
     static OverlayParamsP *inst = new OverlayParamsP;
     return inst;
@@ -291,263 +280,236 @@ OverlayParamsP *instance() {
 
 } // Anonymous namespace
 
-// Auto generated code (Tools/params_utils.py:265)
+// Auto generated code (Tools/params_utils.py:321)
 ParameterGrp::handle OverlayParams::getHandle() {
     return instance()->handle;
 }
 
-// Auto generated code (Tools/params_utils.py:288)
-const char *OverlayParams::docCornerNaviCube() {
-    return "";
-}
-
-// Auto generated code (Tools/params_utils.py:294)
-const long & OverlayParams::getCornerNaviCube() {
-    return instance()->CornerNaviCube;
-}
-
-// Auto generated code (Tools/params_utils.py:300)
-const long & OverlayParams::defaultCornerNaviCube() {
-    const static long def = 1;
-    return def;
-}
-
-// Auto generated code (Tools/params_utils.py:307)
-void OverlayParams::setCornerNaviCube(const long &v) {
-    instance()->handle->SetInt("CornerNaviCube",v);
-    instance()->CornerNaviCube = v;
-}
-
-// Auto generated code (Tools/params_utils.py:314)
-void OverlayParams::removeCornerNaviCube() {
-    instance()->handle->RemoveInt("CornerNaviCube");
-}
-
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayAutoView() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & OverlayParams::getDockOverlayAutoView() {
     return instance()->DockOverlayAutoView;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & OverlayParams::defaultDockOverlayAutoView() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayAutoView(const bool &v) {
     instance()->handle->SetBool("DockOverlayAutoView",v);
     instance()->DockOverlayAutoView = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayAutoView() {
     instance()->handle->RemoveBool("DockOverlayAutoView");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayDelay() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Overlay dock (re),layout delay.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayDelay() {
     return instance()->DockOverlayDelay;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayDelay() {
     const static long def = 200;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayDelay(const long &v) {
     instance()->handle->SetInt("DockOverlayDelay",v);
     instance()->DockOverlayDelay = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayDelay() {
     instance()->handle->RemoveInt("DockOverlayDelay");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayRevealDelay() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayRevealDelay() {
     return instance()->DockOverlayRevealDelay;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayRevealDelay() {
     const static long def = 2000;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayRevealDelay(const long &v) {
     instance()->handle->SetInt("DockOverlayRevealDelay",v);
     instance()->DockOverlayRevealDelay = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayRevealDelay() {
     instance()->handle->RemoveInt("DockOverlayRevealDelay");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlaySplitterHandleTimeout() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Overlay splitter handle auto hide delay. Set zero to disable auto hiding.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlaySplitterHandleTimeout() {
     return instance()->DockOverlaySplitterHandleTimeout;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlaySplitterHandleTimeout() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlaySplitterHandleTimeout(const long &v) {
     instance()->handle->SetInt("DockOverlaySplitterHandleTimeout",v);
     instance()->DockOverlaySplitterHandleTimeout = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlaySplitterHandleTimeout() {
     instance()->handle->RemoveInt("DockOverlaySplitterHandleTimeout");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayActivateOnHover() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Show auto hidden dock overlay on mouse over.\n"
 "If disabled, then show on mouse click.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & OverlayParams::getDockOverlayActivateOnHover() {
     return instance()->DockOverlayActivateOnHover;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & OverlayParams::defaultDockOverlayActivateOnHover() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayActivateOnHover(const bool &v) {
     instance()->handle->SetBool("DockOverlayActivateOnHover",v);
     instance()->DockOverlayActivateOnHover = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayActivateOnHover() {
     instance()->handle->RemoveBool("DockOverlayActivateOnHover");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayAutoMouseThrough() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto mouse click through transparent part of dock overlay.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & OverlayParams::getDockOverlayAutoMouseThrough() {
     return instance()->DockOverlayAutoMouseThrough;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & OverlayParams::defaultDockOverlayAutoMouseThrough() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayAutoMouseThrough(const bool &v) {
     instance()->handle->SetBool("DockOverlayAutoMouseThrough",v);
     instance()->DockOverlayAutoMouseThrough = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayAutoMouseThrough() {
     instance()->handle->RemoveBool("DockOverlayAutoMouseThrough");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayWheelPassThrough() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto pass through mouse wheel event on transparent dock overlay.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & OverlayParams::getDockOverlayWheelPassThrough() {
     return instance()->DockOverlayWheelPassThrough;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & OverlayParams::defaultDockOverlayWheelPassThrough() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayWheelPassThrough(const bool &v) {
     instance()->handle->SetBool("DockOverlayWheelPassThrough",v);
     instance()->DockOverlayWheelPassThrough = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayWheelPassThrough() {
     instance()->handle->RemoveBool("DockOverlayWheelPassThrough");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayWheelDelay() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Delay capturing mouse wheel event for passing through if it is\n"
 "previously handled by other widget.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayWheelDelay() {
     return instance()->DockOverlayWheelDelay;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayWheelDelay() {
     const static long def = 1000;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayWheelDelay(const long &v) {
     instance()->handle->SetInt("DockOverlayWheelDelay",v);
     instance()->DockOverlayWheelDelay = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayWheelDelay() {
     instance()->handle->RemoveInt("DockOverlayWheelDelay");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayAlphaRadius() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "If auto mouse click through is enabled, then this radius\n"
@@ -556,533 +518,533 @@ const char *OverlayParams::docDockOverlayAlphaRadius() {
 "the region are non-opaque.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayAlphaRadius() {
     return instance()->DockOverlayAlphaRadius;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayAlphaRadius() {
     const static long def = 2;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayAlphaRadius(const long &v) {
     instance()->handle->SetInt("DockOverlayAlphaRadius",v);
     instance()->DockOverlayAlphaRadius = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayAlphaRadius() {
     instance()->handle->RemoveInt("DockOverlayAlphaRadius");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayCheckNaviCube() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Leave space for Navigation Cube in dock overlay");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & OverlayParams::getDockOverlayCheckNaviCube() {
     return instance()->DockOverlayCheckNaviCube;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & OverlayParams::defaultDockOverlayCheckNaviCube() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayCheckNaviCube(const bool &v) {
     instance()->handle->SetBool("DockOverlayCheckNaviCube",v);
     instance()->DockOverlayCheckNaviCube = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayCheckNaviCube() {
     instance()->handle->RemoveBool("DockOverlayCheckNaviCube");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintTriggerSize() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide hint visual display triggering width");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayHintTriggerSize() {
     return instance()->DockOverlayHintTriggerSize;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayHintTriggerSize() {
     const static long def = 16;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintTriggerSize(const long &v) {
     instance()->handle->SetInt("DockOverlayHintTriggerSize",v);
     instance()->DockOverlayHintTriggerSize = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintTriggerSize() {
     instance()->handle->RemoveInt("DockOverlayHintTriggerSize");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintSize() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide hint visual display width");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayHintSize() {
     return instance()->DockOverlayHintSize;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayHintSize() {
     const static long def = 8;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintSize(const long &v) {
     instance()->handle->SetInt("DockOverlayHintSize",v);
     instance()->DockOverlayHintSize = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintSize() {
     instance()->handle->RemoveInt("DockOverlayHintSize");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintLeftLength() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide hint visual display length for left panel. Set to zero to fill the space.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayHintLeftLength() {
     return instance()->DockOverlayHintLeftLength;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayHintLeftLength() {
     const static long def = 100;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintLeftLength(const long &v) {
     instance()->handle->SetInt("DockOverlayHintLeftLength",v);
     instance()->DockOverlayHintLeftLength = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintLeftLength() {
     instance()->handle->RemoveInt("DockOverlayHintLeftLength");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintRightLength() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide hint visual display length for right panel. Set to zero to fill the space.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayHintRightLength() {
     return instance()->DockOverlayHintRightLength;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayHintRightLength() {
     const static long def = 100;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintRightLength(const long &v) {
     instance()->handle->SetInt("DockOverlayHintRightLength",v);
     instance()->DockOverlayHintRightLength = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintRightLength() {
     instance()->handle->RemoveInt("DockOverlayHintRightLength");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintTopLength() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide hint visual display length for top panel. Set to zero to fill the space.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayHintTopLength() {
     return instance()->DockOverlayHintTopLength;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayHintTopLength() {
     const static long def = 100;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintTopLength(const long &v) {
     instance()->handle->SetInt("DockOverlayHintTopLength",v);
     instance()->DockOverlayHintTopLength = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintTopLength() {
     instance()->handle->RemoveInt("DockOverlayHintTopLength");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintBottomLength() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide hint visual display length for bottom panel. Set to zero to fill the space.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayHintBottomLength() {
     return instance()->DockOverlayHintBottomLength;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayHintBottomLength() {
     const static long def = 100;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintBottomLength(const long &v) {
     instance()->handle->SetInt("DockOverlayHintBottomLength",v);
     instance()->DockOverlayHintBottomLength = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintBottomLength() {
     instance()->handle->RemoveInt("DockOverlayHintBottomLength");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintLeftOffset() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide hint visual display offset for left panel");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayHintLeftOffset() {
     return instance()->DockOverlayHintLeftOffset;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayHintLeftOffset() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintLeftOffset(const long &v) {
     instance()->handle->SetInt("DockOverlayHintLeftOffset",v);
     instance()->DockOverlayHintLeftOffset = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintLeftOffset() {
     instance()->handle->RemoveInt("DockOverlayHintLeftOffset");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintRightOffset() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide hint visual display offset for right panel");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayHintRightOffset() {
     return instance()->DockOverlayHintRightOffset;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayHintRightOffset() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintRightOffset(const long &v) {
     instance()->handle->SetInt("DockOverlayHintRightOffset",v);
     instance()->DockOverlayHintRightOffset = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintRightOffset() {
     instance()->handle->RemoveInt("DockOverlayHintRightOffset");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintTopOffset() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide hint visual display offset for top panel");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayHintTopOffset() {
     return instance()->DockOverlayHintTopOffset;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayHintTopOffset() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintTopOffset(const long &v) {
     instance()->handle->SetInt("DockOverlayHintTopOffset",v);
     instance()->DockOverlayHintTopOffset = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintTopOffset() {
     instance()->handle->RemoveInt("DockOverlayHintTopOffset");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintBottomOffset() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide hint visual display offset for bottom panel");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayHintBottomOffset() {
     return instance()->DockOverlayHintBottomOffset;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayHintBottomOffset() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintBottomOffset(const long &v) {
     instance()->handle->SetInt("DockOverlayHintBottomOffset",v);
     instance()->DockOverlayHintBottomOffset = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintBottomOffset() {
     instance()->handle->RemoveInt("DockOverlayHintBottomOffset");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintTabBar() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Show tab bar on mouse over when auto hide");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & OverlayParams::getDockOverlayHintTabBar() {
     return instance()->DockOverlayHintTabBar;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & OverlayParams::defaultDockOverlayHintTabBar() {
     const static bool def = false;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintTabBar(const bool &v) {
     instance()->handle->SetBool("DockOverlayHintTabBar",v);
     instance()->DockOverlayHintTabBar = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintTabBar() {
     instance()->handle->RemoveBool("DockOverlayHintTabBar");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHideTabBar() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Hide tab bar in dock overlay");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & OverlayParams::getDockOverlayHideTabBar() {
     return instance()->DockOverlayHideTabBar;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & OverlayParams::defaultDockOverlayHideTabBar() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHideTabBar(const bool &v) {
     instance()->handle->SetBool("DockOverlayHideTabBar",v);
     instance()->DockOverlayHideTabBar = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHideTabBar() {
     instance()->handle->RemoveBool("DockOverlayHideTabBar");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHintDelay() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Delay before show hint visual");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayHintDelay() {
     return instance()->DockOverlayHintDelay;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayHintDelay() {
     const static long def = 200;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHintDelay(const long &v) {
     instance()->handle->SetInt("DockOverlayHintDelay",v);
     instance()->DockOverlayHintDelay = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHintDelay() {
     instance()->handle->RemoveInt("DockOverlayHintDelay");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayAnimationDuration() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide animation duration, 0 to disable");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayAnimationDuration() {
     return instance()->DockOverlayAnimationDuration;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayAnimationDuration() {
     const static long def = 200;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayAnimationDuration(const long &v) {
     instance()->handle->SetInt("DockOverlayAnimationDuration",v);
     instance()->DockOverlayAnimationDuration = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayAnimationDuration() {
     instance()->handle->RemoveInt("DockOverlayAnimationDuration");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayAnimationCurve() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Auto hide animation curve type");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayAnimationCurve() {
     return instance()->DockOverlayAnimationCurve;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayAnimationCurve() {
     const static long def = 7;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayAnimationCurve(const long &v) {
     instance()->handle->SetInt("DockOverlayAnimationCurve",v);
     instance()->DockOverlayAnimationCurve = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayAnimationCurve() {
     instance()->handle->RemoveInt("DockOverlayAnimationCurve");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayHidePropertyViewScrollBar() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Hide property view scroll bar in dock overlay");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & OverlayParams::getDockOverlayHidePropertyViewScrollBar() {
     return instance()->DockOverlayHidePropertyViewScrollBar;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & OverlayParams::defaultDockOverlayHidePropertyViewScrollBar() {
     const static bool def = false;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayHidePropertyViewScrollBar(const bool &v) {
     instance()->handle->SetBool("DockOverlayHidePropertyViewScrollBar",v);
     instance()->DockOverlayHidePropertyViewScrollBar = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayHidePropertyViewScrollBar() {
     instance()->handle->RemoveBool("DockOverlayHidePropertyViewScrollBar");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *OverlayParams::docDockOverlayMinimumSize() {
     return QT_TRANSLATE_NOOP("OverlayParams",
 "Minimum overlay dock widget width/height");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & OverlayParams::getDockOverlayMinimumSize() {
     return instance()->DockOverlayMinimumSize;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & OverlayParams::defaultDockOverlayMinimumSize() {
     const static long def = 30;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void OverlayParams::setDockOverlayMinimumSize(const long &v) {
     instance()->handle->SetInt("DockOverlayMinimumSize",v);
     instance()->DockOverlayMinimumSize = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void OverlayParams::removeDockOverlayMinimumSize() {
     instance()->handle->RemoveInt("DockOverlayMinimumSize");
 }
 
-// Auto generated code (Gui/OverlayParams.py:172)
+// Auto generated code (Gui/OverlayParams.py:171)
 const std::vector<QString> OverlayParams::AnimationCurveTypes = {
     QStringLiteral("Linear"),
     QStringLiteral("InQuad"),
@@ -1129,10 +1091,6 @@ const std::vector<QString> OverlayParams::AnimationCurveTypes = {
 //[[[end]]]
 
 void OverlayParams::onDockOverlayAutoViewChanged() {
-    OverlayManager::instance()->refresh();
-}
-
-void OverlayParams::onCornerNaviCubeChanged() {
     OverlayManager::instance()->refresh();
 }
 

--- a/src/Gui/OverlayParams.h
+++ b/src/Gui/OverlayParams.h
@@ -28,14 +28,14 @@ import OverlayParams
 OverlayParams.declare()
 ]]]*/
 
-// Auto generated code (Gui/OverlayParams.py:158)
+// Auto generated code (Gui/OverlayParams.py:157)
 #include <QString>
 
-// Auto generated code (Tools/params_utils.py:72)
+// Auto generated code (Tools/params_utils.py:82)
 #include <Base/Parameter.h>
 
 
-// Auto generated code (Tools/params_utils.py:78)
+// Auto generated code (Tools/params_utils.py:90)
 namespace Gui {
 /** Convenient class to obtain overlay widgets related parameters
 
@@ -71,18 +71,7 @@ class GuiExport OverlayParams {
 public:
     static ParameterGrp::handle getHandle();
 
-    // Auto generated code (Tools/params_utils.py:122)
-    //@{
-    /// Accessor for parameter CornerNaviCube
-    static const long & getCornerNaviCube();
-    static const long & defaultCornerNaviCube();
-    static void removeCornerNaviCube();
-    static void setCornerNaviCube(const long &v);
-    static const char *docCornerNaviCube();
-    static void onCornerNaviCubeChanged();
-    //@}
-
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayAutoView
     static const bool & getDockOverlayAutoView();
@@ -93,7 +82,7 @@ public:
     static void onDockOverlayAutoViewChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayDelay
     ///
@@ -105,7 +94,7 @@ public:
     static const char *docDockOverlayDelay();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayRevealDelay
     static const long & getDockOverlayRevealDelay();
@@ -115,7 +104,7 @@ public:
     static const char *docDockOverlayRevealDelay();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlaySplitterHandleTimeout
     ///
@@ -127,7 +116,7 @@ public:
     static const char *docDockOverlaySplitterHandleTimeout();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayActivateOnHover
     ///
@@ -140,7 +129,7 @@ public:
     static const char *docDockOverlayActivateOnHover();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayAutoMouseThrough
     ///
@@ -152,7 +141,7 @@ public:
     static const char *docDockOverlayAutoMouseThrough();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayWheelPassThrough
     ///
@@ -164,7 +153,7 @@ public:
     static const char *docDockOverlayWheelPassThrough();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayWheelDelay
     ///
@@ -177,7 +166,7 @@ public:
     static const char *docDockOverlayWheelDelay();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayAlphaRadius
     ///
@@ -192,7 +181,7 @@ public:
     static const char *docDockOverlayAlphaRadius();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayCheckNaviCube
     ///
@@ -205,7 +194,7 @@ public:
     static void onDockOverlayCheckNaviCubeChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintTriggerSize
     ///
@@ -217,7 +206,7 @@ public:
     static const char *docDockOverlayHintTriggerSize();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintSize
     ///
@@ -229,7 +218,7 @@ public:
     static const char *docDockOverlayHintSize();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintLeftLength
     ///
@@ -241,7 +230,7 @@ public:
     static const char *docDockOverlayHintLeftLength();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintRightLength
     ///
@@ -253,7 +242,7 @@ public:
     static const char *docDockOverlayHintRightLength();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintTopLength
     ///
@@ -265,7 +254,7 @@ public:
     static const char *docDockOverlayHintTopLength();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintBottomLength
     ///
@@ -277,7 +266,7 @@ public:
     static const char *docDockOverlayHintBottomLength();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintLeftOffset
     ///
@@ -289,7 +278,7 @@ public:
     static const char *docDockOverlayHintLeftOffset();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintRightOffset
     ///
@@ -301,7 +290,7 @@ public:
     static const char *docDockOverlayHintRightOffset();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintTopOffset
     ///
@@ -313,7 +302,7 @@ public:
     static const char *docDockOverlayHintTopOffset();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintBottomOffset
     ///
@@ -325,7 +314,7 @@ public:
     static const char *docDockOverlayHintBottomOffset();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintTabBar
     ///
@@ -337,7 +326,7 @@ public:
     static const char *docDockOverlayHintTabBar();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHideTabBar
     ///
@@ -350,7 +339,7 @@ public:
     static void onDockOverlayHideTabBarChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHintDelay
     ///
@@ -362,7 +351,7 @@ public:
     static const char *docDockOverlayHintDelay();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayAnimationDuration
     ///
@@ -374,7 +363,7 @@ public:
     static const char *docDockOverlayAnimationDuration();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayAnimationCurve
     ///
@@ -386,7 +375,7 @@ public:
     static const char *docDockOverlayAnimationCurve();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayHidePropertyViewScrollBar
     ///
@@ -398,7 +387,7 @@ public:
     static const char *docDockOverlayHidePropertyViewScrollBar();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DockOverlayMinimumSize
     ///
@@ -411,10 +400,10 @@ public:
     static void onDockOverlayMinimumSizeChanged();
     //@}
 
-    // Auto generated code (Gui/OverlayParams.py:164)
+    // Auto generated code (Gui/OverlayParams.py:163)
     static const std::vector<QString> AnimationCurveTypes;
 
-// Auto generated code (Tools/params_utils.py:150)
+// Auto generated code (Tools/params_utils.py:178)
 }; // class OverlayParams
 } // namespace Gui
 //[[[end]]]

--- a/src/Gui/OverlayParams.py
+++ b/src/Gui/OverlayParams.py
@@ -98,7 +98,6 @@ class ParamAnimationCurve(ParamProxy):
     {param.widget_name}->setCurrentIndex({param.namespace}::{param.class_name}::default{param.name}());''')
 
 Params = [
-    ParamInt('CornerNaviCube', 1, on_change=True),
     ParamBool('DockOverlayAutoView', True, on_change=True, title="Auto hide in non 3D view"),
     ParamInt('DockOverlayDelay', 200, "Overlay dock (re),layout delay.", title="Layout delay (ms)", proxy=ParamSpinBox(0, 5000, 100)),
     ParamInt('DockOverlayRevealDelay', 2000),


### PR DESCRIPTION
Fixes #11020.

In the file I changed, OverlayParams.cpp, I see a bunch of `// Auto generated code (Tools/params_utils.py:xxx)`. Not sure how that auto generation works but this makes me wonder if the manual changes may get overwritten again if the code is regenerated for some reason.