### PR TITLE
Sketcher : Replace toggle icons.

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
+++ b/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
@@ -26,6 +26,7 @@
 
 #include <Gui/Action.h>
 #include <Gui/Application.h>
+#include <Gui/BitmapFactory.h>
 #include <Gui/CommandT.h>
 #include <Gui/Document.h>
 #include <Gui/MainWindow.h>
@@ -62,7 +63,7 @@ namespace SketcherGui
 extern GeometryCreationMode geometryCreationMode;
 
 /* Constrain commands =======================================================*/
-DEF_STD_CMD_A(CmdSketcherToggleConstruction)
+DEF_STD_CMD_AU(CmdSketcherToggleConstruction)
 
 CmdSketcherToggleConstruction::CmdSketcherToggleConstruction()
     : Command("Sketcher_ToggleConstruction")
@@ -112,6 +113,23 @@ CmdSketcherToggleConstruction::CmdSketcherToggleConstruction()
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreatePeriodicBSpline");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CompCreateBSpline");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CarbonCopy");
+    rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_ToggleConstruction");
+}
+
+void CmdSketcherToggleConstruction::updateAction(int mode)
+{
+    auto act = getAction();
+    if (act) {
+        switch (static_cast<GeometryCreationMode>(mode)) {
+            case GeometryCreationMode::Normal:
+                act->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_ToggleConstruction"));
+                break;
+            case GeometryCreationMode::Construction:
+                act->setIcon(
+                    Gui::BitmapFactory().iconFromTheme("Sketcher_ToggleConstruction_Constr"));
+                break;
+        }
+    }
 }
 
 void CmdSketcherToggleConstruction::activated(int iMsg)

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -9688,7 +9688,7 @@ bool CmdSketcherConstrainSnellsLaw::isActive()
 
 // ======================================================================================
 /*** Creation Mode / Toggle to or from Reference ***/
-DEF_STD_CMD_A(CmdSketcherToggleDrivingConstraint)
+DEF_STD_CMD_AU(CmdSketcherToggleDrivingConstraint)
 
 CmdSketcherToggleDrivingConstraint::CmdSketcherToggleDrivingConstraint()
     : Command("Sketcher_ToggleDrivingConstraint")
@@ -9718,7 +9718,23 @@ CmdSketcherToggleDrivingConstraint::CmdSketcherToggleDrivingConstraint()
     rcCmdMgr.addCommandMode("ToggleDrivingConstraint", "Sketcher_CompConstrainRadDia");
     rcCmdMgr.addCommandMode("ToggleDrivingConstraint", "Sketcher_Dimension");
     rcCmdMgr.addCommandMode("ToggleDrivingConstraint", "Sketcher_CompDimensionTools");
+    rcCmdMgr.addCommandMode("ToggleDrivingConstraint", "Sketcher_ToggleDrivingConstraint");
     // rcCmdMgr.addCommandMode("ToggleDrivingConstraint", "Sketcher_ConstrainSnellsLaw");
+}
+
+void CmdSketcherToggleDrivingConstraint::updateAction(int mode)
+{
+    auto act = getAction();
+    if (act) {
+        switch (static_cast<ConstraintCreationMode>(mode)) {
+        case ConstraintCreationMode::Driving:
+            act->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_ToggleConstraint"));
+            break;
+        case ConstraintCreationMode::Reference:
+            act->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_ToggleConstraint_Driven"));
+            break;
+        }
+    }
 }
 
 void CmdSketcherToggleDrivingConstraint::activated(int iMsg)

--- a/src/Mod/Sketcher/Gui/Resources/Sketcher.qrc
+++ b/src/Mod/Sketcher/Gui/Resources/Sketcher.qrc
@@ -56,6 +56,7 @@
         <file>icons/constraints/Sketcher_Crosshair.svg</file>
         <file>icons/constraints/Sketcher_ToggleActiveConstraint.svg</file>
         <file>icons/constraints/Sketcher_ToggleConstraint.svg</file>
+        <file>icons/constraints/Sketcher_ToggleConstraint_Driven.svg</file>
         <file>icons/constraints/Sketcher_Toggle_Constraint_Driven.svg</file>
         <file>icons/constraints/Sketcher_Toggle_Constraint_Driving.svg</file>
     </qresource>
@@ -197,6 +198,7 @@
         <file>icons/geometry/Sketcher_External.svg</file>
         <file>icons/geometry/Sketcher_Split.svg</file>
         <file>icons/geometry/Sketcher_ToggleConstruction.svg</file>
+        <file>icons/geometry/Sketcher_ToggleConstruction_Constr.svg</file>
         <file>icons/geometry/Sketcher_Trimming.svg</file>
     </qresource>
     <qresource>

--- a/src/Mod/Sketcher/Gui/Resources/icons/constraints/Sketcher_ToggleActiveConstraint.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/constraints/Sketcher_ToggleActiveConstraint.svg
@@ -1,103 +1,440 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg width="64px" height="64px" id="svg2816" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <title id="title1152">Sketcher ToggleActiveConstraint</title>
-  <defs id="defs2818">
-    <linearGradient id="linearGradient1146">
-      <stop style="stop-color:#204a87;stop-opacity:1" offset="0" id="stop1142" />
-      <stop style="stop-color:#729fcf;stop-opacity:1" offset="1" id="stop1144" />
+<svg
+   width="64px"
+   height="64px"
+   id="svg2816"
+   version="1.1"
+   sodipodi:docname="Sketcher_ToggleActiveConstraint.svg"
+   inkscape:version="1.1-beta1 (77e7b44db3, 2021-03-28)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview89"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     objecttolerance="10.0"
+     gridtolerance="10.0"
+     guidetolerance="10.0"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.8828125"
+     inkscape:cx="29.662683"
+     inkscape:cy="-2.2948207"
+     inkscape:window-width="3686"
+     inkscape:window-height="1571"
+     inkscape:window-x="145"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2816" />
+  <title
+     id="title1152">Sketcher ToggleActiveConstraint</title>
+  <defs
+     id="defs2818">
+    <linearGradient
+       id="linearGradient1146">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop1142" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop1144" />
     </linearGradient>
-    <linearGradient id="linearGradient1130">
-      <stop style="stop-color:#729fcf;stop-opacity:1" offset="0" id="stop1126" />
-      <stop style="stop-color:#204a87;stop-opacity:1" offset="1" id="stop1128" />
+    <linearGradient
+       id="linearGradient1130">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop1126" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop1128" />
     </linearGradient>
-    <linearGradient id="linearGradient3602">
-      <stop style="stop-color:#ff2600;stop-opacity:1" offset="0" id="stop3604" />
-      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606" />
+    <linearGradient
+       id="linearGradient3602">
+      <stop
+         style="stop-color:#ff2600;stop-opacity:1"
+         offset="0"
+         id="stop3604" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1"
+         offset="1"
+         id="stop3606" />
     </linearGradient>
-    <linearGradient xlink:href="#linearGradient3602" id="linearGradient3608" x1="3.909091" y1="14.363636" x2="24.818181" y2="14.363636" gradientUnits="userSpaceOnUse" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient3608-5" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" gradientUnits="userSpaceOnUse" />
-    <linearGradient id="linearGradient3602-7">
-      <stop style="stop-color:#c51900;stop-opacity:1" offset="0" id="stop3604-1" />
-      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606-3" />
+    <linearGradient
+       xlink:href="#linearGradient3602"
+       id="linearGradient3608"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.818181"
+       y2="14.363636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient3608-5"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3602-7">
+      <stop
+         style="stop-color:#c51900;stop-opacity:1"
+         offset="0"
+         id="stop3604-1" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1"
+         offset="1"
+         id="stop3606-3" />
     </linearGradient>
-    <linearGradient xlink:href="#linearGradient3602-5" id="linearGradient3608-1" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" gradientUnits="userSpaceOnUse" />
-    <linearGradient id="linearGradient3602-5">
-      <stop style="stop-color:#c51900;stop-opacity:1" offset="0" id="stop3604-9" />
-      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606-9" />
+    <linearGradient
+       xlink:href="#linearGradient3602-5"
+       id="linearGradient3608-1"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3602-5">
+      <stop
+         style="stop-color:#c51900;stop-opacity:1"
+         offset="0"
+         id="stop3604-9" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1"
+         offset="1"
+         id="stop3606-9" />
     </linearGradient>
-    <linearGradient y2="14.363636" x2="24.81818" y1="14.363636" x1="3.909091" gradientUnits="userSpaceOnUse" id="linearGradient3686" xlink:href="#linearGradient3602-5" />
-    <linearGradient xlink:href="#linearGradient3602-58" id="linearGradient3608-8" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" gradientUnits="userSpaceOnUse" />
-    <linearGradient id="linearGradient3602-58">
-      <stop style="stop-color:#c51900;stop-opacity:1" offset="0" id="stop3604-2" />
-      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606-2" />
+    <linearGradient
+       y2="14.363636"
+       x2="24.81818"
+       y1="14.363636"
+       x1="3.909091"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3686"
+       xlink:href="#linearGradient3602-5" />
+    <linearGradient
+       xlink:href="#linearGradient3602-58"
+       id="linearGradient3608-8"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3602-58">
+      <stop
+         style="stop-color:#c51900;stop-opacity:1"
+         offset="0"
+         id="stop3604-2" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1"
+         offset="1"
+         id="stop3606-2" />
     </linearGradient>
-    <linearGradient y2="14.363636" x2="24.81818" y1="14.363636" x1="3.909091" gradientUnits="userSpaceOnUse" id="linearGradient3726" xlink:href="#linearGradient3602-58" />
-    <linearGradient id="linearGradient3787">
-      <stop style="stop-color:#0619c0;stop-opacity:1" offset="0" id="stop3789" />
-      <stop style="stop-color:#379cfb;stop-opacity:1" offset="1" id="stop3791" />
+    <linearGradient
+       y2="14.363636"
+       x2="24.81818"
+       y1="14.363636"
+       x1="3.909091"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3726"
+       xlink:href="#linearGradient3602-58" />
+    <linearGradient
+       id="linearGradient3787">
+      <stop
+         style="stop-color:#0619c0;stop-opacity:1"
+         offset="0"
+         id="stop3789" />
+      <stop
+         style="stop-color:#379cfb;stop-opacity:1"
+         offset="1"
+         id="stop3791" />
     </linearGradient>
-    <linearGradient y2="100.10708" x2="609.54919" y1="126.79625" x1="581.26331" gradientUnits="userSpaceOnUse" id="linearGradient3524" xlink:href="#linearGradient3602-58" gradientTransform="matrix(1.3310616,0,0,1.2539521,-770.75488,-101.53511)" />
-    <linearGradient id="linearGradient3144-6">
-      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop3146-9" />
-      <stop offset="1" style="stop-color:#ffffff;stop-opacity:0" id="stop3148-2" />
+    <linearGradient
+       y2="100.10708"
+       x2="609.54919"
+       y1="126.79625"
+       x1="581.26331"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3524"
+       xlink:href="#linearGradient3602-58"
+       gradientTransform="matrix(1.3310616,0,0,1.2539521,-770.75488,-101.53511)" />
+    <linearGradient
+       id="linearGradient3144-6">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3146-9" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3148-2" />
     </linearGradient>
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient3688" xlink:href="#linearGradient3144-6" />
-    <linearGradient id="linearGradient3377">
-      <stop style="stop-color:#ffaa00;stop-opacity:1" offset="0" id="stop3379" />
-      <stop style="stop-color:#faff2b;stop-opacity:1" offset="1" id="stop3381" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3688"
+       xlink:href="#linearGradient3144-6" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1"
+         offset="1"
+         id="stop3381" />
     </linearGradient>
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" offset="0" style="stop-color:black;stop-opacity:0" />
-      <stop style="stop-color:black;stop-opacity:1" offset="0.5" id="stop5056" />
-      <stop id="stop5052" offset="1" style="stop-color:black;stop-opacity:0" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         offset="0"
+         style="stop-color:black;stop-opacity:0" />
+      <stop
+         style="stop-color:black;stop-opacity:1"
+         offset="0.5"
+         id="stop5056" />
+      <stop
+         id="stop5052"
+         offset="1"
+         style="stop-color:black;stop-opacity:0" />
     </linearGradient>
-    <radialGradient id="aigrd2" cx="20.892099" cy="114.5684" r="5.256" fx="20.892099" fy="114.5684" gradientUnits="userSpaceOnUse">
-      <stop offset="0" style="stop-color:#F0F0F0" id="stop15566" />
-      <stop offset="1.0000000" style="stop-color:#9a9a9a;stop-opacity:1" id="stop15568" />
+    <radialGradient
+       id="aigrd2"
+       cx="20.892099"
+       cy="114.5684"
+       r="5.256"
+       fx="20.892099"
+       fy="114.5684"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#F0F0F0"
+         id="stop15566" />
+      <stop
+         offset="1.0000000"
+         style="stop-color:#9a9a9a;stop-opacity:1"
+         id="stop15568" />
     </radialGradient>
-    <radialGradient id="aigrd3" cx="20.892099" cy="64.567902" r="5.257" fx="20.892099" fy="64.567902" gradientUnits="userSpaceOnUse">
-      <stop offset="0" style="stop-color:#F0F0F0" id="stop15573" />
-      <stop offset="1.0000000" style="stop-color:#9a9a9a;stop-opacity:1" id="stop15575" />
+    <radialGradient
+       id="aigrd3"
+       cx="20.892099"
+       cy="64.567902"
+       r="5.257"
+       fx="20.892099"
+       fy="64.567902"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#F0F0F0"
+         id="stop15573" />
+      <stop
+         offset="1.0000000"
+         style="stop-color:#9a9a9a;stop-opacity:1"
+         id="stop15575" />
     </radialGradient>
-    <linearGradient id="linearGradient15662">
-      <stop id="stop15664" offset="0.0000000" style="stop-color:#ffffff;stop-opacity:1" />
-      <stop id="stop15666" offset="1.0000000" style="stop-color:#f8f8f8;stop-opacity:1" />
+    <linearGradient
+       id="linearGradient15662">
+      <stop
+         id="stop15664"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop15666"
+         offset="1.0000000"
+         style="stop-color:#f8f8f8;stop-opacity:1" />
     </linearGradient>
-    <radialGradient xlink:href="#linearGradient259" id="radialGradient4452" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.96049297,0,0,1.041132,-52.144249,-702.33158)" cx="33.966679" cy="35.736916" fx="33.966679" fy="35.736916" r="86.70845" />
-    <linearGradient id="linearGradient259">
-      <stop id="stop260" offset="0.0000000" style="stop-color:#fafafa;stop-opacity:1" />
-      <stop id="stop261" offset="1.0000000" style="stop-color:#bbbbbb;stop-opacity:1" />
+    <radialGradient
+       xlink:href="#linearGradient259"
+       id="radialGradient4452"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96049297,0,0,1.041132,-52.144249,-702.33158)"
+       cx="33.966679"
+       cy="35.736916"
+       fx="33.966679"
+       fy="35.736916"
+       r="86.70845" />
+    <linearGradient
+       id="linearGradient259">
+      <stop
+         id="stop260"
+         offset="0.0000000"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop261"
+         offset="1.0000000"
+         style="stop-color:#bbbbbb;stop-opacity:1" />
     </linearGradient>
-    <radialGradient xlink:href="#linearGradient269" id="radialGradient4454" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.96827297,0,0,1.032767,-48.790699,-701.68513)" cx="8.824419" cy="3.7561285" fx="8.824419" fy="3.7561285" r="37.751713" />
-    <linearGradient id="linearGradient269">
-      <stop id="stop270" offset="0.0000000" style="stop-color:#a3a3a3;stop-opacity:1" />
-      <stop id="stop271" offset="1.0000000" style="stop-color:#4c4c4c;stop-opacity:1" />
+    <radialGradient
+       xlink:href="#linearGradient269"
+       id="radialGradient4454"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96827297,0,0,1.032767,-48.790699,-701.68513)"
+       cx="8.824419"
+       cy="3.7561285"
+       fx="8.824419"
+       fy="3.7561285"
+       r="37.751713" />
+    <linearGradient
+       id="linearGradient269">
+      <stop
+         id="stop270"
+         offset="0.0000000"
+         style="stop-color:#a3a3a3;stop-opacity:1" />
+      <stop
+         id="stop271"
+         offset="1.0000000"
+         style="stop-color:#4c4c4c;stop-opacity:1" />
     </linearGradient>
-    <linearGradient y2="1190.875" x2="1267.9062" y1="1190.875" x1="901.1875" gradientTransform="matrix(0.10456791,0,0,0.10456791,420.90006,-32.97638)" gradientUnits="userSpaceOnUse" id="linearGradient4937" xlink:href="#linearGradient4095" />
-    <linearGradient id="linearGradient4095">
-      <stop id="stop4097" offset="0" style="stop-color:#005bff;stop-opacity:1" />
-      <stop id="stop4099" offset="1" style="stop-color:#c1e3f7;stop-opacity:1" />
+    <linearGradient
+       y2="1190.875"
+       x2="1267.9062"
+       y1="1190.875"
+       x1="901.1875"
+       gradientTransform="matrix(0.10456791,0,0,0.10456791,420.90006,-32.97638)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4937"
+       xlink:href="#linearGradient4095" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         id="stop4097"
+         offset="0"
+         style="stop-color:#005bff;stop-opacity:1" />
+      <stop
+         id="stop4099"
+         offset="1"
+         style="stop-color:#c1e3f7;stop-opacity:1" />
     </linearGradient>
-    <linearGradient gradientUnits="userSpaceOnUse" y2="14.363636" x2="24.818181" y1="14.363636" x1="3.909091" id="linearGradient4396" xlink:href="#linearGradient3602" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient4400" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient4403" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient xlink:href="#linearGradient3787" id="linearGradient4429" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.3180277,0,0,1.2416733,-743.43621,-121.30586)" x1="581.26331" y1="126.79625" x2="609.54919" y2="100.10708" />
-    <linearGradient gradientUnits="userSpaceOnUse" y2="14.363636" x2="24.818181" y1="14.363636" x1="3.909091" id="linearGradient4527" xlink:href="#linearGradient3602" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient4531" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient4534" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient gradientUnits="userSpaceOnUse" y2="14.363636" x2="24.818181" y1="14.363636" x1="3.909091" id="linearGradient3483" xlink:href="#linearGradient3602" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient3487" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient3490" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient xlink:href="#linearGradient1130" id="linearGradient1132" x1="15" y1="13" x2="50" y2="50" gradientUnits="userSpaceOnUse" />
-    <linearGradient xlink:href="#linearGradient1146" id="linearGradient1150" gradientUnits="userSpaceOnUse" x1="50" y1="50" x2="15" y2="13" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="14.363636"
+       x2="24.818181"
+       y1="14.363636"
+       x1="3.909091"
+       id="linearGradient4396"
+       xlink:href="#linearGradient3602" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient4400"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient4403"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       xlink:href="#linearGradient3787"
+       id="linearGradient4429"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3180277,0,0,1.2416733,-743.43621,-121.30586)"
+       x1="581.26331"
+       y1="126.79625"
+       x2="609.54919"
+       y2="100.10708" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="14.363636"
+       x2="24.818181"
+       y1="14.363636"
+       x1="3.909091"
+       id="linearGradient4527"
+       xlink:href="#linearGradient3602" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient4531"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient4534"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="14.363636"
+       x2="24.818181"
+       y1="14.363636"
+       x1="3.909091"
+       id="linearGradient3483"
+       xlink:href="#linearGradient3602" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient3490"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       xlink:href="#linearGradient1130"
+       id="linearGradient1132"
+       x1="15"
+       y1="13"
+       x2="50"
+       y2="50"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(74.311949,8.2166048)" />
+    <linearGradient
+       xlink:href="#linearGradient1146"
+       id="linearGradient1150"
+       gradientUnits="userSpaceOnUse"
+       x1="50"
+       y1="50"
+       x2="15"
+       y2="13"
+       gradientTransform="translate(74.311949,8.2166048)" />
   </defs>
-  <metadata id="metadata2821">
+  <metadata
+     id="metadata2821">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title>Sketcher ToggleActiveConstraint</dc:title>
         <dc:creator>
           <cc:Agent>
@@ -127,18 +464,28 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1">
-    <g id="g1958">
-      <g transform="translate(218.9668,13.671875)" id="g1122">
-        <path style="fill:none;stroke:#280000;stroke-width:9.60000038;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" d="m -198.75391,7.8085938 h -13.69336 V 43.808594 h 36 V 30.003906 Z" id="path1104" />
-        <path style="fill:none;stroke:#cc0000;stroke-width:4.80000019;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" d="m -199.29297,7.8085938 h -13.1543 V 43.808594 h 36 V 30.654297 Z" id="path1114" />
-        <path style="fill:none;stroke:#ef2929;stroke-width:2.4000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" d="m -198.9707,6.609375 h -14.67578 v 38.400391 h 38.40039 V 30.525391 Z" id="path1109" />
-        <path style="fill:none;stroke:#0b1521;stroke-width:9.60000038;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" d="M -197.9668,-6.671875 V 7.8085938 l 21.51953,21.5195312 h 14.48047 v -36 z" id="rect3107-5-2-4" />
-        <path style="fill:none;stroke:#808080;stroke-width:4.80000019;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" d="m -197.9668,-6.671875 v 17.126953 c 4.12917,4.092482 5.27533,5.112301 10.2793,10.123047 4.37809,4.384026 4.98435,5.006318 8.70898,8.75 h 17.01172 v -36 z" id="rect3107-3-3-1-3" />
-        <path style="fill:none;stroke:#bfbfbf;stroke-width:2.4000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-dasharray:none;stroke-opacity:1" d="M -199.16602,-7.8710938 V 6.609375 l 23.91797,23.917969 h 14.48243 V -7.8710938 Z" id="rect3107-6-5-4-5" />
-      </g>
-      <path id="path936-3" d="M 10,10 54,54" style="fill:none;fill-rule:evenodd;stroke:#0b1521;stroke-width:12;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path id="path936" d="M 10,10 54,54" style="fill:url(#linearGradient1132);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1150);stroke-width:6;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <g
+     id="layer1-3"
+     transform="matrix(0,-0.67983925,0.67983925,0,19.462415,44.593065)">
+    <g
+       id="g3894-5"
+       transform="rotate(-45,34.506097,38.050253)">
+      <path
+         id="path3034-9"
+         d="M 17,27 V 19 L -4,32 17,45 v -8 h 40 v 8 L 78,32 57,19 v 8 z"
+         style="fill:#cc0000;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3034-3-6"
+         d="M 15,29 V 22.6 L -0.2,32 15,41.4 V 35 h 44 v 6.4 L 74.2,32 59,22.6 V 29 Z"
+         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
   </g>
+  <path
+     id="path3034-8-9"
+     d="M 40.047184,49.826696 34.858967,55.014913 56.908888,60.203129 51.720672,38.153208 46.532455,43.341425 20.591371,17.400342 25.779588,12.212125 3.7296669,7.0239081 8.9178836,29.073829 14.1061,23.885612 Z"
+     style="fill:#808080;stroke:#0b1521;stroke-width:1.834;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1" />
+  <path
+     id="path3034-3-7-2"
+     d="M 42.641292,49.826696 38.490719,53.977269 54.444485,57.738727 50.683028,41.78496 46.532455,45.935533 17.997263,17.400342 22.147836,13.249768 6.1940698,9.488311 9.9555269,25.442077 14.1061,21.291504 Z"
+     style="fill:none;stroke:#bfbfbf;stroke-width:1.83431;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/constraints/Sketcher_ToggleConstraint_Driven.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/constraints/Sketcher_ToggleConstraint_Driven.svg
@@ -4,7 +4,7 @@
    height="64px"
    id="svg2816"
    version="1.1"
-   sodipodi:docname="Sketcher_ToggleConstraint.svg"
+   sodipodi:docname="Sketcher_ToggleConstraint_Driven.svg"
    inkscape:version="1.1-beta1 (77e7b44db3, 2021-03-28)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -26,9 +26,9 @@
      inkscape:pageopacity="0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="2.9414063"
-     inkscape:cx="41.646746"
-     inkscape:cy="13.428951"
+     inkscape:zoom="8.3195534"
+     inkscape:cx="53.067753"
+     inkscape:cy="31.431976"
      inkscape:window-width="3686"
      inkscape:window-height="1571"
      inkscape:window-x="145"
@@ -421,35 +421,35 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1-2"
-     transform="matrix(0,-0.67268112,0.67268112,0,19.350211,45.14815)">
+     id="layer1-3"
+     transform="matrix(0,-0.67983925,0.67983925,0,19.082143,45.338203)">
     <g
-       id="g3894-8"
+       id="g3894-5"
        transform="rotate(-45,34.506097,38.050253)">
       <path
-         id="path3034-8"
-         d="M 17,27 V 19 L -4,32 17,45 v -8 h 40 v 8 L 78,32 57,19 v 8 z"
-         style="fill:#3465a4;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
-      <path
-         id="path3034-3-7"
-         d="M 15,29 V 22.6 L -0.2,32 15,41.4 V 35 h 44 v 6.4 L 74.2,32 59,22.6 V 29 Z"
-         style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    </g>
-  </g>
-  <g
-     id="layer1"
-     transform="matrix(0,-0.92631783,0.92631783,0,0.31000206,64.013997)">
-    <g
-       id="g3894"
-       transform="rotate(-45,34.506097,38.050253)">
-      <path
-         id="path3034"
+         id="path3034-9"
          d="M 17,27 V 19 L -4,32 17,45 v -8 h 40 v 8 L 78,32 57,19 v 8 z"
          style="fill:#cc0000;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
       <path
-         id="path3034-3"
+         id="path3034-3-6"
          d="M 15,29 V 22.6 L -0.2,32 15,41.4 V 35 h 44 v 6.4 L 74.2,32 59,22.6 V 29 Z"
          style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+  </g>
+  <g
+     id="layer1-2-7"
+     transform="matrix(0,-0.91715581,0.91715581,0,0.58211243,63.699737)">
+    <g
+       id="g3894-8-3"
+       transform="rotate(-45,34.506097,38.050253)">
+      <path
+         id="path3034-8-9"
+         d="M 17,27 V 19 L -4,32 17,45 v -8 h 40 v 8 L 78,32 57,19 v 8 z"
+         style="fill:#3465a4;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3034-3-7-2"
+         d="M 15,29 V 22.6 L -0.2,32 15,41.4 V 35 h 44 v 6.4 L 74.2,32 59,22.6 V 29 Z"
+         style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_ToggleConstruction.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_ToggleConstruction.svg
@@ -1,130 +1,661 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg width="64px" height="64px" id="svg2816" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <defs id="defs2818">
-    <linearGradient id="linearGradient3602">
-      <stop style="stop-color:#ff2600;stop-opacity:1" offset="0" id="stop3604" />
-      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606" />
+<svg
+   width="64px"
+   height="64px"
+   id="svg2816"
+   version="1.1"
+   sodipodi:docname="Sketcher_ToggleConstruction.svg"
+   inkscape:version="1.1-beta1 (77e7b44db3, 2021-03-28)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview109"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     objecttolerance="10.0"
+     gridtolerance="10.0"
+     guidetolerance="10.0"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="8.3195532"
+     inkscape:cx="12.801168"
+     inkscape:cy="43.451853"
+     inkscape:window-width="3686"
+     inkscape:window-height="1571"
+     inkscape:window-x="145"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2816" />
+  <defs
+     id="defs2818">
+    <linearGradient
+       id="linearGradient3602">
+      <stop
+         style="stop-color:#ff2600;stop-opacity:1"
+         offset="0"
+         id="stop3604" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1"
+         offset="1"
+         id="stop3606" />
     </linearGradient>
-    <linearGradient xlink:href="#linearGradient3602" id="linearGradient3608" x1="3.909091" y1="14.363636" x2="24.818181" y2="14.363636" gradientUnits="userSpaceOnUse" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient3608-5" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" gradientUnits="userSpaceOnUse" />
-    <linearGradient id="linearGradient3602-7">
-      <stop style="stop-color:#c51900;stop-opacity:1" offset="0" id="stop3604-1" />
-      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606-3" />
+    <linearGradient
+       xlink:href="#linearGradient3602"
+       id="linearGradient3608"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.818181"
+       y2="14.363636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient3608-5"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3602-7">
+      <stop
+         style="stop-color:#c51900;stop-opacity:1"
+         offset="0"
+         id="stop3604-1" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1"
+         offset="1"
+         id="stop3606-3" />
     </linearGradient>
-    <linearGradient xlink:href="#linearGradient3602-5" id="linearGradient3608-1" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" gradientUnits="userSpaceOnUse" />
-    <linearGradient id="linearGradient3602-5">
-      <stop style="stop-color:#c51900;stop-opacity:1" offset="0" id="stop3604-9" />
-      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606-9" />
+    <linearGradient
+       xlink:href="#linearGradient3602-5"
+       id="linearGradient3608-1"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3602-5">
+      <stop
+         style="stop-color:#c51900;stop-opacity:1"
+         offset="0"
+         id="stop3604-9" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1"
+         offset="1"
+         id="stop3606-9" />
     </linearGradient>
-    <linearGradient y2="14.363636" x2="24.81818" y1="14.363636" x1="3.909091" gradientUnits="userSpaceOnUse" id="linearGradient3686" xlink:href="#linearGradient3602-5" />
-    <linearGradient xlink:href="#linearGradient3602-58" id="linearGradient3608-8" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" gradientUnits="userSpaceOnUse" />
-    <linearGradient id="linearGradient3602-58">
-      <stop style="stop-color:#c51900;stop-opacity:1" offset="0" id="stop3604-2" />
-      <stop style="stop-color:#ff5f00;stop-opacity:1" offset="1" id="stop3606-2" />
+    <linearGradient
+       y2="14.363636"
+       x2="24.81818"
+       y1="14.363636"
+       x1="3.909091"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3686"
+       xlink:href="#linearGradient3602-5" />
+    <linearGradient
+       xlink:href="#linearGradient3602-58"
+       id="linearGradient3608-8"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3602-58">
+      <stop
+         style="stop-color:#c51900;stop-opacity:1"
+         offset="0"
+         id="stop3604-2" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1"
+         offset="1"
+         id="stop3606-2" />
     </linearGradient>
-    <linearGradient y2="14.363636" x2="24.81818" y1="14.363636" x1="3.909091" gradientUnits="userSpaceOnUse" id="linearGradient3726" xlink:href="#linearGradient3602-58" />
-    <linearGradient id="linearGradient3787">
-      <stop style="stop-color:#0619c0;stop-opacity:1" offset="0" id="stop3789" />
-      <stop style="stop-color:#379cfb;stop-opacity:1" offset="1" id="stop3791" />
+    <linearGradient
+       y2="14.363636"
+       x2="24.81818"
+       y1="14.363636"
+       x1="3.909091"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3726"
+       xlink:href="#linearGradient3602-58" />
+    <linearGradient
+       id="linearGradient3787">
+      <stop
+         style="stop-color:#0619c0;stop-opacity:1"
+         offset="0"
+         id="stop3789" />
+      <stop
+         style="stop-color:#379cfb;stop-opacity:1"
+         offset="1"
+         id="stop3791" />
     </linearGradient>
-    <linearGradient id="linearGradient3144-6">
-      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1" id="stop3146-9" />
-      <stop offset="1" style="stop-color:#ffffff;stop-opacity:0" id="stop3148-2" />
+    <linearGradient
+       id="linearGradient3144-6">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3146-9" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3148-2" />
     </linearGradient>
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient3688" xlink:href="#linearGradient3144-6" />
-    <linearGradient id="linearGradient3377">
-      <stop style="stop-color:#ffaa00;stop-opacity:1" offset="0" id="stop3379" />
-      <stop style="stop-color:#faff2b;stop-opacity:1" offset="1" id="stop3381" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3688"
+       xlink:href="#linearGradient3144-6" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1"
+         offset="1"
+         id="stop3381" />
     </linearGradient>
-    <linearGradient id="linearGradient5048">
-      <stop id="stop5050" offset="0" style="stop-color:black;stop-opacity:0" />
-      <stop style="stop-color:black;stop-opacity:1" offset="0.5" id="stop5056" />
-      <stop id="stop5052" offset="1" style="stop-color:black;stop-opacity:0" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         offset="0"
+         style="stop-color:black;stop-opacity:0" />
+      <stop
+         style="stop-color:black;stop-opacity:1"
+         offset="0.5"
+         id="stop5056" />
+      <stop
+         id="stop5052"
+         offset="1"
+         style="stop-color:black;stop-opacity:0" />
     </linearGradient>
-    <radialGradient id="aigrd2" cx="20.892099" cy="114.5684" r="5.256" fx="20.892099" fy="114.5684" gradientUnits="userSpaceOnUse">
-      <stop offset="0" style="stop-color:#F0F0F0" id="stop15566" />
-      <stop offset="1.0000000" style="stop-color:#9a9a9a;stop-opacity:1" id="stop15568" />
+    <radialGradient
+       id="aigrd2"
+       cx="20.892099"
+       cy="114.5684"
+       r="5.256"
+       fx="20.892099"
+       fy="114.5684"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#F0F0F0"
+         id="stop15566" />
+      <stop
+         offset="1.0000000"
+         style="stop-color:#9a9a9a;stop-opacity:1"
+         id="stop15568" />
     </radialGradient>
-    <radialGradient id="aigrd3" cx="20.892099" cy="64.567902" r="5.257" fx="20.892099" fy="64.567902" gradientUnits="userSpaceOnUse">
-      <stop offset="0" style="stop-color:#F0F0F0" id="stop15573" />
-      <stop offset="1.0000000" style="stop-color:#9a9a9a;stop-opacity:1" id="stop15575" />
+    <radialGradient
+       id="aigrd3"
+       cx="20.892099"
+       cy="64.567902"
+       r="5.257"
+       fx="20.892099"
+       fy="64.567902"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#F0F0F0"
+         id="stop15573" />
+      <stop
+         offset="1.0000000"
+         style="stop-color:#9a9a9a;stop-opacity:1"
+         id="stop15575" />
     </radialGradient>
-    <linearGradient id="linearGradient15662">
-      <stop id="stop15664" offset="0.0000000" style="stop-color:#ffffff;stop-opacity:1" />
-      <stop id="stop15666" offset="1.0000000" style="stop-color:#f8f8f8;stop-opacity:1" />
+    <linearGradient
+       id="linearGradient15662">
+      <stop
+         id="stop15664"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop15666"
+         offset="1.0000000"
+         style="stop-color:#f8f8f8;stop-opacity:1" />
     </linearGradient>
-    <radialGradient xlink:href="#linearGradient259" id="radialGradient4452" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.96049297,0,0,1.041132,-52.144249,-702.33158)" cx="33.966679" cy="35.736916" fx="33.966679" fy="35.736916" r="86.70845" />
-    <linearGradient id="linearGradient259">
-      <stop id="stop260" offset="0.0000000" style="stop-color:#fafafa;stop-opacity:1" />
-      <stop id="stop261" offset="1.0000000" style="stop-color:#bbbbbb;stop-opacity:1" />
+    <radialGradient
+       xlink:href="#linearGradient259"
+       id="radialGradient4452"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96049297,0,0,1.041132,-52.144249,-702.33158)"
+       cx="33.966679"
+       cy="35.736916"
+       fx="33.966679"
+       fy="35.736916"
+       r="86.70845" />
+    <linearGradient
+       id="linearGradient259">
+      <stop
+         id="stop260"
+         offset="0.0000000"
+         style="stop-color:#fafafa;stop-opacity:1" />
+      <stop
+         id="stop261"
+         offset="1.0000000"
+         style="stop-color:#bbbbbb;stop-opacity:1" />
     </linearGradient>
-    <radialGradient xlink:href="#linearGradient269" id="radialGradient4454" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.96827297,0,0,1.032767,-48.790699,-701.68513)" cx="8.824419" cy="3.7561285" fx="8.824419" fy="3.7561285" r="37.751713" />
-    <linearGradient id="linearGradient269">
-      <stop id="stop270" offset="0.0000000" style="stop-color:#a3a3a3;stop-opacity:1" />
-      <stop id="stop271" offset="1.0000000" style="stop-color:#4c4c4c;stop-opacity:1" />
+    <radialGradient
+       xlink:href="#linearGradient269"
+       id="radialGradient4454"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96827297,0,0,1.032767,-48.790699,-701.68513)"
+       cx="8.824419"
+       cy="3.7561285"
+       fx="8.824419"
+       fy="3.7561285"
+       r="37.751713" />
+    <linearGradient
+       id="linearGradient269">
+      <stop
+         id="stop270"
+         offset="0.0000000"
+         style="stop-color:#a3a3a3;stop-opacity:1" />
+      <stop
+         id="stop271"
+         offset="1.0000000"
+         style="stop-color:#4c4c4c;stop-opacity:1" />
     </linearGradient>
-    <linearGradient y2="1190.875" x2="1267.9062" y1="1190.875" x1="901.1875" gradientTransform="matrix(0.10456791,0,0,0.10456791,420.90006,-32.97638)" gradientUnits="userSpaceOnUse" id="linearGradient4937" xlink:href="#linearGradient4095" />
-    <linearGradient id="linearGradient4095">
-      <stop id="stop4097" offset="0" style="stop-color:#005bff;stop-opacity:1" />
-      <stop id="stop4099" offset="1" style="stop-color:#c1e3f7;stop-opacity:1" />
+    <linearGradient
+       y2="1190.875"
+       x2="1267.9062"
+       y1="1190.875"
+       x1="901.1875"
+       gradientTransform="matrix(0.10456791,0,0,0.10456791,420.90006,-32.97638)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4937"
+       xlink:href="#linearGradient4095" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         id="stop4097"
+         offset="0"
+         style="stop-color:#005bff;stop-opacity:1" />
+      <stop
+         id="stop4099"
+         offset="1"
+         style="stop-color:#c1e3f7;stop-opacity:1" />
     </linearGradient>
-    <linearGradient gradientUnits="userSpaceOnUse" y2="14.363636" x2="24.818181" y1="14.363636" x1="3.909091" id="linearGradient4396" xlink:href="#linearGradient3602" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient4400" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient4403" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient gradientUnits="userSpaceOnUse" y2="14.363636" x2="24.818181" y1="14.363636" x1="3.909091" id="linearGradient4527" xlink:href="#linearGradient3602" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient4531" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient4534" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient gradientUnits="userSpaceOnUse" y2="14.363636" x2="24.818181" y1="14.363636" x1="3.909091" id="linearGradient3483" xlink:href="#linearGradient3602" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient3487" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient xlink:href="#linearGradient3602-7" id="linearGradient3490" gradientUnits="userSpaceOnUse" x1="3.909091" y1="14.363636" x2="24.81818" y2="14.363636" />
-    <linearGradient id="linearGradient6349">
-      <stop id="stop6351" offset="0" style="stop-color:#000000;stop-opacity:1" />
-      <stop id="stop6353" offset="1" style="stop-color:#000000;stop-opacity:0" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="14.363636"
+       x2="24.818181"
+       y1="14.363636"
+       x1="3.909091"
+       id="linearGradient4396"
+       xlink:href="#linearGradient3602" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient4400"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient4403"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="14.363636"
+       x2="24.818181"
+       y1="14.363636"
+       x1="3.909091"
+       id="linearGradient4527"
+       xlink:href="#linearGradient3602" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient4531"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient4534"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="14.363636"
+       x2="24.818181"
+       y1="14.363636"
+       x1="3.909091"
+       id="linearGradient3483"
+       xlink:href="#linearGradient3602" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient3490"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       id="linearGradient6349">
+      <stop
+         id="stop6351"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1" />
+      <stop
+         id="stop6353"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0" />
     </linearGradient>
-    <linearGradient id="linearGradient3377-8">
-      <stop id="stop3379-3" offset="0" style="stop-color:#0019a3;stop-opacity:1" />
-      <stop id="stop3381-7" offset="1" style="stop-color:#0069ff;stop-opacity:1" />
+    <linearGradient
+       id="linearGradient3377-8">
+      <stop
+         id="stop3379-3"
+         offset="0"
+         style="stop-color:#0019a3;stop-opacity:1" />
+      <stop
+         id="stop3381-7"
+         offset="1"
+         style="stop-color:#0069ff;stop-opacity:1" />
     </linearGradient>
-    <linearGradient gradientTransform="matrix(-1,0,0,1,2199.356,0)" gradientUnits="userSpaceOnUse" y2="1190.875" x2="1267.9062" y1="1190.875" x1="901.1875" id="linearGradient3383" xlink:href="#linearGradient3377-8" />
-    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(-1.4307499,-1.3605156e-7,-1.202713e-8,0.1264801,2674.7488,1244.2826)" r="194.40614" fy="1424.4465" fx="1103.6399" cy="1424.4465" cx="1103.6399" id="radialGradient6355" xlink:href="#linearGradient6349" />
-    <marker style="overflow:visible" id="Arrow2Lend" refX="0.0" refY="0.0" orient="auto">
-      <path transform="scale(1.1) rotate(180) translate(1,0)" d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z " style="font-size:12;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round" id="path3837" />
+    <linearGradient
+       gradientTransform="matrix(-1,0,0,1,2199.356,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1190.875"
+       x2="1267.9062"
+       y1="1190.875"
+       x1="901.1875"
+       id="linearGradient3383"
+       xlink:href="#linearGradient3377-8" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.4307499,-1.3605156e-7,-1.202713e-8,0.1264801,2674.7488,1244.2826)"
+       r="194.40614"
+       fy="1424.4465"
+       fx="1103.6399"
+       cy="1424.4465"
+       cx="1103.6399"
+       id="radialGradient6355"
+       xlink:href="#linearGradient6349" />
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lend"
+       refX="0.0"
+       refY="0.0"
+       orient="auto">
+      <path
+         transform="scale(1.1) rotate(180) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="font-size:12;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         id="path3837" />
     </marker>
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient3904" xlink:href="#linearGradient3144-6" />
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient2370" xlink:href="#linearGradient3144-6" />
-    <radialGradient xlink:href="#linearGradient3144-6" id="radialGradient10504-5" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient10640" xlink:href="#linearGradient3144-6" />
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient10642" xlink:href="#linearGradient3144-6" />
-    <marker style="overflow:visible" id="Arrow2Lend-1" refX="0.0" refY="0.0" orient="auto">
-      <path transform="scale(1.1) rotate(180) translate(1,0)" d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z " style="font-size:12;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round" id="path3837-9" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3904"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2370"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       xlink:href="#linearGradient3144-6"
+       id="radialGradient10504-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10640"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10642"
+       xlink:href="#linearGradient3144-6" />
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lend-1"
+       refX="0.0"
+       refY="0.0"
+       orient="auto">
+      <path
+         transform="scale(1.1) rotate(180) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="font-size:12;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         id="path3837-9" />
     </marker>
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient3904-0" xlink:href="#linearGradient3144-6" />
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient2370-7" xlink:href="#linearGradient3144-6" />
-    <radialGradient xlink:href="#linearGradient3144-6" id="radialGradient10504-5-3" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient10640-6" xlink:href="#linearGradient3144-6" />
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient10642-0" xlink:href="#linearGradient3144-6" />
-    <marker style="overflow:visible" id="Arrow2Lend-7" refX="0.0" refY="0.0" orient="auto">
-      <path transform="scale(1.1) rotate(180) translate(1,0)" d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z " style="font-size:12;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round" id="path3837-95" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3904-0"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2370-7"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       xlink:href="#linearGradient3144-6"
+       id="radialGradient10504-5-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10640-6"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10642-0"
+       xlink:href="#linearGradient3144-6" />
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lend-7"
+       refX="0.0"
+       refY="0.0"
+       orient="auto">
+      <path
+         transform="scale(1.1) rotate(180) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="font-size:12;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         id="path3837-95" />
     </marker>
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient3904-7" xlink:href="#linearGradient3144-6" />
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient2370-8" xlink:href="#linearGradient3144-6" />
-    <radialGradient xlink:href="#linearGradient3144-6" id="radialGradient10504-5-4" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" cx="225.26402" cy="672.79736" fx="225.26402" fy="672.79736" r="34.345188" />
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient10640-7" xlink:href="#linearGradient3144-6" />
-    <radialGradient r="34.345188" fy="672.79736" fx="225.26402" cy="672.79736" cx="225.26402" gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)" gradientUnits="userSpaceOnUse" id="radialGradient10642-1" xlink:href="#linearGradient3144-6" />
-    <linearGradient xlink:href="#linearGradient4096" id="linearGradient4102" x1="26" y1="58" x2="16" y2="26" gradientUnits="userSpaceOnUse" />
-    <linearGradient id="linearGradient4096">
-      <stop style="stop-color:#d3d7cf;stop-opacity:1" offset="0" id="stop4098" />
-      <stop style="stop-color:#ffffff;stop-opacity:1" offset="1" id="stop4100" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3904-7"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2370-8"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       xlink:href="#linearGradient3144-6"
+       id="radialGradient10504-5-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10640-7"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10642-1"
+       xlink:href="#linearGradient3144-6" />
+    <linearGradient
+       xlink:href="#linearGradient4096"
+       id="linearGradient4102"
+       x1="26"
+       y1="58"
+       x2="16"
+       y2="26"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4096">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="0"
+         id="stop4098" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4100" />
     </linearGradient>
-    <linearGradient xlink:href="#linearGradient4096" id="linearGradient4190" gradientUnits="userSpaceOnUse" x1="26" y1="58" x2="16" y2="26" />
+    <linearGradient
+       xlink:href="#linearGradient4096"
+       id="linearGradient4190"
+       gradientUnits="userSpaceOnUse"
+       x1="26"
+       y1="58"
+       x2="16"
+       y2="26" />
+    <linearGradient
+       xlink:href="#linearGradient3836-0-6"
+       id="linearGradient3801-1-3"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
+    <linearGradient
+       id="linearGradient3836-0-6">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-2-7" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-5-5" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3836-0-6"
+       id="linearGradient3801-1-3-5"
+       gradientUnits="userSpaceOnUse"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
   </defs>
-  <metadata id="metadata2821">
+  <metadata
+     id="metadata2821">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
             <dc:title>[wmayer]</dc:title>
@@ -153,15 +684,28 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1">
-    <g transform="translate(23,-23)" id="g3134-7">
-      <rect y="28" x="6" height="30" width="30" id="rect3107-5" style="fill:none;stroke:#204a87;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-opacity:1;stroke-dasharray:6, 12;stroke-dashoffset:20.4" />
-      <rect y="28" x="6" height="30" width="30" id="rect3107-5-6" style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-opacity:1;stroke-dasharray:6, 12;stroke-dashoffset:20.4" />
-    </g>
-    <g id="g3134" transform="translate(2,-2)">
-      <rect y="28" x="8" height="28" width="28" id="rect3107" style="fill:none;stroke:#280000;stroke-width:12;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-opacity:1;stroke-dasharray:none" />
-      <rect y="28" x="8" height="28" width="28" id="rect3107-3" style="fill:none;stroke:#ef2929;stroke-width:7.99999952;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-opacity:1;stroke-dasharray:none" />
-      <rect y="28" x="8" height="28" width="28" id="rect3107-3-7" style="fill:none;stroke:url(#linearGradient4190);stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4.5;stroke-opacity:1;stroke-dasharray:none" />
-    </g>
+  <g
+     id="g1593"
+     transform="matrix(1.1717125,0,0,1.1717125,-4.7144316,-1.2142548)">
+    <path
+       style="fill:#d3d7cf;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 52.27482,49.922109 48.032181,54.16475 5.6057758,11.738344 9.8484153,7.495704 Z"
+       id="path3061" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 48.524081,51.828224 7.9422954,11.246434"
+       id="path3063" />
+  </g>
+  <g
+     id="g1597"
+     transform="matrix(0.78535935,0,0,0.78535935,-28.856324,3.6797714)">
+    <path
+       style="fill:#3465a4;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 67.735801,3.7936952 71.97844,-0.44894628 114.40485,41.97746 110.16221,46.2201 Z"
+       id="path3061-5" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 71.48654,1.8875803 112.06833,42.46937"
+       id="path3063-8" />
   </g>
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_ToggleConstruction_Constr.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/geometry/Sketcher_ToggleConstruction_Constr.svg
@@ -4,7 +4,7 @@
    height="64px"
    id="svg2816"
    version="1.1"
-   sodipodi:docname="Sketcher_ToggleConstraint.svg"
+   sodipodi:docname="Sketcher_ToggleConstruction_Constr.svg"
    inkscape:version="1.1-beta1 (77e7b44db3, 2021-03-28)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -15,7 +15,7 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
-     id="namedview78"
+     id="namedview109"
      pagecolor="#505050"
      bordercolor="#eeeeee"
      borderopacity="1"
@@ -26,9 +26,9 @@
      inkscape:pageopacity="0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="2.9414063"
-     inkscape:cx="41.646746"
-     inkscape:cy="13.428951"
+     inkscape:zoom="5.8828125"
+     inkscape:cx="-65.01992"
+     inkscape:cy="29.662683"
      inkscape:window-width="3686"
      inkscape:window-height="1571"
      inkscape:window-x="145"
@@ -140,15 +140,6 @@
          offset="1"
          id="stop3791" />
     </linearGradient>
-    <linearGradient
-       y2="100.10708"
-       x2="609.54919"
-       y1="126.79625"
-       x1="581.26331"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3524"
-       xlink:href="#linearGradient3602-58"
-       gradientTransform="matrix(1.3310616,0,0,1.2539521,-770.75488,-101.53511)" />
     <linearGradient
        id="linearGradient3144-6">
       <stop
@@ -328,15 +319,6 @@
        x2="24.81818"
        y2="14.363636" />
     <linearGradient
-       xlink:href="#linearGradient3787"
-       id="linearGradient4429"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3180277,0,0,1.2416733,-743.43621,-121.30586)"
-       x1="581.26331"
-       y1="126.79625"
-       x2="609.54919"
-       y2="100.10708" />
-    <linearGradient
        gradientUnits="userSpaceOnUse"
        y2="14.363636"
        x2="24.818181"
@@ -384,6 +366,260 @@
        y1="14.363636"
        x2="24.81818"
        y2="14.363636" />
+    <linearGradient
+       id="linearGradient6349">
+      <stop
+         id="stop6351"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1" />
+      <stop
+         id="stop6353"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-8">
+      <stop
+         id="stop3379-3"
+         offset="0"
+         style="stop-color:#0019a3;stop-opacity:1" />
+      <stop
+         id="stop3381-7"
+         offset="1"
+         style="stop-color:#0069ff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(-1,0,0,1,2199.356,0)"
+       gradientUnits="userSpaceOnUse"
+       y2="1190.875"
+       x2="1267.9062"
+       y1="1190.875"
+       x1="901.1875"
+       id="linearGradient3383"
+       xlink:href="#linearGradient3377-8" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.4307499,-1.3605156e-7,-1.202713e-8,0.1264801,2674.7488,1244.2826)"
+       r="194.40614"
+       fy="1424.4465"
+       fx="1103.6399"
+       cy="1424.4465"
+       cx="1103.6399"
+       id="radialGradient6355"
+       xlink:href="#linearGradient6349" />
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lend"
+       refX="0.0"
+       refY="0.0"
+       orient="auto">
+      <path
+         transform="scale(1.1) rotate(180) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="font-size:12;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         id="path3837" />
+    </marker>
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3904"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2370"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       xlink:href="#linearGradient3144-6"
+       id="radialGradient10504-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10640"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10642"
+       xlink:href="#linearGradient3144-6" />
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lend-1"
+       refX="0.0"
+       refY="0.0"
+       orient="auto">
+      <path
+         transform="scale(1.1) rotate(180) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="font-size:12;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         id="path3837-9" />
+    </marker>
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3904-0"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2370-7"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       xlink:href="#linearGradient3144-6"
+       id="radialGradient10504-5-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10640-6"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10642-0"
+       xlink:href="#linearGradient3144-6" />
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lend-7"
+       refX="0.0"
+       refY="0.0"
+       orient="auto">
+      <path
+         transform="scale(1.1) rotate(180) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="font-size:12;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         id="path3837-95" />
+    </marker>
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3904-7"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2370-8"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       xlink:href="#linearGradient3144-6"
+       id="radialGradient10504-5-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10640-7"
+       xlink:href="#linearGradient3144-6" />
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient10642-1"
+       xlink:href="#linearGradient3144-6" />
+    <linearGradient
+       xlink:href="#linearGradient4096"
+       id="linearGradient4102"
+       x1="26"
+       y1="58"
+       x2="16"
+       y2="26"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4096">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="0"
+         id="stop4098" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4100" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4096"
+       id="linearGradient4190"
+       gradientUnits="userSpaceOnUse"
+       x1="26"
+       y1="58"
+       x2="16"
+       y2="26" />
   </defs>
   <metadata
      id="metadata2821">
@@ -395,17 +631,17 @@
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
-            <dc:title>[Abdullah Tahiri]</dc:title>
+            <dc:title>[wmayer]</dc:title>
           </cc:Agent>
         </dc:creator>
-        <dc:date>2015-05-26</dc:date>
+        <dc:date>2011-10-10</dc:date>
         <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
           <cc:Agent>
             <dc:title>FreeCAD</dc:title>
           </cc:Agent>
         </dc:publisher>
-        <dc:identifier>FreeCAD/src/Mod/Sketcher/Gui/Resources/icons/Sketcher_ToggleConstraint.svg</dc:identifier>
+        <dc:identifier>FreeCAD/src/Mod/Sketcher/Gui/Resources/icons/Sketcher_ToggleConstruction.svg</dc:identifier>
         <dc:rights>
           <cc:Agent>
             <dc:title>FreeCAD LGPL2+</dc:title>
@@ -414,42 +650,35 @@
         <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
         <dc:contributor>
           <cc:Agent>
-            <dc:title>[agryson] Alexander Gryson</dc:title>
+            <dc:title>[agryson] Alexander Gryson
+[JoshuaCall]</dc:title>
           </cc:Agent>
         </dc:contributor>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1-2"
-     transform="matrix(0,-0.67268112,0.67268112,0,19.350211,45.14815)">
-    <g
-       id="g3894-8"
-       transform="rotate(-45,34.506097,38.050253)">
-      <path
-         id="path3034-8"
-         d="M 17,27 V 19 L -4,32 17,45 v -8 h 40 v 8 L 78,32 57,19 v 8 z"
-         style="fill:#3465a4;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
-      <path
-         id="path3034-3-7"
-         d="M 15,29 V 22.6 L -0.2,32 15,41.4 V 35 h 44 v 6.4 L 74.2,32 59,22.6 V 29 Z"
-         style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    </g>
+     id="g1593-1"
+     transform="matrix(0.78879356,0,0,0.78879356,19.59251,-3.2449824)">
+    <path
+       style="fill:#d3d7cf;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 52.27482,49.922109 48.032181,54.16475 5.6057758,11.738344 9.8484153,7.495704 Z"
+       id="path3061-7" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 48.524081,51.828224 7.9422954,11.246434"
+       id="path3063-9" />
   </g>
   <g
-     id="layer1"
-     transform="matrix(0,-0.92631783,0.92631783,0,0.31000206,64.013997)">
-    <g
-       id="g3894"
-       transform="rotate(-45,34.506097,38.050253)">
-      <path
-         id="path3034"
-         d="M 17,27 V 19 L -4,32 17,45 v -8 h 40 v 8 L 78,32 57,19 v 8 z"
-         style="fill:#cc0000;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
-      <path
-         id="path3034-3"
-         d="M 15,29 V 22.6 L -0.2,32 15,41.4 V 35 h 44 v 6.4 L 74.2,32 59,22.6 V 29 Z"
-         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    </g>
+     id="g1597-4"
+     transform="matrix(1.1717126,0,0,1.1717126,-77.264053,8.0703067)">
+    <path
+       style="fill:#3465a4;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 67.735801,3.7936952 71.97844,-0.44894628 114.40485,41.97746 110.16221,46.2201 Z"
+       id="path3061-5-5" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 71.48654,1.8875803 112.06833,42.46937"
+       id="path3063-8-8" />
   </g>
 </svg>


### PR DESCRIPTION
This is my attempt to make the toggle icons more uniform. And remove the confusion between toggleConstruction and carboncopy. Fixes https://github.com/FreeCAD/FreeCAD/issues/11471

The toggle construction and toggle driving icons are changing when you click them.
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/e40faa1a-8eb6-4cc0-90c0-31dc4209e639)
