### PR TITLE
[Sketcher] Fix crash described in #10975

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -256,13 +256,13 @@ public:
                    * b));
 
             if (boost::math::isnan(startAngle) || boost::math::isnan(endAngle)) {
-                sketchgui->purgeHandler();
                 Gui::NotifyError(
                     sketchgui,
                     QT_TRANSLATE_NOOP("Notifications", "Error"),
                     QT_TRANSLATE_NOOP(
                         "Notifications",
                         "Cannot create arc of hyperbola from invalid angles, try again!"));
+                sketchgui->purgeHandler();
                 return false;
             }
 


### PR DESCRIPTION
The crash seems to be caused by the notification area function trying to retrieve the name of a deleted object.

I moved the line `sketchgui->purgeHandler();` after the function, thus fixing the crash described in #10975.

CC @abdullahtahiriyo