### PR TITLE
Sketcher: continuous mode improvements

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -564,6 +564,10 @@ protected:
         onViewIndexWithFocus = 0;
 
         configureOnViewParameters();
+
+        if (init) {
+            handler->moveCursorToSketchPoint(prevCursorPosition);
+        }
     }
     //@}
 

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -427,6 +427,15 @@ public:
         if (key == SoKeyboardEvent::M && pressed && !this->isLastState()) {
             this->iterateToNextConstructionMethod();
         }
+        else if (key == SoKeyboardEvent::ESCAPE && pressed) {
+
+            if (this->isFirstState()) {
+                quit();
+            }
+            else {
+                handleContinuousMode();
+            }
+        }
     }
     //@}
 

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -437,6 +437,19 @@ public:
             }
         }
     }
+
+    void pressRightButton(Base::Vector2d onSketchPos) override
+    {
+        Q_UNUSED(onSketchPos);
+
+        if (this->isFirstState()) {
+            quit();
+        }
+        else {
+            handleContinuousMode();
+        }
+    }
+
     //@}
 
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -378,6 +378,13 @@ void DrawSketchHandler::registerPressedKey(bool pressed, int key)
     }
 }
 
+void DrawSketchHandler::pressRightButton(Base::Vector2d /*onSketchPos*/)
+{
+    // the default behaviour is to quit - specific handler categories may
+    // override this behaviour, for example to implement a continuous mode
+    quit();
+}
+
 //**************************************************************************
 // Helpers
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -26,6 +26,8 @@
 
 #include <QGuiApplication>
 #include <QPainter>
+
+#include <Inventor/events/SoKeyboardEvent.h>
 #endif  // #ifndef _PreComp_
 
 #include <Base/Console.h>
@@ -365,6 +367,15 @@ void DrawSketchHandler::toolWidgetChanged(QWidget* newwidget)
 {
     toolwidget = newwidget;
     onWidgetChanged();
+}
+
+void DrawSketchHandler::registerPressedKey(bool pressed, int key)
+{
+    // the default behaviour is to quit - specific handler categories may
+    // override this behaviour, for example to implement a continuous mode
+    if (key == SoKeyboardEvent::ESCAPE && !pressed) {
+        quit();
+    }
 }
 
 //**************************************************************************

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -152,8 +152,7 @@ public:
     {
         return false;
     }
-    virtual void registerPressedKey(bool /*pressed*/, int /*key*/)
-    {}
+    virtual void registerPressedKey(bool /*pressed*/, int /*key*/);
 
     virtual void quit();
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -152,7 +152,8 @@ public:
     {
         return false;
     }
-    virtual void registerPressedKey(bool /*pressed*/, int /*key*/);
+    virtual void registerPressedKey(bool pressed, int key);
+    virtual void pressRightButton(Base::Vector2d onSketchPos);
 
     virtual void quit();
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1169,8 +1169,8 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
         if (!pressed) {
             switch (Mode) {
                 case STATUS_SKETCH_UseHandler:
-                    // make the handler quit
-                    sketchHandler->quit();
+                    // delegate to handler whether to quit or do otherwise
+                    sketchHandler->pressRightButton(Base::Vector2d(x, y));
                     return true;
                 case STATUS_NONE: {
                     // A right click shouldn't change the Edit Mode

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -690,8 +690,7 @@ bool ViewProviderSketch::keyPressed(bool pressed, int key)
         case SoKeyboardEvent::ESCAPE: {
             // make the handler quit but not the edit mode
             if (isInEditMode() && sketchHandler) {
-                if (!pressed)
-                    sketchHandler->quit();
+                sketchHandler->registerPressedKey(pressed, key); // delegate
                 return true;
             }
             if (isInEditMode() && !drag.DragConstraintSet.empty()) {


### PR DESCRIPTION

As per:
https://forum.freecad.org/viewtopic.php?p=716863#p716863

Problems:
* Continuous mode is not well handled. Eg. drawing a rectangle, if I press Esc/RMB after clicking the first point (and before clicking the second), the rectangle feature is just left, instead of just canceling the current rectangle and be ready for a new one.
* I got some cases where pressing Esc does nothing, but I'm not able to reproduce reliably, so will eventually come back later on this one.

Solution:
- ESC or RMB will reset the handler to the first state machine state if not in the first state. If already in the first state, it terminates the handler.