### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     -   id: check-added-large-files
     -   id: mixed-line-ending
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.12.0
     hooks:
         -   id: black
             args: ['--line-length', '100']

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_git.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_git.py
@@ -35,7 +35,6 @@ from addonmanager_git import GitManager, NoGitFound, GitFailed
 
 
 class TestGit(unittest.TestCase):
-
     MODULE = "test_git"  # file name without extension
 
     def setUp(self):

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_utilities.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_utilities.py
@@ -36,7 +36,6 @@ from addonmanager_utilities import (
 
 
 class TestUtilities(unittest.TestCase):
-
     MODULE = "test_utilities"  # file name without extension
 
     def setUp(self):

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_gui.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_gui.py
@@ -26,7 +26,6 @@ import FreeCAD
 
 
 class TestGui(unittest.TestCase):
-
     MODULE = "test_gui"  # file name without extension
 
     def setUp(self):

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_installer_gui.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_installer_gui.py
@@ -37,7 +37,6 @@ translate = FreeCAD.Qt.translate
 
 
 class TestInstallerGui(unittest.TestCase):
-
     MODULE = "test_installer_gui"  # file name without extension
 
     def setUp(self):
@@ -389,7 +388,6 @@ class TestMacroInstallerGui(unittest.TestCase):
         self.assertEqual(name, "UnitTestCustomToolbar")
 
     def test_ask_for_toolbar_with_dialog_cancelled(self):
-
         # First test: the user cancels the dialog
         self.installer.addon_params.set("alwaysAskForToolbar", True)
         dialog_watcher = DialogWatcher(
@@ -400,7 +398,6 @@ class TestMacroInstallerGui(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_ask_for_toolbar_with_dialog_defaults(self):
-
         # Second test: the user leaves the dialog at all default values, so:
         #   - The checkbox "Ask every time" is unchecked
         #   - The selected toolbar option is "Create new toolbar", which triggers a search for
@@ -422,7 +419,6 @@ class TestMacroInstallerGui(unittest.TestCase):
         self.assertTrue(dialog_watcher.button_found, "Failed to find the expected button")
 
     def test_ask_for_toolbar_with_dialog_selection(self):
-
         # Third test: the user selects a custom toolbar in the dialog, and checks the box to always
         # ask.
         dialog_interactor = DialogInteractor(
@@ -444,7 +440,6 @@ class TestMacroInstallerGui(unittest.TestCase):
         self.assertTrue(self.installer.addon_params.get("alwaysAskForToolbar", False))
 
     def interactor_selection_option_and_checkbox(self, parent):
-
         boxes = parent.findChildren(QtWidgets.QComboBox)
         self.assertEqual(len(boxes), 1)  # Just to make sure...
         box = boxes[0]

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_uninstaller_gui.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_uninstaller_gui.py
@@ -41,7 +41,6 @@ translate = FreeCAD.Qt.translate
 
 
 class TestUninstallerGUI(unittest.TestCase):
-
     MODULE = "test_uninstaller_gui"  # file name without extension
 
     def setUp(self):

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_workers_startup.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_workers_startup.py
@@ -42,7 +42,6 @@ run_slow_tests = False
 
 
 class TestWorkersStartup(unittest.TestCase):
-
     MODULE = "test_workers_startup"  # file name without extension
 
     @unittest.skipUnless(run_slow_tests, "This integration test is slow and uses the network")

--- a/src/Mod/AddonManager/AddonManagerTest/gui/test_workers_utility.py
+++ b/src/Mod/AddonManager/AddonManagerTest/gui/test_workers_utility.py
@@ -31,7 +31,6 @@ import NetworkManager
 
 
 class TestWorkersUtility(unittest.TestCase):
-
     MODULE = "test_workers_utility"  # file name without extension
 
     @unittest.skip("Test is slow and uses the network: refactor!")

--- a/src/Mod/AddonManager/NetworkManager.py
+++ b/src/Mod/AddonManager/NetworkManager.py
@@ -428,7 +428,8 @@ if HAVE_QTNETWORK:
             authenticator: QtNetwork.QAuthenticator,
         ):
             """If proxy authentication is required, attempt to authenticate. If the GUI is running this displays
-            a window asking for credentials. If the GUI is not running, it prompts on the command line."""
+            a window asking for credentials. If the GUI is not running, it prompts on the command line.
+            """
             if HAVE_FREECAD and FreeCAD.GuiUp:
                 proxy_authentication = FreeCADGui.PySideUic.loadUi(
                     os.path.join(os.path.dirname(__file__), "proxy_authentication.ui")
@@ -618,7 +619,6 @@ def InitializeNetworkManager():
 
 
 if __name__ == "__main__":
-
     app = QtCore.QCoreApplication()
 
     InitializeNetworkManager()

--- a/src/Mod/AddonManager/addonmanager_devmode_person_editor.py
+++ b/src/Mod/AddonManager/addonmanager_devmode_person_editor.py
@@ -38,7 +38,6 @@ class PersonEditor:
     """Create or edit a maintainer or author record."""
 
     def __init__(self):
-
         self.dialog = FreeCADGui.PySideUic.loadUi(
             os.path.join(os.path.dirname(__file__), "developer_mode_people.ui")
         )

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -44,7 +44,6 @@ except ImportError:
 import addonmanager_freecad_interface as fci
 
 if fci.FreeCADGui:
-
     # If the GUI is up, we can use the NetworkManager to handle our downloads. If there is no event
     # loop running this is not possible, so fall back to requests (if available), or the native
     # Python urllib.request (if requests is not available).

--- a/src/Mod/AddonManager/addonmanager_workers_installation.py
+++ b/src/Mod/AddonManager/addonmanager_workers_installation.py
@@ -69,7 +69,6 @@ class UpdateMetadataCacheWorker(QtCore.QThread):
         ICON = auto()
 
     def __init__(self, repos):
-
         QtCore.QThread.__init__(self)
         self.repos = repos
         self.requests: Dict[int, (Addon, UpdateMetadataCacheWorker.RequestType)] = {}

--- a/src/Mod/AddonManager/addonmanager_workers_startup.py
+++ b/src/Mod/AddonManager/addonmanager_workers_startup.py
@@ -151,7 +151,6 @@ class CreateAddonListWorker(QtCore.QThread):
                     )
 
     def _get_custom_addons(self):
-
         # querying custom addons first
         addon_list = (
             FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
@@ -518,7 +517,6 @@ class CheckWorkbenchesForUpdatesWorker(QtCore.QThread):
     progress_made = QtCore.Signal(int, int)
 
     def __init__(self, repos: List[Addon]):
-
         QtCore.QThread.__init__(self)
         self.repos = repos
         self.current_thread = None
@@ -615,7 +613,6 @@ class UpdateChecker:
 
         clonedir = self.moddir + os.sep + package.name
         if os.path.exists(clonedir):
-
             # First, try to just do a git-based update, which will give the most accurate results:
             if self.git_manager:
                 self.check_workbench(package)
@@ -861,7 +858,6 @@ class GetMacroDetailsWorker(QtCore.QThread):
     readme_updated = QtCore.Signal(str)
 
     def __init__(self, repo):
-
         QtCore.QThread.__init__(self)
         self.macro = repo.macro
 

--- a/src/Mod/AddonManager/change_branch.py
+++ b/src/Mod/AddonManager/change_branch.py
@@ -39,7 +39,6 @@ except Exception:
 
 
 class ChangeBranchDialog(QtWidgets.QWidget):
-
     branch_changed = QtCore.Signal(str)
 
     def __init__(self, path: os.PathLike, parent=None):
@@ -80,7 +79,6 @@ class ChangeBranchDialog(QtWidgets.QWidget):
 
     def exec(self):
         if self.ui.exec() == QtWidgets.QDialog.Accepted:
-
             selection = self.ui.tableView.selectedIndexes()
             index = self.item_filter.mapToSource(selection[0])
             ref = self.item_model.data(index, ChangeBranchDialogModel.RefAccessRole)
@@ -137,7 +135,6 @@ class ChangeBranchDialog(QtWidgets.QWidget):
 
 
 class ChangeBranchDialogModel(QtCore.QAbstractTableModel):
-
     refs = []
     display_data = []
     DataSortRole = QtCore.Qt.UserRole

--- a/src/Mod/Assembly/CommandCreateJoint.py
+++ b/src/Mod/Assembly/CommandCreateJoint.py
@@ -46,7 +46,6 @@ class CommandCreateJointFixed:
         pass
 
     def GetResources(self):
-
         return {
             "Pixmap": "Assembly_CreateJointFixed",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateJointFixed", "Create Fixed Joint"),
@@ -76,7 +75,6 @@ class CommandCreateJointRevolute:
         pass
 
     def GetResources(self):
-
         return {
             "Pixmap": "Assembly_CreateJointRevolute",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateJointRevolute", "Create Revolute Joint"),
@@ -106,7 +104,6 @@ class CommandCreateJointCylindrical:
         pass
 
     def GetResources(self):
-
         return {
             "Pixmap": "Assembly_CreateJointCylindrical",
             "MenuText": QT_TRANSLATE_NOOP(
@@ -138,7 +135,6 @@ class CommandCreateJointSlider:
         pass
 
     def GetResources(self):
-
         return {
             "Pixmap": "Assembly_CreateJointSlider",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateJointSlider", "Create Slider Joint"),
@@ -168,7 +164,6 @@ class CommandCreateJointBall:
         pass
 
     def GetResources(self):
-
         return {
             "Pixmap": "Assembly_CreateJointBall",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateJointBall", "Create Ball Joint"),
@@ -198,7 +193,6 @@ class CommandCreateJointPlanar:
         pass
 
     def GetResources(self):
-
         return {
             "Pixmap": "Assembly_CreateJointPlanar",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateJointPlanar", "Create Planar Joint"),
@@ -228,7 +222,6 @@ class CommandCreateJointParallel:
         pass
 
     def GetResources(self):
-
         return {
             "Pixmap": "Assembly_CreateJointParallel",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateJointParallel", "Create Parallel Joint"),
@@ -258,7 +251,6 @@ class CommandCreateJointTangent:
         pass
 
     def GetResources(self):
-
         return {
             "Pixmap": "Assembly_CreateJointTangent",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateJointTangent", "Create Tangent Joint"),

--- a/src/Mod/Drawing/DrawingPatterns.py
+++ b/src/Mod/Drawing/DrawingPatterns.py
@@ -135,7 +135,6 @@ AutocadPatterns = {
 
 
 def buildPattern(name, scale=5, thickness=1, color="#000000"):
-
     """buildPattern(name,scale=5,thickness=1,color="#000000")
     builds an SVG <pattern> fragment from a name and path data"""
 
@@ -158,7 +157,6 @@ def buildPattern(name, scale=5, thickness=1, color="#000000"):
 
 
 def buildTextureImage(name, scale=5, thickness=1, color="#000000", size=64):
-
     """buildTextureImage(name,scale,thickness,color="#000000",size=64)
     builds a 64x64 SVG image filled with the given texture"""
 
@@ -190,7 +188,6 @@ def buildTextureImage(name, scale=5, thickness=1, color="#000000", size=64):
 
 
 def buildSwatch(name, scale=5, thickness=1, color="#000000", size=64):
-
     """buildSwatch(name,scale,thickness,color="#000000",size=64)
     builds a 64x64 SVG image filled with the given texture, a
     white background and a border, to serve as a sample"""
@@ -229,7 +226,6 @@ def buildSwatch(name, scale=5, thickness=1, color="#000000", size=64):
 
 
 def buildFileSwatch(name, scale=5, thickness=1, color="#000000", size=64, png=False):
-
     """buildFileSwatch(name,scale,thickness,color="#000000",size=64,png=False)
     builds a 64x64 SVG image filled with the given texture, a
     white background and a border, to serve as a sample. The image
@@ -256,7 +252,6 @@ def buildFileSwatch(name, scale=5, thickness=1, color="#000000", size=64, png=Fa
 
 
 def saveTestImage(filename, scales=[2.5, 5], thicknesses=[0.1, 0.2, 1]):
-
     """saveTestImage(filename,scales=[2.5,5],thicknesses=[0.1,0.2,1])
     builds a test SVG file showing all available patterns at given scales and thicknesses"""
 
@@ -296,7 +291,6 @@ def saveTestImage(filename, scales=[2.5, 5], thicknesses=[0.1, 0.2, 1]):
 
 
 def decodeName(name, scale, thickness):
-
     """decodeName(name,scale,thickness) : decodes names written in the form 'name_5_1'"""
 
     name = name.split("_")
@@ -314,7 +308,6 @@ def decodeName(name, scale, thickness):
 
 
 def getPatternNames():
-
     """getPatternNames : returns available pattern names"""
 
     return Patterns.keys()

--- a/src/Mod/Import/App/PlmXmlParser.py
+++ b/src/Mod/Import/App/PlmXmlParser.py
@@ -154,7 +154,6 @@ def main():
 
 
 def parse(fileName):
-
     tree = ET.parse(fileName)
     root = tree.getroot()
     ProductDef = root.find("{http://www.plmxml.org/Schemas/PLMXMLSchema}ProductDef")

--- a/src/Mod/Import/stepZ.py
+++ b/src/Mod/Import/stepZ.py
@@ -78,7 +78,6 @@ def sayzerr(msg):
 
 
 def import_stpz(fn, fc, doc):
-
     # sayz(fn)
     ext = os.path.splitext(os.path.basename(fn))[1]
     fname = os.path.splitext(os.path.basename(fn))[0]
@@ -106,7 +105,6 @@ def import_stpz(fn, fc, doc):
 
 
 def open(filename, doc=None):
-
     if zf.is_zipfile(filename):
         with zf.ZipFile(filename, "r") as fz:
             file_names = fz.namelist()
@@ -127,7 +125,6 @@ def open(filename, doc=None):
 
 
 def insert(filename, doc):
-
     doc = FreeCAD.ActiveDocument
     open(filename, doc)
 

--- a/src/Mod/Show/ShowUtils.py
+++ b/src/Mod/Show/ShowUtils.py
@@ -23,7 +23,8 @@
 
 def is3DObject(obj):
     """is3DObject(obj): tests if the object has some 3d geometry.
-    TempoVis is made only for objects in 3d view, so all objects that don't pass this check are ignored by TempoVis."""
+    TempoVis is made only for objects in 3d view, so all objects that don't pass this check are ignored by TempoVis.
+    """
 
     # See "Gui Problem Sketcher and TechDraw" https://forum.freecad.org/viewtopic.php?f=3&t=22797
 

--- a/src/Mod/Show/mTempoVis.py
+++ b/src/Mod/Show/mTempoVis.py
@@ -79,7 +79,8 @@ class TempoVis(object):
     MAINSTACK special value (a global stack for the document will be used), or
     None (then, the TV is not in any stack, and can be manually instertd into one if desired).
 
-    Any additional keyword args are assigned as attributes. You can use it to immediately set a tag, for example."""
+    Any additional keyword args are assigned as attributes. You can use it to immediately set a tag, for example.
+    """
 
     document = None
     stack = None  # reference to stack this TV is in
@@ -323,7 +324,8 @@ class TempoVis(object):
     def show(self, doc_obj_or_list, links_too=True, mild_restore=None):
         """show(doc_obj_or_list, links_too = True): shows objects (sets their Visibility to True).
         doc_obj_or_list can be a document object, or a list of document objects.
-        If links_too is True, all Links of the objects are also hidden, by setting LinkVisibility attribute of each object."""
+        If links_too is True, all Links of the objects are also hidden, by setting LinkVisibility attribute of each object.
+        """
         doc_obj_or_list = self._3D_objects(doc_obj_or_list)
         self.saveBodyVisibleFeature(
             doc_obj_or_list
@@ -437,7 +439,8 @@ class TempoVis(object):
 
         Implementation detail: uses SoClipPlane node. If viewprovider already has a node
         of this type as direct child, one is used. Otherwise, new one is created and
-        inserted as the very first node. The node is left, but disabled when tempovis is restoring."""
+        inserted as the very first node. The node is left, but disabled when tempovis is restoring.
+        """
 
         from .SceneDetails.ObjectClipPlane import ObjectClipPlane
         from .ShowUtils import is3DObject

--- a/src/Mod/Sketcher/ProfileLib/RegularPolygon.py
+++ b/src/Mod/Sketcher/ProfileLib/RegularPolygon.py
@@ -38,7 +38,6 @@ def makeRegularPolygon(
     firstCornerPoint=App.Vector(-20.00, 34.64, 0),
     construction=False,
 ):
-
     if not sketch:
         App.Console.PrintError("No sketch specified in 'makeRegularPolygon'")
         return

--- a/src/Mod/Spreadsheet/importXLSX.py
+++ b/src/Mod/Spreadsheet/importXLSX.py
@@ -408,7 +408,6 @@ def handleStrings(theStr, sList):
 
 
 def open(nameXLSX):
-
     if len(nameXLSX) > 0:
         z = zipfile.ZipFile(nameXLSX)
 

--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -92,7 +92,6 @@ def useCachedPNG(image, project):
 
 
 def gethexcolor(color):
-
     "returns a color hex value #000000"
 
     r = str(hex(int(((color >> 24) & 0xFF))))[2:].zfill(2)
@@ -102,7 +101,6 @@ def gethexcolor(color):
 
 
 def isOpenableByFreeCAD(filename):
-
     "check if FreeCAD can handle this file type"
 
     if os.path.isdir(filename):
@@ -120,7 +118,6 @@ def isOpenableByFreeCAD(filename):
 
 
 def getInfo(filename):
-
     "returns available file information"
 
     global iconbank, tempfolder
@@ -166,7 +163,6 @@ def getInfo(filename):
         return None
 
     if os.path.exists(filename):
-
         if os.path.isdir(filename):
             return None
 
@@ -286,7 +282,6 @@ def getInfo(filename):
 
 
 def getDefaultIcon():
-
     "retrieves or creates a default file icon"
 
     global defaulticon
@@ -304,7 +299,6 @@ def getDefaultIcon():
 
 
 def build_new_file_card(template):
-
     """builds an html <li> element representing a new file
     quick start button"""
 
@@ -354,7 +348,6 @@ def build_new_file_card(template):
 
 
 def buildCard(filename, method, arg=None):
-
     """builds an html <li> element representing a file.
     method is a script + a keyword, for ex. url.py?key="""
 
@@ -393,7 +386,6 @@ def buildCard(filename, method, arg=None):
 
 
 def handle():
-
     "builds the HTML code of the start page"
 
     global iconbank, tempfolder
@@ -835,7 +827,6 @@ def handle():
 
 
 def exportTestFile():
-
     "Allow to check if everything is Ok"
 
     with codecs.open(
@@ -848,7 +839,6 @@ def exportTestFile():
 
 
 def postStart(switch_wb=True):
-
     "executes needed operations after loading a file"
 
     param = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Start")
@@ -882,7 +872,6 @@ def postStart(switch_wb=True):
 
 
 def checkPostOpenStartPage():
-
     "on Start WB startup, check if we are loading a file and therefore need to close the StartPage"
 
     import Start

--- a/src/Mod/Start/StartPage/TranslationTexts.py
+++ b/src/Mod/Start/StartPage/TranslationTexts.py
@@ -23,7 +23,6 @@ from PySide import QtGui
 
 
 def translate(context, text):
-
     "convenience function for the Qt translator"
 
     try:
@@ -36,7 +35,6 @@ def translate(context, text):
 
 
 def get(handle):
-
     "returns the translated text of the given handle"
 
     T_TITLE = translate("StartPage", "Start")

--- a/src/Mod/Start/TestStart/TestStartPage.py
+++ b/src/Mod/Start/TestStart/TestStartPage.py
@@ -213,7 +213,6 @@ class TestStartPage(unittest.TestCase):
             )
 
     def sanitize(self, html):
-
         # Anonymize all local filenames
         fileRE = re.compile(r'"file:///.*?"')
         html = fileRE.sub(repl=r'"file:///A/B/C"', string=html)

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -560,6 +560,7 @@ class DocumentBasicCases(unittest.TestCase):
     def testNotification_Issue2996(self):
         if not FreeCAD.GuiUp:
             return
+
         # works only if Gui is shown
         class ViewProvider:
             def __init__(self, vobj):
@@ -794,7 +795,6 @@ class DocumentRecomputeCases(unittest.TestCase):
         self.L2.Link = self.L3
 
     def testRecompute(self):
-
         # sequence to test recompute behaviour
         #       L1---\    L7
         #      /  \   \    |
@@ -1130,7 +1130,6 @@ class UndoRedoCases(unittest.TestCase):
         self.assertEqual(self.Doc.RedoCount, 0)
 
     def testUndoInList(self):
-
         self.Doc.UndoMode = 1
 
         self.Doc.openTransaction("Box")
@@ -1157,7 +1156,6 @@ class UndoRedoCases(unittest.TestCase):
         self.assertTrue(self.Cylinder.InList[0] == self.Doc.Fuse)
 
     def testUndoIssue0003150Part1(self):
-
         self.Doc.UndoMode = 1
 
         self.Doc.openTransaction("Box")
@@ -1284,7 +1282,6 @@ class DocumentGroupCases(unittest.TestCase):
         self.Doc.removeObject("Label_3")
 
     def testGroupAndGeoFeatureGroup(self):
-
         # an object can only be in one group at once, that must be enforced
         obj1 = self.Doc.addObject("App::FeatureTest", "obj1")
         grp1 = self.Doc.addObject("App::DocumentObjectGroup", "Group1")
@@ -2162,7 +2159,6 @@ class DocumentObserverCases(unittest.TestCase):
         self.Obs.clear()
 
     def testUndoDisabledDocument(self):
-
         # testing document level signals
         self.Doc1 = FreeCAD.newDocument("Observer1")
         self.Doc1.UndoMode = 0
@@ -2178,7 +2174,6 @@ class DocumentObserverCases(unittest.TestCase):
         self.Obs.clear()
 
     def testGuiObserver(self):
-
         if not FreeCAD.GuiUp:
             return
 

--- a/src/Mod/Test/TestGui.py
+++ b/src/Mod/Test/TestGui.py
@@ -33,6 +33,7 @@ import FreeCAD, FreeCADGui
 import TestApp  # Test as Module name not possible
 import sys
 
+
 # ---------------------------------------------------------------------------
 # define the Commands of the Test Application module
 # ---------------------------------------------------------------------------

--- a/src/Mod/Tux/PersistentToolbarsGui.py
+++ b/src/Mod/Tux/PersistentToolbarsGui.py
@@ -63,7 +63,6 @@ def onRestore(active):
     pSystem = App.ParamGet("User parameter:Tux/PersistentToolbars/System")
 
     for i in tb:
-
         isConnected(i)
 
         if i.objectName() and not i.isFloating():
@@ -92,7 +91,6 @@ def onRestore(active):
                 and i not in rightRestore
                 and i not in bottomRestore
             ):
-
                 area = mw.toolBarArea(toolbars[i])
 
                 if area == QtCore.Qt.ToolBarArea.LeftToolBarArea:
@@ -156,7 +154,6 @@ def onSave():
 
     for i in tb:
         if i.objectName() and i.isVisible() and not i.isFloating():
-
             area = mw.toolBarArea(i)
 
             x = i.geometry().x()

--- a/src/Tools/SubWCRev.py
+++ b/src/Tools/SubWCRev.py
@@ -19,6 +19,7 @@ try:
 except ImportError:
     from io import StringIO
 
+
 # SAX handler to parse the subversion output
 class SvnHandler(xml.sax.handler.ContentHandler):
     def __init__(self):

--- a/src/Tools/WinVersion.py
+++ b/src/Tools/WinVersion.py
@@ -9,7 +9,6 @@ import SubWCRev, getopt, sys, string
 
 
 def main():
-
     input = ""
     output = "."
 

--- a/src/Tools/doctools.py
+++ b/src/Tools/doctools.py
@@ -9,6 +9,7 @@ import xml.sax.handler
 import xml.sax.xmlreader
 import zipfile
 
+
 # SAX handler to parse the Document.xml
 class DocumentHandler(xml.sax.handler.ContentHandler):
     def __init__(self, dirname):

--- a/src/Tools/embedded/PySide/mainwindow.py
+++ b/src/Tools/embedded/PySide/mainwindow.py
@@ -21,6 +21,7 @@ class MainWindow(QtGui.QMainWindow):
     def showEvent(self, event):
         FreeCADGui.showMainWindow()
         self.setCentralWidget(FreeCADGui.getMainWindow())
+
         # Need version >= 0.16.5949
         class BlankWorkbench(FreeCADGui.Workbench):
             MenuText = "Blank"

--- a/src/Tools/embedded/PySide/mainwindow2.py
+++ b/src/Tools/embedded/PySide/mainwindow2.py
@@ -19,6 +19,7 @@ class MainWindow(QtGui.QMainWindow):
     def showEvent(self, event):
         FreeCADGui.showMainWindow()
         self.setCentralWidget(FreeCADGui.getMainWindow())
+
         # Need version >= 0.16.5949
         class BlankWorkbench(FreeCADGui.Workbench):
             MenuText = "Blank"

--- a/src/Tools/embedded/PySide/mainwindow3.py
+++ b/src/Tools/embedded/PySide/mainwindow3.py
@@ -28,6 +28,7 @@ class MainWindow(QtGui.QMainWindow):
         )
         addr = PyCObject_AsVoidPtr(hwnd)
         FreeCADGui.embedToWindow(hex(addr))
+
         # Need version >= 0.16.5949
         class BlankWorkbench(FreeCADGui.Workbench):
             MenuText = "Blank"

--- a/src/Tools/examplePy2wiki.py
+++ b/src/Tools/examplePy2wiki.py
@@ -36,7 +36,6 @@ def Process(line):
 
 
 def main():
-
     try:
         opts, args = getopt.getopt(
             sys.argv[1:], "hi:o:", ["help", "verbose", "in-file=", "out-file="]

--- a/src/Tools/fcinfo
+++ b/src/Tools/fcinfo
@@ -83,7 +83,6 @@ import re
 
 class FreeCADFileHandler(xml.sax.ContentHandler):
     def __init__(self, zfile, short=0):  # short: 0=normal, 1=short, 2=veryshort
-
         xml.sax.ContentHandler.__init__(self)
         self.zfile = zfile
         self.obj = None
@@ -93,7 +92,6 @@ class FreeCADFileHandler(xml.sax.ContentHandler):
         self.short = short
 
     def startElement(self, tag, attributes):
-
         if tag == "Document":
             self.obj = tag
             self.contents = {}
@@ -223,7 +221,6 @@ class FreeCADFileHandler(xml.sax.ContentHandler):
             self.contents = {}
 
     def endElement(self, tag):
-
         if (tag == "Document") and (self.short != 2):
             items = self.contents.items()
             items = sorted(items)
@@ -236,13 +233,11 @@ class FreeCADFileHandler(xml.sax.ContentHandler):
                     print("        " + key + " : " + value)
 
     def clean(self, value):
-
         value = value.strip()
         return value
 
 
 if __name__ == "__main__":
-
     if len(sys.argv) < 2:
         print(__doc__)
         sys.exit()

--- a/src/Tools/generateBase/generateTools.py
+++ b/src/Tools/generateBase/generateTools.py
@@ -26,6 +26,7 @@ def convertMultilineString(str):
 
 import sys
 
+
 # utility stuff to avoid tests in the mainline code
 class _nevermatch:
     "Polymorphic with a regex that never matches"

--- a/src/Tools/updatecrowdin.py
+++ b/src/Tools/updatecrowdin.py
@@ -221,7 +221,6 @@ THRESHOLD = 25  # how many % must be translated for the translation to be includ
 
 
 class CrowdinUpdater:
-
     BASE_URL = "https://api.crowdin.com/api/v2"
 
     def __init__(self, token, project_identifier, multithread=True):
@@ -337,7 +336,6 @@ def load_token():
 
 
 def updateqrc(qrcpath, lncode):
-
     "updates a qrc file with the given translation entry"
 
     # print("opening " + qrcpath + "...")
@@ -394,7 +392,6 @@ def updateqrc(qrcpath, lncode):
 
 
 def updateTranslatorCpp(lncode):
-
     "updates the Translator.cpp file with the given translation entry"
 
     cppfile = os.path.join(os.path.dirname(__file__), "..", "Gui", "Language", "Translator.cpp")
@@ -436,7 +433,6 @@ def updateTranslatorCpp(lncode):
 
 
 def doFile(tsfilepath, targetpath, lncode, qrcpath):
-
     "updates a single ts file, and creates a corresponding qm file"
 
     basename = os.path.basename(tsfilepath)[:-3]
@@ -471,7 +467,6 @@ def doFile(tsfilepath, targetpath, lncode, qrcpath):
 
 
 def doLanguage(lncode):
-
     "treats a single language"
 
     if lncode == "en":
@@ -492,7 +487,6 @@ def doLanguage(lncode):
 
 
 def applyTranslations(languages):
-
     global tempfolder
     currentfolder = os.getcwd()
     tempfolder = tempfile.mkdtemp()

--- a/src/Tools/updatets.py
+++ b/src/Tools/updatets.py
@@ -197,7 +197,6 @@ QT_VERSION_MAJOR = ""
 
 
 def find_tools(noobsolete=True):
-
     print(Usage + "\nFirst, lets find all necessary tools on your system")
     global QMAKE, LUPDATE, PYLUPDATE, LCONVERT, QT_VERSION_MAJOR
 
@@ -271,7 +270,6 @@ def find_tools(noobsolete=True):
 
 
 def update_translation(entry):
-
     global QMAKE, LUPDATE, LCONVERT, QT_VERSION_MAJOR
     cur = os.getcwd()
     log_redirect = f" 2>> {cur}/tsupdate_stderr.log 1>> {cur}/tsupdate_stdout.log"
@@ -415,7 +413,6 @@ def update_translation(entry):
 
 
 def main(mod=None):
-
     find_tools()
     path = os.path.realpath(__file__)
     path = os.path.dirname(path)


### PR DESCRIPTION
Change Log


23.12.0
Highlights
It's almost 2024, which means it's time for a new edition of Black's stable style! Together with this release, we'll put out an alpha release 24.1a1 showcasing the draft 2024 stable style, which we'll finalize in the January release. Please try it out and share your feedback.

This release (23.12.0) will still produce the 2023 style. Most but not all of the changes in --preview mode will be in the 2024 stable style.

Stable style
Fix bug where # fmt: off automatically dedents when used with the --line-ranges option, even when it is not within the specified line range. (#4084) Fix feature detection for parenthesized context managers (#4104) Preview style
Prefer more equal signs before a break when splitting chained assignments (#4010) Standalone form feed characters at the module level are no longer removed (#4021) Additional cases of immediately nested tuples, lists, and dictionaries are now indented less (#4012) Allow empty lines at the beginning of all blocks, except immediately before a docstring (#4060) Fix crash in preview mode when using a short --line-length (#4086) Keep suites consisting of only an ellipsis on their own lines if they are not functions or class definitions (#4066) (#4103) Configuration
--line-ranges now skips Black's internal stability check in --safe mode. This avoids a crash on rare inputs that have many unformatted same-content lines. (#4034) Packaging
Upgrade to mypy 1.7.1 (#4049) (#4069)
Faster compiled wheels are now available for CPython 3.12 (#4070) Integrations
Enable 3.12 CI (#4035)
Build docker images in parallel (#4054)
Build docker images with 3.12 (#4055)
23.11.0
Highlights
Support formatting ranges of lines with the new --line-ranges command-line option (#4020) Stable style
Fix crash on formatting bytes strings that look like docstrings (#4003) Fix crash when whitespace followed a backslash before newline in a docstring (#4008) Fix standalone comments inside complex blocks crashing Black (#4016) Fix crash on formatting code like await (a ** b) (#3994) No longer treat leading f-strings as docstrings. This matches Python's behaviour and fixes a crash (#4019) Preview style
Multiline dicts and lists that are the sole argument to a function are now indented less (#3964) Multiline unpacked dicts and lists as the sole argument to a function are now also indented less (#3992) In f-string debug expressions, quote types that are visible in the final string are now preserved (#4005) Fix a bug where long case blocks were not split into multiple lines. Also enable general trailing comma rules on case blocks (#4024) Keep requiring two empty lines between module-level docstring and first function or class definition (#4028) Add support for single-line format skip with other comments on the same line (#3959) Configuration
Consistently apply force exclusion logic before resolving symlinks (#4015) Fix a bug in the matching of absolute path names in --include (#3976) Performance
Fix mypyc builds on arm64 on macOS (#4017)
Integrations
Black's pre-commit integration will now run only on git hooks appropriate for a code formatter (#3940) 23.10.1
Highlights
Maintenance release to get a fix out for GitHub Action edge case (#3957) Preview style
Fix merging implicit multiline strings that have inline comments (#3956) Allow empty first line after block open before a comment or compound statement (#3967) Packaging
Change Dockerfile to hatch + compile black (#3965) Integrations
The summary output for GitHub workflows is now suppressible using the summary parameter. (#3958) Fix the action failing when Black check doesn't pass (#3957) Documentation
It is known Windows documentation CI is broken #3968 23.10.0
Stable style
Fix comments getting removed from inside parenthesized strings (#3909) Preview style
Fix long lines with power operators getting split before the line length (#3942) Long type hints are now wrapped in parentheses and properly indented when split across multiple lines (#3899) Magic trailing commas are now respected in return types. (#3916) Require one empty line after module-level docstrings. (#3932) Treat raw triple-quoted strings as docstrings (#3947) Configuration
Fix cache versioning logic when BLACK_CACHE_DIR is set (#3937) Parser
Fix bug where attributes named type were not accepted inside match statements (#3950) Add support for PEP 695 type aliases containing lambdas and other unusual expressions (#3949) Output
Black no longer attempts to provide special errors for attempting to format Python 2 code (#3933) Black will more consistently print stacktraces on internal errors in verbose mode (#3938) Integrations
The action output displayed in the job summary is now wrapped in Markdown (#3914) 23.9.1
Due to various issues, the previous release (23.9.0) did not include compiled mypyc wheels, which make Black significantly faster. These issues have now been fixed, and this release should come with compiled wheels once again.

There will be no wheels for Python 3.12 due to a bug in mypyc. We will provide 3.12 wheels in a future release as soon as the mypyc bug is fixed.

Packaging
Upgrade to mypy 1.5.1 (#3864)
Performance
Store raw tuples instead of NamedTuples in Black's cache, improving performance and decreasing the size of the cache (#3877) 23.9.0
Preview style
More concise formatting for dummy implementations (#3796) In stub files, add a blank line between a statement with a body (e.g an if sys.version_info > (3, x):) and a function definition on the same level (#3862) Fix a bug whereby spaces were removed from walrus operators within subscript(#3823) Configuration
Black now applies exclusion and ignore logic before resolving symlinks (#3846) Performance
Avoid importing IPython if notebook cells do not contain magics (#3782) Improve caching by comparing file hashes as fallback for mtime and size (#3821) Blackd
Fix an issue in blackd with single character input (#3558) Integrations
Black now has an official pre-commit mirror. Swapping https://github.com/psf/black to https://github.com/psf/black-pre-commit-mirror in your .pre-commit-config.yaml will make Black about 2x faster (#3828) The .black.env folder specified by ENV_PATH will now be removed on the completion of the GitHub Action (#3759) 23.7.0
Highlights
Runtime support for Python 3.7 has been removed. Formatting 3.7 code will still be supported until further notice (#3765) Stable style
Fix a bug where an illegal trailing comma was added to return type annotations using PEP 604 unions (#3735) Fix several bugs and crashes where comments in stub files were removed or mishandled under some circumstances (#3745) Fix a crash with multi-line magic comments like type: ignore within parentheses (#3740) Fix error in AST validation when Black removes trailing whitespace in a type comment (#3773) Preview style
Implicitly concatenated strings used as function args are no longer wrapped inside parentheses (#3640) Remove blank lines between a class definition and its docstring (#3692) Configuration
The --workers argument to Black can now be specified via the BLACK_NUM_WORKERS environment variable (#3743) .pytest_cache, .ruff_cache and .vscode are now excluded by default (#3691) Fix Black not honouring pyproject.toml settings when running --stdin-filename and the pyproject.toml found isn't in the current working directory (#3719) Black will now error if exclude and extend-exclude have invalid data types in pyproject.toml, instead of silently doing the wrong thing (#3764) Packaging
Upgrade mypyc from 0.991 to 1.3 (#3697)
Remove patching of Click that mitigated errors on Python 3.6 with LANG=C (#3768) Parser
Add support for the new PEP 695 syntax in Python 3.12 (#3703) Performance
Speed up Black significantly when the cache is full (#3751) Avoid importing IPython in a case where we wouldn't need it (#3748) Output
Use aware UTC datetimes internally, avoids deprecation warning on Python 3.12 (#3728) Change verbose logging to exactly mirror Black's logic for source discovery (#3749) Blackd
The blackd argument parser now shows the default values for options in their help text (#3712) Integrations
Black is now tested with PYTHONWARNDEFAULTENCODING = 1 (#3763) Update GitHub Action to display black output in the job summary (#3688) Documentation
Add a CITATION.cff file to the root of the repository, containing metadata on how to cite this software (#3723) Update the classes and exceptions documentation in Developer reference to match the latest code base (#3755) 23.3.0
Highlights
This release fixes a longstanding confusing behavior in Black's GitHub action, where the version of the action did not determine the version of Black being run (issue #3382). In addition, there is a small bug fix around imports and a number of improvements to the preview style.

Please try out the preview style with black --preview and tell us your feedback. All changes in the preview style are expected to become part of Black's stable style in January 2024.

Stable style
Import lines with # fmt: skip and # fmt: off no longer have an extra blank line added when they are right after another import line (#3610) Preview style
Add trailing commas to collection literals even if there's a comment after the last entry (#3393) async def, async for, and async with statements are now formatted consistently compared to their non-async version. (#3609) with statements that contain two context managers will be consistently wrapped in parentheses (#3589) Let string splitters respect East Asian Width (#3445) Now long string literals can be split after East Asian commas and periods (、 U+3001 IDEOGRAPHIC COMMA, 。 U+3002 IDEOGRAPHIC FULL STOP, & ， U+FF0C FULLWIDTH COMMA) besides before spaces (#3445) For stubs, enforce one blank line after a nested class with a body other than just ... (#3564) Improve handling of multiline strings by changing line split behavior (#1879) Parser
Added support for formatting files with invalid type comments (#3594) Integrations
Update GitHub Action to use the version of Black equivalent to action's version if version input is not specified (#3543) Fix missing Python binary path in autoload script for vim (#3508) Documentation
Document that only the most recent release is supported for security issues; vulnerabilities should be reported through Tidelift (#3612) 23.1.0
Highlights
This is the first release of 2023, and following our stability policy, it comes with a number of improvements to our stable style, including improvements to empty line handling, removal of redundant parentheses in several contexts, and output that highlights implicitly concatenated strings better.

There are also many changes to the preview style; try out black --preview and give us feedback to help us set the stable style for next year.

In addition to style changes, Black now automatically infers the supported Python versions from your pyproject.toml file, removing the need to set Black's target versions separately.

Stable style
Introduce the 2023 stable style, which incorporates most aspects of last year's preview style (#3418). Specific changes: Enforce empty lines before classes and functions with sticky leading comments (#3302) (22.12.0) Reformat empty and whitespace-only files as either an empty file (if no newline is present) or as a single newline character (if a newline is present) (#3348) (22.12.0) Implicitly concatenated strings used as function args are now wrapped inside parentheses (#3307) (22.12.0) Correctly handle trailing commas that are inside a line's leading non-nested parens (#3370) (22.12.0) --skip-string-normalization / -S now prevents docstring prefixes from being normalized as expected (#3168) (since 22.8.0) When using --skip-magic-trailing-comma or -C, trailing commas are stripped from subscript expressions with more than 1 element (#3209) (22.8.0) Implicitly concatenated strings inside a list, set, or tuple are now wrapped inside parentheses (#3162) (22.8.0) Fix a string merging/split issue when a comment is present in the middle of implicitly concatenated strings on its own line (#3227) (22.8.0) Docstring quotes are no longer moved if it would violate the line length limit (#3044, #3430) (22.6.0) Parentheses around return annotations are now managed (#2990) (22.6.0) Remove unnecessary parentheses around awaited objects (#2991) (22.6.0) Remove unnecessary parentheses in with statements (#2926) (22.6.0) Remove trailing newlines after code block open (#3035) (22.6.0) Code cell separators #%% are now standardised to # %% (#2919) (22.3.0) Remove unnecessary parentheses from except statements (#2939) (22.3.0) Remove unnecessary parentheses from tuple unpacking in for loops (#2945) (22.3.0) Avoid magic-trailing-comma in single-element subscripts (#2942) (22.3.0) Fix a crash when a colon line is marked between # fmt: off and # fmt: on (#3439) Preview style
Format hex codes in unicode escape sequences in string literals (#2916) Add parentheses around if-else expressions (#2278) Improve performance on large expressions that contain many strings (#3467) Fix a crash in preview style with assert + parenthesized string (#3415) Fix crashes in preview style with walrus operators used in function return annotations and except clauses (#3423) Fix a crash in preview advanced string processing where mixed implicitly concatenated regular and f-strings start with an empty span (#3463) Fix a crash in preview advanced string processing where a standalone comment is placed before a dict's value (#3469) Fix an issue where extra empty lines are added when a decorator has # fmt: skip applied or there is a standalone comment between decorators (#3470) Do not put the closing quotes in a docstring on a separate line, even if the line is too long (#3430) Long values in dict literals are now wrapped in parentheses; correspondingly unnecessary parentheses around short values in dict literals are now removed; long string lambda values are now wrapped in parentheses (#3440) Fix two crashes in preview style involving edge cases with docstrings (#3451) Exclude string type annotations from improved string processing; fix crash when the return type annotation is stringified and spans across multiple lines (#3462) Wrap multiple context managers in parentheses when targeting Python 3.9+ (#3489) Fix several crashes in preview style with walrus operators used in with statements or tuples (#3473) Fix an invalid quote escaping bug in f-string expressions where it produced invalid code. Implicitly concatenated f-strings with different quotes can now be merged or quote-normalized by changing the quotes used in expressions. (#3509) Fix crash on await (yield) when Black is compiled with mypyc (#3533) Configuration
Black now tries to infer its --target-version from the project metadata specified in pyproject.toml (#3219) Packaging
Upgrade mypyc from 0.971 to 0.991 so mypycified Black can be built on armv7 (#3380) This also fixes some crashes while using compiled Black with a debug build of CPython Drop specific support for the tomli requirement on 3.11 alpha releases, working around a bug that would cause the requirement not to be installed on any non-final Python releases (#3448) Black now depends on packaging version 22.0 or later. This is required for new functionality that needs to parse part of the project metadata (#3219) Output
Calling black --help multiple times will return the same help contents each time (#3516) Verbose logging now shows the values of pyproject.toml configuration variables (#3392) Fix false symlink detection messages in verbose output due to using an incorrect relative path to the project root (#3385) Integrations
Move 3.11 CI to normal flow now that all dependencies support 3.11 (#3446) Docker: Add new latest_prerelease tag automation to follow latest black alpha release on docker images (#3465) Documentation
Expand vim-plug installation instructions to offer more explicit options (#3468)