### PR TITLE
Gui: fix partially initialized default transparency

### DIFF
--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -94,6 +94,7 @@ ViewProviderGeometryObject::ViewProviderGeometryObject()
     pcShapeMaterial = new SoMaterial;
     pcShapeMaterial->diffuseColor.setValue(r, g, b);
     pcShapeMaterial->transparency = float(initialTransparency);
+    ShapeMaterial.setTransparency((float)initialTransparency / 100.0f);
     pcShapeMaterial->ref();
 
     pcBoundingBox = new Gui::SoFCBoundingBox;


### PR DESCRIPTION
As described by @Roy-043 in the forum (see [here](https://forum.freecad.org/viewtopic.php?t=83066)), the transparency of an object is changed from the default transparency to zero after changing the object's color.

The following script can be used to reproduce the problem and to show the resolved behavior:

```python3
import Part

doc = App.newDocument()

pg = App.ParamGet('User parameter:BaseApp/Preferences/View')
backup_default_transparency = pg.GetInt('DefaultShapeTransparency')

pg.SetInt('DefaultShapeTransparency', 70)

obj = doc.addObject('Part::Box')
assert obj.ViewObject.Transparency == 70

obj.ViewObject.ShapeColor = (0.5, 0.0, 0.0)

if obj.ViewObject.Transparency != 70:
    # current behavior before this PR
    print('WARNING: transparency was changed to',
            obj.ViewObject.Transparency, 'when changing the color.')
else:
    # new behavior after this PR
    print('transparency is still ok after changing color')

pg.SetInt('DefaultShapeTransparency', backup_default_transparency)

doc.recompute()
```

My analysis of the problem and description of the fix can be found in the [forum](https://forum.freecad.org/viewtopic.php?p=721846#p721846).
