### PR TITLE
WIP: TopoNaming Phase 3 (card 1.4 of 35+) Write unit tests covering Toposhape current behavior

### DIFF
--- a/tests/src/Mod/Part/App/CMakeLists.txt
+++ b/tests/src/Mod/Part/App/CMakeLists.txt
@@ -3,4 +3,5 @@ target_sources(
     Part_tests_run
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR}/TopoShape.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/TopoShape_static.cpp
 )

--- a/tests/src/Mod/Part/App/TopoShape.cpp
+++ b/tests/src/Mod/Part/App/TopoShape.cpp
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <TopoDS.hxx>
+#include "App/ComplexGeoData.h"
 #include "gtest/gtest.h"
 #include "Mod/Part/App/TopoShape.h"
 
@@ -15,7 +18,11 @@ protected:
         _declaredLoc1234.SetScale(gp_Pnt(1.0, 2.0, 3.0), 4.0);
         _testLocation1234 = TopLoc_Location(_declaredLoc1234);
 
-        _topoShape = Part::TopoShape();
+        gp_Pnt lowerLeftCornerOfBox(1.0, 2.0, 2.0);
+        BRepPrimAPI_MakeBox boxMaker(lowerLeftCornerOfBox, 10, 11, 12);
+        auto box = boxMaker.Shape();
+
+        _topoShape = Part::TopoShape(box);
     }
 
     void TearDown() override {
@@ -26,7 +33,6 @@ public:
     TopLoc_Location _testLocation1234;
     gp_Trsf _declaredLoc1234;
 };
-
 
 TEST_F(TopoShapeTest, setShapeGetShape)
 {
@@ -43,3 +49,68 @@ TEST_F(TopoShapeTest, setShapeGetShape)
     EXPECT_EQ(shapeSeen.Location().Transformation().ScaleFactor(), 4.0);
 }
 
+TEST_F(TopoShapeTest, impliedNamingOfSelf)
+{
+    // Arrange
+    auto silent = false;
+
+    // Act
+    auto generalName = _topoShape.shapeName(silent);
+    auto typeAndIndex = _topoShape.shapeTypeAndIndex("Solid");
+
+    // Assert
+    EXPECT_EQ(generalName, "Solid");
+    EXPECT_EQ(typeAndIndex.first, TopAbs_SOLID);
+    EXPECT_EQ(typeAndIndex.second, 0);
+}
+
+TEST_F(TopoShapeTest, pointsAndFaces)
+{
+    // Arrange
+    std::vector<Base::Vector3d> points;
+    std::vector<Data::ComplexGeoData::Facet> faces;
+    double accuracy(0.0);
+
+    // Act
+    _topoShape.getFaces(points, faces, accuracy); // box at 1,2,3 with dimensions 10,11,12
+
+    // Assert
+    auto thirdPoint = points[2];
+    auto thirdFace = faces[2];
+    EXPECT_EQ(points.size(), 8);
+    EXPECT_EQ(thirdPoint.x, 1);
+    EXPECT_EQ(thirdPoint.y, 11+2);
+    EXPECT_EQ(thirdPoint.z, 2);
+    EXPECT_EQ(faces.size(), 12);
+    EXPECT_EQ(thirdFace.I1, 4);
+    EXPECT_EQ(thirdFace.I2, 5);
+    EXPECT_EQ(thirdFace.I3, 6);
+}
+
+TEST_F(TopoShapeTest, faceNaming)
+{
+    // Arrange
+    std::vector<Base::Vector3d> points;
+    std::vector<Data::ComplexGeoData::Facet> faces;
+    double accuracy(0.0);
+    std::string face = "Face"; // force to string to enable proper std:find matching
+    std::string edge = "Edge";
+    std::string vertex = "Vertex";
+    _topoShape.getFaces(points, faces, accuracy); // box at 1,2,3 with dimensions 10,11,12
+
+    // Act
+    auto elementTypes = _topoShape.getElementTypes();
+    auto faceSubShapes = _topoShape.getSubShapes(TopAbs_FACE);
+    auto thirdFaceByType = faceSubShapes[2];
+
+    // Assert
+//    auto thirdPoint = points[2];
+    EXPECT_TRUE(
+        std::find(elementTypes.begin(), elementTypes.end(), face) != elementTypes.end());
+    EXPECT_TRUE(
+        std::find(elementTypes.begin(), elementTypes.end(), edge) != elementTypes.end());
+    EXPECT_TRUE(
+        std::find(elementTypes.begin(), elementTypes.end(), vertex) != elementTypes.end());
+    EXPECT_EQ(faceSubShapes.size(), 6);
+    EXPECT_EQ(faces.size(), 12);  // why is this twelve???
+}

--- a/tests/src/Mod/Part/App/TopoShape.cpp
+++ b/tests/src/Mod/Part/App/TopoShape.cpp
@@ -119,27 +119,23 @@ TEST_F(TopoShapeTest, faceBySimpleName)
 {
     // Arrange
     // NOTE: _topoShape is a box with lower-left corner at (1, 2, 3) of size (10, 11, 12)
+    std::vector<Base::Vector3d> points;
+    std::vector<Data::ComplexGeoData::Facet> faces;
     auto expectedNameForFace = Part::TopoShape::shapeName(TopAbs_FACE); // "Face"
 
     // Act
+    _topoShape.getFaces(points, faces, 0.0); // box at 1,2,3 with dimensions 10,11,12
     auto fourthPairRef = Part::TopoShape::getElementTypeAndIndex("Face4");
     auto fourthPairName = fourthPairRef.first.c_str();
     auto fourthPairIndex = fourthPairRef.second - 1;
-    auto fourthFace = _topoShape.getSubElement(fourthPairName, fourthPairIndex);
 
     // Assert
     EXPECT_EQ(fourthPairName, expectedNameForFace);
     EXPECT_EQ(fourthPairIndex, 3);
+    EXPECT_EQ(faces[fourthPairIndex].I1, 4);
+    EXPECT_EQ(faces[fourthPairIndex].I2, 6);
+    EXPECT_EQ(faces[fourthPairIndex].I3, 7);
 }
-
-// TODO: for later
-//    >>> d = App.getDocument("Unnamed");
-//    >>> obj = doc.getObject("Box")
-//    >>> shp = obj.Shape
-//    >>> sub = obj.getSubObject("Face2")
-//    >>> sub.BoundBox
-//            BoundBox (10, 0, 0, 10, 10, 10)
-//    >>>
 
     TEST_F(TopoShapeTest, getCharacteristics)
 {

--- a/tests/src/Mod/Part/App/TopoShape.cpp
+++ b/tests/src/Mod/Part/App/TopoShape.cpp
@@ -88,16 +88,16 @@ TEST_F(TopoShapeTest, pointsAndFaces)
     EXPECT_EQ(thirdFace.I3, 6);
 }
 
-TEST_F(TopoShapeTest, faceNaming)
+TEST_F(TopoShapeTest, facesAndFacets)
 {
     // Arrange
     std::vector<Base::Vector3d> points;
-    std::vector<Data::ComplexGeoData::Facet> faces;
+    std::vector<Data::ComplexGeoData::Facet> facets;
     double accuracy(0.0);
     std::string face = "Face"; // force to string to enable proper std:find matching
     std::string edge = "Edge";
     std::string vertex = "Vertex";
-    _topoShape.getFaces(points, faces, accuracy); // box at 1,2,3 with dimensions 10,11,12
+    _topoShape.getFaces(points, facets, accuracy); // box at 1,2,3 with dimensions 10,11,12
 
     // Act
     auto elementTypes = _topoShape.getElementTypes();
@@ -112,32 +112,13 @@ TEST_F(TopoShapeTest, faceNaming)
     EXPECT_TRUE(
         std::find(elementTypes.begin(), elementTypes.end(), vertex) != elementTypes.end());
     EXPECT_EQ(faceSubShapes.size(), 6); // 6 faces (both in/out facets included)
-    EXPECT_EQ(faces.size(), 12);  // 6 inward facing facets + 6 outward facing facets
+    EXPECT_EQ(facets.size(), 6*2);  // two triangular facets per rectangular face
+    EXPECT_EQ(points[facets[0].I1].x, 1);  // first facet of face0; the first point of the facet is origin (1, 2, 3)
+    EXPECT_EQ(points[facets[0].I1].y, 2);
+    EXPECT_EQ(points[facets[0].I1].z, 3);
 }
 
-TEST_F(TopoShapeTest, faceBySimpleName)
-{
-    // Arrange
-    // NOTE: _topoShape is a box with lower-left corner at (1, 2, 3) of size (10, 11, 12)
-    std::vector<Base::Vector3d> points;
-    std::vector<Data::ComplexGeoData::Facet> faces;
-    auto expectedNameForFace = Part::TopoShape::shapeName(TopAbs_FACE); // "Face"
-
-    // Act
-    _topoShape.getFaces(points, faces, 0.0); // box at 1,2,3 with dimensions 10,11,12
-    auto fourthPairRef = Part::TopoShape::getElementTypeAndIndex("Face4");
-    auto fourthPairName = fourthPairRef.first.c_str();
-    auto fourthPairIndex = fourthPairRef.second - 1;
-
-    // Assert
-    EXPECT_EQ(fourthPairName, expectedNameForFace);
-    EXPECT_EQ(fourthPairIndex, 3);
-    EXPECT_EQ(faces[fourthPairIndex].I1, 4);
-    EXPECT_EQ(faces[fourthPairIndex].I2, 6);
-    EXPECT_EQ(faces[fourthPairIndex].I3, 7);
-}
-
-    TEST_F(TopoShapeTest, getCharacteristics)
+TEST_F(TopoShapeTest, getCharacteristics)
 {
     // Arrange
     Base::Vector3d cog;

--- a/tests/src/Mod/Part/App/TopoShape.cpp
+++ b/tests/src/Mod/Part/App/TopoShape.cpp
@@ -1,90 +1,45 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include "gtest/gtest.h"
-#include <Mod/Part/App/TopoShape.h>
+#include "Mod/Part/App/TopoShape.h"
 
-// clang-format off
-TEST(TopoShape, TestElementTypeFace1)
+class TopoShapeTest: public ::testing::Test
 {
-    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Face1"),
-              std::make_pair(std::string("Face"), 1UL));
+protected:
+    static void SetUpTestSuite()
+    {
+    }
+
+    void SetUp() override {
+        _declaredLoc1234 = gp_Trsf();
+        _declaredLoc1234.SetScale(gp_Pnt(1.0, 2.0, 3.0), 4.0);
+        _testLocation1234 = TopLoc_Location(_declaredLoc1234);
+
+        _topoShape = Part::TopoShape();
+    }
+
+    void TearDown() override {
+        _topoShape = Part::TopoShape();
+    }
+public:
+    Part::TopoShape _topoShape;
+    TopLoc_Location _testLocation1234;
+    gp_Trsf _declaredLoc1234;
+};
+
+
+TEST_F(TopoShapeTest, setShapeGetShape)
+{
+    // Arrange
+    auto newShape = TopoDS_Shape();
+    newShape.Location(_testLocation1234);
+
+    // Act
+    _topoShape.setShape(newShape);          // set
+    auto shapeSeen = _topoShape.getShape(); // get
+
+    // Assert
+    EXPECT_EQ(shapeSeen.Location(), _testLocation1234);
+    EXPECT_EQ(shapeSeen.Location().Transformation().ScaleFactor(), 4.0);
 }
 
-TEST(TopoShape, TestElementTypeEdge12)
-{
-    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Edge12"),
-              std::make_pair(std::string("Edge"), 12UL));
-}
-
-TEST(TopoShape, TestElementTypeVertex3)
-{
-    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Vertex3"),
-              std::make_pair(std::string("Vertex"), 3UL));
-}
-
-TEST(TopoShape, TestElementTypeFacer)
-{
-    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Facer"),
-              std::make_pair(std::string(), 0UL));
-}
-
-TEST(TopoShape, TestElementTypeVertex)
-{
-    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Vertex"),
-              std::make_pair(std::string(), 0UL));
-}
-
-TEST(TopoShape, TestElementTypeEmpty)
-{
-    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex(""),
-              std::make_pair(std::string(), 0UL));
-}
-
-TEST(TopoShape, TestElementTypeNull)
-{
-    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex(nullptr),
-              std::make_pair(std::string(), 0UL));
-}
-
-TEST(TopoShape, TestTypeFace1)
-{
-    EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Face1"),
-              std::make_pair(std::string("Face"), 1UL));
-}
-
-TEST(TopoShape, TestTypeEdge12)
-{
-    EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Edge12"),
-              std::make_pair(std::string("Edge"), 12UL));
-}
-
-TEST(TopoShape, TestTypeVertex3)
-{
-    EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Vertex3"),
-              std::make_pair(std::string("Vertex"), 3UL));
-}
-
-TEST(TopoShape, TestTypeFacer)
-{
-    EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Facer"),
-              std::make_pair(std::string("Facer"), 0UL));
-}
-
-TEST(TopoShape, TestTypeVertex)
-{
-    EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Vertex"),
-              std::make_pair(std::string("Vertex"), 0UL));
-}
-
-TEST(TopoShape, TestTypeEmpty)
-{
-    EXPECT_EQ(Part::TopoShape::getTypeAndIndex(""),
-              std::make_pair(std::string(), 0UL));
-}
-
-TEST(TopoShape, TestTypeNull)
-{
-    EXPECT_EQ(Part::TopoShape::getTypeAndIndex(nullptr),
-              std::make_pair(std::string(), 0UL));
-}
-// clang-format on

--- a/tests/src/Mod/Part/App/TopoShape_static.cpp
+++ b/tests/src/Mod/Part/App/TopoShape_static.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "gtest/gtest.h"
+#include <Mod/Part/App/TopoShape.h>
+
+// clang-format off
+TEST(TopoShape, TestElementTypeFace1)
+{
+    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Face1"),
+              std::make_pair(std::string("Face"), 1UL));
+}
+
+TEST(TopoShape, TestElementTypeEdge12)
+{
+    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Edge12"),
+              std::make_pair(std::string("Edge"), 12UL));
+}
+
+TEST(TopoShape, TestElementTypeVertex3)
+{
+    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Vertex3"),
+              std::make_pair(std::string("Vertex"), 3UL));
+}
+
+TEST(TopoShape, TestElementTypeFacer)
+{
+    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Facer"),
+              std::make_pair(std::string(), 0UL));
+}
+
+TEST(TopoShape, TestElementTypeVertex)
+{
+    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Vertex"),
+              std::make_pair(std::string(), 0UL));
+}
+
+TEST(TopoShape, TestElementTypeEmpty)
+{
+    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex(""),
+              std::make_pair(std::string(), 0UL));
+}
+
+TEST(TopoShape, TestElementTypeNull)
+{
+    EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex(nullptr),
+              std::make_pair(std::string(), 0UL));
+}
+
+TEST(TopoShape, TestTypeFace1)
+{
+    EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Face1"),
+              std::make_pair(std::string("Face"), 1UL));
+}
+
+TEST(TopoShape, TestTypeEdge12)
+{
+    EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Edge12"),
+              std::make_pair(std::string("Edge"), 12UL));
+}
+
+TEST(TopoShape, TestTypeVertex3)
+{
+    EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Vertex3"),
+              std::make_pair(std::string("Vertex"), 3UL));
+}
+
+TEST(TopoShape, TestTypeFacer)
+{
+    EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Facer"),
+              std::make_pair(std::string("Facer"), 0UL));
+}
+
+TEST(TopoShape, TestTypeVertex)
+{
+    EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Vertex"),
+              std::make_pair(std::string("Vertex"), 0UL));
+}
+
+TEST(TopoShape, TestTypeEmpty)
+{
+    EXPECT_EQ(Part::TopoShape::getTypeAndIndex(""),
+              std::make_pair(std::string(), 0UL));
+}
+
+TEST(TopoShape, TestTypeNull)
+{
+    EXPECT_EQ(Part::TopoShape::getTypeAndIndex(nullptr),
+              std::make_pair(std::string(), 0UL));
+}
+// clang-format on


### PR DESCRIPTION
see issue:  #11148

In this PR, I am adding unit tests to test the "before" state of the TopoShape class (which wraps OCCT TopoDS_Shape) to help verify we are not breaking anything yet with the TopoNaming fix changes.
