### PR TITLE
Gui: Hide rotation center when in spinning mode

### DIFF
--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -1286,7 +1286,6 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
         break;
 
     case SPINNING:
-        viewer->showRotationCenter(true);
         this->interactiveCountInc();
         viewer->getSoRenderManager()->scheduleRedraw();
         break;


### PR DESCRIPTION
With navigation animations, and the rotation center indicator enabled, the rotation center was shown when the spinning animation was active. For example, after dragging in the OpenInventor navigation style or when using Tools->view  turntable...->Play. I don´t think the rotation center should be shown in animations. Furthermore, the shown rotation center in the spinning animation is wrong.

This change stops showing the rotation center in spinning mode.