### PR TITLE
Gui: Add ability to easily lock Toolbars from UI

### DIFF
--- a/src/Gui/CommandWindow.cpp
+++ b/src/Gui/CommandWindow.cpp
@@ -36,6 +36,7 @@
 #include "Document.h"
 #include "DlgActivateWindowImp.h"
 #include "DockWindowManager.h"
+#include "ToolBarManager.h"
 
 #include <Base/Exception.h>
 #include <App/Document.h>
@@ -340,6 +341,46 @@ Action * StdCmdToolBarMenu::createAction()
 }
 
 //===========================================================================
+// Std_DlgToggleToolBarLock
+//===========================================================================
+DEF_STD_CMD_C(StdCmdToggleToolBarLock)
+
+StdCmdToggleToolBarLock::StdCmdToggleToolBarLock()
+  :Command("Std_ToggleToolBarLock")
+{
+    sGroup        = "Tools";
+    sMenuText     = QT_TR_NOOP("Lock toolbars");
+    sToolTipText  = QT_TR_NOOP("Locks toolbar so they are no longer moveable");
+    sWhatsThis    = "Std_ToggleToolBarLock";
+    sStatusTip    = QT_TR_NOOP("Locks toolbar so they are no longer moveable");
+    eType         = 0;
+}
+
+
+Action* StdCmdToggleToolBarLock::createAction()
+{
+    Action* action = Command::createAction();
+
+    action->setCheckable(true);
+    action->setChecked(ToolBarManager::getInstance()->areToolBarsLocked(), true);
+
+    return action;
+}
+
+void StdCmdToggleToolBarLock::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+
+    auto manager = ToolBarManager::getInstance();
+    auto toggled = !manager->areToolBarsLocked();
+
+    manager->setToolBarsLocked(toggled);
+
+    getAction()->setChecked(toggled);
+}
+
+
+//===========================================================================
 // Std_ViewStatusBar
 //===========================================================================
 
@@ -475,6 +516,7 @@ void CreateWindowStdCommands()
     rcCmdMgr.addCommand(new StdCmdWindows());
     rcCmdMgr.addCommand(new StdCmdDockViewMenu());
     rcCmdMgr.addCommand(new StdCmdToolBarMenu());
+    rcCmdMgr.addCommand(new StdCmdToggleToolBarLock());
     rcCmdMgr.addCommand(new StdCmdWindowsMenu());
     rcCmdMgr.addCommand(new StdCmdStatusBar());
     rcCmdMgr.addCommand(new StdCmdUserInterface());

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1387,6 +1387,10 @@ void MainWindow::onToolBarMenuAboutToShow()
             menu->addAction(action);
         }
     }
+
+    menu->addSeparator();
+
+    Application::Instance->commandManager().getCommandByName("Std_ToggleToolBarLock")->addTo(menu);
 }
 
 void MainWindow::onDockWindowMenuAboutToShow()

--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -408,11 +408,7 @@ void ToolBarManager::restoreState() const
         }
     }
 
-
-    hPref = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
-        ->GetGroup("Preferences")->GetGroup("General");
-    bool lockToolBars = hPref->GetBool("LockToolBars", false);
-    setMovable(!lockToolBars);
+    setMovable(!areToolBarsLocked());
 }
 
 void ToolBarManager::retranslate() const
@@ -424,6 +420,30 @@ void ToolBarManager::retranslate() const
             QApplication::translate("Workbench",
                                     (const char*)toolbarName));
     }
+}
+
+bool Gui::ToolBarManager::areToolBarsLocked() const
+{
+    auto hPref = App::GetApplication()
+                     .GetUserParameter()
+                     .GetGroup("BaseApp")
+                     ->GetGroup("Preferences")
+                     ->GetGroup("General");
+
+    return hPref->GetBool("LockToolBars", false);
+}
+
+void Gui::ToolBarManager::setToolBarsLocked(bool locked) const
+{
+    auto hPref = App::GetApplication()
+                     .GetUserParameter()
+                     .GetGroup("BaseApp")
+                     ->GetGroup("Preferences")
+                     ->GetGroup("General");
+
+    hPref->SetBool("LockToolBars", locked);
+
+    setMovable(!locked);
 }
 
 void Gui::ToolBarManager::setMovable(bool moveable) const

--- a/src/Gui/ToolBarManager.h
+++ b/src/Gui/ToolBarManager.h
@@ -103,13 +103,16 @@ public:
     void restoreState() const;
     void retranslate() const;
 
-    void setMovable(bool movable) const;
+    bool areToolBarsLocked() const;
+    void setToolBarsLocked(bool locked) const;
 
     void setState(const QList<QString>& names, State state);
-    void setState (const QString& name, State state);
-
+    void setState(const QString& name, State state);
+    
 protected:
     void setup(ToolBarItem*, QToolBar*) const;
+
+    void setMovable(bool movable) const;
 
     ToolBarItem::DefaultVisibility getToolbarPolicy(const QToolBar *) const;
 

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -620,6 +620,7 @@ void StdWorkbench::setupContextMenu(const char* recipient, MenuItem* item) const
 
 void StdWorkbench::createMainWindowPopupMenu(MenuItem* item) const
 {
+    *item << "Std_ToggleToolBarLock";
     *item << "Std_DlgCustomize";
 }
 


### PR DESCRIPTION
This adds the Std_ToggleToolBarLock action mentioned in #4992. It is exposed in the context menu of toolbar and also in the view -> toolbars app menu.

![image](https://github.com/FreeCAD/FreeCAD/assets/747404/a7ea3a2f-7ea8-47dc-8a86-1ba2737cc1ad)

Fixes #11595