### PR TITLE
Do not use pthreads in gtest with MSVC compilers.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ if(MSVC)
         gtest_force_shared_crt
         "Use shared (DLL) run-time lib even when Google Test is built as static lib."
         ON)
+    option(gtest_disable_pthreads "Disable uses of pthreads in gtest." ON)
 
     set(Google_Tests_LIBS
         oldnames.lib


### PR DESCRIPTION
`gtest` incorrectly identifies that `pthreads` are available when using MSVC in the `conda` development environment.  This leads to build failures on this platform.

This commit disables `gtest` multithreading when using MSVC.