### PR TITLE
Correct #9377 issue with accuracy in AdditiveHelix

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -241,11 +241,7 @@ App::DocumentObjectExecReturn* Helix::execute()
             mkPS.SetTolerance(Precision::Confusion());
             mkPS.SetTransitionMode(BRepBuilderAPI_Transformed);
 
-            if (Angle.getValue() == 0) {
-                mkPS.SetMode(true);  //This is for frenet
-            } else {
-                mkPS.SetMode(TopoDS::Wire(auxpath), true);  // this is for auxiliary
-            }
+            mkPS.SetMode(TopoDS::Wire(auxpath), true);  // this is for auxiliary
 
             for (TopoDS_Wire& wire : wires) {
                 wire.Move(invObjLoc);

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -254,7 +254,7 @@ App::DocumentObjectExecReturn* Helix::execute()
 
         //check for error value at pipe creation and re-build if needed
         if (Angle.getValue() == 0 && mkPS.ErrorOnSurface() < Precision::Confusion() / 2.0 ) {
-            Base::Console().Log("PartDesign_Helix : Fail back to auxiliary mode\n");
+            Base::Console().Log("PartDesign_Helix : Fall back to auxiliary mode\n");
             mkPS.SetMode(TopoDS::Wire(auxpath), true);
             mkPS.Build();
         }

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -240,10 +240,10 @@ App::DocumentObjectExecReturn* Helix::execute()
             mkPS.Add(wire);
         }
 
-        mkPS.Build();
-
         if (!mkPS.IsReady())
             return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Could not build"));
+
+        mkPS.Build();
 
         if (!mkPS.MakeSolid())
             return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Could not make solid helix with open wire"));

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -254,12 +254,9 @@ App::DocumentObjectExecReturn* Helix::execute()
             shells.push_back(mkPS.Shape());
 
             if (!mkPS.Shape().Closed()) {
-                // shell is not closed - use simulate to get the end wires
-                TopTools_ListOfShape sim;
-                mkPS.Simulate(2, sim);
-
-                frontwires.push_back(TopoDS::Wire(sim.First()));
-                backwires.push_back(TopoDS::Wire(sim.Last()));
+                // shell is not closed - get the end wires
+                frontwires.push_back(TopoDS::Wire(mkPS.FirstShape()));
+                backwires.push_back(TopoDS::Wire(mkPS.LastShape()));
             }
         }
 


### PR DESCRIPTION
After much instrumenting and trial and error, it appears we set the wrong mode when the angle is zero.  Not clear if there was some past version of the library that needed the special case removed here.  Also cleaned up a little unneeded code.

This should fix #9377