### PR TITLE
Detect circular references in sketches, and add corresponding tests

### DIFF
--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -1725,8 +1725,6 @@ Py::Object ObjectIdentifier::access(const ResolveResults &result,
         else if(lastObj) {
             const char *attr = components[idx].getName().c_str();
             auto prop = lastObj->getPropertyByName(attr);
-            // if(!prop && !pyobj.hasAttr(attr))
-                // attr = nullptr;
             setPropDep(lastObj,prop,attr);
             lastObj = nullptr;
         }

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -1725,8 +1725,8 @@ Py::Object ObjectIdentifier::access(const ResolveResults &result,
         else if(lastObj) {
             const char *attr = components[idx].getName().c_str();
             auto prop = lastObj->getPropertyByName(attr);
-            if(!prop && !pyobj.hasAttr(attr))
-                attr = nullptr;
+            // if(!prop && !pyobj.hasAttr(attr))
+                // attr = nullptr;
             setPropDep(lastObj,prop,attr);
             lastObj = nullptr;
         }

--- a/src/Mod/Part/parttests/regression_tests.py
+++ b/src/Mod/Part/parttests/regression_tests.py
@@ -1,4 +1,4 @@
-from FreeCAD import Vector
+from FreeCAD import Vector, newDocument, closeDocument
 import Part
 
 import unittest
@@ -23,3 +23,27 @@ class RegressionTests(unittest.TestCase):
     def test_OptimalBox(self):
         box = Part.makeBox(1, 1, 1)
         self.assertTrue(box.optimalBoundingBox(True, False).isValid())
+
+    def test_CircularReference(self):
+        # put me in def setup(self): ?
+        self.Doc = newDocument("TestSketchExpr")
+
+        cube = self.Doc.addObject("Part::Box","Cube")
+        cube.setExpression('Length', 'Width + 10mm')
+        with self.assertRaises(RuntimeError) as context:
+            cube.setExpression('Width', 'Length + 10mm')
+        assert "Width reference creates a cyclic dependency." in str(context.exception)
+
+        cube.setExpression('.Placement.Base.x', '.Placement.Base.y + 10mm')
+        with self.assertRaises(RuntimeError) as context:
+            cube.setExpression('.Placement.Base.y', '.Placement.Base.x + 10mm')
+        assert ".Placement.Base.y reference creates a cyclic dependency." in str(context.exception)
+
+        cube.recompute()
+        v1 = cube.Placement.Base
+        cube.recompute()
+        assert cube.Placement.Base.isEqual(v1,1e-6)
+
+        # Put me in def tearDown(self): ?
+        closeDocument(self.Doc.Name)
+

--- a/src/Mod/Sketcher/SketcherTests/TestSketchExpression.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchExpression.py
@@ -63,7 +63,7 @@ class TestSketchExpression(unittest.TestCase):
         sketch.renameConstraint(length, "Length")
         sketch.renameConstraint(height, "Height")
 
-        sketch.setExpression("Constraints[{}]".format(height), ".Constraints.Length * 2")
+        sketch.setExpression("Constraints[{}]".format(height), ".Constraints.Length")
 
         with self.assertRaises(RuntimeError) as context:
             sketch.setExpression("Constraints.Length", ".Constraints.Length * 2")

--- a/src/Mod/Sketcher/SketcherTests/TestSketchExpression.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchExpression.py
@@ -73,22 +73,6 @@ class TestSketchExpression(unittest.TestCase):
             sketch.setExpression("Constraints.Length", ".Constraints.Height * 2")
         assert ".Constraints.Length reference creates a cyclic dependency." in str(context.exception)
 
-        cube = self.Doc.addObject("Part::Box","Cube")
-        cube.setExpression('Length', 'Width + 10mm')
-        with self.assertRaises(RuntimeError) as context:
-            cube.setExpression('Width', 'Length + 10mm')
-        assert "Width reference creates a cyclic dependency." in str(context.exception)
-
-        cube.setExpression('.Placement.Base.x', '.Placement.Base.y + 10mm')
-        with self.assertRaises(RuntimeError) as context:
-            cube.setExpression('.Placement.Base.y', '.Placement.Base.x + 10mm')
-        assert ".Placement.Base.y reference creates a cyclic dependency." in str(context.exception)
-
-        cube.recompute()
-        v1 = cube.Placement.Base
-        cube.recompute()
-        assert cube.Placement.Base.isEqual(v1,1e-6)
-
     def tearDown(self):
         # comment out to omit closing document for debugging
         FreeCAD.closeDocument(self.Doc.Name)

--- a/src/Mod/Sketcher/SketcherTests/TestSketchExpression.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchExpression.py
@@ -67,11 +67,15 @@ class TestSketchExpression(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as context:
             sketch.setExpression("Constraints.Length", ".Constraints.Length * 2")
-        assert ".Constraints.Length reference creates a cyclic dependency." in str(context.exception)
+        assert ".Constraints.Length reference creates a cyclic dependency." in str(
+            context.exception
+        )
 
         with self.assertRaises(RuntimeError) as context:
             sketch.setExpression("Constraints.Length", ".Constraints.Height * 2")
-        assert ".Constraints.Length reference creates a cyclic dependency." in str(context.exception)
+        assert ".Constraints.Length reference creates a cyclic dependency." in str(
+            context.exception
+        )
 
     def tearDown(self):
         # comment out to omit closing document for debugging


### PR DESCRIPTION
Fix #10482.