### PR TITLE
Gui: QuantitySpinBox - keep format on setValue

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -495,7 +495,12 @@ void QuantitySpinBox::setValue(const Base::Quantity& value)
 void QuantitySpinBox::setValue(double value)
 {
     Q_D(QuantitySpinBox);
-    setValue(Base::Quantity(value, d->unit));
+
+    Base::QuantityFormat currentformat = d->quantity.getFormat();
+    auto quantity = Base::Quantity(value, d->unit);
+    quantity.setFormat(currentformat);
+
+    setValue(quantity);
 }
 
 bool QuantitySpinBox::hasValidInput() const


### PR DESCRIPTION

Problem:
When the value set is a double, a new Quantity is created, which does not follow the previously configured format (setDecimals).

Solution:
To copy the old format to the newly created quantity.