### PR TITLE
Fix object path in active object when creating new body in App::Part

### DIFF
--- a/src/Gui/ActiveObjectList.cpp
+++ b/src/Gui/ActiveObjectList.cpp
@@ -111,10 +111,34 @@ Gui::ActiveObjectList::ObjectInfo Gui::ActiveObjectList::getObjectInfo(App::Docu
             if (info.obj)
                 break;
         }
+        if(!info.obj) {
+            // No selection is found, try to obtain the object hierarchy using
+            // DocumentObject::getParents()
+            unsigned long count = 0xffffffff;
+            for(auto &v : obj->getParents()) {
+                if(v.first->getDocument() != _Doc->getDocument())
+                    continue;
 
-        if (!info.obj && obj->getDocument()==_Doc->getDocument())
-            info.obj = obj;
+                // We prioritize on non-linked group object having the least
+                // hierarchies.
+                unsigned long cnt = v.first->getSubObjectList(v.second.c_str()).size();
+                if(v.first->getLinkedObject(false) != v.first)
+                    cnt &= 0x8000000;
+                if(cnt < count) {
+                    count = cnt;
+                    info.obj = v.first;
+                    info.subname = v.second;
+                }
+            }
+
+            if(!info.obj) {
+                if (obj->getDocument()!=_Doc->getDocument())
+                    return info;
+                info.obj = obj;
+            }
+        }
     }
+
     return info;
 }
 

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -212,6 +212,12 @@ void CmdPartDesignBody::activated(int iMsg)
         }
     }
     addModule(Gui,"PartDesignGui"); // import the Gui module only once a session
+
+    if (actPart) {
+        doCommand(Doc,"App.activeDocument().%s.addObject(App.ActiveDocument.%s)",
+                 actPart->getNameInDocument(), bodyString);
+    }
+
     doCommand(Gui::Command::Gui, "Gui.activateView('Gui::View3DInventor', True)\n"
                                  "Gui.activeView().setActiveObject('%s', App.activeDocument().%s)",
             PDBODYKEY, bodyString);
@@ -219,10 +225,6 @@ void CmdPartDesignBody::activated(int iMsg)
     // Make the "Create sketch" prompt appear in the task panel
     doCommand(Gui,"Gui.Selection.clearSelection()");
     doCommand(Gui,"Gui.Selection.addSelection(App.ActiveDocument.%s)", bodyString);
-    if (actPart) {
-        doCommand(Doc,"App.activeDocument().%s.addObject(App.ActiveDocument.%s)",
-                 actPart->getNameInDocument(), bodyString);
-    }
 
     // check if a proxy object has been created for the base feature inside the body
     if (baseFeature) {


### PR DESCRIPTION
Fixes #10371

The circular reference is caused by incomplete object path in active object (`Gui.activeView().getActiveObject('pdbody', True)`) when creating new body in an active App::Part.