### PR TITLE
Add test for child visibility in Arch BuildingPart or GroupExtensions

### DIFF
--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -365,7 +365,7 @@ void GroupExtension::extensionOnChanged(const Property* p) {
 
 void GroupExtension::slotChildChanged(const DocumentObject &obj, const Property &prop) {
     if(&prop == &obj.Visibility)
-        _GroupTouched.touch();}
+        _GroupTouched.touch();
 }
 
 bool GroupExtension::extensionGetSubObject(DocumentObject *&ret, const char *subname,

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -364,6 +364,8 @@ void GroupExtension::extensionOnChanged(const Property* p) {
 }
 
 void GroupExtension::slotChildChanged(const DocumentObject &obj, const Property &prop) {
+    if(&prop == &obj.Visibility)
+        _GroupTouched.touch();}
 }
 
 bool GroupExtension::extensionGetSubObject(DocumentObject *&ret, const char *subname,

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -364,8 +364,6 @@ void GroupExtension::extensionOnChanged(const Property* p) {
 }
 
 void GroupExtension::slotChildChanged(const DocumentObject &obj, const Property &prop) {
-    if(&prop == &obj.Visibility)
-        _GroupTouched.touch();
 }
 
 bool GroupExtension::extensionGetSubObject(DocumentObject *&ret, const char *subname,

--- a/src/Mod/Arch/TestArch.py
+++ b/src/Mod/Arch/TestArch.py
@@ -713,10 +713,50 @@ class ArchTest(unittest.TestCase):
         Arch.removeComponents(win, host=wall)
         App.ActiveDocument.recompute()
         bp = Arch.makeBuildingPart()
+
+        # Wall visibility works when standalone
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection('ArchTest',wall.Name)
+        assert wall.Visibility
+        FreeCADGui.runCommand('Std_ToggleVisibility',0)
+        App.ActiveDocument.recompute()
+        assert not wall.Visibility
+        FreeCADGui.runCommand('Std_ToggleVisibility',0)
+        assert wall.Visibility
+
         bp.Group = [wall]
         App.ActiveDocument.recompute()
         # Fails with OCC 7.5
         # self.assertTrue(len(bp.Shape.Faces) == 16, "'{}' failed".format(operation))
+
+        # Wall visibility works when inside a BuildingPart
+        FreeCADGui.runCommand('Std_ToggleVisibility',0)
+        App.ActiveDocument.recompute()
+        assert not wall.Visibility
+        FreeCADGui.runCommand('Std_ToggleVisibility',0)
+        assert wall.Visibility
+
+        # Wall visibility works when BuildingPart Toggled
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection('ArchTest',bp.Name)
+        FreeCADGui.runCommand('Std_ToggleVisibility',0)
+        assert not wall.Visibility
+        FreeCADGui.runCommand('Std_ToggleVisibility',0)
+        assert wall.Visibility
+
+        # Wall visibiity works inside group inside BuildingPart Toggled
+        grp = App.ActiveDocument.addObject("App::DocumentObjectGroup","Group")
+        grp.Label="Group"
+        grp.Group = [wall]
+        bp.Group = [grp]
+        App.ActiveDocument.recompute()
+        assert wall.Visibility
+        FreeCADGui.runCommand('Std_ToggleVisibility',0)
+        App.ActiveDocument.recompute()
+        assert not wall.Visibility
+        FreeCADGui.runCommand('Std_ToggleVisibility',0)
+        App.ActiveDocument.recompute()
+        assert wall.Visibility
 
     def tearDown(self):
         App.closeDocument("ArchTest")


### PR DESCRIPTION
Fix for #9277.

This fixes the immediate issue with space bar or Std_ToggleVisibility,  Thats a step forward.  It seems to allow all the visibility switches at each level to not be overridden when you set them manually,  fixing that issue as well.

I'm not sure if the exact behaviors when you have architectural parts inside a group inside a BuildingPart are completely what we want - you can turn visibility on and off at each level, and it affects the parts at the bottom just fine.  I'm not sure what our expected behaviors are for all permutations of Vis On/Off inside of Vis On/Off inside of Vis On/Off.

The complexity level here is fairly high ( at least for my experience level in this codebase), and it took quite a bit of debug time to locate the issue.