### PR TITLE
Does not rely on the pointervalue returned by getNameInDocument() to use as a DAG key.

### DIFF
--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -292,6 +292,15 @@ std::string DocumentObject::getFullLabel() const {
     return name;
 }
 
+const char* DocumentObject::getDagKey() const
+{
+    if(!pcNameInDocument)
+    {
+        return nullptr;
+    }
+    return pcNameInDocument->c_str();
+}
+
 const char *DocumentObject::getNameInDocument() const
 {
     // Note: It can happen that we query the internal name of an object even if it is not
@@ -808,7 +817,7 @@ DocumentObject *DocumentObject::getSubObject(const char *subname,
         if(outList.size()!=_outListMap.size()) {
             _outListMap.clear();
             for(auto obj : outList)
-                _outListMap[obj->getNameInDocument()] = obj;
+                _outListMap[obj->getDagKey()] = obj;
         }
         auto it = _outListMap.find(name.c_str());
         if(it != _outListMap.end())

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -132,6 +132,8 @@ public:
     DocumentObject();
     ~DocumentObject() override;
 
+    /// returns a value that uniquely identifies this DocumentObject.
+    const char* getDagKey() const;
     /// returns the name which is set in the document for this object (not the name property!)
     const char *getNameInDocument() const;
     /// Return the object ID that is unique within its owner document

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -468,7 +468,7 @@ void LinkBaseExtension::setOnChangeCopyObject(
         }
     }
 
-    const char *key = flags.testFlag(OnChangeCopyOptions::ApplyAll) ? "*" : parent->getNameInDocument();
+    const char *key = flags.testFlag(OnChangeCopyOptions::ApplyAll) ? "*" : parent->getDagKey();
     if (external)
         prop->setValue(key, exclude ? "" : "+");
     else

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -225,7 +225,7 @@ public:
     }
 
     const char *getLinkedName() const {
-        return pcLinked->getObject()->getNameInDocument();
+        return pcLinked->getObject()->getDagKey();
     }
 
     const char *getLinkedLabel() const {


### PR DESCRIPTION
I am splitting the PR https://github.com/FreeCAD/FreeCAD/pull/11053 into a sequence of simpler PRs. This is the second in this sequence. The first one is: https://github.com/FreeCAD/FreeCAD/pull/11139.

Basically, the `DocumentObject::getNameInDocument()` method has three different uses:
1. Obtains the name of this object within the `Document`. (legitimate use)
2. Indicates if the object is attached to a Document. Returns `nullptr` in case not. See: https://github.com/FreeCAD/FreeCAD/pull/11139.
3. Provides a "DAG key" to refer to this object. (this patch)

This PR creates the method `getDagKey()` that shall be used in the context of item 3, instead of relaying on `getNameInDocument()`.

The main idea is to, in the near future, change `getNameInDocument()` and make it never return an invalid string. There are many places in FreeCAD where the developer assumes `nullptr` will never be returned. Changing this `getNameInDocument()` behaviour will fix lots of (potential) bugs, like this: https://github.com/FreeCAD/FreeCAD/issues/10130.