### PR TITLE
PD: fix constructor of TaskTransformedParameters

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
@@ -61,12 +61,8 @@ TaskTransformedParameters::TaskTransformedParameters(ViewProviderTransformed *Tr
     , insideMultiTransform(false)
     , blockUpdate(false)
 {
-    selectionMode = none;
-
-    if (TransformedView) {
-        Gui::Document* doc = TransformedView->getDocument();
-        this->attachDocument(doc);
-    }
+    Gui::Document* doc = TransformedView->getDocument();
+    this->attachDocument(doc);
 
     // remember initial transaction ID
     App::GetApplication().getActiveTransaction(&transactionID);
@@ -80,8 +76,6 @@ TaskTransformedParameters::TaskTransformedParameters(TaskMultiTransformParameter
       insideMultiTransform(true),
       blockUpdate(false)
 {
-    // Original feature selection makes no sense inside a MultiTransform
-    selectionMode = none;
 }
 
 TaskTransformedParameters::~TaskTransformedParameters()

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -225,7 +225,7 @@ protected:
     bool enableTransaction = true;
 
     enum selectionModes { none, addFeature, removeFeature, reference };
-    selectionModes selectionMode;
+    selectionModes selectionMode = none;
 
     /// The MultiTransform parent task of this task
     TaskMultiTransformParameters* parentTask;


### PR DESCRIPTION
https://github.com/FreeCAD/FreeCAD/issues/11091

A null pointer will never be passed to TaskTransformedParameters(). So, there is no point in explicitly checking for a null pointer (in this inconsistent way).