### PR TITLE
Gui: Update rotation center indicator after zoom

### DIFF
--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -739,6 +739,12 @@ void NavigationStyle::doZoom(SoCamera* camera, float logfactor, const SbVec2f& p
         SbViewVolume vv = camera->getViewVolume(vp.getViewportAspectRatio());
         SbPlane panplane = vv.getPlane(camera->focalDistance.getValue());
         panCamera(viewer->getSoRenderManager()->getCamera(), ratio, panplane, pos, SbVec2f(0.5,0.5));
+
+        // Change the position of the rotation center indicator after zooming at cursor
+        // Rotation mode is WindowCenter
+        if (!rotationCenterMode) {
+            viewer->changeRotationCenterPosition(getFocalPoint());
+        }
     }
 }
 

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -744,6 +744,7 @@ void NavigationStyle::doZoom(SoCamera* camera, float logfactor, const SbVec2f& p
         // Rotation mode is WindowCenter
         if (!rotationCenterMode) {
             viewer->changeRotationCenterPosition(getFocalPoint());
+            findBoundingSphere();
         }
     }
 }

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1407,6 +1407,7 @@ void View3DInventorViewer::showRotationCenter(bool show)
             material->transparency = 1.0F - float(color.alphaF());
 
             auto translation = new SoTranslation();
+            translation->setName("translation");
             translation->translation.setValue(center);
 
             auto annotation = new SoAnnotation();
@@ -1431,6 +1432,20 @@ void View3DInventorViewer::showRotationCenter(bool show)
             rotationCenterGroup = nullptr;
         }
     }
+}
+
+// Changes the position of the rotation center indicator
+void View3DInventorViewer::changeRotationCenterPosition(const SbVec3f& newCenter) {
+    if (!rotationCenterGroup) {
+        return;
+    }
+
+    SoTranslation* translation = dynamic_cast<SoTranslation*>(rotationCenterGroup->getByName("translation"));
+    if (!translation) {
+        return;
+    }
+
+    translation->translation = newCenter;
 }
 
 void View3DInventorViewer::setNavigationType(Base::Type type)

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -416,6 +416,7 @@ public:
     bool hasAxisCross();
 
     void showRotationCenter(bool show);
+    void changeRotationCenterPosition(const SbVec3f& newCenter);
 
     void setEnabledFPSCounter(bool on);
     void setEnabledNaviCube(bool on);


### PR DESCRIPTION
#11243 was not completely fixed. This PR fixes #11243. The problem also occurred when dragging and using the scroll wheel to zoom at the same time. This only happend with rotation mode = window center and _zoom at cursor_ enabled. @maxwxyz can you confirm this works?

The problem is resolved by updating the position of the rotation center, to the new focal point, after zooming. ~~This PR also introduces a small regression which is a flickering rotation center after zooming using the scroll wheel. However, when you start dragging again without zooming then it does not flicker anymore. In my opinion not really a problem to worry about. This flickering appears to be resolved by https://github.com/coin3d/coin/pull/509.~~