### PR TITLE
Avoids using getNameInDocument() to test if DocumentObject is attached to a Document.

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1215,7 +1215,7 @@ std::set<DocumentObject *> Application::getLinksTo(
     } else {
         std::set<Document*> docs;
         for(auto o : obj->getInList()) {
-            if(o && o->getNameInDocument() && docs.insert(o->getDocument()).second) {
+            if(o && o->isAttachedToDocument() && docs.insert(o->getDocument()).second) {
                 o->getDocument()->getLinksTo(links,obj,options,maxCount);
                 if(maxCount && (int)links.size()>=maxCount)
                     break;

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1113,7 +1113,7 @@ void Document::exportObjects(const std::vector<App::DocumentObject*>& obj, std::
 
     if(FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG)) {
         for(auto o : obj) {
-            if(o && o->getNameInDocument()) {
+            if(o && o->isAttachedToDocument()) {
                 FC_LOG("exporting " << o->getFullName());
                 if (!o->getPropertyByName("_ObjectUUID")) {
                     auto prop = static_cast<PropertyUUID*>(o->addDynamicProperty(
@@ -1479,7 +1479,7 @@ Document::importObjects(Base::XMLReader& reader)
 
     std::vector<App::DocumentObject*> objs = readObjects(reader);
     for(auto o : objs) {
-        if(o && o->getNameInDocument()) {
+        if(o && o->isAttachedToDocument()) {
             o->setStatus(App::ObjImporting,true);
             FC_LOG("importing " << o->getFullName());
             if (auto propUUID = Base::freecad_dynamic_cast<PropertyUUID>(
@@ -1506,7 +1506,7 @@ Document::importObjects(Base::XMLReader& reader)
     signalFinishImportObjects(objs);
 
     for(auto o : objs) {
-        if(o && o->getNameInDocument())
+        if(o && o->isAttachedToDocument())
             o->setStatus(App::ObjImporting,false);
     }
 
@@ -2411,7 +2411,7 @@ static void _buildDependencyList(const std::vector<App::DocumentObject*> &object
         while(!objs.empty()) {
             auto obj = objs.front();
             objs.pop_front();
-            if(!obj || !obj->getNameInDocument())
+            if(!obj || !obj->isAttachedToDocument())
                 continue;
 
             auto it = outLists.find(obj);
@@ -2438,7 +2438,7 @@ static void _buildDependencyList(const std::vector<App::DocumentObject*> &object
     if(objectMap && depList) {
         for (const auto &v : outLists) {
             for(auto obj : v.second) {
-                if(obj && obj->getNameInDocument())
+                if(obj && obj->isAttachedToDocument())
                     add_edge((*objectMap)[v.first],(*objectMap)[obj],*depList);
             }
         }
@@ -2833,7 +2833,7 @@ int Document::recompute(const std::vector<App::DocumentObject*> &objs, bool forc
             FC_LOG("Recompute pass " << passes);
             for (; idx < topoSortedObjects.size(); ++idx) {
                 auto obj = topoSortedObjects[idx];
-                if(!obj->getNameInDocument() || filter.find(obj)!=filter.end())
+                if(!obj->isAttachedToDocument() || filter.find(obj)!=filter.end())
                     continue;
                 // ask the object if it should be recomputed
                 bool doRecompute = false;
@@ -2890,7 +2890,7 @@ int Document::recompute(const std::vector<App::DocumentObject*> &objs, bool forc
     FC_TIME_LOG(t2, "Recompute");
 
     for(auto obj : topoSortedObjects) {
-        if(!obj->getNameInDocument())
+        if(!obj->isAttachedToDocument())
             continue;
         obj->setStatus(ObjectStatus::PendingRecompute,false);
         obj->setStatus(ObjectStatus::Recompute2,false);
@@ -3051,8 +3051,8 @@ std::vector<App::DocumentObject*> DocumentP::topologicalSort(const std::vector<A
 
     for (auto objectIt : objects) {
         // We now support externally linked objects
-        // if(!obj->getNameInDocument() || obj->getDocument()!=this)
-        if(!objectIt->getNameInDocument())
+        // if(!obj->isAttachedToDocument() || obj->getDocument()!=this)
+        if(!objectIt->isAttachedToDocument())
             continue;
         //we need inlist with unique entries
         auto in = objectIt->getInList();
@@ -3166,7 +3166,7 @@ bool Document::recomputeFeature(DocumentObject* Feat, bool recursive)
     d->clearRecomputeLog(Feat);
 
     // verify that the feature is (active) part of the document
-    if (Feat->getNameInDocument()) {
+    if (Feat->isAttachedToDocument()) {
         if(recursive) {
             bool hasError = false;
             recompute({Feat},true,&hasError);

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -274,7 +274,7 @@ const char* DocumentObject::getStatusString() const
 }
 
 std::string DocumentObject::getFullName() const {
-    if(!getDocument() || !pcNameInDocument)
+    if(!getDocument() || !isAttachedToDocument())
         return "?";
     std::string name(getDocument()->getName());
     name += '#';
@@ -305,13 +305,13 @@ const char *DocumentObject::getNameInDocument() const
 }
 
 int DocumentObject::isExporting() const {
-    if(!getDocument() || !getNameInDocument())
+    if(!getDocument() || !isAttachedToDocument())
         return 0;
     return getDocument()->isExporting(this);
 }
 
 std::string DocumentObject::getExportName(bool forced) const {
-    if(!pcNameInDocument)
+    if(!isAttachedToDocument())
         return {};
 
     if(!forced && !isExporting())
@@ -441,7 +441,7 @@ void DocumentObject::getInListEx(std::set<App::DocumentObject*> &inSet,
     // outLists first here.
     for(auto doc : GetApplication().getDocuments()) {
         for(auto obj : doc->getObjects()) {
-            if(!obj || !obj->getNameInDocument() || obj==this)
+            if(!obj || !obj->isAttachedToDocument() || obj==this)
                 continue;
             const auto &outList = obj->getOutList();
             outLists[obj].insert(outList.begin(),outList.end());
@@ -481,7 +481,7 @@ void DocumentObject::getInListEx(std::set<App::DocumentObject*> &inSet,
         auto obj = pendings.top();
         pendings.pop();
         for(auto o : obj->getInList()) {
-            if(o && o->getNameInDocument() && inSet.insert(o).second) {
+            if(o && o->isAttachedToDocument() && inSet.insert(o).second) {
                 pendings.push(o);
                 if(inList)
                     inList->push_back(o);
@@ -839,7 +839,7 @@ std::vector<DocumentObject*> DocumentObject::getSubObjectList(const char *subnam
         char c = sub[pos+1];
         sub[pos+1] = 0;
         auto sobj = getSubObject(sub.c_str());
-        if(!sobj || !sobj->getNameInDocument())
+        if(!sobj || !sobj->isAttachedToDocument())
             break;
         res.push_back(sobj);
         sub[pos+1] = c;
@@ -859,14 +859,14 @@ std::vector<std::string> DocumentObject::getSubObjects(int reason) const {
 
 std::vector<std::pair<App::DocumentObject *,std::string>> DocumentObject::getParents(int depth) const {
     std::vector<std::pair<App::DocumentObject *, std::string>> ret;
-    if (!getNameInDocument() || !GetApplication().checkLinkDepth(depth, MessageOption::Throw)) {
+    if (!isAttachedToDocument() || !GetApplication().checkLinkDepth(depth, MessageOption::Throw)) {
         return ret;
     }
 
     std::string name(getNameInDocument());
     name += ".";
     for (auto parent : getInList()) {
-        if (!parent || !parent->getNameInDocument()) {
+        if (!parent || !parent->isAttachedToDocument()) {
             continue;
         }
 
@@ -927,7 +927,7 @@ DocumentObject *DocumentObject::getLinkedObject(
 
 void DocumentObject::Save (Base::Writer &writer) const
 {
-    if (this->getNameInDocument())
+    if (this->isAttachedToDocument())
         writer.ObjectName = this->getNameInDocument();
     App::ExtensionContainer::Save(writer);
 }
@@ -1164,7 +1164,7 @@ DocumentObject *DocumentObject::resolve(const char *subname,
 DocumentObject *DocumentObject::resolveRelativeLink(std::string &subname,
         DocumentObject *&link, std::string &linkSub) const
 {
-    if(!link || !link->getNameInDocument() || !getNameInDocument())
+    if(!link || !link->isAttachedToDocument() || !isAttachedToDocument())
         return nullptr;
     auto ret = const_cast<DocumentObject*>(this);
     if(link != ret) {
@@ -1268,6 +1268,6 @@ bool DocumentObject::redirectSubName(std::ostringstream &, DocumentObject *, Doc
 
 void DocumentObject::onPropertyStatusChanged(const Property &prop, unsigned long oldStatus) {
     (void)oldStatus;
-    if(!Document::isAnyRestoring() && getNameInDocument() && getDocument())
+    if(!Document::isAnyRestoring() && isAttachedToDocument() && getDocument())
         getDocument()->signalChangePropertyEditor(*getDocument(),prop);
 }

--- a/src/App/DocumentObserver.cpp
+++ b/src/App/DocumentObserver.cpp
@@ -153,7 +153,7 @@ DocumentObjectT &DocumentObjectT::operator=(DocumentObjectT&& obj)
 
 void DocumentObjectT::operator=(const DocumentObject* obj)
 {
-    if(!obj || !obj->getNameInDocument()) {
+    if(!obj || !obj->isAttachedToDocument()) {
         object.clear();
         label.clear();
         document.clear();

--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -97,7 +97,7 @@ DocumentObject *GeoFeature::resolveElement(DocumentObject *obj, const char *subn
         ElementNameType type, const DocumentObject *filter, 
         const char **_element, GeoFeature **geoFeature)
 {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return nullptr;
     if(!subname)
         subname = "";

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -489,7 +489,7 @@ void GeoFeatureGroupExtension::getInvalidLinkObjects(const DocumentObject* obj, 
 
 bool GeoFeatureGroupExtension::extensionGetSubObjects(std::vector<std::string> &ret, int) const {
     for(auto obj : Group.getValues()) {
-        if(obj && obj->getNameInDocument() && !obj->testStatus(ObjectStatus::GeoExcluded))
+        if(obj && obj->isAttachedToDocument() && !obj->testStatus(ObjectStatus::GeoExcluded))
             ret.push_back(std::string(obj->getNameInDocument())+'.');
     }
     return true;

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -158,7 +158,7 @@ void GroupExtension::removeObjectsFromDocument()
 void GroupExtension::removeObjectFromDocument(DocumentObject* obj)
 {
     // check that object is not invalid
-    if (!obj || !obj->getNameInDocument())
+    if (!obj || !obj->isAttachedToDocument())
         return;
 
     // remove all children
@@ -351,7 +351,7 @@ void GroupExtension::extensionOnChanged(const Property* p) {
     if(p == &Group) {
         _Conns.clear();
         for(auto obj : Group.getValue()) {
-            if(obj && obj->getNameInDocument()) {
+            if(obj && obj->isAttachedToDocument()) {
                 //NOLINTBEGIN
                 _Conns[obj] = obj->signalChanged.connect(std::bind(
                             &GroupExtension::slotChildChanged,this,sp::_1, sp::_2));
@@ -398,7 +398,7 @@ bool GroupExtension::extensionGetSubObject(DocumentObject *&ret, const char *sub
 
 bool GroupExtension::extensionGetSubObjects(std::vector<std::string> &ret, int) const {
     for(auto obj : Group.getValues()) {
-        if(obj && obj->getNameInDocument())
+        if(obj && obj->isAttachedToDocument())
             ret.push_back(std::string(obj->getNameInDocument())+'.');
     }
     return true;
@@ -421,7 +421,7 @@ void GroupExtension::getAllChildren(std::vector<App::DocumentObject*> &res,
         std::set<App::DocumentObject*> &rset) const
 {
     for(auto obj : Group.getValues()) {
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         if(!rset.insert(obj).second)
             continue;

--- a/src/App/GroupExtensionPyImp.cpp
+++ b/src/App/GroupExtensionPyImp.cpp
@@ -62,7 +62,7 @@ PyObject*  GroupExtensionPy::addObject(PyObject *args)
         return nullptr;
 
     DocumentObjectPy* docObj = static_cast<DocumentObjectPy*>(object);
-    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->getNameInDocument()) {
+    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot add an invalid object");
         return nullptr;
     }
@@ -174,7 +174,7 @@ PyObject*  GroupExtensionPy::removeObject(PyObject *args)
         return nullptr;
 
     DocumentObjectPy* docObj = static_cast<DocumentObjectPy*>(object);
-    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->getNameInDocument()) {
+    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot remove an invalid object");
         return nullptr;
     }
@@ -262,7 +262,7 @@ PyObject*  GroupExtensionPy::hasObject(PyObject *args)
 
     DocumentObjectPy* docObj = static_cast<DocumentObjectPy*>(object);
     bool recursive = Base::asBoolean(recursivePy);
-    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->getNameInDocument()) {
+    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot check an invalid object");
         return nullptr;
     }

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -1421,7 +1421,7 @@ void ObjectIdentifier::setDocumentObjectName(ObjectIdentifier::String &&name, bo
 void ObjectIdentifier::setDocumentObjectName(const App::DocumentObject *obj, bool force,
         ObjectIdentifier::String &&subname, bool checkImport)
 {
-    if(!owner || !obj || !obj->getNameInDocument() || !obj->getDocument())
+    if(!owner || !obj || !obj->isAttachedToDocument() || !obj->getDocument())
         FC_THROWM(Base::RuntimeError,"invalid object");
 
     if(checkImport)
@@ -1930,7 +1930,7 @@ bool ObjectIdentifier::isTouched() const {
 }
 
 void ObjectIdentifier::resolveAmbiguity() {
-    if(!owner || !owner->getNameInDocument() || isLocalProperty() ||
+    if(!owner || !owner->isAttachedToDocument() || isLocalProperty() ||
        (documentObjectNameSet && !documentObjectName.getString().empty() &&
         (documentObjectName.isRealString() || documentObjectName.isForceIdentifier())))
     {

--- a/src/App/OriginGroupExtension.cpp
+++ b/src/App/OriginGroupExtension.cpp
@@ -71,7 +71,7 @@ bool OriginGroupExtension::extensionGetSubObject(DocumentObject *&ret, const cha
 {
     App::DocumentObject *originObj = Origin.getValue ();
     const char *dot;
-    if(originObj && originObj->getNameInDocument() &&
+    if(originObj && originObj->isAttachedToDocument() &&
        subname && (dot=strchr(subname,'.')))
     {
         bool found;

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -129,7 +129,7 @@ Property *PropertyExpressionEngine::Copy() const
 void PropertyExpressionEngine::hasSetValue()
 {
     App::DocumentObject *owner = dynamic_cast<App::DocumentObject*>(getContainer());
-    if(!owner || !owner->getNameInDocument() || owner->isRestoring() || testFlag(LinkDetached)) {
+    if(!owner || !owner->isAttachedToDocument() || owner->isRestoring() || testFlag(LinkDetached)) {
         PropertyExpressionContainer::hasSetValue();
         return;
     }

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -146,7 +146,7 @@ void PropertyLinkBase::checkLabelReferences(const std::vector<std::string> &subs
 std::string PropertyLinkBase::updateLabelReference(const App::DocumentObject *parent,
         const char *subname, App::DocumentObject *obj, const std::string &ref, const char *newLabel)
 {
-    if(!obj || !obj->getNameInDocument() || !parent || !parent->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument() || !parent || !parent->isAttachedToDocument())
         return {};
 
     // Because the label is allowed to be the same across different
@@ -169,7 +169,7 @@ std::vector<std::pair<Property*, std::unique_ptr<Property> > >
 PropertyLinkBase::updateLabelReferences(App::DocumentObject *obj, const char *newLabel)
 {
     std::vector<std::pair<Property*,std::unique_ptr<Property> > >  ret;
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return ret;
     auto it = _LabelMap.find(obj->Label.getStrValue());
     if(it == _LabelMap.end())
@@ -525,7 +525,7 @@ void PropertyLink::getLinks(std::vector<App::DocumentObject *> &objs,
 {
     (void)newStyle;
     (void)subs;
-    if((all||_pcScope!=LinkScope::Hidden) && _pcLink && _pcLink->getNameInDocument())
+    if((all||_pcScope!=LinkScope::Hidden) && _pcLink && _pcLink->isAttachedToDocument())
         objs.push_back(_pcLink);
 }
 
@@ -594,7 +594,7 @@ void PropertyLinkList::setSize(int newSize)
 {
     for(int i=newSize;i<(int)_lValueList.size();++i) {
         auto obj = _lValueList[i];
-        if (!obj || !obj->getNameInDocument())
+        if (!obj || !obj->isAttachedToDocument())
             continue;
         _nameMap.erase(obj->getNameInDocument());
 #ifndef USE_OLD_DAG
@@ -620,7 +620,7 @@ void PropertyLinkList::set1Value(int idx, DocumentObject* const &value) {
             return;
     }
 
-    if(!value || !value->getNameInDocument())
+    if(!value || !value->isAttachedToDocument())
         throw Base::ValueError("invalid document object");
 
     _nameMap.clear();
@@ -651,7 +651,7 @@ void PropertyLinkList::setValues(const std::vector<DocumentObject*>& lValue) {
 
     auto parent = Base::freecad_dynamic_cast<App::DocumentObject>(getContainer());
     for(auto obj : lValue) {
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             throw Base::ValueError("PropertyLinkList: invalid document object");
         if(!testFlag(LinkAllowExternal) && parent && parent->getDocument()!=obj->getDocument())
             throw Base::ValueError("PropertyLinkList does not support external object");
@@ -688,7 +688,7 @@ PyObject *PropertyLinkList::getPyObject()
 #endif
     for (int i = 0; i<count; i++) {
         auto obj = _lValueList[i];
-        if(obj && obj->getNameInDocument())
+        if(obj && obj->isAttachedToDocument())
             sequence.setItem(i, Py::asObject(_lValueList[i]->getPyObject()));
         else
             sequence.setItem(i, Py::None());
@@ -818,7 +818,7 @@ DocumentObject *PropertyLinkList::find(const std::string &name, int *pindex) con
         _nameMap.clear();
         for(int i=0;i<(int)_lValueList.size();++i) {
             auto obj = _lValueList[i];
-            if(obj && obj->getNameInDocument())
+            if(obj && obj->isAttachedToDocument())
                 _nameMap[obj->getNameInDocument()] = i;
         }
     }
@@ -837,7 +837,7 @@ void PropertyLinkList::getLinks(std::vector<App::DocumentObject *> &objs,
     if(all||_pcScope!=LinkScope::Hidden) {
         objs.reserve(objs.size()+_lValueList.size());
         for(auto obj : _lValueList) {
-            if(obj && obj->getNameInDocument())
+            if(obj && obj->isAttachedToDocument())
                 objs.push_back(obj);
         }
     }
@@ -911,7 +911,7 @@ void PropertyLinkSub::setValue(App::DocumentObject * lValue,
 {
     auto parent = Base::freecad_dynamic_cast<App::DocumentObject>(getContainer());
     if(lValue) {
-        if(!lValue->getNameInDocument())
+        if(!lValue->isAttachedToDocument())
             throw Base::ValueError("PropertyLinkSub: invalid document object");
         if(!testFlag(LinkAllowExternal) && parent && parent->getDocument()!=lValue->getDocument())
             throw Base::ValueError("PropertyLinkSub does not support external object");
@@ -1067,7 +1067,7 @@ static bool updateLinkReference(App::PropertyLinkBase *prop,
         prop->unregisterElementReference();
     }
     shadows.resize(subs.size());
-    if(!link || !link->getNameInDocument())
+    if(!link || !link->isAttachedToDocument())
         return false;
     auto owner = dynamic_cast<DocumentObject*>(prop->getContainer());
     if(owner && owner->isRestoring())
@@ -1093,7 +1093,7 @@ static bool updateLinkReference(App::PropertyLinkBase *prop,
 
 void PropertyLinkSub::afterRestore() {
     _ShadowSubList.resize(_cSubList.size());
-    if(!testFlag(LinkRestoreLabel) ||!_pcLinkSub || !_pcLinkSub->getNameInDocument())
+    if(!testFlag(LinkRestoreLabel) ||!_pcLinkSub || !_pcLinkSub->isAttachedToDocument())
         return;
     setFlag(LinkRestoreLabel,false);
     for(std::size_t i=0;i<_cSubList.size();++i)
@@ -1102,7 +1102,7 @@ void PropertyLinkSub::afterRestore() {
 
 void PropertyLinkSub::onContainerRestored() {
     unregisterElementReference();
-    if(!_pcLinkSub || !_pcLinkSub->getNameInDocument())
+    if(!_pcLinkSub || !_pcLinkSub->isAttachedToDocument())
         return;
     for(std::size_t i=0;i<_cSubList.size();++i)
         _registerElementReference(_pcLinkSub,_cSubList[i],_ShadowSubList[i]);
@@ -1160,7 +1160,7 @@ const char *PropertyLinkBase::exportSubName(std::string &output,
             doc = GetApplication().getDocument(std::string(sub,hash-sub).c_str());
         else {
             hash = nullptr;
-            if(obj && obj->getNameInDocument())
+            if(obj && obj->isAttachedToDocument())
                 doc = obj->getDocument();
         }
         if(!doc) {
@@ -1168,14 +1168,14 @@ const char *PropertyLinkBase::exportSubName(std::string &output,
             return res;
         }
         obj = doc->getObject(std::string(sub,dot-sub).c_str());
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             return res;
         if(hash) {
             if(!obj->isExporting())
                 str << doc->getName() << '#';
             sub = hash+1;
         }
-    }else if(!obj || !obj->getNameInDocument())
+    }else if(!obj || !obj->isAttachedToDocument())
         return res;
 
     for(const char *dot=strchr(sub,'.');dot;sub=dot+1,dot=strchr(sub,'.')) {
@@ -1185,7 +1185,7 @@ const char *PropertyLinkBase::exportSubName(std::string &output,
             first_obj = false;
         else
             obj = obj->getSubObject(name.c_str());
-        if(!obj || !obj->getNameInDocument()) {
+        if(!obj || !obj->isAttachedToDocument()) {
             FC_WARN("missing sub object '" << name << "' in '" << sub <<"'");
             break;
         }
@@ -1214,7 +1214,7 @@ const char *PropertyLinkBase::exportSubName(std::string &output,
 App::DocumentObject *PropertyLinkBase::tryImport(const App::Document *doc,
             const App::DocumentObject *obj, const std::map<std::string,std::string> &nameMap)
 {
-    if(doc && obj && obj->getNameInDocument())  {
+    if(doc && obj && obj->isAttachedToDocument())  {
         auto it = nameMap.find(obj->getExportName(true));
         if(it!=nameMap.end()) {
             obj = doc->getObject(it->second.c_str());
@@ -1228,7 +1228,7 @@ App::DocumentObject *PropertyLinkBase::tryImport(const App::Document *doc,
 std::string PropertyLinkBase::tryImportSubName(const App::DocumentObject *obj, const char *_subname,
         const App::Document *doc, const std::map<std::string,std::string> &nameMap)
 {
-    if(!doc || !obj || !obj->getNameInDocument())
+    if(!doc || !obj || !obj->isAttachedToDocument())
         return {};
 
     std::ostringstream ss;
@@ -1281,7 +1281,7 @@ void PropertyLinkSub::Save (Base::Writer &writer) const
     std::string internal_name;
     // it can happen that the object is still alive but is not part of the document anymore and thus
     // returns 0
-    if (_pcLinkSub && _pcLinkSub->getNameInDocument())
+    if (_pcLinkSub && _pcLinkSub->isAttachedToDocument())
         internal_name = _pcLinkSub->getExportName();
     writer.Stream() << writer.ind() << "<LinkSub value=\""
         <<  internal_name <<"\" count=\"" <<  _cSubList.size();
@@ -1380,7 +1380,7 @@ template<class Func, class... Args >
 std::vector<std::string> updateLinkSubs(const App::DocumentObject *obj,
         const std::vector<std::string> &subs, Func *f, Args&&... args )
 {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return {};
 
     std::vector<std::string> res;
@@ -1405,7 +1405,7 @@ Property *PropertyLinkSub::CopyOnImportExternal(
     auto owner = dynamic_cast<const DocumentObject*>(getContainer());
     if(!owner || !owner->getDocument())
         return nullptr;
-    if(!_pcLinkSub || !_pcLinkSub->getNameInDocument())
+    if(!_pcLinkSub || !_pcLinkSub->isAttachedToDocument())
         return nullptr;
 
     auto subs = updateLinkSubs(_pcLinkSub,_cSubList,
@@ -1429,7 +1429,7 @@ Property *PropertyLinkSub::CopyOnLabelChange(App::DocumentObject *obj,
     auto owner = dynamic_cast<const DocumentObject*>(getContainer());
     if(!owner || !owner->getDocument())
         return nullptr;
-    if(!_pcLinkSub || !_pcLinkSub->getNameInDocument())
+    if(!_pcLinkSub || !_pcLinkSub->isAttachedToDocument())
         return nullptr;
 
     auto subs = updateLinkSubs(_pcLinkSub,_cSubList,&updateLabelReference,obj,ref,newLabel);
@@ -1475,7 +1475,7 @@ void PropertyLinkSub::getLinks(std::vector<App::DocumentObject *> &objs,
         bool all, std::vector<std::string> *subs, bool newStyle) const
 {
     if(all||_pcScope!=LinkScope::Hidden) {
-        if(_pcLinkSub && _pcLinkSub->getNameInDocument()) {
+        if(_pcLinkSub && _pcLinkSub->isAttachedToDocument()) {
             objs.push_back(_pcLinkSub);
             if(subs)
                 *subs = getSubValues(newStyle);
@@ -1528,7 +1528,7 @@ static App::DocumentObject *adjustLinkSubs(App::PropertyLinkBase *prop,
 bool PropertyLinkSub::adjustLink(const std::set<App::DocumentObject*> &inList) {
     if (_pcScope==LinkScope::Hidden)
         return false;
-    if(!_pcLinkSub || !_pcLinkSub->getNameInDocument() || !inList.count(_pcLinkSub))
+    if(!_pcLinkSub || !_pcLinkSub->isAttachedToDocument() || !inList.count(_pcLinkSub))
         return false;
     auto subs = _cSubList;
     auto link = adjustLinkSubs(this,inList,_pcLinkSub,subs);
@@ -1581,7 +1581,7 @@ void PropertyLinkSubList::setSyncSubObject(bool enable)
 void PropertyLinkSubList::verifyObject(App::DocumentObject* obj, App::DocumentObject* parent)
 {
     if (obj) {
-        if (!obj->getNameInDocument())
+        if (!obj->isAttachedToDocument())
             throw Base::ValueError("PropertyLinkSubList: invalid document object");
         if (!testFlag(LinkAllowExternal) && parent && parent->getDocument() != obj->getDocument())
             throw Base::ValueError("PropertyLinkSubList does not support external object");
@@ -2104,7 +2104,7 @@ void PropertyLinkSubList::Save (Base::Writer &writer) const
 
     int count = 0;
     for(auto obj : _lValueList) {
-        if(obj && obj->getNameInDocument())
+        if(obj && obj->isAttachedToDocument())
             ++count;
     }
     writer.Stream() << writer.ind() << "<LinkSubList count=\"" << count <<"\">" << endl;
@@ -2113,7 +2113,7 @@ void PropertyLinkSubList::Save (Base::Writer &writer) const
     bool exporting = owner && owner->isExporting();
     for (int i = 0; i < getSize(); i++) {
         auto obj = _lValueList[i];
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         const auto &shadow = _ShadowSubList[i];
         // shadow.second stores the old style element name. For backward
@@ -2243,7 +2243,7 @@ Property *PropertyLinkSubList::CopyOnImportExternal(
     for(auto itValue=_lValueList.begin();itValue!=_lValueList.end();++itValue,++itSub) {
         auto value = *itValue;
         const auto &sub = *itSub;
-        if(!value || !value->getNameInDocument()) {
+        if(!value || !value->isAttachedToDocument()) {
             if(!values.empty()) {
                 values.push_back(value);
                 subs.push_back(sub);
@@ -2286,7 +2286,7 @@ Property *PropertyLinkSubList::CopyOnLabelChange(App::DocumentObject *obj,
     for(auto itValue=_lValueList.begin();itValue!=_lValueList.end();++itValue,++itSub) {
         auto value = *itValue;
         const auto &sub = *itSub;
-        if(!value || !value->getNameInDocument()) {
+        if(!value || !value->isAttachedToDocument()) {
             if(!values.empty()) {
                 values.push_back(value);
                 subs.push_back(sub);
@@ -2326,7 +2326,7 @@ Property *PropertyLinkSubList::CopyOnLinkReplace(const App::DocumentObject *pare
     for(auto itValue=_lValueList.begin();itValue!=_lValueList.end();++itValue,++itSub) {
         auto value = *itValue;
         const auto &sub = *itSub;
-        if(!value || !value->getNameInDocument()) {
+        if(!value || !value->isAttachedToDocument()) {
             if(!values.empty()) {
                 values.push_back(value);
                 subs.push_back(sub);
@@ -2420,7 +2420,7 @@ void PropertyLinkSubList::getLinks(std::vector<App::DocumentObject *> &objs,
     if(all||_pcScope!=LinkScope::Hidden) {
         objs.reserve(objs.size()+_lValueList.size());
         for(auto obj : _lValueList) {
-            if(obj && obj->getNameInDocument())
+            if(obj && obj->isAttachedToDocument())
                 objs.push_back(obj);
         }
         if(subs) {
@@ -2466,7 +2466,7 @@ bool PropertyLinkSubList::adjustLink(const std::set<App::DocumentObject*> &inLis
     for(std::string &sub : subs) {
         ++idx;
         auto &link = links[idx];
-        if(!link || !link->getNameInDocument() || !inList.count(link))
+        if(!link || !link->isAttachedToDocument() || !inList.count(link))
             continue;
         touched = true;
         size_t pos = sub.find('.');
@@ -2988,7 +2988,7 @@ void PropertyXLink::restoreLink(App::DocumentObject *lValue) {
     assert(!_pcLink && lValue && docInfo);
 
     auto owner = dynamic_cast<DocumentObject*>(getContainer());
-    if(!owner || !owner->getNameInDocument())
+    if(!owner || !owner->isAttachedToDocument())
         throw Base::RuntimeError("invalid container");
 
     bool touched = owner->isTouched();
@@ -3020,13 +3020,13 @@ void PropertyXLink::setValue(App::DocumentObject *lValue,
     if(_pcLink==lValue && _SubList==subs)
         return;
 
-    if(lValue && (!lValue->getNameInDocument() || !lValue->getDocument())) {
+    if(lValue && (!lValue->isAttachedToDocument() || !lValue->getDocument())) {
         throw Base::ValueError("Invalid object");
         return;
     }
 
     auto owner = dynamic_cast<DocumentObject*>(getContainer());
-    if(!owner || !owner->getNameInDocument())
+    if(!owner || !owner->isAttachedToDocument())
         throw Base::RuntimeError("invalid container");
 
     if(lValue == owner)
@@ -3083,7 +3083,7 @@ void PropertyXLink::setValue(std::string &&filename, std::string &&name,
         return;
     }
     auto owner = dynamic_cast<DocumentObject*>(getContainer());
-    if(!owner || !owner->getNameInDocument())
+    if(!owner || !owner->isAttachedToDocument())
         throw Base::RuntimeError("invalid container");
 
     DocumentObject *pObject=nullptr;
@@ -3199,7 +3199,7 @@ int PropertyXLink::checkRestore(std::string *msg) const {
 
 void PropertyXLink::afterRestore() {
     assert(_SubList.size() == _ShadowSubList.size());
-    if(!testFlag(LinkRestoreLabel) || !_pcLink || !_pcLink->getNameInDocument())
+    if(!testFlag(LinkRestoreLabel) || !_pcLink || !_pcLink->isAttachedToDocument())
         return;
     setFlag(LinkRestoreLabel,false);
     for(size_t i=0;i<_SubList.size();++i)
@@ -3207,7 +3207,7 @@ void PropertyXLink::afterRestore() {
 }
 
 void PropertyXLink::onContainerRestored() {
-    if(!_pcLink || !_pcLink->getNameInDocument())
+    if(!_pcLink || !_pcLink->isAttachedToDocument())
         return;
     for(size_t i=0;i<_SubList.size();++i)
         _registerElementReference(_pcLink,_SubList[i],_ShadowSubList[i]);
@@ -3411,7 +3411,7 @@ Property *PropertyXLink::CopyOnImportExternal(
         const std::map<std::string,std::string> &nameMap) const
 {
     auto owner = Base::freecad_dynamic_cast<const DocumentObject>(getContainer());
-    if(!owner || !owner->getDocument() || !_pcLink || !_pcLink->getNameInDocument())
+    if(!owner || !owner->getDocument() || !_pcLink || !_pcLink->isAttachedToDocument())
         return nullptr;
 
     auto subs = updateLinkSubs(_pcLink,_SubList,
@@ -3440,7 +3440,7 @@ Property *PropertyXLink::CopyOnLabelChange(App::DocumentObject *obj,
         const std::string &ref, const char *newLabel) const
 {
     auto owner = dynamic_cast<const DocumentObject*>(getContainer());
-    if(!owner || !owner->getDocument() || !_pcLink || !_pcLink->getNameInDocument())
+    if(!owner || !owner->getDocument() || !_pcLink || !_pcLink->isAttachedToDocument())
         return nullptr;
     auto subs = updateLinkSubs(_pcLink,_SubList,&updateLabelReference,obj,ref,newLabel);
     if(subs.empty())
@@ -3455,7 +3455,7 @@ void PropertyXLink::copyTo(PropertyXLink &other,
 {
     if(!linked)
         linked = _pcLink;
-    if(linked && linked->getNameInDocument()) {
+    if(linked && linked->isAttachedToDocument()) {
         other.docName = linked->getDocument()->getName();
         other.objectName = linked->getNameInDocument();
         other.docInfo.reset();
@@ -3524,7 +3524,7 @@ bool PropertyXLink::hasXLink(
     std::set<App::Document*> docs;
     bool ret = false;
     for(auto o : objs) {
-        if(o && o->getNameInDocument() && docs.insert(o->getDocument()).second) {
+        if(o && o->isAttachedToDocument() && docs.insert(o->getDocument()).second) {
             if(!hasXLink(o->getDocument()))
                 continue;
             if(!unsaved)
@@ -3553,7 +3553,7 @@ PropertyXLink::getDocumentOutList(App::Document *doc) {
                     || link->testStatus(Property::PropNoPersist))
                 continue;
             auto obj = dynamic_cast<App::DocumentObject*>(link->getContainer());
-            if(!obj || !obj->getNameInDocument() || !obj->getDocument())
+            if(!obj || !obj->isAttachedToDocument() || !obj->getDocument())
                 continue;
             if(doc && obj->getDocument()!=doc)
                 continue;
@@ -3577,7 +3577,7 @@ PropertyXLink::getDocumentInList(App::Document *doc) {
                     || link->testStatus(Property::PropNoPersist))
                 continue;
             auto obj = dynamic_cast<App::DocumentObject*>(link->getContainer());
-            if(obj && obj->getNameInDocument() && obj->getDocument())
+            if(obj && obj->isAttachedToDocument() && obj->getDocument())
                 docs.insert(obj->getDocument());
         }
     }
@@ -3658,7 +3658,7 @@ const char *PropertyXLink::getSubName(bool newStyle) const {
 void PropertyXLink::getLinks(std::vector<App::DocumentObject *> &objs,
         bool all, std::vector<std::string> *subs, bool newStyle) const
 {
-    if((all||_pcScope!=LinkScope::Hidden) && _pcLink && _pcLink->getNameInDocument()) {
+    if((all||_pcScope!=LinkScope::Hidden) && _pcLink && _pcLink->isAttachedToDocument()) {
         objs.push_back(_pcLink);
         if(subs && _SubList.size()==_ShadowSubList.size())
             *subs = getSubValues(newStyle);
@@ -3668,7 +3668,7 @@ void PropertyXLink::getLinks(std::vector<App::DocumentObject *> &objs,
 bool PropertyXLink::adjustLink(const std::set<App::DocumentObject*> &inList) {
     if (_pcScope==LinkScope::Hidden)
         return false;
-    if(!_pcLink || !_pcLink->getNameInDocument() || !inList.count(_pcLink))
+    if(!_pcLink || !_pcLink->isAttachedToDocument() || !inList.count(_pcLink))
         return false;
     auto subs = _SubList;
     auto link = adjustLinkSubs(this,inList,_pcLink,subs);
@@ -3854,7 +3854,7 @@ void PropertyXLinkSubList::setValues(
         std::map<App::DocumentObject*,std::vector<std::string> > &&values)
 {
     for(auto &v : values) {
-        if(!v.first || !v.first->getNameInDocument())
+        if(!v.first || !v.first->isAttachedToDocument())
             FC_THROWM(Base::ValueError,"invalid document object");
     }
 
@@ -3887,7 +3887,7 @@ void PropertyXLinkSubList::addValue(App::DocumentObject *obj,
 void PropertyXLinkSubList::addValue(App::DocumentObject *obj,
         std::vector<std::string> &&subs, bool reset) {
 
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         FC_THROWM(Base::ValueError,"invalid document object");
 
     for(auto &l : _Links) {
@@ -3960,7 +3960,7 @@ const string PropertyXLinkSubList::getPyReprString() const
     ss << '[';
     for(auto &link : _Links) {
         auto obj = link.getValue();
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         ss << "(App.getDocument('" << obj->getDocument()->getName()
            << "').getObject('" << obj->getNameInDocument() << "'),  (";
@@ -4006,7 +4006,7 @@ PyObject *PropertyXLinkSubList::getPyObject()
     Py::List list;
     for(auto &link : _Links) {
         auto obj = link.getValue();
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
 
         Py::Tuple tup(2);
@@ -4279,7 +4279,7 @@ void PropertyXLinkSubList::getLinks(std::vector<App::DocumentObject *> &objs,
             objs.reserve(objs.size()+_Links.size());
             for(auto &l : _Links) {
                 auto obj = l.getValue();
-                if(obj && obj->getNameInDocument())
+                if(obj && obj->isAttachedToDocument())
                     objs.push_back(obj);
             }
             return;
@@ -4287,14 +4287,14 @@ void PropertyXLinkSubList::getLinks(std::vector<App::DocumentObject *> &objs,
         size_t count=0;
         for(auto &l : _Links) {
             auto obj = l.getValue();
-            if(obj && obj->getNameInDocument())
+            if(obj && obj->isAttachedToDocument())
                 count += std::max((int)l.getSubValues().size(), 1);
         }
         if(!count) {
             objs.reserve(objs.size()+_Links.size());
             for(auto &l : _Links) {
                 auto obj = l.getValue();
-                if(obj && obj->getNameInDocument())
+                if(obj && obj->isAttachedToDocument())
                     objs.push_back(obj);
             }
             return;
@@ -4304,7 +4304,7 @@ void PropertyXLinkSubList::getLinks(std::vector<App::DocumentObject *> &objs,
         subs->reserve(subs->size()+count);
         for(auto &l : _Links) {
             auto obj = l.getValue();
-            if(obj && obj->getNameInDocument()) {
+            if(obj && obj->isAttachedToDocument()) {
                 auto subnames = l.getSubValues(newStyle);
                 if (subnames.empty())
                     subnames.emplace_back("");
@@ -4340,7 +4340,7 @@ bool PropertyXLinkSubList::adjustLink(const std::set<App::DocumentObject*> &inLi
     int count=0;
     for(auto &l : _Links) {
         auto obj = l.getValue();
-        if(!obj || !obj->getNameInDocument()) {
+        if(!obj || !obj->isAttachedToDocument()) {
             ++count;
             continue;
         }
@@ -4451,7 +4451,7 @@ PyObject *PropertyXLinkList::getPyObject()
 {
     for(auto &link : _Links) {
         auto obj = link.getValue();
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         if(link.hasSubName())
             return PropertyXLinkSubList::getPyObject();
@@ -4460,7 +4460,7 @@ PyObject *PropertyXLinkList::getPyObject()
     Py::List list;
     for(auto &link : _Links) {
         auto obj = link.getValue();
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         list.append(Py::asObject(obj->getPyObject()));
     }
@@ -4515,10 +4515,10 @@ void PropertyXLinkContainer::afterRestore() {
 }
 
 void PropertyXLinkContainer::breakLink(App::DocumentObject *obj, bool clear) {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return;
     auto owner = dynamic_cast<App::DocumentObject*>(getContainer());
-    if(!owner || !owner->getNameInDocument())
+    if(!owner || !owner->isAttachedToDocument())
         return;
     if(!clear || obj!=owner) {
         auto it = _Deps.find(obj);
@@ -4538,7 +4538,7 @@ void PropertyXLinkContainer::breakLink(App::DocumentObject *obj, bool clear) {
         return;
     for(auto &v : _Deps) {
         auto key = v.first;
-        if(!key || !key->getNameInDocument())
+        if(!key || !key->isAttachedToDocument())
             continue;
         onBreakLink(key);
         if(!v.second && key->getDocument()==owner->getDocument())
@@ -4678,13 +4678,13 @@ bool PropertyXLinkContainer::isLinkedToDocument(const App::Document &doc) const 
 
 void PropertyXLinkContainer::updateDeps(std::map<DocumentObject*,bool> &&newDeps) {
     auto owner = Base::freecad_dynamic_cast<App::DocumentObject>(getContainer());
-    if(!owner || !owner->getNameInDocument())
+    if(!owner || !owner->isAttachedToDocument())
         return;
     newDeps.erase(owner);
 
     for(auto &v : newDeps) {
         auto obj = v.first;
-        if(obj && obj->getNameInDocument()) {
+        if(obj && obj->isAttachedToDocument()) {
             auto it = _Deps.find(obj);
             if(it != _Deps.end()) {
                 if(v.second != it->second) {
@@ -4712,7 +4712,7 @@ void PropertyXLinkContainer::updateDeps(std::map<DocumentObject*,bool> &&newDeps
     }
     for(auto &v : _Deps) {
         auto obj = v.first;
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         if(obj->getDocument()==owner->getDocument()) {
             if(!v.second)
@@ -4736,13 +4736,13 @@ void PropertyXLinkContainer::updateDeps(std::map<DocumentObject*,bool> &&newDeps
 
 void PropertyXLinkContainer::clearDeps() {
     auto owner = dynamic_cast<App::DocumentObject*>(getContainer());
-    if(!owner || !owner->getNameInDocument())
+    if(!owner || !owner->isAttachedToDocument())
         return;
 #ifndef USE_OLD_DAG
     if (!owner->testStatus(ObjectStatus::Destroy)) {
         for(auto &v : _Deps) {
             auto obj = v.first;
-            if(!v.second && obj && obj->getNameInDocument() && obj->getDocument()==owner->getDocument())
+            if(!v.second && obj && obj->isAttachedToDocument() && obj->getDocument()==owner->getDocument())
                 obj->_removeBackLink(owner);
         }
     }

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1315,7 +1315,7 @@ void PropertyString::setValue(const char* newLabel)
     auto obj = dynamic_cast<DocumentObject*>(getContainer());
     bool commit = false;
 
-    if(obj && obj->getNameInDocument() && this==&obj->Label &&
+    if(obj && obj->isAttachedToDocument() && this==&obj->Label &&
        (!obj->getDocument()->testStatus(App::Document::Restoring)||
         obj->getDocument()->testStatus(App::Document::Importing)) &&
        !obj->getDocument()->isPerformingTransaction())
@@ -1456,7 +1456,7 @@ void PropertyString::Save (Base::Writer &writer) const
     auto obj = dynamic_cast<DocumentObject*>(getContainer());
     writer.Stream() << writer.ind() << "<String ";
     bool exported = false;
-    if(obj && obj->getNameInDocument() &&
+    if(obj && obj->isAttachedToDocument() &&
        obj->isExporting() && &obj->Label==this)
     {
         if(obj->allowDuplicateLabel())

--- a/src/Gui/ActiveObjectList.cpp
+++ b/src/Gui/ActiveObjectList.cpp
@@ -46,7 +46,7 @@ App::DocumentObject *ActiveObjectList::getObject(const ObjectInfo &info, bool re
     if (subname)
         *subname = info.subname;
     auto obj = info.obj;
-    if (!obj || !obj->getNameInDocument())
+    if (!obj || !obj->isAttachedToDocument())
         return nullptr;
     if (!info.subname.empty()) {
         obj = obj->getSubObject(info.subname.c_str());
@@ -78,7 +78,7 @@ Gui::ActiveObjectList::ObjectInfo Gui::ActiveObjectList::getObjectInfo(App::Docu
 {
     ObjectInfo info;
     info.obj = nullptr;
-    if (!obj || !obj->getNameInDocument())
+    if (!obj || !obj->isAttachedToDocument())
         return info;
 
     if (subname) {

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -591,7 +591,7 @@ std::string Command::getObjectCmd(const char *Name, const App::Document *doc,
 std::string Command::getObjectCmd(const App::DocumentObject *obj,
         const char *prefix, const char *postfix, bool gui)
 {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return {"None"};
     return getObjectCmd(obj->getNameInDocument(), obj->getDocument(), prefix, postfix,gui);
 }
@@ -782,7 +782,7 @@ void Command::_copyVisual(const char *file, int line, const char* to, const char
 
 void Command::_copyVisual(const char *file, int line, const App::DocumentObject *to, const char* attr_to, const App::DocumentObject *from, const char *attr_from)
 {
-    if(!from || !from->getNameInDocument() || !to || !to->getNameInDocument())
+    if(!from || !from->isAttachedToDocument() || !to || !to->isAttachedToDocument())
         return;
     static std::map<std::string,std::string> attrMap = {
         {"ShapeColor","ShapeMaterial.DiffuseColor"},

--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -110,7 +110,7 @@
  */
 #define _FCMD_OBJ_CMD(_type,_cmd_type,_obj,_cmd) do{\
     auto __obj = _obj;\
-    if(__obj && __obj->getNameInDocument()) {\
+    if(__obj && __obj->isAttachedToDocument()) {\
         std::ostringstream _str;\
         _str << #_type ".getDocument('" << __obj->getDocument()->getName() \
              << "').getObject('" <<  __obj->getNameInDocument() << "')." << _cmd;\
@@ -149,7 +149,7 @@
  */
 #define FCMD_OBJ_CMD2(_cmd,_obj,...) do{\
     auto __obj = _obj;\
-    if(__obj && __obj->getNameInDocument()) {\
+    if(__obj && __obj->isAttachedToDocument()) {\
         Gui::Command::doCommand(Gui::Command::Doc,"App.getDocument('%s').getObject('%s')." _cmd,\
                 __obj->getDocument()->getName(),__obj->getNameInDocument(),## __VA_ARGS__);\
     }\
@@ -162,7 +162,7 @@
  */
 #define FCMD_VOBJ_CMD2(_cmd,_obj,...) do{\
     auto __obj = _obj;\
-    if(__obj && __obj->getNameInDocument()) {\
+    if(__obj && __obj->isAttachedToDocument()) {\
         Gui::Command::doCommand(Gui::Command::Gui,"Gui.getDocument('%s').getObject('%s')." _cmd,\
                 __obj->getDocument()->getName(),__obj->getNameInDocument(),## __VA_ARGS__);\
     }\
@@ -178,7 +178,7 @@
  */
 #define FCMD_SET_EDIT(_obj) do{\
     auto __obj = _obj;\
-    if(__obj && __obj->getNameInDocument()) {\
+    if(__obj && __obj->isAttachedToDocument()) {\
         Gui::Command::doCommand(Gui::Command::Gui,\
             "Gui.ActiveDocument.setEdit(App.getDocument('%s').getObject('%s'), %i)",\
             __obj->getDocument()->getName(), __obj->getNameInDocument(), Gui::Application::Instance->getUserEditMode());\

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1206,7 +1206,7 @@ void StdCmdDuplicateSelection::activated(int iMsg)
     std::vector<App::DocumentObject*> sel;
     std::set<App::DocumentObject*> objSet;
     for(auto &s : Selection().getCompleteSelection()) {
-        if(s.pObject && s.pObject->getNameInDocument() && objSet.insert(s.pObject).second)
+        if(s.pObject && s.pObject->isAttachedToDocument() && objSet.insert(s.pObject).second)
             sel.push_back(s.pObject);
     }
     if(sel.empty())

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -129,7 +129,7 @@ void StdCmdLinkMakeGroup::activated(int option) {
     }
 
     for(auto &sel : Selection().getCompleteSelection()) {
-        if(sel.pObject && sel.pObject->getNameInDocument() &&
+        if(sel.pObject && sel.pObject->isAttachedToDocument() &&
            objset.insert(sel.pObject).second)
             objs.push_back(sel.pObject);
     }
@@ -231,7 +231,7 @@ void StdCmdLinkMake::activated(int) {
 
     std::set<App::DocumentObject*> objs;
     for(auto &sel : Selection().getCompleteSelection()) {
-        if(sel.pObject && sel.pObject->getNameInDocument())
+        if(sel.pObject && sel.pObject->isAttachedToDocument())
            objs.insert(sel.pObject);
     }
 
@@ -296,7 +296,7 @@ void StdCmdLinkMakeRelative::activated(int) {
         std::map<std::pair<App::DocumentObject*,std::string>,
                  std::pair<App::DocumentObject*, std::vector<std::string> > > linkInfo;
         for(auto &sel : Selection().getCompleteSelection(ResolveMode::NoResolve)) {
-            if(!sel.pObject || !sel.pObject->getNameInDocument())
+            if(!sel.pObject || !sel.pObject->isAttachedToDocument())
                 continue;
             auto key = std::make_pair(sel.pObject,
                     Data::noElementName(sel.SubName));
@@ -375,7 +375,7 @@ static void linkConvert(bool unlink) {
         info.inited = true;
         if(unlink) {
             auto linked = obj->getLinkedObject(false);
-            if(!linked || !linked->getNameInDocument() || linked == obj) {
+            if(!linked || !linked->isAttachedToDocument() || linked == obj) {
                 FC_WARN("skip non link");
                 continue;
             }
@@ -410,7 +410,7 @@ static void linkConvert(bool unlink) {
             App::DocumentObject *replaceObj;
             if(unlink) {
                 replaceObj = obj->getLinkedObject(false);
-                if(!replaceObj || !replaceObj->getNameInDocument() || replaceObj == obj)
+                if(!replaceObj || !replaceObj->isAttachedToDocument() || replaceObj == obj)
                     continue;
             }else{
                 auto name = doc->getUniqueObjectName("Link");
@@ -555,10 +555,10 @@ static std::map<App::Document*, std::vector<App::DocumentObject*> > getLinkImpor
     std::map<App::Document*, std::vector<App::DocumentObject*> > objMap;
     for(auto &sel : Selection().getCompleteSelection(ResolveMode::NoResolve)) {
         auto obj = sel.pObject->resolve(sel.SubName);
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         for(auto o : obj->getOutList()) {
-            if(o && o->getNameInDocument() && o->getDocument()!=obj->getDocument()) {
+            if(o && o->isAttachedToDocument() && o->getDocument()!=obj->getDocument()) {
                 objMap[obj->getDocument()].push_back(obj);
                 break;
             }
@@ -693,7 +693,7 @@ static App::DocumentObject *getSelectedLink(bool finalLink, std::string *subname
         return nullptr;
 
     auto linked = linkedVp->getObject();
-    if(!linked || !linked->getNameInDocument())
+    if(!linked || !linked->isAttachedToDocument())
         return nullptr;
 
     if(subname && sels[0].pObject!=sobj && sels[0].SubName) {

--- a/src/Gui/CommandT.h
+++ b/src/Gui/CommandT.h
@@ -301,7 +301,7 @@ inline void cmdGuiDocument(const App::DocumentObject* obj, T&& cmd) {
  */
 template<typename T>
 void _cmdObject(Gui::Command::DoCmd_Type cmdType, const App::DocumentObject* obj, const std::string& mod, T&& cmd) {
-    if (obj && obj->getNameInDocument()) {
+    if (obj && obj->isAttachedToDocument()) {
         std::ostringstream str;
         str << mod << ".getDocument('" << obj->getDocument()->getName() << "')"
                       ".getObject('" << obj->getNameInDocument() << "')."
@@ -352,7 +352,7 @@ inline void cmdAppObjectShow(const App::DocumentObject* obj) {
  * external group.
  */
 inline void cmdSetEdit(const App::DocumentObject* obj, int mod = 0) {
-    if (obj && obj->getNameInDocument()) {
+    if (obj && obj->isAttachedToDocument()) {
         Gui::Command::doCommand(Gui::Command::Gui,
             "Gui.ActiveDocument.setEdit(App.getDocument('%s').getObject('%s'), %d)",
             obj->getDocument()->getName(), obj->getNameInDocument(), mod);

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2707,7 +2707,7 @@ static std::vector<std::string> getBoxSelection(
 {
     std::vector<std::string> ret;
     auto obj = vp->getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return ret;
 
     // DO NOT check this view object Visibility, let the caller do this. Because
@@ -3081,7 +3081,7 @@ bool StdCmdTreeSelectAllInstances::isActive()
     if(sels.empty())
         return false;
     auto obj = sels[0].getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return false;
     return dynamic_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(obj)) != nullptr;
@@ -3094,7 +3094,7 @@ void StdCmdTreeSelectAllInstances::activated(int iMsg)
     if(sels.empty())
         return;
     auto obj = sels[0].getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return;
     auto vpd = dynamic_cast<ViewProviderDocumentObject*>(
             Application::Instance->getViewProvider(obj));

--- a/src/Gui/DlgPropertyLink.cpp
+++ b/src/Gui/DlgPropertyLink.cpp
@@ -143,7 +143,7 @@ QList<App::SubObjectT> DlgPropertyLink::getLinksFromProperty(const App::Property
 
 QString DlgPropertyLink::formatObject(App::Document *ownerDoc, App::DocumentObject *obj, const char *sub)
 {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return QLatin1String("?");
 
     const char *objName = obj->getNameInDocument();
@@ -241,7 +241,7 @@ void DlgPropertyLink::init(const App::DocumentObjectT &prop, bool tryFilter) {
 
     objProp  = prop;
     auto owner = objProp.getObject();
-    if(!owner || !owner->getNameInDocument())
+    if(!owner || !owner->isAttachedToDocument())
         return;
 
     ui->searchBox->setDocumentObject(owner);
@@ -567,7 +567,7 @@ QTreeWidgetItem *DlgPropertyLink::findItem(
     if(pfound)
         *pfound = false;
 
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return nullptr;
 
     std::vector<App::DocumentObject *> sobjs;
@@ -887,7 +887,7 @@ void DlgPropertyLink::itemSearch(const QString &text, bool select) {
 QTreeWidgetItem *DlgPropertyLink::createItem(
         App::DocumentObject *obj, QTreeWidgetItem *parent)
 {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return nullptr;
 
     if(inList.find(obj)!=inList.end())

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -304,7 +304,7 @@ bool Document::setEdit(Gui::ViewProvider* p, int ModNum, const char *subname)
     }
 
     auto obj = vp->getObject();
-    if(!obj->getNameInDocument()) {
+    if(!obj->isAttachedToDocument()) {
         FC_ERR("cannot edit detached object");
         return false;
     }
@@ -316,7 +316,7 @@ bool Document::setEdit(Gui::ViewProvider* p, int ModNum, const char *subname)
         auto sels = Gui::Selection().getCompleteSelection(ResolveMode::NoResolve);
         App::DocumentObject *parentObj = nullptr;
         for(auto &sel : sels) {
-            if(!sel.pObject || !sel.pObject->getNameInDocument())
+            if(!sel.pObject || !sel.pObject->isAttachedToDocument())
                 continue;
             if(!parentObj)
                 parentObj = sel.pObject;
@@ -385,7 +385,7 @@ bool Document::setEdit(Gui::ViewProvider* p, int ModNum, const char *subname)
     //     }
     // }
     auto sobj = obj->getSubObject(subname,nullptr,&d->_editingTransform);
-    if(!sobj || !sobj->getNameInDocument()) {
+    if(!sobj || !sobj->isAttachedToDocument()) {
         FC_ERR("Invalid sub object '" << obj->getFullName()
                 << '.' << (subname?subname:"") << "'");
         return false;
@@ -957,7 +957,7 @@ void Document::slotSkipRecompute(const App::Document& doc, const std::vector<App
     }
     if(!obj)
         obj = doc.getActiveObject();
-    if(!obj || !obj->getNameInDocument() || (!objs.empty() && objs.front()!=obj))
+    if(!obj || !obj->isAttachedToDocument() || (!objs.empty() && objs.front()!=obj))
         return;
     obj->recomputeFeature(true);
 }
@@ -2501,7 +2501,7 @@ void Document::handleChildren3D(ViewProvider* viewProvider, bool deleting)
             // add the remaining old children back to toplevel invertor node
             for(auto vpd : oldChildren) {
                 auto obj = vpd->getObject();
-                if(!obj || !obj->getNameInDocument())
+                if(!obj || !obj->isAttachedToDocument())
                     continue;
 
                 for (BaseView* view : d->baseViews) {

--- a/src/Gui/DocumentPyImp.cpp
+++ b/src/Gui/DocumentPyImp.cpp
@@ -138,7 +138,7 @@ PyObject* DocumentPy::setEdit(PyObject *args)
     }
 
     if (!vp) {
-        if (!obj || !obj->getNameInDocument() || !(vp=Application::Instance->getViewProvider(obj))) {
+        if (!obj || !obj->isAttachedToDocument() || !(vp=Application::Instance->getViewProvider(obj))) {
             PyErr_SetString(PyExc_ValueError,"Invalid document object");
             return nullptr;
         }
@@ -467,7 +467,7 @@ Py::Object DocumentPy::getInEditInfo() const {
     std::string subname,subelement;
     int mode = 0;
     getDocumentPtr()->getInEdit(&vp,&subname,&mode,&subelement);
-    if (!vp || !vp->getObject() || !vp->getObject()->getNameInDocument())
+    if (!vp || !vp->getObject() || !vp->getObject()->isAttachedToDocument())
         return Py::None();
 
     return Py::TupleN(Py::Object(vp->getObject()->getPyObject(),true),

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -673,7 +673,7 @@ void ExpressionCompleter::init() {
 
 void ExpressionCompleter::setDocumentObject(const App::DocumentObject* obj, bool _checkInList)
 {
-    if (!obj || !obj->getNameInDocument())
+    if (!obj || !obj->isAttachedToDocument())
         currentObj = App::DocumentObjectT();
     else
         currentObj = obj;

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2087,7 +2087,7 @@ QMimeData * MainWindow::createMimeDataFromSelection () const
     std::vector<App::DocumentObject*> sel;
     std::set<App::DocumentObject*> objSet;
     for(auto &s : Selection().getCompleteSelection()) {
-        if(s.pObject && s.pObject->getNameInDocument() && objSet.insert(s.pObject).second)
+        if(s.pObject && s.pObject->isAttachedToDocument() && objSet.insert(s.pObject).second)
             sel.push_back(s.pObject);
     }
     if(sel.empty())

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -467,7 +467,7 @@ App::DocumentObject *SelectionSingleton::getObjectOfType(_SelObj &sel, Base::Typ
                                                          ResolveMode resolve, const char **subelement)
 {
     auto obj = sel.pObject;
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return nullptr;
     const char *subname = sel.SubName.c_str();
     if (resolve != ResolveMode::NoResolve) {
@@ -1274,7 +1274,7 @@ void SelectionSingleton::setVisible(VisibleState vis) {
         App::DocumentObject *parent = nullptr;
         std::string elementName;
         obj = obj->resolve(sel.SubName.c_str(),&parent,&elementName);
-        if (!obj || !obj->getNameInDocument() || (parent && !parent->getNameInDocument()))
+        if (!obj || !obj->isAttachedToDocument() || (parent && !parent->isAttachedToDocument()))
             continue;
         // try call parent object's setElementVisible
         if (parent) {
@@ -1342,7 +1342,7 @@ void SelectionSingleton::setSelection(const char* pDocName, const std::vector<Ap
 
     bool touched = false;
     for(auto obj : sel) {
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         _SelObj temp;
         int ret = checkSelection(pDocName,obj->getNameInDocument(), nullptr, ResolveMode::NoResolve, temp);
@@ -1447,7 +1447,7 @@ bool SelectionSingleton::isSelected(const char* pDocName, const char* pObjectNam
 
 bool SelectionSingleton::isSelected(App::DocumentObject* pObject, const char* pSubName, ResolveMode resolve) const
 {
-    if (!pObject || !pObject->getNameInDocument() || !pObject->getDocument())
+    if (!pObject || !pObject->isAttachedToDocument() || !pObject->getDocument())
         return false;
     _SelObj sel;
     return checkSelection(pObject->getDocument()->getName(),
@@ -1557,7 +1557,7 @@ const char *SelectionSingleton::getSelectedElement(App::DocumentObject *obj, con
 
 void SelectionSingleton::slotDeletedObject(const App::DocumentObject& Obj)
 {
-    if(!Obj.getNameInDocument())
+    if(!Obj.isAttachedToDocument())
         return;
 
     // For safety reason, don't bother checking
@@ -1900,7 +1900,7 @@ PyObject *SelectionSingleton::sAddSelection(PyObject * /*self*/, PyObject *args)
                 &subname,&x,&y,&z,&PyBool_Type,&clearPreselect)) {
         auto docObjPy = static_cast<App::DocumentObjectPy*>(object);
         App::DocumentObject* docObj = docObjPy->getDocumentObjectPtr();
-        if (!docObj || !docObj->getNameInDocument()) {
+        if (!docObj || !docObj->isAttachedToDocument()) {
             PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot check invalid object");
             return nullptr;
         }
@@ -1918,7 +1918,7 @@ PyObject *SelectionSingleton::sAddSelection(PyObject * /*self*/, PyObject *args)
     {
         auto docObjPy = static_cast<App::DocumentObjectPy*>(object);
         App::DocumentObject* docObj = docObjPy->getDocumentObjectPtr();
-        if (!docObj || !docObj->getNameInDocument()) {
+        if (!docObj || !docObj->isAttachedToDocument()) {
             PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot check invalid object");
             return nullptr;
         }
@@ -1956,7 +1956,7 @@ PyObject *SelectionSingleton::sUpdateSelection(PyObject * /*self*/, PyObject *ar
 
     auto docObjPy = static_cast<App::DocumentObjectPy*>(object);
     App::DocumentObject* docObj = docObjPy->getDocumentObjectPtr();
-    if (!docObj || !docObj->getNameInDocument()) {
+    if (!docObj || !docObj->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot check invalid object");
         return nullptr;
     }
@@ -1986,7 +1986,7 @@ PyObject *SelectionSingleton::sRemoveSelection(PyObject * /*self*/, PyObject *ar
 
     auto docObjPy = static_cast<App::DocumentObjectPy*>(object);
     App::DocumentObject* docObj = docObjPy->getDocumentObjectPtr();
-    if (!docObj || !docObj->getNameInDocument()) {
+    if (!docObj || !docObj->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot check invalid object");
         return nullptr;
     }
@@ -2124,7 +2124,7 @@ PyObject *SelectionSingleton::sSetPreselection(PyObject * /*self*/, PyObject *ar
                                             &subname, &x, &y, &z, &type)) {
         auto docObjPy = static_cast<App::DocumentObjectPy*>(object);
         App::DocumentObject* docObj = docObjPy->getDocumentObjectPtr();
-        if (!docObj || !docObj->getNameInDocument()) {
+        if (!docObj || !docObj->isAttachedToDocument()) {
             PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot check invalid object");
             return nullptr;
         }

--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -488,7 +488,7 @@ bool SoFCUnifiedSelection::setHighlight(SoFullPath *path, const SoDetail *det,
 
     bool highlighted = false;
     if(path && path->getLength() &&
-       vpd && vpd->getObject() && vpd->getObject()->getNameInDocument())
+       vpd && vpd->getObject() && vpd->getObject()->isAttachedToDocument())
     {
         const char *docname = vpd->getObject()->getDocument()->getName();
         const char *objname = vpd->getObject()->getNameInDocument();
@@ -568,9 +568,9 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo> &infos, bo
     auto vpd = info.vpd;
     if(!vpd)
         return false;
-    const char *objname = vpd->getObject()->getNameInDocument();
-    if(!objname)
+    if(!vpd->getObject()->isAttachedToDocument())
         return false;
+    const char *objname = vpd->getObject()->getNameInDocument();
     const char *docname = vpd->getObject()->getDocument()->getName();
 
     bool hasNext = false;

--- a/src/Gui/View3DInventorSelection.cpp
+++ b/src/Gui/View3DInventorSelection.cpp
@@ -108,7 +108,7 @@ void View3DInventorSelection::checkGroupOnTop(const SelectionChanges &Reason)
     if(!getDocument() || !Reason.pDocName || !Reason.pDocName[0] || !Reason.pObjectName)
         return;
     auto obj = getDocument()->getDocument()->getObject(Reason.pObjectName);
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return;
     std::string key(obj->getNameInDocument());
     key += '.';
@@ -155,7 +155,7 @@ void View3DInventorSelection::checkGroupOnTop(const SelectionChanges &Reason)
     auto svp = vp;
     if(subname && *subname) {
         auto sobj = obj->getSubObject(subname);
-        if(!sobj || !sobj->getNameInDocument())
+        if(!sobj || !sobj->isAttachedToDocument())
             return;
         if(sobj!=obj) {
             svp = dynamic_cast<ViewProviderDocumentObject*>(
@@ -206,7 +206,7 @@ void View3DInventorSelection::checkGroupOnTop(const SelectionChanges &Reason)
     std::set<ViewProvider*> visited;
     for(auto childVp=vp;;childVp=grpVp) {
         auto grp = App::GeoFeatureGroupExtension::getGroupOfObject(childVp->getObject());
-        if (!grp || !grp->getNameInDocument()) {
+        if (!grp || !grp->isAttachedToDocument()) {
             break;
         }
 

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -331,7 +331,7 @@ void ViewProviderDocumentObject::attach(App::DocumentObject *pcObj)
     // save Object pointer
     pcObject = pcObj;
 
-    if(pcObj && pcObj->getNameInDocument() &&
+    if(pcObj && pcObj->isAttachedToDocument() &&
        Visibility.getValue()!=pcObj->Visibility.getValue())
         pcObj->Visibility.setValue(Visibility.getValue());
 
@@ -519,14 +519,14 @@ bool ViewProviderDocumentObject::canDropObjectEx(App::DocumentObject* obj, App::
 int ViewProviderDocumentObject::replaceObject(
         App::DocumentObject *oldObj, App::DocumentObject *newObj)
 {
-    if(!oldObj || !oldObj->getNameInDocument()
-            || !newObj || !newObj->getNameInDocument())
+    if(!oldObj || !oldObj->isAttachedToDocument()
+            || !newObj || !newObj->isAttachedToDocument())
     {
         FC_THROWM(Base::RuntimeError,"Invalid object");
     }
 
     auto obj = getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         FC_THROWM(Base::RuntimeError,"View provider not attached");
 
     int res = ViewProvider::replaceObject(oldObj,newObj);
@@ -606,7 +606,7 @@ bool ViewProviderDocumentObject::getElementPicked(const SoPickedPoint *pp, std::
     if(!vp)
         return false;
     auto obj = vp->getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return false;
     std::ostringstream str;
     str << obj->getNameInDocument() << '.';
@@ -635,7 +635,7 @@ bool ViewProviderDocumentObject::getDetailPath(const char *subname, SoFullPath *
     if(!dot)
         return false;
     auto obj = getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return false;
     auto sobj = obj->getSubObject(std::string(subname,dot-subname+1).c_str());
     if(!sobj)
@@ -676,7 +676,7 @@ ViewProviderDocumentObject *ViewProviderDocumentObject::getLinkedViewProvider(
 {
     (void)subname;
     auto self = const_cast<ViewProviderDocumentObject*>(this);
-    if(!pcObject || !pcObject->getNameInDocument())
+    if(!pcObject || !pcObject->isAttachedToDocument())
         return self;
     auto linked = pcObject->getLinkedObject(recursive);
     if(!linked || linked == pcObject)

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
@@ -96,7 +96,7 @@ std::vector<App::DocumentObject*> ViewProviderGeoFeatureGroupExtension::extensio
     // remove the otherwise handled objects, preserving their order so the order in the TreeWidget is correct
     std::vector<App::DocumentObject*> Result;
     for(auto obj : model) {
-        if(!obj || !obj->getNameInDocument())
+        if(!obj || !obj->isAttachedToDocument())
             continue;
         if(outSet.count(obj))
             obj->setStatus(App::ObjectStatus::GeoExcluded,true);

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -135,7 +135,7 @@ public:
     std::map<qint64, QIcon> iconMap;
 
     static ViewProviderDocumentObject *getView(App::DocumentObject *obj) {
-        if(obj && obj->getNameInDocument()) {
+        if(obj && obj->isAttachedToDocument()) {
             Document *pDoc = Application::Instance->getDocument(obj->getDocument());
             if(pDoc) {
                 ViewProvider *vp = pDoc->getViewProvider(obj);
@@ -221,7 +221,7 @@ public:
 
     bool isLinked() const {
         return pcLinked && pcLinked->getObject() &&
-           pcLinked->getObject()->getNameInDocument();
+           pcLinked->getObject()->isAttachedToDocument();
     }
 
     const char *getLinkedName() const {
@@ -1777,13 +1777,13 @@ bool ViewProviderLink::setLinkType(App::LinkBaseExtension *ext) {
 }
 
 App::LinkBaseExtension *ViewProviderLink::getLinkExtension() {
-    if(!pcObject || !pcObject->getNameInDocument())
+    if(!pcObject || !pcObject->isAttachedToDocument())
         return nullptr;
     return pcObject->getExtensionByType<App::LinkBaseExtension>(true);
 }
 
 const App::LinkBaseExtension *ViewProviderLink::getLinkExtension() const{
-    if(!pcObject || !pcObject->getNameInDocument())
+    if(!pcObject || !pcObject->isAttachedToDocument())
         return nullptr;
     return const_cast<App::DocumentObject*>(pcObject)->getExtensionByType<App::LinkBaseExtension>(true);
 }

--- a/src/Gui/ViewProviderOriginGroupExtension.cpp
+++ b/src/Gui/ViewProviderOriginGroupExtension.cpp
@@ -139,7 +139,7 @@ void ViewProviderOriginGroupExtension::slotChangedObjectGui ( const Gui::ViewPro
 void ViewProviderOriginGroupExtension::updateOriginSize () {
     auto owner = getExtendedViewProvider()->getObject();
 
-    if(!owner->getNameInDocument() ||
+    if(!owner->isAttachedToDocument() ||
        owner->isRemoving() ||
        owner->getDocument()->testStatus(App::Document::Restoring))
         return;

--- a/src/Gui/ViewProviderPythonFeature.cpp
+++ b/src/Gui/ViewProviderPythonFeature.cpp
@@ -1136,8 +1136,8 @@ ViewProviderPythonFeatureImp::ValueT
 ViewProviderPythonFeatureImp::replaceObject(
         App::DocumentObject *oldObj, App::DocumentObject *newObj)
 {
-    if(!oldObj || !oldObj->getNameInDocument()
-            || !newObj || !newObj->getNameInDocument())
+    if(!oldObj || !oldObj->isAttachedToDocument()
+            || !newObj || !newObj->isAttachedToDocument())
         return NotImplemented;
 
     FC_PY_CALL_CHECK(replaceObject);

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -306,7 +306,7 @@ void PropertyEditor::openEditor(const QModelIndex &index)
             break;
         }
     }
-    if(obj && obj->getNameInDocument())
+    if(obj && obj->isAttachedToDocument())
         str << obj->getNameInDocument() << '.';
     else
         str << tr("property").toUtf8().constData() << ' ';

--- a/src/Mod/Import/App/ExportOCAF2.cpp
+++ b/src/Mod/Import/App/ExportOCAF2.cpp
@@ -611,7 +611,7 @@ bool ExportOCAF2::canFallback(std::vector<App::DocumentObject*> objs)
 {
     for (size_t i = 0; i < objs.size(); ++i) {
         auto obj = objs[i];
-        if (!obj || !obj->getNameInDocument()) {
+        if (!obj || !obj->isAttachedToDocument()) {
             continue;
         }
         if (obj->getExtensionByType<App::LinkBaseExtension>(true)) {

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -448,7 +448,7 @@ TopoShape Feature::getTopoShape(const App::DocumentObject *obj, const char *subn
         bool needSubElement, Base::Matrix4D *pmat, App::DocumentObject **powner,
         bool resolveLink, bool transform, bool noElementMap)
 {
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return {};
 
     std::vector<App::DocumentObject*> linkStack;

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -1003,7 +1003,7 @@ void TaskAttacher::visibilityAutomation(bool opening_not_closing)
             return;
         if (!ViewProvider->getObject())
             return;
-        if (!ViewProvider->getObject()->getNameInDocument())
+        if (!ViewProvider->getObject()->isAttachedToDocument())
             return;
 
         auto editDoc = Gui::Application::Instance->editDocument();

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -396,11 +396,11 @@ App::DocumentObject* SubShapeBinder::getSubObject(const char* subname, PyObject*
     std::string name(subname, dot - subname);
     for (auto& l : Support.getSubListValues()) {
         auto obj = l.getValue();
-        if (!obj || !obj->getNameInDocument())
+        if (!obj || !obj->isAttachedToDocument())
             continue;
         for (auto& sub : l.getSubValues()) {
             auto sobj = obj->getSubObject(sub.c_str());
-            if (!sobj || !sobj->getNameInDocument())
+            if (!sobj || !sobj->isAttachedToDocument())
                 continue;
             if (subname[0] == '$') {
                 if (sobj->Label.getStrValue() != name.c_str() + 1)
@@ -512,7 +512,7 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
     std::unordered_map<const App::DocumentObject*, Base::Matrix4D> mats;
     for (auto& l : Support.getSubListValues()) {
         auto obj = l.getValue();
-        if (!obj || !obj->getNameInDocument())
+        if (!obj || !obj->isAttachedToDocument())
             continue;
         auto res = mats.emplace(obj, Base::Matrix4D());
         if (parent && res.second) {
@@ -909,7 +909,7 @@ void SubShapeBinder::setLinks(std::map<App::DocumentObject*, std::vector<std::st
     inSet.insert(this);
 
     for (auto& v : values) {
-        if (!v.first || !v.first->getNameInDocument())
+        if (!v.first || !v.first->isAttachedToDocument())
             FC_THROWM(Base::ValueError, "Invalid document object");
         if (inSet.find(v.first) != inSet.end())
             FC_THROWM(Base::ValueError, "Cyclic reference to " << v.first->getFullName());

--- a/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
@@ -337,7 +337,7 @@ void TaskDlgBooleanParameters::clicked(int)
 bool TaskDlgBooleanParameters::accept()
 {
     auto obj = BooleanView->getObject();
-    if(!obj || !obj->getNameInDocument())
+    if(!obj || !obj->isAttachedToDocument())
         return false;
     BooleanView->Visibility.setValue(true);
 

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -73,7 +73,7 @@ App::DocumentObject* getParent(App::DocumentObject* obj, std::string& subname)
 }
 
 bool setEdit(App::DocumentObject *obj, PartDesign::Body *body) {
-    if (!obj || !obj->getNameInDocument()) {
+    if (!obj || !obj->isAttachedToDocument()) {
         FC_ERR("invalid object");
         return false;
     }

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -324,7 +324,7 @@ bool ViewProviderSubShapeBinder::setEdit(int ModNum) {
         Gui::Selection().clearSelection();
         for (auto& link : self->Support.getSubListValues()) {
             auto obj = link.getValue();
-            if (!obj || !obj->getNameInDocument())
+            if (!obj || !obj->isAttachedToDocument())
                 continue;
             const auto& subs = link.getSubValues();
             if (!subs.empty())

--- a/src/Mod/Path/App/FeaturePathCompoundPyImp.cpp
+++ b/src/Mod/Path/App/FeaturePathCompoundPyImp.cpp
@@ -43,7 +43,7 @@ PyObject*  FeaturePathCompoundPy::addObject(PyObject *args)
         return nullptr;
 
     DocumentObjectPy* docObj = static_cast<DocumentObjectPy*>(object);
-    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->getNameInDocument()) {
+    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot add an invalid object");
         return nullptr;
     }
@@ -88,7 +88,7 @@ PyObject*  FeaturePathCompoundPy::removeObject(PyObject *args)
         return nullptr;
 
     DocumentObjectPy* docObj = static_cast<DocumentObjectPy*>(object);
-    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->getNameInDocument()) {
+    if (!docObj->getDocumentObjectPtr() || !docObj->getDocumentObjectPtr()->isAttachedToDocument()) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, "Cannot remove an invalid object");
         return nullptr;
     }

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -1668,7 +1668,7 @@ void PropertySheet::recomputeDependencies(CellAddress key)
 
 void PropertySheet::hasSetValue()
 {
-    if (updateCount == 0 || !owner || !owner->getNameInDocument() || owner->isRestoring()
+    if (updateCount == 0 || !owner || !owner->isAttachedToDocument() || owner->isRestoring()
         || this != &owner->cells || testFlag(LinkDetached)) {
         PropertyExpressionContainer::hasSetValue();
         return;

--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -279,8 +279,7 @@ int DrawPage::removeView(App::DocumentObject* docObj)
         return -1;
     }
 
-    const char* name = docObj->getNameInDocument();
-    if (!name) {
+    if (!docObj->isAttachedToDocument()) {
         return -1;
     }
     const std::vector<App::DocumentObject*> currViews = Views.getValues();
@@ -292,7 +291,7 @@ int DrawPage::removeView(App::DocumentObject* docObj)
             continue;
         }
 
-        std::string viewName = name;
+        std::string viewName = docObj->getNameInDocument();
         if (viewName.compare((*it)->getNameInDocument()) != 0) {
             newViews.push_back((*it));
         }

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -940,7 +940,7 @@ void QGSPage::fixOrphans(bool force)
     // if we ever have collections of collections, we'll need to revisit this
     TechDraw::DrawPage* thisPage = m_vpPage->getDrawPage();
 
-    if (!thisPage->getNameInDocument())
+    if (!thisPage->isAttachedToDocument())
         return;
 
     std::vector<App::DocumentObject*> pChildren = thisPage->getAllViews();

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -85,11 +85,10 @@ void ViewProviderDrawingView::attach(App::DocumentObject *pcFeat)
     //NOLINTEND
     auto feature = getViewObject();
     if (feature) {
-        const char* temp = feature->getNameInDocument();
-        if (temp) {
+        if (feature->isAttachedToDocument()) {
             // it could happen that feature is not completely in the document yet and getNameInDocument returns
             // nullptr, so we only update m_myName if we got a valid string.
-            m_myName = temp;
+            m_myName = feature->getNameInDocument();
         }
         connectGuiRepaint = feature->signalGuiPaint.connect(bnd);
         connectProgressMessage = feature->signalProgressMessage.connect(bndProgressMessage);

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -120,11 +120,10 @@ void ViewProviderPage::attach(App::DocumentObject* pcFeat)
     TechDraw::DrawPage* feature = dynamic_cast<TechDraw::DrawPage*>(pcFeat);
     if (feature) {
         connectGuiRepaint = feature->signalGuiPaint.connect(bnd);
-        const char* temp = feature->getNameInDocument();
-        if (temp) {
+        if (feature->isAttachedToDocument()) {
             // it could happen that feature is not completely in the document yet and getNameInDocument returns
             // nullptr, so we only update m_myName if we got a valid string.
-            m_pageName = temp;
+            m_pageName = feature->getNameInDocument();
         }
         m_graphicsScene->setObjectName(QString::fromLocal8Bit(m_pageName.c_str()));
     }


### PR DESCRIPTION
This patch substitutes by isAttachedToDocument() (almost) everywhere where getNameInDocument() is used for this purpose.

The very few places not touched by this patch demand a (just a little) less trivial change. When we change the returning type of getNameInDocument() to std::string, those places will be easily found, because they shall generate a compiler error (converting std::string to bool).

Rationale:
The fact that getNameInDocument() return nullptr to indicate that the object is not attached to a document is responsible for lots of bugs where the developer does not check for "nullptr".

The idea is to eliminate all those uses of getNameInDocument() and, in the near future, make getNameInDocument() return always a valid std::string.

This is the first PR on a series to satisfy:
https://github.com/FreeCAD/FreeCAD/pull/11053#issuecomment-1764862715