### PR TITLE
[0.21] [Preferences] Exclude 8514oem from Monospace fonts

### DIFF
--- a/src/Gui/DlgEditorImp.cpp
+++ b/src/Gui/DlgEditorImp.cpp
@@ -300,7 +300,9 @@ void DlgSettingsEditorImp::loadSettings()
     QStringList fixedFamilyNames;
     for (const auto &name : familyNames) {
         if (QFontDatabase().isFixedPitch(name)) {
-            fixedFamilyNames.append(name);
+            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0) {
+                fixedFamilyNames.append(name);
+            }
         }
     }
 #else
@@ -308,7 +310,9 @@ void DlgSettingsEditorImp::loadSettings()
     QStringList fixedFamilyNames;
     for (const auto &name : familyNames) {
         if (QFontDatabase::isFixedPitch(name)) {
-            fixedFamilyNames.append(name);
+            if (name.compare(QLatin1String("8514oem"), Qt::CaseInsensitive) != 0) {
+                fixedFamilyNames.append(name);
+            }
         }
     }
 #endif


### PR DESCRIPTION
This is in effect a backport of https://github.com/FreeCAD/FreeCAD/commit/951aafde6085eb58711505459a7d3b13c78c5864 though the file structure changed during the 0.22.dev cycle.