### PR TITLE
Draft: increase DXF Python library version to 1.42

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -48,7 +48,7 @@ texts, colors,layers (from groups)
 # scaling factor between autocad font sizes and coin font sizes
 TEXTSCALING = 1.35
 # the minimum version of the dxfLibrary needed to run
-CURRENTDXFLIB = 1.41
+CURRENTDXFLIB = 1.42
 
 import sys
 import os


### PR DESCRIPTION
See: https://github.com/yorikvanhavre/Draft-dxf-importer/pull/28
