### PR TITLE
fix python get value rotation are a Long .

### DIFF
--- a/src/Base/RotationPyImp.cpp
+++ b/src/Base/RotationPyImp.cpp
@@ -635,7 +635,7 @@ PyObject* RotationPy::number_power_handler(PyObject* self, PyObject* other, PyOb
     }
 
     Rotation a = static_cast<RotationPy*>(self)->value();
-    long b = Py::Int(other);
+    long b = Py::Long(other);
 
     Vector3d axis;
     double rfAngle {};

--- a/src/Tools/generateTemplates/templateClassPyExport.py
+++ b/src/Tools/generateTemplates/templateClassPyExport.py
@@ -465,10 +465,8 @@ PyNumberMethods @self.export.Name@::Number[] = { {
     nullptr,    /*nb_inplace_floor_divide*/
     nullptr,    /*nb_inplace_true_divide*/
     nullptr     /*nb_index*/
-#if PY_VERSION_HEX >= 0x03050000
    ,nullptr     /*nb_matrix_multiply*/
    ,nullptr     /*nb_inplace_matrix_multiply*/
-#endif
 } };
 -
 


### PR DESCRIPTION
remove old check python >=3.5 -> freecad require python 3.6
move from  Py::Int  to Py::Long (Wrong cast)