### PR TITLE
Gui: Fix window center rotation mode and orthographic view clipping

### DIFF
--- a/src/Gui/NavigationAnimation.cpp
+++ b/src/Gui/NavigationAnimation.cpp
@@ -57,6 +57,7 @@ FixedTimeAnimation::FixedTimeAnimation(NavigationStyle* navigation, const SbRota
 
 void FixedTimeAnimation::initialize()
 {
+    navigation->findBoundingSphere();
     prevAngle = 0;
     prevTranslation = SbVec3f(0, 0, 0);
 
@@ -133,6 +134,7 @@ SpinningAnimation::SpinningAnimation(NavigationStyle* navigation, const SbVec3f&
 
 void SpinningAnimation::initialize()
 {
+    navigation->findBoundingSphere();
     prevAngle = 0;
 
     navigation->setViewing(true);

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -503,17 +503,37 @@ void NavigationStyle::reorientCamera(SoCamera* camera, const SbRotation& rotatio
     // Set new orientation value by accumulating the new rotation
     camera->orientation = rotation * camera->orientation.getValue();
 
-    // Fix issue with near clipping in orthogonal view
-    if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {
-        camera->focalDistance = static_cast<SoOrthographicCamera*>(camera)->height;
-    }
-
     // Distance from rotation center to new camera position in global coordinate system
     SbVec3f newRotationCenterDistance;
     camera->orientation.getValue().multVec(rotationCenterDistanceCam, newRotationCenterDistance);
 
     // Reposition camera so the rotation center stays in the same place
     camera->position = rotationCenter + newRotationCenterDistance;
+
+    // Fix issue with near clipping in orthogonal view
+    if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {
+
+        // Find a bounding sphere for the scene
+        SoGetBoundingBoxAction action(viewer->getSoRenderManager()->getViewportRegion());
+        action.apply(viewer->getSceneGraph());
+        SbSphere boundingSphere;
+        boundingSphere.circumscribe(action.getBoundingBox());
+
+        // The center of the bounding sphere in camera coordinate system
+        SbVec3f center;
+        camera->orientation.getValue().inverse().multVec(boundingSphere.getCenter() - camera->position.getValue(), center);
+
+        SbVec3f dir;
+        camera->orientation.getValue().multVec(SbVec3f(0, 0, -1), dir);
+
+        // Reposition the camera but keep the focal point the same
+        // nearDistance is 0 and farDistance is the diameter of the bounding sphere
+        float repositionDistance = -center.getValue()[2] - boundingSphere.getRadius();
+        camera->position = camera->position.getValue() + repositionDistance * dir;
+        camera->nearDistance = 0;
+        camera->farDistance = 2 * boundingSphere.getRadius();
+        camera->focalDistance = camera->focalDistance.getValue() - repositionDistance;
+    }
 }
 
 void NavigationStyle::panCamera(SoCamera * cam, float aspectratio, const SbPlane & panplane,

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -1300,8 +1300,8 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
         // Set up initial projection point for the projector object when
         // first starting a drag operation.
         animator->stop();
-        findBoundingSphere();
         viewer->showRotationCenter(true);
+        findBoundingSphere();
         this->spinprojector->project(this->lastmouseposition);
         this->interactiveCountInc();
         this->clearLog();

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -479,6 +479,13 @@ void NavigationStyle::viewAll()
     }
 }
 
+void NavigationStyle::findBoundingSphere() {
+    // Find a bounding sphere for the scene
+    SoGetBoundingBoxAction action(viewer->getSoRenderManager()->getViewportRegion());
+    action.apply(viewer->getSceneGraph());
+    boundingSphere.circumscribe(action.getBoundingBox());
+}
+
 /** Rotate the camera by the given amount, then reposition it so we're still pointing at the same
  * focal point
  */
@@ -511,29 +518,23 @@ void NavigationStyle::reorientCamera(SoCamera* camera, const SbRotation& rotatio
     camera->position = rotationCenter + newRotationCenterDistance;
 
     // Fix issue with near clipping in orthogonal view
-    if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {
+     if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {
 
-        // Find a bounding sphere for the scene
-        SoGetBoundingBoxAction action(viewer->getSoRenderManager()->getViewportRegion());
-        action.apply(viewer->getSceneGraph());
-        SbSphere boundingSphere;
-        boundingSphere.circumscribe(action.getBoundingBox());
+         // The center of the bounding sphere in camera coordinate system
+         SbVec3f center;
+         camera->orientation.getValue().inverse().multVec(boundingSphere.getCenter() - camera->position.getValue(), center);
 
-        // The center of the bounding sphere in camera coordinate system
-        SbVec3f center;
-        camera->orientation.getValue().inverse().multVec(boundingSphere.getCenter() - camera->position.getValue(), center);
+         SbVec3f dir;
+         camera->orientation.getValue().multVec(SbVec3f(0, 0, -1), dir);
 
-        SbVec3f dir;
-        camera->orientation.getValue().multVec(SbVec3f(0, 0, -1), dir);
-
-        // Reposition the camera but keep the focal point the same
-        // nearDistance is 0 and farDistance is the diameter of the bounding sphere
-        float repositionDistance = -center.getValue()[2] - boundingSphere.getRadius();
-        camera->position = camera->position.getValue() + repositionDistance * dir;
-        camera->nearDistance = 0;
-        camera->farDistance = 2 * boundingSphere.getRadius();
-        camera->focalDistance = camera->focalDistance.getValue() - repositionDistance;
-    }
+         // Reposition the camera but keep the focal point the same
+         // nearDistance is 0 and farDistance is the diameter of the bounding sphere
+         float repositionDistance = -center.getValue()[2] - boundingSphere.getRadius();
+         camera->position = camera->position.getValue() + repositionDistance * dir;
+         camera->nearDistance = 0;
+         camera->farDistance = 2 * boundingSphere.getRadius();
+         camera->focalDistance = camera->focalDistance.getValue() - repositionDistance;
+     }
 }
 
 void NavigationStyle::panCamera(SoCamera * cam, float aspectratio, const SbPlane & panplane,
@@ -1299,6 +1300,7 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
         // Set up initial projection point for the projector object when
         // first starting a drag operation.
         animator->stop();
+        findBoundingSphere();
         viewer->showRotationCenter(true);
         this->spinprojector->project(this->lastmouseposition);
         this->interactiveCountInc();

--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -28,6 +28,7 @@
 #include <Inventor/SbBox2s.h>
 #include <Inventor/SbPlane.h>
 #include <Inventor/SbRotation.h>
+#include <Inventor/SbSphere.h>
 #include <Inventor/SbTime.h>
 #include <Inventor/SbVec2f.h>
 #include <Inventor/SbVec2s.h>
@@ -151,6 +152,7 @@ public:
     SoCamera* getCamera() const;
     void setCameraOrientation(const SbRotation& orientation, SbBool moveToCenter = false);
     void translateCamera(const SbVec3f& translation);
+    void findBoundingSphere();
     void reorientCamera(SoCamera* camera, const SbRotation& rotation);
     void reorientCamera(SoCamera* camera, const SbRotation& rotation, const SbVec3f& rotationCenter);
 
@@ -278,6 +280,8 @@ private:
     NavigationStyle::RotationCenterModes rotationCenterMode;
     float sensitivity;
     SbBool resetcursorpos;
+
+    SbSphere boundingSphere;
 };
 
 /** Sub-classes of this class appear in the preference dialog where users can

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1498,6 +1498,8 @@ void View3DInventorViewer::setSceneGraph(SoNode* root)
             static_cast<SoSeparator*>(scene)->insertChild(this->backlight, 0);
         }
     }
+
+    navigation->findBoundingSphere();
 }
 
 void View3DInventorViewer::savePicture(int width, int height, int sample, const QColor& bg, QImage& img) const


### PR DESCRIPTION
This PR fixes #11243 and re-fixes #6836. #9699, The original fix for #6836 was a huge improvement but I was still able to reproduce the cut corners and sometimes random glitches. With this fix that does not happen anymore, at least during my testing.

The new approach finds a bounding sphere of the scene, then it is repositioning the camera such that the `nearDistance` can be 0 and the `farDistance` the diameter of the bounding sphere. Finally, to fix #11243, we change the focal distance so the focal point stays the same.

Currently, this fix runs only in `NavigationStyle::reorientCamera(..)`. There are also other methods that change the camera where it is still possible to get glitchy results.  I am going to take a look at coin3d `SoRenderManagerP::setClippingPlanes()` to see if I can make a fix there, so this PR is maybe a temporary fix.