### PR TITLE
[Part Workbench]Prevent error when using link in boolean cut

### DIFF
--- a/src/Mod/Part/BOPTools/BOPFeatures.py
+++ b/src/Mod/Part/BOPTools/BOPFeatures.py
@@ -104,4 +104,9 @@ class BOPFeatures:
     def copy_visual_attributes(self, target, source):
         if target.ViewObject:
             target.ViewObject.ShapeColor = source.ViewObject.ShapeColor
-            target.ViewObject.DisplayMode = source.ViewObject.DisplayMode
+            displayMode = source.ViewObject.DisplayMode
+            src = source
+            while displayMode == "Link":
+                src = src.LinkedObject
+                displayMode = src.ViewObject.DisplayMode
+            target.ViewObject.DisplayMode = displayMode

--- a/src/Tools/SubWCRev.py
+++ b/src/Tools/SubWCRev.py
@@ -523,7 +523,7 @@ def main():
             inp = open("%s/src/Build/Version.h.in" % (bindir))
             lines = inp.readlines()
             inp.close()
-            #lines = i.writeVersion(lines)
+            # lines = i.writeVersion(lines)
             out = open("%s/src/Build/Version.h.out" % (bindir), "w")
             out.writelines(lines)
             out.write("\n")


### PR DESCRIPTION
See https://forum.freecad.org/viewtopic.php?t=82687

When doing a boolean cut using a link as a cutting tool there is an error message in the report view related to copying visual attributes, in particular the view object's DisplayMode property.  When the object is a link the view object's DisplayMode property is "Link", which is not in the enumeration ["Flat Lines", "Shaded", "WireFrame", "Points"].

This PR will fetch the DisplayMode of the linked object and copy that instead of the link object itself.

@realthunder Would you mind taking a look at this?  Perhaps there is a better way?