### PR TITLE
Draft: remove the tolerance preference

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -61,8 +61,7 @@ from draftutils.utils import (type_check,
                               set_param,
                               setParam,
                               precision,
-                              tolerance,
-                              epsilon)
+                              tolerance)
 
 from draftutils.utils import (get_real_name,
                               getRealName,

--- a/src/Mod/Draft/Resources/ui/preferences-draft.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draft.ui
@@ -136,59 +136,6 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_15">
-        <item>
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Tolerance</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_8">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="gui::prefdoublespinbox">
-          <property name="maximumSize">
-           <size>
-            <width>60</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>This is the value used by functions that use a tolerance.
-Values with differences below this value will be treated as same. This value will be obsoleted soon so the precision level above controls both.</string>
-          </property>
-          <property name="suffix">
-           <string/>
-          </property>
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="value">
-           <double>0.050000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>tolerance</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
        <widget class="Gui::PrefCheckBox" name="checkBox_3">
         <property name="toolTip">
          <string>If this option is checked, the layers drop-down list will also show groups, allowing you to automatically add objects to groups too.</string>

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -177,8 +177,7 @@ def get_param_type(param):
                    "FontFile", "ClonePrefix", "overrideUnit",
                    "labeltype", "gridSpacing") or "inCommandShortcut" in param:
         return "string"
-    elif param in ("textheight", "tolerance",
-                   "arrowsize", "extlines", "dimspacing",
+    elif param in ("textheight", "arrowsize", "extlines", "dimspacing",
                    "dimovershoot", "extovershoot", "HatchPatternSize"):
         return "float"
     elif param in ("selectBaseObjects", "alwaysSnap", "grid",
@@ -345,38 +344,14 @@ def precision():
 
 
 def tolerance():
-    """Return the tolerance value from the parameter database.
-
-    This specifies a tolerance around a quantity.
-    ::
-        value + tolerance
-        value - tolerance
-
-    By default the tolerance is 0.05.
+    """Return a tolerance based on the precision() value
 
     Returns
     -------
     float
-        get_param("tolerance", 0.05)
+        10 ** -precision()
     """
-    return getParam("tolerance", 0.05)
-
-
-def epsilon():
-    """Return a small number based on the tolerance for use in comparisons.
-
-    The epsilon value is used in floating point comparisons. Use with caution.
-    ::
-        denom = 10**tolerance
-        num = 1
-        epsilon = num/denom
-
-    Returns
-    -------
-    float
-        1/(10**tolerance)
-    """
-    return 1.0/(10.0**tolerance())
+    return 10 ** -precision()
 
 
 def get_real_name(name):


### PR DESCRIPTION
The tolerance function now derives its value from the precision preference.

Additonally:
Removed the epsilon() function. It did not make sense and was not used.
