### PR TITLE
Part: Add BRepFeat_MakeRevol.hxx to Precompiled header

### DIFF
--- a/src/Mod/Part/App/OpenCascadeAll.h
+++ b/src/Mod/Part/App/OpenCascadeAll.h
@@ -142,6 +142,7 @@
 #include <BRepExtrema_MapOfIntegerPackedMapOfInteger.hxx>
 #include <BRepExtrema_ShapeProximity.hxx>
 #include <BRepFeat_MakePrism.hxx>
+#include <BRepFeat_MakeRevol.hxx>
 #include <BRepFeat_SplitShape.hxx>
 #include <BRepFill.hxx>
 #include <BRepFill_Filling.hxx>


### PR DESCRIPTION
When https://github.com/FreeCAD/FreeCAD/pull/7193 merged today it broke the headers when using PCH -- adding this OCCT header to OpenCascadeAll.h resolves the issue.