### PR TITLE
Fix build failing due to f566b44

### DIFF
--- a/src/Gui/InventorAll.h
+++ b/src/Gui/InventorAll.h
@@ -86,6 +86,7 @@
 #include <Inventor/details/SoPointDetail.h>
 
 #include <Inventor/draggers/SoCenterballDragger.h>
+#include <Inventor/draggers/SoDirectionalLightDragger.h>
 #include <Inventor/draggers/SoDragger.h>
 #include <Inventor/draggers/SoTrackballDragger.h>
 #include <Inventor/draggers/SoTransformerDragger.h>


### PR DESCRIPTION
Build is failing on window this morning. After looking into it it comes from https://github.com/FreeCAD/FreeCAD/commit/f566b449a68bbdf0836dd5474c12214ced0ea379
The header is missing from precompiled.
#include <Inventor/draggers/SoDirectionalLightDragger.h>

@wwmayer 