### PR TITLE
CI: add pipefail to additional workflow actions.

### DIFF
--- a/.github/workflows/actions/linux/configure/action.yml
+++ b/.github/workflows/actions/linux/configure/action.yml
@@ -52,6 +52,7 @@ runs:
       id: configure
       shell: bash -l {0}
       run: |
+        set -o pipefail
         (stdbuf -oL -eL cmake -S ${{ inputs.sourcedir }} -B ${{ inputs.builddir }} -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE ${{inputs.extraParameters }}) \
         2> >(tee -a ${{ inputs.errorFile }}) | tee -a ${{ inputs.logFile }}
     - name: Write report

--- a/.github/workflows/actions/linux/install/action.yml
+++ b/.github/workflows/actions/linux/install/action.yml
@@ -48,6 +48,7 @@ runs:
       id: install
       shell: bash -l {0}
       run: |
+        set -o pipefail
         (stdbuf -oL -eL sudo cmake --install ${{ inputs.builddir }} ${{ inputs.extraParameters }}) \
         2> >(tee -a ${{ inputs.errorFile }}) | tee -a ${{ inputs.logFile }}
     - name: Write report

--- a/.github/workflows/actions/runCPPTests/runSingleTest/action.yml
+++ b/.github/workflows/actions/runCPPTests/runSingleTest/action.yml
@@ -45,7 +45,9 @@ runs:
   steps:
     - name: Run C++ tests
       shell: bash -l {0}
-      run: ${{ inputs.testCommand }} | tee -a ${{ inputs.testLogFile }}
+      run: |
+        set -o pipefail
+        ${{ inputs.testCommand }} | tee -a ${{ inputs.testLogFile }}
     - name: Parse test results
       if: always()
       id: report

--- a/.github/workflows/actions/runPythonTests/action.yml
+++ b/.github/workflows/actions/runPythonTests/action.yml
@@ -45,6 +45,7 @@ runs:
       id: runTests
       shell: bash -l {0}
       run: |
+        set -o pipefail
         ${{ inputs.testCommand }} | sed -Ee "/[[:blank:]]*\([[:digit:]]{1,3} %\)[[:blank:]]*/d" | tee -a ${{ inputs.logFile }}
     - name: Write report
       shell: bash -l {0}


### PR DESCRIPTION
As noted in [this comment](https://github.com/FreeCAD/FreeCAD/pull/11758#issuecomment-1859788651), additional actions should fail if any sub-process fails.

This commit adds `pipefail` option to:

* .github/workflows/actions/linux/configure/action.yml
* .github/workflows/actions/linux/install/action.yml
* .github/workflows/actions/runCPPTests/runSingleTest/action.yml
* .github/workflows/actions/runPythonTests/action.yml
