### PR TITLE
Gui: save active palette

### DIFF
--- a/src/Gui/ExpressionBinding.cpp
+++ b/src/Gui/ExpressionBinding.cpp
@@ -295,6 +295,7 @@ QPixmap ExpressionWidget::getIcon(const char* name, const QSize& size) const
 void ExpressionWidget::makeLabel(QLineEdit* le)
 {
     defaultPalette = le->palette();
+    defaultPalette.setCurrentColorGroup(QPalette::Active);
 
     /* Icon for f(x) */
     QFontMetrics fm(le->font());


### PR DESCRIPTION
If the QLineEdit is disabled the current color group of the cached QPalette is set to 'Inactive'. Now when enabling the QLineEdit the wrong palette is set and the text looks like it's inactive.

See forum: https://forum.freecad.org/viewtopic.php?p=719459#p719459