### PR TITLE
Draft: make default anno style non-global

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
@@ -311,6 +311,26 @@ such as &quot;Arial:Bold&quot;</string>
        </layout>
       </item>
       <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_11">
+        <item>
+         <widget class="Gui::PrefCheckBox" name="checkBox">
+          <property name="text">
+           <string>Show the dimension line</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>DimShowLine</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_14">
         <item>
          <widget class="QLabel" name="label">

--- a/src/Mod/Draft/draftguitools/gui_annotationstyleeditor.py
+++ b/src/Mod/Draft/draftguitools/gui_annotationstyleeditor.py
@@ -36,7 +36,6 @@ import draftguitools.gui_base as gui_base
 
 from draftutils.translate import translate
 from draftutils import utils
-from draftutils.utils import ANNOTATION_STYLE as DEFAULT
 
 param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
@@ -326,8 +325,9 @@ class AnnotationStyleEditor(gui_base.GuiCommandSimplest):
         Some properties were missing or misspelled.
         Some float values were wrongly stored as strings.
         """
+        default = utils.get_default_annotation_style()
         new = {}
-        for key, val in DEFAULT.items():
+        for key, val in default.items():
             if style.get(key) is None:
                 new[key] = val[1]
             elif type(style[key]) == type(val[1]):
@@ -340,9 +340,10 @@ class AnnotationStyleEditor(gui_base.GuiCommandSimplest):
 
     def fill_editor(self, style=None):
         """Fill the editor fields with the contents of a style."""
+        default = utils.get_default_annotation_style()
         if style is None or style == "":
             style = {}
-            for key, val in DEFAULT.items():
+            for key, val in default.items():
                 style[key] = val[1]
         elif isinstance(style, dict):
             pass
@@ -353,23 +354,23 @@ class AnnotationStyleEditor(gui_base.GuiCommandSimplest):
 
         for key, value in style.items():
             control = getattr(self.form, key)
-            if DEFAULT[key][0] == "str":
+            if default[key][0] == "str":
                 control.setText(value)
-            elif DEFAULT[key][0] == "font":
+            elif default[key][0] == "font":
                 control.setCurrentFont(QtGui.QFont(value))
-            elif DEFAULT[key][0] == "color":
+            elif default[key][0] == "color":
                 color = QtGui.QColor(utils.rgba_to_argb(value))
                 control.setProperty("color", color)
-            elif DEFAULT[key][0] == "int":
+            elif default[key][0] == "int":
                 control.setValue(value)
-            elif DEFAULT[key][0] == "float":
+            elif default[key][0] == "float":
                 if hasattr(control, "setText"):
                     control.setText(App.Units.Quantity(value, App.Units.Length).UserString)
                 else:
                     control.setValue(value)
-            elif DEFAULT[key][0] == "bool":
+            elif default[key][0] == "bool":
                 control.setChecked(value)
-            elif DEFAULT[key][0] == "index":
+            elif default[key][0] == "index":
                 control.setCurrentIndex(value)
 
     def update_style(self):
@@ -380,25 +381,26 @@ class AnnotationStyleEditor(gui_base.GuiCommandSimplest):
             self.styles[style] = self.get_editor_values()
 
     def get_editor_values(self):
+        default = utils.get_default_annotation_style()
         values = {}
-        for key in DEFAULT.keys():
+        for key in default.keys():
             control = getattr(self.form, key)
-            if DEFAULT[key][0] == "str":
+            if default[key][0] == "str":
                 values[key] = control.text()
-            elif DEFAULT[key][0] == "font":
+            elif default[key][0] == "font":
                 values[key] = control.currentFont().family()
-            elif DEFAULT[key][0] == "color":
+            elif default[key][0] == "color":
                 values[key] = utils.argb_to_rgba(control.property("color").rgba())
-            elif DEFAULT[key][0] == "int":
+            elif default[key][0] == "int":
                 values[key] = control.value()
-            elif DEFAULT[key][0] == "float":
+            elif default[key][0] == "float":
                 if hasattr(control, "setText"):
                     values[key] = App.Units.Quantity(control.text()).Value
                 else:
                     values[key] = control.value()
-            elif DEFAULT[key][0] == "bool":
+            elif default[key][0] == "bool":
                 values[key] = control.isChecked()
-            elif DEFAULT[key][0] == "index":
+            elif default[key][0] == "index":
                 values[key] = control.currentIndex()
         return values
 

--- a/src/Mod/Draft/draftutils/init_draft_statusbar.py
+++ b/src/Mod/Draft/draftutils/init_draft_statusbar.py
@@ -97,22 +97,21 @@ def scale_to_label(scale):
     """
     transform a float number into a 1:X or X:1 scale and return it as label
     """
-    f = round(scale, 2)
-    if f == 1.0:
+    if scale <= 0:
         return "1:1"
-    elif f > 1.0:
+    f = round(scale, 2)
+    if f == 1:
+        return "1:1"
+    if f > 1:
         f = f.as_integer_ratio()
         if f[1] == 1:
             return str(f[0]) + ":1"
-        else:
-            return str(scale)
-    else:
-        f = round(1/scale, 2)
-        f = f.as_integer_ratio()
-        if f[1] == 1:
-            return "1:" + str(f[0])
-        else:
-            return str(scale)
+        return str(scale)
+    f = round(1/scale, 2)
+    f = f.as_integer_ratio()
+    if f[1] == 1:
+        return "1:" + str(f[0])
+    return str(scale)
 
 def label_to_scale(label):
     """

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -56,28 +56,31 @@ if App.GuiUp:
 ARROW_TYPES = ["Dot", "Circle", "Arrow", "Tick", "Tick-2"]
 arrowtypes = ARROW_TYPES
 
-param_draft = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-param_view  = App.ParamGet("User parameter:BaseApp/Preferences/View")
 
-ANNOTATION_STYLE = {
-    "ArrowSize":       ("float", param_draft.GetFloat("arrowsize", 20)),
-    "ArrowType":       ("index", param_draft.GetInt("dimsymbol", 0)),
-    "Decimals":        ("int",   param_draft.GetInt("dimPrecision", 2)),
-    "DimOvershoot":    ("float", param_draft.GetFloat("dimovershoot", 20)),
-    "ExtLines":        ("float", param_draft.GetFloat("extlines", 300)),
-    "ExtOvershoot":    ("float", param_draft.GetFloat("extovershoot", 20)),
-    "FontName":        ("font",  param_draft.GetString("textfont", "Sans")),
-    "FontSize":        ("float", param_draft.GetFloat("textheight", 100)),
-    "LineColor":       ("color", param_view.GetUnsigned("DefaultShapeLineColor", 255)),
-    "LineSpacing":     ("float", param_draft.GetFloat("LineSpacing", 1)),
-    "LineWidth":       ("int",   param_view.GetInt("DefaultShapeLineWidth", 1)),
-    "ScaleMultiplier": ("float", 1),
-    "ShowLine":        ("bool",  True),
-    "ShowUnit":        ("bool",  param_draft.GetBool("showUnit", True)),
-    "TextColor":       ("color", param_draft.GetUnsigned("DefaultTextColor", 255)),
-    "TextSpacing":     ("float", param_draft.GetFloat("dimspacing", 20)),
-    "UnitOverride":    ("str",   param_draft.GetString("overrideUnit", "")),
-}
+def get_default_annotation_style():
+    param_draft = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+    param_view = App.ParamGet("User parameter:BaseApp/Preferences/View")
+    anno_scale = param_draft.GetFloat("DraftAnnotationScale", 1)
+    scale_mult = 1 / anno_scale if anno_scale > 0 else 1
+    return {
+        "ArrowSize":       ("float", param_draft.GetFloat("arrowsize", 20)),
+        "ArrowType":       ("index", param_draft.GetInt("dimsymbol", 0)),
+        "Decimals":        ("int",   param_draft.GetInt("dimPrecision", 2)),
+        "DimOvershoot":    ("float", param_draft.GetFloat("dimovershoot", 20)),
+        "ExtLines":        ("float", param_draft.GetFloat("extlines", 300)),
+        "ExtOvershoot":    ("float", param_draft.GetFloat("extovershoot", 20)),
+        "FontName":        ("font",  param_draft.GetString("textfont", "Sans")),
+        "FontSize":        ("float", param_draft.GetFloat("textheight", 100)),
+        "LineColor":       ("color", param_view.GetUnsigned("DefaultShapeLineColor", 255)),
+        "LineSpacing":     ("float", param_draft.GetFloat("LineSpacing", 1)),
+        "LineWidth":       ("int",   param_view.GetInt("DefaultShapeLineWidth", 1)),
+        "ScaleMultiplier": ("float", scale_mult),
+        "ShowLine":        ("bool",  param_draft.GetBool("DimShowLine", True)),
+        "ShowUnit":        ("bool",  param_draft.GetBool("showUnit", True)),
+        "TextColor":       ("color", param_draft.GetUnsigned("DefaultTextColor", 255)),
+        "TextSpacing":     ("float", param_draft.GetFloat("dimspacing", 20)),
+        "UnitOverride":    ("str",   param_draft.GetString("overrideUnit", "")),
+    }
 
 
 def string_encode_coin(ustr):
@@ -181,7 +184,7 @@ def get_param_type(param):
                    "dimovershoot", "extovershoot", "HatchPatternSize"):
         return "float"
     elif param in ("selectBaseObjects", "alwaysSnap", "grid",
-                   "fillmode", "maxSnap",
+                   "fillmode", "maxSnap", "DimShowLine",
                    "SvgLinesBlack", "dxfStdSize", "showSnapBar",
                    "hideSnapBar", "alwaysShowGrid", "renderPolylineWidth",
                    "showPlaneTracker", "UsePartPrimitives",

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -260,7 +260,7 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
                              "ShowLine",
                              "Graphics",
                              _tip)
-            vobj.ShowLine = True
+            vobj.ShowLine = utils.get_param("DimShowLine", True)
 
     def getDefaultDisplayMode(self):
         """Return the default display mode."""
@@ -361,6 +361,7 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
         self.onChanged(vobj, "LineColor")
         self.onChanged(vobj, "DimOvershoot")
         self.onChanged(vobj, "ExtOvershoot")
+        self.onChanged(vobj, "ShowLine")
 
     def updateData(self, obj, prop):
         """Execute when a property from the Proxy class is changed.

--- a/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
+++ b/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
@@ -90,9 +90,8 @@ class ViewProviderDraftAnnotation(object):
                              "ScaleMultiplier",
                              "Annotation",
                              _tip)
-            annotation_scale = param.GetFloat("DraftAnnotationScale", 1.0)
-            if annotation_scale != 0:
-                vobj.ScaleMultiplier = 1 / annotation_scale
+            anno_scale = param.GetFloat("DraftAnnotationScale", 1)
+            vobj.ScaleMultiplier = 1 / anno_scale if anno_scale > 0 else 1
 
         if "AnnotationStyle" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property",
@@ -200,7 +199,7 @@ class ViewProviderDraftAnnotation(object):
                 # unset style
                 _msg(16 * "-")
                 _msg("Unset style")
-                for visprop in utils.ANNOTATION_STYLE.keys():
+                for visprop in utils.get_default_annotation_style().keys():
                     if visprop in properties:
                         # make property writable
                         vobj.setPropertyStatus(visprop, '-ReadOnly')


### PR DESCRIPTION
Additionally:
* Added the DimShowLine preference. Layout of the tab will be updated later.
* Improved handling of DraftAnnotationScale preference: catch division by zero and use it for the default anno style.
