### PR TITLE
Core: Hide macro toolbar by default.

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -802,7 +802,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     }
 
     // Macro
-    auto macro = new ToolBarItem( root );
+    auto macro = new ToolBarItem( root, ToolBarItem::DefaultVisibility::Hidden);
     macro->setCommand("Macro");
     *macro << "Std_DlgMacroRecord" << "Std_DlgMacroExecute"
            << "Std_DlgMacroExecuteDirect";


### PR DESCRIPTION
Following the discussion https://forum.freecad.org/viewtopic.php?t=82937&start=20 which seemed to reach consensus about this.
This PR hides macro toolbar by default.