### PR TITLE
Draft: PlaneGui: minor fixes

### DIFF
--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -1694,6 +1694,8 @@ class PlaneGui(PlaneBase):
             return
         if data == self._history["data_list"][-1]:
             return
+        if self.auto is True and self._history["data_list"][-1]["auto"] is True:
+            return
 
         max_len = 10  # Max. length of data_list.
         idx = self._history["idx"]
@@ -1747,12 +1749,12 @@ def get_working_plane(update=True):
         return wp
 
     wp = PlaneGui()
-    wp._view = view
-    wp.set_to_default()
-
-    if view is not None:
-        FreeCAD.draft_working_planes[0].append(view)
-        FreeCAD.draft_working_planes[1].append(wp)
+    if FreeCAD.GuiUp:
+        wp.set_to_default()
+        wp._view = view
+        if view is not None:
+            FreeCAD.draft_working_planes[0].append(view)
+            FreeCAD.draft_working_planes[1].append(wp)
 
     return wp
 


### PR DESCRIPTION
Related issue:
#5603.

* An 'auto' WP should not be added to the history if the previous WP in the history is also 'auto'.
* The `get_working_plane` function should only call `set_to_default` if the GUI is up. The axis of the returned WP should match global +Z if the GUI is not up.
