### PR TITLE
[Sketcher] Group Trim/extend/split.

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -1666,6 +1666,37 @@ bool CmdSketcherSplit::isActive()
     return isCommandActive(getActiveGuiDocument());
 }
 
+// Comp for curve edition tools =======================================================
+
+class CmdSketcherCompCurveEdition: public Gui::GroupCommand
+{
+public:
+    CmdSketcherCompCurveEdition()
+        : GroupCommand("Sketcher_CompCurveEdition")
+    {
+        sAppModule = "Sketcher";
+        sGroup = "Sketcher";
+        sMenuText = QT_TR_NOOP("Curve Edition");
+        sToolTipText = QT_TR_NOOP("Curve Edition tools.");
+        sWhatsThis = "Sketcher_CompCurveEdition";
+        sStatusTip = sToolTipText;
+        eType = ForEdit;
+
+        setCheckable(false);
+
+        addCommand("Sketcher_Trimming");
+        addCommand("Sketcher_Split");
+        addCommand("Sketcher_Extend");
+    }
+
+    const char* className() const override
+    {
+        return "CmdSketcherCompCurveEdition";
+    }
+};
+
+// ======================================================================================
+
 DEF_STD_CMD_A(CmdSketcherExternal)
 
 CmdSketcherExternal::CmdSketcherExternal()
@@ -2208,6 +2239,7 @@ void CreateSketcherCommandsCreateGeo()
     rcCmdMgr.addCommand(new CmdSketcherTrimming());
     rcCmdMgr.addCommand(new CmdSketcherExtend());
     rcCmdMgr.addCommand(new CmdSketcherSplit());
+    rcCmdMgr.addCommand(new CmdSketcherCompCurveEdition());
     rcCmdMgr.addCommand(new CmdSketcherExternal());
     rcCmdMgr.addCommand(new CmdSketcherCarbonCopy());
 }

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -369,6 +369,23 @@ inline void SketcherAddWorkspaceFillets<Gui::ToolBarItem>(Gui::ToolBarItem& geom
 }
 
 template<typename T>
+void SketcherAddWorkspaceCurveEdition(T& geom);
+
+template<>
+inline void SketcherAddWorkspaceCurveEdition<Gui::MenuItem>(Gui::MenuItem& geom)
+{
+    geom << "Sketcher_Trimming"
+         << "Sketcher_Extend"
+         << "Sketcher_Split";
+}
+
+template<>
+inline void SketcherAddWorkspaceCurveEdition<Gui::ToolBarItem>(Gui::ToolBarItem& geom)
+{
+    geom << "Sketcher_CompCurveEdition";
+}
+
+template<typename T>
 inline void SketcherAddWorkbenchGeometries(T& geom)
 {
     geom << "Sketcher_CreatePoint"
@@ -381,10 +398,8 @@ inline void SketcherAddWorkbenchGeometries(T& geom)
     geom << "Sketcher_CreateSlot"
          << "Separator";
     SketcherAddWorkspaceFillets(geom);
-    geom << "Sketcher_Trimming"
-         << "Sketcher_Extend"
-         << "Sketcher_Split"
-         << "Sketcher_External"
+    SketcherAddWorkspaceCurveEdition(geom);
+    geom << "Sketcher_External"
          << "Sketcher_CarbonCopy"
          << "Sketcher_ToggleConstruction"
         /*<< "Sketcher_CreateText"*/


### PR DESCRIPTION
Create a command group for trim extend split.
The goal is to reduce the size of toolbars (https://github.com/FreeCAD/FreeCAD/issues/11208).