### PR TITLE
Notification Area Improvements

### DIFF
--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -423,8 +423,9 @@ void PropertyEnumeration::Restore(Base::XMLReader &reader)
 
     if (val < 0) {
         // If the enum is empty at this stage do not print a warning
-        if (_enum.hasEnums())
-            Base::Console().Warning("Enumeration index %d is out of range, ignore it\n", val);
+        if (_enum.hasEnums()) {
+            Base::Console().DeveloperWarning(std::string("PropertyEnumeration"), "Enumeration index %d is out of range, ignore it\n", val);
+        }
         val = getValue();
     }
 


### PR DESCRIPTION

Two requests under issue #11183:

- Do not expose developer message to the user
- Improve the notification area so that a same message is not repeated over and over, but grouped together indicating the number of repetitions.