### PR TITLE
Migrate away from deprecated distutils python package where possible

### DIFF
--- a/src/Ext/freecad/CMakeLists.txt
+++ b/src/Ext/freecad/CMakeLists.txt
@@ -1,6 +1,16 @@
-EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c
-"from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True))"
-OUTPUT_VARIABLE python_libs OUTPUT_STRIP_TRAILING_WHITESPACE )
+if (${PYTHON_VERSION_STRING} VERSION_LESS "3.10")
+    # deprecated distutils package still required for ubuntu 20.04 and similar
+    # see https://bugs.launchpad.net/ubuntu/+source/python3.8/+bug/2039511
+    # TODO: remove this once we drop support for 20.04
+    EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c
+        "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True))"
+        OUTPUT_VARIABLE python_libs OUTPUT_STRIP_TRAILING_WHITESPACE )
+else()
+    EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c
+        "from sysconfig import get_path; print(get_path('purelib'))"
+        OUTPUT_VARIABLE python_libs OUTPUT_STRIP_TRAILING_WHITESPACE )
+endif()
+
 SET(PYTHON_MAIN_DIR ${python_libs})
 
 set(NAMESPACE_DIR "${CMAKE_BINARY_DIR}/Ext/freecad")

--- a/src/Mod/Fem/femsolver/settings.py
+++ b/src/Mod/Fem/femsolver/settings.py
@@ -244,7 +244,7 @@ class _SolverDlg(object):
         # get the whole binary path name for the given command or binary path and return it
         # None is returned if the binary has not been found
         # The user does not know what exactly has going wrong.
-        from distutils.spawn import find_executable as find_bin
+        from shutil import which as find_bin
         the_found_binary = find_bin(binary)
         if (the_found_binary is None) and (not silent):
             FreeCAD.Console.PrintError(

--- a/src/Mod/Path/libarea/CMakeLists.txt
+++ b/src/Mod/Path/libarea/CMakeLists.txt
@@ -170,11 +170,18 @@ SET_BIN_DIR(area area /Mod/Path)
 SET_PYTHON_PREFIX_SUFFIX(area)
 
 # this figures out where to install the Python modules
-execute_process(
-    COMMAND python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
-    OUTPUT_VARIABLE Python_site_packages
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if (${PYTHON_VERSION_STRING} VERSION_LESS "3.10")
+    # deprecated distutils package still required for ubuntu 20.04 and similar
+    # see https://bugs.launchpad.net/ubuntu/+source/python3.8/+bug/2039511
+    # TODO: remove this once we drop support for 20.04
+    EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c
+        "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True))"
+        OUTPUT_VARIABLE Python_site_packages OUTPUT_STRIP_TRAILING_WHITESPACE )
+else()
+    EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c
+        "from sysconfig import get_path; print(get_path('platlib'))"
+        OUTPUT_VARIABLE Python_site_packages OUTPUT_STRIP_TRAILING_WHITESPACE )
+endif()
 
 message(STATUS "area module (for Path Workbench) will be installed to: " ${CMAKE_INSTALL_LIBDIR})
 

--- a/src/Mod/Plot/Plot.py
+++ b/src/Mod/Plot/Plot.py
@@ -23,7 +23,6 @@ import FreeCAD
 
 import PySide
 from PySide import QtCore, QtGui
-from distutils.version import LooseVersion as V
 import sys
 
 try:


### PR DESCRIPTION
supersedes #6753

debian (and therefore ubuntu) includes a patch for sysconfig on python 3.10 and above:
https://salsa.debian.org/cpython-team/python3/-/blob/python3.10/debian/patches/series?ref_type=heads#L8
https://salsa.debian.org/cpython-team/python3/-/blob/python3.10/debian/patches/sysconfig-debian-schemes.diff

debian packagers should set the env variable `DEB_PYTHON_INSTALL_LAYOUT=deb_system` to install to `/usr/lib/python3/dist-packages`