### PR TITLE
[TD]Template field underline

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -83,6 +83,13 @@ DrawViewDetail::DrawViewDetail() : m_waitingForDetail(false), m_saveDvp(nullptr)
     ADD_PROPERTY_TYPE(Radius, (10.0), dgroup, App::Prop_None, "Size of detail area");
     ADD_PROPERTY_TYPE(Reference, ("1"), dgroup, App::Prop_None, "An identifier for this detail");
 
+    static const char* agroup{"Appearance"};
+    ADD_PROPERTY_TYPE(ShowMatting, (Preferences::showDetailMatting()), agroup, App::Prop_None,
+             "Show or hide the matting around the detail view");
+    ADD_PROPERTY_TYPE(ShowHighlight, (Preferences::showDetailHighlight()), agroup, App::Prop_None,
+             "Show or hide the detail highlight in the source view");
+
+
     getParameters();
     m_fudge = 1.01;
 

--- a/src/Mod/TechDraw/App/DrawViewDetail.h
+++ b/src/Mod/TechDraw/App/DrawViewDetail.h
@@ -61,6 +61,9 @@ public:
     App::PropertyFloat  Radius;
     App::PropertyString Reference;
 
+    App::PropertyBool   ShowMatting;
+    App::PropertyBool   ShowHighlight;
+
     short mustExecute() const override;
     App::DocumentObjectExecReturn *execute() override;
     void onChanged(const App::Property* prop) override;

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
@@ -34,215 +34,7 @@
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="1" column="0">
        <layout class="QGridLayout" name="gridLayout_2" columnstretch="2,0,1">
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_18">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Length of horizontal portion of Balloon leader</string>
-          </property>
-          <property name="text">
-           <string>Ballon Leader Kink Length</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbPrintCenterMarks">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Show arc centers in printed output</string>
-          </property>
-          <property name="text">
-           <string>Print Center Marks</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>PrintCenterMarks</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="2">
-         <widget class="Gui::PrefUnitSpinBox" name="pdsbBalloonKink">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Length of balloon leader line kink</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>BalloonKink</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Dimensions</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Balloon Shape</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="Gui::PrefComboBox" name="cbCutSurface">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Default appearance of cut surface in section view</string>
-          </property>
-          <property name="currentIndex">
-           <number>2</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>CutSurfaceDisplay</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Decorations</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>Hide</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Solid Color</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>SVG Hatch</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>PAT Hatch</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Balloon Leader End</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbPyramidOrtho">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Restrict Filled Triangle line end to vertical or horizontal directions</string>
-          </property>
-          <property name="text">
-           <string>Balloon Orthogonal Triangle</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>PyramidOrtho</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="1" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbComplexMarks">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Show or hide marks at direction changes on ComplexSection lines.</string>
-          </property>
-          <property name="text">
-           <string>Complex Section Line Marks</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SectionLineMarks</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
+        <item row="8" column="2">
          <widget class="Gui::PrefCheckBox" name="cbAutoHoriz">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -270,6 +62,93 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/LeaderLine</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbShowCenterMarks">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Show arc center marks in views</string>
+          </property>
+          <property name="text">
+           <string>Show Center Marks</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ShowCenterMarks</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbComplexMarks">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Show or hide marks at direction changes on ComplexSection lines.</string>
+          </property>
+          <property name="text">
+           <string>Complex Section Line Marks</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SectionLineMarks</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_19">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Section Cut Surface</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_18">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Length of horizontal portion of Balloon leader</string>
+          </property>
+          <property name="text">
+           <string>Ballon Leader Kink Length</string>
           </property>
          </widget>
         </item>
@@ -316,68 +195,7 @@
           </item>
          </widget>
         </item>
-        <item row="4" column="2">
-         <widget class="Gui::PrefComboBox" name="pcbBalloonArrow">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Style for balloon leader line ends</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>BalloonArrow</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbShowCenterMarks">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Show arc center marks in views</string>
-          </property>
-          <property name="text">
-           <string>Show Center Marks</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ShowCenterMarks</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
+        <item row="5" column="2">
          <widget class="Gui::PrefComboBox" name="pcbBalloonShape">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -474,15 +292,121 @@
           </item>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_19">
+        <item row="7" column="2">
+         <widget class="Gui::PrefUnitSpinBox" name="pdsbBalloonKink">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Length of balloon leader line kink</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>BalloonKink</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbPyramidOrtho">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Restrict Filled Triangle line end to vertical or horizontal directions</string>
+          </property>
+          <property name="text">
+           <string>Balloon Orthogonal Triangle</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>PyramidOrtho</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_3">
           <property name="font">
            <font>
             <italic>true</italic>
            </font>
           </property>
           <property name="text">
-           <string>Section Cut Surface</string>
+           <string>Balloon Leader End</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbDetailMatting">
+          <property name="toolTip">
+           <string>This checkbox controls whether or not to display the outline around a detail view.</string>
+          </property>
+          <property name="text">
+           <string>Detail View Show Matting</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ShowDetailMatting</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Balloon Shape</string>
           </property>
          </widget>
         </item>
@@ -495,6 +419,120 @@
           </property>
           <property name="text">
            <string>Detail View Outline Shape</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbPrintCenterMarks">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Show arc centers in printed output</string>
+          </property>
+          <property name="text">
+           <string>Print Center Marks</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>PrintCenterMarks</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="Gui::PrefComboBox" name="cbCutSurface">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Default appearance of cut surface in section view</string>
+          </property>
+          <property name="currentIndex">
+           <number>2</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>CutSurfaceDisplay</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Decorations</cstring>
+          </property>
+          <item>
+           <property name="text">
+            <string>Hide</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Solid Color</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>SVG Hatch</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>PAT Hatch</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="Gui::PrefComboBox" name="pcbBalloonArrow">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Style for balloon leader line ends</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>BalloonArrow</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbDetailHighlight">
+          <property name="toolTip">
+           <string>This checkbox controls whether or not to display a highlight around the detail area in the detail's source view.</string>
+          </property>
+          <property name="text">
+           <string>Detail Source Show Highlight</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ShowDetailHighlight</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/General</cstring>
           </property>
          </widget>
         </item>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.cpp
@@ -94,6 +94,8 @@ void DlgPrefsTechDrawAnnotationImp::saveSettings()
     ui->pcbHighlightStyle->onSave();
     ui->cbEndCap->onSave();
     ui->pcbHiddenStyle->onSave();
+    ui->pcbDetailMatting->onSave();
+    ui->pcbDetailHighlight->onSave();
 }
 
 void DlgPrefsTechDrawAnnotationImp::loadSettings()
@@ -129,6 +131,9 @@ void DlgPrefsTechDrawAnnotationImp::loadSettings()
     ui->pcbMatting->onRestore();
     ui->pdsbBalloonKink->onRestore();
     ui->cbCutSurface->onRestore();
+    ui->pcbDetailMatting->onRestore();
+    ui->pcbDetailHighlight->onRestore();
+
 
     ui->pcbBalloonArrow->onRestore();
     DrawGuiUtil::loadArrowBox(ui->pcbBalloonArrow);

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
@@ -49,36 +49,15 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="10" column="1">
-         <widget class="Gui::PrefColorButton" name="pcbLightTextColor">
-          <property name="toolTip">
-           <string>Monochrome text color</string>
+        <item row="4" column="3">
+         <widget class="QLabel" name="label_7">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
           </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>LightTextColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="4">
-         <widget class="Gui::PrefColorButton" name="pcb_Hidden">
-          <property name="toolTip">
-           <string>Hidden line color</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>HiddenColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Colors</cstring>
+          <property name="text">
+           <string>Geometric Hatch</string>
           </property>
          </widget>
         </item>
@@ -99,66 +78,21 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
-         <widget class="Gui::PrefColorButton" name="pcbDimColor">
+        <item row="11" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbMonochrome">
           <property name="toolTip">
-           <string>Color of dimension lines and text.</string>
+           <string>If checked FreeCAD will use a single color for all text and lines. 
+
+</string>
           </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
+          <property name="text">
+           <string>Monochrome</string>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>Color</cstring>
+           <cstring>Monochrome</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Dimensions</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Background</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="lbl_PreSelect">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Preselected</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Grid Color</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_18">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Detail Highlight</string>
+           <cstring>/Mod/TechDraw/Colors</cstring>
           </property>
          </widget>
         </item>
@@ -171,69 +105,6 @@
           </property>
           <property name="text">
            <string>Selected</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
-         <widget class="Gui::PrefCheckBox" name="pcbLightOnDark">
-          <property name="toolTip">
-           <string>Check this to use light text and lines on dark backgrounds. Set Page Color to a dark color. Transparent or light color faces are recommended with this option.</string>
-          </property>
-          <property name="text">
-           <string>Light on dark</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>LightOnDark</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="4">
-         <widget class="Gui::PrefColorButton" name="pcb_Hatch">
-          <property name="toolTip">
-           <string>Hatch image color</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>Hatch</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="4">
-         <widget class="Gui::PrefColorButton" name="pcbMarkup">
-          <property name="toolTip">
-           <string>Default color for leader lines</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>Color</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Markups</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="3">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Page Color</string>
           </property>
          </widget>
         </item>
@@ -257,49 +128,6 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="3">
-         <widget class="QLabel" name="label_3">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Section Face</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="3">
-         <widget class="QLabel" name="label_14">
-          <property name="text">
-           <string>Section Line</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_15">
-          <property name="text">
-           <string>Centerline</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <widget class="Gui::PrefColorButton" name="pcb_Grid">
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>gridColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="2">
          <spacer name="horizontalSpacer_3">
           <property name="orientation">
@@ -313,46 +141,10 @@
           </property>
          </spacer>
         </item>
-        <item row="4" column="3">
-         <widget class="QLabel" name="label_7">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Geometric Hatch</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="3">
-         <widget class="QLabel" name="label_17">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Leaderline</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="3">
-         <widget class="QLabel" name="label_5">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Hatch</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="4">
-         <widget class="Gui::PrefColorButton" name="pcbSectionLine">
+        <item row="5" column="1">
+         <widget class="Gui::PrefColorButton" name="pcbCenterColor">
           <property name="toolTip">
-           <string>Section line color</string>
+           <string>Centerline color</string>
           </property>
           <property name="color">
            <color>
@@ -362,30 +154,29 @@
            </color>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>SectionColor</cstring>
+           <cstring>CenterColor</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Decorations</cstring>
+           <cstring>Mod/TechDraw/Decorations</cstring>
           </property>
          </widget>
         </item>
-        <item row="7" column="4">
-         <widget class="Gui::PrefColorButton" name="pcb_Face">
-          <property name="toolTip">
-           <string>Face color (if not transparent)</string>
+        <item row="1" column="3">
+         <widget class="QLabel" name="label_3">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
           </property>
-          <property name="color">
-           <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
-           </color>
+          <property name="text">
+           <string>Section Face</string>
           </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>FaceColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Colors</cstring>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_15">
+          <property name="text">
+           <string>Centerline</string>
           </property>
          </widget>
         </item>
@@ -409,19 +200,103 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="3">
-         <widget class="QLabel" name="lbl_Hidden">
+        <item row="5" column="3">
+         <widget class="QLabel" name="label_16">
+          <property name="text">
+           <string>Vertex</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_4">
           <property name="font">
            <font>
             <italic>true</italic>
            </font>
           </property>
           <property name="text">
-           <string>Hidden Line</string>
+           <string>Background</string>
           </property>
          </widget>
         </item>
-        <item row="10" column="4">
+        <item row="7" column="4">
+         <widget class="Gui::PrefColorButton" name="pcb_Face">
+          <property name="toolTip">
+           <string>Face color (if not transparent)</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>FaceColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="lbl_PreSelect">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Preselected</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="3">
+         <widget class="QLabel" name="label_17">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Leaderline</string>
+          </property>
+         </widget>
+        </item>
+        <item row="11" column="1">
+         <widget class="Gui::PrefColorButton" name="pcbLightTextColor">
+          <property name="toolTip">
+           <string>Monochrome text color</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>LightTextColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="Gui::PrefColorButton" name="pcbDimColor">
+          <property name="toolTip">
+           <string>Color of dimension lines and text.</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>Color</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="11" column="4">
          <widget class="Gui::PrefColorButton" name="pcbPageColor">
           <property name="toolTip">
            <string>Use a light color for dark text and dark color for light text.</string>
@@ -438,6 +313,127 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="4">
+         <widget class="Gui::PrefColorButton" name="pcb_Hatch">
+          <property name="toolTip">
+           <string>Hatch image color</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>Hatch</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="4">
+         <widget class="Gui::PrefColorButton" name="pcbSectionLine">
+          <property name="toolTip">
+           <string>Section line color</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SectionColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="4">
+         <widget class="Gui::PrefColorButton" name="pcb_GeomHatch">
+          <property name="toolTip">
+           <string>Geometric hatch pattern color</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>GeomHatch</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_18">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Detail Highlight</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="3">
+         <widget class="QLabel" name="label_5">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Hatch</string>
+          </property>
+         </widget>
+        </item>
+        <item row="11" column="3">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Page Color</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="3">
+         <widget class="QLabel" name="label_14">
+          <property name="text">
+           <string>Section Line</string>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbLightOnDark">
+          <property name="toolTip">
+           <string>Check this to use light text and lines on dark backgrounds. Set Page Color to a dark color. Transparent or light color faces are recommended with this option.</string>
+          </property>
+          <property name="text">
+           <string>Light on dark</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>LightOnDark</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
           </property>
          </widget>
         </item>
@@ -461,10 +457,10 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
-         <widget class="Gui::PrefColorButton" name="pcbCenterColor">
+        <item row="6" column="4">
+         <widget class="Gui::PrefColorButton" name="pcbMarkup">
           <property name="toolTip">
-           <string>Centerline color</string>
+           <string>Default color for leader lines</string>
           </property>
           <property name="color">
            <color>
@@ -474,77 +470,10 @@
            </color>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>CenterColor</cstring>
+           <cstring>Color</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="3">
-         <widget class="QLabel" name="label_16">
-          <property name="text">
-           <string>Vertex</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="Gui::PrefColorButton" name="pcb_Normal">
-          <property name="toolTip">
-           <string>Normal line color</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>NormalColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="4">
-         <widget class="Gui::PrefColorButton" name="pcb_Surface">
-          <property name="toolTip">
-           <string>Section face color</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>211</red>
-            <green>211</green>
-            <blue>211</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>CutSurfaceColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Colors</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="4">
-         <widget class="Gui::PrefColorButton" name="pcbVertexColor">
-          <property name="toolTip">
-           <string>Color of vertices in views</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>VertexColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
+           <cstring>Mod/TechDraw/Markups</cstring>
           </property>
          </widget>
         </item>
@@ -575,10 +504,10 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="4">
-         <widget class="Gui::PrefColorButton" name="pcb_GeomHatch">
+        <item row="0" column="1">
+         <widget class="Gui::PrefColorButton" name="pcb_Normal">
           <property name="toolTip">
-           <string>Geometric hatch pattern color</string>
+           <string>Normal line color</string>
           </property>
           <property name="color">
            <color>
@@ -588,10 +517,93 @@
            </color>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>GeomHatch</cstring>
+           <cstring>NormalColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="4">
+         <widget class="Gui::PrefColorButton" name="pcb_Hidden">
+          <property name="toolTip">
+           <string>Hidden line color</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>HiddenColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="Gui::PrefColorButton" name="pcb_Grid">
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>gridColor</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Colors</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_13">
+          <property name="text">
+           <string>Dimension</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="4">
+         <widget class="Gui::PrefColorButton" name="pcbVertexColor">
+          <property name="toolTip">
+           <string>Color of vertices in views</string>
+          </property>
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>VertexColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Grid Color</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <widget class="QLabel" name="lbl_Hidden">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Hidden Line</string>
           </property>
          </widget>
         </item>
@@ -607,35 +619,47 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_13">
-          <property name="text">
-           <string>Dimension</string>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="0">
-         <widget class="Gui::PrefCheckBox" name="pcbMonochrome">
+        <item row="1" column="4">
+         <widget class="Gui::PrefColorButton" name="pcb_Surface">
           <property name="toolTip">
-           <string>If checked FreeCAD will use a single color for all text and lines. 
-
-</string>
+           <string>Section face color</string>
           </property>
-          <property name="text">
-           <string>Monochrome</string>
+          <property name="color">
+           <color>
+            <red>211</red>
+            <green>211</green>
+            <blue>211</blue>
+           </color>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>Monochrome</cstring>
+           <cstring>CutSurfaceColor</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Colors</cstring>
+           <cstring>Mod/TechDraw/Colors</cstring>
           </property>
          </widget>
         </item>
         <item row="8" column="0">
-         <widget class="QLabel" name="label_6">
+         <widget class="QLabel" name="label_8">
           <property name="text">
-           <string/>
+           <string>Template Underline</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <widget class="Gui::PrefColorButton" name="pcbUnderline">
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>255</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>TemplateUnderlineColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Colors</cstring>
           </property>
          </widget>
         </item>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColorsImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColorsImp.cpp
@@ -65,6 +65,7 @@ void DlgPrefsTechDrawColorsImp::saveSettings()
     ui->pcbLightOnDark->onSave();
     ui->pcbMonochrome->onSave();
     ui->pcbLightTextColor->onSave();
+    ui->pcbUnderline->onSave();
 }
 
 void DlgPrefsTechDrawColorsImp::loadSettings()
@@ -90,6 +91,7 @@ void DlgPrefsTechDrawColorsImp::loadSettings()
     ui->pcbLightOnDark->onRestore();
     ui->pcbMonochrome->onRestore();
     ui->pcbLightTextColor->onRestore();
+    ui->pcbUnderline->onRestore();
 }
 
 /**

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -279,3 +279,16 @@ QColor PreferencesGui::lightenColor(QColor orig)
     return QColor(red, green, blue, alpha);
 }
 
+
+double PreferencesGui::templateClickBoxSize()
+{
+    return Preferences::getPreferenceGroup("General")->GetFloat("TemplateDotSize", 5.0);
+}
+
+
+QColor PreferencesGui::templateClickBoxColor()
+{
+    App::Color fcColor;
+    fcColor.setPackedValue(Preferences::getPreferenceGroup("Colors")->GetUnsigned("TemplateUnderlineColor", 0x0000FFFF));  //#0000FF blue
+    return fcColor.asValue<QColor>();
+}

--- a/src/Mod/TechDraw/Gui/PreferencesGui.h
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.h
@@ -78,6 +78,9 @@ static QColor       getAccessibleQColor(QColor orig);
 static QColor       lightTextQColor();
 static QColor       reverseColor(QColor orig);
 static QColor       lightenColor(QColor orig);
+
+static double       templateClickBoxSize();
+static QColor       templateClickBoxColor();
 };
 
 } //end namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -29,11 +29,14 @@
 # include <QGraphicsSvgItem>
 # include <QPen>
 # include <QSvgRenderer>
+# include <QRegularExpression>
+# include <QRegularExpressionMatch>
 #endif// #ifndef _PreComp_
 
 #include <App/Application.h>
 #include <Base/Console.h>
 #include <Base/Parameter.h>
+#include <Base/Tools.h>
 
 #include <Mod/TechDraw/App/DrawSVGTemplate.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
@@ -165,13 +168,10 @@ void QGISVGTemplate::createClickHandles()
 
     //TODO: Find location of special fields (first/third angle) and make graphics items for them
 
-    double editClickBoxSize = Rez::guiX(Preferences::getPreferenceGroup("General")->GetFloat("TemplateDotSize", 3.0));
+    double editClickBoxSize = Rez::guiX(PreferencesGui::templateClickBoxSize());
+    QColor editClickBoxColor = PreferencesGui::templateClickBoxColor();
 
-    QColor editClickBoxColor = Qt::green;
-    editClickBoxColor.setAlpha(128);//semi-transparent
-
-    double width = editClickBoxSize;
-    double height = editClickBoxSize;
+    auto textMap = svgTemplate->EditableTexts.getValues();
 
     TechDraw::XMLQuery query(templateDocument);
 
@@ -185,27 +185,47 @@ void QGISVGTemplate::createClickHandles()
             textElement.attribute(QString::fromUtf8("x"), QString::fromUtf8("0.0")).toDouble());
         double y = Rez::guiX(
             textElement.attribute(QString::fromUtf8("y"), QString::fromUtf8("0.0")).toDouble());
-
         if (name.isEmpty()) {
             Base::Console().Warning(
                 "QGISVGTemplate::createClickHandles - no name for editable text at %f, %f\n", x, y);
             return true;
         }
+        std::string itemText = textMap[Base::Tools::toStdString(name)];
 
+        // default box size
+        double textHeight = editClickBoxSize;
+        double charWidth = textHeight * 0.6;
+        QString style = textElement.attribute(QString::fromUtf8("style"));
+        if (!style.isEmpty()) {
+            QRegularExpression rxFontSize(QString::fromUtf8("font-size:([0-9]*\.?[0-9]*)px;"));
+            QRegularExpression rxAnchor(QString::fromUtf8("text-anchor:(middle);"));
+            QRegularExpressionMatch match;
+
+            int pos{0};
+            pos = style.indexOf(rxFontSize, pos, &match);
+            if (pos != -1) {
+                textHeight = match.captured(1).toDouble() * 10.0;
+            }
+            charWidth = textHeight * 0.6;
+            pos = 0;
+            pos = style.indexOf(rxAnchor, pos, &match);
+            if (pos != -1) {
+                x = x - itemText.length() * charWidth / 2;
+            }
+        }
+        double textLength = itemText.length() * charWidth;
+        textLength = std::max(charWidth, textLength);
         auto item(new TemplateTextField(this, svgTemplate, name.toStdString()));
 
         double pad = 1.0;
-        item->setRect(x - pad, Rez::guiX(-svgTemplate->getHeight()) + y - height - pad,
-                      width + 2.0 * pad, height + 2.0 * pad);
-
-        QPen myPen;
-        myPen.setStyle(Qt::SolidLine);
-        myPen.setColor(editClickBoxColor);
-        myPen.setWidth(0);// 0 means "cosmetic pen" - always 1px
-        item->setPen(myPen);
-
-        QBrush myBrush(editClickBoxColor, Qt::SolidPattern);
-        item->setBrush(myBrush);
+        double top = Rez::guiX(-svgTemplate->getHeight()) + y - textHeight - pad;
+        double bottom = top + textHeight + 2.0 * pad;
+        double left = x - pad;
+        item->setRectangle(QRectF(left, top,
+                      textLength + 2.0 * pad, textHeight + 2.0 * pad));
+        item->setLine(QPointF( left, bottom),
+                      QPointF(left + textLength + 2.0 * pad, bottom));
+        item->setLineColor(editClickBoxColor);
 
         item->setZValue(ZVALUE::SVGTEMPLATE + 1);
         addToGroup(item);

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -826,9 +826,6 @@ void QGIViewPart::drawCenterLines(bool b)
 
 void QGIViewPart::drawAllHighlights()
 {
-    if (!Preferences::showDetailHighlight()) {
-        return;
-    }
     // dvp and vp already validated
     auto dvp(static_cast<TechDraw::DrawViewPart*>(getViewObject()));
 
@@ -853,6 +850,11 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
     if (!vpDetail) {
         return;
     }
+
+    if (!viewDetail->ShowHighlight.getValue()) {
+        return;
+    }
+
     if (b) {
         double fontSize = Preferences::labelFontSizeMM();
         QGIHighlight* highlight = new QGIHighlight();
@@ -907,15 +909,16 @@ void QGIViewPart::highlightMoved(QGIHighlight* highlight, QPointF newPos)
 
 void QGIViewPart::drawMatting()
 {
-    if (!Preferences::showDetailMatting()) {
-        return;
-    }
     auto viewPart(dynamic_cast<TechDraw::DrawViewPart*>(getViewObject()));
     TechDraw::DrawViewDetail* dvd = nullptr;
     if (viewPart && viewPart->isDerivedFrom(TechDraw::DrawViewDetail::getClassTypeId())) {
         dvd = static_cast<TechDraw::DrawViewDetail*>(viewPart);
     }
     else {
+        return;
+    }
+
+    if (!dvd->ShowMatting.getValue()) {
         return;
     }
 

--- a/src/Mod/TechDraw/Gui/TemplateTextField.cpp
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.cpp
@@ -40,25 +40,34 @@ using namespace TechDrawGui;
 TemplateTextField::TemplateTextField(QGraphicsItem *parent,
                                      TechDraw::DrawTemplate *myTmplte,
                                      const std::string &myFieldName)
-    : QGraphicsRectItem(parent),
+    : QGraphicsItemGroup(parent),
       tmplte(myTmplte),
       fieldNameStr(myFieldName)
 {
     setToolTip(QObject::tr("Click to update text"));
+    m_rect = new QGraphicsRectItem();
+    addToGroup(m_rect);
+    QPen rectPen(Qt::transparent);
+    QBrush rectBrush(Qt::NoBrush);
+    m_rect->setPen(rectPen);
+    m_rect->setBrush(rectBrush);
+
+    m_line = new QGraphicsPathItem();
+    addToGroup(m_line);
  }
 
 void TemplateTextField::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-    if ( tmplte && rect().contains(event->pos()) ) {
+    if ( tmplte && m_rect->rect().contains(event->pos()) ) {
         event->accept();
     } else {
-        QGraphicsRectItem::mousePressEvent(event);
+        QGraphicsItemGroup::mousePressEvent(event);
     }
 }
 
 void TemplateTextField::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
-    if ( tmplte && rect().contains(event->pos()) ) {
+    if ( tmplte && m_rect->rect().contains(event->pos()) ) {
         event->accept();
 
         DlgTemplateField ui;
@@ -77,7 +86,25 @@ void TemplateTextField::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         }
 
     } else {
-        QGraphicsRectItem::mouseReleaseEvent(event);
+        QGraphicsItemGroup::mouseReleaseEvent(event);
     }
 }
 
+void TemplateTextField::setRectangle(QRectF rect)
+{
+    m_rect->setRect(rect);
+}
+
+void TemplateTextField::setLine(QPointF from, QPointF to)
+{
+    QPainterPath path(from);
+    path.lineTo(to);
+    m_line->setPath(path);
+}
+
+void TemplateTextField::setLineColor(QColor color)
+{
+    QPen pen(color);
+    pen.setWidth(5);
+    m_line->setPen(pen);
+}

--- a/src/Mod/TechDraw/Gui/TemplateTextField.h
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.h
@@ -25,7 +25,9 @@
 
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
+#include <QGraphicsItemGroup>
 #include <QGraphicsRectItem>
+#include <QGraphicsPathItem>
 
 namespace TechDraw {
 class DrawTemplate;
@@ -33,12 +35,12 @@ class DrawTemplate;
 
 namespace TechDrawGui
 {
-    /// QGraphicsRectItem-derived class for the text fields in title blocks
+    /// QGraphicsItemGroupm-derived class for the text fields in title blocks
     /*!
      * Makes an area on the drawing that's clickable, so appropriate
      * Properties of the template can be modified.
      */
-class TechDrawGuiExport TemplateTextField : public QGraphicsRectItem
+class TechDrawGuiExport TemplateTextField : public QGraphicsItemGroup
 {
     public:
         TemplateTextField(QGraphicsItem *parent,
@@ -53,6 +55,10 @@ class TechDrawGuiExport TemplateTextField : public QGraphicsRectItem
         /// Returns the field name that this TemplateTextField represents
         std::string fieldName() const { return fieldNameStr; }
 
+        void setRectangle(QRectF rect);
+        void setLine(QPointF from, QPointF to);
+        void setLineColor(QColor color);
+
     protected:
         TechDraw::DrawTemplate *tmplte;
         std::string fieldNameStr;
@@ -62,6 +68,9 @@ class TechDrawGuiExport TemplateTextField : public QGraphicsRectItem
 
         /// Trigger the dialog for editing template text
         void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+
+        QGraphicsRectItem* m_rect;
+        QGraphicsPathItem* m_line;
 };
 }   // namespace TechDrawGui
 


### PR DESCRIPTION
This PR implements 2 changes:
> use of an underline instead of the small green squares to identify editable text in templates.
> adds preferences and properties to control the display of detail view highlights.