### PR TITLE
Draft: Introduce DefaultAnnoScaleMultiplier parameter

### DIFF
--- a/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
@@ -273,6 +273,21 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_ScaleMultiplier">
+        <property name="text">
+         <string>Scale multiplier</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QDoubleSpinBox" name="ScaleMultiplier">
+        <property name="toolTip">
+         <string>The annotation scale multiplier is the inverse of the scale set in the 
+Annotation scale widget. If the scale is 1:100 the multiplier is 100.</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-drafttexts.ui
@@ -329,7 +329,41 @@ as &quot;Arial&quot;, a style such as &quot;sans&quot;, &quot;serif&quot; or &qu
       <string>Units</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0" colspan="3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_DefaultAnnoScaleMultiplier">
+        <property name="text">
+         <string>Scale multiplier</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefDoubleSpinBox" name="spinBox_DefaultAnnoScaleMultiplier">
+        <property name="toolTip">
+         <string>The default annotation scale multiplier. This is the inverse of the scale set
+in the Annotation scale widget. If the scale is 1:100 the multiplier is 100.</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="value">
+         <double>1.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultAnnoScaleMultiplier</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0" colspan="3">
        <widget class="Gui::PrefCheckBox" name="checkBox_showUnit">
         <property name="toolTip">
          <string>If checked, a unit symbol is added to dimension texts by default</string>
@@ -348,14 +382,14 @@ as &quot;Arial&quot;, a style such as &quot;sans&quot;, &quot;serif&quot; or &qu
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_overrideUnit">
         <property name="text">
          <string>Unit override</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="Gui::PrefLineEdit" name="lineEdit_overrideUnit">
         <property name="maximumSize">
          <size>
@@ -375,21 +409,14 @@ or cm, leave blank to use the current unit defined in FreeCAD.</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label_dimPrecision">
         <property name="text">
          <string>Number of decimals</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="Gui::PrefSpinBox" name="spinBox_dimPrecision">
         <property name="toolTip">
          <string>The default number of decimal places for dimension texts</string>
@@ -411,14 +438,14 @@ or cm, leave blank to use the current unit defined in FreeCAD.</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label_FeetSeparator">
         <property name="text">
          <string>Feet separator</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="Gui::PrefLineEdit" name="lineEdit_FeetSeparator">
         <property name="maximumSize">
          <size>

--- a/src/Mod/Draft/draftguitools/gui_setstyle.py
+++ b/src/Mod/Draft/draftguitools/gui_setstyle.py
@@ -97,6 +97,7 @@ class Draft_SetStyle_TaskPanel:
         self.form.TextFont.setCurrentFont(QtGui.QFont(param_draft.GetString("textfont", "Sans")))
         self.form.TextSize.setText(U.Quantity(param_draft.GetFloat("textheight", 3.5), U.Length).UserString)
         self.form.LineSpacing.setValue(param_draft.GetFloat("LineSpacing", 1))
+        self.form.ScaleMultiplier.setValue(param_draft.GetFloat("DefaultAnnoScaleMultiplier", 1))
         self.form.AnnoLineColor.setProperty("color", self.getColor(param_draft.GetUnsigned("DefaultAnnoLineColor", 255)))
         self.form.AnnoLineWidth.setValue(param_draft.GetInt("DefaultAnnoLineWidth", 2))
         self.form.ArrowStyle.setCurrentIndex(param_draft.GetInt("dimsymbol", 0))
@@ -148,6 +149,7 @@ class Draft_SetStyle_TaskPanel:
         preset["TextFont"] = self.form.TextFont.currentFont().family()
         preset["TextSize"] = U.Quantity(self.form.TextSize.text()).Value
         preset["LineSpacing"] = self.form.LineSpacing.value()
+        preset["ScaleMultiplier"] = self.form.ScaleMultiplier.value()
         preset["AnnoLineColor"] = utils.argb_to_rgba(self.form.AnnoLineColor.property("color").rgba())
         preset["AnnoLineWidth"] = self.form.AnnoLineWidth.value()
         preset["ArrowStyle"] = self.form.ArrowStyle.currentIndex()
@@ -181,6 +183,7 @@ class Draft_SetStyle_TaskPanel:
         self.form.TextFont.setCurrentFont(QtGui.QFont(preset.get("TextFont", "Sans")))
         self.form.TextSize.setText(U.Quantity(preset.get("TextSize", 3.5),U.Length).UserString)
         self.form.LineSpacing.setValue(preset.get("LineSpacing", 1))
+        self.form.ScaleMultiplier.setValue(preset.get("ScaleMultiplier", 1))
         self.form.AnnoLineColor.setProperty("color", self.getColor(preset.get("AnnoLineColor", preset.get("LineColor", 255))))
         self.form.AnnoLineWidth.setValue(preset.get("AnnoLineWidth", preset.get("LineWidth", 2)))
         self.form.ArrowStyle.setCurrentIndex(preset.get("ArrowStyle", 0))
@@ -213,6 +216,7 @@ class Draft_SetStyle_TaskPanel:
         param_draft.SetString("textfont", self.form.TextFont.currentFont().family())
         param_draft.SetFloat("textheight", U.Quantity(self.form.TextSize.text()).Value)
         param_draft.SetFloat("LineSpacing", self.form.LineSpacing.value())
+        param_draft.SetFloat("DefaultAnnoScaleMultiplier", self.form.ScaleMultiplier.value())
         param_draft.SetUnsigned("DefaultAnnoLineColor", utils.argb_to_rgba(self.form.AnnoLineColor.property("color").rgba()))
         param_draft.SetInt("DefaultAnnoLineWidth", self.form.AnnoLineWidth.value())
         param_draft.SetInt("dimsymbol", self.form.ArrowStyle.currentIndex())
@@ -275,6 +279,8 @@ class Draft_SetStyle_TaskPanel:
                 vobj.FontSize = U.Quantity(self.form.TextSize.text()).Value
             if "LineSpacing" in properties:
                 vobj.LineSpacing = self.form.LineSpacing.value()
+            if "ScaleMultiplier" in properties:
+                vobj.ScaleMultiplier = self.form.ScaleMultiplier.value()
             if "LineColor" in properties:
                 vobj.LineColor = self.form.AnnoLineColor.property("color").getRgbF()[:3]
             if "LineWidth" in properties:

--- a/src/Mod/Draft/draftutils/init_draft_statusbar.py
+++ b/src/Mod/Draft/draftutils/init_draft_statusbar.py
@@ -126,7 +126,7 @@ def label_to_scale(label):
         elif "=" in label:
             f = label.split("=")
         else:
-            return
+            return None
         if len(f) == 2:
             try:
                 num = App.Units.Quantity(f[0]).Value
@@ -161,14 +161,16 @@ def _set_scale(action):
             scale = label_to_scale(custom_scale[0])
             if scale is None:
                 return
-            param.SetFloat("DraftAnnotationScale", scale)
+            if scale <= 0:
+                return
+            param.SetFloat("DefaultAnnoScaleMultiplier", 1 / scale)
             cs = scale_to_label(scale)
             scale_widget.scaleLabel.setText(cs)
     else:
         text_scale = action.text()
         scale_widget.scaleLabel.setText(text_scale)
         scale = label_to_scale(text_scale)
-        param.SetFloat("DraftAnnotationScale", scale)
+        param.SetFloat("DefaultAnnoScaleMultiplier", 1 / scale)
 
 #----------------------------------------------------------------------------
 # MAIN DRAFT STATUSBAR FUNCTIONS
@@ -190,7 +192,8 @@ def init_draft_statusbar_scale():
     draft_scales = get_scales()
 
     # get draft annotation scale
-    draft_annotation_scale = param.GetFloat("DraftAnnotationScale", 1.0)
+    scale_multiplier = param.GetFloat("DefaultAnnoScaleMultiplier", 1)
+    annotation_scale = 1 / scale_multiplier if scale_multiplier > 0 else 1
 
     # initializes scale widget
     scale_widget.draft_scales = draft_scales
@@ -205,7 +208,7 @@ def init_draft_statusbar_scale():
         menu.addAction(a)
     scaleLabel.setMenu(menu)
     gUnits.triggered.connect(_set_scale)
-    scale_label = scale_to_label(draft_annotation_scale)
+    scale_label = scale_to_label(annotation_scale)
     scaleLabel.setText(scale_label)
     scaleLabel.setToolTip(translate("draft",
                                     "Set the scale used by draft annotation tools"))

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -35,38 +35,41 @@ from draftviewproviders import view_base
 
 class ParamObserverDraft:
 
-    def slotParamChanged(self, param, tp, name, value):
-        if name == "textheight":
+    def slotParamChanged(self, param_grp, typ, entry, value):
+        if entry == "textheight":
             _param_observer_callback_tray()
             return
-        if name in ("gridBorder", "gridShowHuman", "coloredGridAxes", "gridEvery",
+        if entry in ("gridBorder", "gridShowHuman", "coloredGridAxes", "gridEvery",
                     "gridSpacing", "gridSize", "gridTransparency", "gridColor"):
             _param_observer_callback_grid()
             return
-        if name == "SnapBarShowOnlyDuringCommands":
+        if entry == "DefaultAnnoScaleMultiplier":
+            _param_observer_callback_scalemultiplier(value)
+            return
+        if entry == "SnapBarShowOnlyDuringCommands":
             _param_observer_callback_snapbar(value)
             return
-        if name == "DisplayStatusbarSnapWidget":
+        if entry == "DisplayStatusbarSnapWidget":
             _param_observer_callback_snapwidget()
             return
-        if name == "DisplayStatusbarScaleWidget":
+        if entry == "DisplayStatusbarScaleWidget":
             _param_observer_callback_scalewidget()
             return
-        if name == "snapStyle":
+        if entry == "snapStyle":
             _param_observer_callback_snapstyle()
             return
-        if name == "snapcolor":
+        if entry == "snapcolor":
             _param_observer_callback_snapcolor()
             return
-        if name == "patternFile":
+        if entry == "patternFile":
             _param_observer_callback_svg_pattern()
             return
 
 
 class ParamObserverView:
 
-    def slotParamChanged(self, param, tp, name, value):
-        if name in ("DefaultShapeColor", "DefaultShapeLineColor", "DefaultShapeLineWidth"):
+    def slotParamChanged(self, param_grp, typ, entry, value):
+        if entry in ("DefaultShapeColor", "DefaultShapeLineColor", "DefaultShapeLineWidth"):
             _param_observer_callback_tray()
             return
 
@@ -78,6 +81,18 @@ def _param_observer_callback_tray():
     if tray is None:
         return
     Gui.draftToolBar.setStyleButton()
+
+
+def _param_observer_callback_scalemultiplier(value):
+    value = float(value)  # value is a string
+    if value <= 0:
+        return
+    mw = Gui.getMainWindow()
+    sb = mw.statusBar()
+    scale_widget = sb.findChild(QtGui.QToolBar,"draft_scale_widget")
+    if scale_widget is not None:
+        scale_label = init_draft_statusbar.scale_to_label(1 / value)
+        scale_widget.scaleLabel.setText(scale_label)
 
 
 def _param_observer_callback_grid():
@@ -98,13 +113,12 @@ def _param_observer_callback_grid():
 
 
 def _param_observer_callback_snapbar(value):
-    # value is a string: "0" or "1"
     if Gui.activeWorkbench().name() not in ("DraftWorkbench", "ArchWorkbench", "BIMWorkbench"):
         return
     if hasattr(Gui, "Snapper"):
         toolbar = Gui.Snapper.get_snap_toolbar()
         if toolbar is not None:
-            toolbar.setVisible(value == "0")
+            toolbar.setVisible(value == "0")  # value is a string: "0" or "1"
 
 
 def _param_observer_callback_snapwidget():
@@ -183,9 +197,9 @@ def _param_observer_start():
     _param_observer_start_view()
 
 
-def _param_observer_start_draft(param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")):
-    param.AttachManager(ParamObserverDraft())
+def _param_observer_start_draft(param_grp = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")):
+    param_grp.AttachManager(ParamObserverDraft())
 
 
-def _param_observer_start_view(param = App.ParamGet("User parameter:BaseApp/Preferences/View")):
-    param.AttachManager(ParamObserverView())
+def _param_observer_start_view(param_grp = App.ParamGet("User parameter:BaseApp/Preferences/View")):
+    param_grp.AttachManager(ParamObserverView())

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -62,8 +62,6 @@ arrowtypes = ARROW_TYPES
 
 def get_default_annotation_style():
     param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-    anno_scale = param.GetFloat("DraftAnnotationScale", 1)
-    scale_mult = 1 / anno_scale if anno_scale > 0 else 1
     arrow_type_index = param.GetInt("dimsymbol", 0)
     return {
         "ArrowSize":       ("float", param.GetFloat("arrowsize", 1)),
@@ -77,7 +75,7 @@ def get_default_annotation_style():
         "LineColor":       ("color", param.GetUnsigned("DefaultAnnoLineColor", 255)),
         "LineSpacing":     ("float", param.GetFloat("LineSpacing", 1)),
         "LineWidth":       ("int",   param.GetInt("DefaultAnnoLineWidth", 2)),
-        "ScaleMultiplier": ("float", scale_mult),
+        "ScaleMultiplier": ("float", param.GetFloat("DefaultAnnoScaleMultiplier", 1)),
         "ShowLine":        ("bool",  param.GetBool("DimShowLine", True)),
         "ShowUnit":        ("bool",  param.GetBool("showUnit", True)),
         "TextColor":       ("color", param.GetUnsigned("DefaultTextColor", 255)),
@@ -205,7 +203,7 @@ def get_param_type(param):
         return "string"
     elif param in ("textheight", "arrowsize", "extlines", "dimspacing",
                    "dimovershoot", "extovershoot", "HatchPatternSize",
-                   "LineSpacing"):
+                   "LineSpacing", "DefaultAnnoScaleMultiplier"):
         return "float"
     elif param in ("selectBaseObjects", "alwaysSnap", "grid",
                    "fillmode", "DimShowLine",

--- a/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
+++ b/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
@@ -54,9 +54,6 @@ from draftutils.messages import _msg
 from draftutils.translate import translate
 
 
-param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-
-
 class ViewProviderDraftAnnotation(object):
     """The base class for Draft Annotation viewproviders.
 
@@ -90,8 +87,7 @@ class ViewProviderDraftAnnotation(object):
                              "ScaleMultiplier",
                              "Annotation",
                              _tip)
-            anno_scale = param.GetFloat("DraftAnnotationScale", 1)
-            vobj.ScaleMultiplier = 1 / anno_scale if anno_scale > 0 else 1
+            vobj.ScaleMultiplier = utils.get_param("DefaultAnnoScaleMultiplier", 1)
 
         if "AnnotationStyle" not in properties:
             _tip = QT_TRANSLATE_NOOP("App::Property",


### PR DESCRIPTION
This parameter replaces DraftAnnotationScale.

The parameter can be changed in the preferences and with the Draft_SetStyle command.