### PR TITLE
[TechDraw] Multiselection mode for vertices/edges/faces

### DIFF
--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -455,7 +455,7 @@ void DrawView::setPosition(double x, double y, bool force)
     if ( (!isLocked()) ||
          (force) ) {
         double currX = X.getValue();
-        double currY = X.getValue();
+        double currY = Y.getValue();
         if (!DrawUtil::fpCompare(currX, x, 0.001)) {    // 0.001mm tolerance
             X.setValue(x);
         }

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -868,6 +868,62 @@ for ProjectionGroups</string>
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="gbSelection">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>100</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Selection</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <item>
+       <layout class="QGridLayout" name="gridLayout_7">
+        <item row="0" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbMultiSelection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>If enabled, clicking without Ctrl does not clear existing vertex/edge/face selection</string>
+          </property>
+          <property name="text">
+           <string>Enable Multiselection Mode</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>multiSelection</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="label_12">
      <property name="font">
       <font>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
@@ -71,6 +71,8 @@ void DlgPrefsTechDrawGeneralImp::saveSettings()
     ui->le_NamePattern->onSave();
     ui->cb_ShowGrid->onSave();
     ui->psb_GridSpacing->onSave();
+
+    ui->cbMultiSelection->onSave();
 }
 
 void DlgPrefsTechDrawGeneralImp::loadSettings()
@@ -107,6 +109,10 @@ void DlgPrefsTechDrawGeneralImp::loadSettings()
     double spacingDefault = PreferencesGui::gridSpacing();
     ui->psb_GridSpacing->setValue(spacingDefault);
     ui->psb_GridSpacing->onRestore();
+
+    bool multiSelectionDefault = PreferencesGui::multiSelection();
+    ui->cbMultiSelection->setChecked(multiSelectionDefault);
+    ui->cbMultiSelection->onRestore();
 }
 
 /**

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -957,8 +957,10 @@ bool MDIViewPage::compareSelections(std::vector<Gui::SelectionObject> treeSel,
     }
 
     int treeCount = 0;
+    int subCount = 0;
     int sceneCount = 0;
     int ppCount = 0;
+
     std::vector<std::string> treeNames;
     std::vector<std::string> sceneNames;
 
@@ -966,6 +968,7 @@ bool MDIViewPage::compareSelections(std::vector<Gui::SelectionObject> treeSel,
         if (tn.getObject()->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
             std::string s = tn.getObject()->getNameInDocument();
             treeNames.push_back(s);
+            subCount += tn.getSubNames().size();
         }
     }
     std::sort(treeNames.begin(), treeNames.end());
@@ -1017,7 +1020,7 @@ bool MDIViewPage::compareSelections(std::vector<Gui::SelectionObject> treeSel,
     }
 
     //Objects all match, check subs
-    if (treeCount != ppCount) {
+    if (subCount != ppCount) {
         return false;
     }
 

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -206,6 +206,11 @@ bool PreferencesGui::showGrid()
     return Preferences::getPreferenceGroup("General")->GetBool("showGrid", false);
 }
 
+bool PreferencesGui::multiSelection()
+{
+  return Preferences::getPreferenceGroup("General")->GetBool("multiSelection", false);
+}
+
 App::Color PreferencesGui::pageColor()
 {
     App::Color result;

--- a/src/Mod/TechDraw/Gui/PreferencesGui.h
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.h
@@ -72,6 +72,7 @@ static bool showGrid();
 static App::Color gridColor();
 static QColor gridQColor();
 static double gridSpacing();
+static bool multiSelection();
 
 static QColor       getAccessibleQColor(QColor orig);
 static QColor       lightTextQColor();

--- a/src/Mod/TechDraw/Gui/QGEPath.h
+++ b/src/Mod/TechDraw/Gui/QGEPath.h
@@ -63,6 +63,7 @@ Q_SIGNALS:
     void endEdit();
 
 protected:
+    bool multiselectEligible() override { return false; }
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
 
 private:

--- a/src/Mod/TechDraw/Gui/QGIEdge.h
+++ b/src/Mod/TechDraw/Gui/QGIEdge.h
@@ -57,6 +57,8 @@ protected:
 
     void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
 
+    bool multiselectEligible() override { return true; }
+
     int projIndex;                                                     //index of edge in Projection. must exist.
 
     bool isCosmetic;

--- a/src/Mod/TechDraw/Gui/QGIFace.h
+++ b/src/Mod/TechDraw/Gui/QGIFace.h
@@ -150,6 +150,8 @@ protected:
 
     bool m_hideSvgTiles;
 
+    bool multiselectEligible() override { return true; }
+
 private:
     QPixmap m_texture;                          //
 

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -32,6 +32,10 @@
 
 #include <App/Application.h>
 
+#include <Gui/Selection.h>
+
+#include <Mod/TechDraw/App/DrawView.h>
+
 #include "QGIPrimPath.h"
 #include "PreferencesGui.h"
 #include "QGIView.h"
@@ -55,6 +59,7 @@ QGIPrimPath::QGIPrimPath():
     setAcceptHoverEvents(true);
 
     isHighlighted = false;
+    multiselectActivated = false;
 
     m_colOverride = false;
     m_colNormal = getNormalColor();
@@ -257,6 +262,50 @@ Qt::PenCapStyle QGIPrimPath::prefCapStyle()
             result = static_cast<Qt::PenCapStyle>(0x20);
     }
     return result;
+}
+
+void QGIPrimPath::mousePressEvent(QGraphicsSceneMouseEvent *event)
+{
+    Qt::KeyboardModifiers originalModifiers = event->modifiers();
+    if (event->button()&Qt::LeftButton) {
+        multiselectActivated = false;
+    }
+
+    if (event->button() == Qt::LeftButton
+        && multiselectEligible()
+        && PreferencesGui::multiSelection()) {
+
+        auto parent = dynamic_cast<QGIView *>(parentItem());
+        if (parent) {
+            std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
+            if (selection.size() == 1
+                && selection.front().getObject() == parent->getViewObject()) {
+
+                multiselectActivated = true;
+                event->setModifiers(originalModifiers | Qt::ControlModifier);
+            }
+        }
+    }
+
+    QGraphicsPathItem::mousePressEvent(event);
+
+    event->setModifiers(originalModifiers);
+}
+
+void QGIPrimPath::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
+{
+    Qt::KeyboardModifiers originalModifiers = event->modifiers();
+    if ((event->button()&Qt::LeftButton) && multiselectActivated) {
+        if (PreferencesGui::multiSelection()) {
+            event->setModifiers(originalModifiers | Qt::ControlModifier);
+        }
+
+        multiselectActivated = false;
+    }
+
+    QGraphicsPathItem::mouseReleaseEvent(event);
+
+    event->setModifiers(originalModifiers);
 }
 
 void QGIPrimPath::setFill(QColor c, Qt::BrushStyle s) {

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -259,26 +259,6 @@ Qt::PenCapStyle QGIPrimPath::prefCapStyle()
     return result;
 }
 
-void QGIPrimPath::mousePressEvent(QGraphicsSceneMouseEvent * event)
-{
-    //wf: this seems a bit of a hack. does it mess up selection of QGIPP??
-    QGIView *parent;
-    QGraphicsItem* qparent = parentItem();
-    if (qparent) {
-        parent = dynamic_cast<QGIView *> (qparent);
-        if (parent) {
-//            Base::Console().Message("QGIPP::mousePressEvent - passing event to QGIV parent\n");
-            parent->mousePressEvent(event);
-        } else {
-//            qparent->mousePressEvent(event);  //protected!
-            QGraphicsPathItem::mousePressEvent(event);
-        }
-    } else {
-//        Base::Console().Message("QGIPP::mousePressEvent - passing event to ancestor\n");
-        QGraphicsPathItem::mousePressEvent(event);
-    }
-}
-
 void QGIPrimPath::setFill(QColor c, Qt::BrushStyle s) {
     setFillColor(c);
     m_fillNormal = s;

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.h
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.h
@@ -79,6 +79,11 @@ protected:
     void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
+    virtual bool multiselectEligible() { return false; }
+
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+
     virtual QColor getNormalColor();
     virtual QColor getPreColor();
     virtual QColor getSelectColor();
@@ -86,6 +91,7 @@ protected:
     virtual Qt::PenCapStyle prefCapStyle();
 
     bool isHighlighted;
+    bool multiselectActivated;
 
     QPen m_pen;
     QColor m_colCurrent;

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.h
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.h
@@ -78,7 +78,6 @@ protected:
     void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
     void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
-    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
 
     virtual QColor getNormalColor();
     virtual QColor getPreColor();

--- a/src/Mod/TechDraw/Gui/QGIVertex.h
+++ b/src/Mod/TechDraw/Gui/QGIVertex.h
@@ -46,6 +46,8 @@ public:
     virtual void setRadius(float r);
 
 protected:
+    bool multiselectEligible() override { return true; }
+
     int projIndex;
     float m_radius;
 

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -107,11 +107,6 @@ QGIView::QGIView()
     m_lock->hide();
 }
 
-QGIView::~QGIView()
-{
-    signalSelectPoint.disconnect_all_slots();
-}
-
 void QGIView::onSourceChange(TechDraw::DrawView* newParent)
 {
     Q_UNUSED(newParent);
@@ -204,7 +199,6 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
 void QGIView::mousePressEvent(QGraphicsSceneMouseEvent * event)
 {
 //    Base::Console().Message("QGIV::mousePressEvent() - %s\n", getViewName());
-    signalSelectPoint(this, event->pos());
     if (m_dragState == NODRAG) {
         m_dragState = DRAGSTARTED;
     }

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -175,8 +175,7 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
         } else {
             Gui::ViewProvider *vp = getViewProvider(viewObj);
             if (vp && !vp->isRestoring()) {
-                viewObj->setPosition(Rez::appX(newPos.x()),
-                                     Rez::appX(isInnerView() ? getYInClip(newPos.y()) : -newPos.y()));
+                viewObj->setPosition(Rez::appX(newPos.x()), Rez::appX(-newPos.y()));
             }
         }
 
@@ -243,26 +242,16 @@ void QGIView::setPosition(qreal xPos, qreal yPos)
 {
 //    Base::Console().Message("QGIV::setPosition(%.3f, %.3f) (gui)\n", x, y);
     double newX = xPos;
-    double newY;
+    double newY = -yPos;
     double oldX = pos().x();
     double oldY = pos().y();
-    if (!isInnerView()) {
-        newY = -yPos;
-    } else {
-        newY = getYInClip(yPos);
-    }
+
     if (TechDraw::DrawUtil::fpCompare(newX, oldX) &&
         TechDraw::DrawUtil::fpCompare(newY, oldY)) {
         return;
     } else {
         setPos(newX, newY);
     }
-}
-
-//is this needed anymore???
-double QGIView::getYInClip(double y)
-{
-    return -y;
 }
 
 QGIViewClip* QGIView::getClipGroup()

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -64,18 +64,13 @@
 using namespace TechDrawGui;
 using namespace TechDraw;
 
-#define NODRAG 0
-#define DRAGSTARTED 1
-#define DRAGGING 2
-
 const float labelCaptionFudge = 0.2f;   // temp fiddle for devel
 
 QGIView::QGIView()
     :QGraphicsItemGroup(),
      viewObj(nullptr),
      m_locked(false),
-     m_innerView(false),
-     m_dragState(NODRAG)
+     m_innerView(false)
 {
     setCacheMode(QGraphicsItem::NoCache);
     setHandlesChildEvents(false);
@@ -205,27 +200,17 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
 void QGIView::mousePressEvent(QGraphicsSceneMouseEvent * event)
 {
 //    Base::Console().Message("QGIV::mousePressEvent() - %s\n", getViewName());
-    if (m_dragState == NODRAG) {
-        m_dragState = DRAGSTARTED;
-    }
-
     QGraphicsItemGroup::mousePressEvent(event);
 }
 
 void QGIView::mouseMoveEvent(QGraphicsSceneMouseEvent * event)
 {
-    if (m_dragState == DRAGSTARTED) {
-        m_dragState = DRAGGING;
-    }
-
     QGraphicsItemGroup::mouseMoveEvent(event);
 }
 
 void QGIView::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
 {
 //    Base::Console().Message("QGIV::mouseReleaseEvent() - %s\n", getViewName());
-    m_dragState = NODRAG;
-
     QGraphicsItemGroup::mouseReleaseEvent(event);
 }
 

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -118,7 +118,6 @@ public:
     inline qreal getY() { return y() * -1; }
     bool isInnerView() const { return m_innerView; }
     void isInnerView(bool state) { m_innerView = state; }
-    double getYInClip(double y);
     QGIViewClip* getClipGroup();
 
 

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -183,6 +183,7 @@ private:
     QHash<QString, QGraphicsItem*> alignHash;
     bool m_locked;
     bool m_innerView;                                                  //View is inside another View
+    bool m_multiselectActivated;
 
     QPen m_pen;
     QBrush m_brush;

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -200,7 +200,6 @@ private:
     QPen m_decorPen;
     double m_lockWidth;
     double m_lockHeight;
-    int m_dragState;
     int m_zOrder;
 
 };

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -77,7 +77,6 @@ class TechDrawGuiExport  QGIView : public QObject, public QGraphicsItemGroup
     Q_OBJECT
 public:
     QGIView();
-    ~QGIView() override;
 
     enum {Type = QGraphicsItem::UserType + 101};
     int type() const override { return Type;}
@@ -162,8 +161,6 @@ public:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
-
-    boost::signals2::signal<void (QGIView*, QPointF)> signalSelectPoint;
 
 public Q_SLOTS:
     virtual void onSourceChange(TechDraw::DrawView* newParent);


### PR DESCRIPTION
When creating a larger drawing, the need to hold the Ctrl key every moment is quite tedious . This pull request adds "Enable Multiselection Mode" option to TechDraw's General preferences, which allows to add/remove vertices, edges and faces in the same view to/from the selection by plain clicking. If more than one item in the tree is selected, the multiselection mode is not activated.

The pull request consist of 2 commits fixing the issues I have encountered during the development, then 4 commits cleaning the code or removing obsolete features and finally the single commit implementing the multiselection mode.

The way how multiselection mode for TechDraw is implemented is rather a "hack". Unfortunately, QGraphicsItem does not support SelectionMode in the manner the QAbstractItemView does. The only way how to achieve the "MultiSelection" behavior is to set Qt::ControlModifier on the event passing through mousePressEvent/mouseReleaseEvent handlers when suitable. On the other hand, it works consistently well and I did not encounter any problems so far.

If for some reasons the multiselection mode option gets rejected, the pull request's fix and refactoring commits are ready to be used on their own.

I hope you will find this new feature useful, in case of any problems please let me know.