### PR TITLE
Gui: Target 3DViewer directly for overlay wheel events

### DIFF
--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -1948,9 +1948,14 @@ void OverlayManager::Private::interceptEvent(QWidget *widget, QEvent *ev)
 #endif
         lastIntercept = getChildAt(widget, globalPos);
 
-        for (auto parent = lastIntercept->parentWidget(); parent; parent = parent->parentWidget()) {
-            if (qobject_cast<QGraphicsView*>(parent)) {
+        // For some reason in case of 3D View we have to target it directly instead of targeting
+        // the viewport of QAbstractScrollArea like it works for all other widgets of that kind.
+        // That's why for this event we have to traverse up the widget tree to find if it is part
+        // of the 3D view.
+        for (auto parent = lastIntercept; parent; parent = parent->parentWidget()) {
+            if (qobject_cast<View3DInventorViewer*>(parent)) {
                 lastIntercept = parent;
+                break;
             }
         }
 


### PR DESCRIPTION
I've no idea why, but for some reason if synthesized event is passed into `QGraphicsView` it is not processed. It however works ok if we pass `graphicsView->viewport()` as receiver of the event. However as `View3DInventorViewer` also indirectly derives from `QAbstractScrollArea` it is also affected by the `qobject_cast<QAbstractScrollArea*>(parent)`, and in that case passing events to viewport does not work. Maybe some Qt experts know why, I'm not one of them.

Changing `qobject_cast` to more specific class seems to work fine for both cases, and does not make the code worse.

@wwmayer if you could take a look please, maybe you will be able to find better solution.

Fixes: #11015