### PR TITLE
[Sketcher] Tool parameter : various fixes

### DIFF
--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -47,10 +47,12 @@ struct NodeData {
 EditableDatumLabel::EditableDatumLabel(View3DInventorViewer* view,
                                        const Base::Placement& plc,
                                        SbColor color,
-                                       bool autoDistance)
+                                       bool autoDistance,
+                                       bool avoidMouseCursor)
     : isSet(false)
     , autoDistance(autoDistance)
     , autoDistanceReverse(false)
+    , avoidMouseCursor(avoidMouseCursor)
     , value(0.0)
     , viewer(view)
     , spinBox(nullptr)
@@ -246,8 +248,19 @@ void EditableDatumLabel::positionSpinbox()
     QSize wSize = spinBox->size();
     QSize vSize = viewer->size();
     QPoint pxCoord = viewer->toQPoint(viewer->getPointOnViewport(getTextCenterPoint()));
+
     int posX = std::min(std::max(pxCoord.x() - wSize.width() / 2, 0), vSize.width() - wSize.width());
     int posY = std::min(std::max(pxCoord.y() - wSize.height() / 2, 0), vSize.height() - wSize.height());
+
+    if (avoidMouseCursor) {
+        QPoint cursorPos = viewer->mapFromGlobal(QCursor::pos());
+        int margin = static_cast<int>(wSize.height() * 0.7); // NOLINT
+        if ((cursorPos.x() > posX - margin && cursorPos.x() < posX + wSize.width() + margin)
+            && (cursorPos.y() > posY - margin && cursorPos.y() < posY + wSize.height() + margin)) {
+            posY = cursorPos.y() + ((cursorPos.y() > pxCoord.y()) ? - wSize.height() - margin : margin);
+        }
+    }
+
     pxCoord.setX(posX);
     pxCoord.setY(posY);
     spinBox->move(pxCoord);
@@ -380,4 +393,4 @@ void EditableDatumLabel::setSpinboxVisibleToMouse(bool val)
     spinBox->setAttribute(Qt::WA_TransparentForMouseEvents, !val);
 }
 
-#include "moc_EditableDatumLabel.cpp"
+#include "moc_EditableDatumLabel.cpp" // NOLINT

--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -239,6 +239,10 @@ void EditableDatumLabel::positionSpinbox()
         return;
     }
 
+    if (spinBox->hasFocus()) {
+        spinBox->raise();
+    }
+
     QSize wSize = spinBox->size();
     QSize vSize = viewer->size();
     QPoint pxCoord = viewer->toQPoint(viewer->getPointOnViewport(getTextCenterPoint()));

--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -240,9 +240,12 @@ void EditableDatumLabel::positionSpinbox()
     }
 
     QSize wSize = spinBox->size();
+    QSize vSize = viewer->size();
     QPoint pxCoord = viewer->toQPoint(viewer->getPointOnViewport(getTextCenterPoint()));
-    pxCoord.setX(std::max(pxCoord.x() - wSize.width() / 2, 0));
-    pxCoord.setY(std::max(pxCoord.y() - wSize.height() / 2, 0));
+    int posX = std::min(std::max(pxCoord.x() - wSize.width() / 2, 0), vSize.width() - wSize.width());
+    int posY = std::min(std::max(pxCoord.y() - wSize.height() / 2, 0), vSize.height() - wSize.height());
+    pxCoord.setX(posX);
+    pxCoord.setY(posY);
     spinBox->move(pxCoord);
 }
 

--- a/src/Gui/EditableDatumLabel.h
+++ b/src/Gui/EditableDatumLabel.h
@@ -45,7 +45,7 @@ class GuiExport EditableDatumLabel : public QObject
     Q_DISABLE_COPY(EditableDatumLabel)
 
 public:
-    EditableDatumLabel(View3DInventorViewer* view, const Base::Placement& plc, SbColor color, bool autoDistance = false);
+    EditableDatumLabel(View3DInventorViewer* view, const Base::Placement& plc, SbColor color, bool autoDistance = false, bool avoidMouseCursor = false);
     ~EditableDatumLabel() override;
 
     void activate();
@@ -76,6 +76,7 @@ public:
     bool isSet;
     bool autoDistance;
     bool autoDistanceReverse;
+    bool avoidMouseCursor;
     double value;
     // NOLINTEND
 

--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -241,8 +241,6 @@ public:
     /** function that is called by the handler when the construction mode changed */
     void onConstructionMethodChanged()
     {
-        nOnViewParameter = OnViewParametersT::size(handler->constructionMethod());
-
         doConstructionMethodChanged();  // NVI
 
         handler->updateCursor();
@@ -560,6 +558,7 @@ protected:
     /** Resets the on-view parameter controls */
     void resetOnViewParameters()
     {
+        nOnViewParameter = OnViewParametersT::size(handler->constructionMethod());
         initNOnViewParameters(nOnViewParameter);
         onViewIndexWithFocus = 0;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -467,7 +467,8 @@ protected:
                                      viewer,
                                      placement,
                                      colorManager.dimConstrDeactivatedColor,
-                                     /*autoDistance = */ true))
+                                     /*autoDistance = */ true,
+                                     /*avoidMouseCursor = */ true))
                                  .get();
 
             QObject::connect(parameter, &Gui::EditableDatumLabel::valueChanged, [=](double value) {

--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -530,13 +530,27 @@ protected:
         if (index >= onViewParameters.size()) {
             index = 0;
         }
+
         while (index < onViewParameters.size()) {
             if (isOnViewParameterOfCurrentMode(index)) {
                 setFocusToOnViewParameter(index);
-                break;
+                return;
             }
             index++;
         }
+        // There is no more onViewParameter after onViewIndexWithFocus + 1 in this mode
+
+        // So we go back to start.
+        index = 0;
+        while (index < onViewParameters.size()) {
+            if (isOnViewParameterOfCurrentMode(index)) {
+                setFocusToOnViewParameter(index);
+                return;
+            }
+            index++;
+        }
+
+        // At that point if no onViewParameter is found, there is none.
     }
 
     /** Returns whether the provided on-view parameter index belongs to the current state of the

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultWidgetController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultWidgetController.h
@@ -253,25 +253,7 @@ protected:
 
     /// Automatic default method update in combobox
     void doConstructionMethodChanged() override
-    {
-        nParameter = WidgetParametersT::size(handler->constructionMethod());
-        nCheckbox = WidgetCheckboxesT::size(handler->constructionMethod());
-        nCombobox = WidgetComboboxesT::size(handler->constructionMethod());
-
-        // update the combobox only if necessary (if the change was not triggered by the
-        // combobox)
-        if constexpr (PFirstComboboxIsConstructionMethod == true) {
-            auto currentindex = toolWidget->getComboboxIndex(WCombobox::FirstCombo);
-            auto methodint = static_cast<int>(handler->constructionMethod());
-
-            if (currentindex != methodint) {
-                // avoid triggering of method change
-                boost::signals2::shared_connection_block combobox_block(
-                    connectionComboboxSelectionChanged);
-                toolWidget->setComboboxIndex(WCombobox::FirstCombo, methodint);
-            }
-        }
-    }
+    {}
     //@}
 
 private:
@@ -306,11 +288,29 @@ private:
         boost::signals2::shared_connection_block checkbox_block(connectionCheckboxCheckedChanged);
         boost::signals2::shared_connection_block combobox_block(connectionComboboxSelectionChanged);
 
+        nParameter = WidgetParametersT::size(handler->constructionMethod());
+        nCheckbox = WidgetCheckboxesT::size(handler->constructionMethod());
+        nCombobox = WidgetComboboxesT::size(handler->constructionMethod());
+
         toolWidget->initNParameters(nParameter);
         toolWidget->initNCheckboxes(nCheckbox);
         toolWidget->initNComboboxes(nCombobox);
 
         configureToolWidget();
+
+        // update the combobox only if necessary (if the change was not triggered by the
+        // combobox)
+        if constexpr (PFirstComboboxIsConstructionMethod == true) {
+            auto currentindex = toolWidget->getComboboxIndex(WCombobox::FirstCombo);
+            auto methodint = static_cast<int>(handler->constructionMethod());
+
+            if (currentindex != methodint) {
+                // avoid triggering of method change
+                boost::signals2::shared_connection_block combobox_block(
+                    connectionComboboxSelectionChanged);
+                toolWidget->setComboboxIndex(WCombobox::FirstCombo, methodint);
+            }
+        }
     }
 
 private:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -392,27 +392,27 @@ private:
                 }
 
                 bool create = false;
-                int posi, posj;
+                PointPos posi, posj;
 
                 if ((firstStartPoint - secondStartPoint).Length() < Precision::Confusion()) {
                     create = true;
-                    posi = 1;
-                    posj = 1;
+                    posi = PointPos::start;
+                    posj = PointPos::start;
                 }
                 else if ((firstStartPoint - secondEndPoint).Length() < Precision::Confusion()) {
                     create = true;
-                    posi = 1;
-                    posj = 2;
+                    posi = PointPos::start;
+                    posj = PointPos::end;
                 }
                 else if ((firstEndPoint - secondStartPoint).Length() < Precision::Confusion()) {
                     create = true;
-                    posi = 2;
-                    posj = 1;
+                    posi = PointPos::end;
+                    posj = PointPos::start;
                 }
                 else if ((firstEndPoint - secondEndPoint).Length() < Precision::Confusion()) {
                     create = true;
-                    posi = 2;
-                    posj = 2;
+                    posi = PointPos::end;
+                    posj = PointPos::end;
                 }
 
                 if (create) {
@@ -420,8 +420,8 @@ private:
                         needTangent(listOfOffsetGeoIds[i], listOfOffsetGeoIds[j], posi, posj);
                     stream << "conList.append(Sketcher.Constraint('"
                            << (tangent ? "Tangent" : "Coincident");
-                    stream << "'," << listOfOffsetGeoIds[i] << "," << posi << ", "
-                           << listOfOffsetGeoIds[j] << "," << posj << "))\n";
+                    stream << "'," << listOfOffsetGeoIds[i] << "," << static_cast<int>(posi) << ", "
+                           << listOfOffsetGeoIds[j] << "," << static_cast<int>(posj) << "))\n";
                 }
             }
         }
@@ -431,69 +431,56 @@ private:
         Gui::Command::doCommand(Gui::Command::Doc, stream.str().c_str());
     }
 
-    bool needTangent(int geoId1, int geoId2, int pos1, int pos2)
+    bool needTangent(int geoId1, int geoId2, PointPos pos1, PointPos pos2)
     {
+        // Todo: add cases for arcOfellipse parabolas hyperbolas bspline
+
         SketchObject* Obj = sketchgui->getSketchObject();
         const Part::Geometry* geo1 = Obj->getGeometry(geoId1);
         const Part::Geometry* geo2 = Obj->getGeometry(geoId2);
 
-        if (geo1->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
-            || geo2->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) {
-            Base::Vector3d perpendicular1, perpendicular2, p1, p2;
-            if (geo1->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
-                || geo1->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()) {
-                const Part::GeomArcOfConic* arcOfCircle =
-                    static_cast<const Part::GeomArcOfConic*>(geo1);
-                p1 = arcOfCircle->getEndPoint();
-                if (pos1 == 1) {
-                    p1 = arcOfCircle->getStartPoint();
-                }
-                perpendicular1.x = -(arcOfCircle->getCenter() - p1).y;
-                perpendicular1.y = (arcOfCircle->getCenter() - p1).x;
-            }
-            else if (geo1->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
-                const Part::GeomLineSegment* line = static_cast<const Part::GeomLineSegment*>(geo1);
-                p1 = line->getEndPoint();
-                perpendicular1 = line->getStartPoint() - line->getEndPoint();
-                if (pos1 == 1) {
-                    p1 = line->getStartPoint();
-                    perpendicular1 = line->getEndPoint() - line->getStartPoint();
-                }
-            }
-            else {
-                return false;
-            }
-            // Todo: add cases for arcOfellipse parabolas hyperbolas bspline
-            if (geo2->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
-                || geo2->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()) {
-                const Part::GeomArcOfConic* arcOfCircle =
-                    static_cast<const Part::GeomArcOfConic*>(geo2);
-                p2 = arcOfCircle->getEndPoint();
-                if (pos2 == 1) {
-                    p2 = arcOfCircle->getStartPoint();
-                }
-                perpendicular2.x = -(arcOfCircle->getCenter() - p2).y;
-                perpendicular2.y = (arcOfCircle->getCenter() - p2).x;
-            }
-            else if (geo2->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
-                const Part::GeomLineSegment* line = static_cast<const Part::GeomLineSegment*>(geo2);
-                p2 = line->getEndPoint();
-                perpendicular2 = line->getStartPoint() - line->getEndPoint();
-                if (pos2 == 1) {
-                    p2 = line->getStartPoint();
-                    perpendicular2 = line->getEndPoint() - line->getStartPoint();
-                }
-            }
-            else {
-                return false;
-            }
-            // Todo: add cases for arcOfellipse parabolas hyperbolas bspline
-
-            // if lines are parallel
-            if ((perpendicular1 % perpendicular2).Length() < Precision::Intersection()) {
-                return true;
-            }
+        if (!isArcOfCircle(*geo1) && !isArcOfCircle(*geo2)) {
+            return false;
         }
+
+        Base::Vector3d perpendicular1, perpendicular2, p1, p2;
+        if (isArcOfCircle(*geo1)) {
+            auto* arcOfCircle = static_cast<const Part::GeomArcOfCircle*>(geo1);
+            p1 = pos1 == PointPos::start ? arcOfCircle->getStartPoint(true)
+                                         : arcOfCircle->getEndPoint(true);
+
+            perpendicular1.x = -(arcOfCircle->getCenter() - p1).y;
+            perpendicular1.y = (arcOfCircle->getCenter() - p1).x;
+        }
+        else if (isLineSegment(*geo1)) {
+            auto* line = static_cast<const Part::GeomLineSegment*>(geo1);
+            perpendicular1 = line->getStartPoint() - line->getEndPoint();
+        }
+        else {
+            return false;
+        }
+
+        if (isArcOfCircle(*geo2)) {
+            auto* arcOfCircle = static_cast<const Part::GeomArcOfCircle*>(geo2);
+            p2 = pos2 == PointPos::start ? arcOfCircle->getStartPoint(true)
+                                         : arcOfCircle->getEndPoint(true);
+
+            perpendicular2.x = -(arcOfCircle->getCenter() - p2).y;
+            perpendicular2.y = (arcOfCircle->getCenter() - p2).x;
+        }
+        else if (isLineSegment(*geo2)) {
+            auto* line = static_cast<const Part::GeomLineSegment*>(geo2);
+            perpendicular2 = line->getStartPoint() - line->getEndPoint();
+        }
+        else {
+            return false;
+        }
+
+        // if lines are parallel
+        if ((perpendicular1 % perpendicular2).Length() < Precision::Confusion()) {
+            return true;
+        }
+
         return false;
     }
 
@@ -520,7 +507,13 @@ private:
 
         std::stringstream stream;
         stream << "conList = []\n";
+        // We separate the constraints of new lines in case the construction lines are not needed.
+        std::stringstream newLinesStream;
+        newLinesStream << "conList2 = []\n";
+
         vCCO = generatevCC(listOfOffsetGeoIds);
+
+        int geoIdCandidate1, geoIdCandidate2;
 
         int newCurveCounter = 0;
         int prevCurveCounter = 0;
@@ -573,8 +566,7 @@ private:
                     // Check if geoId is the offsetted curve giving curve[j].
                     const Part::Geometry* geo2 = Obj->getGeometry(geoId);
 
-                    if (geo->getTypeId() == Part::GeomCircle::getClassTypeId()
-                        && geo2->getTypeId() == Part::GeomCircle::getClassTypeId()) {
+                    if (isCircle(*geo) && isCircle(*geo2)) {
                         auto* circle = static_cast<const Part::GeomCircle*>(geo);
                         auto* circle2 = static_cast<const Part::GeomCircle*>(geo2);
                         Base::Vector3d p1 = circle->getCenter();
@@ -583,6 +575,7 @@ private:
                             // coincidence of center
                             stream << "conList.append(Sketcher.Constraint('Coincident'," << curve[j]
                                    << ",3, " << geoId << ",3))\n";
+
                             // Create line between both circles.
                             auto* line = new Part::GeomLineSegment();
                             p1.x = p1.x + circle->getRadius();
@@ -591,24 +584,26 @@ private:
                             GeometryFacade::setConstruction(line, true);
                             geometriesToAdd.push_back(line);
                             newCurveCounter++;
-                            stream << "conList.append(Sketcher.Constraint('Perpendicular',"
-                                   << getHighestCurveIndex() + newCurveCounter << ", " << curve[j]
-                                   << "))\n";
-                            stream << "conList.append(Sketcher.Constraint('PointOnObject',"
-                                   << getHighestCurveIndex() + newCurveCounter << ",1, " << curve[j]
-                                   << "))\n";
-                            stream << "conList.append(Sketcher.Constraint('PointOnObject',"
-                                   << getHighestCurveIndex() + newCurveCounter << ",2, " << geoId
-                                   << "))\n";
+                            newLinesStream << "conList2.append(Sketcher.Constraint('Perpendicular',"
+                                           << getHighestCurveIndex() + newCurveCounter << ", "
+                                           << curve[j] << "))\n";
+                            newLinesStream << "conList2.append(Sketcher.Constraint('PointOnObject',"
+                                           << getHighestCurveIndex() + newCurveCounter << ",1, "
+                                           << curve[j] << "))\n";
+                            newLinesStream << "conList2.append(Sketcher.Constraint('PointOnObject',"
+                                           << getHighestCurveIndex() + newCurveCounter << ",2, "
+                                           << geoId << "))\n";
+
+                            geoIdCandidate1 = curve[j];
+                            geoIdCandidate2 = geoId;
+
                             break;
                         }
                     }
-                    else if (geo->getTypeId() == Part::GeomEllipse::getClassTypeId()
-                             && geo2->getTypeId() == Part::GeomEllipse::getClassTypeId()) {
+                    else if (isEllipse(*geo) && isEllipse(*geo2)) {
                         // same as circle but 2 lines
                     }
-                    else if (geo->getTypeId() == Part::GeomLineSegment::getClassTypeId()
-                             && geo2->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
+                    else if (isLineSegment(*geo) && isLineSegment(*geo2)) {
                         auto* lineSeg1 = static_cast<const Part::GeomLineSegment*>(geo);
                         auto* lineSeg2 = static_cast<const Part::GeomLineSegment*>(geo2);
                         Base::Vector3d p1[2], p2[2];
@@ -639,32 +634,36 @@ private:
                                     geometriesToAdd.push_back(line);
                                     newCurveCounter++;
 
-                                    stream << "conList.append(Sketcher.Constraint('Perpendicular',"
-                                           << getHighestCurveIndex() + newCurveCounter << ", "
-                                           << curve[j] << "))\n";
-                                    stream << "conList.append(Sketcher.Constraint('PointOnObject',"
-                                           << getHighestCurveIndex() + newCurveCounter << ",1, "
-                                           << curve[j] << "))\n";
-                                    stream << "conList.append(Sketcher.Constraint('PointOnObject',"
-                                           << getHighestCurveIndex() + newCurveCounter << ",2, "
-                                           << geoId << "))\n";
+                                    newLinesStream
+                                        << "conList2.append(Sketcher.Constraint('Perpendicular',"
+                                        << getHighestCurveIndex() + newCurveCounter << ", "
+                                        << curve[j] << "))\n";
+                                    newLinesStream
+                                        << "conList2.append(Sketcher.Constraint('PointOnObject',"
+                                        << getHighestCurveIndex() + newCurveCounter << ",1, "
+                                        << curve[j] << "))\n";
+                                    newLinesStream
+                                        << "conList2.append(Sketcher.Constraint('PointOnObject',"
+                                        << getHighestCurveIndex() + newCurveCounter << ",2, "
+                                        << geoId << "))\n";
+
+                                    geoIdCandidate1 = curve[j];
+                                    geoIdCandidate2 = geoId;
                                 }
                                 break;
                             }
                         }
                     }
-                    else if (geo->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) {
+                    else if (isArcOfCircle(*geo)) {
                         // multiple cases because arc join mode creates arcs or circle.
-                        const Part::GeomArcOfCircle* arcOfCircle =
-                            static_cast<const Part::GeomArcOfCircle*>(geo);
+                        auto* arcOfCircle = static_cast<const Part::GeomArcOfCircle*>(geo);
                         Base::Vector3d p1 = arcOfCircle->getCenter();
 
-                        if (geo2->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()) {
-                            const Part::GeomArcOfCircle* arcOfCircle2 =
-                                static_cast<const Part::GeomArcOfCircle*>(geo2);
+                        if (isArcOfCircle(*geo2)) {
+                            auto* arcOfCircle2 = static_cast<const Part::GeomArcOfCircle*>(geo2);
                             Base::Vector3d p2 = arcOfCircle2->getCenter();
-                            Base::Vector3d p3 = arcOfCircle2->getStartPoint();
-                            Base::Vector3d p4 = arcOfCircle2->getEndPoint();
+                            Base::Vector3d p3 = arcOfCircle2->getStartPoint(true);
+                            Base::Vector3d p4 = arcOfCircle2->getEndPoint(true);
 
                             if ((p1 - p2).Length() < Precision::Confusion()) {
                                 // coincidence of center. Offset arc is the offset of an arc
@@ -672,22 +671,28 @@ private:
                                        << curve[j] << ",3, " << geoId << ",3))\n";
                                 if (createLine) {
                                     // Create line between both circles.
-                                    Part::GeomLineSegment* line = new Part::GeomLineSegment();
+                                    auto* line = new Part::GeomLineSegment();
                                     p1.x = p1.x + arcOfCircle->getRadius();
                                     p2.x = p2.x + arcOfCircle2->getRadius();
                                     line->setPoints(p1, p2);
                                     GeometryFacade::setConstruction(line, true);
                                     geometriesToAdd.push_back(line);
                                     newCurveCounter++;
-                                    stream << "conList.append(Sketcher.Constraint('Perpendicular',"
-                                           << getHighestCurveIndex() + newCurveCounter << ", "
-                                           << curve[j] << "))\n";
-                                    stream << "conList.append(Sketcher.Constraint('PointOnObject',"
-                                           << getHighestCurveIndex() + newCurveCounter << ",1, "
-                                           << curve[j] << "))\n";
-                                    stream << "conList.append(Sketcher.Constraint('PointOnObject',"
-                                           << getHighestCurveIndex() + newCurveCounter << ",2, "
-                                           << geoId << "))\n";
+                                    newLinesStream
+                                        << "conList2.append(Sketcher.Constraint('Perpendicular',"
+                                        << getHighestCurveIndex() + newCurveCounter << ", "
+                                        << curve[j] << "))\n";
+                                    newLinesStream
+                                        << "conList2.append(Sketcher.Constraint('PointOnObject',"
+                                        << getHighestCurveIndex() + newCurveCounter << ",1, "
+                                        << curve[j] << "))\n";
+                                    newLinesStream
+                                        << "conList2.append(Sketcher.Constraint('PointOnObject',"
+                                        << getHighestCurveIndex() + newCurveCounter << ",2, "
+                                        << geoId << "))\n";
+
+                                    geoIdCandidate1 = curve[j];
+                                    geoIdCandidate2 = geoId;
                                 }
                                 break;
                             }
@@ -715,47 +720,43 @@ private:
                                 break;
                             }
                         }
-                        else if (geo2->getTypeId() == Part::GeomLineSegment::getClassTypeId()
+                        else if (isLineSegment(*geo2)
                                  || geo2->getTypeId() == Part::GeomArcOfConic::getClassTypeId()
-                                 || geo2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
+                                 || isBSplineCurve(*geo2)) {
                             // cases where arc is created by arc join mode.
                             Base::Vector3d p2, p3;
 
                             if (getFirstSecondPoints(geoId, p2, p3)) {
-                                if (((p1 - p2).Length() < Precision::Confusion())
-                                    || ((p1 - p3).Length() < Precision::Confusion())) {
-                                    if ((p1 - p2).Length() < Precision::Confusion()) {
-                                        // coincidence of center to startpoint
-                                        stream << "conList.append(Sketcher.Constraint('Coincident',"
-                                               << curve[j] << ",3, " << geoId << ", 1))\n";
-                                    }
-                                    else if ((p1 - p3).Length() < Precision::Confusion()) {
-                                        // coincidence of center to endpoint
-                                        stream << "conList.append(Sketcher.Constraint('Coincident',"
-                                               << curve[j] << ",3, " << geoId << ", 2))\n";
-                                    }
+                                bool startCoincidence = (p1 - p2).Length() < Precision::Confusion();
+                                bool endCoincidence = (p1 - p3).Length() < Precision::Confusion();
+
+                                if (startCoincidence || endCoincidence) {
+                                    // coincidence of center to startpoint
+                                    stream << "conList.append(Sketcher.Constraint('Coincident',"
+                                           << curve[j] << ", 3, " << geoId << ", "
+                                           << (startCoincidence ? 1 : 2) << "))\n";
+
+                                    geoIdCandidate1 = curve[j];
+                                    geoIdCandidate2 = geoId;
+
                                     break;
                                 }
                             }
                         }
                     }
-                    else if (geo->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()
-                             && geo2->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()) {
+                    else if (isArcOfEllipse(*geo) && isArcOfEllipse(*geo2)) {
                         // const Part::GeomArcOfEllipse* arcOfEllipse = static_cast<const
                         // Part::GeomArcOfEllipse*>(geo2);
                     }
-                    else if (geo->getTypeId() == Part::GeomArcOfHyperbola::getClassTypeId()
-                             && geo2->getTypeId() == Part::GeomArcOfHyperbola::getClassTypeId()) {
+                    else if (isArcOfHyperbola(*geo) && isArcOfHyperbola(*geo2)) {
                         // const Part::GeomArcOfHyperbola* arcOfHyperbola = static_cast<const
                         // Part::GeomArcOfHyperbola*>(geo2);
                     }
-                    else if (geo->getTypeId() == Part::GeomArcOfParabola::getClassTypeId()
-                             && geo2->getTypeId() == Part::GeomArcOfParabola::getClassTypeId()) {
+                    else if (isArcOfParabola(*geo) && isArcOfParabola(*geo2)) {
                         // const Part::GeomArcOfParabola* arcOfParabola = static_cast<const
                         // Part::GeomArcOfParabola*>(geo2);
                     }
-                    else if (geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()
-                             && geo2->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {}
+                    else if (isBSplineCurve(*geo) && isBSplineCurve(*geo2)) {}
                 }
                 if (newCurveCounter != prevCurveCounter) {
                     prevCurveCounter = newCurveCounter;
@@ -777,11 +778,42 @@ private:
                 }
             }
         }
-        if (newCurveCounter != 0) {
+
+        if (newCurveCounter >= 2) {
             stream << "conList.append(Sketcher.Constraint('Distance'," << getHighestCurveIndex() + 1
                    << ", " << fabs(offsetLength) << "))\n";
+
+            Obj->addGeometry(std::move(geometriesToAdd));
+
+            newLinesStream << Gui::Command::getObjectCmd(sketchgui->getObject())
+                           << ".addConstraint(conList2)\n";
+            newLinesStream << "del conList2\n";
+            Gui::Command::doCommand(Gui::Command::Doc, newLinesStream.str().c_str());
         }
-        Obj->addGeometry(std::move(geometriesToAdd));
+        else {
+            // If there is a single construction line, then its not needed.
+            const Part::Geometry* geo = Obj->getGeometry(geoIdCandidate1);
+
+            if (isCircle(*geo)) {
+                stream << "conList.append(Sketcher.Constraint('Distance'," << geoIdCandidate1
+                       << ", " << geoIdCandidate2 << ", " << fabs(offsetLength) << "))\n";
+            }
+            else if (isLineSegment(*geo)) {
+                stream << "conList.append(Sketcher.Constraint('Distance'," << geoIdCandidate1
+                       << ", 1," << geoIdCandidate2 << ", " << fabs(offsetLength) << "))\n";
+            }
+            else if (isArcOfCircle(*geo)) {
+                const Part::Geometry* geo2 = Obj->getGeometry(geoIdCandidate2);
+                if (isArcOfCircle(*geo2)) {
+                    stream << "conList.append(Sketcher.Constraint('Distance'," << geoIdCandidate1
+                           << ", 1," << geoIdCandidate2 << ", 1, " << fabs(offsetLength) << "))\n";
+                }
+                else if (isLineSegment(*geo2)) {
+                    stream << "conList.append(Sketcher.Constraint('Distance'," << geoIdCandidate1
+                           << ", 3," << geoIdCandidate1 << ", 1, " << fabs(offsetLength) << "))\n";
+                }
+            }
+        }
 
         stream << Gui::Command::getObjectCmd(sketchgui->getObject()) << ".addConstraint(conList)\n";
         stream << "del conList\n";
@@ -797,13 +829,9 @@ private:
         for (auto geoId : listOfGeo) {
             std::vector<int> vecOfGeoIds;
             const Part::Geometry* geo = Obj->getGeometry(geoId);
-            if (geo->getTypeId() == Part::GeomCircle::getClassTypeId()
-                || geo->getTypeId() == Part::GeomEllipse::getClassTypeId()) {
+            if (isCircle(*geo) || isEllipse(*geo)) {
                 vecOfGeoIds.push_back(geoId);
                 vcc.push_back(vecOfGeoIds);
-                continue;
-            }
-            else if (geo->getTypeId() == Part::GeomPoint::getClassTypeId()) {
                 continue;
             }
 
@@ -871,10 +899,10 @@ private:
 
         SketchObject* Obj = sketchgui->getSketchObject();
 
-        for (size_t i = 0; i < vCC.size(); i++) {
+        for (auto& CC : vCC) {
             BRepBuilderAPI_MakeWire mkWire;
-            for (size_t j = 0; j < vCC[i].size(); j++) {
-                mkWire.Add(TopoDS::Edge(Obj->getGeometry(vCC[i][j])->toShape()));
+            for (auto& curve : CC) {
+                mkWire.Add(TopoDS::Edge(Obj->getGeometry(curve)->toShape()));
             }
             sourceWires.push_back(mkWire.Wire());
         }
@@ -919,22 +947,20 @@ private:
     {
         const Part::Geometry* geo = sketchgui->getSketchObject()->getGeometry(geoId);
 
-        if (geo->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
+        if (isLineSegment(*geo)) {
             const auto* line = static_cast<const Part::GeomLineSegment*>(geo);
             startPoint = line->getStartPoint();
             endPoint = line->getEndPoint();
             return true;
         }
-        else if (geo->getTypeId() == Part::GeomArcOfCircle::getClassTypeId()
-                 || geo->getTypeId() == Part::GeomArcOfEllipse::getClassTypeId()
-                 || geo->getTypeId() == Part::GeomArcOfHyperbola::getClassTypeId()
-                 || geo->getTypeId() == Part::GeomArcOfParabola::getClassTypeId()) {
+        else if (isArcOfCircle(*geo) || isArcOfEllipse(*geo) || isArcOfHyperbola(*geo)
+                 || isArcOfParabola(*geo)) {
             const auto* arcOfConic = static_cast<const Part::GeomArcOfConic*>(geo);
             startPoint = arcOfConic->getStartPoint(true);
             endPoint = arcOfConic->getEndPoint(true);
             return true;
         }
-        else if (geo->getTypeId() == Part::GeomBSplineCurve::getClassTypeId()) {
+        else if (isBSplineCurve(*geo)) {
             const auto* bSpline = static_cast<const Part::GeomBSplineCurve*>(geo);
             startPoint = bSpline->getStartPoint();
             endPoint = bSpline->getEndPoint();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -1600,8 +1600,8 @@ template<>
 void DSHRectangleController::configureToolWidget()
 {
     if (!init) {  // Code to be executed only upon initialisation
-        QStringList names = {QStringLiteral("Diagonal corners"),
-                             QStringLiteral("Center and corner"),
+        QStringList names = {QStringLiteral("Corner, length & width"),
+                             QStringLiteral("Center, length & width"),
                              QStringLiteral("3 corners"),
                              QStringLiteral("Center and 2 corners")};
         toolWidget->setComboboxElements(WCombobox::FirstCombo, names);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -1329,12 +1329,14 @@ private:
                                                   firstCurve + 5,
                                                   Sketcher::PointPos::none,
                                                   firstCurve + 7);
-                            if (fabs(angle123 - M_PI / 2) < Precision::Confusion()) {
-                                addToShapeConstraints(Sketcher::Perpendicular,
-                                                      firstCurve + 4,
-                                                      Sketcher::PointPos::none,
-                                                      firstCurve + 5);
-                            }
+                            addToShapeConstraints(Sketcher::Parallel,
+                                                  firstCurve,
+                                                  Sketcher::PointPos::none,
+                                                  firstCurve + 4);
+                            addToShapeConstraints(Sketcher::Parallel,
+                                                  firstCurve + 1,
+                                                  Sketcher::PointPos::none,
+                                                  firstCurve + 5);
                         }
 
                         // add construction lines

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -1838,7 +1838,7 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 else {
                     if (onViewParameters[OnViewParameter::Sixth]->isSet) {
                         double thickness = onViewParameters[OnViewParameter::Sixth]->getValue();
-                        if (thickness < Precision::Confusion()) {
+                        if (thickness <= -std::min(handler->width, handler->length) / 2) {
                             unsetOnViewParameter(onViewParameters[OnViewParameter::Sixth].get());
                             return;
                         }
@@ -1931,7 +1931,7 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
 
                 if (onViewParameters[OnViewParameter::Sixth]->isSet) {
                     double thickness = onViewParameters[OnViewParameter::Sixth]->getValue();
-                    if (thickness < Precision::Confusion()) {
+                    if (thickness <= -std::min(handler->width, handler->length) / 2) {
                         unsetOnViewParameter(onViewParameters[OnViewParameter::Sixth].get());
                         return;
                     }
@@ -1958,7 +1958,7 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
                 else {
                     if (onViewParameters[OnViewParameter::Eighth]->isSet) {
                         double thickness = onViewParameters[OnViewParameter::Eighth]->getValue();
-                        if (thickness < Precision::Confusion()) {
+                        if (thickness <= -std::min(handler->width, handler->length) / 2) {
                             unsetOnViewParameter(onViewParameters[OnViewParameter::Eighth].get());
                             return;
                         }
@@ -1973,7 +1973,7 @@ void DSHRectangleControllerBase::doEnforceControlParameters(Base::Vector2d& onSk
         case SelectMode::SeekFifth: {
             if (onViewParameters[OnViewParameter::Eighth]->isSet) {
                 double thickness = onViewParameters[OnViewParameter::Eighth]->getValue();
-                if (thickness < Precision::Confusion()) {
+                if (thickness <= -std::min(handler->width, handler->length) / 2) {
                     unsetOnViewParameter(onViewParameters[OnViewParameter::Eighth].get());
                     return;
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -1553,14 +1553,24 @@ auto DSHRectangleControllerBase::getState(int labelindex) const
                 return SelectMode::SeekSecond;
                 break;
             case OnViewParameter::Fifth:
-                return SelectMode::SeekThird;
-                break;
-            case OnViewParameter::Sixth:
-                if (!handler->roundCorners) {
+                if (handler->roundCorners) {
                     return SelectMode::SeekThird;
                 }
                 else {
-                    return SelectMode::SeekFourth;
+                    return SelectMode::End;
+                }
+                break;
+            case OnViewParameter::Sixth:
+                if (handler->makeFrame) {
+                    if (!handler->roundCorners) {
+                        return SelectMode::SeekThird;
+                    }
+                    else {
+                        return SelectMode::SeekFourth;
+                    }
+                }
+                else {
+                    return SelectMode::End;
                 }
                 break;
             default:
@@ -1582,14 +1592,24 @@ auto DSHRectangleControllerBase::getState(int labelindex) const
                 return SelectMode::SeekThird;
                 break;
             case OnViewParameter::Seventh:
-                return SelectMode::SeekFourth;
-                break;
-            case OnViewParameter::Eighth:
-                if (!handler->roundCorners) {
+                if (handler->roundCorners) {
                     return SelectMode::SeekFourth;
                 }
                 else {
-                    return SelectMode::SeekFifth;
+                    return SelectMode::End;
+                }
+                break;
+            case OnViewParameter::Eighth:
+                if (handler->makeFrame) {
+                    if (!handler->roundCorners) {
+                        return SelectMode::SeekFourth;
+                    }
+                    else {
+                        return SelectMode::SeekFifth;
+                    }
+                }
+                else {
+                    return SelectMode::End;
                 }
                 break;
             default:


### PR DESCRIPTION
@abdullahtahiriyo this PR fixes a first batch of comments that has been made.
It does not implement the preference to disable onviewparameters as you are doing it already.

Fixes issues by @0penBrain 

> * Most severe one is probably the Tab management. Eg. when drawing a rectangle, X coord is the selected one. If I press Tab, I go to Y coord. Fine. But here if I press Tab again, then coord selection is lost forever. I would expect Tab only to circle between currently available coords/dims. Also I'd expect Shift+Tab to work (circling in the other direction).
> * While keeping the coord/dim boxes on the viewport is well handled on top and left, it isn't on right and bottom where they disappear out of view.
> 
> * The mode named "Diagonal corners" isn't. It is "1 corner + length & width". A true "diagonal corners" mode is missing.
> * Same goes for "Center and corner" which actually is "Center + length & width".

Fixes issue from chrisb:

> In certasin positions the dynamically moving input fields are lying over each other. In that case the one having the focus should be on top.

Fixes the issue of spinbox getting in the way raised on the german topic.

Fixes https://github.com/FreeCAD/FreeCAD/issues/11289
Fixes https://github.com/FreeCAD/FreeCAD/issues/11288
Fixes https://github.com/FreeCAD/FreeCAD/issues/11287
Fixes https://github.com/FreeCAD/FreeCAD/issues/11285
Fixes https://github.com/FreeCAD/FreeCAD/issues/11284