### PR TITLE
CI: Fix issues affecting conda devenv installation resulting in failures.

### DIFF
--- a/conda/conda-env.yaml
+++ b/conda/conda-env.yaml
@@ -3,6 +3,6 @@ channels:
 - conda-forge
 dependencies:
 - conda-devenv
-- mamba==1.4.9  # NOTE: Pin to highest version supported by the devenv
-- python==3.11  # dependencies. If a higher version is installed, a crash
-                # occurs during the downgrade process.
+- mamba==1.4.9    # NOTE: Pin to highest version supported by the devenv
+- python==3.11.*  # dependencies. If a higher version is installed, a crash
+                  # occurs during the downgrade process.

--- a/conda/setup-environment.cmd
+++ b/conda/setup-environment.cmd
@@ -7,4 +7,4 @@ call conda config --add envs_dirs %CD%/.conda
 call conda config --set env_prompt "({name})"
 
 :: install the FreeCAD dependencies into the environment
-call mamba run --live-stream -n freecad mamba-devenv -f conda/environment.devenv.yml
+call mamba run --live-stream -n freecad mamba-devenv --no-prune -f conda/environment.devenv.yml

--- a/conda/setup-environment.sh
+++ b/conda/setup-environment.sh
@@ -9,4 +9,4 @@ conda config --add envs_dirs $(pwd)/.conda
 conda config --set env_prompt "({name})"
 
 # install the FreeCAD dependencies into the environment
-mamba run --live-stream -n freecad mamba-devenv -f conda/environment.devenv.yml
+mamba run --live-stream -n freecad mamba-devenv --no-prune -f conda/environment.devenv.yml


### PR DESCRIPTION
During the installation of the devenv, some packages are re-installed.  As this may take place in parallel with the installation of other packages, re-installation of the base packages may break the other packages due to missing core libraries resulting in a failure.

This PR correctly sets the Python to 3.11.x, preventing an unnecessary upgrade, and also sets the `--no-prune` option to `mamba-devenv`, preventing the re-installation of the core packages.