### PR TITLE
Start: Fixed default time format

### DIFF
--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -126,7 +126,7 @@ def getInfo(filename):
     global iconbank, tempfolder
 
     tformat = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Start").GetString(
-        "TimeFormat", "%m/%d/%Y %H:%M:%S"
+        "TimeFormat", "%c"
     )
 
     def getLocalTime(timestamp):


### PR DESCRIPTION
Makes the tooltips of the start page items respect the locale time format
Fixes #10793