### PR TITLE
Path:  Added typing to the refactored postprocessors.

### DIFF
--- a/src/Mod/Path/Path/Post/UtilsArguments.py
+++ b/src/Mod/Path/Path/Post/UtilsArguments.py
@@ -33,7 +33,7 @@ These are functions related to arguments and values for creating custom post pro
 import argparse
 import os
 import shlex
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Tuple, Union
 
 from FreeCAD import Units
 
@@ -118,11 +118,12 @@ def init_shared_arguments(
     """Initialize the arguments for postprocessors."""
     help_message: str
     parser: Parser
+    shared: argparse._ArgumentGroup
 
     parser = argparse.ArgumentParser(
         prog=values["MACHINE_NAME"], usage=argparse.SUPPRESS, add_help=False
     )
-    shared = parser.add_argument_group("Arguments that are commonly used")  # type: ignore
+    shared = parser.add_argument_group("Arguments that are commonly used")
     add_flag_type_arguments(
         shared,
         argument_defaults["metric_inches"],
@@ -321,7 +322,7 @@ def init_shared_arguments(
     return parser
 
 
-def init_shared_values(values: Values):
+def init_shared_values(values: Values) -> None:
     """Initialize the default values in postprocessors."""
     #
     # The starting axis precision is 3 digits after the decimal point.
@@ -607,8 +608,9 @@ def process_shared_arguments(
     argstring: str,
     all_visible: Parser,
     filename: str,
-):
+) -> Tuple[bool, Union[str, argparse.Namespace]]:
     """Process the arguments to the postprocessor."""
+    args: argparse.Namespace
     argument_text: str
     v: str
 

--- a/src/Mod/Path/Path/Post/scripts/refactored_centroid_post.py
+++ b/src/Mod/Path/Path/Post/scripts/refactored_centroid_post.py
@@ -25,9 +25,16 @@
 # ***************************************************************************
 
 
+import argparse
+
+from typing import Any, Dict, Union
+
 import Path.Post.UtilsArguments as PostUtilsArguments
 import Path.Post.UtilsExport as PostUtilsExport
 
+# Define some types that are used throughout this file
+Parser = argparse.ArgumentParser
+Values = Dict[str, Any]
 
 #
 # The following variables need to be global variables
@@ -42,7 +49,7 @@ import Path.Post.UtilsExport as PostUtilsExport
 #    called to create TOOLTIP_ARGS, so they also end up having to be globals.
 #    TOOLTIP_ARGS can be defined, so they end up being global variables also.
 #
-TOOLTIP = """
+TOOLTIP: str = """
 This is a postprocessor file for the Path workbench. It is used to
 take a pseudo-G-code fragment outputted by a Path object, and output
 real G-code suitable for a centroid 3 axis mill. This postprocessor, once placed
@@ -55,14 +62,12 @@ refactored_centroid_post.export(object,"/path/to/file.ncc","")
 #
 # Default to metric mode
 #
-UNITS = "G21"
+UNITS: str = "G21"
 
 
-def init_values(values):
+def init_values(values: Values) -> None:
     """Initialize values that are used throughout the postprocessor."""
     #
-    global UNITS
-
     PostUtilsArguments.init_shared_values(values)
     #
     # Set any values here that need to override the default values set
@@ -131,6 +136,10 @@ def init_values(values):
     #
     values["PREAMBLE"] = """G53 G00 G17"""
     #
+    # Output any messages.
+    #
+    values["REMOVE_MESSAGES"] = False
+    #
     # Any commands in this value are output after the header but before the preamble,
     # then again after the TOOLRETURN but before the POSTAMBLE.
     #
@@ -169,7 +178,7 @@ G49 H0"""
     #
 
 
-def init_argument_defaults(argument_defaults):
+def init_argument_defaults(argument_defaults: Dict[str, bool]) -> None:
     """Initialize which arguments (in a pair) are shown as the default argument."""
     PostUtilsArguments.init_argument_defaults(argument_defaults)
     #
@@ -189,7 +198,7 @@ def init_argument_defaults(argument_defaults):
     #
 
 
-def init_arguments_visible(arguments_visible):
+def init_arguments_visible(arguments_visible: Dict[str, bool]) -> None:
     """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
     PostUtilsArguments.init_arguments_visible(arguments_visible)
     #
@@ -200,9 +209,13 @@ def init_arguments_visible(arguments_visible):
     arguments_visible["tlo"] = False
 
 
-def init_arguments(values, argument_defaults, arguments_visible):
+def init_arguments(
+    values: Values,
+    argument_defaults: Dict[str, bool],
+    arguments_visible: Dict[str, bool],
+) -> Parser:
     """Initialize the shared argument definitions."""
-    parser = PostUtilsArguments.init_shared_arguments(
+    parser: Parser = PostUtilsArguments.init_shared_arguments(
         values, argument_defaults, arguments_visible
     )
     #
@@ -216,41 +229,46 @@ def init_arguments(values, argument_defaults, arguments_visible):
 # Creating global variables and using functions to modify them
 # is useful for being able to test things later.
 #
-values = {}
-init_values(values)
-argument_defaults = {}
-init_argument_defaults(argument_defaults)
-arguments_visible = {}
-init_arguments_visible(arguments_visible)
-parser = init_arguments(values, argument_defaults, arguments_visible)
+global_values: Values = {}
+init_values(global_values)
+global_argument_defaults: Dict[str, bool] = {}
+init_argument_defaults(global_argument_defaults)
+global_arguments_visible: Dict[str, bool] = {}
+init_arguments_visible(global_arguments_visible)
+global_parser: Parser = init_arguments(
+    global_values, global_argument_defaults, global_arguments_visible
+)
 #
 # The TOOLTIP_ARGS value is created from the help information about the arguments.
 #
-TOOLTIP_ARGS = parser.format_help()
+TOOLTIP_ARGS: str = global_parser.format_help()
 #
 # Create another parser just to get a list of all possible arguments
 # that may be output using --output_all_arguments.
 #
-all_arguments_visible = {}
-for k in iter(arguments_visible):
-    all_arguments_visible[k] = True
-all_visible = init_arguments(values, argument_defaults, all_arguments_visible)
+global_all_arguments_visible: Dict[str, bool] = {}
+k: str
+for k in iter(global_arguments_visible):
+    global_all_arguments_visible[k] = True
+global_all_visible: Parser = init_arguments(
+    global_values, global_argument_defaults, global_all_arguments_visible
+)
 
 
-def export(objectslist, filename, argstring):
+def export(objectslist, filename: str, argstring: str) -> str:
     """Postprocess the objects in objectslist to filename."""
-    #
-    global parser
-    global UNITS
-    global values
+    args: Union[str, argparse.Namespace]
+    flag: bool
+
+    global UNITS  # pylint: disable=global-statement
 
     # print(parser.format_help())
 
     (flag, args) = PostUtilsArguments.process_shared_arguments(
-        values, parser, argstring, all_visible, filename
+        global_values, global_parser, argstring, global_all_visible, filename
     )
     if not flag:
-        return args
+        return args  # type: ignore
     #
     # Process any additional arguments here
     #
@@ -259,6 +277,6 @@ def export(objectslist, filename, argstring):
     # Update the global variables that might have been modified
     # while processing the arguments.
     #
-    UNITS = values["UNITS"]
+    UNITS = global_values["UNITS"]
 
-    return PostUtilsExport.export_common(values, objectslist, filename)
+    return PostUtilsExport.export_common(global_values, objectslist, filename)

--- a/src/Mod/Path/Path/Post/scripts/refactored_grbl_post.py
+++ b/src/Mod/Path/Path/Post/scripts/refactored_grbl_post.py
@@ -26,8 +26,16 @@
 # ***************************************************************************
 
 
+import argparse
+
+from typing import Any, Dict, Union
+
 import Path.Post.UtilsArguments as PostUtilsArguments
 import Path.Post.UtilsExport as PostUtilsExport
+
+# Define some types that are used throughout this file
+Parser = argparse.ArgumentParser
+Values = Dict[str, Any]
 
 #
 # The following variables need to be global variables
@@ -41,7 +49,7 @@ import Path.Post.UtilsExport as PostUtilsExport
 #    need to be defined before the "init_shared_arguments" routine can be
 #    called to create TOOLTIP_ARGS, so they also end up having to be globals.
 #
-TOOLTIP = """
+TOOLTIP: str = """
 Generate g-code from a Path that is compatible with the grbl controller:
 
 import refactored_grbl_post
@@ -50,14 +58,12 @@ refactored_grbl_post.export(object, "/path/to/file.ncc")
 #
 # Default to metric mode
 #
-UNITS = "G21"
+UNITS: str = "G21"
 
 
-def init_values(values):
+def init_values(values: Values) -> None:
     """Initialize values that are used throughout the postprocessor."""
     #
-    global UNITS
-
     PostUtilsArguments.init_shared_values(values)
     #
     # Set any values here that need to override the default values set
@@ -134,7 +140,7 @@ M2"""
     values["USE_TLO"] = False
 
 
-def init_argument_defaults(argument_defaults):
+def init_argument_defaults(argument_defaults: Dict[str, bool]) -> None:
     """Initialize which arguments (in a pair) are shown as the default argument."""
     PostUtilsArguments.init_argument_defaults(argument_defaults)
     #
@@ -156,7 +162,7 @@ def init_argument_defaults(argument_defaults):
     argument_defaults["tool_change"] = False
 
 
-def init_arguments_visible(arguments_visible):
+def init_arguments_visible(arguments_visible: Dict[str, bool]) -> None:
     """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
     PostUtilsArguments.init_arguments_visible(arguments_visible)
     #
@@ -171,9 +177,13 @@ def init_arguments_visible(arguments_visible):
     arguments_visible["wait-for-spindle"] = True
 
 
-def init_arguments(values, argument_defaults, arguments_visible):
+def init_arguments(
+    values: Values,
+    argument_defaults: Dict[str, bool],
+    arguments_visible: Dict[str, bool],
+) -> Parser:
     """Initialize the shared argument definitions."""
-    parser = PostUtilsArguments.init_shared_arguments(
+    parser: Parser = PostUtilsArguments.init_shared_arguments(
         values, argument_defaults, arguments_visible
     )
     #
@@ -187,41 +197,46 @@ def init_arguments(values, argument_defaults, arguments_visible):
 # Creating global variables and using functions to modify them
 # is useful for being able to test things later.
 #
-values = {}
-init_values(values)
-argument_defaults = {}
-init_argument_defaults(argument_defaults)
-arguments_visible = {}
-init_arguments_visible(arguments_visible)
-parser = init_arguments(values, argument_defaults, arguments_visible)
+global_values: Values = {}
+init_values(global_values)
+global_argument_defaults: Dict[str, bool] = {}
+init_argument_defaults(global_argument_defaults)
+global_arguments_visible: Dict[str, bool] = {}
+init_arguments_visible(global_arguments_visible)
+global_parser: Parser = init_arguments(
+    global_values, global_argument_defaults, global_arguments_visible
+)
 #
 # The TOOLTIP_ARGS value is created from the help information about the arguments.
 #
-TOOLTIP_ARGS = parser.format_help()
+TOOLTIP_ARGS: str = global_parser.format_help()
 #
 # Create another parser just to get a list of all possible arguments
 # that may be output using --output_all_arguments.
 #
-all_arguments_visible = {}
-for k in iter(arguments_visible):
-    all_arguments_visible[k] = True
-all_visible = init_arguments(values, argument_defaults, all_arguments_visible)
+global_all_arguments_visible: Dict[str, bool] = {}
+k: str
+for k in iter(global_arguments_visible):
+    global_all_arguments_visible[k] = True
+global_all_visible: Parser = init_arguments(
+    global_values, global_argument_defaults, global_all_arguments_visible
+)
 
 
-def export(objectslist, filename, argstring):
+def export(objectslist, filename, argstring) -> str:
     """Postprocess the objects in objectslist to filename."""
-    #
-    global parser
-    global UNITS
-    global values
+    args: Union[str, argparse.Namespace]
+    flag: bool
+
+    global UNITS  # pylint: disable=global-statement
 
     # print(parser.format_help())
 
     (flag, args) = PostUtilsArguments.process_shared_arguments(
-        values, parser, argstring, all_visible, filename
+        global_values, global_parser, argstring, global_all_visible, filename
     )
     if not flag:
-        return args
+        return args  # type: ignore
     #
     # Process any additional arguments here
     #
@@ -230,6 +245,6 @@ def export(objectslist, filename, argstring):
     # Update the global variables that might have been modified
     # while processing the arguments.
     #
-    UNITS = values["UNITS"]
+    UNITS = global_values["UNITS"]
 
-    return PostUtilsExport.export_common(values, objectslist, filename)
+    return PostUtilsExport.export_common(global_values, objectslist, filename)

--- a/src/Mod/Path/Path/Post/scripts/refactored_linuxcnc_post.py
+++ b/src/Mod/Path/Path/Post/scripts/refactored_linuxcnc_post.py
@@ -23,8 +23,16 @@
 # ***************************************************************************
 
 
+import argparse
+
+from typing import Any, Dict, Union
+
 import Path.Post.UtilsArguments as PostUtilsArguments
 import Path.Post.UtilsExport as PostUtilsExport
+
+# Define some types that are used throughout this file
+Parser = argparse.ArgumentParser
+Values = Dict[str, Any]
 
 #
 # The following variables need to be global variables
@@ -38,9 +46,9 @@ import Path.Post.UtilsExport as PostUtilsExport
 #    need to be defined before the "init_shared_arguments" routine can be
 #    called to create TOOLTIP_ARGS, so they also end up having to be globals.
 #
-TOOLTIP = """This is a postprocessor file for the Path workbench. It is used to
-take a pseudo-G-code fragment outputted by a Path object, and output
-real G-code suitable for a linuxcnc 3 axis mill. This postprocessor, once placed
+TOOLTIP: str = """This is a postprocessor file for the Path workbench. It is used to
+take a pseudo-gcode fragment outputted by a Path object, and output
+real GCode suitable for a linuxcnc 3 axis mill. This postprocessor, once placed
 in the appropriate PathScripts folder, can be used directly from inside
 FreeCAD, via the GUI importer or via python scripts with:
 
@@ -50,14 +58,12 @@ refactored_linuxcnc_post.export(object,"/path/to/file.ncc","")
 #
 # Default to metric mode
 #
-UNITS = "G21"
+UNITS: str = "G21"
 
 
-def init_values(values):
+def init_values(values: Values) -> None:
     """Initialize values that are used throughout the postprocessor."""
     #
-    global UNITS
-
     PostUtilsArguments.init_shared_values(values)
     #
     # Set any values here that need to override the default values set
@@ -109,7 +115,7 @@ M2"""
     values["UNITS"] = UNITS
 
 
-def init_argument_defaults(argument_defaults):
+def init_argument_defaults(argument_defaults: Dict[str, bool]) -> None:
     """Initialize which arguments (in a pair) are shown as the default argument."""
     PostUtilsArguments.init_argument_defaults(argument_defaults)
     #
@@ -129,7 +135,7 @@ def init_argument_defaults(argument_defaults):
     #
 
 
-def init_arguments_visible(arguments_visible):
+def init_arguments_visible(arguments_visible: Dict[str, bool]) -> None:
     """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
     PostUtilsArguments.init_arguments_visible(arguments_visible)
     #
@@ -137,9 +143,13 @@ def init_arguments_visible(arguments_visible):
     #
 
 
-def init_arguments(values, argument_defaults, arguments_visible):
+def init_arguments(
+    values: Values,
+    argument_defaults: Dict[str, bool],
+    arguments_visible: Dict[str, bool],
+) -> Parser:
     """Initialize the shared argument definitions."""
-    parser = PostUtilsArguments.init_shared_arguments(
+    parser: Parser = PostUtilsArguments.init_shared_arguments(
         values, argument_defaults, arguments_visible
     )
     #
@@ -153,41 +163,45 @@ def init_arguments(values, argument_defaults, arguments_visible):
 # Creating global variables and using functions to modify them
 # is useful for being able to test things later.
 #
-values = {}
-init_values(values)
-argument_defaults = {}
-init_argument_defaults(argument_defaults)
-arguments_visible = {}
-init_arguments_visible(arguments_visible)
-parser = init_arguments(values, argument_defaults, arguments_visible)
+global_values: Values = {}
+init_values(global_values)
+global_argument_defaults: Dict[str, bool] = {}
+init_argument_defaults(global_argument_defaults)
+global_arguments_visible: Dict[str, bool] = {}
+init_arguments_visible(global_arguments_visible)
+global_parser: Parser = init_arguments(
+    global_values, global_argument_defaults, global_arguments_visible
+)
 #
 # The TOOLTIP_ARGS value is created from the help information about the arguments.
 #
-TOOLTIP_ARGS = parser.format_help()
+TOOLTIP_ARGS: str = global_parser.format_help()
 #
 # Create another parser just to get a list of all possible arguments
 # that may be output using --output_all_arguments.
 #
-all_arguments_visible = {}
-for k in iter(arguments_visible):
-    all_arguments_visible[k] = True
-all_visible = init_arguments(values, argument_defaults, all_arguments_visible)
+global_all_arguments_visible: Dict[str, bool] = {}
+for k in iter(global_arguments_visible):
+    global_all_arguments_visible[k] = True
+global_all_visible: Parser = init_arguments(
+    global_values, global_argument_defaults, global_all_arguments_visible
+)
 
 
-def export(objectslist, filename, argstring):
+def export(objectslist, filename: str, argstring: str) -> str:
     """Postprocess the objects in objectslist to filename."""
-    #
-    global parser
-    global UNITS
-    global values
+    args: Union[str, argparse.Namespace]
+    flag: bool
+
+    global UNITS  # pylint: disable=global-statement
 
     # print(parser.format_help())
 
     (flag, args) = PostUtilsArguments.process_shared_arguments(
-        values, parser, argstring, all_visible, filename
+        global_values, global_parser, argstring, global_all_visible, filename
     )
     if not flag:
-        return args
+        return args  # type: ignore
     #
     # Process any additional arguments here
     #
@@ -196,6 +210,6 @@ def export(objectslist, filename, argstring):
     # Update the global variables that might have been modified
     # while processing the arguments.
     #
-    UNITS = values["UNITS"]
+    UNITS = global_values["UNITS"]
 
-    return PostUtilsExport.export_common(values, objectslist, filename)
+    return PostUtilsExport.export_common(global_values, objectslist, filename)

--- a/src/Mod/Path/Path/Post/scripts/refactored_mach3_mach4_post.py
+++ b/src/Mod/Path/Path/Post/scripts/refactored_mach3_mach4_post.py
@@ -23,8 +23,16 @@
 # ***************************************************************************/
 
 
+import argparse
+
+from typing import Any, Dict, Union
+
 import Path.Post.UtilsArguments as PostUtilsArguments
 import Path.Post.UtilsExport as PostUtilsExport
+
+# Define some types that are used throughout this file
+Parser = argparse.ArgumentParser
+Values = Dict[str, Any]
 
 #
 # The following variables need to be global variables
@@ -38,7 +46,7 @@ import Path.Post.UtilsExport as PostUtilsExport
 #    need to be defined before the "init_shared_arguments" routine can be
 #    called to create TOOLTIP_ARGS, so they also end up having to be globals.
 #
-TOOLTIP = """
+TOOLTIP: str = """
 This is a postprocessor file for the Path workbench. It is used to
 take a pseudo-G-code fragment outputted by a Path object, and output
 real G-code suitable for a mach3_4 3 axis mill. This postprocessor, once placed
@@ -51,14 +59,12 @@ mach3_mach4_post.export(object,"/path/to/file.ncc","")
 #
 # Default to metric mode
 #
-UNITS = "G21"
+UNITS: str = "G21"
 
 
-def init_values(values):
+def init_values(values: Values) -> None:
     """Initialize values that are used throughout the postprocessor."""
     #
-    global UNITS
-
     PostUtilsArguments.init_shared_values(values)
     #
     # Set any values here that need to override the default values set
@@ -116,7 +122,7 @@ M2"""
     values["UNITS"] = UNITS
 
 
-def init_argument_defaults(argument_defaults):
+def init_argument_defaults(argument_defaults: Dict[str, bool]) -> None:
     """Initialize which arguments (in a pair) are shown as the default argument."""
     PostUtilsArguments.init_argument_defaults(argument_defaults)
     #
@@ -136,7 +142,7 @@ def init_argument_defaults(argument_defaults):
     #
 
 
-def init_arguments_visible(arguments_visible):
+def init_arguments_visible(arguments_visible: Dict[str, bool]) -> None:
     """Initialize which argument pairs are visible in TOOLTIP_ARGS."""
     PostUtilsArguments.init_arguments_visible(arguments_visible)
     #
@@ -145,9 +151,13 @@ def init_arguments_visible(arguments_visible):
     arguments_visible["axis-modal"] = True
 
 
-def init_arguments(values, argument_defaults, arguments_visible):
+def init_arguments(
+    values: Values,
+    argument_defaults: Dict[str, bool],
+    arguments_visible: Dict[str, bool],
+) -> Parser:
     """Initialize the shared argument definitions."""
-    parser = PostUtilsArguments.init_shared_arguments(
+    parser: Parser = PostUtilsArguments.init_shared_arguments(
         values, argument_defaults, arguments_visible
     )
     #
@@ -161,41 +171,46 @@ def init_arguments(values, argument_defaults, arguments_visible):
 # Creating global variables and using functions to modify them
 # is useful for being able to test things later.
 #
-values = {}
-init_values(values)
-argument_defaults = {}
-init_argument_defaults(argument_defaults)
-arguments_visible = {}
-init_arguments_visible(arguments_visible)
-parser = init_arguments(values, argument_defaults, arguments_visible)
+global_values: Values = {}
+init_values(global_values)
+global_argument_defaults: Dict[str, bool] = {}
+init_argument_defaults(global_argument_defaults)
+global_arguments_visible: Dict[str, bool] = {}
+init_arguments_visible(global_arguments_visible)
+global_parser: Parser = init_arguments(
+    global_values, global_argument_defaults, global_arguments_visible
+)
 #
 # The TOOLTIP_ARGS value is created from the help information about the arguments.
 #
-TOOLTIP_ARGS = parser.format_help()
+TOOLTIP_ARGS: str = global_parser.format_help()
 #
 # Create another parser just to get a list of all possible arguments
 # that may be output using --output_all_arguments.
 #
-all_arguments_visible = {}
-for k in iter(arguments_visible):
-    all_arguments_visible[k] = True
-all_visible = init_arguments(values, argument_defaults, all_arguments_visible)
+global_all_arguments_visible: Dict[str, bool] = {}
+k: str
+for k in iter(global_arguments_visible):
+    global_all_arguments_visible[k] = True
+global_all_visible: Parser = init_arguments(
+    global_values, global_argument_defaults, global_all_arguments_visible
+)
 
 
-def export(objectslist, filename, argstring):
+def export(objectslist, filename, argstring) -> str:
     """Postprocess the objects in objectslist to filename."""
-    #
-    global parser
-    global UNITS
-    global values
+    args: Union[str, argparse.Namespace]
+    flag: bool
+
+    global UNITS  # pylint: disable=global-statement
 
     # print(parser.format_help())
 
     (flag, args) = PostUtilsArguments.process_shared_arguments(
-        values, parser, argstring, all_visible, filename
+        global_values, global_parser, argstring, global_all_visible, filename
     )
     if not flag:
-        return args
+        return args  # type: ignore
     #
     # Process any additional arguments here
     #
@@ -204,6 +219,6 @@ def export(objectslist, filename, argstring):
     # Update the global variables that might have been modified
     # while processing the arguments.
     #
-    UNITS = values["UNITS"]
+    UNITS = global_values["UNITS"]
 
-    return PostUtilsExport.export_common(values, objectslist, filename)
+    return PostUtilsExport.export_common(global_values, objectslist, filename)

--- a/src/Mod/Path/PathTests/TestRefactoredMach3Mach4Post.py
+++ b/src/Mod/Path/PathTests/TestRefactoredMach3Mach4Post.py
@@ -35,7 +35,7 @@ Path.Log.trackModule(Path.Log.thisModule())
 
 class TestRefactoredMach3Mach4Post(PathTestUtils.PathTestBase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         """setUpClass()...
         This method is called upon instantiation of this test class.  Add code
         and objects here that are needed for the duration of the test() methods
@@ -49,7 +49,7 @@ class TestRefactoredMach3Mach4Post(PathTestUtils.PathTestBase):
         FreeCAD.newDocument("Unnamed")
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         """tearDownClass()...
         This method is called prior to destruction of this test class.  Add
         code and objects here that cleanup the test environment after the
@@ -61,7 +61,7 @@ class TestRefactoredMach3Mach4Post(PathTestUtils.PathTestBase):
         FreeCAD.closeDocument(FreeCAD.ActiveDocument.Name)
 
     # Setup and tear down methods called before and after each unit test
-    def setUp(self):
+    def setUp(self) -> None:
         """setUp()...
         This method is called prior to each `test()` method.  Add code and
         objects here that are needed for multiple `test()` methods.
@@ -73,14 +73,14 @@ class TestRefactoredMach3Mach4Post(PathTestUtils.PathTestBase):
             postprocessor
         )  # technical debt.  This shouldn't be necessary but here to bypass a bug
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         """tearDown()...
         This method is called after each test() method. Add cleanup instructions here.
         Such cleanup instructions will likely undo those in the setUp() method.
         """
         FreeCAD.ActiveDocument.removeObject("testpath")
 
-    def test000(self):
+    def test000(self) -> None:
         """Test Output Generation.
         Empty path.  Produces only the preamble and postable.
         """


### PR DESCRIPTION
This is part of the work for  #6117.

This is one in a series of PR's where I am taking code from at least 4 postprocessor files partially written by different people, combining them into a few files, then trying to make the code more consistent and simpler. The long term goal is to enable much simpler postprocessor files with much less copied code in each postprocessor file and much more "shared" code in the Utils*.py files.

In this PR I added typing information to the refactored postprocessors.
