### PR TITLE
[TechDraw] - Cosmetic edge fixes

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandAnnotate.cpp
@@ -1066,11 +1066,12 @@ void execLine2Points(Gui::Command* cmd)
     //check if editing existing edge
     if (!edgeNames.empty() && (edgeNames.size() == 1)) {
         TechDraw::CosmeticEdge* ce = baseFeat->getCosmeticEdgeBySelection(edgeNames.front());
-        if (!ce) {
+        if (!ce || ce->m_geometry->getGeomType() != TechDraw::GeomType::GENERIC) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong Selection"),
                              QObject::tr("Selection is not a Cosmetic Line."));
             return;
         }
+
         Gui::Control().showDialog(new TaskDlgCosmeticLine(baseFeat,
                                                           edgeNames.front()));
         return;
@@ -1208,11 +1209,14 @@ void execCosmeticCircle(Gui::Command* cmd)
     //check if editing existing edge
     if (!edgeNames.empty() && (edgeNames.size() == 1)) {
         TechDraw::CosmeticEdge* ce = baseFeat->getCosmeticEdgeBySelection(edgeNames.front());
-        if (!ce) {
+        if (!ce
+            || !(ce->m_geometry->getGeomType() == TechDraw::GeomType::CIRCLE
+                || ce->m_geometry->getGeomType() == TechDraw::GeomType::ARCOFCIRCLE)) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong Selection"),
-                             QObject::tr("Selection is not a Cosmetic edge."));
+                             QObject::tr("Selection is not a Cosmetic Circle or a Cosmetic Arc of Circle."));
             return;
         }
+
         Gui::Control().showDialog(new TaskDlgCosmeticCircle(baseFeat,
                                                           edgeNames.front()));
         return;

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -289,6 +289,8 @@ void QGIViewPart::drawAllEdges()
         item->setNormalColor(PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor()));
         item->setStyle(Qt::SolidLine);
         if ((*itGeom)->getCosmetic()) {
+            item->setCosmetic(true);
+
             // cosmetic edge - format appropriately
             int source = (*itGeom)->source();
             if (source == COSMETICEDGE) {


### PR DESCRIPTION
Two small fixes:
1) If a cosmetic circle/arc is selected, but _CosmeticLine_ command invoked followed by _OK_ press, program crashes. The same happens if straight cosmetic edge is selected, _CosmeticCircle_ command invoked and _OK_ pressed. The extended condition prevents the crash.
2) The cosmetic edge Qt object should be marked properly as "cosmetic". Though the property is not used right now, it should be set correctly.