### PR TITLE
Add .vscode folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ install_manifest.txt
 /src/Tools/offlinedoc/localwiki/
 /src/Tools/offlinedoc/*.txt
 /conda/environment.yml
+/.vscode/
 OpenSCAD_rc.py
 tags
 /CMakeUserPresets.json


### PR DESCRIPTION
Since we moved vscode files to `contrib/.vscode` in https://github.com/FreeCAD/FreeCAD/commit/d98f0e1ae386e1a3722d45593b4ac3c08b8ad797 we should add the folder to .gitignore