### PR TITLE
Add conda and mamba to the conda-devenv.

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -60,6 +60,7 @@ dependencies:
 - cmake
 - coin3d
 - compilers
+- conda
 - conda-build
 - conda-devenv
 - conda-smithy
@@ -72,6 +73,7 @@ dependencies:
 - graphviz
 - hdf5
 - libcxx
+- mamba==1.4.9
 - matplotlib
 - ninja
 - numpy


### PR DESCRIPTION
Alter the `conda/environment.devenv.yml` to include `conda` and `mamba` as dependencies.

`mamba-devenv` will remove any package not listed in this file, removing the packages `conda` and `mamba` from the newly created conda environment.  This renders the newly created conda environment inoperable.  I believe this is a behavioral difference with `conda devenv` which was previously used.