### PR TITLE
Tweak section tolerance to make base layer of paths work again

### DIFF
--- a/src/Mod/Path/Path/Op/Area.py
+++ b/src/Mod/Path/Path/Op/Area.py
@@ -223,7 +223,7 @@ class ObjectOp(PathOp.ObjectOp):
         area.add(baseobject)
 
         areaParams = self.areaOpAreaParams(obj, isHole)
-        areaParams["SectionTolerance"] = 1e-07
+        areaParams["SectionTolerance"] = FreeCAD.Base.Precision.confusion() * 10 # basically 1e-06
 
         heights = [i for i in self.depthparams]
         Path.Log.debug("depths: {}".format(heights))


### PR DESCRIPTION
Fix #11411 

I've spent a while going through all the Area and AreaParams code, and most of Path.  As far as I can see, there are several other places using precision at 1e-06.

From a practical milling standpoint, 0.1 microns or 1e-04 mm or 4e-06 inches appears to be the limit, so this seems reasonable.

I wasn't able to find any other ways to fix this problem, nor was I successful in pinpointing what change between 0.20.2 and 0.21.0 triggered it.