### PR TITLE
Gui: fix drag and drop of ViewProvider

### DIFF
--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -769,12 +769,13 @@ bool ViewProvider::canDropObjects() const {
 bool ViewProvider::canDragAndDropObject(App::DocumentObject* obj) const {
 
     auto vector = getExtensionsDerivedFromType<Gui::ViewProviderExtension>();
-    for(Gui::ViewProviderExtension* ext : vector){
-        if(!ext->extensionCanDragAndDropObject(obj))
-            return false;
+    for (Gui::ViewProviderExtension* ext : vector) {
+        if (ext->extensionCanDragAndDropObject(obj)) {
+            return true;
+        }
     }
 
-    return true;
+    return false;
 }
 
 void ViewProvider::dropObject(App::DocumentObject* obj) {
@@ -782,11 +783,9 @@ void ViewProvider::dropObject(App::DocumentObject* obj) {
     for (Gui::ViewProviderExtension* ext : vector) {
         if (ext->extensionCanDropObject(obj)) {
             ext->extensionDropObject(obj);
-            return;
+            break;
         }
     }
-
-    throw Base::RuntimeError("ViewProvider::dropObject: no extension for dropping given object available.");
 }
 
 bool ViewProvider::canDropObjectEx(App::DocumentObject* obj, App::DocumentObject *owner,


### PR DESCRIPTION
* ViewProvider::canDragAndDropObject should only return true if an extension handles drag and drop Currently it returns true if no extension is available
* ViewProvider::dropObject shouldn't throw an exception if no extension handles drag and drop

As an example consider https://forum.freecad.org/viewtopic.php?t=82957 When selecting two objects then ViewProvider::dropObject is called twice. But for the first call both objects are moved to the destination and for the second call no extension handles drag and drop any more. This incorrectly leads to a thrown exception.