### PR TITLE
Start: Allow dynamic translation of start page

### DIFF
--- a/src/Mod/Start/Gui/Workbench.cpp
+++ b/src/Mod/Start/Gui/Workbench.cpp
@@ -76,6 +76,7 @@ void StartGui::Workbench::loadStartPage()
         std::string escapedstr = Base::Tools::escapedUnicodeFromUtf8(utf8Title);
         std::stringstream str;
         str << "import WebGui,sys,Start\n"
+            << "from PySide import QtCore\n"
             << "from StartPage import StartPage\n\n"
             << "class WebPage(object):\n"
             << "    def __init__(self):\n"
@@ -89,16 +90,19 @@ void StartGui::Workbench::loadStartPage()
 #endif
             << "    def onChange(self, par, reason):\n"
             << "        try:\n"
-            << "            if reason == 'RecentFiles':\n"
-#if defined(FC_OS_WIN32)
-            << "                self.browser.setHtml(StartPage.handle(), App.getResourceDir() + "
-               "'Mod/Start/StartPage/')\n\n"
-#else
-            << "                self.browser.setHtml(StartPage.handle(), 'file://' + "
-               "App.getResourceDir() + 'Mod/Start/StartPage/')\n\n"
-#endif
+            << "            if reason in ('RecentFiles','Language'):\n"
+            << "                QtCore.QTimer.singleShot(100, self.reload)\n"
             << "        except RuntimeError as e:\n"
             << "            pass\n"
+            << "    def reload(self):\n"
+#if defined(FC_OS_WIN32)
+            << "        self.browser.setHtml(StartPage.handle(), App.getResourceDir() + "
+               "'Mod/Start/StartPage/')\n\n"
+#else
+            << "        self.browser.setHtml(StartPage.handle(), 'file://' + "
+               "App.getResourceDir() + 'Mod/Start/StartPage/')\n\n"
+#endif
+
             << "class WebView(object):\n"
             << "    def __init__(self):\n"
             << "        self.pargrp = FreeCAD.ParamGet('User "

--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -176,8 +176,8 @@ def getInfo(filename):
         ctime = getLocalTime(s.st_ctime)
         mtime = getLocalTime(s.st_mtime)
         author = ""
-        company = TranslationTexts.T_UNKNOWN
-        lic = TranslationTexts.T_UNKNOWN
+        company = TranslationTexts.get("T_UNKNOWN")
+        lic = TranslationTexts.get("T_UNKNOWN")
         image = None
         descr = ""
         path = os.path.abspath(filename)
@@ -310,25 +310,25 @@ def build_new_file_card(template):
 
     templates = {
         "empty_file": [
-            TranslationTexts.T_TEMPLATE_EMPTYFILE_NAME,
-            TranslationTexts.T_TEMPLATE_EMPTYFILE_DESC,
+            TranslationTexts.get("T_TEMPLATE_EMPTYFILE_NAME"),
+            TranslationTexts.get("T_TEMPLATE_EMPTYFILE_DESC"),
         ],
         "open_file": [
-            TranslationTexts.T_TEMPLATE_OPENFILE_NAME,
-            TranslationTexts.T_TEMPLATE_OPENFILE_DESC,
+            TranslationTexts.get("T_TEMPLATE_OPENFILE_NAME"),
+            TranslationTexts.get("T_TEMPLATE_OPENFILE_DESC"),
         ],
         "parametric_part": [
-            TranslationTexts.T_TEMPLATE_PARAMETRICPART_NAME,
-            TranslationTexts.T_TEMPLATE_PARAMETRICPART_DESC,
+            TranslationTexts.get("T_TEMPLATE_PARAMETRICPART_NAME"),
+            TranslationTexts.get("T_TEMPLATE_PARAMETRICPART_DESC"),
         ],
-        # "csg_part": [TranslationTexts.T_TEMPLATE_CSGPART_NAME, TranslationTexts.T_TEMPLATE_CSGPART_DESC],
+        # "csg_part": [TranslationTexts.get("T_TEMPLATE_CSGPART_NAME"), TranslationTexts.get("T_TEMPLATE_CSGPART_DESC")],
         "2d_draft": [
-            TranslationTexts.T_TEMPLATE_2DDRAFT_NAME,
-            TranslationTexts.T_TEMPLATE_2DDRAFT_DESC,
+            TranslationTexts.get("T_TEMPLATE_2DDRAFT_NAME"),
+            TranslationTexts.get("T_TEMPLATE_2DDRAFT_DESC"),
         ],
         "architecture": [
-            TranslationTexts.T_TEMPLATE_ARCHITECTURE_NAME,
-            TranslationTexts.T_TEMPLATE_ARCHITECTURE_DESC,
+            TranslationTexts.get("T_TEMPLATE_ARCHITECTURE_NAME"),
+            TranslationTexts.get("T_TEMPLATE_ARCHITECTURE_DESC"),
         ],
     }
 
@@ -366,12 +366,12 @@ def buildCard(filename, method, arg=None):
         finfo = getInfo(filename)
         if finfo:
             image, size, author, ctime, mtime, descr, company, lic, path = finfo
-            infostring = TranslationTexts.T_CREATIONDATE + ": " + ctime + "\n"
-            infostring += TranslationTexts.T_LASTMODIFIED + ": " + mtime + "\n"
-            infostring += TranslationTexts.T_SIZE + ": " + size + "\n"
-            infostring += TranslationTexts.T_AUTHOR + ": " + author + "\n"
-            infostring += TranslationTexts.T_LICENSE + ": " + lic + "\n"
-            infostring += TranslationTexts.T_FILEPATH + ": " + path + "\n"
+            infostring = TranslationTexts.get("T_CREATIONDATE") + ": " + ctime + "\n"
+            infostring += TranslationTexts.get("T_LASTMODIFIED") + ": " + mtime + "\n"
+            infostring += TranslationTexts.get("T_SIZE") + ": " + size + "\n"
+            infostring += TranslationTexts.get("T_AUTHOR") + ": " + author + "\n"
+            infostring += TranslationTexts.get("T_LICENSE") + ": " + lic + "\n"
+            infostring += TranslationTexts.get("T_FILEPATH") + ": " + path + "\n"
             if finfo[5]:
                 infostring += "\n\n" + descr
             if size:
@@ -509,7 +509,7 @@ def handle():
 
     v = FreeCAD.Version()
     VERSIONSTRING = (
-        TranslationTexts.T_VERSION
+        TranslationTexts.get("T_VERSION")
         + " "
         + v[0]
         + "."
@@ -517,7 +517,7 @@ def handle():
         + "."
         + v[2]
         + " "
-        + TranslationTexts.T_BUILD
+        + TranslationTexts.get("T_BUILD")
         + " "
         + v[3]
     )
@@ -525,9 +525,9 @@ def handle():
 
     # translate texts
 
-    texts = [t for t in dir(TranslationTexts) if t.startswith("T_")]
+    texts = [t for t in TranslationTexts.get("index") if t.startswith("T_")]
     for text in texts:
-        HTML = HTML.replace(text, getattr(TranslationTexts, text))
+        HTML = HTML.replace(text, TranslationTexts.get(text))
 
     # build a "create new" icon with the FreeCAD background color gradient
 
@@ -548,7 +548,7 @@ def handle():
 
     # build SECTION_NEW_FILE
 
-    SECTION_NEW_FILE = "<h2>" + TranslationTexts.T_NEWFILE + "</h2>"
+    SECTION_NEW_FILE = "<h2>" + TranslationTexts.get("T_NEWFILE") + "</h2>"
     SECTION_NEW_FILE += "<ul>"
     SECTION_NEW_FILE += build_new_file_card("empty_file")
     SECTION_NEW_FILE += build_new_file_card("open_file")
@@ -563,7 +563,7 @@ def handle():
 
     rf = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/RecentFiles")
     rfcount = rf.GetInt("RecentFiles", 0)
-    SECTION_RECENTFILES = "<h2>" + TranslationTexts.T_RECENTFILES + "</h2>"
+    SECTION_RECENTFILES = "<h2>" + TranslationTexts.get("T_RECENTFILES") + "</h2>"
     SECTION_RECENTFILES += "<ul>"
     for i in range(rfcount):
         filename = rf.GetString("MRU%d" % (i))
@@ -577,7 +577,7 @@ def handle():
     if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Start").GetBool(
         "ShowExamples", True
     ):
-        SECTION_EXAMPLES = "<h2>" + TranslationTexts.T_EXAMPLES + "</h2>"
+        SECTION_EXAMPLES = "<h2>" + TranslationTexts.get("T_EXAMPLES") + "</h2>"
         SECTION_EXAMPLES += "<ul>"
         examples_path = FreeCAD.getResourceDir() + "examples"
         if os.path.exists(examples_path):

--- a/src/Mod/Start/StartPage/TranslationTexts.py
+++ b/src/Mod/Start/StartPage/TranslationTexts.py
@@ -136,7 +136,8 @@ def get(handle):
     T_UNKNOWN = translate("StartPage", "Unknown")
     T_FORUM = translate("StartPage", "Forum")
     T_DESCR_FORUM = translate(
-        "StartPage", 'The latest posts on the <a href="https://forum.freecad.org">FreeCAD forum</a>:'
+        "StartPage",
+        'The latest posts on the <a href="https://forum.freecad.org">FreeCAD forum</a>:',
     )
     T_EXTERNALLINKS = translate(
         "StartPage",

--- a/src/Mod/Start/StartPage/TranslationTexts.py
+++ b/src/Mod/Start/StartPage/TranslationTexts.py
@@ -35,114 +35,124 @@ def translate(context, text):
     return u.replace(chr(39), "&rsquo;")
 
 
-T_TITLE = translate("StartPage", "Start")
-T_WELCOME = translate("StartPage", "Welcome to FreeCAD")
-T_DOCUMENTS = translate("StartPage", "Documents")
-T_HELP = translate("StartPage", "Help")
-T_ACTIVITY = translate("StartPage", "Activity")
-T_BLOG = translate("StartPage", "Blog")
-T_TOOLTIP_BLOG = translate("StartPage", "Link to the FreeCAD blog")
-T_NEWFILE = translate("StartPage", "New file")
-T_TEMPLATE_EMPTYFILE_NAME = translate("StartPage", "Empty File")
-T_TEMPLATE_EMPTYFILE_DESC = translate("StartPage", "Create an empty FreeCAD file")
-T_TEMPLATE_OPENFILE_NAME = translate("StartPage", "Open File")
-T_TEMPLATE_OPENFILE_DESC = translate("StartPage", "Open an existing CAD file or 3D model")
-T_TEMPLATE_PARAMETRICPART_NAME = translate("StartPage", "Standard Part")
-T_TEMPLATE_PARAMETRICPART_DESC = translate(
-    "StartPage", "Create a part with the Part Design workbench"
-)
-# T_TEMPLATE_CSGPART_NAME = translate("StartPage", "CSG Part")
-# T_TEMPLATE_CSGPART_DESC = translate("StartPage", "Create a part with the Part workbench")
-T_TEMPLATE_2DDRAFT_NAME = translate("StartPage", "2D Draft")
-T_TEMPLATE_2DDRAFT_DESC = translate("StartPage", "Create a 2D draft with the Draft workbench")
-T_TEMPLATE_ARCHITECTURE_NAME = translate("StartPage", "BIM/Architecture")
-T_TEMPLATE_ARCHITECTURE_DESC = translate("StartPage", "Create an architecture project")
-T_RECENTFILES = translate("StartPage", "Recent files")
-T_TIP = translate("StartPage", "Tip")
-T_ADJUSTRECENT = translate(
-    "StartPage",
-    "Adjust the number of recent files to be shown here in menu Edit -> Preferences -> General -> Size of recent file list",
-)
-T_EXAMPLES = translate("StartPage", "Examples")
-T_GENERALDOCUMENTATION = translate("StartPage", "General documentation")
-T_USERHUB = translate("StartPage", "User hub")
-T_DESCR_USERHUB = translate(
-    "StartPage",
-    "This section contains documentation useful for FreeCAD users in general: a list of all the workbenches, detailed instructions on how to install and use the FreeCAD application, tutorials, and all you need to get started.",
-)
-T_POWERHUB = translate("StartPage", "Power users hub")
-T_DESCR_POWERHUB = translate(
-    "StartPage",
-    "This section gathers documentation for advanced users and people interested in writing python scripts. You will also find there a repository of macros, instructions on how to install and use them, and more information about customizing FreeCAD to your specific needs.",
-)
-T_DEVHUB = translate("StartPage", "Developers hub")
-T_DESCR_DEVHUB = translate(
-    "StartPage",
-    "This section contains material for developers: How to compile FreeCAD yourself, how the FreeCAD source code is structured + how to navigate in it, how to develop new workbenches and/or embed FreeCAD in your own application.",
-)
-T_MANUAL = translate("StartPage", "Manual")
-T_DESCR_MANUAL = translate(
-    "StartPage",
-    'The FreeCAD manual is another, more linear way to present the information contained in this wiki. It is made to be read like a book, and will gently introduce you to many other pages from the hubs above. <a href="https://www.gitbook.com/book/yorikvanhavre/a-freecad-manual/details">e-book versions</a> are also available.',
-)
-T_WBHELP = translate("StartPage", "Workbenches documentation")
-T_DESCR_WBHELP = translate(
-    "StartPage",
-    "These are the help pages of all the workbenches currently installed on this computer.",
-)
-T_COMMUNITYHELP = translate("StartPage", "Getting help from the community")
-T_DESCR_COMMUNITYHELP1 = translate(
-    "StartPage",
-    'The <a href="https://forum.freecad.org">FreeCAD forum</a> is a great place to get help from other FreeCAD users and developers. The forum has many sections for different types of issues and discussion subjects. If in doubt, post in the more general <a href="https://forum.freecad.org/viewforum.php?f=3">Help on using FreeCAD</a> section.',
-)
-T_DESCR_COMMUNITYHELP2 = translate(
-    "StartPage",
-    'If it is the first time you are posting on the forum, be sure to <a href="https://forum.freecad.org/viewtopic.php?f=3&t=2264">read the guidelines</a> first!',
-)
-T_DESCR_COMMUNITYHELP3 = translate(
-    "StartPage",
-    'FreeCAD also maintains a public <a href="https://www.freecad.org/tracker">bug tracker</a> where anybody can submit bugs and propose new features. To avoid causing extra work and give the best chances to see your bug solved, make sure you read the <a href="https://forum.freecad.org/viewtopic.php?f=3&t=5236">bug submission guide</a> before posting.',
-)
-T_ADDONS = translate("StartPage", "Available addons")
-T_DESCR_ADDONS = translate(
-    "StartPage",
-    "Below is a list of available extra workbenches that can be added to your FreeCAD installation. Browse and install them from menu Tools -> Addons manager. You can learn more about any of them by clicking the links below.",
-)
-T_OFFLINEHELP = translate(
-    "StartPage",
-    "If not bundled with your FreeCAD version, install the FreeCAD documentation package to get documentation hubs, workbench help and individual command documentation without an internet connection.",
-)
-T_OFFLINEPLACEHOLDER = translate(
-    "StartPage",
-    'Cannot fetch information from GitHub. <a href="EnableDownload.py">Authorize FreeCAD to access the internet</a> and reload the Start page.',
-)
-T_RECENTCOMMITS = translate("StartPage", "Recent commits")
-T_DESCR_RECENTCOMMITS = translate(
-    "StartPage",
-    'Below are the latest changes added to the <a href="http://github.com/FreeCAD/FreeCAD/">FreeCAD source code</a>. These changes might not reflect yet in the FreeCAD version that you are currently running. Check the <a href="https://www.freecad.org/wiki/Downloads">available options</a> if you wish to obtain a development version.',
-)
-T_SEEONGITHUB = translate("StartPage", "See all commits on github")
-T_CUSTOM = translate(
-    "StartPage",
-    "You can configure a custom folder to display here in menu Edit -> Preferences -> Start -> Show additional folder",
-)
-T_VERSION = translate("StartPage", "version")
-T_BUILD = translate("StartPage", "build")
-T_CREATENEW = translate("StartPage", "Create new...")
-T_UNKNOWN = translate("StartPage", "Unknown")
-T_FORUM = translate("StartPage", "Forum")
-T_DESCR_FORUM = translate(
-    "StartPage", 'The latest posts on the <a href="https://forum.freecad.org">FreeCAD forum</a>:'
-)
-T_EXTERNALLINKS = translate(
-    "StartPage",
-    "To open any of the links above in your desktop browser, Right-click -> Open in external browser",
-)
-T_CREATIONDATE = translate("StartPage", "Creation date")
-T_LASTMODIFIED = translate("StartPage", "Last modification")
-T_SIZE = translate("StartPage", "Size")
-T_AUTHOR = translate("StartPage", "Author")
-T_LICENSE = translate("StartPage", "License")
-T_FILEPATH = translate("StartPage", "File path")
-T_NOTES = translate("StartPage", "Notes")
-T_VTOOLTIP = translate("StartPage", "Open start page preferences")
+def get(handle):
+
+    "returns the translated text of the given handle"
+
+    T_TITLE = translate("StartPage", "Start")
+    T_WELCOME = translate("StartPage", "Welcome to FreeCAD")
+    T_DOCUMENTS = translate("StartPage", "Documents")
+    T_HELP = translate("StartPage", "Help")
+    T_ACTIVITY = translate("StartPage", "Activity")
+    T_BLOG = translate("StartPage", "Blog")
+    T_TOOLTIP_BLOG = translate("StartPage", "Link to the FreeCAD blog")
+    T_NEWFILE = translate("StartPage", "New file")
+    T_TEMPLATE_EMPTYFILE_NAME = translate("StartPage", "Empty File")
+    T_TEMPLATE_EMPTYFILE_DESC = translate("StartPage", "Create an empty FreeCAD file")
+    T_TEMPLATE_OPENFILE_NAME = translate("StartPage", "Open File")
+    T_TEMPLATE_OPENFILE_DESC = translate("StartPage", "Open an existing CAD file or 3D model")
+    T_TEMPLATE_PARAMETRICPART_NAME = translate("StartPage", "Standard Part")
+    T_TEMPLATE_PARAMETRICPART_DESC = translate(
+        "StartPage", "Create a part with the Part Design workbench"
+    )
+    # T_TEMPLATE_CSGPART_NAME = translate("StartPage", "CSG Part")
+    # T_TEMPLATE_CSGPART_DESC = translate("StartPage", "Create a part with the Part workbench")
+    T_TEMPLATE_2DDRAFT_NAME = translate("StartPage", "2D Draft")
+    T_TEMPLATE_2DDRAFT_DESC = translate("StartPage", "Create a 2D draft with the Draft workbench")
+    T_TEMPLATE_ARCHITECTURE_NAME = translate("StartPage", "BIM/Architecture")
+    T_TEMPLATE_ARCHITECTURE_DESC = translate("StartPage", "Create an architecture project")
+    T_RECENTFILES = translate("StartPage", "Recent files")
+    T_TIP = translate("StartPage", "Tip")
+    T_ADJUSTRECENT = translate(
+        "StartPage",
+        "Adjust the number of recent files to be shown here in menu Edit -> Preferences -> General -> Size of recent file list",
+    )
+    T_EXAMPLES = translate("StartPage", "Examples")
+    T_GENERALDOCUMENTATION = translate("StartPage", "General documentation")
+    T_USERHUB = translate("StartPage", "User hub")
+    T_DESCR_USERHUB = translate(
+        "StartPage",
+        "This section contains documentation useful for FreeCAD users in general: a list of all the workbenches, detailed instructions on how to install and use the FreeCAD application, tutorials, and all you need to get started.",
+    )
+    T_POWERHUB = translate("StartPage", "Power users hub")
+    T_DESCR_POWERHUB = translate(
+        "StartPage",
+        "This section gathers documentation for advanced users and people interested in writing python scripts. You will also find there a repository of macros, instructions on how to install and use them, and more information about customizing FreeCAD to your specific needs.",
+    )
+    T_DEVHUB = translate("StartPage", "Developers hub")
+    T_DESCR_DEVHUB = translate(
+        "StartPage",
+        "This section contains material for developers: How to compile FreeCAD yourself, how the FreeCAD source code is structured + how to navigate in it, how to develop new workbenches and/or embed FreeCAD in your own application.",
+    )
+    T_MANUAL = translate("StartPage", "Manual")
+    T_DESCR_MANUAL = translate(
+        "StartPage",
+        'The FreeCAD manual is another, more linear way to present the information contained in this wiki. It is made to be read like a book, and will gently introduce you to many other pages from the hubs above. <a href="https://www.gitbook.com/book/yorikvanhavre/a-freecad-manual/details">e-book versions</a> are also available.',
+    )
+    T_WBHELP = translate("StartPage", "Workbenches documentation")
+    T_DESCR_WBHELP = translate(
+        "StartPage",
+        "These are the help pages of all the workbenches currently installed on this computer.",
+    )
+    T_COMMUNITYHELP = translate("StartPage", "Getting help from the community")
+    T_DESCR_COMMUNITYHELP1 = translate(
+        "StartPage",
+        'The <a href="https://forum.freecad.org">FreeCAD forum</a> is a great place to get help from other FreeCAD users and developers. The forum has many sections for different types of issues and discussion subjects. If in doubt, post in the more general <a href="https://forum.freecad.org/viewforum.php?f=3">Help on using FreeCAD</a> section.',
+    )
+    T_DESCR_COMMUNITYHELP2 = translate(
+        "StartPage",
+        'If it is the first time you are posting on the forum, be sure to <a href="https://forum.freecad.org/viewtopic.php?f=3&t=2264">read the guidelines</a> first!',
+    )
+    T_DESCR_COMMUNITYHELP3 = translate(
+        "StartPage",
+        'FreeCAD also maintains a public <a href="https://www.freecad.org/tracker">bug tracker</a> where anybody can submit bugs and propose new features. To avoid causing extra work and give the best chances to see your bug solved, make sure you read the <a href="https://forum.freecad.org/viewtopic.php?f=3&t=5236">bug submission guide</a> before posting.',
+    )
+    T_ADDONS = translate("StartPage", "Available addons")
+    T_DESCR_ADDONS = translate(
+        "StartPage",
+        "Below is a list of available extra workbenches that can be added to your FreeCAD installation. Browse and install them from menu Tools -> Addons manager. You can learn more about any of them by clicking the links below.",
+    )
+    T_OFFLINEHELP = translate(
+        "StartPage",
+        "If not bundled with your FreeCAD version, install the FreeCAD documentation package to get documentation hubs, workbench help and individual command documentation without an internet connection.",
+    )
+    T_OFFLINEPLACEHOLDER = translate(
+        "StartPage",
+        'Cannot fetch information from GitHub. <a href="EnableDownload.py">Authorize FreeCAD to access the internet</a> and reload the Start page.',
+    )
+    T_RECENTCOMMITS = translate("StartPage", "Recent commits")
+    T_DESCR_RECENTCOMMITS = translate(
+        "StartPage",
+        'Below are the latest changes added to the <a href="http://github.com/FreeCAD/FreeCAD/">FreeCAD source code</a>. These changes might not reflect yet in the FreeCAD version that you are currently running. Check the <a href="https://www.freecad.org/wiki/Downloads">available options</a> if you wish to obtain a development version.',
+    )
+    T_SEEONGITHUB = translate("StartPage", "See all commits on github")
+    T_CUSTOM = translate(
+        "StartPage",
+        "You can configure a custom folder to display here in menu Edit -> Preferences -> Start -> Show additional folder",
+    )
+    T_VERSION = translate("StartPage", "version")
+    T_BUILD = translate("StartPage", "build")
+    T_CREATENEW = translate("StartPage", "Create new...")
+    T_UNKNOWN = translate("StartPage", "Unknown")
+    T_FORUM = translate("StartPage", "Forum")
+    T_DESCR_FORUM = translate(
+        "StartPage", 'The latest posts on the <a href="https://forum.freecad.org">FreeCAD forum</a>:'
+    )
+    T_EXTERNALLINKS = translate(
+        "StartPage",
+        "To open any of the links above in your desktop browser, Right-click -> Open in external browser",
+    )
+    T_CREATIONDATE = translate("StartPage", "Creation date")
+    T_LASTMODIFIED = translate("StartPage", "Last modification")
+    T_SIZE = translate("StartPage", "Size")
+    T_AUTHOR = translate("StartPage", "Author")
+    T_LICENSE = translate("StartPage", "License")
+    T_FILEPATH = translate("StartPage", "File path")
+    T_NOTES = translate("StartPage", "Notes")
+    T_VTOOLTIP = translate("StartPage", "Open start page preferences")
+
+    if handle == "index":
+        return locals()
+    elif handle in locals():
+        return locals()[handle]
+    return ""


### PR DESCRIPTION
- reloading the start page now retranslates all the texts
- extend the observer to watch language changes

Fixes #9996