### PR TITLE
[TechDraw] Use OCC to compute intersections for any types of edges

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.h
+++ b/src/Mod/TechDraw/App/Geometry.h
@@ -111,6 +111,7 @@ class TechDrawExport BaseGeom : public std::enable_shared_from_this<BaseGeom>
         Base::Vector3d nearPoint(const BaseGeomPtr p);
         static BaseGeomPtr baseFactory(TopoDS_Edge edge);
         static bool validateEdge(TopoDS_Edge edge);
+        static TopoDS_Edge completeEdge(const TopoDS_Edge &edge);
         bool closed();
         BaseGeomPtr copy();
         std::string dump();
@@ -154,16 +155,6 @@ class TechDrawExport BaseGeom : public std::enable_shared_from_this<BaseGeom>
 
 protected:
         void createNewTag();
-
-        void intersectionLL(TechDraw::BaseGeomPtr geom1,
-                            TechDraw::BaseGeomPtr geom2,
-                            std::vector<Base::Vector3d>& interPoints);
-        void intersectionCL(TechDraw::BaseGeomPtr geom1,
-                            TechDraw::BaseGeomPtr geom2,
-                            std::vector<Base::Vector3d>& interPoints);
-        void intersectionCC(TechDraw::BaseGeomPtr geom1,
-                            TechDraw::BaseGeomPtr geom2,
-                            std::vector<Base::Vector3d>& interPoints);
 
         GeomType geomType;
         ExtractionType extractType;     //obs

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -817,7 +817,7 @@ CmdTechDrawExtensionVertexAtIntersection::CmdTechDrawExtensionVertexAtIntersecti
     sMenuText = QT_TR_NOOP("Add Cosmetic Intersection Vertex(es)");
     sToolTipText =
         QT_TR_NOOP("Add cosmetic vertex(es) at the intersection(s) of selected edges:<br>\
-- Select two edges (lines, circles and/or arcs)<br>\
+- Select two edges<br>\
 - Click this tool");
     sWhatsThis = "TechDraw_ExtensionVertexAtIntersection";
     sStatusTip = sMenuText;

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -834,7 +834,6 @@ void CmdTechDrawExtensionVertexAtIntersection::activated(int iMsg)
         return;
     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Cosmetic Intersection Vertex(es)"));
     const std::vector<std::string> SubNames = selection[0].getSubNames();
-    std::vector<Base::Vector3d> interPoints;
     if (SubNames.size() >= 2) {
         std::string GeoType1 = TechDraw::DrawUtil::getGeomTypeFromName(SubNames[0]);
         std::string GeoType2 = TechDraw::DrawUtil::getGeomTypeFromName(SubNames[1]);
@@ -843,15 +842,12 @@ void CmdTechDrawExtensionVertexAtIntersection::activated(int iMsg)
             TechDraw::BaseGeomPtr geom1 = objFeat->getGeomByIndex(GeoId1);
             int GeoId2 = TechDraw::DrawUtil::getIndexFromName(SubNames[1]);
             TechDraw::BaseGeomPtr geom2 = objFeat->getGeomByIndex(GeoId2);
-            interPoints = geom1->intersection(geom2);
-            if (!interPoints.empty()) {
-                double scale = objFeat->getScale();
-                std::string id1 = objFeat->addCosmeticVertex(interPoints[0] / scale);
-                objFeat->add1CVToGV(id1);
-                if (interPoints.size() >= 2) {
-                    std::string id2 = objFeat->addCosmeticVertex(interPoints[1] / scale);
-                    objFeat->add1CVToGV(id2);
-                }
+
+            double scale = objFeat->getScale();
+            std::vector<Base::Vector3d> interPoints = geom1->intersection(geom2);
+            for (auto pt : interPoints) {
+                std::string ptId = objFeat->addCosmeticVertex(pt/scale);
+                objFeat->add1CVToGV(ptId);
             }
         }
     }


### PR DESCRIPTION
This pull requests hands over the computation of intersections to OCC, so we  to compute them between any two arbitrary edges the TechDraw views use. As a result, the number of intersection points created can be now higher than two, e.g. for BSplines.

The current algorithm did not limit the results to the edge boundaries, which I find quite useful, so I have tried to preserve this behavior, though for lines it does not have much sense to create unreachable cosmetic points in a galaxy far far away. Therefore there is a limit derived from the "crazy edge" detection procedure, namely 10.000mm. Of course, this constant can be changed to any other reasonable value.

I have tried to test the change as much as possible, however still there can be some catches. In case of any issues, please let me know, so we can find the best solution.