### PR TITLE
[TechDraw] - Cosmetic Circle fixes

### DIFF
--- a/src/Mod/TechDraw/App/Cosmetic.cpp
+++ b/src/Mod/TechDraw/App/Cosmetic.cpp
@@ -255,7 +255,7 @@ void CosmeticEdge::Save(Base::Writer &writer) const
         circ->Save(writer);
     } else if (m_geometry->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE) {
         TechDraw::AOCPtr aoc = std::static_pointer_cast<TechDraw::AOC>(m_geometry);
-        aoc->Save(writer);
+        aoc->inverted()->Save(writer);
     } else {
         Base::Console().Warning("CE::Save - unimplemented geomType: %d\n", static_cast<int>(m_geometry->getGeomType()));
     }
@@ -298,9 +298,9 @@ void CosmeticEdge::Restore(Base::XMLReader &reader)
         TechDraw::AOCPtr aoc = std::make_shared<TechDraw::AOC> ();
         aoc->Restore(reader);
         aoc->setOCCEdge(GeometryUtils::edgeFromCircleArc(aoc));
-        m_geometry = aoc;
-        permaStart = aoc->startPnt;
-        permaEnd   = aoc->endPnt;
+        m_geometry = aoc->inverted();
+        permaStart = aoc->center;
+        permaEnd   = aoc->center;
         permaRadius = aoc->radius;
     } else {
         Base::Console().Warning("CE::Restore - unimplemented geomType: %d\n", static_cast<int>(gType));

--- a/src/Mod/TechDraw/Gui/TaskCosmeticCircle.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticCircle.cpp
@@ -109,7 +109,7 @@ void TaskCosmeticCircle::changeEvent(QEvent *e)
 
 void TaskCosmeticCircle::setUiPrimary()
 {
-    setWindowTitle(QObject::tr("Create Cosmetic Line"));
+    setWindowTitle(QObject::tr("Create Cosmetic Circle"));
 //    Base::Console().Message("TCC::setUiPrimary() - m_center: %s is3d: %d\n",
 //        DU::formatVector(m_center).c_str(), m_is3d);
     double rotDeg = m_partFeat->Rotation.getValue();
@@ -143,7 +143,7 @@ void TaskCosmeticCircle::setUiPrimary()
 
 void TaskCosmeticCircle::setUiEdit()
 {
-    setWindowTitle(QObject::tr("Edit Cosmetic Line"));
+    setWindowTitle(QObject::tr("Edit Cosmetic Circle"));
 
     ui->rb2d1->setChecked(true);
     ui->rb3d1->setChecked(false);


### PR DESCRIPTION
Hello,

with this PR I would like to provide 3 fixes for Cosmetic Circle, or Cosmetic Arc of Circle resp.
1) Correct task dialog title: This is trivial.
2) Problems with changed center coordinates after save/reload: The dialog takes (and stores) center coordinates from AoC permaStart, however when restored, permaStart is not filled from AoC center, but from startPnt. This is here fixed in Cosmetic.cpp:302-303
3) Problems with "reversing" AoC after save/reload: If a cosmetic AoC is created (e.g. from angle 0 to 270), it correctly shows the arc, however when saved and restored, the arc is now displayed like 90 to 360. The reason is the underlying OCC edge must be flipped along the ZX plane, because Qt uses screen coordinates system ([0, 0] in top left corner). When such "inverted" AoC edge is saved and later restored, the OCC edge is constructed incorrectly, with reversed circulation. The simplest and most elegant solution is to save inverted geometry and after recreating the OCC edge invert it for the Qt once again. This is fixed in Cosmetic.cpp lines 258 and 301.

I hope you will find this fix useful, in case of any issues, please let me know.