### PR TITLE
[TechDraw] Fixes #6527 - Implement face transparency

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -80,21 +80,15 @@ QGIFace::QGIFace(int index) :
     getParameters();
 
     // set up style & colour defaults
-    App::Color temp {static_cast<uint32_t>(Preferences::getPreferenceGroup("Colors")->GetUnsigned("FaceColor",0xffffffff))};
-    setFillColor(temp.asValue<QColor>());
-    m_colDefFill = temp.asValue<QColor>();
+    m_colDefFill = App::Color(static_cast<uint32_t>(Preferences::getPreferenceGroup("Colors")->GetUnsigned("FaceColor", 0xFFFFFF)))
+                   .asValue<QColor>();
+    m_colDefFill.setAlpha(Preferences::getPreferenceGroup("Colors")->GetBool("ClearFace", false) ? 0 : 255);
+
     m_fillDef = Qt::SolidPattern;
     m_fillSelect = Qt::SolidPattern;
 
-    if (m_defClearFace) {
-        setFillMode(NoFill);
-        m_colDefFill = Qt::transparent;
-        setFill(Qt::transparent, m_fillDef);
-    } else {
-        setFillMode(PlainFill);
-        m_colDefFill = Qt::white;
-        setFill(m_colDefFill, m_fillDef);
-    }
+    setFillMode(m_colDefFill.alpha() ? PlainFill : NoFill);
+    setFill(m_colDefFill, m_fillDef);
 
     m_sharedRender = new QSvgRenderer();
     m_patMaker = new PATPathMaker(this, 1.0, 1.0);
@@ -425,8 +419,6 @@ void QGIFace::getParameters()
 {
     m_maxSeg = Preferences::getPreferenceGroup("PAT")->GetInt("MaxSeg", 10000l);
     m_maxTile = Preferences::getPreferenceGroup("Decorations")->GetInt("MaxSVGTile", 10000l);
-
-    m_defClearFace = Preferences::getPreferenceGroup("Colors")->GetBool("ClearFace", false);
 }
 
 QRectF QGIFace::boundingRect() const

--- a/src/Mod/TechDraw/Gui/QGIFace.h
+++ b/src/Mod/TechDraw/Gui/QGIFace.h
@@ -159,7 +159,7 @@ private:
 
     QColor m_geomColor;                        //color for crosshatch lines
     double m_geomWeight;                       //lineweight for crosshatch lines
-    bool m_defClearFace;
+
     QColor m_defFaceColor;
 
     double m_hatchRotation;

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -192,14 +192,23 @@ void QGIViewPart::drawAllFaces(void)
     // dvp already validated
     auto dvp(static_cast<TechDraw::DrawViewPart*>(getViewObject()));
 
+    QColor faceColor;
+    auto vpp = dynamic_cast<ViewProviderViewPart *>(getViewProvider(getViewObject()));
+    if (vpp) {
+        faceColor = vpp->FaceColor.getValue().asValue<QColor>();
+        faceColor.setAlpha((100 - vpp->FaceTransparency.getValue())*255/100);
+    }
+
     std::vector<TechDraw::DrawHatch*> regularHatches = dvp->getHatches();
     std::vector<TechDraw::DrawGeomHatch*> geomHatches = dvp->getGeomHatches();
     const std::vector<TechDraw::FacePtr>& faceGeoms = dvp->getFaceGeometry();
     int iFace(0);
     for (auto& face : faceGeoms) {
         QGIFace* newFace = drawFace(face, iFace);
-        newFace->isHatched(false);
-        newFace->setFillMode(QGIFace::PlainFill);
+        if (faceColor.isValid()) {
+            newFace->setFillColor(faceColor);
+            newFace->setFillMode(faceColor.alpha() ? QGIFace::PlainFill : QGIFace::NoFill);
+        }
 
         TechDraw::DrawHatch* fHatch = faceIsHatched(iFace, regularHatches);
         TechDraw::DrawGeomHatch* fGeom = faceIsGeomHatched(iFace, geomHatches);

--- a/src/Mod/TechDraw/Gui/QGIViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSection.cpp
@@ -56,10 +56,10 @@ void QGIViewSection::drawSectionFace()
         return;
     }
 
-    Gui::ViewProvider* gvp = QGIView::getViewProvider(section);
-    ViewProviderViewSection* sectionVp = dynamic_cast<ViewProviderViewSection*>(gvp);
-    if (!sectionVp || !sectionVp->ShowCutSurface.getValue())
+    ViewProviderViewSection* sectionVp = dynamic_cast<ViewProviderViewSection*>(QGIView::getViewProvider(section));
+    if (!sectionVp) {
         return;
+    }
 
     auto sectionFaces( section->getTDFaceGeometry() );
     if (sectionFaces.empty()) {
@@ -83,12 +83,14 @@ void QGIViewSection::drawSectionFace()
 
         if (section->CutSurfaceDisplay.isValue("Hide")) {
             return;
-        } else if (section->CutSurfaceDisplay.isValue("Color")) {
-            newFace->isHatched(false);
-            newFace->setFillMode(QGIFace::PlainFill);
-            QColor faceColor = (sectionVp->CutSurfaceColor.getValue()).asValue<QColor>();
-            newFace->setFillColor(faceColor);
-            newFace->setFillStyle(Qt::SolidPattern);
+        }
+
+        QColor faceColor = (sectionVp->CutSurfaceColor.getValue()).asValue<QColor>();
+        faceColor.setAlpha((100 - sectionVp->CutSurfaceTransparency.getValue())*255/100);
+        newFace->setFillColor(faceColor);
+
+        if (section->CutSurfaceDisplay.isValue("Color")) {
+            newFace->setFillMode(faceColor.alpha() ? QGIFace::PlainFill : QGIFace::NoFill);
         } else if (section->CutSurfaceDisplay.isValue("SvgHatch")) {
             newFace->setFillMode(QGIFace::SvgFill);
             newFace->setHatchColor(sectionVp->HatchColor.getValue());

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -73,6 +73,8 @@ const char* ViewProviderViewPart::LineStyleEnums[] = { "NoLine",
                                                   "DashDotDot",
                                                   nullptr };
 
+const App::PropertyIntegerConstraint::Constraints intPercent = { 0, 100, 5 };
+
 //**************************************************************************
 // Construction/Destruction
 
@@ -84,6 +86,7 @@ ViewProviderViewPart::ViewProviderViewPart()
     static const char *dgroup = "Decoration";
     static const char *hgroup = "Highlight";
     static const char *sgroup = "Section Line";
+    static const char *fgroup = "Faces";
 
     //default line weights
 
@@ -127,6 +130,13 @@ ViewProviderViewPart::ViewProviderViewPart()
     ADD_PROPERTY_TYPE(HighlightAdjust, (0.0), hgroup, App::Prop_None, "Adjusts the rotation of the Detail highlight");
 
     ADD_PROPERTY_TYPE(ShowAllEdges ,(false)    ,dgroup, App::Prop_None, "Temporarily show invisible lines");
+
+    // Faces related properties
+    ADD_PROPERTY_TYPE(FaceColor, (Preferences::getPreferenceGroup("Colors")->GetUnsigned("FaceColor", 0xFFFFFF)),
+                      fgroup, App::Prop_None, "Set color of faces");
+    ADD_PROPERTY_TYPE(FaceTransparency, (Preferences::getPreferenceGroup("Colors")->GetBool("ClearFace", false) ? 100 : 0),
+                      fgroup, App::Prop_None, "Set transparency of faces");
+    FaceTransparency.setConstraints(&intPercent);
 }
 
 ViewProviderViewPart::~ViewProviderViewPart()
@@ -159,8 +169,10 @@ void ViewProviderViewPart::onChanged(const App::Property* prop)
         prop == &(SectionLineMarks) ||
         prop == &(HighlightLineStyle) ||
         prop == &(HighlightLineColor) ||
-        prop == &(HorizCenterLine)  ||
-        prop == &(VertCenterLine) ) {
+        prop == &(HorizCenterLine) ||
+        prop == &(VertCenterLine)  ||
+        prop == &(FaceColor) ||
+        prop == &(FaceTransparency)) {
         // redraw QGIVP
         QGIView* qgiv = getQView();
         if (qgiv) {

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
@@ -60,6 +60,8 @@ public:
     App::PropertyColor  HighlightLineColor;
     App::PropertyFloat  HighlightAdjust;
     App::PropertyBool   ShowAllEdges;
+    App::PropertyColor   FaceColor;
+    App::PropertyPercent FaceTransparency;
 
     static const char* LineStyleEnums[];
 

--- a/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
@@ -52,17 +52,23 @@ using namespace TechDrawGui;
 
 PROPERTY_SOURCE(TechDrawGui::ViewProviderViewSection, TechDrawGui::ViewProviderViewPart)
 
+const App::PropertyIntegerConstraint::Constraints intPercent = { 0, 100, 5 };
+
 //**************************************************************************
 // Construction/Destruction
 
 ViewProviderViewSection::ViewProviderViewSection()
 {
-    static const char *sgroup = "Cut Surface";
+    static const char *fgroup = "Faces";
     static const char *hgroup = "Surface Hatch";
     sPixmap = "TechDraw_TreeSection";
-    //ShowCutSurface is obsolete - use CutSurfaceDisplay
-    ADD_PROPERTY_TYPE(ShowCutSurface ,(true), sgroup, App::Prop_Hidden, "Show/hide the cut surface");
-    ADD_PROPERTY_TYPE(CutSurfaceColor, (0.0, 0.0, 0.0), sgroup, App::Prop_None, "The color to shade the cut surface");
+
+    ADD_PROPERTY_TYPE(CutSurfaceColor, (Preferences::getPreferenceGroup("Colors")->GetUnsigned("FaceColor", 0xFFFFFF)),
+                      fgroup, App::Prop_None, "Set color of the cut surface");
+    ADD_PROPERTY_TYPE(CutSurfaceTransparency, (Preferences::getPreferenceGroup("Colors")->GetBool("ClearFace", false) ? 100 : 0),
+                      fgroup, App::Prop_None, "Set transparency of the cut surface");
+    CutSurfaceTransparency.setConstraints(&intPercent);
+
     //HatchCutSurface is obsolete - use CutSurfaceDisplay
     ADD_PROPERTY_TYPE(HatchCutSurface ,(false), hgroup, App::Prop_Hidden, "Hatch the cut surface");
 
@@ -88,8 +94,8 @@ void ViewProviderViewSection::onChanged(const App::Property* prop)
 //        prop == &HatchCutSurface ||
         prop == &HatchColor      ||
         prop == &GeomHatchColor      ||
-//        prop == &ShowCutSurface  ||
-        prop == &CutSurfaceColor ) {
+        prop == &CutSurfaceColor ||
+        prop == &CutSurfaceTransparency) {
         updateGraphic();
     }
 

--- a/src/Mod/TechDraw/Gui/ViewProviderViewSection.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewSection.h
@@ -43,8 +43,9 @@ public:
     /// destructor
     ~ViewProviderViewSection() override;
 
-    App::PropertyBool   ShowCutSurface;        //obsolete - use CutSurfaceDisplay
-    App::PropertyColor  CutSurfaceColor;
+    App::PropertyColor   CutSurfaceColor;
+    App::PropertyPercent CutSurfaceTransparency;
+
     App::PropertyBool   HatchCutSurface;       //obsolete - use CutSurfaceDisplay
     App::PropertyColor  HatchColor;
     App::PropertyColor  GeomHatchColor;


### PR DESCRIPTION
This pull request implements #6527 with the possibility to set color and transparency of faces per view. The default color and transparency are obtained from TechDraw Preferences - Color - (Transparent) Faces setting. On top of that, also the color and transparency of the section cut surface can be set independently of the color of the faces.

For transparency values 0 (opaque) and 100 (invisible) everything works perfectly. However because the transparency can be set as a percentage (identically what the 3D view allows), there are some issues, which can not be easily resolved. Let's inspect the figure below, all views have faces color set to blue rgb(0, 0, 255) and transparency to 50%:

![Transparency](https://github.com/FreeCAD/FreeCAD/assets/25648708/597ffe34-e6d8-4ba1-83a9-e288cb204f5d)
-  View1 is drawn as desired and expected. There are no problems with single face views.

- View2 consists of 3 faces. Left, right and the "big" one hidden underneath, covering the area of both mentioned before. The color is darker than for View1, because left and right faces are drawn on top of the big face. To get the same look as  View1 has, we would need to increase the transparency to values around 70%.

- View3 is a view of a thick frame. It consists of 2 faces, the large one (outer border) and the small one (inner border). Because the small face is drawn on the top of the large face, the inner square is darker than the outer one. Unfortunately, there is no way around this, as long as the large face covers the whole area of the inner face.

With regards to these limitations, I believe the pull request overall increases the TechDraw abilities and the benefits prevail the known issues.

If you find any other problem than the one discussed above, please let me know.