### PR TITLE
bugfix: exit() is not async-signal-safe!

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1808,7 +1808,7 @@ void segmentation_fault_handler(int sig)
 #if defined(FC_DEBUG)
     abort();
 #else
-    exit(1);
+    _exit(1);
 #endif
 #else
     switch (sig) {


### PR DESCRIPTION
This has got to be the most complex "1-character Pull Request" I have ever seen, but I will do my best to explain what is going on and how I debugged it without violating my non-disclosure agreement

# TL;DR
## Problem
When running a python script with C-extensions (including FreeCAD 0.21.0 and others), it would have a small chance of just hanging forever. This was rare (~0.25% of the time), but reproducible if running the same script a few hundred times.

After like 10 days of going crazy, I found the culprit here: https://github.com/FreeCAD/FreeCAD/blob/a1c08dbf43d4f887a1ac4682360264cb390f83ad/src/App/Application.cpp#L1811

Thanks to [Rodrigo's answer to "Can exit() fail to terminate process?" ](https://stackoverflow.com/questions/8833394/can-exit-fail-to-terminate-process), which points out that [according to the signal-safety man page](https://man7.org/linux/man-pages/man7/signal-safety.7.html), the `exit()` function is not async-signal-safe and should not be called from signal handlers (which is exactly what is currently being done). 

He also points out that despite it not being async-safe, it will work "most of the time", which is one of the main reasons this was so tricky to debug:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/18612100/97f00326-a9ff-4142-b391-f6d7a1057703)

## Solution
After switching from `exit()` to `_exit()`, the issue I was having went away.

There are other alternatives (i.e. `_Exit()`, and `abort()` but I went for `_exit()` because it seemed like the most similar according to the [man page](https://man7.org/linux/man-pages/man2/_exit.2.html). However, it would be interesting to get a core-developer's opinion on this choice.


# More background
I attached the `gdb` debugger to a hung python process and saw that 2 threads were deadlocked, threads 1 & 32:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/18612100/9b01edb2-1120-451d-aada-b660b380f71b)

## Thread 1 `bt`
![grafik](https://github.com/FreeCAD/FreeCAD/assets/18612100/a6df3c06-ba0b-4dd0-98b4-9f253d4c01b9)

## Thread 32 `bt`
![Selection_005](https://github.com/FreeCAD/FreeCAD/assets/18612100/2b7ebb4f-9178-485c-bdbe-bac965cd10e1)

## What is going on?
![grafik](https://github.com/FreeCAD/FreeCAD/assets/18612100/7f6cb57c-3e91-4b01-9764-a96534c8b7aa)
It seems like:
- exit is being called
- which runs the exit handlers
- which triggers the `segmentation_fault_handler(int)` in `libFreeCADApp.so`
    - (see "`SIGSEV` signal?" below)
- This calls `exit()` **again**
- which runs the exit handlers **again**
- which leads to a `futex_wait` that has a small chance to deadlock

As explained in the summary, this is due to the non-async-safe nature of the `exit()` function.

### `SIGSEV` signal?
I'm not exactly sure why `segmentation_fault_handler()` is called since I cannot see where a `SIGSEV` signal could be coming from. But I can confirm that `segmentation_fault_handler()` is indeed called reproducibly in my program and I do not see any `STDERR` (as I would have expected [from these lines](https://github.com/FreeCAD/FreeCAD/blob/a1c08dbf43d4f887a1ac4682360264cb390f83ad/src/App/Application.cpp#L1806-L1807)), core-dump or any other remnants of a segmentation fault.

# Conclusion
I suspect that this issue is not affecting too many users besides myself, (perhaps it's just related to something weird in the script I'm using).

However, this small change should make FreeCAD a bit more reliable and hopefully save some people a big headache :)

## My "about"
```
OS: Ubuntu 22.04.3 LTS (ubuntu:GNOME/ubuntu)
Word size of FreeCAD: 64-bit
Version: 0.21.0.33668 +7 (Git)
Build type: Unknown
Branch: (HEAD detached at 0.21.0)
Hash: 41b058e2087de60dc8fef3d3e68c7d0129e13abf
Python 3.10.12, Qt 5.15.3, Coin 4.0.0, Vtk 7.1.1, OCC 7.7.2
Locale: English/United States (en_US)
```