### PR TITLE
Path:  Added separator lines to make the tests easier to find

### DIFF
--- a/src/Mod/Path/PathTests/TestRefactoredTestPost.py
+++ b/src/Mod/Path/PathTests/TestRefactoredTestPost.py
@@ -109,6 +109,7 @@ class TestRefactoredTestPost(PathTestUtils.PathTestBase):
             print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[2], expected)
 
+    #############################################################################
     #
     # The tests are organized into groups:
     #
@@ -117,6 +118,7 @@ class TestRefactoredTestPost(PathTestUtils.PathTestBase):
     #   01000 - 01999  tests for the various G codes at 1000 + 10 * g_code_value
     #   02000 - 02999  tests for the various M codes at 2000 + 10 * m_code_value
     #
+    #############################################################################
 
     def test00100(self):
         """Test axis modal.
@@ -139,11 +141,15 @@ class TestRefactoredTestPost(PathTestUtils.PathTestBase):
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[3], "G0 X10.000 Y30.000 Z30.000")
 
+    #############################################################################
+
     def test00110(self):
         """Test axis-precision."""
         self.compare_third_line(
             "G0 X10 Y20 Z30", "G0 X10.00 Y20.00 Z30.00", "--axis-precision=2"
         )
+
+    #############################################################################
 
     def test00120(self):
         """Test bcnc."""
@@ -168,6 +174,8 @@ G21
             "--no-bcnc",
         )
 
+    #############################################################################
+
     def test00130(self):
         """Test comments."""
         c = Path.Command("(comment)")
@@ -177,6 +185,8 @@ G21
         gcode = postprocessor.export(postables, "gcode.tmp", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[4], "(comment)")
+
+    #############################################################################
 
     def test00140(self):
         """Test feed-precision."""
@@ -199,6 +209,8 @@ G21
         # Note:  The "internal" F speed is in mm/s,
         #        while the output F speed is in mm/min.
         self.assertEqual(gcode.splitlines()[2], "G1 X10.000 Y20.000 Z30.000 F7387.41")
+
+    #############################################################################
 
     def test00150(self):
         """Test output with an empty path.
@@ -266,11 +278,15 @@ G21
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode, expected)
 
+    #############################################################################
+
     def test00160(self):
         """Test Line Numbers."""
         self.compare_third_line(
             "G0 X10 Y20 Z30", "N120 G0 X10.000 Y20.000 Z30.000", "--line-numbers"
         )
+
+    #############################################################################
 
     def test00170(self):
         """Test inches."""
@@ -287,6 +303,8 @@ G21
             gcode.splitlines()[2],
             "G0 X0.3937 Y0.7874 Z1.1811 A0.3937 B0.7874 C1.1811 U0.3937 V0.7874 W1.1811",
         )
+
+    #############################################################################
 
     def test00180(self):
         """Test modal.
@@ -305,6 +323,8 @@ G21
         gcode = postprocessor.export(postables, "gcode.tmp", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[3], "G0 X10.000 Y30.000 Z30.000")
+
+    #############################################################################
 
     def test00190(self):
         """Test Outputting all arguments.
@@ -385,12 +405,16 @@ G21
         expected = "".join(expected.split())
         self.assertEqual(gcode, expected)
 
+    #############################################################################
+
     def test00200(self):
         """Test Outputting visible arguments.
 
         Empty path.  Outputs visible arguments.
         """
         self.single_compare([], "", "--output_visible_arguments")
+
+    #############################################################################
 
     def test00210(self):
         """Test Post-amble."""
@@ -402,6 +426,8 @@ G21
         self.assertEqual(gcode.splitlines()[-2], "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
 
+    #############################################################################
+
     def test00220(self):
         """Test Pre-amble."""
         self.docobj.Path = Path.Path([])
@@ -410,6 +436,8 @@ G21
         gcode = postprocessor.export(postables, "gcode.tmp", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[0], "G18 G55")
+
+    #############################################################################
 
     def test00230(self):
         """Test precision."""
@@ -424,9 +452,13 @@ G21
             "--inches --precision=2",
         )
 
+    #############################################################################
+
     def test00240(self):
         """Test return-to."""
         self.compare_third_line("", "G0 X12 Y34 Z56", "--return-to='12,34,56'")
+
+    #############################################################################
 
     def test00250(self):
         """Test tlo."""
@@ -447,6 +479,8 @@ G21
         self.assertEqual(gcode.splitlines()[2], "M6 T2")
         self.assertEqual(gcode.splitlines()[3], "M3 S3000")
 
+    #############################################################################
+
     def test00260(self):
         """Test tool_change."""
         c = Path.Command("M6 T2")
@@ -463,6 +497,8 @@ G21
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[5], "( M6 T2 )")
         self.assertEqual(gcode.splitlines()[6], "M3 S3000")
+
+    #############################################################################
 
     def test00270(self):
         """Test wait-for-spindle."""

--- a/src/Mod/Path/PathTests/TestRefactoredTestPostGCodes.py
+++ b/src/Mod/Path/PathTests/TestRefactoredTestPostGCodes.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2022 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2022-2023 Larry Woestman <LarryWoestman2@gmail.com>     *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -110,6 +110,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[2], expected)
 
+    #############################################################################
     #
     # The tests are organized into groups:
     #
@@ -118,6 +119,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
     #   10000 - 19999  tests for the various G codes at 10000 + 10 * g_code_value
     #   20000 - 29999  tests for the various M codes at 20000 + 10 * m_code_value
     #
+    #############################################################################
 
     def test10000(self):
         """Test G0 command Generation."""
@@ -137,6 +139,8 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             ),
             "",
         )
+
+    #############################################################################
 
     def test10010(self):
         """Test G1 command Generation."""
@@ -174,6 +178,8 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             "--inches",
         )
 
+    #############################################################################
+
     def test10020(self):
         """Test G2 command Generation."""
         #
@@ -203,6 +209,8 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             "--inches",
         )
 
+    #############################################################################
+
     def test10030(self):
         """Test G3 command Generation."""
         self.compare_third_line(
@@ -231,6 +239,8 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             "--inches",
         )
 
+    #############################################################################
+
     def test10040(self):
         """Test G4 command Generation."""
         # Should some sort of "precision" be applied to the P parameter?
@@ -242,13 +252,19 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
         self.compare_third_line("G04 P1.23456", "G04 P1.23456", "")
         self.compare_third_line("G4 P1.23456", "G4 P1.23456", "--inches")
 
+    #############################################################################
+
     def test10070(self):
         """Test G7 command Generation."""
         self.compare_third_line("G7", "G7", "")
 
+    #############################################################################
+
     def test10080(self):
         """Test G8 command Generation."""
         self.compare_third_line("G8", "G8", "")
+
+    #############################################################################
 
     def test10100(self):
         """Test G10 command Generation."""
@@ -292,37 +308,55 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             "",
         )
 
+    #############################################################################
+
     def test10170(self):
         """Test G17 command Generation."""
         self.compare_third_line("G17", "G17", "")
+
+    #############################################################################
 
     def test10171(self):
         """Test G17.1 command Generation."""
         self.compare_third_line("G17.1", "G17.1", "")
 
+    #############################################################################
+
     def test10180(self):
         """Test G18 command Generation."""
         self.compare_third_line("G18", "G18", "")
+
+    #############################################################################
 
     def test10181(self):
         """Test G18.1 command Generation."""
         self.compare_third_line("G18.1", "G18.1", "")
 
+    #############################################################################
+
     def test10190(self):
         """Test G19 command Generation."""
         self.compare_third_line("G19", "G19", "")
+
+    #############################################################################
 
     def test10191(self):
         """Test G19.1 command Generation."""
         self.compare_third_line("G19.1", "G19.1", "")
 
+    #############################################################################
+
     def test10200(self):
         """Test G20 command Generation."""
         self.compare_third_line("G20", "G20", "")
 
+    #############################################################################
+
     def test10210(self):
         """Test G21 command Generation."""
         self.compare_third_line("G21", "G21", "")
+
+    #############################################################################
 
     def test10280(self):
         """Test G28 command Generation."""
@@ -336,9 +370,13 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             "",
         )
 
+    #############################################################################
+
     def test10281(self):
         """Test G28.1 command Generation."""
         self.compare_third_line("G28.1", "G28.1", "")
+
+    #############################################################################
 
     def test10300(self):
         """Test G30 command Generation."""
@@ -352,6 +390,8 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             "",
         )
 
+    #############################################################################
+
     def test10382(self):
         """Test G38.2 command Generation."""
         self.compare_third_line(
@@ -362,6 +402,8 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             ),
             "",
         )
+
+    #############################################################################
 
     def test10383(self):
         """Test G38.3 command Generation."""
@@ -374,6 +416,8 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             "",
         )
 
+    #############################################################################
+
     def test10384(self):
         """Test G38.4 command Generation."""
         self.compare_third_line(
@@ -384,6 +428,8 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             ),
             "",
         )
+
+    #############################################################################
 
     def test10385(self):
         """Test G38.5 command Generation."""
@@ -396,14 +442,20 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             "",
         )
 
+    #############################################################################
+
     def test10301(self):
         """Test G30.1 command Generation."""
         self.compare_third_line("G30.1", "G30.1", "")
+
+    #############################################################################
 
     def test10400(self):
         """Test G40 command Generation."""
         self.compare_third_line("G40", "G40", "")
         self.compare_third_line("G40", "G40", "--inches")
+
+    #############################################################################
 
     def test10410(self):
         """Test G41 command Generation."""
@@ -411,10 +463,14 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
         self.compare_third_line("G41 D0", "G41 D0", "")
         self.compare_third_line("G41 D1.23456", "G41 D1", "--inches")
 
+    #############################################################################
+
     def test10411(self):
         """Test G41.1 command Generation."""
         self.compare_third_line("G41.1 D1.23456 L3", "G41.1 D1.235 L3", "")
         self.compare_third_line("G41.1 D1.23456 L3", "G41.1 D0.0486 L3", "--inches")
+
+    #############################################################################
 
     def test10420(self):
         """Test G42 command Generation."""
@@ -422,10 +478,14 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
         self.compare_third_line("G42 D0", "G42 D0", "")
         self.compare_third_line("G42 D1.23456", "G42 D1", "--inches")
 
+    #############################################################################
+
     def test10421(self):
         """Test G42.1 command Generation."""
         self.compare_third_line("G42.1 D1.23456 L3", "G42.1 D1.235 L3", "")
         self.compare_third_line("G42.1 D1.23456 L3", "G42.1 D0.0486 L3", "--inches")
+
+    #############################################################################
 
     def test10430(self):
         """Test G43 command Generation."""
@@ -433,6 +493,8 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
         self.compare_third_line("G43 H1.23456", "G43 H1", "")
         self.compare_third_line("G43 H0", "G43 H0", "")
         self.compare_third_line("G43 H1.23456", "G43 H1", "--inches")
+
+    #############################################################################
 
     def test10431(self):
         """Test G43.1 command Generation."""
@@ -456,13 +518,19 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
             "--inches",
         )
 
+    #############################################################################
+
     def test10432(self):
         """Test G43.2 command Generation."""
         self.compare_third_line("G43.2 H1.23456", "G43.2 H1", "")
 
+    #############################################################################
+
     def test10490(self):
         """Test G49 command Generation."""
         self.compare_third_line("G49", "G49", "")
+
+    #############################################################################
 
     def test10520(self):
         """Test G52 command Generation."""
@@ -505,6 +573,8 @@ G52 X0.0000 Y0.0000 Z0.0000 A0.0000 B0.0000 C0.0000 U0.0000 V0.0000 W0.0000
             "--inches",
         )
 
+    #############################################################################
+
     #     def test10530(self):
     #         """Test G53 command Generation."""
     #         #
@@ -531,9 +601,13 @@ G52 X0.0000 Y0.0000 Z0.0000 A0.0000 B0.0000 C0.0000 U0.0000 V0.0000 W0.0000
     #         print("--------\n" + gcode + "--------\n")
     #         self.assertEqual(gcode, expected)
 
+    #############################################################################
+
     def test10540(self):
         """Test G54 command Generation."""
         self.compare_third_line("G54", "G54", "")
+
+    #############################################################################
 
     def test10541(self):
         """Test G54.1 command Generation."""
@@ -543,21 +617,31 @@ G52 X0.0000 Y0.0000 Z0.0000 A0.0000 B0.0000 C0.0000 U0.0000 V0.0000 W0.0000
         #
         self.compare_third_line("G54.1 P2.34567", "G54.1 P2", "")
 
+    #############################################################################
+
     def test10550(self):
         """Test G55 command Generation."""
         self.compare_third_line("G55", "G55", "")
+
+    #############################################################################
 
     def test10560(self):
         """Test G56 command Generation."""
         self.compare_third_line("G56", "G56", "")
 
+    #############################################################################
+
     def test10570(self):
         """Test G57 command Generation."""
         self.compare_third_line("G57", "G57", "")
 
+    #############################################################################
+
     def test10580(self):
         """Test G58 command Generation."""
         self.compare_third_line("G58", "G58", "")
+
+    #############################################################################
 
     def test10590(self):
         """Test G59 command Generation."""
@@ -565,53 +649,77 @@ G52 X0.0000 Y0.0000 Z0.0000 A0.0000 B0.0000 C0.0000 U0.0000 V0.0000 W0.0000
         #
         # Some gcode interpreters use G59 P- to select additional
         # work coordinate systems.  This is considered somewhat
-        # obsolete and is being replaces by G54.1 P- instead.
+        # obsolete and is being replaced by G54.1 P- instead.
         #
         self.compare_third_line("G59 P2.34567", "G59 P2", "")
+
+    #############################################################################
 
     def test10591(self):
         """Test G59.1 command Generation."""
         self.compare_third_line("G59.1", "G59.1", "")
 
+    #############################################################################
+
     def test10592(self):
         """Test G59.2 command Generation."""
         self.compare_third_line("G59.2", "G59.2", "")
+
+    #############################################################################
 
     def test10593(self):
         """Test G59.3 command Generation."""
         self.compare_third_line("G59.3", "G59.3", "")
 
+    #############################################################################
+
     def test10594(self):
         """Test G59.4 command Generation."""
         self.compare_third_line("G59.4", "G59.4", "")
+
+    #############################################################################
 
     def test10595(self):
         """Test G59.5 command Generation."""
         self.compare_third_line("G59.5", "G59.5", "")
 
+    #############################################################################
+
     def test10596(self):
         """Test G59.6 command Generation."""
         self.compare_third_line("G59.6", "G59.6", "")
+
+    #############################################################################
 
     def test10597(self):
         """Test G59.7 command Generation."""
         self.compare_third_line("G59.7", "G59.7", "")
 
+    #############################################################################
+
     def test10598(self):
         """Test G59.8 command Generation."""
         self.compare_third_line("G59.8", "G59.8", "")
+
+    #############################################################################
 
     def test10599(self):
         """Test G59.9 command Generation."""
         self.compare_third_line("G59.9", "G59.9", "")
 
+    #############################################################################
+
     def test10610(self):
         """Test G61 command Generation."""
         self.compare_third_line("G61", "G61", "")
 
+    #############################################################################
+
     def test10611(self):
         """Test G61.1 command Generation."""
         self.compare_third_line("G61.1", "G61.1", "")
+
+    #############################################################################
 
     def test10640(self):
         """Test G64 command Generation."""
@@ -621,6 +729,8 @@ G52 X0.0000 Y0.0000 Z0.0000 A0.0000 B0.0000 C0.0000 U0.0000 V0.0000 W0.0000
         self.compare_third_line(
             "G64 P3.456789 Q4.567891", "G64 P0.1361 Q0.1798", "--inches"
         )
+
+    #############################################################################
 
     def test10730(self):
         """Test G73 command Generation."""
@@ -792,6 +902,8 @@ G90
             "--comments --translate_drill",
         )
 
+    #############################################################################
+
     def test10810(self):
         """Test G81 command Generation."""
         path = [
@@ -925,6 +1037,8 @@ G90
 """,
             "--comments --translate_drill",
         )
+
+    #############################################################################
 
     def test10820(self):
         """Test G82 command Generation."""
@@ -1063,6 +1177,8 @@ G90
 """,
             "--comments --translate_drill",
         )
+
+    #############################################################################
 
     def test10830(self):
         """Test G83 command Generation."""
@@ -1234,21 +1350,31 @@ G90
             "--comments --translate_drill",
         )
 
+    #############################################################################
+
     def test10900(self):
         """Test G90 command Generation."""
         self.compare_third_line("G90", "G90", "")
+
+    #############################################################################
 
     def test10901(self):
         """Test G90.1 command Generation."""
         self.compare_third_line("G90.1", "G90.1", "")
 
+    #############################################################################
+
     def test10910(self):
         """Test G91 command Generation."""
         self.compare_third_line("G91", "G91", "")
 
+    #############################################################################
+
     def test10911(self):
         """Test G91.1 command Generation."""
         self.compare_third_line("G91.1", "G91.1", "")
+
+    #############################################################################
 
     def test10920(self):
         """Test G92 command Generation."""
@@ -1261,33 +1387,49 @@ G90
             "",
         )
 
+    #############################################################################
+
     def test10921(self):
         """Test G92.1 command Generation."""
         self.compare_third_line("G92.1", "G92.1", "")
+
+    #############################################################################
 
     def test10922(self):
         """Test G92.2 command Generation."""
         self.compare_third_line("G92.2", "G92.2", "")
 
+    #############################################################################
+
     def test10923(self):
         """Test G92.3 command Generation."""
         self.compare_third_line("G92.3", "G92.3", "")
+
+    #############################################################################
 
     def test10930(self):
         """Test G93 command Generation."""
         self.compare_third_line("G93", "G93", "")
 
+    #############################################################################
+
     def test10940(self):
         """Test G94 command Generation."""
         self.compare_third_line("G94", "G94", "")
+
+    #############################################################################
 
     def test10950(self):
         """Test G95 command Generation."""
         self.compare_third_line("G95", "G95", "")
 
+    #############################################################################
+
     def test10980(self):
         """Test G98 command Generation."""
         self.compare_third_line("G98", "G98", "")
+
+    #############################################################################
 
     def test10990(self):
         """Test G99 command Generation."""

--- a/src/Mod/Path/PathTests/TestRefactoredTestPostMCodes.py
+++ b/src/Mod/Path/PathTests/TestRefactoredTestPostMCodes.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2022 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
+# *   Copyright (c) 2022-2023 Larry Woestman <LarryWoestman2@gmail.com>     *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -110,6 +110,7 @@ class TestRefactoredTestPostMCodes(PathTestUtils.PathTestBase):
             print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[2], expected)
 
+    #############################################################################
     #
     # The tests are organized into groups:
     #
@@ -118,68 +119,95 @@ class TestRefactoredTestPostMCodes(PathTestUtils.PathTestBase):
     #   10000 - 19999  tests for the various G codes at 10000 + 10 * g_code_value
     #   20000 - 29999  tests for the various M codes at 20000 + 10 * m_code_value
     #
+    #############################################################################
 
     def test20000(self):
         """Test M0 command Generation."""
         self.compare_third_line("M0", "M0", "")
         self.compare_third_line("M00", "M00", "")
 
+    #############################################################################
+
     def test20010(self):
         """Test M1 command Generation."""
         self.compare_third_line("M1", "M1", "")
         self.compare_third_line("M01", "M01", "")
+
+    #############################################################################
 
     def test20020(self):
         """Test M2 command Generation."""
         self.compare_third_line("M2", "M2", "")
         self.compare_third_line("M02", "M02", "")
 
+    #############################################################################
+
     def test20030(self):
         """Test M3 command Generation."""
         self.compare_third_line("M3", "M3", "")
         self.compare_third_line("M03", "M03", "")
+
+    #############################################################################
 
     def test20040(self):
         """Test M4 command Generation."""
         self.compare_third_line("M4", "M4", "")
         self.compare_third_line("M04", "M04", "")
 
+    #############################################################################
+
     def test20050(self):
         """Test M5 command Generation."""
         self.compare_third_line("M5", "M5", "")
         self.compare_third_line("M05", "M05", "")
+
+    #############################################################################
 
     def test20060(self):
         """Test M6 command Generation."""
         self.compare_third_line("M6", "M6", "")
         self.compare_third_line("M06", "M06", "")
 
+    #############################################################################
+
     def test20070(self):
         """Test M7 command Generation."""
         self.compare_third_line("M7", "M7", "")
         self.compare_third_line("M07", "M07", "")
+
+    #############################################################################
 
     def test20080(self):
         """Test M8 command Generation."""
         self.compare_third_line("M8", "M8", "")
         self.compare_third_line("M08", "M08", "")
 
+    #############################################################################
+
     def test20090(self):
         """Test M9 command Generation."""
         self.compare_third_line("M9", "M9", "")
         self.compare_third_line("M09", "M09", "")
 
+    #############################################################################
+
     def test20300(self):
         """Test M30 command Generation."""
         self.compare_third_line("M30", "M30", "")
+
+    #############################################################################
 
     def test20480(self):
         """Test M48 command Generation."""
         self.compare_third_line("M48", "M48", "")
 
+    #############################################################################
+
     def test20490(self):
         """Test M49 command Generation."""
         self.compare_third_line("M49", "M49", "")
+
+    #############################################################################
 
     def test20600(self):
         """Test M60 command Generation."""


### PR DESCRIPTION
This is part of the work for #6117.

This is one in a series of PR's where I am taking code from at least 4 postprocessor files partially written by different people, combining them into a few files, then trying to make the code more consistent and simpler. The long term goal is to enable much simpler postprocessor files with much less copied code in each postprocessor file and much more "shared" code in the Utils*.py files.

In this PR I added some lines of "###..." between the tests to make them easier to find and fixed a few typo's.