### PR TITLE
VSCode: Change setup conda environment task type to process.

### DIFF
--- a/contrib/.vscode/tasks.json
+++ b/contrib/.vscode/tasks.json
@@ -1,7 +1,7 @@
 {
   "tasks": [
     {
-      "type": "shell",
+      "type": "process",
       "label": "FreeCAD: setup conda environment",
       "linux": {
         "command": "conda/setup-environment.sh",


### PR DESCRIPTION
The task type `shell` on Windows would invoke the user's default shell, which may not always correctly run the `conda/setup-environment.cmd` script.  Using the type `process` invokes the script directly, avoiding the issue.