### PR TITLE
conda: pin coin3d to v4.0.0 until a fix to v4.0.1 is released.

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -58,7 +58,7 @@ dependencies:
 - boost
 - boost-cpp
 - cmake
-- coin3d
+- coin3d==4.0.0
 - compilers
 - conda
 - conda-build


### PR DESCRIPTION
As noted on https://github.com/coin3d/coin/issues/513, the ABI was broken in v4.0.1 causing pivy to not operate correctly.

Pin `coin3d` to v4.0.0 will prevent the issue until a compatible release of `coin3d` or `pivy` is made.