### PR TITLE
Correct code tag for info

### DIFF
--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -800,7 +800,7 @@ void AboutDialog::copyToClipboard()
             deskInfo = QLatin1String(" (") + deskEnv + QLatin1String("/") + deskSess + QLatin1String(")");
     }
 
-    str << "[code]\n";
+    str << "```\n";
     str << "OS: " << prettyProductInfoWrapper() << deskInfo << '\n';
     str << "Word size of " << exe << ": " << QSysInfo::WordSize << "-bit\n";
     str << "Version: " << major << "." << minor << "." << point << suffix << "." << build;
@@ -881,7 +881,7 @@ void AboutDialog::copyToClipboard()
         }
     }
 
-    str << "[/code]\n";
+    str << "```\n";
     QClipboard* cb = QApplication::clipboard();
     cb->setText(data);
 }


### PR DESCRIPTION
Change [code] to ``` as code tag don't recognize and user need manualy correct tag when post About info on github.