### PR TITLE
Gui: Allow ActionGroups to not remember choice

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -430,11 +430,12 @@ void Action::setMenuRole(QAction::MenuRole menuRole)
  * Constructs an action called \a name with parent \a parent. It also stores a pointer
  * to the command object.
  */
-ActionGroup::ActionGroup ( Command* pcCmd,QObject * parent)
-  : Action(pcCmd, parent)
-  , _group(nullptr)
-  , _dropDown(false)
-  , _isMode(false)
+ActionGroup::ActionGroup(Command* pcCmd, QObject* parent)
+    : Action(pcCmd, parent)
+    , _group(nullptr)
+    , _dropDown(false)
+    , _isMode(false)
+    , _rememberLast(true)
 {
     _group = new QActionGroup(this);
     connect(_group, &QActionGroup::triggered, this, qOverload<QAction*>(&ActionGroup::onActivated));
@@ -526,6 +527,16 @@ void ActionGroup::setVisible( bool check )
     groupAction()->setVisible(check);
 }
 
+void ActionGroup::setRememberLast(bool remember)
+{
+    _rememberLast = remember;
+}
+
+bool ActionGroup::doesRememberLast() const
+{
+    return _rememberLast;
+}
+
 QAction* ActionGroup::addAction(QAction* action)
 {
     int index = groupAction()->actions().size();
@@ -585,14 +596,16 @@ void ActionGroup::onToggled(bool check)
  */
 void ActionGroup::onActivated (QAction* act)
 {
-    int index = groupAction()->actions().indexOf(act);
+    if (_rememberLast) {
+        int index = groupAction()->actions().indexOf(act);
 
-    this->setIcon(act->icon());
-    if (!this->_isMode) {
-        this->setToolTip(act->toolTip(), act->text());
+        this->setIcon(act->icon());
+        if (!this->_isMode) {
+            this->setToolTip(act->toolTip(), act->text());
+        }
+        this->setProperty("defaultAction", QVariant(index));
+        command()->invoke(index, Command::TriggerChildAction);
     }
-    this->setProperty("defaultAction", QVariant(index));
-    command()->invoke(index, Command::TriggerChildAction);
 }
 
 void ActionGroup::onHovered (QAction *act)

--- a/src/Gui/Action.h
+++ b/src/Gui/Action.h
@@ -143,6 +143,9 @@ public:
     void setVisible (bool) override;
     void setIsMode(bool check) { _isMode = check; }
 
+    void setRememberLast(bool);
+    bool doesRememberLast() const;
+
     void setDropDownMenu(bool check) { _dropDown = check; }
     QAction* addAction(QAction*);
     QAction* addAction(const QString&);
@@ -171,6 +174,7 @@ private:
     QActionGroup* _group;
     bool _dropDown;
     bool _isMode;
+    bool _rememberLast;
 
 private:
     Q_DISABLE_COPY(ActionGroup)

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1026,6 +1026,16 @@ void GroupCommand::setExclusive(bool on)
     exclusive = on;
 }
 
+bool GroupCommand::doesRememberLast() const
+{
+    return rememberLast;
+}
+
+void GroupCommand::setRememberLast(bool on)
+{
+    rememberLast = on;
+}
+
 bool GroupCommand::hasDropDownMenu() const
 {
     return dropDownMenu;
@@ -1063,6 +1073,7 @@ Action * GroupCommand::createAction() {
     pcAction->setDropDownMenu(hasDropDownMenu());
     pcAction->setExclusive(isExclusive());
     pcAction->setCheckable(isCheckable());
+    pcAction->setRememberLast(doesRememberLast());
     pcAction->setWhatsThis(QString::fromLatin1(sWhatsThis));
 
     for(auto &v : cmds) {

--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -656,6 +656,8 @@ protected:
     void setCheckable(bool);
     bool isExclusive() const;
     void setExclusive(bool);
+    bool doesRememberLast() const;
+    void setRememberLast(bool);
     bool hasDropDownMenu() const;
     void setDropDownMenu(bool);
     void activated(int iMsg) override;
@@ -667,6 +669,7 @@ protected:
 protected:
     bool checkable = true;
     bool exclusive = false;
+    bool rememberLast = true;
     bool dropDownMenu = true;
     std::vector<std::pair<Command*,size_t> > cmds;
 };

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1163,6 +1163,7 @@ public:
         eType = ForEdit;
 
         setCheckable(false);
+        setRememberLast(false);
 
         addCommand("Sketcher_Dimension");
         addCommand(); //separator


### PR DESCRIPTION
This is fix to issue mentioned in the #11717, on discord and forum that for smart dimension tool the chosen tool should not be remembered. This will ensure that the "smart" tool is always visible on the toolbar and other tools are accessible in case that such explicit choice is needed.

It does not have issue attached as I simply wanted to check how hard it would be to fix - quite easy as it seems.


https://github.com/FreeCAD/FreeCAD/assets/747404/684d84bb-60d0-4c6e-9685-89cfbd8b953e

I changed only the behavior of smart dimension tool, everything else should be considered as part of other PRs. 

