### PR TITLE
Gui: Do not add non-existing files to open recent menu

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -941,7 +941,10 @@ void RecentFilesAction::restore()
     std::vector<std::string> MRU = hGrp->GetASCIIs("MRU");
     QStringList files;
     for(const auto& it : MRU) {
-        files.append(QString::fromUtf8(it.c_str()));
+        auto filePath = QString::fromUtf8(it.c_str());
+        if (QFileInfo::exists(filePath)) {
+            files.append(filePath);
+        }
     }
     setFiles(files);
 }


### PR DESCRIPTION
It might happen that files stored in MRU list do not exist anymore e.g. have been deleted by the user from the file system.
In such a case they shouldn't be added to "Open recent" menu.

This PR fixes #11247 