### PR TITLE
[Path] Sanity, change default zero CycleTime from float to string

### DIFF
--- a/src/Mod/Path/Path/Main/Gui/Sanity.py
+++ b/src/Mod/Path/Path/Main/Gui/Sanity.py
@@ -1427,7 +1427,7 @@ class CommandPathSanity:
             data["items"] = []
             for op in obj.Operations.Group:
                 oplabel = op.Label
-                ctime = op.CycleTime if hasattr(op, "CycleTime") else 0.0
+                ctime = op.CycleTime if hasattr(op, "CycleTime") else "00:00:00"
                 cool = op.CoolantMode if hasattr(op, "CoolantMode") else "N/A"
 
                 o = op
@@ -1440,7 +1440,7 @@ class CommandPathSanity:
 
                 if hasattr(op, "Active") and not op.Active:
                     oplabel = "{} (INACTIVE)".format(oplabel)
-                    ctime = 0.0
+                    ctime = "00:00:00"
 
                 if op.Path.BoundBox.isValid():
                     zmin = FreeCAD.Units.Quantity(


### PR DESCRIPTION
Attempts to fix https://github.com/FreeCAD/FreeCAD/issues/11479 though there seems to be some deeper issue that I just can't replicate with the OP's setup.
