### PR TITLE
Gui: Add ScrollArea to Preferences and auto expand groups

### DIFF
--- a/src/Gui/DlgPreferences.ui
+++ b/src/Gui/DlgPreferences.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>1000</width>
+    <height>900</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>1000</width>
+    <height>600</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Preferences</string>
@@ -209,13 +215,65 @@ QFrame::item { padding: 6px 8px };</string>
          </layout>
         </item>
         <item>
-         <widget class="QStackedWidget" name="groupWidgetStack">
+         <widget class="QScrollArea" name="scrollArea">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>1</horstretch>
-            <verstretch>1</verstretch>
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="horizontalScrollBarPolicy">
+           <enum>Qt::ScrollBarAlwaysOff</enum>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QAbstractScrollArea::AdjustIgnored</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>726</width>
+             <height>669</height>
+            </rect>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QStackedWidget" name="groupWidgetStack">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                <horstretch>1</horstretch>
+                <verstretch>1</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
          </widget>
         </item>
         <item>

--- a/src/Gui/DlgPreferencesImp.cpp
+++ b/src/Gui/DlgPreferencesImp.cpp
@@ -114,6 +114,10 @@ DlgPreferencesImp::DlgPreferencesImp(QWidget* parent, Qt::WindowFlags fl)
             &QPushButton::clicked,
             this,
             &DlgPreferencesImp::showResetOptions);
+    connect(ui->groupWidgetStack,
+            &QStackedWidget::currentChanged,
+            this,
+            &DlgPreferencesImp::onStackWidgetChange);
 
     ui->groupsTreeView->setModel(&_model);
     
@@ -193,6 +197,15 @@ PreferencesPageItem* DlgPreferencesImp::createGroup(const std::string &groupName
     auto groupPages = new QStackedWidget;
     groupPages->setProperty(GroupNameProperty, QVariant(groupNameQString));
 
+    connect(groupPages,
+            &QStackedWidget::currentChanged,
+            this,
+            &DlgPreferencesImp::onStackWidgetChange);
+
+
+    if (ui->groupWidgetStack->count() > 0) {
+        groupPages->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+    }
     ui->groupWidgetStack->addWidget(groupPages);
 
     auto item = new PreferencesPageItem;
@@ -255,6 +268,11 @@ void DlgPreferencesImp::createPageInGroup(PreferencesPageItem *groupItem, const 
         page->loadSettings();
 
         auto pages = qobject_cast<QStackedWidget*>(groupItem->getWidget());
+
+        if (pages->count() > 0) {
+            page->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+        }
+
         pages->addWidget(page);
     }
     catch (const Base::Exception& e) {
@@ -637,7 +655,6 @@ void DlgPreferencesImp::restartIfRequired()
 
 void DlgPreferencesImp::showEvent(QShowEvent* ev)
 {
-    this->adjustSize();
     QDialog::showEvent(ev);
 }
 
@@ -666,6 +683,20 @@ void DlgPreferencesImp::onPageSelected(const QModelIndex& index)
     }
 
     updatePageDependentLabels();
+}
+
+void DlgPreferencesImp::onStackWidgetChange(int index)
+{
+    auto stack = qobject_cast<QStackedWidget*>(sender());
+
+    for (int i = 0; i < stack->count(); i++) {
+        auto current = stack->widget(i);
+        current->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+    }
+
+    if (auto selected = stack->widget(index)) {
+        selected->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    }
 }
 
 void DlgPreferencesImp::changeEvent(QEvent *e)

--- a/src/Gui/DlgPreferencesImp.h
+++ b/src/Gui/DlgPreferencesImp.h
@@ -46,10 +46,14 @@ public:
     QWidget* getWidget() const;
     void setWidget(QWidget* widget);
 
+    bool isExpanded() const;
+    void setExpanded(bool expanded);
+
     static constexpr char const* PropertyName = "SettingsPageItem";
 
 private:
-    QWidget *_widget = nullptr;
+    QWidget* _widget = nullptr;
+    bool _expanded = false;
 };
 
 /**
@@ -152,6 +156,9 @@ protected Q_SLOTS:
     void onButtonBoxClicked(QAbstractButton*);
     void onPageSelected(const QModelIndex &index);
     void onStackWidgetChange(int index);
+
+    void onGroupExpanded(const QModelIndex &index);
+    void onGroupCollapsed(const QModelIndex &index);
 
 private:
     /** @name for internal use only */

--- a/src/Gui/DlgPreferencesImp.h
+++ b/src/Gui/DlgPreferencesImp.h
@@ -28,6 +28,7 @@
 
 #include <QDialog>
 #include <QStandardItemModel>
+#include <QStackedWidget>
 #include <memory>
 #include <FCGlobal.h>
 
@@ -150,6 +151,7 @@ protected:
 protected Q_SLOTS:
     void onButtonBoxClicked(QAbstractButton*);
     void onPageSelected(const QModelIndex &index);
+    void onStackWidgetChange(int index);
 
 private:
     /** @name for internal use only */


### PR DESCRIPTION
This adds QScrollArea widget to DlgPreferences which in turn allows preference pages to be scrollable. Stacked widget sizes are forced to selected widget so scroll area should appear when it is needed.

Second commit ensures that after selecting item the group is automatically expanded. User can force expansion by explcitly clicking expand button, groups expanded that way will stay expanded unless user collapses them. Otherwise non-active group will be collapsed automatically.

This PR also changes default size of the dialog to 1000x900 - for pages that are larger it results in vertical scroll.

Fixes #11511
Fixes #11530
Fixes #11004 