### PR TITLE
Assembly: Fixes #10748 (Card 4: Elements should highlight)

### DIFF
--- a/src/Mod/Assembly/CommandCreateJoint.py
+++ b/src/Mod/Assembly/CommandCreateJoint.py
@@ -328,6 +328,8 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
         self.form.jointType.addItems(JointObject.JointTypes)
         self.form.jointType.setCurrentIndex(jointTypeIndex)
 
+        self.setJointsPickableState(False)
+
         Gui.Selection.clearSelection()
         Gui.Selection.addSelectionGate(
             MakeJointSelGate(self, self.assembly), Gui.Selection.ResolveMode.NoResolve
@@ -363,6 +365,7 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
         Gui.Selection.clearSelection()
         self.view.removeEventCallback("SoLocation2Event", self.callbackMove)
         self.view.removeEventCallback("SoKeyboardEvent", self.callbackKey)
+        self.setJointsPickableState(True)
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
 
@@ -492,6 +495,17 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
     def clearSelection(self, doc_name):
         self.current_selection.clear()
         self.updateJoint()
+
+    def setJointsPickableState(self, state: bool):
+        """Make all joints in assembly selectable (True) or unselectable (False) in 3D view"""
+        try:
+            joints = self.assembly.getObject("Joints").getSubObjects()
+            for joint_str in joints:
+                joint = self.assembly.getObject(joint_str[0:-1]) # remove '.' ('Joint001.' -> 'Joint001')
+                joint.ViewObject.Proxy.setPickableState(state)
+        except Exception as e:
+            s = '' if state else 'un'
+            App.Console.PrintWarning(f'Failed to set joints {s}pickable: {e}')
 
 
 if App.GuiUp:

--- a/src/Mod/Assembly/CommandCreateJoint.py
+++ b/src/Mod/Assembly/CommandCreateJoint.py
@@ -501,11 +501,13 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
         try:
             joints = self.assembly.getObject("Joints").getSubObjects()
             for joint_str in joints:
-                joint = self.assembly.getObject(joint_str[0:-1]) # remove '.' ('Joint001.' -> 'Joint001')
+                joint = self.assembly.getObject(
+                    joint_str[0:-1]
+                )  # remove '.' ('Joint001.' -> 'Joint001')
                 joint.ViewObject.Proxy.setPickableState(state)
         except Exception as e:
-            s = '' if state else 'un'
-            App.Console.PrintWarning(f'Failed to set joints {s}pickable: {e}')
+            s = "" if state else "un"
+            App.Console.PrintWarning(f"Failed to set joints {s}pickable: {e}")
 
 
 if App.GuiUp:

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -279,7 +279,11 @@ class ViewProviderJoint:
         self.switch_JCS2 = self.JCS_sep(obj, self.transform2)
         self.switch_JCS_preview = self.JCS_sep(obj, self.transform3)
 
-        self.display_mode = coin.SoGroup()
+        self.pick = coin.SoPickStyle()
+        self.pick.style.setValue(coin.SoPickStyle.UNPICKABLE)
+
+        self.display_mode = coin.SoType.fromName('SoFCSelection').createInstance()
+        self.display_mode.addChild(self.pick)
         self.display_mode.addChild(self.switch_JCS1)
         self.display_mode.addChild(self.switch_JCS2)
         self.display_mode.addChild(self.switch_JCS_preview)
@@ -290,12 +294,8 @@ class ViewProviderJoint:
         self.axisScale.scaleFactor.setValue(scaleF, scaleF, scaleF)
 
     def JCS_sep(self, obj, soTransform):
-        pick = coin.SoPickStyle()
-        pick.style.setValue(coin.SoPickStyle.UNPICKABLE)
-
         JCS = coin.SoAnnotation()
         JCS.addChild(soTransform)
-        JCS.addChild(pick)
 
         base_plane_sep = self.plane_sep(0.4, 15)
         X_axis_sep = self.line_sep([0.5, 0, 0], [1, 0, 0], self.x_axis_so_color)
@@ -349,7 +349,7 @@ class ViewProviderJoint:
         material.ambientColor.setValue([1, 1, 1])
         material.specularColor.setValue([1, 1, 1])
         material.emissiveColor.setValue([1, 1, 1])
-        material.transparency.setValue(0.7)
+        material.transparency.setValue(0.3)
 
         face_sep = coin.SoAnnotation()
         face_sep.addChild(self.axisScale)
@@ -409,6 +409,13 @@ class ViewProviderJoint:
     def getDefaultDisplayMode(self):
         """Return the name of the default display mode. It must be defined in getDisplayModes."""
         return "Wireframe"
+
+    def setPickableState(self, state: bool):
+        """Set JCS selectable or unselectable in 3D view"""
+        if not state:
+            self.pick.style.setValue(coin.SoPickStyle.UNPICKABLE)
+        else:
+            self.pick.style.setValue(coin.SoPickStyle.SHAPE_ON_TOP)
 
     def onChanged(self, vp, prop):
         """Here we can do something when a single property got changed"""

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -282,7 +282,7 @@ class ViewProviderJoint:
         self.pick = coin.SoPickStyle()
         self.pick.style.setValue(coin.SoPickStyle.UNPICKABLE)
 
-        self.display_mode = coin.SoType.fromName('SoFCSelection').createInstance()
+        self.display_mode = coin.SoType.fromName("SoFCSelection").createInstance()
         self.display_mode.addChild(self.pick)
         self.display_mode.addChild(self.switch_JCS1)
         self.display_mode.addChild(self.switch_JCS2)


### PR DESCRIPTION
- Added methods to change JCS pick properties
- Joints are unpickable when creating new joints, pickable elsewhere
- Lowered JCS transparency to make selection highlighting more visible