### PR TITLE
Gui: Add a separate checkbox for enabling spinning animations

### DIFF
--- a/src/Gui/DemoMode.cpp
+++ b/src/Gui/DemoMode.cpp
@@ -180,7 +180,7 @@ void DemoMode::onAngleSliderValueChanged(int v)
         SbRotation rot(SbVec3f(-1, 0, 0), angle);
         reorientCamera(cam ,rot);
         this->oldvalue = v;
-        if (view->getViewer()->isAnimating()) {
+        if (view->getViewer()->isSpinning()) {
             startAnimation(view);
         }
     }
@@ -206,7 +206,7 @@ void DemoMode::onSpeedSliderValueChanged(int v)
 {
     Q_UNUSED(v);
     Gui::View3DInventor* view = activeView();
-    if (view && view->getViewer()->isAnimating()) {
+    if (view && view->getViewer()->isSpinning()) {
         startAnimation(view);
     }
 }
@@ -216,7 +216,7 @@ void DemoMode::onPlayButtonToggled(bool pressed)
     Gui::View3DInventor* view = activeView();
     if (view) {
         if (pressed) {
-            if (!view->getViewer()->isAnimating()) {
+            if (!view->getViewer()->isSpinning()) {
                 SoCamera* cam = view->getViewer()->getSoRenderManager()->getCamera();
                 if (cam) {
                     SbRotation rot = cam->orientation.getValue();
@@ -263,7 +263,7 @@ void DemoMode::onTimeoutValueChanged(int v)
 void DemoMode::onAutoPlay()
 {
     Gui::View3DInventor* view = activeView();
-    if (view && !view->getViewer()->isAnimating()) {
+    if (view && !view->getViewer()->isSpinning()) {
         ui->playButton->setChecked(true);
         startAnimation(view);
     }
@@ -271,9 +271,6 @@ void DemoMode::onAutoPlay()
 
 void DemoMode::startAnimation(Gui::View3DInventor* view)
 {
-    if (!view->getViewer()->isAnimationEnabled())
-        view->getViewer()->setAnimationEnabled(true);
-
     view->getViewer()->startSpinningAnimation(getDirection(view),
                                               getSpeed(ui->speedSlider->value()));
 }

--- a/src/Gui/NavigationAnimator.cpp
+++ b/src/Gui/NavigationAnimator.cpp
@@ -90,3 +90,15 @@ void NavigationAnimator::stop()
         activeAnimation.reset();
     }
 }
+
+/**
+ * @return Whether or not an animation is active
+ */
+bool NavigationAnimator::isAnimating() const
+{
+    if (activeAnimation != nullptr) {
+        return activeAnimation->state() == QAbstractAnimation::State::Running;
+    }
+
+    return false;
+}

--- a/src/Gui/NavigationAnimator.h
+++ b/src/Gui/NavigationAnimator.h
@@ -42,6 +42,7 @@ public:
     void start(const std::shared_ptr<NavigationAnimation>& animation);
     bool startAndWait(const std::shared_ptr<NavigationAnimation>& animation);
     void stop();
+    bool isAnimating() const;
 
 private:
     std::shared_ptr<NavigationAnimation> activeAnimation;

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -1103,7 +1103,7 @@ SbBool NavigationStyle::isSpinningAnimationEnabled() const
  */
 SbBool NavigationStyle::isAnimating() const
 {
-    return false;
+    return animator->isAnimating();
 }
 
 /**

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -176,7 +176,8 @@ NavigationStyle& NavigationStyle::operator = (const NavigationStyle& ns)
 {
     this->panningplane = ns.panningplane;
     this->menuenabled = ns.menuenabled;
-    this->spinanimatingallowed = ns.spinanimatingallowed;
+    this->animationEnabled = ns.animationEnabled;
+    this->spinningAnimationEnabled = ns.spinningAnimationEnabled;
     static_cast<FCSphereSheetProjector*>(this->spinprojector)->setOrbitStyle
         (static_cast<FCSphereSheetProjector*>(ns.spinprojector)->getOrbitStyle());
     return *this;
@@ -194,7 +195,8 @@ void NavigationStyle::initialize()
     this->sensitivity = 2.0f;
     this->resetcursorpos = false;
     this->currentmode = NavigationStyle::IDLE;
-    this->spinanimatingallowed = true;
+    this->animationEnabled = true;
+    this->spinningAnimationEnabled = false;
     this->spinsamplecounter = 0;
     this->spinincrement = SbRotation::identity();
     this->rotationCenterFound = false;
@@ -909,7 +911,7 @@ SbBool NavigationStyle::doSpin()
 {
     if (this->log.historysize >= 3) {
         SbTime stoptime = (SbTime::getTimeOfDay() - this->log.time[0]);
-        if (this->spinanimatingallowed && stoptime.getValue() < 0.100) {
+        if (isSpinningAnimationEnabled() && stoptime.getValue() < 0.100) {
             const SbViewportRegion & vp = viewer->getSoRenderManager()->getViewportRegion();
             const SbVec2s glsize(vp.getViewportSizePixels());
             SbVec3f from = this->spinprojector->project(SbVec2f(float(this->log.position[2][0]) / float(std::max(glsize[0]-1, 1)),
@@ -1054,38 +1056,62 @@ SbBool NavigationStyle::handleEventInForeground(const SoEvent* const e)
     return action.isHandled();
 }
 
-/*!
-  Decide if it should be possible to start a spin animation of the
-  model in the viewer by releasing the mouse button while dragging.
-
-  If the \a enable flag is \c false and we're currently animating, the
-  spin will be stopped.
-*/
-void
-NavigationStyle::setAnimationEnabled(const SbBool enable)
+/**
+ * @brief Decide if it should be possible to start any animation
+ *
+ * If the enable flag is false and we're currently animating, the animation will be stopped
+ */
+void NavigationStyle::setAnimationEnabled(const SbBool enable)
 {
-    this->spinanimatingallowed = enable;
-    if (!enable && this->isAnimating()) { animator->stop(); }
+    animationEnabled = enable;
+    if (!enable && isAnimating()) {
+        animator->stop();
+    }
 }
 
-/*!
-  Query whether or not it is possible to start a spinning animation by
-  releasing the left mouse button while dragging the mouse.
-*/
-
-SbBool
-NavigationStyle::isAnimationEnabled() const
+/**
+ * @brief Decide if it should be possible to start a spin animation of the model in the viewer by releasing the mouse button while dragging
+ *
+ * If the enable flag is false and we're currently animating, the spin animation will be stopped
+ */
+void NavigationStyle::setSpinningAnimationEnabled(const SbBool enable)
 {
-    return this->spinanimatingallowed;
+    spinningAnimationEnabled = enable;
+    if (!enable && isSpinning()) {
+        animator->stop();
+    }
 }
 
-/*!
-  Query if the model in the viewer is currently in spinning mode after
-  a user drag.
-*/
+/**
+ * @return Whether or not it is possible to start any animation
+ */
+SbBool NavigationStyle::isAnimationEnabled() const
+{
+    return animationEnabled;
+}
+
+/**
+ * @return Whether or not it is possible to start a spinning animation e.g. after dragging
+ */
+SbBool NavigationStyle::isSpinningAnimationEnabled() const
+{
+    return animationEnabled && spinningAnimationEnabled;
+}
+
+/**
+ * @return Whether or not any animation is currently active
+ */
 SbBool NavigationStyle::isAnimating() const
 {
-    return this->currentmode == NavigationStyle::SPINNING;
+    return false;
+}
+
+/**
+ * @return Whether or not a spinning animation is currently active e.g. after a user drag
+ */
+SbBool NavigationStyle::isSpinning() const
+{
+    return currentmode == NavigationStyle::SPINNING;
 }
 
 void NavigationStyle::startAnimating(const std::shared_ptr<NavigationAnimation>& animation, bool wait) const

--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -123,9 +123,11 @@ public:
     void setViewer(View3DInventorViewer*);
 
     void setAnimationEnabled(const SbBool enable);
+    void setSpinningAnimationEnabled(const SbBool enable);
     SbBool isAnimationEnabled() const;
-
+    SbBool isSpinningAnimationEnabled() const;
     SbBool isAnimating() const;
+    SbBool isSpinning() const;
     void startAnimating(const std::shared_ptr<NavigationAnimation>& animation, bool wait = false) const;
     void stopAnimating() const;
 
@@ -242,6 +244,7 @@ protected:
 
     View3DInventorViewer* viewer{nullptr};
     NavigationAnimator* animator;
+    SbBool animationEnabled;
     ViewerMode currentmode;
     SoMouseButtonEvent mouseDownConsumedEvent;
     SbVec2f lastmouseposition;
@@ -266,7 +269,7 @@ protected:
 
     /** @name Spinning data */
     //@{
-    SbBool spinanimatingallowed;
+    SbBool spinningAnimationEnabled;
     int spinsamplecounter;
     SbRotation spinincrement;
     SbSphereSheetProjector * spinprojector;

--- a/src/Gui/PreferencePackTemplates/View.cfg
+++ b/src/Gui/PreferencePackTemplates/View.cfg
@@ -33,6 +33,7 @@
           <FCBool Name="ShowNaviCube" Value="1"/>
           <FCBool Name="ShowSelectionBoundingBox" Value="0"/>
           <FCBool Name="UseNavigationAnimations" Value="1"/>
+          <FCBool Name="UseSpinningAnimations" Value="0"/>
           <FCFloat Name="AnimationDuration" Value="0.25"/>
           <FCBool Name="UseVBO" Value="0"/>
           <FCFloat Name="ViewScalingFactor" Value="1.0"/>

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
@@ -89,6 +89,7 @@ void DlgSettingsNavigation::saveSettings()
     ui->rotationCenterColor->onSave();
     ui->spinBoxZoomStep->onSave();
     ui->spinBoxAnimationDuration->onSave();
+    ui->checkBoxSpinningAnimations->onSave();
     ui->qspinNewDocScale->onSave();
     ui->prefStepByTurn->onSave();
     ui->naviCubeCorner->onSave();
@@ -133,6 +134,7 @@ void DlgSettingsNavigation::loadSettings()
     ui->rotationCenterColor->onRestore();
     ui->spinBoxZoomStep->onRestore();
     ui->spinBoxAnimationDuration->onRestore();
+    ui->checkBoxSpinningAnimations->onRestore();
     ui->qspinNewDocScale->onRestore();
     ui->prefStepByTurn->onRestore();
     ui->naviCubeCorner->onRestore();

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
@@ -88,7 +88,6 @@ void DlgSettingsNavigation::saveSettings()
     ui->rotationCenterSize->onSave();
     ui->rotationCenterColor->onSave();
     ui->spinBoxZoomStep->onSave();
-    ui->checkBoxNavigationAnimations->onSave();
     ui->spinBoxAnimationDuration->onSave();
     ui->qspinNewDocScale->onSave();
     ui->prefStepByTurn->onSave();
@@ -102,6 +101,9 @@ void DlgSettingsNavigation::saveSettings()
 
     bool showRotationCenter = ui->groupBoxRotationCenter->isChecked();
     hGrp->SetBool("ShowRotationCenter", showRotationCenter);
+
+    bool useNavigationAnimations = ui->groupBoxAnimations->isChecked();
+    hGrp->SetBool("UseNavigationAnimations", useNavigationAnimations);
 
     QVariant camera = ui->comboNewDocView->itemData(ui->comboNewDocView->currentIndex(),
         Qt::UserRole);
@@ -130,7 +132,6 @@ void DlgSettingsNavigation::loadSettings()
     ui->rotationCenterSize->onRestore();
     ui->rotationCenterColor->onRestore();
     ui->spinBoxZoomStep->onRestore();
-    ui->checkBoxNavigationAnimations->onRestore();
     ui->spinBoxAnimationDuration->onRestore();
     ui->qspinNewDocScale->onRestore();
     ui->prefStepByTurn->onRestore();
@@ -157,6 +158,9 @@ void DlgSettingsNavigation::loadSettings()
 
     bool showRotationCenter = hGrp->GetBool("ShowRotationCenter", true);
     ui->groupBoxRotationCenter->setChecked(showRotationCenter);
+
+    bool useNavigationAnimations = hGrp->GetBool("UseNavigationAnimations", true);
+    ui->groupBoxAnimations->setChecked(useNavigationAnimations);
 
     ui->comboNewDocView->addItem(tr("Isometric"), QByteArray("Isometric"));
     ui->comboNewDocView->addItem(tr("Dimetric"), QByteArray("Dimetric"));

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.ui
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>484</width>
-    <height>586</height>
+    <width>516</width>
+    <height>687</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -565,92 +565,6 @@ The value is the diameter of the sphere to fit on the screen.</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="Gui::PrefCheckBox" name="checkBoxNavigationAnimations">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>Enable navigation animations</string>
-        </property>
-        <property name="text">
-         <string>Enable navigation animations</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>UseNavigationAnimations</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QLabel" name="navigationAnimationsLabel">
-        <property name="toolTip">
-         <string>Duration of navigation animations that have a fixed duration</string>
-        </property>
-        <property name="text">
-         <string>Animation duration</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="2">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="Gui::PrefSpinBox" name="spinBoxAnimationDuration">
-          <property name="maximumSize">
-           <size>
-            <width>60</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>The duration of navigation animations in milliseconds</string>
-          </property>
-          <property name="minimum">
-           <number>100</number>
-          </property>
-          <property name="maximum">
-           <number>10000</number>
-          </property>
-          <property name="singleStep">
-           <number>50</number>
-          </property>
-          <property name="value">
-           <number>250</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>AnimationDuration</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::MinimumExpanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>10</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
       <item row="6" column="0">
        <widget class="Gui::PrefCheckBox" name="checkBoxZoomAtCursor">
         <property name="toolTip">
@@ -771,6 +685,75 @@ Mouse tilting is not disabled by this setting.</string>
          <cstring>View</cstring>
         </property>
        </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBoxAnimations">
+     <property name="title">
+      <string>Animations</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="1" column="0">
+       <widget class="QLabel" name="navigationAnimationsLabel">
+        <property name="toolTip">
+         <string>Duration of navigation animations that have a fixed duration</string>
+        </property>
+        <property name="text">
+         <string>Animation duration</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBoxAnimationDuration">
+        <property name="maximumSize">
+         <size>
+          <width>60</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The duration of navigation animations in milliseconds</string>
+        </property>
+        <property name="minimum">
+         <number>100</number>
+        </property>
+        <property name="maximum">
+         <number>10000</number>
+        </property>
+        <property name="singleStep">
+         <number>50</number>
+        </property>
+        <property name="value">
+         <number>250</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>AnimationDuration</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer_6">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.ui
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.ui
@@ -699,7 +699,7 @@ Mouse tilting is not disabled by this setting.</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="1" column="0">
-       <widget class="QLabel" name="navigationAnimationsLabel">
+       <widget class="QLabel" name="animationDurationLabel">
         <property name="toolTip">
          <string>Duration of navigation animations that have a fixed duration</string>
         </property>
@@ -754,6 +754,25 @@ Mouse tilting is not disabled by this setting.</string>
          </size>
         </property>
        </spacer>
+      </item>
+      <item row="2" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBoxSpinningAnimations">
+        <property name="toolTip">
+         <string>Enable spinning animations that are used in some navigation styles after dragging</string>
+        </property>
+        <property name="text">
+         <string>Enable spinning animations</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>UseSpinningAnimations</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -2382,7 +2382,7 @@ void View3DInventorViewer::renderScene()
     glDepthRange(0.1,1.0);
 #endif
 
-    // Immediately reschedule to get continuous spin animation.
+    // Immediately reschedule to get continuous animation.
     if (this->isAnimating()) {
         this->getSoRenderManager()->scheduleRedraw();
     }

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3218,37 +3218,56 @@ void View3DInventorViewer::viewSelection()
     }
 }
 
-/*!
-  Decide if it should be possible to start a spin animation of the
-  model in the viewer by releasing the mouse button while dragging.
-
-  If the \a enable flag is \c false and we're currently animating, the
-  spin will be stopped.
-*/
-void
-View3DInventorViewer::setAnimationEnabled(bool enable)
+/**
+ * @brief Decide if it should be possible to start any animation
+ *
+ * If the enable flag is false and we're currently animating, the animation will be stopped
+ */
+void View3DInventorViewer::setAnimationEnabled(bool enable)
 {
     navigation->setAnimationEnabled(enable);
 }
 
-/*!
-  Query whether or not it is possible to start a spinning animation by
-  releasing the left mouse button while dragging the mouse.
-*/
+/**
+ * @brief Decide if it should be possible to start a spin animation of the model in the viewer by releasing the mouse button while dragging
+ *
+ * If the enable flag is false and we're currently animating, the spin animation will be stopped
+ */
+void View3DInventorViewer::setSpinningAnimationEnabled(bool enable)
+{
+    navigation->setSpinningAnimationEnabled(enable);
+}
 
-bool
-View3DInventorViewer::isAnimationEnabled() const
+/**
+ * @return Whether or not it is possible to start any animation
+ */
+bool View3DInventorViewer::isAnimationEnabled() const
 {
     return navigation->isAnimationEnabled();
 }
 
-/*!
-  Query if the model in the viewer is currently in spinning mode after
-  a user drag.
-*/
+/**
+ * @return Whether or not it is possible to start a spinning animation e.g. after dragging
+ */
+bool View3DInventorViewer::isSpinningAnimationEnabled() const
+{
+    return navigation->isSpinningAnimationEnabled();
+}
+
+/**
+ * @return Whether or not any animation is currently active
+ */
 bool View3DInventorViewer::isAnimating() const
 {
     return navigation->isAnimating();
+}
+
+/**
+ * @return Whether or not a spinning animation is currently active e.g. after a user drag
+ */
+bool View3DInventorViewer::isSpinning() const
+{
+    return navigation->isSpinning();
 }
 
 /**

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -159,16 +159,18 @@ public:
     bool searchNode(SoNode*) const;
 
     void setAnimationEnabled(bool enable);
+    void setSpinningAnimationEnabled(bool enable);
     bool isAnimationEnabled() const;
-
-    void setPopupMenuEnabled(bool on);
-    bool isPopupMenuEnabled() const;
-
+    bool isSpinningAnimationEnabled() const;
+    bool isAnimating() const;
+    bool isSpinning() const;
     void startAnimation(const SbRotation& orientation, const SbVec3f& rotationCenter,
                         const SbVec3f& translation, int duration = -1, bool wait = false);
     void startSpinningAnimation(const SbVec3f& axis, float velocity);
     void stopAnimating();
-    bool isAnimating() const;
+
+    void setPopupMenuEnabled(bool on);
+    bool isPopupMenuEnabled() const;
 
     void setFeedbackVisibility(bool enable);
     bool isFeedbackVisible() const;

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -75,6 +75,7 @@ void View3DSettings::applySettings()
     OnChange(*hGrp,"CornerCoordSystemSize");
     OnChange(*hGrp,"ShowAxisCross");
     OnChange(*hGrp,"UseNavigationAnimations");
+    OnChange(*hGrp,"UseSpinningAnimations");
     OnChange(*hGrp,"Gradient");
     OnChange(*hGrp,"RadialGradient");
     OnChange(*hGrp,"BackgroundColor");
@@ -297,6 +298,11 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp::M
     else if (strcmp(Reason,"UseNavigationAnimations") == 0) {
         for (auto _viewer : _viewers) {
             _viewer->setAnimationEnabled(rGrp.GetBool("UseNavigationAnimations", true));
+        }
+    }
+    else if (strcmp(Reason,"UseSpinningAnimations") == 0) {
+        for (auto _viewer : _viewers) {
+            _viewer->setSpinningAnimationEnabled(rGrp.GetBool("UseSpinningAnimations", false));
         }
     }
     else if (strcmp(Reason,"Gradient") == 0 || strcmp(Reason,"RadialGradient") == 0) {


### PR DESCRIPTION
There are some complaints about the infinite spin animation in the OpenInventor and CAD navigation style after dragging.  [here on reddit](https://www.reddit.com/r/FreeCAD/comments/17yhq1f/stop_that_crazy_autorotation/), and here https://github.com/FreeCAD/FreeCAD/issues/11243#issuecomment-1789149331. I personally also find this spin animation slightly annoying but I would still like to use the other animations so disabling animations is not the solution.

This PR groups settings for animations together and adds a separate checkbox to enable the spin animations. This checkbox is disabled by default. With this change it is still possible to have animations when selecting standard views or the navigation cube but the annoying spin animation will only be played when you enable it.