### PR TITLE
Draft: remove maxSnap parameter

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -85,15 +85,13 @@ class Snapper:
     def __init__(self):
         self.activeview = None
         self.lastObj = []
-        self.maxEdges = 0
         self.radius = 0
         self.constraintAxis = None
         self.basepoint = None
         self.affinity = None
         self.mask = None
         self.cursorMode = None
-        if Draft.getParam("maxSnap", 0):
-            self.maxEdges = Draft.getParam("maxSnapEdges", 0)
+        self.maxEdges = Draft.getParam("maxSnapEdges", 0)
 
         # we still have no 3D view when the draft module initializes
         self.tracker = None

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -208,7 +208,7 @@ def get_param_type(param):
                    "LineSpacing"):
         return "float"
     elif param in ("selectBaseObjects", "alwaysSnap", "grid",
-                   "fillmode", "maxSnap", "DimShowLine",
+                   "fillmode", "DimShowLine",
                    "SvgLinesBlack", "dxfStdSize", "SnapBarShowOnlyDuringCommands",
                    "alwaysShowGrid", "renderPolylineWidth",
                    "showPlaneTracker", "UsePartPrimitives",


### PR DESCRIPTION
It is superfluous. The maxSnapEdges parameter can be set to zero.
