### PR TITLE
[Python editor] match current indentation for next line when  pressin…

### DIFF
--- a/src/Gui/PythonEditor.h
+++ b/src/Gui/PythonEditor.h
@@ -66,6 +66,7 @@ protected:
     /** Pops up the context menu with some extensions */
     void contextMenuEvent ( QContextMenuEvent* e ) override;
     void drawMarker(int line, int x, int y, QPainter*) override;
+    void keyPressEvent(QKeyEvent *) override;
 
 private:
     //PythonSyntaxHighlighter* pythonSyntax;


### PR DESCRIPTION
…g enter key, addresses issue 5551.

The current python editor treats the enter key as a standard text editor, inserting a new line and a carriage return.  But in python coding it is beneficial that enter/return key should match the current line's indentation rather than require the user to tab/space over to the correct indent.  I have also added a feature that if the current line ends in a colon (:) then the next line also gets an additional indent.  The colon always signifies a new logical block, such as if: else: def function(): class name:, etc.

I have also added the feature that Shift+Enter should remove one indent from the next line.  Example usage:

```
if bool1: #enter would indent next line
    logic for bool1 goes here #Enter keeps this level of indentation for the next line
    logic for bool1 continues #Shift+Enter restores previous indentation, for example for the else: clause
else:
    logic for else goes here #Shift+Enter goes back to previous indentation
```
