### PR TITLE
conda: Remove conda-build and conda-smithy. Add git.

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -67,6 +67,7 @@ dependencies:
 - eigen
 - fmt
 - freetype
+- git
 - gmsh
 - graphviz
 - hdf5

--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -61,9 +61,7 @@ dependencies:
 - coin3d==4.0.0
 - compilers
 - conda
-- conda-build
 - conda-devenv
-- conda-smithy
 - debugpy
 - doxygen
 - eigen


### PR DESCRIPTION
On Windows, installing either `conda-build` or `conda-smithy` results in a broken environment.  Some of the `.exe` binaries will fail either silently or with the following message:

![image](https://github.com/FreeCAD/FreeCAD/assets/622450/15f0babd-548e-4a38-8904-50685542bef6)

I believe this is because a dependency of the `conda-build` or `conda-smithy` has a broken install script that results in broken library linkages.

The addition of `git`, which was included by `conda-build` and `conda-smithy`, is required for some tests in `AddonManager`.