### PR TITLE
fix default state of combo view #backport

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2337,7 +2337,7 @@ void Application::runApplication()
 
     // Reactivate the startup workbench
     app.activateWorkbench(start.c_str());
-
+    Gui::Control().showModelView();
     Instance->d->startingUp = false;
 
     // gets called once we start the event loop


### PR DESCRIPTION
Hi, this is my first PR to FreeCAD.

This is related to the following forum thread: [Start-up, Combo-View: task panel instead of Model panel](https://forum.freecad.org/viewtopic.php?t=74583)

I know, that I should actually base a PR on "main", but as this has - at least from my observation - no impact on 0.22, I chose 0.21 as a base.
I saw that a 0.21.2 is in the making... I hope, this is not too late.
thanks