### PR TITLE
[ARCH, GUI, DRAFT] Update Arch and Draft to use QuantitySpinbox widget in place of InputField

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -407,8 +407,11 @@ void QuantitySpinBox::resizeEvent(QResizeEvent * event)
 
 void Gui::QuantitySpinBox::keyPressEvent(QKeyEvent *event)
 {
-    if (!handleKeyEvent(event->text()))
+    if (!handleKeyEvent(event->text())) {
+        if(event->matches(QKeySequence::InsertParagraphSeparator)) //Key is Enter
+            Q_EMIT returnPressed(); 
         QAbstractSpinBox::keyPressEvent(event);
+    }
 }
 
 void Gui::QuantitySpinBox::paintEvent(QPaintEvent*)

--- a/src/Gui/QuantitySpinBox.h
+++ b/src/Gui/QuantitySpinBox.h
@@ -186,6 +186,7 @@ Q_SIGNALS:
      *  or finished (false).
      */
     void showFormulaDialog(bool);
+    void returnPressed();
 
 private:
     QScopedPointer<QuantitySpinBoxPrivate> d_ptr;

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -2299,7 +2299,7 @@ if FreeCAD.GuiUp:
                     editor = QtGui.QComboBox(parent)
                     editor.addItems(["True","False"])
                 elif "Measure" in ptype:
-                    editor = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+                    editor = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
                     editor.setParent(parent)
                 else:
                     editor = QtGui.QLineEdit(parent)

--- a/src/Mod/Arch/ArchGrid.py
+++ b/src/Mod/Arch/ArchGrid.py
@@ -357,13 +357,13 @@ class ArchGridTaskPanel:
         layout.addLayout(hbox3)
         self.wLabel = QtGui.QLabel(self.form)
         hbox3.addWidget(self.wLabel)
-        self.widthUi = uil.createWidget("Gui::InputField")
+        self.widthUi = uil.createWidget("Gui::QuantitySpinBox")
         hbox3.addWidget(self.widthUi)
         hbox4 = QtGui.QHBoxLayout()
         layout.addLayout(hbox4)
         self.hLabel = QtGui.QLabel(self.form)
         hbox4.addWidget(self.hLabel)
-        self.heightUi = uil.createWidget("Gui::InputField")
+        self.heightUi = uil.createWidget("Gui::QuantitySpinBox")
         hbox4.addWidget(self.heightUi)
         self.title = QtGui.QLabel(self.form)
         layout.addWidget(self.title)
@@ -448,8 +448,8 @@ class ArchGridTaskPanel:
                 if i < len(hlabels):
                     hlabels[i] = FreeCAD.Units.Quantity(v,FreeCAD.Units.Length).getUserPreferred()[0]
             self.table.setHorizontalHeaderLabels(hlabels)
-        self.widthUi.setText(self.obj.Width.getUserPreferred()[0])
-        self.heightUi.setText(self.obj.Height.getUserPreferred()[0])
+        self.widthUi.setProperty('value', FreeCAD.Units.Quantity(self.obj.Width.getUserPreferred()[0]))
+        self.heightUi.setProperty('value', FreeCAD.Units.Quantity(self.obj.Height.getUserPreferred()[0]))
         self.spans = []
         for s in self.obj.Spans:
             span = [int(i.strip()) for i in s.split(",")]

--- a/src/Mod/Arch/ArchMaterial.py
+++ b/src/Mod/Arch/ArchMaterial.py
@@ -822,7 +822,7 @@ if FreeCAD.GuiUp:
                 editor = QtGui.QComboBox(parent)
             elif index.column() == 2:
                 ui = FreeCADGui.UiLoader()
-                editor = ui.createWidget("Gui::InputField")
+                editor = ui.createWidget("Gui::QuantitySpinBox")
                 editor.setSizePolicy(QtGui.QSizePolicy.Preferred,QtGui.QSizePolicy.Minimum)
                 editor.setParent(parent)
             else:

--- a/src/Mod/Arch/ArchPanel.py
+++ b/src/Mod/Arch/ArchPanel.py
@@ -221,22 +221,22 @@ class CommandPanel:
 
         # length
         label1 = QtGui.QLabel(translate("Arch","Length"))
-        self.vLength = ui.createWidget("Gui::InputField")
-        self.vLength.setText(FreeCAD.Units.Quantity(self.Length,FreeCAD.Units.Length).UserString)
+        self.vLength = ui.createWidget("Gui::QuantitySpinBox")
+        self.vLength.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Length, "mm")))
         grid.addWidget(label1,1,0,1,1)
         grid.addWidget(self.vLength,1,1,1,1)
 
         # width
         label2 = QtGui.QLabel(translate("Arch","Width"))
-        self.vWidth = ui.createWidget("Gui::InputField")
-        self.vWidth.setText(FreeCAD.Units.Quantity(self.Width,FreeCAD.Units.Length).UserString)
+        self.vWidth = ui.createWidget("Gui::QuantitySpinBox")
+        self.vWidth.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Width, "mm")))
         grid.addWidget(label2,2,0,1,1)
         grid.addWidget(self.vWidth,2,1,1,1)
 
         # height
         label3 = QtGui.QLabel(translate("Arch","Thickness"))
-        self.vHeight = ui.createWidget("Gui::InputField")
-        self.vHeight.setText(FreeCAD.Units.Quantity(self.Thickness,FreeCAD.Units.Length).UserString)
+        self.vHeight = ui.createWidget("Gui::QuantitySpinBox")
+        self.vHeight.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Thickness, "mm")))
         grid.addWidget(label3,3,0,1,1)
         grid.addWidget(self.vHeight,3,1,1,1)
 
@@ -303,9 +303,9 @@ class CommandPanel:
     def setPreset(self,i):
 
         if i > 0:
-            self.vLength.setText(FreeCAD.Units.Quantity(float(Presets[i][1]),FreeCAD.Units.Length).UserString)
-            self.vWidth.setText(FreeCAD.Units.Quantity(float(Presets[i][2]),FreeCAD.Units.Length).UserString)
-            self.vHeight.setText(FreeCAD.Units.Quantity(float(Presets[i][3]),FreeCAD.Units.Length).UserString)
+            self.vLength.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(float(Presets[i][1]), "mm")))
+            self.vWidth.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(float(Presets[i][2]), "mm")))
+            self.vHeight.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(float(Presets[i][3]), "mm")))
 
     def rotate(self):
 

--- a/src/Mod/Arch/ArchPrecast.py
+++ b/src/Mod/Arch/ArchPrecast.py
@@ -796,27 +796,27 @@ class _PrecastTaskPanel:
         self.grid.addWidget(self.valueSlabType,1,1,1,1)
 
         self.labelChamfer = QtGui.QLabel()
-        self.valueChamfer = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueChamfer = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelChamfer,2,0,1,1)
         self.grid.addWidget(self.valueChamfer,2,1,1,1)
 
         self.labelDentLength = QtGui.QLabel()
-        self.valueDentLength = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueDentLength = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelDentLength,3,0,1,1)
         self.grid.addWidget(self.valueDentLength,3,1,1,1)
 
         self.labelDentWidth = QtGui.QLabel()
-        self.valueDentWidth = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueDentWidth = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelDentWidth,4,0,1,1)
         self.grid.addWidget(self.valueDentWidth,4,1,1,1)
 
         self.labelDentHeight = QtGui.QLabel()
-        self.valueDentHeight = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueDentHeight = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelDentHeight,5,0,1,1)
         self.grid.addWidget(self.valueDentHeight,5,1,1,1)
 
         self.labelBase = QtGui.QLabel()
-        self.valueBase = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueBase = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelBase,6,0,1,1)
         self.grid.addWidget(self.valueBase,6,1,1,1)
 
@@ -826,17 +826,17 @@ class _PrecastTaskPanel:
         self.grid.addWidget(self.valueHoleNumber,7,1,1,1)
 
         self.labelHoleMajor = QtGui.QLabel()
-        self.valueHoleMajor = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueHoleMajor = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelHoleMajor,8,0,1,1)
         self.grid.addWidget(self.valueHoleMajor,8,1,1,1)
 
         self.labelHoleMinor = QtGui.QLabel()
-        self.valueHoleMinor = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueHoleMinor = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelHoleMinor,9,0,1,1)
         self.grid.addWidget(self.valueHoleMinor,9,1,1,1)
 
         self.labelHoleSpacing = QtGui.QLabel()
-        self.valueHoleSpacing = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueHoleSpacing = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelHoleSpacing,10,0,1,1)
         self.grid.addWidget(self.valueHoleSpacing,10,1,1,1)
 
@@ -846,17 +846,17 @@ class _PrecastTaskPanel:
         self.grid.addWidget(self.valueGrooveNumber,11,1,1,1)
 
         self.labelGrooveDepth = QtGui.QLabel()
-        self.valueGrooveDepth = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueGrooveDepth = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelGrooveDepth,12,0,1,1)
         self.grid.addWidget(self.valueGrooveDepth,12,1,1,1)
 
         self.labelGrooveHeight = QtGui.QLabel()
-        self.valueGrooveHeight = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueGrooveHeight = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelGrooveHeight,13,0,1,1)
         self.grid.addWidget(self.valueGrooveHeight,13,1,1,1)
 
         self.labelGrooveSpacing = QtGui.QLabel()
-        self.valueGrooveSpacing = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueGrooveSpacing = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelGrooveSpacing,14,0,1,1)
         self.grid.addWidget(self.valueGrooveSpacing,14,1,1,1)
 
@@ -866,17 +866,17 @@ class _PrecastTaskPanel:
         self.grid.addWidget(self.valueRiserNumber,15,1,1,1)
 
         self.labelDownLength = QtGui.QLabel()
-        self.valueDownLength = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueDownLength = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelDownLength,16,0,1,1)
         self.grid.addWidget(self.valueDownLength,16,1,1,1)
 
         self.labelRiser = QtGui.QLabel()
-        self.valueRiser = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueRiser = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelRiser,17,0,1,1)
         self.grid.addWidget(self.valueRiser,17,1,1,1)
 
         self.labelTread = QtGui.QLabel()
-        self.valueTread = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueTread = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelTread,18,0,1,1)
         self.grid.addWidget(self.valueTread,18,1,1,1)
 
@@ -917,7 +917,7 @@ class _PrecastTaskPanel:
         self.form.hide()
 
     def restoreValue(self, widget, val):
-        widget.setText(FreeCAD.Units.Quantity(val, FreeCAD.Units.Length).UserString)
+        widget.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(val, "mm")))
 
     def getValues(self):
         d = {}
@@ -1288,27 +1288,27 @@ class _DentsTaskPanel:
 
         # parameters
         self.labelLength = QtGui.QLabel()
-        self.valueLength = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueLength = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelLength,4,0,1,1)
         self.grid.addWidget(self.valueLength,4,1,1,1)
 
         self.labelWidth = QtGui.QLabel()
-        self.valueWidth = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueWidth = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelWidth,5,0,1,1)
         self.grid.addWidget(self.valueWidth,5,1,1,1)
 
         self.labelHeight = QtGui.QLabel()
-        self.valueHeight = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueHeight = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelHeight,6,0,1,1)
         self.grid.addWidget(self.valueHeight,6,1,1,1)
 
         self.labelSlant = QtGui.QLabel()
-        self.valueSlant = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueSlant = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelSlant,7,0,1,1)
         self.grid.addWidget(self.valueSlant,7,1,1,1)
 
         self.labelLevel = QtGui.QLabel()
-        self.valueLevel = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueLevel = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelLevel,8,0,1,1)
         self.grid.addWidget(self.valueLevel,8,1,1,1)
 
@@ -1320,7 +1320,7 @@ class _DentsTaskPanel:
         self.grid.addWidget(self.valueRotation,9,1,1,1)
 
         self.labelOffset = QtGui.QLabel()
-        self.valueOffset = FreeCADGui.UiLoader().createWidget("Gui::InputField")
+        self.valueOffset = FreeCADGui.UiLoader().createWidget("Gui::QuantitySpinBox")
         self.grid.addWidget(self.labelOffset,10,0,1,1)
         self.grid.addWidget(self.valueOffset,10,1,1,1)
 
@@ -1394,13 +1394,13 @@ class _DentsTaskPanel:
             s = self.listDents.currentItem().text()
             s = s.split(":")[1]
             s = s.split(";")
-            self.valueLength.setText(FreeCAD.Units.Quantity(float(s[0]),FreeCAD.Units.Length).UserString)
-            self.valueWidth.setText(FreeCAD.Units.Quantity(float(s[1]),FreeCAD.Units.Length).UserString)
-            self.valueHeight.setText(FreeCAD.Units.Quantity(float(s[2]),FreeCAD.Units.Length).UserString)
-            self.valueSlant.setText(FreeCAD.Units.Quantity(float(s[3]),FreeCAD.Units.Length).UserString)
-            self.valueLevel.setText(FreeCAD.Units.Quantity(float(s[4]),FreeCAD.Units.Length).UserString)
+            self.valueLength.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(float(s[0]), "mm")))
+            self.valueWidth.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(float(s[1]), "mm")))
+            self.valueHeight.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(float(s[2]), "mm")))
+            self.valueSlant.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(float(s[3]), "mm")))
+            self.valueLevel.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(float(s[4]), "mm")))
             self.valueRotation.setCurrentIndex(self.RotationAngles.index(int(s[5])))
-            self.valueOffset.setText(FreeCAD.Units.Quantity(float(s[6]),FreeCAD.Units.Length).UserString)
+            self.valueOffset.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(float(s[6]), "mm")))
 
     def retranslateUi(self, dialog):
         from PySide import QtGui

--- a/src/Mod/Arch/ArchStructure.py
+++ b/src/Mod/Arch/ArchStructure.py
@@ -459,28 +459,28 @@ class _CommandStructure:
 
         # length
         label1 = QtGui.QLabel(translate("Arch","Length"))
-        self.vLength = ui.createWidget("Gui::InputField")
+        self.vLength = ui.createWidget("Gui::QuantitySpinBox")
         if self.modeb.isChecked():
-            self.vLength.setText(FreeCAD.Units.Quantity(self.Height,FreeCAD.Units.Length).UserString)
+            self.vLength.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Height, "mm")))
         else:
-            self.vLength.setText(FreeCAD.Units.Quantity(self.Length,FreeCAD.Units.Length).UserString)
+            self.vLength.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Length, "mm")))
         grid.addWidget(label1,4,0,1,1)
         grid.addWidget(self.vLength,4,1,1,1)
 
         # width
         label2 = QtGui.QLabel(translate("Arch","Width"))
-        self.vWidth = ui.createWidget("Gui::InputField")
-        self.vWidth.setText(FreeCAD.Units.Quantity(self.Width,FreeCAD.Units.Length).UserString)
+        self.vWidth = ui.createWidget("Gui::QuantitySpinBox")
+        self.vWidth.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Width, "mm")))
         grid.addWidget(label2,5,0,1,1)
         grid.addWidget(self.vWidth,5,1,1,1)
 
         # height
         label3 = QtGui.QLabel(translate("Arch","Height"))
-        self.vHeight = ui.createWidget("Gui::InputField")
+        self.vHeight = ui.createWidget("Gui::QuantitySpinBox")
         if self.modeb.isChecked():
-            self.vHeight.setText(FreeCAD.Units.Quantity(self.Length,FreeCAD.Units.Length).UserString)
+            self.vHeight.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Length, "mm")))
         else:
-            self.vHeight.setText(FreeCAD.Units.Quantity(self.Height,FreeCAD.Units.Length).UserString)
+            self.vHeight.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Height, "mm")))
         grid.addWidget(label3,6,0,1,1)
         grid.addWidget(self.vHeight,6,1,1,1)
 
@@ -555,7 +555,7 @@ class _CommandStructure:
                     self.tracker.update([self.bpoint.add(delta),point.add(delta)])
                     self.tracker.on()
                     l = (point.sub(self.bpoint)).Length
-                    self.vLength.setText(FreeCAD.Units.Quantity(l,FreeCAD.Units.Length).UserString)
+                    self.vLength.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(1, "mm")))
                 else:
                     self.tracker.off()
 
@@ -626,8 +626,8 @@ class _CommandStructure:
                 FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").SetString("StructurePreset",self.Profile)
             else:
                 p=elt[0]-1 # Presets indexes are 1-based
-                self.vLength.setText(FreeCAD.Units.Quantity(float(Presets[p][4]),FreeCAD.Units.Length).UserString)
-                self.vWidth.setText(FreeCAD.Units.Quantity(float(Presets[p][5]),FreeCAD.Units.Length).UserString)
+                self.vLength.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(float(Presets[p][4]), "mm")))
+                self.vWidth.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(float(Presets[p][5]), "mm")))
                 self.Profile = Presets[p]
                 FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").SetString("StructurePreset",";".join([str(i) for i in self.Profile]))
 
@@ -647,15 +647,15 @@ class _CommandStructure:
 
         h = self.Height
         l = self.Length
-        self.vLength.setText(FreeCAD.Units.Quantity(h,FreeCAD.Units.Length).UserString)
-        self.vHeight.setText(FreeCAD.Units.Quantity(l,FreeCAD.Units.Length).UserString)
+        self.vLength.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(h, "mm")))
+        self.vHeight.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(1, "mm")))
 
     def rotateLW(self):
 
         w = self.Width
         l = self.Length
-        self.vLength.setText(FreeCAD.Units.Quantity(w,FreeCAD.Units.Length).UserString)
-        self.vWidth.setText(FreeCAD.Units.Quantity(l,FreeCAD.Units.Length).UserString)
+        self.vLength.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(w, "mm")))
+        self.vWidth.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(1, "mm")))
 
 
 class _Structure(ArchComponent.Component):

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -482,7 +482,8 @@ class _CommandWall:
                 dv = dv.negative()
                 self.tracker.update([b.add(dv),point.add(dv)])
             if self.Length:
-                self.Length.setText(FreeCAD.Units.Quantity(bv.Length,FreeCAD.Units.Length).UserString)
+                quantity = FreeCAD.Units.Quantity("{} {}".format(bv.Length, "mm"))
+                self.Length.setProperty('value', quantity)
 
     def taskbox(self):
         """Set up a simple gui widget for the interactive mode."""
@@ -509,20 +510,20 @@ class _CommandWall:
         grid.addWidget(matCombo,0,0,1,2)
 
         label5 = QtGui.QLabel(translate("Arch","Length"))
-        self.Length = ui.createWidget("Gui::InputField")
-        self.Length.setText("0.00 mm")
+        self.Length = ui.createWidget("Gui::QuantitySpinBox")
+        self.Length.setProperty('value', "0 mm")
         grid.addWidget(label5,1,0,1,1)
         grid.addWidget(self.Length,1,1,1,1)
 
         label1 = QtGui.QLabel(translate("Arch","Width"))
-        value1 = ui.createWidget("Gui::InputField")
-        value1.setText(FreeCAD.Units.Quantity(self.Width,FreeCAD.Units.Length).UserString)
+        value1 = ui.createWidget("Gui::QuantitySpinBox")
+        value1.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Width, "mm")))
         grid.addWidget(label1,2,0,1,1)
         grid.addWidget(value1,2,1,1,1)
 
         label2 = QtGui.QLabel(translate("Arch","Height"))
-        value2 = ui.createWidget("Gui::InputField")
-        value2.setText(FreeCAD.Units.Quantity(self.Height,FreeCAD.Units.Length).UserString)
+        value2 = ui.createWidget("Gui::QuantitySpinBox")
+        value2.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Height, "mm")))
         grid.addWidget(label2,3,0,1,1)
         grid.addWidget(value2,3,1,1,1)
 

--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -378,7 +378,7 @@ class _CommandWindow:
 
         # sill height
         labels = QtGui.QLabel(translate("Arch","Sill height"))
-        values = ui.createWidget("Gui::InputField")
+        values = ui.createWidget("Gui::QuantitySpinBox")
         grid.addWidget(labels,1,0,1,1)
         grid.addWidget(values,1,1,1,1)
         QtCore.QObject.connect(values,QtCore.SIGNAL("valueChanged(double)"),self.setSill)
@@ -437,23 +437,23 @@ class _CommandWindow:
         i = 5
         for param in self.wparams:
             lab = QtGui.QLabel(translate("Arch",param))
-            setattr(self,"val"+param,ui.createWidget("Gui::InputField"))
+            setattr(self,"val"+param,ui.createWidget("Gui::QuantitySpinBox"))
             wid = getattr(self,"val"+param)
             if param == "Width":
-                wid.setText(FreeCAD.Units.Quantity(self.Width,FreeCAD.Units.Length).UserString)
+                wid.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Width, "mm")))
             elif param == "Height":
-                wid.setText(FreeCAD.Units.Quantity(self.Height,FreeCAD.Units.Length).UserString)
+                wid.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.Height, "mm")))
             elif param == "O1":
                 n = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetFloat("WindowO1",0.0)
-                wid.setText(FreeCAD.Units.Quantity(n,FreeCAD.Units.Length).UserString)
+                wid.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(n, "mm")))
                 setattr(self,param,n)
             elif param == "W1":
                 n = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetFloat("WindowW1",self.Thickness*2)
-                wid.setText(FreeCAD.Units.Quantity(n,FreeCAD.Units.Length).UserString)
+                wid.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(n, "mm")))
                 setattr(self,param,n)
             else:
                 n = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetFloat("Window"+param,self.Thickness)
-                wid.setText(FreeCAD.Units.Quantity(n,FreeCAD.Units.Length).UserString)
+                wid.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(n, "mm")))
                 setattr(self,param,n)
             grid.addWidget(lab,i,0,1,1)
             grid.addWidget(wid,i,1,1,1)
@@ -471,7 +471,7 @@ class _CommandWindow:
             d = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetFloat("WindowSill",0)
         if i < valuep.count():
             valuep.setCurrentIndex(i)
-        values.setText(FreeCAD.Units.Quantity(d,FreeCAD.Units.Length).UserString)
+        values.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(d, "mm")))
 
         return w
 
@@ -1425,8 +1425,8 @@ class _ArchWindowTaskPanel:
         self.field1 = QtGui.QLineEdit(self.baseform)
         self.field2 = QtGui.QComboBox(self.baseform)
         self.field3 = QtGui.QLineEdit(self.baseform)
-        self.field4 = ui.createWidget("Gui::InputField")
-        self.field5 = ui.createWidget("Gui::InputField")
+        self.field4 = ui.createWidget("Gui::QuantitySpinBox")
+        self.field5 = ui.createWidget("Gui::QuantitySpinBox")
         self.field6 = QtGui.QPushButton(self.baseform)
         self.field7 = QtGui.QComboBox(self.baseform)
         self.addp4 = QtGui.QCheckBox(self.baseform)
@@ -1605,8 +1605,8 @@ class _ArchWindowTaskPanel:
 
         self.field1.setText('')
         self.field3.setText('')
-        self.field4.setText('')
-        self.field5.setText('')
+        self.field4.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
+        self.field5.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
         self.field6.setText(QtGui.QApplication.translate("Arch", "Get selected edge", None))
         self.field7.setCurrentIndex(0)
         self.addp4.setChecked(False)

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -327,7 +327,7 @@ class DraftToolBar:
         return lineedit
 
     def _inputfield (self,name, layout, hide=True, width=None):
-        inputfield = self.uiloader.createWidget("Gui::InputField")
+        inputfield = self.uiloader.createWidget("Gui::QuantitySpinBox")
         inputfield.setObjectName(name)
         if hide: inputfield.hide()
         if not width:
@@ -395,15 +395,15 @@ class DraftToolBar:
         self.labelx = self._label("labelx", xl)
         self.xValue = self._inputfield("xValue", xl) #width=60
         self.xValue.installEventFilter(self.baseWidget)
-        self.xValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
+        self.xValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
         self.labely = self._label("labely", yl)
         self.yValue = self._inputfield("yValue", yl)
         self.yValue.installEventFilter(self.baseWidget) # Required to detect snap cycling in case of Y constraining.
-        self.yValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
+        self.yValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
         self.labelz = self._label("labelz", zl)
         self.zValue = self._inputfield("zValue", zl)
         self.zValue.installEventFilter(self.baseWidget) # Required to detect snap cycling in case of Z constraining.
-        self.zValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
+        self.zValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
         self.pointButton = self._pushbutton("addButton", bl, icon="Draft_AddPoint")
 
         # text
@@ -426,11 +426,11 @@ class DraftToolBar:
         self.labellength = self._label("labellength", ll)
         self.lengthValue = self._inputfield("lengthValue", ll)
         self.lengthValue.installEventFilter(self.baseWidget) # Required to detect snap cycling if focusOnLength is True.
-        self.lengthValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
+        self.lengthValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
         self.labelangle = self._label("labelangle", al)
         self.angleLock = self._checkbox("angleLock",al,checked=self.alock)
         self.angleValue = self._inputfield("angleValue", al)
-        self.angleValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Angle).UserString)
+        self.angleValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "deg")))
 
         # options
 
@@ -444,7 +444,7 @@ class DraftToolBar:
         self.layout.addLayout(rl)
         self.labelRadius = self._label("labelRadius", rl)
         self.radiusValue = self._inputfield("radiusValue", rl)
-        self.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
+        self.radiusValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
         bl = QtGui.QHBoxLayout()
         self.layout.addLayout(bl)
         self.undoButton = self._pushbutton("undoButton", bl, icon='Draft_Rotate')
@@ -503,12 +503,12 @@ class DraftToolBar:
         QtCore.QObject.connect(self.xValue,QtCore.SIGNAL("returnPressed()"),self.checkx)
         QtCore.QObject.connect(self.yValue,QtCore.SIGNAL("returnPressed()"),self.checky)
         QtCore.QObject.connect(self.lengthValue,QtCore.SIGNAL("returnPressed()"),self.checklength)
-        QtCore.QObject.connect(self.xValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
-        QtCore.QObject.connect(self.yValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
-        QtCore.QObject.connect(self.zValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
-        QtCore.QObject.connect(self.lengthValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
-        QtCore.QObject.connect(self.radiusValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
-        QtCore.QObject.connect(self.angleValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
+        #QtCore.QObject.connect(self.xValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
+        #QtCore.QObject.connect(self.yValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
+        #QtCore.QObject.connect(self.zValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
+        #QtCore.QObject.connect(self.lengthValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
+        #QtCore.QObject.connect(self.radiusValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
+        #QtCore.QObject.connect(self.angleValue,QtCore.SIGNAL("textEdited(QString)"),self.checkSpecialChars)
         QtCore.QObject.connect(self.zValue,QtCore.SIGNAL("returnPressed()"),self.validatePoint)
         QtCore.QObject.connect(self.pointButton,QtCore.SIGNAL("clicked()"),self.validatePoint)
         QtCore.QObject.connect(self.radiusValue,QtCore.SIGNAL("returnPressed()"),self.validatePoint)
@@ -699,22 +699,28 @@ class DraftToolBar:
     def setFocus(self,f=None):
         if _param_draft.GetBool("focusOnLength",False) and self.lengthValue.isVisible():
             self.lengthValue.setFocus()
-            self.lengthValue.setSelection(0,self.number_length(self.lengthValue.text()))
+            #self.lengthValue.setSelection(0,self.number_length(self.lengthValue.text()))
+            self.lengthValue.selectAll()
         elif self.angleLock.isVisible() and self.angleLock.isChecked():
             self.lengthValue.setFocus()
-            self.lengthValue.setSelection(0,self.number_length(self.lengthValue.text()))
+            #self.lengthValue.setSelection(0,self.number_length(self.lengthValue.text()))
+            self.lengthValue.selectAll()
         elif (f is None) or (f == "x"):
             self.xValue.setFocus()
-            self.xValue.setSelection(0,self.number_length(self.xValue.text()))
+            #self.xValue.setSelection(0,self.number_length(self.xValue.text()))
+            self.xValue.selectAll()
         elif f == "y":
             self.yValue.setFocus()
-            self.yValue.setSelection(0,self.number_length(self.yValue.text()))
+            #self.yValue.setSelection(0,self.number_length(self.yValue.text()))
+            self.yValue.selectAll()
         elif f == "z":
             self.zValue.setFocus()
-            self.zValue.setSelection(0,self.number_length(self.zValue.text()))
+            #self.zValue.setSelection(0,self.number_length(self.zValue.text()))
+            self.zValue.selectAll()
         elif f == "radius":
             self.radiusValue.setFocus()
-            self.radiusValue.setSelection(0,self.number_length(self.radiusValue.text()))
+            #self.radiusValue.setSelection(0,self.number_length(self.radiusValue.text()))
+            self.radiusValue.selectAll()
 
     def number_length(self, str):
         nl = 0
@@ -806,9 +812,9 @@ class DraftToolBar:
         self.yValue.show()
         self.zValue.show()
         # reset UI to (0,0,0) on start
-        self.xValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
-        self.yValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
-        self.zValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
+        self.xValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
+        self.yValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
+        self.zValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
         self.x = 0
         self.y = 0
         self.z = 0
@@ -842,7 +848,7 @@ class DraftToolBar:
         self.occOffset.show()
         self.labelRadius.setText(translate("draft","Distance"))
         self.radiusValue.setToolTip(translate("draft", "Offset distance"))
-        self.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
+        self.radiusValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
         todo.delay(self.radiusValue.setFocus,None)
         self.radiusValue.selectAll()
 
@@ -860,7 +866,7 @@ class DraftToolBar:
         self.radiusUi()
         self.labelRadius.setText(translate("draft","Distance"))
         self.radiusValue.setToolTip(translate("draft", "Offset distance"))
-        self.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
+        self.radiusValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
         todo.delay(self.radiusValue.setFocus,None)
         self.radiusValue.selectAll()
 
@@ -869,7 +875,7 @@ class DraftToolBar:
         self.labelRadius.setText(translate("draft", "Radius"))
         self.radiusValue.setToolTip(translate("draft", "Radius of Circle"))
         self.labelRadius.show()
-        self.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
+        self.radiusValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(0, "mm")))
         self.radiusValue.show()
         todo.delay(self.radiusValue.setFocus,None)
         self.radiusValue.selectAll()
@@ -1050,7 +1056,8 @@ class DraftToolBar:
     def checkx(self):
         if self.yValue.isEnabled():
             self.yValue.setFocus()
-            self.yValue.setSelection(0,self.number_length(self.yValue.text()))
+            #self.yValue.setSelection(0,self.number_length(self.yValue.text()))
+            self.yValue.selectAll()
             self.updateSnapper()
         else:
             self.checky()
@@ -1058,7 +1065,8 @@ class DraftToolBar:
     def checky(self):
         if self.zValue.isEnabled():
             self.zValue.setFocus()
-            self.zValue.setSelection(0,self.number_length(self.zValue.text()))
+            #self.zValue.setSelection(0,self.number_length(self.zValue.text()))
+            self.zValue.selectAll()
             self.updateSnapper()
         else:
             self.validatePoint()
@@ -1066,7 +1074,8 @@ class DraftToolBar:
     def checklength(self):
         if self.angleValue.isEnabled():
             self.angleValue.setFocus()
-            self.angleValue.setSelection(0,self.number_length(self.angleValue.text()))
+            #self.angleValue.setSelection(0,self.number_length(self.angleValue.text()))
+            self.angleValue.selectAll()
             self.updateSnapper()
         else:
             self.validatePoint()
@@ -1316,26 +1325,26 @@ class DraftToolBar:
         # set widgets
         if dp:
             if self.mask in ['y','z']:
-                self.xValue.setText(display_external(dp.x,None,'Length'))
+                self.xValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(dp.x, "mm")))
             else:
-                self.xValue.setText(display_external(dp.x,None,'Length'))
+                self.xValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(dp.x, "mm")))
             if self.mask in ['x','z']:
-                self.yValue.setText(display_external(dp.y,None,'Length'))
+                self.yValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(dp.y, "mm")))
             else:
-                self.yValue.setText(display_external(dp.y,None,'Length'))
+                self.yValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(dp.y, "mm")))
             if self.mask in ['x','y']:
-                self.zValue.setText(display_external(dp.z,None,'Length'))
+                self.zValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(dp.z, "mm")))
             else:
-                self.zValue.setText(display_external(dp.z,None,'Length'))
+                self.zValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(dp.z, "mm")))
 
         # set length and angle
         if last and dp and plane:
             length, theta, phi = DraftVecUtils.get_spherical_coords(*dp)
             theta = math.degrees(theta)
             phi = math.degrees(phi)
-            self.lengthValue.setText(display_external(length,None,'Length'))
+            self.lengthValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(length, "mm")))
             #if not self.angleLock.isChecked():
-            self.angleValue.setText(display_external(phi,None,'Angle'))
+            self.angleValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(phi, "deg")))
             if not mask:
                 # automask, phi is rounded to identify one of the below cases
                 phi = round(phi, Draft.precision())
@@ -1502,15 +1511,10 @@ class DraftToolBar:
         self.sourceCmd.proceed(str(action.text()))
 
     def setRadiusValue(self,val,unit=None):
-        #print("DEBUG: setRadiusValue val: ", val, " unit: ", unit)
-        if  not isinstance(val, (int, float)):       #??some code passes strings or ???
-            t = val
-        elif unit:
-            t= display_external(val,None, unit)
-        else:
+        print("DEBUG: setRadiusValue val: ", val, " unit: ", unit)
+        if unit == None:
             print("Error: setRadiusValue called for number without Dimension")
-            t = display_external(val,None, None)
-        self.radiusValue.setText(t)
+        self.radiusValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(val, "mm")))
         self.radiusValue.setFocus()
 
     def runAutoGroup(self):
@@ -1634,17 +1638,17 @@ class DraftToolBar:
         self.avalue = math.degrees(phi)
         self.angle = FreeCAD.Vector(DraftVecUtils.get_cartesian_coords(
             1, theta, phi))
-        self.lengthValue.setText(display_external(self.lvalue,None,'Length'))
-        self.angleValue.setText(display_external(self.avalue,None,'Angle'))
+        self.lengthValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.lvalue, "mm")))
+        self.angleValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.avalue, "deg")))
 
     def update_cartesian_coords(self):
         self.x, self.y, self.z = DraftVecUtils.get_cartesian_coords(
             self.lvalue,math.radians(self.pvalue),math.radians(self.avalue))
         self.angle = FreeCAD.Vector(DraftVecUtils.get_cartesian_coords(
             1, math.radians(self.pvalue), math.radians(self.avalue)))
-        self.xValue.setText(display_external(self.x,None,'Length'))
-        self.yValue.setText(display_external(self.y,None,'Length'))
-        self.zValue.setText(display_external(self.z,None,'Length'))
+        self.xValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.x, "mm")))
+        self.yValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.y, "mm")))
+        self.zValue.setProperty('value', FreeCAD.Units.Quantity("{} {}".format(self.z, "mm")))
 
 #---------------------------------------------------------------------------
 # TaskView operations

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -276,7 +276,7 @@ class Arc(gui_base_original.Creator):
                         else:
                             self.ui.labelRadius.setText(translate("draft", "Start angle"))
                             self.ui.radiusValue.setToolTip(translate("draft", "Start angle"))
-                            self.ui.radiusValue.setText(U.Quantity(0, U.Angle).UserString)
+                            self.ui.radiusValue.setProperty('value', App.Units.Quantity("{} {}".format(0, "deg")))
                             self.linetrack.p1(self.center)
                             self.linetrack.on()
                             self.step = 2
@@ -443,7 +443,7 @@ class Arc(gui_base_original.Creator):
                 self.ui.radiusValue.setToolTip(translate("draft", "Start angle"))
                 self.linetrack.p1(self.center)
                 self.linetrack.on()
-                self.ui.radiusValue.setText("")
+                self.ui.radiusValue.setProperty('value', App.Units.Quantity("{} {}".format(0, "deg")))
                 self.ui.radiusValue.setFocus()
                 _msg(translate("draft", "Pick start angle"))
         elif self.step == 2:
@@ -455,7 +455,7 @@ class Arc(gui_base_original.Creator):
                                              self.wp.axis)
             self.arctrack.setStartAngle(self.firstangle - ang_offset)
             self.step = 3
-            self.ui.radiusValue.setText("")
+            self.ui.radiusValue.setProperty('value', App.Units.Quantity("{} {}".format(0, "deg")))
             self.ui.radiusValue.setFocus()
             _msg(translate("draft", "Pick aperture angle"))
         else:


### PR DESCRIPTION
This solve this issue: https://github.com/FreeCAD/FreeCAD/issues/11345

Issue is for Building US unit system the InputField widget cannot accept the #'#"+#/#" format that the expression parser generates.

This solves this by swapping the Gui::InputField widget with the almost identical Gui::QuantitySpinbox widget. 

1. bf3138856d8c2505b2082748f81047f7241daf5d Adds the returnPressed() signal to QuantitySpinbox; Functionality that existed in InputField but not QuantitySpinBox.
2. 167bda538a36ad76ca2a84b0d9e7300e90816f86 Swaps the widgets in src/Mod/Arch (standalone).
3. 44e1961fffaf9b35c927f18207a7f7c234b14365 Swaps the widgets in src/Mod/Draft (standalone); these are used to run the interactive part of the Arch inputs. There is a small but noticeable delay in the wire frame preview after this commit. 

