### PR TITLE
CI: set pipefail Linux build action

### DIFF
--- a/.github/workflows/actions/linux/build/action.yml
+++ b/.github/workflows/actions/linux/build/action.yml
@@ -48,6 +48,7 @@ runs:
       id: build
       shell: bash -l {0}
       run: |
+        set -o pipefail
         (stdbuf -oL -eL cmake --build ${{ inputs.builddir }} -j$(nproc) ${{ inputs.extraParameters }}) \
         2> >(tee -a ${{ inputs.errorFile }}) | tee -a ${{ inputs.logFile }}
     - name: Write report


### PR DESCRIPTION
Errors in the Ubuntu builds are not caught because the exit code of `tee` is observed instead of the exit code of the build.

Setting the shell option `set -o pipefail` will propagate the exit code of any process in a pipeline that is not successful, permitting the CI script to get an accurate assessment of the build status.