### PR TITLE
[Material] Revert cmake_path command from...

### DIFF
--- a/src/Mod/Material/CMakeLists.txt
+++ b/src/Mod/Material/CMakeLists.txt
@@ -295,7 +295,7 @@ INSTALL(
 )
 
 foreach(file ${MaterialLib_Files} ${FluidMaterial_Files} ${AppearanceLib_Files} ${MaterialModel_Files})
-    cmake_path(REMOVE_FILENAME file OUTPUT_VARIABLE filepath)
+    get_filename_component(filepath ${file} DIRECTORY)
     INSTALL(
         FILES ${file}
         DESTINATION ${CMAKE_INSTALL_DATADIR}/Mod/Material/${filepath}


### PR DESCRIPTION
...https://github.com/FreeCAD/FreeCAD/commit/2c7638b7aaf79f05ed9e98899e4b3ad65a8ce675

My understanding is CMake 3.16 is still supported and the `cmake_path` command was introduced in 3.20.