### PR TITLE
Make C++ DXF importer set entity colors per DXF contents

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -335,11 +335,11 @@ Example: for files in millimeters: 1, in centimeters: 10,
         <item>
          <widget class="Gui::PrefCheckBox" name="checkBox_2">
           <property name="toolTip">
-           <string>Colors will be retrieved from the DXF objects whenever possible.
-Otherwise default colors will be applied. </string>
+           <string>Colors will set as specified in the DXF file whenever possible.
+Otherwise default colors will be applied.</string>
           </property>
           <property name="text">
-           <string>Get original colors from the DXF file (legacy importer only)</string>
+           <string>Use colors from the DXF file</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>dxfGetOriginalColors</cstring>

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -2813,8 +2813,12 @@ def open(filename):
         doc = FreeCAD.newDocument(docname)
         doc.Label = docname
         FreeCAD.setActiveDocument(doc.Name)
-        import Import
-        Import.readDXF(filename)
+        try:
+            import ImportGui
+            ImportGui.readDXF(filename)
+        except Exception:
+            import Import
+            Import.readDXF(filename)
         Draft.convert_draft_texts() # convert annotations to Draft texts
         doc.recompute()
 
@@ -2855,8 +2859,12 @@ def insert(filename, docname):
         else:
             errorDXFLib(gui)
     else:
-        import Import
-        Import.readDXF(filename)
+        try:
+            import ImportGui
+            ImportGui.readDXF(filename)
+        except Exception:
+            import Import
+            Import.readDXF(filename)
         Draft.convert_draft_texts() # convert annotations to Draft texts
         doc.recompute()
 

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -363,6 +363,13 @@ private:
         return Py::None();
     }
 
+    // This readDXF method is an almost exact duplicate of the one in ImportGui::Module.
+    // The only difference is the CDxfRead class derivation that is created.
+    // It would seem desirable to have most of this code in just one place, passing it
+    // e.g. a pointer to a function that does the 4 lines during the lifetime of the
+    // CDxfRead object, but right now Import::Module and ImportGui::Module cannot see
+    // each other's functions so this shared code would need some place to live where
+    // both places could include a declaration.
     Py::Object readDXF(const Py::Tuple& args)
     {
         char* Name = nullptr;

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -55,12 +55,15 @@
 #include <App/Annotation.h>
 #include <App/Application.h>
 #include <App/Document.h>
+#include <App/DocumentObjectPy.h>
+#include <App/FeaturePythonPyImp.h>
 #include <Base/Console.h>
 #include <Base/Interpreter.h>
 #include <Base/Matrix.h>
 #include <Base/Parameter.h>
 #include <Base/Vector3D.h>
 #include <Base/PlacementPy.h>
+#include <Base/VectorPy.h>
 #include <Mod/Part/App/PartFeature.h>
 
 #include "ImpExpDxf.h"
@@ -92,17 +95,12 @@ void ImpExpDxfRead::setOptions()
     optionScaling = hGrp->GetFloat("dxfScaling", 1.0);
 }
 
-gp_Pnt ImpExpDxfRead::makePoint(const double* p)
+gp_Pnt ImpExpDxfRead::makePoint(const double point3d[3]) const
 {
-    double sp1(p[0]);
-    double sp2(p[1]);
-    double sp3(p[2]);
     if (optionScaling != 1.0) {
-        sp1 = sp1 * optionScaling;
-        sp2 = sp2 * optionScaling;
-        sp3 = sp3 * optionScaling;
+        return {point3d[0] * optionScaling, point3d[1] * optionScaling, point3d[2] * optionScaling};
     }
-    return {sp1, sp2, sp3};
+    return {point3d[0], point3d[1], point3d[2]};
 }
 
 void ImpExpDxfRead::OnReadLine(const double* s, const double* e, bool /*hidden*/)
@@ -333,13 +331,27 @@ void ImpExpDxfRead::OnReadText(const double* point,
             PyObject* placement = new Base::PlacementPy(Base::Placement(insertionPoint, rot));
             draftModule = PyImport_ImportModule("Draft");
             if (draftModule != nullptr) {
-                PyObject_CallMethod(draftModule, "make_text", "sOif", text, placement, 0, height);
+                // returns a wrapped App::FeaturePython
+                auto builtText = static_cast<App::FeaturePythonPyT<App::DocumentObjectPy>*>(
+                    PyObject_CallMethod(draftModule,
+                                        "make_text",
+                                        "sOif",
+                                        text,
+                                        placement,
+                                        0,
+                                        height));
+                if (builtText != nullptr) {
+                    ApplyGuiStyles(
+                        static_cast<App::FeaturePython*>(builtText->getDocumentObjectPtr()));
+                }
             }
             // We own all the return values so we must release them.
             Py_DECREF(placement);
             Py_XDECREF(draftModule);
         }
-        // else std::cout << "skipped text in block: " << LayerName() << std::endl;
+        else {
+            UnsupportedFeature("TEXT or MTEXT in BLOCK definition");
+        }
     }
 }
 
@@ -395,27 +407,36 @@ void ImpExpDxfRead::OnReadDimension(const double* s,
                                     double /*rotation*/)
 {
     if (optionImportAnnotations) {
-        Base::Interpreter().runString("import Draft");
-        Base::Interpreter().runStringArg("p1=FreeCAD.Vector(%f,%f,%f)",
-                                         s[0] * optionScaling,
-                                         s[1] * optionScaling,
-                                         s[2] * optionScaling);
-        Base::Interpreter().runStringArg("p2=FreeCAD.Vector(%f,%f,%f)",
-                                         e[0] * optionScaling,
-                                         e[1] * optionScaling,
-                                         e[2] * optionScaling);
-        Base::Interpreter().runStringArg("p3=FreeCAD.Vector(%f,%f,%f)",
-                                         point[0] * optionScaling,
-                                         point[1] * optionScaling,
-                                         point[2] * optionScaling);
-        Base::Interpreter().runString("Draft.makeDimension(p1,p2,p3)");
+        PyObject* draftModule = nullptr;
+        PyObject* start = new Base::VectorPy(Base::Vector3d(s[0], s[1], s[2]) * optionScaling);
+        PyObject* end = new Base::VectorPy(Base::Vector3d(e[0], e[1], e[2]) * optionScaling);
+        PyObject* lineLocation =
+            new Base::VectorPy(Base::Vector3d(point[0], point[1], point[2]) * optionScaling);
+        draftModule = PyImport_ImportModule("Draft");
+        if (draftModule != nullptr) {
+            // returns a wrapped App::FeaturePython
+            auto builtDim = static_cast<App::FeaturePythonPyT<App::DocumentObjectPy>*>(
+                PyObject_CallMethod(draftModule,
+                                    "make_linear_dimension",
+                                    "OOO",
+                                    start,
+                                    end,
+                                    lineLocation));
+            if (builtDim != nullptr) {
+                ApplyGuiStyles(static_cast<App::FeaturePython*>(builtDim->getDocumentObjectPtr()));
+            }
+        }
+        // We own all the return values so we must release them.
+        Py_DECREF(start);
+        Py_DECREF(end);
+        Py_DECREF(lineLocation);
+        Py_XDECREF(draftModule);
     }
 }
 
 
 void ImpExpDxfRead::AddObject(Part::TopoShape* shape)
 {
-    // std::cout << "layer:" << LayerName() << std::endl;
     std::vector<Part::TopoShape*> vec;
     if (layers.count(LayerName())) {
         vec = layers[LayerName()];
@@ -427,6 +448,7 @@ void ImpExpDxfRead::AddObject(Part::TopoShape* shape)
             Part::Feature* pcFeature =
                 static_cast<Part::Feature*>(document->addObject("Part::Feature", "Shape"));
             pcFeature->Shape.setValue(shape->getShape());
+            ApplyGuiStyles(pcFeature);
         }
     }
 }
@@ -517,10 +539,7 @@ void gPntToTuple(double* result, gp_Pnt& p)
 
 point3D gPntTopoint3D(gp_Pnt& p)
 {
-    point3D result;
-    result.x = p.X();
-    result.y = p.Y();
-    result.z = p.Z();
+    point3D result = {p.X(), p.Y(), p.Z()};
     return result;
 }
 

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -27,6 +27,7 @@
 
 #include <App/Document.h>
 #include <Mod/Part/App/TopoShape.h>
+#include <Mod/Part/App/PartFeature.h>
 
 #include "dxf.h"
 
@@ -83,9 +84,13 @@ public:
     void setOptions();
 
 private:
-    gp_Pnt makePoint(const double* p);
+    gp_Pnt makePoint(const double point3d[3]) const;
 
 protected:
+    virtual void ApplyGuiStyles(Part::Feature*)
+    {}
+    virtual void ApplyGuiStyles(App::FeaturePython*)
+    {}
     App::Document* document;
     bool optionGroupLayers;
     bool optionImportAnnotations;

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -22,6 +22,8 @@
 #include <vector>
 
 #include <Base/Vector3D.h>
+#include <Base/Console.h>
+#include <App/Color.h>
 #include <Mod/Import/ImportGlobal.h>
 
 
@@ -56,12 +58,12 @@ typedef enum
 // spline data for reading
 struct SplineData
 {
-    double norm[3];
-    int degree;
-    int knots;
-    int control_points;
-    int fit_points;
-    int flag;
+    double norm[3] = {0, 0, 0};
+    int degree = 0;
+    int knots = 0;
+    int control_points = 0;
+    int fit_points = 0;
+    int flag = 0;
     std::list<double> starttanx;
     std::list<double> starttany;
     std::list<double> starttanz;
@@ -199,7 +201,7 @@ protected:
     std::vector<std::string> m_blkRecordList;
 
 public:
-    CDxfWrite(const char* filepath);
+    explicit CDxfWrite(const char* filepath);
     ~CDxfWrite();
 
     void init();
@@ -309,25 +311,59 @@ public:
 class ImportExport CDxfRead
 {
 private:
+    // Low-level reader members
     std::ifstream* m_ifs;
+    int m_record_type = 0;
+    char m_record_data[1024] = "";
+    bool m_not_eof = true;
+    int m_line = 0;
+    bool m_repeat_last_record = false;
 
-    bool m_fail;
-    char m_str[1024];
-    char m_unused_line[1024];
-    eDxfUnits_t m_eUnits;
-    bool m_measurement_inch;
-    char m_layer_name[1024];
-    char m_section_name[1024];
-    char m_block_name[1024];
-    bool m_ignore_errors;
+    // file-level options/properties
+    eDxfUnits_t m_eUnits = eMillimeters;
+    bool m_measurement_inch = false;
 
+    // The following provide a state when reading any entity: If m_block_name is not empty the
+    // entity is in a BLOCK being defined, and LayerName() will return "BLOCKS xxxx" where xxxx is
+    // the block name. Otherwise m_layer_name will be the layer name from the entity records
+    // (default to "0") and LayerName() will return "ENTITIES xxxx" where xxxx is the layer name.
+    // This is clunky but it is a non-private interface and so difficult to change.
+    char m_layer_name[1024] = "0";
+    char m_block_name[1024] = "";
+
+
+    // Error-handling control
+    bool m_ignore_errors = true;
+    bool m_fail = false;
 
     std::map<std::string, ColorIndex_t>
         m_layer_ColorIndex_map;  // Mapping from layer name -> layer color index
     const ColorIndex_t ColorBylayer = 256;
+    const ColorIndex_t ColorByBlock = 0;
+
+    // Readers for various parts of the DXF file.
+    // Section readers (sections are identified by the type-2 (name) record they start with and each
+    // has its own reader function
+    bool ReadHeaderSection();
+    bool ReadTablesSection();
+    bool ReadBlocksSection();
+    bool ReadEntitiesSection();
+
+    bool ReadIgnoredSection();
+
+    // The Tables section consists of several tables (again identified by their type-2 record asfter
+    // th 0-TABLE record) each with its own reader
+    bool ReadLayerTable();
+
+    // Some tables we ignore completely, using this method, which some of the above are
+    // inline-defined to.
+    bool ReadIgnoredTable();
 
     bool ReadUnits();
     bool ReadLayer();
+
+    bool ReadEntity();  // Identify entity type and read it
+    // Readers for specific entity types
     bool ReadLine();
     bool ReadText();
     bool ReadArc();
@@ -337,7 +373,13 @@ private:
     bool ReadSpline();
     bool ReadLwPolyLine();
     bool ReadPolyLine();
-    bool ReadVertex(double* pVertex, bool* bulge_found, double* bulge);
+    typedef struct
+    {
+        double location[3];
+        double bulge;
+    } VertexInfo;
+
+    bool OnReadPolyline(std::list<VertexInfo>&, int flags);
     void OnReadArc(double start_angle,
                    double end_angle,
                    double radius,
@@ -352,31 +394,79 @@ private:
                        double end_angle);
     bool ReadInsert();
     bool ReadDimension();
+    bool ReadUnknownEntity();
+    // Helper for reading common attributes for entities
+    void InitializeAttributes();
+    void InitializeCommonEntityAttributes();
+    void Setup3DVectorAttribute(int x_record_type, double destination[3]);
+    void SetupScaledDoubleAttribute(int record_type, double& destination);
+    void SetupScaledDoubleIntoList(int record_type, std::list<double>& destination);
+    void Setup3DCoordinatesIntoLists(int x_record_type,
+                                     std::list<double>& x_destination,
+                                     std::list<double>& y_destination,
+                                     std::list<double>& z_destination);
+    void SetupStringAttribute(int record_type, char* destination);
+    void SetupStringAttribute(int record_type, std::string& destination);
+    std::map<int, std::pair<void (*)(CDxfRead*, void*), void*>> m_coordinate_attributes;
+    static void ProcessScaledDouble(CDxfRead* object, void* target);
+    static void ProcessScaledDoubleIntoList(CDxfRead* object, void* target);
+    static void ProcessString(CDxfRead* object, void* target);
+    static void ProcessStdString(CDxfRead* object, void* target);
+    // For all types T where strean >> x and x = 0 works
+    template<typename T>
+    void SetupValueAttribute(int record_type, T& target);
+    // TODO: Once all compilers used for FreeCAD support class-level template specializations,
+    // SetupValueAttribute could have specializations and replace SetupStringAttribute etc.
+    // The template specialization is required to handle the (char *) case, which would
+    // otherwise try to read the actual pointer from the stream, or... what?
+    // The specialization would also handle the default value when it cannot be zero.
+    template<typename T>
+    static void ProcessValue(CDxfRead* object, void* target);
+
+    bool ProcessAttribute();
+    void ProcessAllAttributes();
+
     bool ReadBlockInfo();
     bool ReadVersion();
     bool ReadDWGCodePage();
     bool ResolveEncoding();
 
-    void get_line();
-    void put_line(const char* value);
-    void ResolveColorIndex();
+    bool get_next_record();
+    void repeat_last_record();
 
 protected:
-    ColorIndex_t m_ColorIndex;
-    eDXFVersion_t m_version;  // Version from $ACADVER variable in DXF
-    const char* (CDxfRead::*stringToUTF8)(const char*) const;
+    // common entity properties. Some properties are accumulated local to the reader method and
+    // passed to the ReadXxxx virtual method. Others are collected here as private values and also
+    // passed to ReadXxxx. Finally some of the attributes are accessed using references to
+    // public/protected fields or methods (such as LayerName()). Altogether a bit of a mishmash.
+    ColorIndex_t m_ColorIndex = 0;
+    char m_LineType[1024] = "";
+    eDXFVersion_t m_version = RUnknown;  // Version from $ACADVER variable in DXF
+    const char* (CDxfRead::*stringToUTF8)(const char*) const = &CDxfRead::UTF8ToUTF8;
+    // Although this is called "ImportWarning" it is just a wrapper to write a warning eithout any
+    // additional information such as a line number and as such, may be split into a basic
+    // message-writer and something that adds a line number.
+    template<typename... args>
+    void ImportError(const char* format, args... argValues) const
+    {
+        Base::ConsoleSingleton::Instance().Warning(format, argValues...);
+    }
+    void UnsupportedFeature(const char* format, ...);
 
 private:
-    const std::string* m_CodePage;  // Code Page name from $DWGCODEPAGE or null if none/not read yet
+    std::map<std::string, std::pair<int, int>> m_unsupportedFeaturesNoted;
+    const std::string* m_CodePage =
+        nullptr;  // Code Page name from $DWGCODEPAGE or null if none/not read yet
     // The following was going to be python's canonical name for the encoding, but this is (a) not
     // easily found and (b) does not speed up finding the encoding object.
-    const std::string* m_encoding;  // A name for the encoding implied by m_version and m_CodePage
+    const std::string* m_encoding =
+        nullptr;  // A name for the encoding implied by m_version and m_CodePage
     const char* UTF8ToUTF8(const char* encoded) const;
     const char* GeneralToUTF8(const char* encoded) const;
 
 public:
-    CDxfRead(const char* filepath);  // this opens the file
-    virtual ~CDxfRead();             // this closes the file
+    explicit CDxfRead(const char* filepath);  // this opens the file
+    virtual ~CDxfRead();                      // this closes the file
 
     bool Failed()
     {
@@ -433,6 +523,12 @@ public:
     virtual void AddGraphics() const
     {}
 
+    // These give the derived class access to common object properties
     std::string LayerName() const;
+    bool LineTypeIsHidden() const
+    {
+        return m_LineType[0] == 'h' || m_LineType[0] == 'H';
+    }
+    App::Color ObjectColor() const;  // as rgba value
 };
 #endif

--- a/src/Mod/Import/Gui/CMakeLists.txt
+++ b/src/Mod/Import/Gui/CMakeLists.txt
@@ -25,6 +25,8 @@ SET(ImportGui_SRCS
     Command.cpp
     ExportOCAFGui.cpp
     ExportOCAFGui.h
+    dxf/ImpExpDxfGui.cpp
+    dxf/ImpExpDxfGui.h
     ImportOCAFGui.cpp
     ImportOCAFGui.h
     OCAFBrowser.cpp

--- a/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
+++ b/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
@@ -1,0 +1,71 @@
+/***************************************************************************
+ *   Copyright (c) 2015 Yorik van Havre (yorik@uncreated.net)              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef _PreComp_
+#include <Standard_Version.hxx>
+#if OCC_VERSION_HEX < 0x070600
+#include <BRepAdaptor_HCurve.hxx>
+#endif
+#include <Approx_Curve3d.hxx>
+#include <BRepAdaptor_Curve.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <BRep_Builder.hxx>
+#include <GCPnts_UniformAbscissa.hxx>
+#include <GeomAPI_Interpolate.hxx>
+#include <GeomAPI_PointsToBSpline.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Shape.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <gp_Ax1.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Elips.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Vec.hxx>
+#endif
+
+//#include <App/Annotation.h>
+//#include <App/Application.h>
+//#include <App/Document.h>
+//#include <Base/Console.h>
+//#include <Base/Interpreter.h>
+//#include <Base/Matrix.h>
+//#include <Base/Parameter.h>
+//#include <Base/Vector3D.h>
+//#include <Base/PlacementPy.h>
+//#include <Mod/Part/App/PartFeature.h>
+
+#include "ImpExpDxfGui.h"
+
+using namespace ImportGui;
+
+ImpExpDxfReadGui::ImpExpDxfReadGui(std::string filepath, App::Document* pcDoc)
+    : ImpExpDxfRead(filepath, pcDoc)
+{}
+

--- a/src/Mod/Import/Gui/dxf/ImpExpDxfGui.h
+++ b/src/Mod/Import/Gui/dxf/ImpExpDxfGui.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *   Copyright (c) 2015 Yorik van Havre (yorik@uncreated.net)              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef IMPEXPDXFGUI_H
+#define IMPEXPDXFGUI_H
+
+#include <gp_Pnt.hxx>
+
+#include <App/Document.h>
+#include <Mod/Part/App/TopoShape.h>
+
+#include <Mod/Import/App/dxf/ImpExpDxf.h>
+
+
+namespace ImportGui
+{
+class ImpExpDxfReadGui: public Import::ImpExpDxfRead
+{
+public:
+    ImpExpDxfReadGui(std::string filepath, App::Document* pcDoc);
+};
+}  // namespace ImportGui
+
+#endif  // IMPEXPDXFGUI_H

--- a/src/Mod/Import/Gui/dxf/ImpExpDxfGui.h
+++ b/src/Mod/Import/Gui/dxf/ImpExpDxfGui.h
@@ -26,6 +26,7 @@
 #include <gp_Pnt.hxx>
 
 #include <App/Document.h>
+#include <Gui/Document.h>
 #include <Mod/Part/App/TopoShape.h>
 
 #include <Mod/Import/App/dxf/ImpExpDxf.h>
@@ -37,6 +38,11 @@ class ImpExpDxfReadGui: public Import::ImpExpDxfRead
 {
 public:
     ImpExpDxfReadGui(std::string filepath, App::Document* pcDoc);
+
+protected:
+    void ApplyGuiStyles(Part::Feature*);
+    void ApplyGuiStyles(App::FeaturePython*);
+    Gui::Document* GuiDocument;
 };
 }  // namespace ImportGui
 


### PR DESCRIPTION
Fixes #8806
Fixes #6924
This change:

1. Provides a hook for GUI-dependent code in the C++ importer (since color is a Gui concept) via a new class `ImpExpDxfReadGui` derived from `ImpExpDxfRead` and ultimately created by importDXF.py if the ImportGui module is available.
2. Sets the color on created FreeCAD objects based on the color specified in the DXF file, including handling BYLAYER color, using a new virtual methods which do nothing in `ImpExpDxfRead` but set color in `ImpExpDxfReadGui`.
3. Refactors the reader code in CDxfRead to remove substantial duplication involved in reading the individual attribute records that make up each entity. My goal here was to eliminate, or at least greatly reduce, the lint that shows up when a PR is submitted, and on noticing that it was mostly the same lint duplicated about a dozen times, it seemed clear that the code should be shared rather than duplicated. The refactored code is also much less likely to get out of sync between reading record types and record contents (the cause for #6924).
4. Annotates (on the Python console) unimplemented features of DXF. This annotation is incomplete (there are still plenty of features that are quietly ignored), but it might help someone importing a file to realize what might be missing from their drawing.