### PR TITLE
Draft: implement DefaultAnnoLineWidth and DefaultAnnoLineColor prefs

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -92,7 +92,8 @@ from draftutils.utils import (string_encode_coin,
                               get_rgb,
                               getrgb,
                               argb_to_rgba,
-                              rgba_to_argb)
+                              rgba_to_argb,
+                              get_rgba_tuple)
 
 from draftfunctions.svg import (get_svg,
                                 getSVG)

--- a/src/Mod/Draft/Resources/ui/preferences-draft.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draft.ui
@@ -11,149 +11,126 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>General settings</string>
+   <string>General</string>
   </property>
   <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <property name="leftMargin">
-    <number>9</number>
-   </property>
-   <property name="topMargin">
-    <number>9</number>
-   </property>
-   <property name="rightMargin">
-    <number>9</number>
-   </property>
-   <property name="bottomMargin">
-    <number>9</number>
-   </property>
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+    <widget class="QGroupBox" name="groupBox_1">
      <property name="title">
-      <string>General Draft Settings</string>
+      <string>General</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="QLabel" name="label_12">
-          <property name="text">
-           <string>Default working plane</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_7">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefComboBox" name="gui::prefcombobox_2">
-          <property name="prefEntry" stdset="0">
-           <cstring>defaultWP</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>None</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>XY (Top)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>XZ (Front)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>YZ (Side)</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_precision">
+        <property name="text">
+         <string>Internal precision level</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_13">
-        <item>
-         <widget class="QLabel" name="label_8">
-          <property name="text">
-           <string>Internal precision level</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="gui::prefspinbox_3">
-          <property name="maximumSize">
-           <size>
-            <width>60</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>The number of decimals in internal coordinates operations (for ex. 3 = 0.001). Values between 6 and 8 are usually considered the best trade-off among FreeCAD users.</string>
-          </property>
-          <property name="maximum">
-           <number>10</number>
-          </property>
-          <property name="value">
-           <number>6</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>precision</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_3">
+      <item row="0" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_precision">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="toolTip">
-         <string>If this option is checked, the layers drop-down list will also show groups, allowing you to automatically add objects to groups too.</string>
+         <string>The number of decimals used in internal coordinate operations (for example 3 = 0.001).
+Values between 6 and 8 are usually considered the best trade-off.</string>
+        </property>
+        <property name="maximum">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>6</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>precision</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_defaultWP">
+        <property name="text">
+         <string>Default working plane</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefComboBox" name="comboBox_defaultWP">
+        <property name="toolTip">
+         <string>The default working plane for new views. If set to &quot;Automatic&quot; the working plane
+will automatically align with the current view whenever a command is started.
+Additionally it will align to preselected planar faces, or when points on planar
+faces are picked during commands.</string>
+        </property>
+        <property name="currentIndex">
+         <number>1</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>defaultWP</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+        <item>
+         <property name="text">
+          <string>Automatic</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>XY (Top)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>XZ (Front)</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>YZ (Side)</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_showPlaneTracker">
+        <property name="toolTip">
+         <string>If checked, a widget indicating the current working
+plane orientation appears when picking points</string>
         </property>
         <property name="text">
-         <string>Show groups in layers list drop-down button</string>
+         <string>Show working plane tracker</string>
         </property>
-        <property name="checked">
-         <bool>false</bool>
+        <property name="prefEntry" stdset="0">
+         <cstring>showPlaneTracker</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_AutogroupAddGroups">
+        <property name="toolTip">
+         <string>If checked, the layers drop-down list also includes groups.
+Objects can then automatically be added to groups as well.</string>
+        </property>
+        <property name="text">
+         <string>Include groups in layer list</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>AutogroupAddGroups</cstring>
@@ -167,222 +144,272 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="verticalGroupBox">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Draft tools options</string>
+      <string>Command options</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="leftMargin">
-       <number>9</number>
-      </property>
-      <property name="topMargin">
-       <number>9</number>
-      </property>
-      <property name="rightMargin">
-       <number>9</number>
-      </property>
-      <property name="bottomMargin">
-       <number>9</number>
-      </property>
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <property name="topMargin">
-         <number>0</number>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_ToolMessages">
+        <property name="toolTip">
+         <string>If checked, instructions are displayed in the Report view when using Draft commands</string>
         </property>
-        <item row="0" column="0">
-         <widget class="Gui::PrefCheckBox" name="checkBox">
-          <property name="toolTip">
-           <string>When drawing lines, set focus on Length instead of X coordinate.
-This allows to point the direction and type the distance.</string>
-          </property>
-          <property name="text">
-           <string>Set focus on Length instead of X coordinate</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>focusOnLength</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_13">
-          <property name="toolTip">
-           <string>Force Draft Tools to create Part primitives instead of Draft objects.
-Note that this is not fully supported, and many object will be not editable with Draft Modifiers.</string>
-          </property>
-          <property name="text">
-           <string>Use Part Primitives when available</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>UsePartPrimitives</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_3">
-          <property name="toolTip">
-           <string>Normally, after copying objects, the copies get selected.
-If this option is checked, the base objects will be selected instead.</string>
-          </property>
-          <property name="text">
-           <string>Select base objects after copying</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>selectBaseObjects</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="Gui::PrefCheckBox" name="checkBox_2">
-          <property name="toolTip">
-           <string>If this is checked, prompt messages will be printed
-in the report view when using Draft tools, to help
-knowing which action to take next.</string>
-          </property>
-          <property name="text">
-           <string>Show prompts in the report view</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ToolMessages</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        <property name="text">
+         <string>Show prompts in the Report view</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ToolMessages</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Prefix labels of Clones with:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefLineEdit" name="lineEdit">
-          <property name="text">
-           <string/>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ClonePrefix</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="1" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_focusOnLength">
+        <property name="toolTip">
+         <string>If checked, Length input, instead of the X coordinate, will have the initial focus.
+This allows to indicate a direction and then type a distance.</string>
+        </property>
+        <property name="text">
+         <string>Set focus on Length instead of X coordinate</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>focusOnLength</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_selectBaseObjects">
+        <property name="toolTip">
+         <string>If checked, base objects, instead of created copies, are selected after copying</string>
+        </property>
+        <property name="text">
+         <string>Select base objects after copying</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>selectBaseObjects</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_UsePartPrimitives">
+        <property name="toolTip">
+         <string>If checked, Draft commands will create Part primitives instead of Draft objects.
+Note that this is not fully supported, and many objects will not be editable with
+Draft modification commands.</string>
+        </property>
+        <property name="text">
+         <string>Create Part primitives if possible</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>UsePartPrimitives</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_preserveFaceColor">
+        <property name="toolTip">
+         <string>If checked, Draft Downgrade and Draft Upgrade will keep face colors.
+Only for the splitFaces and makeShell options.</string>
+        </property>
+        <property name="text">
+         <string>Keep face colors during downgrade/upgrade</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>preserveFaceColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_preserveFaceNames">
+        <property name="toolTip">
+         <string>If checked, Draft Downgrade and Draft Upgrade will keep face names.
+Only for the splitFaces and makeShell options.</string>
+        </property>
+        <property name="text">
+         <string>Keep face names during downgrade/upgrade</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>preserveFaceNames</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_DraftEditMaxObjects">
+        <property name="text">
+         <string>Max. number of editable objects</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_DraftEditMaxObjects">
+        <property name="toolTip">
+         <string>The maximum number of objects Draft Edit is allowed to process at the same time</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>25</number>
+        </property>
+        <property name="value">
+         <number>5</number>
+        </property>
+        <property name="displayIntegerBase">
+         <number>10</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DraftEditMaxObjects</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_DraftEditPickRadius">
+        <property name="text">
+         <string>Edit node pick radius</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_DraftEditPickRadius">
+        <property name="toolTip">
+         <string>The pick radius of edit nodes</string>
+        </property>
+        <property name="suffix">
+         <string> px</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="value">
+         <number>20</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DraftEditPickRadius</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_ClonePrefix">
+        <property name="text">
+         <string>Label prefix for clones</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_ClonePrefix">
+        <property name="maximumSize">
+         <size>
+          <width>140</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The default prefix added to the label of new clones</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ClonePrefix</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_constructiongroupname">
+        <property name="text">
+         <string>Construction group label</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_constructiongroupname">
+        <property name="maximumSize">
+         <size>
+          <width>140</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The default label for the construction geometry group</string>
+        </property>
+        <property name="text">
+         <string>Construction</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>constructiongroupname</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QLabel" name="label_constructioncolor">
+        <property name="text">
+         <string>Construction geometry color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_constructioncolor">
+        <property name="toolTip">
+         <string>The default color for Draft objects in construction mode</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>44</red>
+          <green>125</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>constructioncolor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string>Construction Geometry</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_10">
-        <item>
-         <widget class="QLabel" name="label_10">
-          <property name="text">
-           <string>Construction group name</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefLineEdit" name="gui::preflineedit_2">
-          <property name="toolTip">
-           <string>This is the default group name for construction geometry</string>
-          </property>
-          <property name="text">
-           <string>Construction</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>constructiongroupname</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <widget class="QLabel" name="label_9">
-          <property name="text">
-           <string>Construction geometry color</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_9">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefColorButton" name="gui::prefcolorbutton_3">
-          <property name="toolTip">
-           <string>This is the default color for objects being drawn while in construction mode.</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>44</red>
-            <green>125</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>constructioncolor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
      </property>
     </spacer>
    </item>
@@ -392,23 +419,13 @@ knowing which action to take next.</string>
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
-   <class>Gui::ColorButton</class>
-   <extends>QPushButton</extends>
-   <header>Gui/Widgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefColorButton</class>
-   <extends>Gui::ColorButton</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefLineEdit</class>
+   <extends>QLineEdit</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
@@ -417,8 +434,18 @@ knowing which action to take next.</string>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefLineEdit</class>
-   <extends>QLineEdit</extends>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header>Gui/Widgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefColorButton</class>
+   <extends>Gui::ColorButton</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftinterface.ui
@@ -11,1046 +11,781 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>User interface settings</string>
+   <string>Interface</string>
   </property>
   <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <property name="margin">
-    <number>9</number>
-   </property>
+   <item>
+    <widget class="QGroupBox" name="groupBox_1">
+     <property name="title">
+      <string>In-command shortcuts</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutRelative">
+        <property name="text">
+         <string>Relative</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutRelative">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>R</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutRelative</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutGlobal">
+        <property name="text">
+         <string>Global</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutGlobal">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>G</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutGlobal</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutLength">
+        <property name="text">
+         <string>Length</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutLength">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>L</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutLength</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="8">
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutFill">
+        <property name="text">
+         <string>Fill</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutFill">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>F</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutFill</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutSelectEdge">
+        <property name="text">
+         <string>Select edge</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutSelectEdge">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>E</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutSelectEdge</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutSubelementMode">
+        <property name="text">
+         <string>Subelement mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutSubelementMode">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>B</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutSubelementMode</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutCopy">
+        <property name="text">
+         <string>Copy</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutCopy">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>C</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutCopy</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutUndo">
+        <property name="text">
+         <string>Undo</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutUndo">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string notr="true">/</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutUndo</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutWipe">
+        <property name="text">
+         <string>Wipe</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutWipe">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>W</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutWipe</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutClose">
+        <property name="text">
+         <string>Close</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutClose">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>O</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutClose</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutExit">
+        <property name="text">
+         <string>Exit</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutExit">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>A</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutExit</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutContinue">
+        <property name="text">
+         <string>Continue</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutContinue">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>N</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutContinue</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutCycleSnap">
+        <property name="text">
+         <string>Cycle snap</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutCycleSnap">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string notr="true">`</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutCycleSnap</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutAddHold">
+        <property name="text">
+         <string>Add hold</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutAddHold">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Q</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutAddHold</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutSetWP">
+        <property name="text">
+         <string>Set working plane</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutSetWP">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>U</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutSetWP</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutSnap">
+        <property name="text">
+         <string>Snap</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutSnap">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>S</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutSnap</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutIncreaseRadius">
+        <property name="text">
+         <string>Increase radius</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutIncreaseRadius">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string notr="true">P</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutIncreaseRadius</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutDecreaseRadius">
+        <property name="text">
+         <string>Decrease radius</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutDecreaseRadius">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string notr="true">M</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutDecreaseRadius</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_inCommandShortcutRestrictX">
+        <property name="text">
+         <string>Restrict X</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutRestrictX">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>X</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutRestrictX</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="3">
+       <widget class="QLabel" name="label_inCommandShortcutRestrictY">
+        <property name="text">
+         <string>Restrict Y</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="4">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutRestrictY">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Y</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutRestrictY</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="6">
+       <widget class="QLabel" name="label_inCommandShortcutRestrictZ">
+        <property name="text">
+         <string>Restrict Z</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="7">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_inCommandShortcutRestrictZ">
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Z</string>
+        </property>
+        <property name="maxLength">
+         <number>1</number>
+        </property>
+        <property name="clearButtonEnabled" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>inCommandShortcutRestrictZ</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>In-Command Shortcuts</string>
+      <string>UI options</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
-      <item>
-       <layout class="QGridLayout" name="gridLayout_3">
-        <property name="topMargin">
-         <number>0</number>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBox_SnapBarShowOnlyDuringCommands">
+        <property name="toolTip">
+         <string>If checked, the Draft snap toolbar will only be visible during commands</string>
         </property>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Relative</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_2">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>R</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutRelative</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </spacer>
-        </item>
-        <item row="0" column="3">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Continue</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="4">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_3">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>T</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutContinue</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="5">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </spacer>
-        </item>
-        <item row="0" column="6">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Close</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="7">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_4">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>O</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutClose</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="8">
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </spacer>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Copy</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_5">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>P</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutCopy</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3">
-         <widget class="QLabel" name="label_6">
-          <property name="text">
-           <string>Subelement Mode</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="4">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_11">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>D</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutSubelementMode</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="6">
-         <widget class="QLabel" name="label_11">
-          <property name="text">
-           <string>Fill</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="7">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_12">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>L</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutFill</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_13">
-          <property name="text">
-           <string>Exit</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_6">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>A</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutExit</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="3">
-         <widget class="QLabel" name="label_17">
-          <property name="text">
-           <string>Select Edge</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="4">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_13">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>E</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutSelectEdge</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="6">
-         <widget class="QLabel" name="label_18">
-          <property name="text">
-           <string>Add Hold</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="7">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_15">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Q</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutAddHold</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_20">
-          <property name="text">
-           <string>Length</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_7">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>H</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutLength</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="3">
-         <widget class="QLabel" name="label_21">
-          <property name="text">
-           <string>Wipe</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="4">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_14">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>W</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutWipe</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="6">
-         <widget class="QLabel" name="label_22">
-          <property name="text">
-           <string>Set WP</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="7">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_16">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>U</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutSetWP</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_24">
-          <property name="text">
-           <string>Cycle Snap</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_8">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string notr="true">`</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutCycleSnap</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="3">
-         <widget class="QLabel" name="label_27">
-          <property name="text">
-           <string>Global</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="4">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_21">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>G</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutGlobal</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="6">
-         <widget class="QLabel" name="label_28">
-          <property name="text">
-           <string>Undo</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="7">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_22">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string notr="true">/</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutUndo</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_14">
-          <property name="text">
-           <string>Snap</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_9">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>S</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutSnap</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="3">
-         <widget class="QLabel" name="label_15">
-          <property name="text">
-           <string>Increase Radius</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="4">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_19">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string notr="true">[</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutIncreaseRadius</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="6">
-         <widget class="QLabel" name="label_16">
-          <property name="text">
-           <string>Decrease Radius</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="7">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_17">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string notr="true">]</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutDecreaseRadius</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_23">
-          <property name="text">
-           <string>Restrict X</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_10">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>X</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutRestrictX</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="3">
-         <widget class="QLabel" name="label_25">
-          <property name="text">
-           <string>Restrict Y</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="4">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_20">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Y</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>inCommandShortcutRestrictY</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="6">
-         <widget class="QLabel" name="label_26">
-          <property name="text">
-           <string>Restrict Z</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="7">
-         <widget class="Gui::PrefLineEdit" name="lineEdit_18">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Z</string>
-          </property>
-          <property name="maxLength">
-           <number>1</number>
-          </property>
-          <property name="placeholderText">
-           <string/>
-          </property>
-          <property name="clearButtonEnabled" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>RestrictZ</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        </layout>
+        <property name="text">
+         <string>Only show the Draft snap toolbar during commands</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SnapBarShowOnlyDuringCommands</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBox_DisplayStatusbarSnapWidget">
+        <property name="toolTip">
+         <string>If checked, the Snap widget is displayed in the Draft statusbar</string>
+        </property>
+        <property name="text">
+         <string>Show the Snap widget in the Draft Workbench</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DisplayStatusbarSnapWidget</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBox_DisplayStatusbarScaleWidget">
+        <property name="toolTip">
+         <string>If checked, the Annotation scale widget is displayed in the Draft statusbar</string>
+        </property>
+        <property name="text">
+         <string>Show the Annotation scale widget in the Draft Workbench</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DisplayStatusbarScaleWidget</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string>Draft Statusbar</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="gridLayout_4">
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <item row="0" column="0">
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_3">
-          <property name="toolTip">
-           <string>Enable snap statusbar widget</string>
-          </property>
-          <property name="text">
-           <string>Draft snap widget</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>DisplayStatusbarSnapWidget</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_13">
-          <property name="toolTip">
-           <string>Enable draft statusbar annotation scale widget</string>
-          </property>
-          <property name="text">
-           <string>Annotation scale widget</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>DisplayStatusbarScaleWidget</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
      </property>
     </spacer>
    </item>

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -14,269 +14,13 @@
    <string>Grid and snapping</string>
   </property>
   <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <property name="leftMargin">
-    <number>9</number>
-   </property>
-   <property name="topMargin">
-    <number>9</number>
-   </property>
-   <property name="rightMargin">
-    <number>9</number>
-   </property>
-   <property name="bottomMargin">
-    <number>9</number>
-   </property>
    <item>
     <widget class="QGroupBox" name="groupBox_1">
      <property name="title">
-      <string>Snapping</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_1">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_1">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_alwaysSnap">
-          <property name="toolTip">
-           <string>If checked, snapping is activated without the need to press the Snap mod key</string>
-          </property>
-          <property name="text">
-           <string>Always snap</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>alwaysSnap</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="label_modsnap">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Snap mod</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_1">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefComboBox" name="comboBox_modsnap">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="toolTip">
-           <string>The Snap modifier key</string>
-          </property>
-          <property name="currentIndex">
-           <number>1</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>modsnap</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>Shift</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Ctrl</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Alt</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="label_modconstrain">
-          <property name="text">
-           <string>Constrain mod</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefComboBox" name="comboBox_modconstrain">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>The Constraining modifier key</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>modconstrain</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>Shift</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Ctrl</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Alt</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QLabel" name="label_modalt">
-          <property name="text">
-           <string>Alt mod</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefComboBox" name="comboBox_modalt">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>The Alt modifier key. The function of this key depends on the command.</string>
-          </property>
-          <property name="currentIndex">
-           <number>2</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>modalt</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>Shift</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Ctrl</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Alt</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_SnapBarShowOnlyDuringCommands">
-          <property name="toolTip">
-           <string>If checked, the Snap toolbar will only be visible during commands</string>
-          </property>
-          <property name="text">
-           <string>Only show the Draft snap toolbar during commands</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SnapBarShowOnlyDuringCommands</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
       <string>Grid</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
+     <layout class="QGridLayout" name="gridLayout_1">
+      <item row="0" column="0" colspan="3">
        <widget class="Gui::PrefCheckBox" name="checkBox_alwaysShowGrid">
         <property name="toolTip">
          <string>If checked, the grid will always be visible in new views.
@@ -296,7 +40,7 @@ Use Draft ToggleGrid to change this for the active view.</string>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="1" column="0" colspan="3">
        <widget class="Gui::PrefCheckBox" name="checkBox_grid">
         <property name="enabled">
          <bool>false</bool>
@@ -319,10 +63,11 @@ Use Draft ToggleGrid to change this for the active view.</string>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="2" column="0" colspan="3">
        <widget class="Gui::PrefCheckBox" name="checkBox_gridBorder">
         <property name="toolTip">
-         <string>If checked, an additional border is displayed around the grid, showing the main square size in the bottom left border</string>
+         <string>If checked, an additional border is displayed around the grid,
+showing the main square size in the bottom left corner</string>
         </property>
         <property name="text">
          <string>Show grid border</string>
@@ -338,14 +83,15 @@ Use Draft ToggleGrid to change this for the active view.</string>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="3" column="0" colspan="3">
        <widget class="Gui::PrefCheckBox" name="checkBox_gridShowHuman">
         <property name="enabled">
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>If checked, the outline of a human figure is displayed at the bottom left corner of the grid.
-This option is only effective if the BIM workbench is installed and if Show grid border is enabled.</string>
+         <string>If checked, the outline of a human figure is displayed at the bottom left
+corner of the grid. Only effective if the BIM workbench is installed and
+&quot;Show grid border&quot; is enabled.</string>
         </property>
         <property name="text">
          <string>Show human figure</string>
@@ -361,10 +107,10 @@ This option is only effective if the BIM workbench is installed and if Show grid
         </property>
        </widget>
       </item>
-      <item>
+      <item row="4" column="0" colspan="3">
        <widget class="Gui::PrefCheckBox" name="checkBox_coloredGridAxes">
         <property name="toolTip">
-         <string>If checked, the two main axes of the grid will be colored red, green or blue
+         <string>If checked, the two main axes of the grid are colored red, green or blue
 if they match the X, Y or Z axis of the global coordinate system</string>
         </property>
         <property name="text">
@@ -381,349 +127,371 @@ if they match the X, Y or Z axis of the global coordinate system</string>
         </property>
        </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
-         <widget class="QLabel" name="label_gridEvery">
-          <property name="text">
-           <string>Main lines every</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox_gridEvery">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>The number of squares between main grid lines. These lines are thicker than normal grid lines.</string>
-          </property>
-          <property name="value">
-           <number>10</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>gridEvery</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_gridEvery">
+        <property name="text">
+         <string>Main lines every</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
-         <widget class="QLabel" name="label_gridSpacing">
-          <property name="text">
-           <string>Grid spacing</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefQuantitySpinBox" name="spinBox_gridSpacing">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>The distance between grid lines</string>
-          </property>
-          <property name="decimals">
-           <number>4</number>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="rawValue">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="unit">
-           <string notr="true">mm</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>gridSpacing</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="5" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_gridEvery">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The number of squares between main grid lines.
+These lines are thicker than normal grid lines.</string>
+        </property>
+        <property name="value">
+         <number>10</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>gridEvery</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <widget class="QLabel" name="label_gridSize">
-          <property name="text">
-           <string>Grid size</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_6">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox_gridSize">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>The number of horizontal and vertical lines of the grid</string>
-          </property>
-          <property name="suffix">
-           <string> lines</string>
-          </property>
-          <property name="maximum">
-           <number>9999</number>
-          </property>
-          <property name="value">
-           <number>100</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>gridSize</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="5" column="2">
+       <spacer name="horizontalSpacer_1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="QLabel" name="label_gridColor_gridTransparency">
-          <property name="text">
-           <string>Grid color and transparency</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_7">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefColorButton" name="colorButton_gridColor">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>The color of the grid</string>
-          </property>
-          <property name="color" stdset="0">
-           <color>
-            <red>50</red>
-            <green>50</green>
-            <blue>75</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>gridColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox_gridTransparency">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>The overall transparency of the grid</string>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>gridTransparency</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_gridSpacing">
+        <property name="text">
+         <string>Grid spacing</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="Gui::PrefQuantitySpinBox" name="spinBox_gridSpacing">
+        <property name="toolTip">
+         <string>The distance between grid lines</string>
+        </property>
+        <property name="decimals">
+         <number>4</number>
+        </property>
+        <property name="maximum">
+         <double>9999.989999999999782</double>
+        </property>
+        <property name="rawValue">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="unit">
+         <string notr="true">mm</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>gridSpacing</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_gridSize">
+        <property name="text">
+         <string>Grid size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_gridSize">
+        <property name="toolTip">
+         <string>The number of horizontal and vertical lines in the grid</string>
+        </property>
+        <property name="suffix">
+         <string> lines</string>
+        </property>
+        <property name="maximum">
+         <number>9999</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>gridSize</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_gridTransparency">
+        <property name="text">
+         <string>Grid transparency</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_gridTransparency">
+        <property name="toolTip">
+         <string>The overall transparency of the grid</string>
+        </property>
+        <property name="suffix">
+         <string> %</string>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>gridTransparency</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_gridColor">
+        <property name="text">
+         <string>Grid color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_gridColor">
+        <property name="toolTip">
+         <string>The color of the grid</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>50</red>
+          <green>50</green>
+          <blue>75</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>gridColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_3">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Edit</string>
+      <string>Snapping and modifier keys</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_10">
-        <item>
-         <widget class="QLabel" name="label_DraftEditMaxObjects">
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="text">
-           <string>Maximum number of objects for Draft Edit</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_8">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox_DraftEditMaxObjects">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>The maximum number of objects Draft Edit is allowed to process at the same time</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>25</number>
-          </property>
-          <property name="value">
-           <number>5</number>
-          </property>
-          <property name="displayIntegerBase">
-           <number>10</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>DraftEditMaxObjects</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_snapStyle">
+        <property name="text">
+         <string>Snap symbol style</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_11">
+      <item row="0" column="1">
+       <widget class="Gui::PrefComboBox" name="comboBox_snapStyle">
+        <property name="toolTip">
+         <string>The style for snap symbols</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>snapStyle</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
         <item>
-         <widget class="QLabel" name="label_DraftEditPickRadius">
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="text">
-           <string>Pick radius for Draft Edit</string>
-          </property>
-         </widget>
+         <property name="text">
+          <string>Draft classic style</string>
+         </property>
         </item>
         <item>
-         <spacer name="horizontalSpacer_9">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
+         <property name="text">
+          <string>Bitsnpieces style</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_snapcolor">
+        <property name="text">
+         <string>Snap symbol color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_snapcolor">
+        <property name="toolTip">
+         <string>The color for snap symbols</string>
+        </property>
+        <property name="color">
+         <color>
+          <red>255</red>
+          <green>170</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>snapcolor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_alwaysSnap">
+        <property name="toolTip">
+         <string>If checked, snapping is activated without the need to press the Snap modifier key</string>
+        </property>
+        <property name="text">
+         <string>Always snap</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>alwaysSnap</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_modsnap">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Snap modifier</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefComboBox" name="comboBox_modsnap">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>The Snap modifier key</string>
+        </property>
+        <property name="currentIndex">
+         <number>1</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>modsnap</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+        <item>
+         <property name="text">
+          <string>Shift</string>
+         </property>
         </item>
         <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox_DraftEditPickRadius">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>The pick radius (in pixels) of edit nodes</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="value">
-           <number>20</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>DraftEditPickRadius</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
+         <property name="text">
+          <string>Ctrl</string>
+         </property>
         </item>
-       </layout>
+        <item>
+         <property name="text">
+          <string>Alt</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_modconstrain">
+        <property name="text">
+         <string>Constrain modifier</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefComboBox" name="comboBox_modconstrain">
+        <property name="toolTip">
+         <string>The Constrain modifier key</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>modconstrain</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+        <item>
+         <property name="text">
+          <string>Shift</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Ctrl</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Alt</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_modalt">
+        <property name="text">
+         <string>Alt modifier</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="Gui::PrefComboBox" name="comboBox_modalt">
+        <property name="toolTip">
+         <string>The Alt modifier key. The function of this key depends on the command.</string>
+        </property>
+        <property name="currentIndex">
+         <number>2</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>modalt</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+        <item>
+         <property name="text">
+          <string>Shift</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Ctrl</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Alt</string>
+         </property>
+        </item>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -733,12 +501,6 @@ if they match the X, Y or Z axis of the global coordinate system</string>
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>40</height>
-      </size>
-     </property>
     </spacer>
    </item>
   </layout>
@@ -746,21 +508,6 @@ if they match the X, Y or Z axis of the global coordinate system</string>
  <layoutdefault spacing="6" margin="11"/>
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
-  <customwidget>
-   <class>Gui::ColorButton</class>
-   <extends>QPushButton</extends>
-   <header>Gui/Widgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefColorButton</class>
-   <extends>Gui::ColorButton</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
   <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
@@ -772,25 +519,28 @@ if they match the X, Y or Z axis of the global coordinate system</string>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
    <class>Gui::PrefQuantitySpinBox</class>
    <extends>QDoubleSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header>Gui/Widgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefColorButton</class>
+   <extends>Gui::ColorButton</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>
  <resources/>
  <connections>
-  <connection>
-   <sender>checkBox_alwaysSnap</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>label_modsnap</receiver>
-   <slot>setDisabled(bool)</slot>
-  </connection>
-  <connection>
-   <sender>checkBox_alwaysSnap</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>comboBox_modsnap</receiver>
-   <slot>setDisabled(bool)</slot>
-  </connection>
   <connection>
    <sender>checkBox_alwaysShowGrid</sender>
    <signal>toggled(bool)</signal>
@@ -802,6 +552,18 @@ if they match the X, Y or Z axis of the global coordinate system</string>
    <signal>toggled(bool)</signal>
    <receiver>checkBox_gridShowHuman</receiver>
    <slot>setEnabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>checkBox_alwaysSnap</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_modsnap</receiver>
+   <slot>setDisabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>checkBox_alwaysSnap</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>comboBox_modsnap</receiver>
+   <slot>setDisabled(bool)</slot>
   </connection>
  </connections>
 </ui>

--- a/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
@@ -14,107 +14,137 @@
    <string>Texts and dimensions</string>
   </property>
   <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <property name="leftMargin">
-    <number>9</number>
-   </property>
-   <property name="topMargin">
-    <number>9</number>
-   </property>
-   <property name="rightMargin">
-    <number>9</number>
-   </property>
-   <property name="bottomMargin">
-    <number>9</number>
-   </property>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_1">
      <property name="title">
-      <string>Text settings</string>
+      <string>Texts</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Font family</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefLineEdit" name="gui::preflineedit">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>This is the default font name for all Draft texts and dimensions.
-It can be a font name such as &quot;Arial&quot;, a default style such as &quot;sans&quot;, &quot;serif&quot;
-or &quot;mono&quot;, or a family such as &quot;Arial,Helvetica,sans&quot; or a name with a style
-such as &quot;Arial:Bold&quot;</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="placeholderText">
-           <string>Internal font</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>textfont</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_textfont">
+        <property name="text">
+         <string>Font name or family</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
-         <widget class="QLabel" name="label_20">
-          <property name="text">
-           <string>Font size</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="gui::prefdoublespinbox_2">
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Default height for texts and dimensions</string>
-          </property>
-          <property name="suffix">
-           <string>mm</string>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="value">
-           <double>0.200000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>textheight</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="0" column="1" colspan="2">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_textfont">
+        <property name="toolTip">
+         <string>The default font for texts, dimensions and labels. It can be a font name such
+as &quot;Arial&quot;, a style such as &quot;sans&quot;, &quot;serif&quot; or &quot;mono&quot;, or a family such as
+&quot;Arial,Helvetica,sans&quot;, or a name with a style such as &quot;Arial:Bold&quot;.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="placeholderText">
+         <string>Internal font</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>textfont</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_textheight">
+        <property name="text">
+         <string>Font size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_textheight">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The default height for texts, dimension texts and label texts</string>
+        </property>
+        <property name="singleStep">
+         <double>0.05</double>
+        </property>
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="minimum" stdset="0">
+         <double>0.0</double>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>3.5</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>textheight</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer_1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_LineSpacing">
+        <property name="text">
+         <string>Line spacing factor</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefDoubleSpinBox" name="spinBox_LineSpacing">
+        <property name="toolTip">
+         <string>The default line spacing for multi-line texts and labels (relative to the font size)</string>
+        </property>
+        <property name="singleStep">
+         <double>0.05</double>
+        </property>
+        <property name="value">
+         <double>1.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>LineSpacing</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_DefaultTextColor">
+        <property name="text">
+         <string>Text color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_DefaultTextColor">
+        <property name="toolTip">
+         <string>The default color for texts, dimension texts and label texts</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>0</red>
+          <green>0</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultTextColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -122,419 +152,173 @@ such as &quot;Arial:Bold&quot;</string>
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Dimension settings</string>
+      <string>Lines and arrows</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="QLabel" name="label_21">
-          <property name="text">
-           <string>Display mode</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefComboBox" name="gui::prefcombobox_4">
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>DefaultAnnoDisplayMode</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>World</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Screen</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_DimShowLine">
+        <property name="toolTip">
+         <string>If checked, the dimension line is displayed by default</string>
+        </property>
+        <property name="text">
+         <string>Show dimension line</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DimShowLine</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
-         <widget class="QLabel" name="label_19">
-          <property name="text">
-           <string>Number of decimals</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="gui::prefspinbox_5">
-          <property name="maximum">
-           <number>8</number>
-          </property>
-          <property name="value">
-           <number>2</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dimPrecision</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_DefaultAnnoLineWidth">
+        <property name="text">
+         <string>Line width</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="label_18">
-          <property name="text">
-           <string>Extension lines size</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="gui::prefdoublespinbox_4">
-          <property name="toolTip">
-           <string>The default size of dimensions extension lines</string>
-          </property>
-          <property name="suffix">
-           <string>mm</string>
-          </property>
-          <property name="minimum">
-           <double>-9999.989999999999782</double>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="value">
-           <double>0.300000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>extlines</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="1" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_DefaultAnnoLineWidth">
+        <property name="toolTip">
+         <string>The default line width</string>
+        </property>
+        <property name="suffix">
+         <string> px</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="value">
+         <number>2</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultAnnoLineWidth</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_extovershoot">
-        <item>
-         <widget class="QLabel" name="label_extovershoot">
-          <property name="text">
-           <string>Extension line overshoot</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="gui::prefdoublespinbox_extovershoot">
-          <property name="toolTip">
-           <string>The default length of extension line above dimension line</string>
-          </property>
-          <property name="suffix">
-           <string>mm</string>
-          </property>
-          <property name="minimum">
-           <double>-9999.989999999999782</double>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="value">
-           <double>0.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>extovershoot</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_dimovershoot">
-        <item>
-         <widget class="QLabel" name="label_dimovershoot">
-          <property name="text">
-           <string>Dimension line overshoot</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="gui::prefdoublespinbox_dimovershoot">
-          <property name="toolTip">
-           <string>The default distance the dimension line is extended past extension lines</string>
-          </property>
-          <property name="suffix">
-           <string>mm</string>
-          </property>
-          <property name="minimum">
-           <double>-9999.989999999999782</double>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="value">
-           <double>0.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dimovershoot</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_dimsymbol">
+        <property name="text">
+         <string>Arrow type</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_11">
+      <item row="2" column="1">
+       <widget class="Gui::PrefComboBox" name="comboBox_dimsymbol">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The default symbol displayed at the ends of dimension lines</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>dimsymbol</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
         <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox">
-          <property name="text">
-           <string>Show the dimension line</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>DimShowLine</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
+         <property name="text">
+          <string>Dot</string>
+         </property>
         </item>
-       </layout>
+        <item>
+         <property name="text">
+          <string>Circle</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Arrow</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Tick</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Tick-2</string>
+         </property>
+        </item>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_14">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Arrows style</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefComboBox" name="gui::prefcombobox">
-          <property name="prefEntry" stdset="0">
-           <cstring>dimsymbol</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>Dot</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Circle</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Arrow</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Tick</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Tick-2</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_arrowsize">
+        <property name="text">
+         <string>Arrow size</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="label_9">
-          <property name="text">
-           <string>Arrows size</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="gui::prefdoublespinbox">
-          <property name="toolTip">
-           <string>The default size of arrows</string>
-          </property>
-          <property name="suffix">
-           <string>mm</string>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="value">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>arrowsize</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="3" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_arrowsize">
+        <property name="toolTip">
+         <string>The default arrow size</string>
+        </property>
+        <property name="singleStep">
+         <double>0.05</double>
+        </property>
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="minimum" stdset="0">
+         <double>0.0</double>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>1.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>arrowsize</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QLabel" name="label_12">
-          <property name="text">
-           <string>Text spacing</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="gui::prefdoublespinbox_5">
-          <property name="toolTip">
-           <string>The space between the dimension line and the dimension text</string>
-          </property>
-          <property name="suffix">
-           <string>mm</string>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="value">
-           <double>0.050000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>dimspacing</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_DefaultAnnoLineColor">
+        <property name="text">
+         <string>Line and arrow color</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox">
-          <property name="text">
-           <string>Show the unit suffix in dimensions</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>showUnit</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Override unit</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefLineEdit" name="lineEdit">
-          <property name="toolTip">
-           <string>By leaving this field blank, the dimension measurements will be shown in the current unit defined in FreeCAD. By indicating a unit here such as m or cm, you can force new dimensions to be shown in that unit.</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>overrideUnit</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_10">
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Feet separator</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefLineEdit" name="lineEdit_2">
-          <property name="toolTip">
-           <string>Optional string to appear between the feet and inches values in dimensions</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>FeetSeparator</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="4" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_DefaultAnnoLineColor">
+        <property name="toolTip">
+         <string>The default color for lines and arrows</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>0</red>
+          <green>0</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultAnnoLineColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -542,86 +326,311 @@ such as &quot;Arial:Bold&quot;</string>
    <item>
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
-      <string>ShapeString settings</string>
+      <string>Units</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_23">
-        <item>
-         <widget class="QLabel" name="label_24">
-          <property name="text">
-           <string>Default ShapeString font file</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefFileChooser" name="gui::preffilechooser">
-          <property name="minimumSize">
-           <size>
-            <width>300</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="filter">
-           <string>Font files (*.ttf *.otf *.pfb *.TTF *.OTF *.PFB)</string>
-          </property>
-          <property name="toolTip">
-           <string>Select a font file</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>FontFile</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_showUnit">
+        <property name="toolTip">
+         <string>If checked, a unit symbol is added to dimension texts by default</string>
+        </property>
+        <property name="text">
+         <string>Show unit</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>showUnit</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_overrideUnit">
+        <property name="text">
+         <string>Unit override</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_overrideUnit">
+        <property name="maximumSize">
+         <size>
+          <width>140</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The default unit override for dimensions. Enter a unit such as m
+or cm, leave blank to use the current unit defined in FreeCAD.</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>overrideUnit</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_dimPrecision">
+        <property name="text">
+         <string>Number of decimals</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_dimPrecision">
+        <property name="toolTip">
+         <string>The default number of decimal places for dimension texts</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>8</number>
+        </property>
+        <property name="value">
+         <number>2</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>dimPrecision</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_FeetSeparator">
+        <property name="text">
+         <string>Feet separator</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_FeetSeparator">
+        <property name="maximumSize">
+         <size>
+          <width>140</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The optional string inserted between the feet and inches values in dimensions</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>FeetSeparator</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="title">
+      <string>Dimension details</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_dimovershoot">
+        <property name="text">
+         <string>Dimension line overshoot</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_dimovershoot">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The default distance the dimension line is extended past the extension lines</string>
+        </property>
+        <property name="singleStep">
+         <double>0.05</double>
+        </property>
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>0.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>dimovershoot</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_extlines">
+        <property name="text">
+         <string>Extension line length</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_extlines">
+        <property name="toolTip">
+         <string>The default length of extension lines. Use 0 for full extension lines. A negative
+value defines the gap between the ends of the extension lines and the measured
+points. A positive value defines the maximum length of the extension lines. Only
+used for linear dimensions.</string>
+        </property>
+        <property name="singleStep">
+         <double>0.05</double>
+        </property>
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>-0.5</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>extlines</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_extovershoot">
+        <property name="text">
+         <string>Extension line overshoot</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_extovershoot">
+        <property name="toolTip">
+         <string>The default length of extension lines above the dimension line</string>
+        </property>
+        <property name="singleStep">
+         <double>0.05</double>
+        </property>
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>2.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>extovershoot</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_dimspacing">
+        <property name="text">
+         <string>Text spacing</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_dimspacing">
+        <property name="toolTip">
+         <string>The default space between the dimension line and the dimension text</string>
+        </property>
+        <property name="singleStep">
+         <double>0.05</double>
+        </property>
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="minimum" stdset="0">
+         <double>0.0</double>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>1.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>dimspacing</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_5">
+     <property name="title">
+      <string>ShapeStrings</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_1">
+      <item>
+       <widget class="QLabel" name="label_FontFile">
+        <property name="text">
+         <string>Default ShapeString font file</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefFileChooser" name="fileChooser_FontFile">
+        <property name="filter">
+         <string>Font files (*.ttf *.otf *.pfb *.TTF *.OTF *.PFB)</string>
+        </property>
+        <property name="toolTip">
+         <string>Select a font file</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>FontFile</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
      </property>
     </spacer>
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11"/>
+ <layoutdefault spacing="6" margin="30"/>
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
-   <class>Gui::FileChooser</class>
-   <extends>QWidget</extends>
-   <header>Gui/FileDialog.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefFileChooser</class>
-   <extends>Gui::FileChooser</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefComboBox</class>
-   <extends>QComboBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
@@ -630,8 +639,48 @@ such as &quot;Arial:Bold&quot;</string>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
+   <class>Gui::PrefComboBox</class>
+   <extends>QComboBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
    <class>Gui::PrefDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefUnitSpinBox</class>
+   <extends>Gui::QuantitySpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header>Gui/Widgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefColorButton</class>
+   <extends>Gui::ColorButton</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::FileChooser</class>
+   <extends>QWidget</extends>
+   <header>Gui/FileDialog.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefFileChooser</class>
+   <extends>Gui::FileChooser</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/Draft/Resources/ui/preferences-draftvisual.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftvisual.ui
@@ -11,453 +11,188 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Visual settings</string>
+   <string>Visual</string>
   </property>
   <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <property name="leftMargin">
-    <number>9</number>
-   </property>
-   <property name="topMargin">
-    <number>9</number>
-   </property>
-   <property name="rightMargin">
-    <number>9</number>
-   </property>
-   <property name="bottomMargin">
-    <number>9</number>
-   </property>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_1">
      <property name="title">
-      <string>Visual Settings</string>
+      <string>SVG patterns</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Snap symbols style</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefComboBox" name="gui::prefcombobox_2">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>snapStyle</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>Draft classic style</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Bitsnpieces style</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_8">
-          <property name="text">
-           <string>Color</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefColorButton" name="gui::prefcolorbutton_2">
-          <property name="toolTip">
-           <string>The default color for snap symbols</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>snapcolor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_HatchPatternSize">
+        <property name="text">
+         <string>SVG pattern size</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_12">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_11">
-          <property name="toolTip">
-           <string>If checked, a widget indicating the current working plane orientation appears during drawing operations</string>
-          </property>
-          <property name="text">
-           <string>Show Working Plane tracker</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>showPlaneTracker</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="0" column="1">
+       <widget class="Gui::PrefDoubleSpinBox" name="spinBox_HatchPatternSize">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The default size for SVG patterns. A higher value results in a denser pattern.</string>
+        </property>
+        <property name="singleStep">
+         <double>0.05</double>
+        </property>
+        <property name="value">
+         <double>1.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>HatchPatternSize</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="label_13">
-          <property name="text">
-           <string>Alternate SVG patterns location</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_10">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefFileChooser" name="gui::preffilechooser_3">
-          <property name="minimumSize">
-           <size>
-            <width>300</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="mode">
-           <enum>Gui::FileChooser::Directory</enum>
-          </property>
-          <property name="toolTip">
-           <string>Here you can specify a directory with custom SVG files containing &lt;pattern&gt; definitions to be added to the standard patterns</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>patternFile</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_18">
-        <item>
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>SVG pattern resolution</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_12">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="gui::prefspinbox_2">
-          <property name="toolTip">
-           <string>The resolution to draw the patterns in. Default value is 128. Higher values give better resolutions, lower values make drawing faster</string>
-          </property>
-          <property name="maximum">
-           <number>512</number>
-          </property>
-          <property name="value">
-           <number>128</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>HatchPatternResolution</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_patternFile">
+        <property name="text">
+         <string>Additional SVG pattern location</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>SVG pattern default size</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox">
-          <property name="toolTip">
-           <string>The default size for SVG patterns</string>
-          </property>
-          <property name="decimals">
-           <number>4</number>
-          </property>
-          <property name="minimum">
-           <double>0.000100000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>HatchPatternSize</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox">
-          <property name="toolTip">
-           <string>Check this if you want to preserve colors of faces while doing downgrade and upgrade (splitFaces and makeShell only)</string>
-          </property>
-          <property name="text">
-           <string>Preserve colors of faces during downgrade/upgrade</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>preserveFaceColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox">
-          <property name="toolTip">
-           <string>Check this if you want the face names to derive from the originating object name and vice versa while doing downgrade/upgrade (splitFaces and makeShell only)</string>
-          </property>
-          <property name="text">
-           <string>Preserve names of faces during downgrade/upgrade</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>preserveFaceNames</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="1" column="1" colspan="2">
+       <widget class="Gui::PrefFileChooser" name="fileChooser_patternFile">
+        <property name="mode">
+         <enum>Gui::FileChooser::Directory</enum>
+        </property>
+        <property name="toolTip">
+         <string>An optional directory with custom SVG files containing
+pattern definitions to be added to the standard patterns</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>patternFile</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_3">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Drawing view line definitions</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <widget class="QLabel" name="label_15">
-          <property name="text">
-           <string>Dashed line definition</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_7">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefLineEdit" name="lineEdit">
-          <property name="toolTip">
-           <string>An SVG linestyle definition</string>
-          </property>
-          <property name="text">
-           <string notr="true">2,2</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>svgDashedLine</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_svgDashedLine">
+        <property name="text">
+         <string>Dashed line definition</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_10">
-        <item>
-         <widget class="QLabel" name="label_16">
-          <property name="text">
-           <string>Dashdot line definition</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_8">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefLineEdit" name="lineEdit_2">
-          <property name="toolTip">
-           <string>An SVG linestyle definition</string>
-          </property>
-          <property name="text">
-           <string notr="true">3,2,0.2,2</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>svgDashdotLine</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="0" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_svgDashedLine">
+        <property name="maximumSize">
+         <size>
+          <width>140</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>An SVG linestyle definition</string>
+        </property>
+        <property name="text">
+         <string notr="true">2,2</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>svgDashedLine</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_13">
-        <item>
-         <widget class="QLabel" name="label_22">
-          <property name="text">
-           <string>Dotted line definition</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_14">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefLineEdit" name="lineEdit_3">
-          <property name="toolTip">
-           <string>An SVG linestyle definition</string>
-          </property>
-          <property name="text">
-           <string notr="true">0.2,2</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>svgDottedLine</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Draft</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_svgDashdotLine">
+        <property name="text">
+         <string>Dashdot line definition</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_svgDashdotLine">
+        <property name="maximumSize">
+         <size>
+          <width>140</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>An SVG linestyle definition</string>
+        </property>
+        <property name="text">
+         <string notr="true">3,2,0.2,2</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>svgDashdotLine</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_svgDottedLine">
+        <property name="text">
+         <string>Dotted line definition</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_svgDottedLine">
+        <property name="maximumSize">
+         <size>
+          <width>140</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>An SVG linestyle definition</string>
+        </property>
+        <property name="text">
+         <string notr="true">0.2,2</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>svgDottedLine</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
      </property>
     </spacer>
    </item>
@@ -467,41 +202,6 @@
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
-   <class>Gui::FileChooser</class>
-   <extends>QWidget</extends>
-   <header>Gui/FileDialog.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::ColorButton</class>
-   <extends>QPushButton</extends>
-   <header>Gui/Widgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefFileChooser</class>
-   <extends>Gui::FileChooser</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefColorButton</class>
-   <extends>Gui::ColorButton</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefCheckBox</class>
-   <extends>QCheckBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefComboBox</class>
-   <extends>QComboBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
    <class>Gui::PrefLineEdit</class>
    <extends>QLineEdit</extends>
    <header>Gui/PrefWidgets.h</header>
@@ -509,6 +209,16 @@
   <customwidget>
    <class>Gui::PrefDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::FileChooser</class>
+   <extends>QWidget</extends>
+   <header>Gui/FileDialog.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefFileChooser</class>
+   <extends>Gui::FileChooser</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -329,7 +329,7 @@ class Snapper:
         fp = self.cstr(lastpoint, constrain, point)
         if self.trackLine and lastpoint and (not noTracker):
             self.trackLine.p2(fp)
-            self.trackLine.color.rgb = Gui.draftToolBar.getDefaultColor("line")
+            self.trackLine.setColor()
             self.trackLine.on()
         # Set the arch point tracking
         if lastpoint:
@@ -499,7 +499,7 @@ class Snapper:
             fp = self.cstr(lastpoint, constrain, winner[2])
             if self.trackLine and lastpoint:
                 self.trackLine.p2(fp)
-                self.trackLine.color.rgb = Gui.draftToolBar.getDefaultColor("line")
+                self.trackLine.setColor()
                 self.trackLine.on()
             # set the cursor
             self.setCursor(winner[1])
@@ -559,7 +559,7 @@ class Snapper:
             if self.extLine:
                 self.extLine.p1(tsnap[0])
                 self.extLine.p2(tsnap[2])
-                self.extLine.color.rgb = Gui.draftToolBar.getDefaultColor("line")
+                self.extLine.setColor()
                 self.extLine.on()
             self.setCursor(tsnap[1])
             return tsnap[2], eline
@@ -573,7 +573,7 @@ class Snapper:
                         self.tracker.on()
                     if self.extLine:
                         self.extLine.p2(tsnap[2])
-                        self.extLine.color.rgb = Gui.draftToolBar.getDefaultColor("line")
+                        self.extLine.setColor()
                         self.extLine.on()
                     self.setCursor(tsnap[1])
                     return tsnap[2], eline
@@ -587,7 +587,7 @@ class Snapper:
                             self.tracker.on()
                         if self.extLine:
                             self.extLine.p2(tsnap[2])
-                            self.extLine.color.rgb = Gui.draftToolBar.getDefaultColor("line")
+                            self.extLine.setColor()
                             self.extLine.on()
                         self.setCursor(tsnap[1])
                         return tsnap[2], eline
@@ -623,13 +623,9 @@ class Snapper:
                                         self.tracker.setMarker(self.mk['extension'])
                                         self.tracker.on()
                                     if self.extLine:
-                                        if self.snapStyle:
-                                            dv = np.sub(p0)
-                                            self.extLine.p1(p0.add(dv.multiply(0.5)))
-                                        else:
-                                            self.extLine.p1(p0)
+                                        self.extLine.p1(p0)
                                         self.extLine.p2(np)
-                                        self.extLine.color.rgb = Gui.draftToolBar.getDefaultColor("line")
+                                        self.extLine.setColor()
                                         self.extLine.on()
                                     self.setCursor('extension')
                                     ne = Part.LineSegment(p0,np).toShape()
@@ -681,14 +677,10 @@ class Snapper:
                                     p0 = self.lastExtensions[1].Vertexes[0].Point
                                 else:
                                     p0 = self.lastExtensions[0].Vertexes[0].Point
-                                if self.snapStyle:
-                                    dv = p.sub(p0)
-                                    self.extLine2.p1(p0.add(dv.multiply(0.5)))
-                                else:
-                                    self.extLine2.p1(p0)
+                                self.extLine2.p1(p0)
                                 self.extLine2.p2(p)
                                 self.extLine.p2(p)
-                                self.extLine.color.rgb = Gui.draftToolBar.getDefaultColor("line")
+                                self.extLine.setColor()
                                 self.extLine2.on()
                             return p
         return None
@@ -1283,10 +1275,7 @@ class Snapper:
 
         # setup trackers if needed
         if not self.constrainLine:
-            if self.snapStyle:
-                self.constrainLine = trackers.lineTracker(scolor=Gui.draftToolBar.getDefaultColor("snap"))
-            else:
-                self.constrainLine = trackers.lineTracker(dotted=True)
+            self.constrainLine = trackers.lineTracker(dotted=True)
 
         # setting basepoint
         if not basepoint:
@@ -1612,13 +1601,8 @@ class Snapper:
                     self.grid.show_during_command = True
                 self.tracker = trackers.snapTracker()
                 self.trackLine = trackers.lineTracker()
-                if self.snapStyle:
-                    c = Gui.draftToolBar.getDefaultColor("snap")
-                    self.extLine = trackers.lineTracker(scolor=c)
-                    self.extLine2 = trackers.lineTracker(scolor=c)
-                else:
-                    self.extLine = trackers.lineTracker(dotted=True)
-                    self.extLine2 = trackers.lineTracker(dotted=True)
+                self.extLine = trackers.lineTracker(dotted=True)
+                self.extLine2 = trackers.lineTracker(dotted=True)
                 self.radiusTracker = trackers.radiusTracker()
                 self.dim1 = trackers.archDimTracker(mode=2)
                 self.dim2 = trackers.archDimTracker(mode=3)
@@ -1652,7 +1636,7 @@ class Snapper:
         if self.spoint and self.spoint not in self.holdPoints:
             if self.holdTracker:
                 self.holdTracker.addCoords(self.spoint)
-                self.holdTracker.color.rgb = Gui.draftToolBar.getDefaultColor("line")
+                self.holdTracker.setColor()
                 self.holdTracker.on()
             self.holdPoints.append(self.spoint)
 

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -44,6 +44,7 @@ import Draft
 import DraftVecUtils
 
 from FreeCAD import Vector
+from draftutils import utils
 from draftutils.todo import ToDo
 from draftutils.messages import _msg
 
@@ -62,7 +63,6 @@ class Tracker:
         import DraftGeomUtils
         self.ontop = ontop
         self.color = coin.SoBaseColor()
-        self.color.rgb = scolor or FreeCADGui.draftToolBar.getDefaultColor("line")
         drawstyle = coin.SoDrawStyle()
         if swidth:
             drawstyle.lineWidth = swidth
@@ -78,6 +78,7 @@ class Tracker:
             self.switch.setName(name)
         self.switch.addChild(node)
         self.switch.whichChild = -1
+        self.setColor(scolor)
         self.Visible = False
         ToDo.delay(self._insertSwitch, self.switch)
 
@@ -139,6 +140,18 @@ class Tracker:
             sg = Draft.get3DView().getSceneGraph()
             sg.removeChild(self.switch)
             sg.insertChild(self.switch, 0)
+
+    def setColor(self, color=None):
+        """Set the color."""
+        if color is not None:
+            self.color.rgb = color
+        elif hasattr(FreeCAD, "activeDraftCommand") \
+                and FreeCAD.activeDraftCommand is not None \
+                and FreeCAD.activeDraftCommand.featureName in ("Dimension", "Label", "Text"):
+            color = utils.get_rgba_tuple(utils.get_param("DefaultAnnoLineColor", 255))[:3]
+            self.color.rgb = color
+        else:
+            self.color.rgb = FreeCADGui.draftToolBar.getDefaultColor("line")
 
     def _get_wp(self):
         return FreeCAD.DraftWorkingPlane
@@ -696,7 +709,7 @@ class ghostTracker(Tracker):
         self.children.append(rootsep)
         super().__init__(dotted, scolor, swidth,
                          children=self.children, name="ghostTracker")
-        self.setColor()
+        self.setColor(scolor)
 
     def setColor(self, color=None):
         """Set the color."""

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -58,28 +58,27 @@ arrowtypes = ARROW_TYPES
 
 
 def get_default_annotation_style():
-    param_draft = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-    param_view = App.ParamGet("User parameter:BaseApp/Preferences/View")
-    anno_scale = param_draft.GetFloat("DraftAnnotationScale", 1)
+    param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+    anno_scale = param.GetFloat("DraftAnnotationScale", 1)
     scale_mult = 1 / anno_scale if anno_scale > 0 else 1
     return {
-        "ArrowSize":       ("float", param_draft.GetFloat("arrowsize", 20)),
-        "ArrowType":       ("index", param_draft.GetInt("dimsymbol", 0)),
-        "Decimals":        ("int",   param_draft.GetInt("dimPrecision", 2)),
-        "DimOvershoot":    ("float", param_draft.GetFloat("dimovershoot", 20)),
-        "ExtLines":        ("float", param_draft.GetFloat("extlines", 300)),
-        "ExtOvershoot":    ("float", param_draft.GetFloat("extovershoot", 20)),
-        "FontName":        ("font",  param_draft.GetString("textfont", "Sans")),
-        "FontSize":        ("float", param_draft.GetFloat("textheight", 100)),
-        "LineColor":       ("color", param_view.GetUnsigned("DefaultShapeLineColor", 255)),
-        "LineSpacing":     ("float", param_draft.GetFloat("LineSpacing", 1)),
-        "LineWidth":       ("int",   param_view.GetInt("DefaultShapeLineWidth", 1)),
+        "ArrowSize":       ("float", param.GetFloat("arrowsize", 20)),
+        "ArrowType":       ("index", param.GetInt("dimsymbol", 0)),
+        "Decimals":        ("int",   param.GetInt("dimPrecision", 2)),
+        "DimOvershoot":    ("float", param.GetFloat("dimovershoot", 20)),
+        "ExtLines":        ("float", param.GetFloat("extlines", 300)),
+        "ExtOvershoot":    ("float", param.GetFloat("extovershoot", 20)),
+        "FontName":        ("font",  param.GetString("textfont", "Sans")),
+        "FontSize":        ("float", param.GetFloat("textheight", 100)),
+        "LineColor":       ("color", param.GetUnsigned("DefaultAnnoLineColor", 255)),
+        "LineSpacing":     ("float", param.GetFloat("LineSpacing", 1)),
+        "LineWidth":       ("int",   param.GetInt("DefaultAnnoLineWidth", 1)),
         "ScaleMultiplier": ("float", scale_mult),
-        "ShowLine":        ("bool",  param_draft.GetBool("DimShowLine", True)),
-        "ShowUnit":        ("bool",  param_draft.GetBool("showUnit", True)),
-        "TextColor":       ("color", param_draft.GetUnsigned("DefaultTextColor", 255)),
-        "TextSpacing":     ("float", param_draft.GetFloat("dimspacing", 20)),
-        "UnitOverride":    ("str",   param_draft.GetString("overrideUnit", "")),
+        "ShowLine":        ("bool",  param.GetBool("DimShowLine", True)),
+        "ShowUnit":        ("bool",  param.GetBool("showUnit", True)),
+        "TextColor":       ("color", param.GetUnsigned("DefaultTextColor", 255)),
+        "TextSpacing":     ("float", param.GetFloat("dimspacing", 20)),
+        "UnitOverride":    ("str",   param.GetString("overrideUnit", "")),
     }
 
 
@@ -173,7 +172,8 @@ def get_param_type(param):
                  "precision", "defaultWP", "snapRange", "gridEvery",
                  "linewidth", "modconstrain", "modsnap",
                  "maxSnapEdges", "modalt", "HatchPatternResolution",
-                 "snapStyle", "DefaultAnnoDisplayMode", "gridSize", "gridTransparency"):
+                 "snapStyle", "DefaultAnnoDisplayMode", "DefaultAnnoLineWidth",
+                 "gridSize", "gridTransparency"):
         return "int"
     elif param in ("constructiongroupname", "textfont",
                    "patternFile", "snapModes",
@@ -192,8 +192,8 @@ def get_param_type(param):
                    "DiscretizeEllipses", "showUnit", "coloredGridAxes",
                    "Draft_array_fuse", "Draft_array_Link", "gridBorder"):
         return "bool"
-    elif param in ("color", "constructioncolor",
-                   "snapcolor", "gridColor"):
+    elif param in ("color", "constructioncolor", "snapcolor",
+                   "gridColor", "DefaultTextColor", "DefaultAnnoLineColor"):
         return "unsigned"
     else:
         return None
@@ -830,6 +830,27 @@ def rgba_to_argb(color):
     """Change byte order of a 4 byte color int from RGBA (FreeCAD) to ARGB (Qt).
     """
     return ((color & 0xFFFFFF00) >> 8) + ((color & 0xFF) << 24)
+
+
+def get_rgba_tuple(color, typ=1.0):
+    """Return an RGBA tuple.
+
+    Parameters
+    ----------
+    color: int
+        RGBA integer.
+    typ: any float (default = 1.0) or int (use 255)
+        If float the values in the returned tuple are in the 0.0-1.0 range.
+        Else the values are in the 0-255 range.
+    """
+    color = ((color >> 24) & 0xFF,
+             (color >> 16) & 0xFF,
+             (color >> 8) & 0xFF,
+             color & 0xFF)
+    if type(typ) == float:
+        return tuple([x / 255.0 for x in color])
+    else:
+        return color
 
 
 def filter_objects_for_modifiers(objects, isCopied=False):

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -358,6 +358,7 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
         self.onChanged(vobj, "DimOvershoot")
         self.onChanged(vobj, "ExtOvershoot")
         self.onChanged(vobj, "ShowLine")
+        self.onChanged(vobj, "LineWidth")
 
     def updateData(self, obj, prop):
         """Execute when a property from the Proxy class is changed.

--- a/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
+++ b/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
@@ -141,6 +141,7 @@ class ViewProviderDraftAnnotation(object):
                              "TextColor",
                              "Text",
                              _tip)
+            vobj.TextColor = utils.get_param("DefaultTextColor", 255) & 0xFFFFFF00
 
     def set_units_properties(self, vobj, properties):
         return
@@ -153,6 +154,7 @@ class ViewProviderDraftAnnotation(object):
                              "LineWidth",
                              "Graphics",
                              _tip)
+            vobj.LineWidth = utils.get_param("DefaultAnnoLineWidth", 2)
 
         if "LineColor" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property", "Line color")
@@ -160,6 +162,7 @@ class ViewProviderDraftAnnotation(object):
                              "LineColor",
                              "Graphics",
                              _tip)
+            vobj.LineColor = utils.get_param("DefaultAnnoLineColor", 255) & 0xFFFFFF00
 
     def dumps(self):
         """Return a tuple of objects to save or None."""


### PR DESCRIPTION
The format_object function in gui_utils.py still requires some work (in connection with the Draft_SetStyle command). This will be done later.