### PR TITLE
Fem: Setup manipulator plane

### DIFF
--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -2292,6 +2292,10 @@ void CmdFemPostFunctions::activated(int iMsg)
                       center[0],
                       center[1],
                       center[2]);
+            doCommand(Doc,
+                      "Gui.ActiveDocument.%s.Scale = %f",
+                      FeatName.c_str(),
+                      box.GetDiagonalLength());
         }
         else if (iMsg == 1) {  // Sphere
             doCommand(Doc,

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 
 #include <Inventor/actions/SoSearchAction.h>
+#include <Inventor/draggers/SoDragPointDragger.h>
 #include <Inventor/draggers/SoHandleBoxDragger.h>
 #include <Inventor/draggers/SoJackDragger.h>
 #include <Inventor/manips/SoCenterballManip.h>
@@ -797,7 +798,7 @@ void ViewProviderFemPostPlaneFunction::draggerUpdate(SoDragger* m)
     const SbVec3f& base = dragger->translation.getValue();
     const SbVec3f& scale = dragger->scaleFactor.getValue();
 
-    SbVec3f norm(0.0, 1.0, 0.0);
+    SbVec3f norm(0.0, 0.0, 1.0);
     dragger->rotation.getValue().multVec(norm, norm);
     func->Origin.setValue(base[0], base[1], base[2]);
     func->Normal.setValue(norm[0], norm[1], norm[2]);
@@ -847,7 +848,7 @@ void ViewProviderFemPostPlaneFunction::updateData(const App::Property* p)
         Base::Vector3d norm = func->Normal.getValue();
 
         norm.Normalize();
-        SbRotation rot(SbVec3f(0.0, 1.0, 0.0), SbVec3f(norm.x, norm.y, norm.z));
+        SbRotation rot(SbVec3f(0.0, 0.0, 1.0), SbVec3f(norm.x, norm.y, norm.z));
         float scale = static_cast<float>(Scale.getValue());
 
         SbMatrix mat;
@@ -860,7 +861,13 @@ void ViewProviderFemPostPlaneFunction::updateData(const App::Property* p)
 
 SoTransformManip* ViewProviderFemPostPlaneFunction::setupManipulator()
 {
-    return new SoJackManip;
+    auto manip = new SoJackManip;
+
+    // Set axis translator to Z-axis
+    SoNode* trans = manip->getDragger()->getPart("translator", false);
+    static_cast<SoDragPointDragger*>(trans)->showNextDraggerSet();
+
+    return manip;
 }
 
 

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.h
@@ -300,9 +300,6 @@ protected:
     void draggerUpdate(SoDragger* mat) override;
     void updateData(const App::Property*) override;
     void onChanged(const App::Property*) override;
-
-private:
-    bool m_detectscale;
 };
 
 


### PR DESCRIPTION
Currently, in the jack manipulator used by the plane function an additional rotation is added to align the axis translator (which can be changed by pressing the CTRL key) with the Z-axis, since by default the translator is aligned with the Y-axis.
This additional rotation also changes the blue `postPlane` rectangle used to represent the real plane, leaving the blue rectangle and the real plane perpendicular.
The first commit fix removes the extra rotation and changes the direction of the axis translator in the manipulator settings.
Now the blue plane match with real plane.

The second commit set auto-scaling to `false` and set initial scaling in the command call based on the pipeline size.
Currently, the plan is scaled using not only the pipeline size but also all objects in the 3D view.
Also removes some unnecessary code used when the value of the object's properties change for the first time.