### PR TITLE
Sketcher: Control visibility of OVPs via parameter

### DIFF
--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -346,9 +346,10 @@ void EditableDatumLabel::setPoints(Base::Vector3d p1, Base::Vector3d p2)
 }
 
 // NOLINTNEXTLINE
-void EditableDatumLabel::setLabelType(SoDatumLabel::Type type)
+void EditableDatumLabel::setLabelType(SoDatumLabel::Type type, Function funct)
 {
     label->datumtype = type;
+    function = funct;
 }
 
 // NOLINTNEXTLINE
@@ -393,4 +394,10 @@ void EditableDatumLabel::setSpinboxVisibleToMouse(bool val)
     spinBox->setAttribute(Qt::WA_TransparentForMouseEvents, !val);
 }
 
+EditableDatumLabel::Function EditableDatumLabel::getFunction()
+{
+    return function;
+}
+
 #include "moc_EditableDatumLabel.cpp" // NOLINT
+

--- a/src/Gui/EditableDatumLabel.h
+++ b/src/Gui/EditableDatumLabel.h
@@ -46,6 +46,12 @@ class GuiExport EditableDatumLabel : public QObject
 
 public:
     EditableDatumLabel(View3DInventorViewer* view, const Base::Placement& plc, SbColor color, bool autoDistance = false, bool avoidMouseCursor = false);
+
+    enum class Function {
+        Positioning,
+        Dimensioning
+    };
+
     ~EditableDatumLabel() override;
 
     void activate();
@@ -63,13 +69,15 @@ public:
     void setPoints(SbVec3f p1, SbVec3f p2);
     void setPoints(Base::Vector3d p1, Base::Vector3d p2);
     void setFocusToSpinbox();
-    void setLabelType(SoDatumLabel::Type type);
+    void setLabelType(SoDatumLabel::Type type, Function function = Function::Positioning);
     void setLabelDistance(double val);
     void setLabelStartAngle(double val);
     void setLabelRange(double val);
     void setLabelRecommendedDistance();
     void setLabelAutoDistanceReverse(bool val);
     void setSpinboxVisibleToMouse(bool val);
+
+    Function getFunction();
 
     // NOLINTBEGIN
     SoDatumLabel* label;
@@ -94,6 +102,8 @@ private:
     QuantitySpinBox* spinBox;
     SoNodeSensor* cameraSensor;
     SbVec3f midpos;
+
+    Function function;
 };
 
 }

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -460,6 +460,8 @@ SbVec3f SoDatumLabel::getLabelTextCenter()
     else if (datumtype.getValue() == SoDatumLabel::ANGLE) {
         return getLabelTextCenterAngle(p1);
     }
+
+    return p1;
 }
 
 SbVec3f SoDatumLabel::getLabelTextCenterDistance(const SbVec3f& p1, const SbVec3f& p2)

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -2520,6 +2520,8 @@ protected:
 
             return !arcInfo.isRadiusDoF();
         }
+
+        return false;
     }
 
     void restartCommand(const char* cstrName) {

--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -189,7 +189,12 @@ public:
         , keymanager(std::make_unique<DrawSketchKeyboardManager>())
     {}
 
-    ~DrawSketchController()
+    DrawSketchController(const DrawSketchController&) = delete;
+    DrawSketchController(DrawSketchController&&) = delete;
+    bool operator=(const DrawSketchController&) = delete;
+    bool operator=(DrawSketchController&&) = delete;
+
+    virtual ~DrawSketchController()
     {}
 
     /** @name functions NOT intended for specialisation offering a NVI for extension */

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultWidgetController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultWidgetController.h
@@ -117,7 +117,7 @@ public:
         : ControllerBase(dshandler)
     {}
 
-    ~DrawSketchDefaultWidgetController()
+    ~DrawSketchDefaultWidgetController() override
     {
         connectionParameterValueChanged.disconnect();
         connectionCheckboxCheckedChanged.disconnect();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLine.h
@@ -306,11 +306,17 @@ void DSHLineController::configureToolWidget()
     onViewParameters[OnViewParameter::Second]->setLabelType(Gui::SoDatumLabel::DISTANCEY);
 
     if (handler->constructionMethod() == ConstructionMethod::OnePointLengthAngle) {
-        onViewParameters[OnViewParameter::Fourth]->setLabelType(Gui::SoDatumLabel::ANGLE);
+        onViewParameters[OnViewParameter::Fourth]->setLabelType(
+            Gui::SoDatumLabel::ANGLE,
+            Gui::EditableDatumLabel::Function::Dimensioning);
     }
     else {
-        onViewParameters[OnViewParameter::Third]->setLabelType(Gui::SoDatumLabel::DISTANCEX);
-        onViewParameters[OnViewParameter::Fourth]->setLabelType(Gui::SoDatumLabel::DISTANCEY);
+        onViewParameters[OnViewParameter::Third]->setLabelType(
+            Gui::SoDatumLabel::DISTANCEX,
+            Gui::EditableDatumLabel::Function::Dimensioning);
+        onViewParameters[OnViewParameter::Fourth]->setLabelType(
+            Gui::SoDatumLabel::DISTANCEY,
+            Gui::EditableDatumLabel::Function::Dimensioning);
     }
 }
 
@@ -392,11 +398,11 @@ void DSHLineController::adaptParameters(Base::Vector2d onSketchPos)
     switch (handler->state()) {
         case SelectMode::SeekFirst: {
             if (!onViewParameters[OnViewParameter::First]->isSet) {
-                onViewParameters[OnViewParameter::First]->setSpinboxValue(onSketchPos.x);
+                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
             }
 
             if (!onViewParameters[OnViewParameter::Second]->isSet) {
-                onViewParameters[OnViewParameter::Second]->setSpinboxValue(onSketchPos.y);
+                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
             }
 
             bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
@@ -414,11 +420,11 @@ void DSHLineController::adaptParameters(Base::Vector2d onSketchPos)
                 Base::Vector3d vec = end - start;
 
                 if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    onViewParameters[OnViewParameter::Third]->setSpinboxValue(vec.x);
+                    setOnViewParameterValue(OnViewParameter::Third, vec.x);
                 }
 
                 if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    onViewParameters[OnViewParameter::Fourth]->setSpinboxValue(vec.y);
+                    setOnViewParameterValue(OnViewParameter::Fourth, vec.y);
                 }
 
                 bool sameSign = vec.x * vec.y > 0.;
@@ -435,13 +441,14 @@ void DSHLineController::adaptParameters(Base::Vector2d onSketchPos)
                 Base::Vector3d vec = end - start;
 
                 if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    onViewParameters[OnViewParameter::Third]->setSpinboxValue(vec.Length());
+                    setOnViewParameterValue(OnViewParameter::Third, vec.Length());
                 }
 
                 double range = (handler->endPoint - handler->startPoint).Angle();
                 if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    onViewParameters[OnViewParameter::Fourth]->setSpinboxValue(range * 180 / M_PI,
-                                                                               Base::Unit::Angle);
+                    setOnViewParameterValue(OnViewParameter::Fourth,
+                                            range * 180 / M_PI,
+                                            Base::Unit::Angle);
                 }
 
                 onViewParameters[OnViewParameter::Third]->setPoints(start, end);
@@ -450,11 +457,11 @@ void DSHLineController::adaptParameters(Base::Vector2d onSketchPos)
             }
             else {
                 if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    onViewParameters[OnViewParameter::Third]->setSpinboxValue(onSketchPos.x);
+                    setOnViewParameterValue(OnViewParameter::Third, onSketchPos.x);
                 }
 
                 if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    onViewParameters[OnViewParameter::Fourth]->setSpinboxValue(onSketchPos.y);
+                    setOnViewParameterValue(OnViewParameter::Fourth, onSketchPos.y);
                 }
 
                 bool sameSign = onSketchPos.x * onSketchPos.y > 0.;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -1140,7 +1140,7 @@ void DSHOffsetController::adaptParameters(Base::Vector2d onSketchPos)
     switch (handler->state()) {
         case SelectMode::SeekFirst: {
             if (!onViewParameters[OnViewParameter::First]->isSet) {
-                onViewParameters[OnViewParameter::First]->setSpinboxValue(handler->offsetLength);
+                setOnViewParameterValue(OnViewParameter::First, handler->offsetLength);
             }
 
             onViewParameters[OnViewParameter::First]->setPoints(

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -190,11 +190,11 @@ void DSHPointController::adaptParameters(Base::Vector2d onSketchPos)
     switch (handler->state()) {
         case SelectMode::SeekFirst: {
             if (!onViewParameters[OnViewParameter::First]->isSet) {
-                onViewParameters[OnViewParameter::First]->setSpinboxValue(onSketchPos.x);
+                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
             }
 
             if (!onViewParameters[OnViewParameter::Second]->isSet) {
-                onViewParameters[OnViewParameter::Second]->setSpinboxValue(onSketchPos.y);
+                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
             }
 
             bool sameSign = onSketchPos.x * onSketchPos.y > 0.;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -369,11 +369,11 @@ void DSHPolygonController::adaptParameters(Base::Vector2d onSketchPos)
     switch (handler->state()) {
         case SelectMode::SeekFirst: {
             if (!onViewParameters[OnViewParameter::First]->isSet) {
-                onViewParameters[OnViewParameter::First]->setSpinboxValue(onSketchPos.x);
+                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
             }
 
             if (!onViewParameters[OnViewParameter::Second]->isSet) {
-                onViewParameters[OnViewParameter::Second]->setSpinboxValue(onSketchPos.y);
+                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
             }
 
             bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
@@ -390,13 +390,14 @@ void DSHPolygonController::adaptParameters(Base::Vector2d onSketchPos)
             Base::Vector3d vec = end - start;
 
             if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                onViewParameters[OnViewParameter::Third]->setSpinboxValue(vec.Length());
+                setOnViewParameterValue(OnViewParameter::Third, vec.Length());
             }
 
             double range = (handler->firstCorner - handler->centerPoint).Angle();
             if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                onViewParameters[OnViewParameter::Fourth]->setSpinboxValue(range * 180 / M_PI,
-                                                                           Base::Unit::Angle);
+                setOnViewParameterValue(OnViewParameter::Fourth,
+                                        range * 180 / M_PI,
+                                        Base::Unit::Angle);
             }
 
             onViewParameters[OnViewParameter::Third]->setPoints(start, end);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRectangle.h
@@ -2005,11 +2005,11 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
     switch (handler->state()) {
         case SelectMode::SeekFirst: {
             if (!onViewParameters[OnViewParameter::First]->isSet) {
-                onViewParameters[OnViewParameter::First]->setSpinboxValue(onSketchPos.x);
+                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
             }
 
             if (!onViewParameters[OnViewParameter::Second]->isSet) {
-                onViewParameters[OnViewParameter::Second]->setSpinboxValue(onSketchPos.y);
+                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
             }
 
             bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
@@ -2025,12 +2025,12 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
                 || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
                 if (!onViewParameters[OnViewParameter::Third]->isSet) {
                     double length = handler->cornersReversed ? handler->width : handler->length;
-                    onViewParameters[OnViewParameter::Third]->setSpinboxValue(length);
+                    setOnViewParameterValue(OnViewParameter::Third, length);
                 }
 
                 if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
                     double width = handler->cornersReversed ? handler->length : handler->width;
-                    onViewParameters[OnViewParameter::Fourth]->setSpinboxValue(width);
+                    setOnViewParameterValue(OnViewParameter::Fourth, width);
                 }
 
                 Base::Vector3d start = toVector3d(handler->corner1);
@@ -2049,16 +2049,16 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
             }
             else if (handler->constructionMethod() == ConstructionMethod::ThreePoints) {
                 if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    onViewParameters[OnViewParameter::Third]->setSpinboxValue(handler->length);
+                    setOnViewParameterValue(OnViewParameter::Third, handler->length);
                 }
 
                 onViewParameters[OnViewParameter::Third]->setPoints(toVector3d(handler->corner4),
                                                                     toVector3d(handler->corner3));
 
                 if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    onViewParameters[OnViewParameter::Fourth]->setSpinboxValue(handler->angle * 180
-                                                                                   / M_PI,
-                                                                               Base::Unit::Angle);
+                    setOnViewParameterValue(OnViewParameter::Fourth,
+                                            handler->angle * 180 / M_PI,
+                                            Base::Unit::Angle);
                 }
 
                 onViewParameters[OnViewParameter::Fourth]->setPoints(toVector3d(handler->corner1),
@@ -2068,11 +2068,11 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
             }
             else {
                 if (!onViewParameters[OnViewParameter::Third]->isSet) {
-                    onViewParameters[OnViewParameter::Third]->setSpinboxValue(onSketchPos.x);
+                    setOnViewParameterValue(OnViewParameter::Third, onSketchPos.x);
                 }
 
                 if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
-                    onViewParameters[OnViewParameter::Fourth]->setSpinboxValue(onSketchPos.y);
+                    setOnViewParameterValue(OnViewParameter::Fourth, onSketchPos.y);
                 }
 
                 bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
@@ -2089,7 +2089,7 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
                 || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
                 if (handler->roundCorners) {
                     if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                        onViewParameters[OnViewParameter::Fifth]->setSpinboxValue(handler->radius);
+                        setOnViewParameterValue(OnViewParameter::Fifth, handler->radius);
                     }
 
                     Base::Vector3d center = handler->center3;
@@ -2104,8 +2104,7 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
                 }
                 else {
                     if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                        onViewParameters[OnViewParameter::Sixth]->setSpinboxValue(
-                            handler->thickness);
+                        setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
                     }
 
                     Base::Vector3d start = toVector3d(handler->corner3);
@@ -2122,8 +2121,8 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
                 bool notReversed = threePoints && !handler->cornersReversed;
 
                 if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
-                    onViewParameters[OnViewParameter::Fifth]->setSpinboxValue(
-                        notReversed ? handler->width : handler->length);
+                    setOnViewParameterValue(OnViewParameter::Fifth,
+                                            notReversed ? handler->width : handler->length);
                 }
 
                 Base::Vector3d start = toVector3d(handler->corner1);
@@ -2136,15 +2135,11 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
                 if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
                     if (threePoints) {
                         double val = handler->angle123 * 180 / M_PI;
-                        onViewParameters[OnViewParameter::Sixth]->setSpinboxValue(
-                            val,
-                            Base::Unit::Angle);
+                        setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
                     }
                     else {
                         double val = handler->angle412 * 180 / M_PI;
-                        onViewParameters[OnViewParameter::Sixth]->setSpinboxValue(
-                            val,
-                            Base::Unit::Angle);
+                        setOnViewParameterValue(OnViewParameter::Sixth, val, Base::Unit::Angle);
                     }
                 }
 
@@ -2172,7 +2167,7 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
             if (handler->constructionMethod() == ConstructionMethod::Diagonal
                 || handler->constructionMethod() == ConstructionMethod::CenterAndCorner) {
                 if (!onViewParameters[OnViewParameter::Sixth]->isSet) {
-                    onViewParameters[OnViewParameter::Sixth]->setSpinboxValue(handler->thickness);
+                    setOnViewParameterValue(OnViewParameter::Sixth, handler->thickness);
                 }
 
                 Base::Vector3d start = toVector3d(handler->corner3);
@@ -2183,8 +2178,7 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
             else {
                 if (handler->roundCorners) {
                     if (!onViewParameters[OnViewParameter::Seventh]->isSet) {
-                        onViewParameters[OnViewParameter::Seventh]->setSpinboxValue(
-                            handler->radius);
+                        setOnViewParameterValue(OnViewParameter::Seventh, handler->radius);
                     }
 
                     Base::Vector3d center = handler->center3;
@@ -2199,8 +2193,7 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
                 }
                 else {
                     if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
-                        onViewParameters[OnViewParameter::Eighth]->setSpinboxValue(
-                            handler->thickness);
+                        setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
                     }
 
                     Base::Vector3d start = toVector3d(handler->corner3);
@@ -2213,7 +2206,7 @@ void DSHRectangleController::adaptParameters(Base::Vector2d onSketchPos)
         } break;
         case SelectMode::SeekFifth: {
             if (!onViewParameters[OnViewParameter::Eighth]->isSet) {
-                onViewParameters[OnViewParameter::Eighth]->setSpinboxValue(handler->thickness);
+                setOnViewParameterValue(OnViewParameter::Eighth, handler->thickness);
             }
 
             Base::Vector3d start = toVector3d(handler->corner3);


### PR DESCRIPTION

Three modes controlled by parameter:
Grp: Preferences/Mod/Sketcher/Tools
Name: OnViewParameterVisibility

0 => disabled
1 => only dimensional OVP
2 => all OVP visible

OVP = On-View Parameters

DSHs need to mark whether an OVP is positioning or dimensional. It is done for DSH_Line. Others need follow.

There is a mode for dynamic overriding of default setting. This is yet unconnected pending deciding how to trigger it.