### PR TITLE
MDI tabs, meaningful icons.

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1821,7 +1821,6 @@ MDIView *Document::createView(const Base::Type& typeId)
 
         view3D->setWindowTitle(title);
         view3D->setWindowModified(this->isModified());
-        view3D->setWindowIcon(QApplication::windowIcon());
         view3D->resize(400, 300);
 
         if (!cameraSettings.empty()) {

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -57,6 +57,7 @@
 #include "View3DInventor.h"
 #include "View3DSettings.h"
 #include "Application.h"
+#include "BitmapFactory.h"
 #include "Camera.h"
 #include "Document.h"
 #include "FileDialog.h"
@@ -134,6 +135,8 @@ View3DInventor::View3DInventor(Gui::Document* pcDocument, QWidget* parent,
 
     stopSpinTimer = new QTimer(this);
     connect(stopSpinTimer, &QTimer::timeout, this, &View3DInventor::stopAnimating);
+
+    setWindowIcon(Gui::BitmapFactory().pixmap("Document"));
 }
 
 View3DInventor::~View3DInventor()


### PR DESCRIPTION
Goal : change the icons of the document tabs in the mdi tab bar.
Fixes : #11150

![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/d4c5b185-ec64-41e1-b849-9c689df0ede0)
