### PR TITLE
fix compatibility with current Mac 3Dconnexion driver

### DIFF
--- a/src/Gui/3Dconnexion/GuiNativeEventMac.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventMac.cpp
@@ -164,9 +164,7 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow *window)
     /* register our app with the driver */
     // Pascal string Application name required to register driver for application
     UInt8  tdxAppName[] = {7,'F','r','e','e','C','A','D'};
-    // 32bit appID to register driver for application
-    UInt32 tdxAppID = 'FCAd';
-    tdxClientID = RegisterConnexionClient( tdxAppID, tdxAppName,
+    tdxClientID = RegisterConnexionClient( kConnexionClientWildcard, tdxAppName,
                                            kConnexionClientModeTakeOver,
                                            kConnexionMaskAll );
     if (tdxClientID == 0)


### PR DESCRIPTION
For quite some time the MacOS version of FreeCAD detects the SpaceMouse from 3DConnexion but is unable to receive any events when using the recent drivers. The last working driver seems to be the 10.7.0.

This PR changes the registration of the application to the driver to use the wildcard constant instead of a bundle ID that the FreeCAD does not seem to possess. The driver then uses the application name to do the check.

Tested on MacBook Air M2 15" running Sonoma 14.2, with SpaceMouse Pro and driver 10.8.2.