### PR TITLE
SplashScreen: add parameter to disable messages on the splashscreen

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -252,7 +252,7 @@ struct MainWindowP
     QMdiArea* mdiArea;
     QPointer<MDIView> activeView;
     QSignalMapper* windowMapper;
-    QSplashScreen* splashscreen;
+    SplashScreen* splashscreen;
     StatusBarObserver* status;
     bool whatsthis;
     QString whatstext;
@@ -1830,6 +1830,11 @@ void MainWindow::startSplasher()
         // first search for an external image file
         if (hGrp->GetBool("ShowSplasher", true)) {
             d->splashscreen = new SplashScreen(this->splashImage());
+
+            if (!hGrp->GetBool("ShowSplasherMessages", true)) {
+                d->splashscreen->setShowMessages(false);
+            }
+
             d->splashscreen->show();
 #if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
             d->screen = d->splashscreen->screen();

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -250,6 +250,14 @@ void SplashScreen::drawContents ( QPainter * painter )
     QSplashScreen::drawContents(painter);
 }
 
+void SplashScreen::setShowMessages(bool on)
+{
+    messages->bErr = on;
+    messages->bMsg = on;
+    messages->bLog = on;
+    messages->bWrn = on;
+}
+
 // ------------------------------------------------------------------------------
 
 AboutDialogFactory* AboutDialogFactory::factory = nullptr;

--- a/src/Gui/Splashscreen.h
+++ b/src/Gui/Splashscreen.h
@@ -44,6 +44,8 @@ public:
     explicit SplashScreen(  const QPixmap & pixmap = QPixmap ( ), Qt::WindowFlags f = Qt::WindowFlags() );
     ~SplashScreen() override;
 
+    void setShowMessages(bool on);
+
 protected:
     void drawContents ( QPainter * painter ) override;
 


### PR DESCRIPTION
Add a parameter to disable messages of the splashscreen. Boot faster without loosing the splashscreen.