### PR TITLE
Fix #11449 3rdPart/salomesmesh vtk 9.3 compatibility

### DIFF
--- a/src/3rdParty/salomesmesh/inc/SMESH_SMDS.hxx
+++ b/src/3rdParty/salomesmesh/inc/SMESH_SMDS.hxx
@@ -39,10 +39,6 @@
  #define SMDS_EXPORT
 #endif
 
-#ifdef VTK_HAS_MTIME_TYPE
 #define VTK_MTIME_TYPE vtkMTimeType
-#else
-#define VTK_MTIME_TYPE unsigned long
-#endif
 
 #endif

--- a/src/3rdParty/salomesmesh/src/SMDS/SMDS_UnstructuredGrid.cpp
+++ b/src/3rdParty/salomesmesh/src/SMDS/SMDS_UnstructuredGrid.cpp
@@ -1026,7 +1026,12 @@ void SMDS_UnstructuredGrid::BuildLinks()
   GetLinks()->Allocate(this->GetNumberOfPoints());
   GetLinks()->Register(this);
 //FIXME: vtk9
+  #if VTK_VERSION_NUMBER < VTK_VERSION_CHECK(9,3,0)
   GetLinks()->BuildLinks(this);
+  #else
+  GetLinks()->SetDataSet(this);
+  GetLinks()->BuildLinks();
+  #endif
   GetLinks()->Delete();
 #else
   this->Links = SMDS_CellLinks::New();


### PR DESCRIPTION
vtkMTimeType was introduced in vtk 7.1 so minimum required vtk version with this is 7.1 which available on ubuntu 20.04

@wwmayer 