### PR TITLE
Draft: store more command modes in prefs

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-draft.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draft.ui
@@ -188,26 +188,6 @@ This allows to point the direction and type the distance.</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_6">
-          <property name="toolTip">
-           <string>If this is checked, objects will appear as filled by default.
-Otherwise, they will appear as wireframe</string>
-          </property>
-          <property name="text">
-           <string>Fill objects with faces whenever possible</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>fillmode</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="0">
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_3">
           <property name="toolTip">
@@ -225,7 +205,7 @@ If this option is checked, the base objects will be selected instead.</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="2" column="0">
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_13">
           <property name="toolTip">
            <string>Force Draft Tools to create Part primitives instead of Draft objects.

--- a/src/Mod/Draft/draftguitools/gui_stretch.py
+++ b/src/Mod/Draft/draftguitools/gui_stretch.py
@@ -160,7 +160,7 @@ class Stretch(gui_base_original.Modifier):
             # first rctangle point
             _msg(translate("draft", "Pick opposite point "
                                     "of selection rectangle"))
-            self.ui.setRelative()
+            self.ui.setRelative(-1)
             self.rectracker.setorigin(point)
             self.rectracker.on()
             if self.planetrack:
@@ -169,6 +169,7 @@ class Stretch(gui_base_original.Modifier):
         elif self.step == 2:
             # second rectangle point
             _msg(translate("draft", "Pick start point of displacement"))
+            self.ui.setRelative(-2)
             self.rectracker.off()
             nodes = []
             self.ops = []


### PR DESCRIPTION
With this PR the following 5 command modes are automatically stored in the preferences:
* "ContinueMode"
* "RelativeMode"
* "GlobalMode"
* "fillmode" (existing preference, removed from the Preferences Editor)
* "SubelementMode"

Additionally:
Three commands (Draft_Ellipse, Draft_Rectangle and Draft_Stretch) call `setRelative` after the 1st point has been specified and would permanently switch on relativeMode. After this PR this switch is temporarily.
