### PR TITLE
Arch: remove global precision variables

### DIFF
--- a/src/Mod/Arch/importIFClegacy.py
+++ b/src/Mod/Arch/importIFClegacy.py
@@ -40,7 +40,6 @@ MAKETEMPFILES = False # if True, shapes are passed from ifcopenshell to freecad 
 DEBUG = True # this is only for the python console, this value is overridden when importing through the GUI
 SKIP = ["IfcBuildingElementProxy","IfcFlowTerminal","IfcFurnishingElement"] # default. overwritten by the GUI options
 IFCLINE_RE = re.compile("#(\d+)[ ]?=[ ]?(.*?)\((.*)\);[\\r]?$")
-PRECISION = 4 # rounding value, in number of digits
 APPLYFIX = True # if true, the ifcopenshell bug-fixing function is applied when saving files
 # end config
 
@@ -944,7 +943,6 @@ def export(exportList,filename):
 
     # creating base IFC project
     getConfig()
-    PRECISION = Draft.precision()
     p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch")
     scaling = p.GetFloat("IfcScalingFactor",1.0)
     exporttxt = p.GetBool("IfcExportList",False)
@@ -1904,7 +1902,7 @@ def getTuple(vec):
     structures: tuple, list, 3d vector, or occ vertex"""
     def fmt(t):
         t = float(t)
-        t = round(t,PRECISION)
+        t = round(t,Draft.precision())
         return t
     if isinstance(vec,tuple):
         return tuple([fmt(v) for v in vec])
@@ -1918,12 +1916,13 @@ def getTuple(vec):
 def getValueAndDirection(vec):
     """getValueAndDirection(vec): returns a length and a tuple
     representing a normalized vector from a tuple"""
+    pre = Draft.precision()
     vec = getTuple(vec)
-    length = round(math.sqrt(vec[0]**2 + vec[1]**2 + vec[2]**2),PRECISION)
+    length = round(math.sqrt(vec[0]**2 + vec[1]**2 + vec[2]**2),pre)
     ratio = 1/length
-    x = round(vec[0]*ratio,PRECISION)
-    y = round(vec[1]*ratio,PRECISION)
-    z = round(vec[2]*ratio,PRECISION)
+    x = round(vec[0]*ratio,pre)
+    y = round(vec[1]*ratio,pre)
+    z = round(vec[2]*ratio,pre)
     normal = (x,y,z)
     return length,normal
 

--- a/src/Mod/Arch/importOBJ.py
+++ b/src/Mod/Arch/importOBJ.py
@@ -49,13 +49,12 @@ else:
 #  and supports exporting faces with more than 3 vertices
 #  and supports object colors / materials
 
-p = Draft.precision()
-
 if open.__module__ in ['__builtin__','io']:
     pythonopen = open
 
 def findVert(aVertex,aList):
     "finds aVertex in aList, returns index"
+    p = Draft.precision()
     for i in range(len(aList)):
         if round(aVertex.X,p) == round(aList[i].X,p):
             if round(aVertex.Y,p) == round(aList[i].Y,p):
@@ -65,6 +64,7 @@ def findVert(aVertex,aList):
 
 def getIndices(obj,shape,offsetv,offsetvn):
     "returns a list with 2 lists: vertices and face indexes, offset with the given amount"
+    p = Draft.precision()
     vlist = []
     vnlist = []
     elist = []


### PR DESCRIPTION
To avoid having to restart after changing the Draft precision parameter.
