### PR TITLE
Part: Use materialIndex.setValuesPointer() only if the new values are different

### DIFF
--- a/src/Mod/Part/Gui/SoBrepFaceSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepFaceSet.cpp
@@ -733,7 +733,7 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction *action, SelContext
             SoMaterialBindingElement::set(state,SoMaterialBindingElement::OVERALL);
             SoOverrideElement::setMaterialBindingOverride(state, this, true);
             packedColors.push_back(diffuseColor);
-            SoLazyElement::setPacked(state, this,1, &packedColors[0], hasTransparency);
+            SoLazyElement::setPacked(state, this,1, packedColors.data(), hasTransparency);
             SoTextureEnabledElement::set(state,this,false);
 
             if(hasTransparency && action->isRenderingDelayedPaths()) {
@@ -834,14 +834,14 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction *action, SelContext
         }
 
         size_t num = materialIndex.getNum();
-        if (num != matIndex.size() || materialIndex.getValues(0) != &matIndex[0]) {
+        if (num != matIndex.size() || materialIndex.getValues(0) != matIndex.data()) {
             SbBool notify = enableNotify(FALSE);
-            materialIndex.setValuesPointer(matIndex.size(), &matIndex[0]);
+            materialIndex.setValuesPointer(matIndex.size(), matIndex.data());
             if (notify) enableNotify(notify);
         }
 
         SoMaterialBindingElement::set(state, this, SoMaterialBindingElement::PER_PART_INDEXED);
-        SoLazyElement::setPacked(state, this, packedColors.size(), &packedColors[0], hasTransparency);
+        SoLazyElement::setPacked(state, this, packedColors.size(), packedColors.data(), hasTransparency);
         SoTextureEnabledElement::set(state,this,false);
 
         if(hasTransparency && action->isRenderingDelayedPaths()) {

--- a/src/Mod/Part/Gui/SoBrepFaceSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepFaceSet.cpp
@@ -643,9 +643,6 @@ void SoBrepFaceSet::GLRender(SoGLRenderAction *action)
     }
 
     if(pushed) {
-        SbBool notify = enableNotify(FALSE);
-        materialIndex.setNum(0);
-        if(notify) enableNotify(notify);
         state->pop();
     }else if(action->isRenderingDelayedPaths()) {
         renderSelection(action,ctx);
@@ -836,9 +833,12 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction *action, SelContext
             }
         }
 
-        SbBool notify = enableNotify(FALSE);
-        materialIndex.setValuesPointer(matIndex.size(),&matIndex[0]);
-        if(notify) enableNotify(notify);
+        size_t num = materialIndex.getNum();
+        if (num != matIndex.size() || materialIndex.getValues(0) != &matIndex[0]) {
+            SbBool notify = enableNotify(FALSE);
+            materialIndex.setValuesPointer(matIndex.size(), &matIndex[0]);
+            if (notify) enableNotify(notify);
+        }
 
         SoMaterialBindingElement::set(state, this, SoMaterialBindingElement::PER_PART_INDEXED);
         SoLazyElement::setPacked(state, this, packedColors.size(), &packedColors[0], hasTransparency);


### PR DESCRIPTION
This fixes #11517. See https://github.com/FreeCAD/FreeCAD/issues/11517#issuecomment-1837139082 for the cause of the problem.

Using `materialIndex.setValuesPointer()` only when the values change prevents the continuous cache invalidation and fixes the low fps.

To make this work I also had to remove [these](https://github.com/FreeCAD/FreeCAD/commit/6711e53d1681e86d9ea88783fa9353a8b84c13ce#diff-e4fb66281089c4211e8116c2a8bf4e05736a12e47518ca5786f3481ddb4f714fL646-L648) lines. I am not sure what the intention of these lines was and if removing it causes any side effects. Please review carefully.