### PR TITLE
Sketcher: commandConstraint : remove leftover bothexternal variable.

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -8744,9 +8744,6 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
     }
     else if (SubNames.size() < 3) {
 
-        bool bothexternal = areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2);
-        Q_UNUSED(bothexternal)
-
         if (isVertex(GeoId1, PosId1) && isEdge(GeoId2, PosId2)) {
             std::swap(GeoId1, GeoId2);
             std::swap(PosId1, PosId2);


### PR DESCRIPTION
Remove unused bothexternal variable that is a leftover of a refactor.