### PR TITLE
Draft: Improve grid behavior

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -30,20 +30,20 @@
     <number>9</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="groupBox_1">
      <property name="title">
       <string>Snapping</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_1">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_11">
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
         <item>
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox">
+         <widget class="Gui::PrefCheckBox" name="checkBox_alwaysSnap">
           <property name="toolTip">
-           <string>If this is checked, snapping is activated without the need to press the snap mod key</string>
+           <string>If checked, snapping is activated without the need to press the Snap mod key</string>
           </property>
           <property name="text">
-           <string>Always snap (disable snap mod)</string>
+           <string>Always snap</string>
           </property>
           <property name="checked">
            <bool>true</bool>
@@ -59,29 +59,102 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QLabel" name="label_20">
+         <widget class="QLabel" name="label_modsnap">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="text">
-           <string>Constrain mod</string>
+           <string>Snap mod</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_5">
+         <spacer name="horizontalSpacer_1">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>0</height>
            </size>
           </property>
          </spacer>
         </item>
         <item>
-         <widget class="Gui::PrefComboBox" name="gui::prefcombobox_5">
+         <widget class="Gui::PrefComboBox" name="comboBox_modsnap">
+          <property name="minimumSize">
+           <size>
+            <width>140</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>The Snap modifier key</string>
+          </property>
+          <property name="currentIndex">
+           <number>1</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>modsnap</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+          <item>
+           <property name="text">
+            <string>Shift</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Ctrl</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Alt</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="label_modconstrain">
+          <property name="text">
+           <string>Constrain mod</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="comboBox_modconstrain">
+          <property name="minimumSize">
+           <size>
+            <width>140</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="toolTip">
            <string>The Constraining modifier key</string>
           </property>
@@ -113,9 +186,9 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
-         <widget class="QLabel" name="label_21">
+         <widget class="QLabel" name="label_modalt">
           <property name="text">
-           <string>Snap mod</string>
+           <string>Alt mod</string>
           </property>
          </widget>
         </item>
@@ -127,70 +200,21 @@
           <property name="sizeHint" stdset="0">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>0</height>
            </size>
           </property>
          </spacer>
         </item>
         <item>
-         <widget class="Gui::PrefComboBox" name="gui::prefcombobox_6">
-          <property name="toolTip">
-           <string>The snap modifier key</string>
-          </property>
-          <property name="currentIndex">
-           <number>1</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>modsnap</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>Shift</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Ctrl</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Alt</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="QLabel" name="label_22">
-          <property name="text">
-           <string>Alt mod</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_6">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
+         <widget class="Gui::PrefComboBox" name="comboBox_modalt">
+          <property name="minimumSize">
            <size>
-            <width>40</width>
-            <height>20</height>
+            <width>140</width>
+            <height>0</height>
            </size>
           </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefComboBox" name="gui::prefcombobox_7">
           <property name="toolTip">
-           <string>The Alt modifier key</string>
+           <string>The Alt modifier key. The function of this key depends on the command.</string>
           </property>
           <property name="currentIndex">
            <number>2</number>
@@ -221,14 +245,14 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_21">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_7">
+         <widget class="Gui::PrefCheckBox" name="checkBox_showSnapBar">
           <property name="toolTip">
            <string>If checked, the Snap toolbar will be shown whenever you use snapping</string>
           </property>
           <property name="text">
-           <string>Show Draft Snap toolbar</string>
+           <string>Show Draft snap toolbar</string>
           </property>
           <property name="checked">
            <bool>true</bool>
@@ -246,9 +270,12 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_9">
+         <widget class="Gui::PrefCheckBox" name="checkBox_hideSnapBar">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
           <property name="text">
-           <string>Hide Draft snap toolbar after use</string>
+           <string>If checked, the Draft snap toolbar is hidden after use</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>hideSnapBar</cstring>
@@ -261,43 +288,19 @@
        </layout>
       </item>
      </layout>
-     <zorder/>
-     <zorder/>
-     <zorder/>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Grid</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_2">
+       <widget class="Gui::PrefCheckBox" name="checkBox_alwaysShowGrid">
         <property name="toolTip">
-         <string>If checked, a grid will appear when drawing</string>
-        </property>
-        <property name="text">
-         <string>Use grid</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>grid</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_10">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>If checked, the Draft grid will always be visible when the Draft workbench is active. Otherwise only when using a command</string>
+         <string>If checked, the grid will always be visible in new views.
+Use Draft ToggleGrid to change this for the active view.</string>
         </property>
         <property name="text">
          <string>Always show the grid</string>
@@ -314,7 +317,30 @@
        </widget>
       </item>
       <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox">
+       <widget class="Gui::PrefCheckBox" name="checkBox_grid">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>If checked, the grid will be visible during commands in new views.
+Use Draft ToggleGrid to change this for the active view.</string>
+        </property>
+        <property name="text">
+         <string>Show the grid during commands</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>grid</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_gridBorder">
         <property name="toolTip">
          <string>If checked, an additional border is displayed around the grid, showing the main square size in the bottom left border</string>
         </property>
@@ -333,9 +359,13 @@
        </widget>
       </item>
       <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_gridShowHuman">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, the outline of a human figure is displayed at the bottom left corner of the grid. This option is only effective if the BIM workbench is installed and if &amp;quot;Show grid border&amp;quot; option is enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>If checked, the outline of a human figure is displayed at the bottom left corner of the grid.
+This option is only effective if the BIM workbench is installed and if Show grid border is enabled.</string>
         </property>
         <property name="text">
          <string>Show human figure</string>
@@ -352,9 +382,10 @@
        </widget>
       </item>
       <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_2">
+       <widget class="Gui::PrefCheckBox" name="checkBox_coloredGridAxes">
         <property name="toolTip">
-         <string>If set, the grid will have its two main axes colored in red, green or blue when they match global axes</string>
+         <string>If checked, the two main axes of the grid will be colored red, green or blue
+if they match the X, Y or Z axis of the global coordinate system</string>
         </property>
         <property name="text">
          <string>Use colored axes</string>
@@ -371,40 +402,37 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_13">
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
         <item>
-         <widget class="QLabel" name="label_16">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
+         <widget class="QLabel" name="label_gridEvery">
           <property name="text">
            <string>Main lines every</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_8">
+         <spacer name="horizontalSpacer_4">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>0</height>
            </size>
           </property>
          </spacer>
         </item>
         <item>
-         <widget class="Gui::PrefSpinBox" name="gui::prefspinbox_5">
-          <property name="enabled">
-           <bool>true</bool>
+         <widget class="Gui::PrefSpinBox" name="spinBox_gridEvery">
+          <property name="minimumSize">
+           <size>
+            <width>140</width>
+            <height>0</height>
+           </size>
           </property>
           <property name="toolTip">
-           <string>Mainlines will be drawn thicker. Specify here how many squares between mainlines.</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <string>The number of squares between main grid lines. These lines are thicker than normal grid lines.</string>
           </property>
           <property name="value">
            <number>10</number>
@@ -420,40 +448,37 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_10">
+       <layout class="QHBoxLayout" name="horizontalLayout_8">
         <item>
-         <widget class="QLabel" name="label_15">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
+         <widget class="QLabel" name="label_gridSpacing">
           <property name="text">
            <string>Grid spacing</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_7">
+         <spacer name="horizontalSpacer_5">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>0</height>
            </size>
           </property>
          </spacer>
         </item>
         <item>
-         <widget class="Gui::PrefQuantitySpinBox" name="gui::prefdoublespinbox_3">
-          <property name="enabled">
-           <bool>true</bool>
+         <widget class="Gui::PrefQuantitySpinBox" name="spinBox_gridSpacing">
+          <property name="minimumSize">
+           <size>
+            <width>140</width>
+            <height>0</height>
+           </size>
           </property>
           <property name="toolTip">
-           <string>The spacing between each grid line</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <string>The distance between grid lines</string>
           </property>
           <property name="decimals">
            <number>4</number>
@@ -478,34 +503,37 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
         <item>
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="label_gridSize">
           <property name="text">
            <string>Grid size</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer">
+         <spacer name="horizontalSpacer_6">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>0</height>
            </size>
           </property>
          </spacer>
         </item>
         <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox">
-          <property name="toolTip">
-           <string>The number of horizontal or vertical lines of the grid</string>
+         <widget class="Gui::PrefSpinBox" name="spinBox_gridSize">
+          <property name="minimumSize">
+           <size>
+            <width>140</width>
+            <height>0</height>
+           </size>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <property name="toolTip">
+           <string>The number of horizontal and vertical lines of the grid</string>
           </property>
           <property name="suffix">
            <string> lines</string>
@@ -527,29 +555,35 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
         <item>
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="label_gridColor_gridTransparency">
           <property name="text">
            <string>Grid color and transparency</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_9">
+         <spacer name="horizontalSpacer_7">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>0</height>
            </size>
           </property>
          </spacer>
         </item>
         <item>
-         <widget class="Gui::PrefColorButton" name="gui::prefcolorbutton">
+         <widget class="Gui::PrefColorButton" name="colorButton_gridColor">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="toolTip">
            <string>The color of the grid</string>
           </property>
@@ -569,7 +603,13 @@
          </widget>
         </item>
         <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox_2">
+         <widget class="Gui::PrefSpinBox" name="spinBox_gridTransparency">
+          <property name="minimumSize">
+           <size>
+            <width>140</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="toolTip">
            <string>The overall transparency of the grid</string>
           </property>
@@ -590,61 +630,46 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="verticalGroupBox">
-     <property name="toolTip">
-      <string>Draft Edit preferences</string>
-     </property>
+    <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Edit</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_9">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_16" stretch="0,0,0">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_11">
         <item>
-         <widget class="QLabel" name="label_8">
+         <widget class="QLabel" name="label_DraftEditMaxObjects">
           <property name="toolTip">
            <string/>
           </property>
           <property name="text">
-           <string>Maximum number of contemporary edited objects</string>
+           <string>Maximum number of objects for Draft Edit</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_14">
+         <spacer name="horizontalSpacer_8">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>0</height>
            </size>
           </property>
          </spacer>
         </item>
         <item>
-         <widget class="Gui::PrefSpinBox" name="gui::prefspinbox_10">
-          <property name="enabled">
-           <bool>true</bool>
+         <widget class="Gui::PrefSpinBox" name="spinBox_DraftEditMaxObjects">
+          <property name="minimumSize">
+           <size>
+            <width>140</width>
+            <height>0</height>
+           </size>
           </property>
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets the maximum number of objects Draft Edit&lt;/p&gt;&lt;p&gt;can process at the same time&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <string>The maximum number of objects Draft Edit is allowed to process at the same time</string>
           </property>
           <property name="minimum">
            <number>1</number>
@@ -669,52 +694,40 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
         <item>
-         <widget class="QLabel" name="label_3">
+         <widget class="QLabel" name="label_DraftEditPickRadius">
           <property name="toolTip">
            <string/>
           </property>
           <property name="text">
-           <string>Draft edit pick radius</string>
+           <string>Pick radius for Draft Edit</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_4">
+         <spacer name="horizontalSpacer_9">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
             <width>40</width>
-            <height>20</height>
+            <height>0</height>
            </size>
           </property>
          </spacer>
         </item>
         <item>
-         <widget class="Gui::PrefSpinBox" name="gui::prefspinbox_4">
-          <property name="enabled">
-           <bool>true</bool>
+         <widget class="Gui::PrefSpinBox" name="spinBox_DraftEditPickRadius">
+          <property name="minimumSize">
+           <size>
+            <width>140</width>
+            <height>0</height>
+           </size>
           </property>
           <property name="toolTip">
-           <string>Controls pick radius of edit nodes</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <string>The pick radius (in pixels) of edit nodes</string>
           </property>
           <property name="minimum">
            <number>1</number>
@@ -736,13 +749,13 @@
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
+       <width>0</width>
        <height>40</height>
       </size>
      </property>
@@ -787,20 +800,34 @@
  <resources/>
  <connections>
   <connection>
-   <sender>gui::prefcheckbox_7</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>gui::prefcheckbox_9</receiver>
+   <sender>checkBox_alwaysSnap</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_modsnap</receiver>
+   <slot>setDisabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>checkBox_alwaysSnap</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>comboBox_modsnap</receiver>
+   <slot>setDisabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>checkBox_showSnapBar</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>checkBox_hideSnapBar</receiver>
    <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>158</x>
-     <y>290</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>400</x>
-     <y>293</y>
-    </hint>
-   </hints>
+  </connection>
+  <connection>
+   <sender>checkBox_alwaysShowGrid</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>checkBox_grid</receiver>
+   <slot>setDisabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>checkBox_gridBorder</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>checkBox_gridShowHuman</receiver>
+   <slot>setEnabled(bool)</slot>
   </connection>
  </connections>
 </ui>

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -335,8 +335,6 @@ class Edit(gui_base_original.Modifier):
             self.deformat_objects_after_editing(self.edited_objects)
 
         super(Edit, self).finish()
-        if Gui.Snapper.grid:
-            Gui.Snapper.grid.set()
         self.running = False
         # delay resetting edit mode otherwise it doesn't happen
         from PySide import QtCore

--- a/src/Mod/Draft/draftguitools/gui_grid.py
+++ b/src/Mod/Draft/draftguitools/gui_grid.py
@@ -31,9 +31,11 @@
 # @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
+import FreeCAD as App
 import FreeCADGui as Gui
-import draftguitools.gui_base as gui_base
+import WorkingPlane
 
+from draftguitools import gui_base
 from draftutils.translate import translate
 
 
@@ -48,34 +50,42 @@ class ToggleGrid(gui_base.GuiCommandSimplest):
     """
 
     def __init__(self):
-        super(ToggleGrid, self).__init__(name=translate("draft","Toggle grid"))
+        super().__init__(name=translate("draft", "Toggle grid"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
 
-        d = {'Pixmap': 'Draft_Grid',
-             'Accel': "G,R",
-             'MenuText': QT_TRANSLATE_NOOP("Draft_ToggleGrid","Toggle grid"),
-             'ToolTip': QT_TRANSLATE_NOOP("Draft_ToggleGrid","Toggles the Draft grid on and off."),
-             'CmdType': 'ForEdit'}
-
-        return d
+        return {"Pixmap": "Draft_Grid",
+                "Accel": "G, R",
+                "MenuText": QT_TRANSLATE_NOOP("Draft_ToggleGrid", "Toggle grid"),
+                "ToolTip": QT_TRANSLATE_NOOP("Draft_ToggleGrid",
+                                             "Toggles the Draft grid on and off."),
+                "CmdType": "ForEdit"}
 
     def Activated(self):
         """Execute when the command is called."""
-        super(ToggleGrid, self).Activated()
+        super().Activated()
 
-        if hasattr(Gui, "Snapper"):
-            Gui.Snapper.setTrackers(tool=True)
-            if Gui.Snapper.grid:
-                if Gui.Snapper.grid.Visible:
-                    Gui.Snapper.grid.off()
-                    Gui.Snapper.forceGridOff = True
-                else:
-                    Gui.Snapper.grid.on()
-                    Gui.Snapper.forceGridOff = False
+        if not hasattr(Gui, "Snapper"):
+            return
+        Gui.Snapper.setTrackers(update_grid=False)
+        grid = Gui.Snapper.grid
+        # This command is never set as App.activeDraftCommand.
+        cmdactive = hasattr(App, "activeDraftCommand") and App.activeDraftCommand
 
+        if grid.Visible:
+            grid.off()
+            grid.show_always = False
+            if cmdactive:
+                grid.show_during_command = False
+        elif cmdactive:
+            grid.on()
+            grid.show_during_command = True
+        else:
+            grid.on()
+            WorkingPlane.get_working_plane()
+            grid.show_always = True
 
-Gui.addCommand('Draft_ToggleGrid', ToggleGrid())
+Gui.addCommand("Draft_ToggleGrid", ToggleGrid())
 
 ## @}

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -1065,6 +1065,8 @@ class gridTracker(Tracker):
         s.addChild(texts)
 
         super().__init__(children=[s], name="gridTracker")
+        self.show_during_command = False
+        self.show_always = False
         self.reset()
 
     def getGridColor(self):
@@ -1245,8 +1247,7 @@ class gridTracker(Tracker):
         self.trans.translation.setValue([P.x, P.y, P.z])
         self.displayHumanFigure(wp)
         self.setAxesColor(wp)
-        if tool:
-            self.on()
+        self.on()
 
     def getClosestNode(self, point):
         """Return the closest node from the given point."""


### PR DESCRIPTION
This PR improves the behavior of the Draft grid:
* Options in the preferences: "Always show the grid" and "Show the grid during commands".
* The parameters are used for new views. In existing views the grid can be toggled either during a command or when no command is active.
* When switching to a different workbench all grids are hidden unless GridHideInOtherWorkbenches is set to `False`. This can be a Fine-tuning parameter IMO.

Notes:
* The defaultCameraHeight parameter becomes obsolete. It was only used in very specific circumstances.
* The code of PR #8818 becomes obsolete. It makes more sense to use `App.activeDraftCommand` instead of adding a `tool` argument to some functions. Will do some related cleanup later.
* Improved alignment for the related preference ui. The checkbox interaction has been fixed as well.
