### PR TITLE
[TechDraw] Fixes #7317 - Calculate Area of Arbitrary Faces

### DIFF
--- a/src/Mod/TechDraw/Gui/Resources/icons/TechDraw_ExtensionAreaAnnotation.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/TechDraw_ExtensionAreaAnnotation.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   width="8.47mm"
-   height="8.47mm"
+   width="32"
+   height="32"
    fill-rule="evenodd"
    stroke-linejoin="round"
    stroke-width="28.222"

--- a/src/Mod/TechDraw/Gui/Resources/icons/TechDraw_ExtensionAreaAnnotation.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/TechDraw_ExtensionAreaAnnotation.svg
@@ -1,61 +1,88 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
-<svg width="8.47mm" height="8.47mm" fill-rule="evenodd" stroke-linejoin="round" stroke-width="28.222" preserveAspectRatio="xMidYMid" version="1.2" viewBox="0 0 847 847" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
- <defs class="ClipPathGroup">
-  <clipPath id="presentation_clip_path">
-   <rect width="847" height="847"/>
-  </clipPath>
- </defs>
- <defs>
-  <font id="EmbeddedFont_1" horiz-adv-x="2048">
-   <font-face font-family="Liberation Sans embedded" font-weight="bold" ascent="1852" descent="423" units-per-em="2048"/>
-   <missing-glyph d="M 0,0 L 2047,0 2047,2047 0,2047 0,0 Z" horiz-adv-x="2048"/>
-   <glyph d="M 1133,0 L 1008,360 471,360 346,0 51,0 565,1409 913,1409 1425,0 1133,0 Z M 739,1192 L 733,1170 C 726,1146 718,1119 709,1088 700,1057 642,889 537,582 L 942,582 803,987 760,1123 739,1192 Z" horiz-adv-x="1351" unicode="A"/>
-   <glyph d="M 71,0 L 71,195 C 108,276 160,354 228,431 295,508 380,588 483,671 582,751 651,817 691,869 730,921 750,972 750,1022 750,1145 688,1206 565,1206 505,1206 459,1190 428,1158 396,1125 375,1077 366,1012 L 83,1028 C 99,1159 148,1258 230,1327 311,1396 422,1430 563,1430 715,1430 832,1395 913,1326 994,1257 1035,1159 1035,1034 1035,968 1022,908 996,855 970,802 937,753 896,708 855,663 810,620 761,581 711,542 663,503 616,466 569,429 527,391 489,353 450,315 422,274 403,231 L 1057,231 1057,0 71,0 Z" horiz-adv-x="1006" unicode="2"/>
-  </font>
- </defs>
- <defs class="EmbeddedBulletChars">
- </defs>
- <g class="SlideGroup">
-   <g id="container-id1">
-    <g id="id1" class="Slide" clip-path="url(#presentation_clip_path)">
-     <g class="Page">
-      <g class="Graphic">
-       <g id="id3">
-        <rect class="BoundingBox" width="847" height="847" fill="none"/>
-        <defs>
-         <clipPath id="clip_path_1">
-          <path d="m0 0h846v846h-846v-846z"/>
-         </clipPath>
-        </defs>
-        <g clip-path="url(#clip_path_1)">
-         <path d="m415 105h-293v-33h586v33h-293z" fill="#f00"/>
-         <path d="m415 105h-293v-33h586v33h-293z" fill="none" stroke="#f00" stroke-linejoin="miter" stroke-width="25"/>
-         <path d="m117 420v293h-33v-587h33v294z" fill="#f00"/>
-         <path d="m117 420v293h-33v-587h33v294z" fill="none" stroke="#f00" stroke-linejoin="miter" stroke-width="25"/>
-         <path d="m775 416v293h-33v-586h33v293z" fill="#f00"/>
-         <path d="m775 416v293h-33v-586h33v293z" fill="none" stroke="#f00" stroke-linejoin="miter" stroke-width="25"/>
-         <path d="m89 739v-38h658v75h-658v-37z" fill="#ff0"/>
-         <path d="m89 739v-38h658v75h-658v-37z" fill="none" stroke="#2b2200" stroke-linejoin="round" stroke-width="25"/>
-         <path d="m89 97v-38h658v76h-658v-38z" fill="#ff0"/>
-         <path d="m89 97v-38h658v76h-658v-38z" fill="none" stroke="#2b2200" stroke-linejoin="round" stroke-width="25"/>
-         <path d="m749 92h37v658h-75v-658h38z" fill="#ff0"/>
-         <path d="m749 92h37v658h-75v-658h38z" fill="none" stroke="#2b2200" stroke-linejoin="round" stroke-width="25"/>
-         <path d="m100 92h38v658h-75v-658h37z" fill="#ff0"/>
-         <path d="m100 92h38v658h-75v-658h37z" fill="none" stroke="#2b2200" stroke-linejoin="round" stroke-width="25"/>
-         <path d="m18 747c0-14 4-29 11-41 8-13 18-24 31-31s28-11 43-11 30 4 43 11 23 18 31 31c7 12 11 27 11 41 0 15-4 29-11 42-8 13-18 23-31 31-13 7-28 11-43 11s-30-4-43-11c-13-8-23-18-31-31-7-13-11-27-11-42z" fill="#ff0"/>
-         <path d="m18 747c0-14 4-29 11-41 8-13 18-24 31-31s28-11 43-11 30 4 43 11 23 18 31 31c7 12 11 27 11 41 0 15-4 29-11 42-8 13-18 23-31 31-13 7-28 11-43 11s-30-4-43-11c-13-8-23-18-31-31-7-13-11-27-11-42z" fill="none" stroke="#2b2200" stroke-linejoin="miter" stroke-width="32"/>
-         <path d="m655 740c0-14 4-29 12-41 7-13 18-24 31-31s28-11 43-11 29 4 42 11 24 18 31 31c8 12 12 27 12 42 0 14-4 29-12 41-7 13-18 24-31 31s-27 11-42 11-30-4-43-11-24-18-31-31c-8-12-12-27-12-41v-1z" fill="#ff0"/>
-         <path d="m655 740c0-14 4-29 12-41 7-13 18-24 31-31s28-11 43-11 29 4 42 11 24 18 31 31c8 12 12 27 12 42 0 14-4 29-12 41-7 13-18 24-31 31s-27 11-42 11-30-4-43-11-24-18-31-31c-8-12-12-27-12-41" fill="none" stroke="#2b2200" stroke-linejoin="miter" stroke-width="32"/>
-         <path d="m17 99c0-15 4-29 11-42 8-13 18-23 31-31 13-7 28-11 43-11s30 4 43 11c13 8 23 18 31 31 7 13 11 27 11 42 0 14-4 29-11 41-8 13-18 24-31 31s-28 11-43 11-30-4-43-11-23-18-31-31c-7-12-11-27-11-41z" fill="#ff0"/>
-         <path d="m17 99c0-15 4-29 11-42 8-13 18-23 31-31 13-7 28-11 43-11s30 4 43 11c13 8 23 18 31 31 7 13 11 27 11 42 0 14-4 29-11 41-8 13-18 24-31 31s-28 11-43 11-30-4-43-11-23-18-31-31c-7-12-11-27-11-41z" fill="none" stroke="#2b2200" stroke-linejoin="miter" stroke-width="32"/>
-         <path d="m659 102c0-15 4-29 11-42 8-13 18-23 31-31 13-7 28-11 43-11s30 4 43 11c13 8 23 18 31 31 7 13 11 27 11 42s-4 29-11 42c-8 12-18 23-31 30-13 8-28 12-43 12s-30-4-43-12c-13-7-23-18-31-30-7-13-11-27-11-42z" fill="#ff0"/>
-         <path d="m659 102c0-15 4-29 11-42 8-13 18-23 31-31 13-7 28-11 43-11s30 4 43 11c13 8 23 18 31 31 7 13 11 27 11 42s-4 29-11 42c-8 12-18 23-31 30-13 8-28 12-43 12s-30-4-43-12c-13-7-23-18-31-30-7-13-11-27-11-42z" fill="none" stroke="#2b2200" stroke-linejoin="miter" stroke-width="32"/>
-        </g>
-       </g>
-      </g>
-     </g>
-    </g>
-   </g>
- </g>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="8.47mm"
+   height="8.47mm"
+   fill-rule="evenodd"
+   stroke-linejoin="round"
+   stroke-width="28.222"
+   preserveAspectRatio="xMidYMid"
+   version="1.2"
+   viewBox="0 0 847 847"
+   xml:space="preserve"
+   id="svg82"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs59741" />
+   <path
+   style="fill:#ffff00;fill-opacity:1;stroke:none;stroke-width:40;stroke-dasharray:none;stroke-opacity:1"
+   d="m 132.29166,145.52083 c 2.59961,79.30664 0,560.91664 0,560.91664 h 555.62497 c 0,0 -60.40195,-478.89582 -555.62497,-560.91664 z"
+   id="path9284" /><path
+   d="m 89,739 v -38 h 658 v 75 H 89 Z"
+   fill="#ffff00"
+   id="path39"
+   style="stroke-width:26.45833208;stroke-dasharray:none;fill:#ffff00;fill-opacity:0.5" /><path
+   style="color:#000000;fill:#ffff00;fill-opacity:0.5;stroke:#000000;stroke-opacity:1;stroke-width:26.45833208;stroke-dasharray:none"
+   d="M 103.6582,66.435547 95.142578,140.95117 C 411.93941,177.15284 662.08158,425.70415 700.30273,742.26367 l 74.45899,-8.99023 C 732.42643,382.63938 454.5551,106.53397 103.6582,66.435547 Z"
+   id="path3929" /><path
+   d="m 89,739 v -38 h 658 v 75 H 89 Z"
+   fill="none"
+   stroke="#2b2200"
+   stroke-linejoin="round"
+   stroke-width="25"
+   id="path41" /><path
+   d="m 100,92 h 38 V 750 H 63 V 92 Z"
+   fill="#ffff00"
+   id="path51"
+   style="fill:#ffff00;fill-opacity:0.5" /><path
+   d="m 100,92 h 38 V 750 H 63 V 92 Z"
+   fill="none"
+   stroke="#2b2200"
+   stroke-linejoin="round"
+   stroke-width="25"
+   id="path53"
+   style="stroke-width:26.45833208;stroke-dasharray:none;stroke:#2b2200;stroke-opacity:1" /><path
+   d="m 18,747 c 0,-14 4,-29 11,-41 8,-13 18,-24 31,-31 13,-7 28,-11 43,-11 15,0 30,4 43,11 13,7 23,18 31,31 7,12 11,27 11,41 0,15 -4,29 -11,42 -8,13 -18,23 -31,31 -13,7 -28,11 -43,11 C 88,831 73,827 60,820 47,812 37,802 29,789 22,776 18,762 18,747 Z"
+   fill="#ffff00"
+   id="path55" /><path
+   d="m 18,747 c 0,-14 4,-29 11,-41 8,-13 18,-24 31,-31 13,-7 28,-11 43,-11 15,0 30,4 43,11 13,7 23,18 31,31 7,12 11,27 11,41 0,15 -4,29 -11,42 -8,13 -18,23 -31,31 -13,7 -28,11 -43,11 C 88,831 73,827 60,820 47,812 37,802 29,789 22,776 18,762 18,747 Z"
+   fill="none"
+   stroke="#2b2200"
+   stroke-linejoin="miter"
+   stroke-width="32"
+   id="path57"
+   transform="translate(-1)"
+   style="stroke-width:31.74999664;stroke-dasharray:none" /><path
+   d="m 655,740 c 0,-14 4,-29 12,-41 7,-13 18,-24 31,-31 13,-7 28,-11 43,-11 15,0 29,4 42,11 13,7 24,18 31,31 8,12 12,27 12,42 0,14 -4,29 -12,41 -7,13 -18,24 -31,31 -13,7 -27,11 -42,11 -15,0 -30,-4 -43,-11 -13,-7 -24,-18 -31,-31 -8,-12 -12,-27 -12,-41 z"
+   fill="#ffff00"
+   id="path59" /><path
+   d="M 17,99 C 17,84 21,70 28,57 36,44 46,34 59,26 72,19 87,15 102,15 c 15,0 30,4 43,11 13,8 23,18 31,31 7,13 11,27 11,42 0,14 -4,29 -11,41 -8,13 -18,24 -31,31 -13,7 -28,11 -43,11 C 87,182 72,178 59,171 46,164 36,153 28,140 21,128 17,113 17,99 Z"
+   fill="#ffff00"
+   id="path63" /><path
+   d="M 17,99 C 17,84 21,70 28,57 36,44 46,34 59,26 72,19 87,15 102,15 c 15,0 30,4 43,11 13,8 23,18 31,31 7,13 11,27 11,42 0,14 -4,29 -11,41 -8,13 -18,24 -31,31 -13,7 -28,11 -43,11 C 87,182 72,178 59,171 46,164 36,153 28,140 21,128 17,113 17,99 Z"
+   fill="none"
+   stroke="#2b2200"
+   stroke-linejoin="miter"
+   stroke-width="32"
+   id="path65"
+   transform="translate(0,0.99999995)"
+   style="stroke-width:31.74999849;stroke-dasharray:none" /><path
+   d="m 656,746.97497 c 0,-14 4,-29 11,-41 8,-13 18,-24 31,-31 13,-7 28,-11 43,-11 15,0 30,4 43,11 13,7 23,18 31,31 7,12 11,27 11,41 0,15 -4,29 -11,42 -8,13 -18,23 -31,31 -13,7 -28,11 -43,11 -15,0 -30,-4 -43,-11 -13,-8 -23,-18 -31,-31 -7,-13 -11,-27 -11,-42 z"
+   fill="none"
+   stroke="#2b2200"
+   stroke-linejoin="miter"
+   stroke-width="32"
+   id="path2099"
+   style="stroke-width:31.69999859;stroke-dasharray:none" /><path
+   style="fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-width:31.75;stroke-linecap:square;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+   d="m 355.76119,499.64268 271.75349,-272.10103 170.23756,0.82473 -170.23756,-0.82473 z"
+   id="path11628" /><g
+   aria-label="m²"
+   id="text12358"
+   style="fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-width:15;stroke-linecap:square;stroke-opacity:1"
+   transform="translate(24.619763,-23.169807)"><path
+     d="m 628.46354,90.830168 q 0,-3.617357 2.68718,-6.097829 1.65365,-1.550296 5.89112,-1.550296 0,0 67.79959,0 13.4359,0 22.2209,8.061537 10.43866,9.50848 10.43866,21.80749 0,0 0,70.69347 0,9.09507 -7.23471,9.09507 -7.95818,0 -7.95818,-9.40513 0,0 0,-68.83312 0,-7.13135 -4.34083,-11.26548 -5.0643,-4.857588 -12.60907,-4.857588 h -14.67613 v 85.059548 q 0,8.99171 -7.33807,8.99171 -8.26824,0 -8.26824,-8.26824 V 98.478292 h -31.72938 v 86.299778 q 0,7.85483 -7.44142,7.85483 -7.44142,0 -7.44142,-7.33806 z"
+     style="font-family:osifont;fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-opacity:1"
+     id="path37062" /><path
+     d="m 792.58816,58.894081 q 0,-6.8213 -7.75148,-6.8213 -5.68441,0 -8.68165,7.338065 -2.48047,6.097829 -6.51124,6.097829 -8.3716,0 -8.3716,-7.131359 0,-4.547534 2.89389,-8.578302 4.44418,-6.201182 8.5783,-9.095066 4.54753,-3.203944 13.12583,-3.203944 10.43866,0 17.88008,8.785007 4.13412,4.857593 4.13412,12.092305 0,9.095067 -7.64812,18.500192 l -15.29625,17.880075 h 13.43589 q 9.71519,0 9.71519,7.028007 0,8.06154 -8.47495,8.06154 h -30.17909 q -8.16489,0 -8.16489,-7.13136 0,-2.790536 4.34083,-7.958187 l 24.59802,-29.352261 q 2.37712,-2.997238 2.37712,-6.511241 z"
+     style="font-family:osifont;fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-opacity:1"
+     id="path37064" /></g></svg>


### PR DESCRIPTION
This pull request implements #7317 so face area computation is not limited to polygons. I have tested several shapes with arcs and bezier curves, the computation seems to work fine.

There are other 2 minor changes. First is a proposed icon change. I have tried to create an icon, which would better represent the "face area" operation. From my point of view it looks better, however if the old one stays, I am not offended!

The second additional change is converting length units ending with ^2 (squared) to length units with ² superscript. E.g. "mm^2" → "mm²". Again, for me this looks much better, but definitely it is not something extra important.

I believe the change will fulfill the expectations, in case of any issues please let me know.