### PR TITLE
[TechDraw] - Line Decoration Improvements

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIEdge.cpp
+++ b/src/Mod/TechDraw/Gui/QGIEdge.cpp
@@ -32,9 +32,14 @@
 #include <App/Material.h>
 #include <Base/Console.h>
 #include <Base/Parameter.h>
+#include <Gui/Control.h>
+#include <Mod/TechDraw/App/DrawUtil.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
 
 #include "QGIEdge.h"
+#include "QGIViewPart.h"
 #include "PreferencesGui.h"
+#include "TaskLineDecor.h"
 
 
 using namespace TechDrawGui;
@@ -112,4 +117,15 @@ QPainterPath QGIEdge::shape() const
     stroker.setWidth(getEdgeFuzz());
     outline = stroker.createStroke(path());
     return outline;
+}
+
+void QGIEdge::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)
+{
+    QGIView *parent = dynamic_cast<QGIView *>(parentItem());
+    if (parent && parent->getViewObject() && parent->getViewObject()->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+        TechDraw::DrawViewPart *baseFeat = static_cast<TechDraw::DrawViewPart *>(parent->getViewObject());
+        std::vector<std::string> edgeName(1, DrawUtil::makeGeomName("Edge", getProjIndex()));
+
+        Gui::Control().showDialog(new TaskDlgLineDecor(baseFeat, edgeName));
+    }
 }

--- a/src/Mod/TechDraw/Gui/QGIEdge.h
+++ b/src/Mod/TechDraw/Gui/QGIEdge.h
@@ -54,6 +54,9 @@ public:
     double getEdgeFuzz(void) const;
 
 protected:
+
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
+
     int projIndex;                                                     //index of edge in Projection. must exist.
 
     bool isCosmetic;

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -308,6 +308,7 @@ void QGIPrimPath::paint ( QPainter * painter, const QStyleOptionGraphicsItem * o
 
     m_pen.setWidthF(m_width);
     m_pen.setColor(m_colCurrent);
+    m_pen.setStyle(m_styleCurrent);
     setPen(m_pen);
 
     m_brush.setColor(m_fillColorCurrent);

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.cpp
@@ -35,7 +35,6 @@
 #include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/DrawViewPart.h>
 #include <Mod/TechDraw/App/CenterLine.h>
-#include <Mod/TechDraw/App/Cosmetic.h>
 #include <Mod/TechDraw/App/Geometry.h>
 
 #include "TaskLineDecor.h"
@@ -56,15 +55,16 @@ TaskLineDecor::TaskLineDecor(TechDraw::DrawViewPart* partFeat,
     m_edges(edgeNames),
     m_apply(true)
 {
+    initializeRejectArrays();
+
     getDefaults();
     ui->setupUi(this);
+    initUi();
 
     connect(ui->cb_Style, qOverload<int>(&QComboBox::currentIndexChanged), this, &TaskLineDecor::onStyleChanged);
     connect(ui->cc_Color, &ColorButton::changed, this, &TaskLineDecor::onColorChanged);
     connect(ui->dsb_Weight, qOverload<double>(&QuantitySpinBox::valueChanged), this, &TaskLineDecor::onWeightChanged);
     connect(ui->cb_Visible, qOverload<int>(&QComboBox::currentIndexChanged), this, &TaskLineDecor::onVisibleChanged);
-
-    initUi();
 }
 
 TaskLineDecor::~TaskLineDecor()
@@ -94,6 +94,65 @@ void TaskLineDecor::initUi()
     ui->cb_Visible->setCurrentIndex(m_visible);
 }
 
+TechDraw::LineFormat *TaskLineDecor::getFormatAccessPtr(const std::string &edgeName, std::string *newFormatTag)
+{
+    BaseGeomPtr bg = m_partFeat->getEdge(edgeName);
+    if (bg) {
+        if (bg->getCosmetic()) {
+            if (bg->source() == SourceType::COSEDGE) {
+                TechDraw::CosmeticEdge *ce = m_partFeat->getCosmeticEdgeBySelection(edgeName);
+                if (ce) {
+                    return &ce->m_format;
+                }
+            }
+            else if (bg->source() == SourceType::CENTERLINE) {
+                TechDraw::CenterLine *cl = m_partFeat->getCenterLineBySelection(edgeName);
+                if (cl) {
+                    return &cl->m_format;
+                }
+            }
+        }
+        else {
+            TechDraw::GeomFormat *gf = m_partFeat->getGeomFormatBySelection(edgeName);
+            if (gf) {
+                return &gf->m_format;
+            }
+            else {
+                ViewProviderViewPart *viewPart = dynamic_cast<ViewProviderViewPart *>(QGIView::getViewProvider(m_partFeat));
+                if (viewPart) {
+                    TechDraw::LineFormat lineFormat(Qt::SolidLine, viewPart->LineWidth.getValue(), LineFormat::getDefEdgeColor(), true);
+                    TechDraw::GeomFormat geomFormat(DrawUtil::getIndexFromName(edgeName), lineFormat);
+
+                    std::string formatTag = m_partFeat->addGeomFormat(&geomFormat);
+                    if (newFormatTag) {
+                        *newFormatTag = formatTag;
+                    }
+
+                    return &m_partFeat->getGeomFormat(formatTag)->m_format;
+                }
+            }
+        }
+    }
+}
+
+void TaskLineDecor::initializeRejectArrays()
+{
+    m_originalFormats.resize(m_edges.size());
+    m_createdFormatTags.resize(m_edges.size());
+
+    for (size_t i = 0; i < m_edges.size(); ++i) {
+        std::string newTag;
+        TechDraw::LineFormat *accessPtr = getFormatAccessPtr(m_edges[i], &newTag);
+
+        if (accessPtr) {
+            m_originalFormats[i] = *accessPtr;
+            if (!newTag.empty()) {
+                m_createdFormatTags[i] = newTag;
+            }
+        }
+    }
+}
+
 void TaskLineDecor::getDefaults()
 {
 //    Base::Console().Message("TLD::getDefaults()\n");
@@ -103,44 +162,12 @@ void TaskLineDecor::getDefaults()
     m_visible = true;
 
     //set defaults to format of 1st edge
-    if (!m_edges.empty()) {
-        int num = DrawUtil::getIndexFromName(m_edges.front());
-        BaseGeomPtr bg = m_partFeat->getGeomByIndex(num);
-        if (bg) {
-            if (bg->getCosmetic()) {
-                if (bg->source() == 1) {
-                    TechDraw::CosmeticEdge* ce = m_partFeat->getCosmeticEdgeBySelection(m_edges.front());
-                    m_style = ce->m_format.m_style;
-                    m_color = ce->m_format.m_color;
-                    m_weight = ce->m_format.m_weight;
-                    m_visible = ce->m_format.m_visible;
-                } else if (bg->source() == 2) {
-//                    TechDraw::CenterLine* cl = m_partFeat->getCenterLine(bg->getCosmeticTag);
-                    TechDraw::CenterLine* cl = m_partFeat->getCenterLineBySelection(m_edges.front());
-                    m_style = cl->m_format.m_style;
-                    m_color = cl->m_format.m_color;
-                    m_weight = cl->m_format.m_weight;
-                    m_visible = cl->m_format.m_visible;
-                }
-            } else {
-                TechDraw::GeomFormat* gf = m_partFeat->getGeomFormatBySelection(num);
-                if (gf) {
-                    m_style = gf->m_format.m_style;
-                    m_color = gf->m_format.m_color;
-                    m_weight = gf->m_format.m_weight;
-                    m_visible = gf->m_format.m_visible;
-                } else {
-                    Gui::ViewProvider* vp = QGIView::getViewProvider(m_partFeat);
-                    auto partVP = dynamic_cast<ViewProviderViewPart*>(vp);
-                    if (partVP) {
-                        m_weight = partVP->LineWidth.getValue();
-                        m_style = Qt::SolidLine;                  // = 1
-                        m_color = LineFormat::getDefEdgeColor();
-                        m_visible = true;
-                    }
-                }
-            }
-        }
+    if (!m_originalFormats.empty()) {
+        LineFormat &lf = m_originalFormats.front();
+        m_style = lf.m_style;
+        m_color = lf.m_color;
+        m_weight = lf.m_weight;
+        m_visible = lf.m_visible;
     }
 }
 
@@ -176,42 +203,12 @@ void TaskLineDecor::applyDecorations()
 {
 //    Base::Console().Message("TLD::applyDecorations()\n");
     for (auto& e: m_edges) {
-        int num = DrawUtil::getIndexFromName(e);
-        BaseGeomPtr bg = m_partFeat->getGeomByIndex(num);
-        if (bg) {
-            if (bg->getCosmetic()) {
-                if (bg->source() == 1) {
-                    TechDraw::CosmeticEdge* ce = m_partFeat->getCosmeticEdgeBySelection(e);
-                    ce->m_format.m_style = m_style;
-                    ce->m_format.m_color = m_color;
-                    ce->m_format.m_weight = m_weight;
-                    ce->m_format.m_visible = m_visible;
-                } else if (bg->source() == 2) {
-//                    TechDraw::CenterLine* cl = m_partFeat->getCenterLine(bg->getCosmeticTag());
-                    TechDraw::CenterLine* cl = m_partFeat->getCenterLineBySelection(e);
-                    cl->m_format.m_style = m_style;
-                    cl->m_format.m_color = m_color;
-                    cl->m_format.m_weight = m_weight;
-                    cl->m_format.m_visible = m_visible;
-                }
-            } else {
-                TechDraw::GeomFormat* gf = m_partFeat->getGeomFormatBySelection(num);
-                if (gf) {
-                    gf->m_format.m_style = m_style;
-                    gf->m_format.m_color = m_color;
-                    gf->m_format.m_weight = m_weight;
-                    gf->m_format.m_visible = m_visible;
-                } else {
-                    TechDraw::LineFormat fmt(m_style,
-                                             m_weight,
-                                             m_color,
-                                             m_visible);
-                    TechDraw::GeomFormat* newGF = new TechDraw::GeomFormat(num,
-                                                                           fmt);
-//                    int idx =
-                    m_partFeat->addGeomFormat(newGF);
-               }
-            }
+        LineFormat *lf = getFormatAccessPtr(e);
+        if (lf) {
+            lf->m_style = m_style;
+            lf->m_color = m_color;
+            lf->m_weight = m_weight;
+            lf->m_visible = m_visible;
         }
     }
 }
@@ -241,6 +238,21 @@ bool TaskLineDecor::reject()
     Gui::Document* doc = Gui::Application::Instance->getDocument(m_partFeat->getDocument());
     if (!doc)
         return false;
+
+    for (size_t i = 0; i < m_originalFormats.size(); ++i) {
+        std::string &formatTag = m_createdFormatTags[i];
+        if (formatTag.empty()) {
+            LineFormat *lf = getFormatAccessPtr(m_edges[i]);
+            if (lf) {
+                *lf = m_originalFormats[i];
+            }
+        }
+        else {
+            m_partFeat->removeGeomFormat(formatTag);
+        }
+    }
+
+    m_partFeat->requestPaint();
 
     Gui::Command::doCommand(Gui::Command::Gui, "Gui.ActiveDocument.resetEdit()");
     return false;

--- a/src/Mod/TechDraw/Gui/TaskLineDecor.h
+++ b/src/Mod/TechDraw/Gui/TaskLineDecor.h
@@ -26,7 +26,7 @@
 #include <Gui/TaskView/TaskDialog.h>
 #include <Gui/TaskView/TaskView.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
-
+#include <Mod/TechDraw/App/Cosmetic.h>
 
 namespace App
 {
@@ -62,6 +62,10 @@ protected Q_SLOTS:
 protected:
     void changeEvent(QEvent *e) override;
     void initUi();
+
+    TechDraw::LineFormat *getFormatAccessPtr(const std::string &edgeName, std::string *newFormatTag = nullptr);
+    void initializeRejectArrays();
+
     void applyDecorations();
     void getDefaults();
 
@@ -69,6 +73,10 @@ private:
     std::unique_ptr<Ui_TaskLineDecor> ui;
     TechDraw::DrawViewPart* m_partFeat;
     std::vector<std::string> m_edges;
+
+    std::vector<TechDraw::LineFormat> m_originalFormats;
+    std::vector<std::string> m_createdFormatTags;
+
     int m_style;
     App::Color m_color;
     double m_weight;


### PR DESCRIPTION
This PR improves line decoration handling:
1) Double clicking on an edge invokes Line Decoration dialog. This aims to improve productivity when creating a drawing. The changes involved are in files QGIEdge.h and QGIEdge.cpp .
2) When the Line Decoration dialog is invoked, all updates to style are immediately reflected. This is perfect. However when _Cancel_ is pressed, the old style values were not stored anywhere and in fact, there was no difference between pressing _OK_ or _Cancel_. It just closed the dialog. With this PR, the line styles are fully preserved and restored, if the user decides to press _Cancel_. These changes are contained in TaskLineDecor.h and taskLineDecor.cpp files.
3) Small fix of earlier refactorization. Without setting the pen style, all lines are drawn as solid. Code change in QGIPrimPath:311.

I hope you will find this addition useful, in case of any issues or questions, please leave a comment!