### PR TITLE
Gui: Cap starting height of Preferences dialog

### DIFF
--- a/src/Gui/DlgPreferences.ui
+++ b/src/Gui/DlgPreferences.ui
@@ -13,7 +13,7 @@
   <property name="minimumSize">
    <size>
     <width>1000</width>
-    <height>600</height>
+    <height>500</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/src/Gui/DlgPreferencesImp.cpp
+++ b/src/Gui/DlgPreferencesImp.cpp
@@ -39,6 +39,7 @@
 # include <QToolTip>
 # include <QProcess>
 # include <QPushButton>
+# include <QWindow>
 #endif
 
 #include <App/Application.h>
@@ -690,6 +691,22 @@ void DlgPreferencesImp::restartIfRequired()
 void DlgPreferencesImp::showEvent(QShowEvent* ev)
 {
     QDialog::showEvent(ev);
+
+    auto screen = windowHandle()->screen();
+    auto availableSize = screen->availableSize();
+
+    // leave at least 100 px of height so preferences window does not take
+    // entire screen height. User will still be able to resize the window,
+    // but it should never start too tall.
+    auto maxStartHeight = availableSize.height() - 100;
+
+    if (height() > maxStartHeight) {
+        auto heightDifference = availableSize.height() - maxStartHeight;
+
+        // resize and reposition window so it is fully visible
+        resize(width(), maxStartHeight);
+        move(x(), heightDifference / 2);
+    }
 }
 
 QModelIndex findRootIndex(const QModelIndex& index)


### PR DESCRIPTION
This ensures that preference windows does not start taller than available geometry. Preferences dialog will now leave at least 100px of free space so it does not exceed available screen height and does not take entire screen height. 