### PR TITLE
[PartDesign] Revolution fix regression in reference selection

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -357,7 +357,10 @@ void TaskRevolutionParameters::updateUI(int index)
 void TaskRevolutionParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
     if (msg.Type == Gui::SelectionChanges::AddSelection) {
-        if (selectionFace) {
+        int mode = ui->changeMode->currentIndex();
+        if (static_cast<PartDesign::Revolution::RevolMethod>(mode)
+                == PartDesign::Revolution::RevolMethod::ToFace
+            && selectionFace) {
             QString refText = onAddSelection(msg);
             if (refText.length() > 0) {
                 QSignalBlocker block(ui->lineFaceName);
@@ -371,7 +374,7 @@ void TaskRevolutionParameters::onSelectionChanged(const Gui::SelectionChanges& m
                 clearFaceName();
             }
         }
-        else {
+        else { // Reference Selection for datum lines and edges
             exitSelectionMode();
             std::vector<std::string> axis;
             App::DocumentObject* selObj;
@@ -379,6 +382,7 @@ void TaskRevolutionParameters::onSelectionChanged(const Gui::SelectionChanges& m
                 propReferenceAxis->setValue(selObj, axis);
 
                 recomputeFeature();
+                updateUI();
             }
         }
     }

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -382,7 +382,7 @@ void TaskRevolutionParameters::onSelectionChanged(const Gui::SelectionChanges& m
                 propReferenceAxis->setValue(selObj, axis);
 
                 recomputeFeature();
-                updateUI();
+                updateUI(mode);
             }
         }
     }


### PR DESCRIPTION
Fix regression introduced by https://github.com/FreeCAD/FreeCAD/commit/2cef4cfdbe1a6b9ebf50a85c04fbe99f23cd3829
as highlighted in https://github.com/FreeCAD/FreeCAD/issues/11713 but this needs thoroughly testing by a PartDesign power user as I'm not fully understanding what the author was trying to achieve with the change in the first place.