### PR TITLE
Sketcher Gui: Clang tidy diagnostic errors and dead code fixes

### DIFF
--- a/src/Gui/Notifications.h
+++ b/src/Gui/Notifications.h
@@ -33,6 +33,8 @@
 
 namespace Gui {
 
+    class ViewProviderDocumentObject;
+
 /** Methods to seamlessly provide intrusive or non-intrusive notifications of error, warning,
  * messages, translated notifications, or untranslated notifications originating in a given
  * document object.

--- a/src/Mod/Sketcher/App/SketchAnalysis.h
+++ b/src/Mod/Sketcher/App/SketchAnalysis.h
@@ -27,6 +27,8 @@
 #include <memory>
 #include <vector>
 
+#include <Precision.hxx>
+
 #include <Base/Vector3D.h>
 
 #include "Analyse.h"

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -793,7 +793,6 @@ int SketchSelection::setUp()
             return -1;
         }
 
-        SketchObj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
         SketchSubNames = selection[0].getSubNames();
     }
     else if (selection.size() == 2) {
@@ -2163,6 +2162,9 @@ protected:
         bool isCircleGeom = true;
 
         const Part::Geometry* geom = Obj->getGeometry(GeoId);
+
+        if(!geom)
+            return;
 
         if (geom && isArcOfCircle(*geom)) {
             auto arc = static_cast<const Part::GeomArcOfCircle*>(geom);
@@ -5407,8 +5409,6 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
 
         Base::Vector3d pnt = Obj->getPoint(GeoId1, PosId1);
         double ActY = pnt.y;
-
-        arebothpointsorsegmentsfixed = isPointOrSegmentFixed(Obj, GeoId1);
 
         openCommand(QT_TRANSLATE_NOOP("Command", "Add fixed y-coordinate constraint"));
         Gui::cmdAppObjectArgs(selection[0].getObject(),

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -4499,9 +4499,7 @@ void CmdSketcherConstrainDistance::applyConstraint(std::vector<SelIdPair>& selSe
         case 2:// {SelEdge}
         case 3:// {SelExternalEdge}
         {
-            GeoId1 = GeoId2 = selSeq.at(0).GeoId;
-            PosId1 = Sketcher::PointPos::start;
-            PosId2 = Sketcher::PointPos::end;
+            GeoId1 = selSeq.at(0).GeoId;
 
             arebothpointsorsegmentsfixed = isPointOrSegmentFixed(Obj, GeoId1);
 
@@ -4549,7 +4547,6 @@ void CmdSketcherConstrainDistance::applyConstraint(std::vector<SelIdPair>& selSe
             GeoId1 = selSeq.at(0).GeoId;
             GeoId2 = selSeq.at(1).GeoId;
             PosId1 = selSeq.at(0).PosId;
-            PosId2 = selSeq.at(1).PosId;
 
             Base::Vector3d pnt = Obj->getPoint(GeoId1, PosId1);
             const Part::Geometry* geom = Obj->getGeometry(GeoId2);

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -33,9 +33,11 @@
 #include <Mod/Sketcher/App/GeoEnum.h>
 #include <Mod/Sketcher/App/GeometryFacade.h>
 #include <Mod/Sketcher/App/PythonConverter.h>
+#include <Mod/Sketcher/App/SketchObject.h>
 #include <Mod/Sketcher/App/SolverGeometryExtension.h>
 
 #include "DrawSketchHandler.h"
+#include "ViewProviderSketch.h"
 
 #include "Utils.h"
 
@@ -387,6 +389,8 @@ public:
         ConstructionMethodT constructionmethod = static_cast<ConstructionMethodT>(0))
         : ConstructionMethodMachine<ConstructionMethodT>(constructionmethod)
         , sugConstraints(PInitAutoConstraintSize)
+        , avoidRedundants(true)
+        , continuousMode(true)
     {
         applyCursor();
     }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -23,8 +23,12 @@
 #ifndef SKETCHERGUI_DrawSketchHandler_H
 #define SKETCHERGUI_DrawSketchHandler_H
 
+#include <QCursor>
+#include <QPixmap>
+
 #include <Inventor/SbString.h>
 
+#include <Base/Parameter.h>
 #include <Base/Tools2D.h>
 #include <Gui/Selection.h>
 #include <Mod/Part/App/Geometry.h>
@@ -32,8 +36,7 @@
 
 #include "AutoConstraint.h"
 
-
-class QPixmap;
+class QWidget;
 
 namespace Sketcher
 {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -24,8 +24,16 @@
 #define SKETCHERGUI_DrawSketchHandlerArc_H
 
 #include <Gui/Notifications.h>
+#include <Gui/CommandT.h>
 
+#include <Mod/Part/App/Geometry2d.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 using namespace std;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -298,10 +298,6 @@ public:
                 minAxisPoint = centerPoint + minAxisDir;
                 endAngle += M_PI / 2;
                 startAngle += M_PI / 2;
-                phi -= M_PI / 2;
-                double t = a;
-                a = b;
-                b = t;  // swap a,b
             }
 
             int currentgeoid = getHighestCurveIndex();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -24,8 +24,16 @@
 #define SKETCHERGUI_DrawSketchHandlerArcOfEllipse_H
 
 #include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
+
 
 namespace SketcherGui
 {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -26,8 +26,15 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 
 #include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -221,12 +221,9 @@ public:
             double ustartpoint = (cos(phi) * (startingPoint.y - axisPoint.y)
                                   - (startingPoint.x - axisPoint.x) * sin(phi));
 
-            double uendpoint =
-                (cos(phi) * (endPoint.y - axisPoint.y) - (endPoint.x - axisPoint.x) * sin(phi));
-
             double startAngle = ustartpoint;
 
-            double endAngle = uendpoint;
+            double endAngle;
 
             bool isOriginalArcCCW = true;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -23,9 +23,19 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerArcOfParabola_H
 #define SKETCHERGUI_DrawSketchHandlerArcOfParabola_H
 
-#include "GeometryCreationMode.h"
+#include <boost/math/special_functions/fpclassify.hpp>
 
 #include <Gui/Notifications.h>
+
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
+#include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 namespace SketcherGui
 {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -27,8 +27,15 @@
 #include <QInputDialog>
 
 #include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSplineByInterpolation.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSplineByInterpolation.h
@@ -27,8 +27,15 @@
 #include <QInputDialog>
 
 #include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -23,9 +23,22 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerCarbonCopy_H
 #define SKETCHERGUI_DrawSketchHandlerCarbonCopy_H
 
-#include <Gui/Notifications.h>
+#include <QApplication>
 
+#include <Gui/Notifications.h>
+#include <Gui/SelectionFilter.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+#include <Gui/MDIView.h>
+#include <Gui/View3DInventor.h>
+#include <Gui/View3DInventorViewer.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -23,7 +23,18 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerCircle_H
 #define SKETCHERGUI_DrawSketchHandlerCircle_H
 
+#include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+
+#include <Mod/Part/App/Geometry2d.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -28,8 +28,15 @@
 #include <cmath>
 
 #include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -746,7 +746,7 @@ private:
         int count = 0;
         int limit = 25;  // no infinite loops!
         bool success = false;
-        double tempB = b;
+        double tempB;
 
         // adjust b until our mangled vectors produce a good ellipse in GC_MakeEllipse
         // and the mangled major and minor lines in LinePy::PyInit(...) are such that

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExtend.h
@@ -24,8 +24,16 @@
 #define SKETCHERGUI_DrawSketchHandlerExtend_H
 
 #include <Gui/Notifications.h>
+#include <Gui/SelectionFilter.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -23,9 +23,23 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerExternal_H
 #define SKETCHERGUI_DrawSketchHandlerExternal_H
 
-#include <Gui/Notifications.h>
+#include <App/OriginFeature.h>
+#include <Mod/Part/App/DatumFeature.h>
 
+#include <Gui/Notifications.h>
+#include <Gui/SelectionFilter.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+#include <Gui/View3DInventor.h>
+#include <Gui/View3DInventorViewer.h>
+#include <Gui/MDIView.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerFillet.h
@@ -24,9 +24,16 @@
 #define SKETCHERGUI_DrawSketchHandlerFillet_H
 
 #include <Gui/Notifications.h>
+#include <Gui/SelectionFilter.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
-
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 namespace SketcherGui
 {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -24,6 +24,13 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerLine_H
 #define SKETCHERGUI_DrawSketchHandlerLine_H
 
+#include <Gui/BitmapFactory.h>
+#include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -23,12 +23,21 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerLineSet_H
 #define SKETCHERGUI_DrawSketchHandlerLineSet_H
 
+#include <QApplication>
+
 #include <Inventor/events/SoKeyboardEvent.h>
 #include <boost/math/special_functions/fpclassify.hpp>
 
 #include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -24,6 +24,8 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerOffset_H
 #define SKETCHERGUI_DrawSketchHandlerOffset_H
 
+#include <QApplication>
+
 #include <BRep_Tool.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepClass_FaceClassifier.hxx>
@@ -36,13 +38,23 @@
 #include <BRepExtrema_DistShapeShape.hxx>
 #include <TopoDS.hxx>
 
+#include <Base/Exception.h>
+
+#include <Gui/BitmapFactory.h>
+#include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include <Mod/Sketcher/App/GeometryFacade.h>
+
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"
 
 #include "GeometryCreationMode.h"
 #include "Utils.h"
 
-#include <Mod/Sketcher/App/GeometryFacade.h>
 
 using namespace Sketcher;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -23,7 +23,12 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerPoint_H
 #define SKETCHERGUI_DrawSketchHandlerPoint_H
 
+#include <Gui/BitmapFactory.h>
 #include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
 
 #include "GeometryCreationMode.h"
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -24,6 +24,15 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerPolygon_H
 #define SKETCHERGUI_DrawSketchHandlerPolygon_H
 
+#include <QApplication>
+
+#include <Gui/BitmapFactory.h>
+#include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
 #include "GeometryCreationMode.h"
 #include "Utils.h"
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -24,6 +24,14 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerRectangle_H
 #define SKETCHERGUI_DrawSketchHandlerRectangle_H
 
+#include <QApplication>
+
+#include <Gui/BitmapFactory.h>
+#include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
 
 #include "DrawSketchDefaultWidgetController.h"
 #include "DrawSketchControllableHandler.h"

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSlot.h
@@ -23,9 +23,20 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerSlot_H
 #define SKETCHERGUI_DrawSketchHandlerSlot_H
 
-#include <Gui/Notifications.h>
+#include <sstream>
 
+#include <QApplication>
+
+#include <Gui/Notifications.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui
@@ -208,7 +219,7 @@ public:
                     lastCons = sugConstr2.back();
                 }
 
-                ostringstream snapCon = ostringstream("");
+                std::ostringstream snapCon = std::ostringstream("");
                 if (SnapMode == SNAP_MODE_Straight) {
                     snapCon << "conList.append(Sketcher.Constraint('";
                     if (SnapDir == SNAP_DIR_Horz) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -24,8 +24,16 @@
 #define SKETCHERGUI_DrawSketchHandlerSplitting_H
 
 #include <Gui/Notifications.h>
+#include <Gui/SelectionFilter.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -23,9 +23,20 @@
 #ifndef SKETCHERGUI_DrawSketchHandlerTrimming_H
 #define SKETCHERGUI_DrawSketchHandlerTrimming_H
 
-#include <Gui/Notifications.h>
+#include <QApplication>
+#include <Base/Tools.h>
 
+#include <Gui/Notifications.h>
+#include <Gui/SelectionFilter.h>
+#include <Gui/Command.h>
+#include <Gui/CommandT.h>
+
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
+#include "Utils.h"
+#include "ViewProviderSketch.h"
 
 
 namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -1195,7 +1195,7 @@ Restart:
                            || Constr->Second == GeoEnum::GeoUndef);
 
                     SbVec3f p0;
-                    double startangle, range, endangle;
+                    double startangle, range;
                     if (Constr->Second != GeoEnum::GeoUndef) {
                         Base::Vector3d dir1, dir2;
                         if (Constr->Third == GeoEnum::GeoUndef) {  // angle between two lines
@@ -1278,8 +1278,6 @@ Restart:
                             range = atan2(dir1.x * dir2.y - dir1.y * dir2.x,
                                           dir1.x * dir2.x + dir1.y * dir2.y);
                         }
-
-                        endangle = startangle + range;
                     }
                     else if (Constr->First != GeoEnum::GeoUndef) {
                         const Part::Geometry* geo =
@@ -1293,13 +1291,13 @@ Restart:
                             Base::Vector3d dir = lineSeg->getEndPoint() - lineSeg->getStartPoint();
                             startangle = 0.;
                             range = atan2(dir.y, dir.x);
-                            endangle = startangle + range;
                         }
                         else if (geo->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) {
                             const Part::GeomArcOfCircle* arc =
                                 static_cast<const Part::GeomArcOfCircle*>(geo);
                             p0 = Base::convertTo<SbVec3f>(arc->getCenter());
 
+                            double endangle;
                             arc->getRange(startangle, endangle, /*emulateCCWXY=*/true);
                             range = endangle - startangle;
                         }

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
@@ -34,6 +34,7 @@
 #include <Inventor/nodes/SoInfo.h>
 
 #include <Mod/Sketcher/App/GeoList.h>
+#include <Mod/Sketcher/App/Constraint.h>
 
 #include "EditModeCoinManagerParameters.h"
 
@@ -60,7 +61,6 @@ class Geometry;
 
 namespace Sketcher
 {
-class Constraint;
 class PropertyConstraintList;
 };  // namespace Sketcher
 

--- a/src/Mod/Sketcher/Gui/SnapManager.h
+++ b/src/Mod/Sketcher/Gui/SnapManager.h
@@ -24,9 +24,16 @@
 #ifndef SKETCHERGUI_SnapManager_H
 #define SKETCHERGUI_SnapManager_H
 
-
 #include <App/Application.h>
 
+#include <Base/Tools2D.h>
+#include <Base/Vector3D.h>
+
+namespace Part
+{
+class GeomLineSegment;
+class GeomArcOfCircle;
+}  // namespace Part
 
 namespace SketcherGui
 {

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
@@ -100,7 +100,7 @@ public:
 
 protected:
     void changeEvent(QEvent* e) override;
-    virtual void languageChange();
+    void languageChange();
 
 private:
     using filterItemRepr =

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -229,7 +229,7 @@ public:
 
 protected:
     void changeEvent(QEvent* e) override;
-    virtual void languageChange();
+    void languageChange();
 
 private:
     using filterItemRepr =

--- a/src/Mod/Sketcher/Gui/VisualLayer.h
+++ b/src/Mod/Sketcher/Gui/VisualLayer.h
@@ -26,6 +26,12 @@
 #include <map>
 #include <memory>
 
+namespace Base
+{
+class Writer;
+class XMLReader;
+}  // namespace Base
+
 namespace SketcherGui
 {
 


### PR DESCRIPTION

- Adding headers and forward declarations as needed to fix the clang-tidy diagnose errors.
- Fixing some errors detected by clang-tidy once the headers were added.


