### PR TITLE
Draft: prefs: remove copymode, useSupport no longer via UI

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -944,8 +944,7 @@ class DraftToolBar:
         self.isCopy.show()
         self.isSubelementMode.show()
         p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-        if p.GetBool("copymode",False):
-            self.isCopy.setChecked(p.GetBool("copymodeValue",False))
+        self.isCopy.setChecked(p.GetBool("copymodeValue",False))
         self.continueCmd.show()
 
     def checkLocal(self):
@@ -996,11 +995,11 @@ class DraftToolBar:
 
     def setCopymode(self,val=0):
         p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-        p.SetBool("copymodeValue",bool(val))
         # special value for offset command
-        if self.sourceCmd:
-            if self.sourceCmd.featureName == "Offset":
-                p.SetBool("OffsetCopyMode",bool(val))
+        if self.sourceCmd and self.sourceCmd.featureName == "Offset":
+            p.SetBool("OffsetCopyMode",bool(val))
+        else:
+            p.SetBool("copymodeValue",bool(val))
 
     def setSubelementMode(self):
         self.sourceCmd.set_ghosts()

--- a/src/Mod/Draft/Resources/ui/preferences-draft.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draft.ui
@@ -189,39 +189,6 @@ This allows to point the direction and type the distance.</string>
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_3">
-          <property name="toolTip">
-           <string>Normally, after copying objects, the copies get selected.
-If this option is checked, the base objects will be selected instead.</string>
-          </property>
-          <property name="text">
-           <string>Select base objects after copying</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>selectBaseObjects</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="Gui::PrefCheckBox" name="checkBox_2">
-          <property name="toolTip">
-           <string>If this option is set, when creating Draft objects on top of an existing face of another object, the "Support" property of the Draft object will be set to the base object. This was the standard behaviour before FreeCAD 0.19</string>
-          </property>
-          <property name="text">
-           <string>Set the Support property when possible</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>useSupport</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_6">
           <property name="toolTip">
            <string>If this is checked, objects will appear as filled by default.
@@ -241,27 +208,24 @@ Otherwise, they will appear as wireframe</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_5">
+        <item row="1" column="0">
+         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_3">
           <property name="toolTip">
-           <string>If this is checked, copy mode will be kept across command,
-otherwise commands will always start in no-copy mode</string>
+           <string>Normally, after copying objects, the copies get selected.
+If this option is checked, the base objects will be selected instead.</string>
           </property>
           <property name="text">
-           <string>Global copy mode</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
+           <string>Select base objects after copying</string>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>copymode</cstring>
+           <cstring>selectBaseObjects</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/Draft</cstring>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="1" column="1">
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_13">
           <property name="toolTip">
            <string>Force Draft Tools to create Part primitives instead of Draft objects.


### PR DESCRIPTION
This PR removes the copymode (Global copy mode) preference.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=82679

Additionally useSupport is removed from preferences-draft.ui, turning it into a fine-tuning preference. Use of this feature is rare and may not be supported in the future. No need to present this preference to new users in the UI.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=80689
