### PR TITLE
[TD]handle loose geometry via HLR

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -167,7 +167,7 @@ App::DocumentObjectExecReturn* DrawViewDetail::execute()
     }
 
     detailExec(shape, dvp, dvs);
-    addShapes2d();
+    addPoints();
 
     dvp->requestPaint();//to refresh detail highlight in base view
     return DrawView::execute();

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -201,15 +201,12 @@ std::vector<App::DocumentObject*> DrawViewPart::getAllSources() const
     return result;
 }
 
-//! pick supported 2d shapes out of the Source properties and
+//! pick vertex objects out of the Source properties and
 //! add them directly to the geometry without going through HLR
-//! NOTE: this is for loose 2d shapes such as Part line or circle and is
-//! not meant to include complex 2d shapes such as Sketches.
-void DrawViewPart::addShapes2d(void)
+void DrawViewPart::addPoints(void)
 {
-//    Base::Console().Message("DVP::addShapes2d()\n");
-    // get all the 2d shapes in the sources, then pick through them for loose edges
-    // or vertices.
+//    Base::Console().Message("DVP::addPoints()\n");
+    // get all the 2d shapes in the sources, then pick through them for vertices.
     std::vector<TopoDS_Shape> shapes = ShapeExtractor::getShapes2d(getAllSources());
     for (auto& s : shapes) {
         if (s.ShapeType() == TopAbs_VERTEX) {
@@ -220,21 +217,6 @@ void DrawViewPart::addShapes2d(void)
             Base::Vector3d projected = projectPoint(vp * getScale());
             TechDraw::VertexPtr v1(std::make_shared<TechDraw::Vertex>(projected));
             geometryObject->addVertex(v1);
-        }
-        else if (s.ShapeType() == TopAbs_EDGE) {
-            TopoDS_Shape sTrans = ShapeUtils::moveShape(s,
-                                                      m_saveCentroid * -1.0);
-            TopoDS_Shape sScale = ShapeUtils::scaleShape(sTrans,
-                                                       getScale());
-            TopoDS_Shape sMirror = ShapeUtils::mirrorShape(sScale);
-            TopoDS_Edge edge = TopoDS::Edge(sMirror);
-            BaseGeomPtr bg = projectEdge(edge);
-
-            geometryObject->addEdge(bg);
-
-        } else {
-            // message for developers.
-            //Base::Console().Message("DEVEL: DVP::addShapes2d - shape is not a vertex or edge\n");
         }
     }
 }
@@ -448,7 +430,7 @@ void DrawViewPart::postHlrTasks(void)
     addCosmeticVertexesToGeom();
     addCosmeticEdgesToGeom();
     addReferencesToGeom();
-    addShapes2d();
+    addPoints();
 
     //balloons need to be recomputed here because their
     //references will be invalid until the geometry exists

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -225,7 +225,7 @@ protected:
                                                             const gp_Ax2& viewAxis);
     virtual TechDraw::GeometryObjectPtr makeGeometryForShape(TopoDS_Shape& shape);//const??
     void partExec(TopoDS_Shape& shape);
-    virtual void addShapes2d(void);
+    virtual void addPoints(void);
 
     void extractFaces();
     void findFacesNew(const std::vector<TechDraw::BaseGeomPtr>& goEdges);

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -421,7 +421,7 @@ App::DocumentObjectExecReturn* DrawViewSection::execute()
     }
 
     sectionExec(baseShape);
-    addShapes2d();
+    addPoints();
 
     return DrawView::execute();
 }

--- a/src/Mod/TechDraw/App/ShapeExtractor.cpp
+++ b/src/Mod/TechDraw/App/ShapeExtractor.cpp
@@ -47,7 +47,6 @@
 
 #include "ShapeExtractor.h"
 #include "DrawUtil.h"
-#include "Preferences.h"
 #include "ShapeUtils.h"
 
 
@@ -55,14 +54,15 @@ using namespace TechDraw;
 using DU = DrawUtil;
 using SU = ShapeUtils;
 
-std::vector<TopoDS_Shape> ShapeExtractor::getShapes2d(const std::vector<App::DocumentObject*> links, bool overridePref)
+
+//! pick out the 2d document objects objects in the list of links and return a vector of their shapes
+//! Note that point objects will not make it through the hlr/projection process.
+std::vector<TopoDS_Shape> ShapeExtractor::getShapes2d(const std::vector<App::DocumentObject*> links)
 {
 //    Base::Console().Message("SE::getShapes2d() - links: %d\n", links.size());
 
     std::vector<TopoDS_Shape> shapes2d;
-    if (!prefAdd2d() && !overridePref) {
-        return shapes2d;
-    }
+
     for (auto& l:links) {
         const App::GroupExtension* gex = dynamic_cast<const App::GroupExtension*>(l);
         if (gex) {
@@ -333,7 +333,7 @@ TopoDS_Shape ShapeExtractor::getShapesFused(const std::vector<App::DocumentObjec
 
     // if there are 2d shapes in the links they will not fuse with the 3d shapes,
     // so instead we return a compound of the fused 3d shapes and the 2d shapes
-    std::vector<TopoDS_Shape> shapes2d = getShapes2d(links, true);
+    std::vector<TopoDS_Shape> shapes2d = getShapes2d(links);
     if (!shapes2d.empty()) {
         shapes2d.push_back(baseShape);
         return DrawUtil::shapeVectorToCompound(shapes2d, false);
@@ -470,11 +470,5 @@ TopoDS_Shape ShapeExtractor::getLocatedShape(const App::DocumentObject* docObj)
             shape.setPlacement(pf->globalPlacement());
         }
         return shape.getShape();
-}
-
-//! true if we should include loose 2d geometry
-bool ShapeExtractor::prefAdd2d()
-{
-    return Preferences::getPreferenceGroup("General")->GetBool("ShowLoose2d", false);
 }
 

--- a/src/Mod/TechDraw/App/ShapeExtractor.h
+++ b/src/Mod/TechDraw/App/ShapeExtractor.h
@@ -40,7 +40,7 @@ class TechDrawExport ShapeExtractor
 {
 public:
     static TopoDS_Shape getShapes(const std::vector<App::DocumentObject*> links, bool include2d = true);
-    static std::vector<TopoDS_Shape> getShapes2d(const std::vector<App::DocumentObject*> links, bool overridePref = false);
+    static std::vector<TopoDS_Shape> getShapes2d(const std::vector<App::DocumentObject*> links);
     static std::vector<TopoDS_Shape> getXShapes(const App::Link* xLink);
     static std::vector<TopoDS_Shape> getShapesFromObject(const App::DocumentObject* docObj);
     static TopoDS_Shape getShapesFused(const std::vector<App::DocumentObject*> links);
@@ -51,7 +51,6 @@ public:
     static bool isPointType(App::DocumentObject* obj);
     static bool isDraftPoint(App::DocumentObject* obj);
     static Base::Vector3d getLocation3dFromFeat(App::DocumentObject *obj);
-    static bool prefAdd2d();
 
     static TopoDS_Shape stripInfiniteShapes(TopoDS_Shape inShape);
 

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
@@ -40,6 +40,316 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout" columnstretch="1,0,0">
+        <item row="2" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbFuseBeforeSection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Perform a fuse operation on input shape(s) before Section view processing</string>
+          </property>
+          <property name="text">
+           <string>Fuse Before Section</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SectionFuseFirst</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbDebugSection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Dump intermediate results during Section view processing</string>
+          </property>
+          <property name="text">
+           <string>Debug Section</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>debugSection</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/debug</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbEdgeFuzz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>174</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Size of selection area around edges
+Each unit is approx. 0.1 mm wide</string>
+          </property>
+          <property name="statusTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>EdgeFuzz</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Edge Fuzz</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbCrazyEdges">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Include edges with unexpected geometry (zero length etc.) in results</string>
+          </property>
+          <property name="text">
+           <string>Allow Crazy Edges</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>allowCrazyEdge</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/debug</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="2">
+         <widget class="Gui::PrefSpinBox" name="sbMaxPat">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Maximum hatch line segments to use
+when hatching a face with a PAT pattern</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight</set>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>1000000</number>
+          </property>
+          <property name="singleStep">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>10000</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>MaxSeg</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/PAT</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Mark Fuzz</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="8" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="pdsbMarkFuzz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>174</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Selection area around center marks
+Each unit is approx. 0.1 mm wide</string>
+          </property>
+          <property name="statusTip">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>MarkFuzz</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Max SVG Hatch Tiles</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="2">
+         <widget class="Gui::PrefSpinBox" name="sbMaxTiles">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Limit of 64x64 pixel SVG tiles used to hatch a single face.
+For large scalings you might get an error about to many SVG tiles.
+Then you need to increase the tile limit.</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight</set>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>1000000</number>
+          </property>
+          <property name="singleStep">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>10000</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>MaxSVGTile</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbDebugDetail">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Dump intermediate results during Detail view processing</string>
+          </property>
+          <property name="text">
+           <string>Debug Detail</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>debugDetail</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/debug</cstring>
+          </property>
+         </widget>
+        </item>
         <item row="2" column="0">
          <widget class="Gui::PrefCheckBox" name="cbShowSectionEdges">
           <property name="sizePolicy">
@@ -87,93 +397,6 @@
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Overlap Edges Scrub Passes</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Line End Cap Shape</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbMarkFuzz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>174</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Selection area around center marks
-Each unit is approx. 0.1 mm wide</string>
-          </property>
-          <property name="statusTip">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>MarkFuzz</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
-         <widget class="Gui::PrefSpinBox" name="sbScrubCount">
-          <property name="toolTip">
-           <string>The number of times FreeCAD should try to remove overlapping edges returned by the Hidden Line Removal algorithm. A value of 0 indicates no scrubbing, 1 indicates a single pass and 2 indicates a second pass should be performed. Values above 2 are generally not productive. Each pass adds to the time required to produce the drawing.</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="suffix">
-           <string/>
-          </property>
-          <property name="prefix">
-           <string/>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ScrubCount</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="0">
          <widget class="Gui::PrefCheckBox" name="cbNewFaceFinder">
           <property name="toolTip">
@@ -193,57 +416,25 @@ Each unit is approx. 0.1 mm wide</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
+        <item row="1" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbAutoCorrectRefs">
+          <property name="toolTip">
+           <string>If checked, system will attempt to automatically correct dimension references when the model changes.</string>
           </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
+          <property name="statusTip">
+           <string/>
           </property>
           <property name="text">
-           <string>Edge Fuzz</string>
+           <string>Auto Correct Dimension Refs</string>
           </property>
-         </widget>
-        </item>
-        <item row="11" column="2">
-         <widget class="Gui::PrefSpinBox" name="sbMaxPat">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Maximum hatch line segments to use
-when hatching a face with a PAT pattern</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight</set>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>1000000</number>
-          </property>
-          <property name="singleStep">
-           <number>100</number>
-          </property>
-          <property name="value">
-           <number>10000</number>
+          <property name="checked">
+           <bool>true</bool>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>MaxSeg</cstring>
+           <cstring>AutoCorrectRefs</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/PAT</cstring>
+           <cstring>Mod/TechDraw/Dimensions</cstring>
           </property>
          </widget>
         </item>
@@ -275,277 +466,45 @@ can be a performance penalty in complex models.</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbFuseBeforeSection">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_3">
           <property name="font">
            <font>
             <italic>true</italic>
            </font>
           </property>
-          <property name="toolTip">
-           <string>Perform a fuse operation on input shape(s) before Section view processing</string>
-          </property>
           <property name="text">
-           <string>Fuse Before Section</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SectionFuseFirst</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
+           <string>Overlap Edges Scrub Passes</string>
           </property>
          </widget>
         </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Mark Fuzz</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="pdsbEdgeFuzz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>174</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Size of selection area around edges
-Each unit is approx. 0.1 mm wide</string>
-          </property>
-          <property name="statusTip">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>EdgeFuzz</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbDebugDetail">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Dump intermediate results during Detail view processing</string>
-          </property>
-          <property name="text">
-           <string>Debug Detail</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>debugDetail</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/debug</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="2">
-         <widget class="Gui::PrefSpinBox" name="sbMaxTiles">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Limit of 64x64 pixel SVG tiles used to hatch a single face.
-For large scalings you might get an error about to many SVG tiles.
-Then you need to increase the tile limit.</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight</set>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>1000000</number>
-          </property>
-          <property name="singleStep">
-           <number>100</number>
-          </property>
-          <property name="value">
-           <number>10000</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>MaxSVGTile</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="11" column="0">
+        <item row="10" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
            <string>Max PAT Hatch Segments</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbAutoCorrectRefs">
+        <item row="6" column="2">
+         <widget class="Gui::PrefSpinBox" name="sbScrubCount">
           <property name="toolTip">
-           <string>If checked, system will attempt to automatically correct dimension references when the model changes.</string>
+           <string>The number of times FreeCAD should try to remove overlapping edges returned by the Hidden Line Removal algorithm. A value of 0 indicates no scrubbing, 1 indicates a single pass and 2 indicates a second pass should be performed. Values above 2 are generally not productive. Each pass adds to the time required to produce the drawing.</string>
           </property>
-          <property name="statusTip">
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="suffix">
            <string/>
           </property>
-          <property name="text">
-           <string>Auto Correct Dimension Refs</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
+          <property name="prefix">
+           <string/>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>AutoCorrectRefs</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Dimensions</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="4" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbDebugSection">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Dump intermediate results during Section view processing</string>
-          </property>
-          <property name="text">
-           <string>Debug Section</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>debugSection</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/debug</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbCrazyEdges">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Include edges with unexpected geometry (zero length etc.) in results</string>
-          </property>
-          <property name="text">
-           <string>Allow Crazy Edges</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>allowCrazyEdge</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/debug</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Max SVG Hatch Tiles</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="2">
-         <widget class="Gui::PrefComboBox" name="cbEndCap">
-          <property name="toolTip">
-           <string>Shape of line end caps.
-Only change unless you know what you are doing!</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>EdgeCapStyle</cstring>
+           <cstring>ScrubCount</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/General</cstring>
           </property>
-          <item>
-           <property name="text">
-            <string>Round</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Square</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Flat</string>
-           </property>
-          </item>
          </widget>
         </item>
        </layout>
@@ -596,11 +555,6 @@ Only change unless you know what you are doing!</string>
   <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefComboBox</class>
-   <extends>QComboBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
This PR simplifies the handling of non-solids in the source of Views.  Lines, etc will be sent through the same processing steps as solids, and only vertex objects will be handled separately.