### PR TITLE
[Base/Units] Change strings' description

### DIFF
--- a/src/Base/QuantityLexer.c
+++ b/src/Base/QuantityLexer.c
@@ -2149,7 +2149,7 @@ static int yy_get_next_buffer (void)
     void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer )
 {
 
-	/* TODO. We should be able to replace this entire function body
+	/* TODO: We should be able to replace this entire function body
 	 * with
 	 *		yypop_buffer_state();
 	 *		yypush_buffer_state(new_buffer);

--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -66,9 +66,9 @@ QString UnitsApi::getDescription(UnitSystem system)
 {
     switch (system) {
         case UnitSystem::SI1:
-            return tr("Standard (mm, kg, s, degree)");
+            return tr("Standard (mm, kg, s, °)");
         case UnitSystem::SI2:
-            return tr("MKS (m, kg, s, degree)");
+            return tr("MKS (m, kg, s, °)");
         case UnitSystem::Imperial1:
             return tr("US customary (in, lb)");
         case UnitSystem::ImperialDecimal:
@@ -80,7 +80,7 @@ QString UnitsApi::getDescription(UnitSystem system)
         case UnitSystem::MmMin:
             return tr("Metric small parts & CNC(mm, mm/min)");
         case UnitSystem::ImperialCivil:
-            return tr("Imperial for Civil Eng (ft, ft/sec)");
+            return tr("Imperial for Civil Eng (ft, ft/s)");
         case UnitSystem::FemMilliMeterNewton:
             return tr("FEM (mm, N, s)");
         case UnitSystem::MeterDecimal:

--- a/src/Base/UnitsSchema.h
+++ b/src/Base/UnitsSchema.h
@@ -42,7 +42,7 @@ enum class UnitSystem
     Centimeters = 4,     /** All lengths in centimeters, areas and volumes in square/cubic meters */
     ImperialBuilding = 5, /** All lengths in feet + inches + fractions */
     MmMin = 6, /** Lengths in mm, Speed in mm/min. Angle in degrees. Useful for small parts & CNC */
-    ImperialCivil = 7, /** Lengths in ft, Speed in ft/sec. Used in Civil Eng in North America */
+    ImperialCivil = 7,       /** Lengths in ft, Speed in ft/s. Used in Civil Eng in North America */
     FemMilliMeterNewton = 8, /** Lengths in mm, Mass in t, TimeSpan in s, thus force is in N */
     MeterDecimal = 9,        /** Lengths in metres always */
     NumUnitSystemTypes       // must be the last item!

--- a/src/Base/UnitsSchemaImperial1.cpp
+++ b/src/Base/UnitsSchemaImperial1.cpp
@@ -82,19 +82,19 @@ UnitsSchemaImperial1::schemaTranslate(const Quantity& quant, double& factor, QSt
         factor = 1.0;
     }
     else if (unit == Unit::Area) {
-        // TODO Cascade for the Areas
+        // TODO: Cascade for the Areas
         // default action for all cases without special treatment:
         unitString = QString::fromLatin1("in^2");
         factor = 645.16;
     }
     else if (unit == Unit::Volume) {
-        // TODO Cascade for the Volume
+        // TODO: Cascade for the Volume
         // default action for all cases without special treatment:
         unitString = QString::fromLatin1("in^3");
         factor = 16387.064;
     }
     else if (unit == Unit::Mass) {
-        // TODO Cascade for the weights
+        // TODO: Cascade for the weights
         // default action for all cases without special treatment:
         unitString = QString::fromLatin1("lb");
         factor = 0.45359237;
@@ -149,19 +149,19 @@ QString UnitsSchemaImperialDecimal::schemaTranslate(const Base::Quantity& quant,
         factor = 1.0;
     }
     else if (unit == Unit::Area) {
-        // TODO Cascade for the Areas
+        // TODO: Cascade for the Areas
         // default action for all cases without special treatment:
         unitString = QString::fromLatin1("in^2");
         factor = 645.16;
     }
     else if (unit == Unit::Volume) {
-        // TODO Cascade for the Volume
+        // TODO: Cascade for the Volume
         // default action for all cases without special treatment:
         unitString = QString::fromLatin1("in^3");
         factor = 16387.064;
     }
     else if (unit == Unit::Mass) {
-        // TODO Cascade for the weights
+        // TODO: Cascade for the weights
         // default action for all cases without special treatment:
         unitString = QString::fromLatin1("lb");
         factor = 0.45359237;

--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -117,7 +117,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, QStr
         }
     }
     else if (unit == Unit::Angle) {
-        // TODO Cascade for the Areas
+        // TODO: Cascade for the Areas
         // default action for all cases without special treatment:
         unitString = QString::fromUtf8("\xC2\xB0");
         factor = 1.0;

--- a/src/Base/VectorPyImp.cpp
+++ b/src/Base/VectorPyImp.cpp
@@ -713,7 +713,7 @@ int VectorPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
     return 0;
 }
 
-// TODO for v0.18:
+// TODO: for v0.18
 // In generation script allow to more precisely define which slots
 // of the number protocol should be supported instead of setting all.
 


### PR DESCRIPTION
Currently in the string description for unit system "degree" (unit name) appears instead of "°" (symbol). In the same entries appear "mm", "kg", "s" opposed to "millimeter", "kilogram", "second". So I think could be a better fit to use the symbol for the unit instead.

As an example SOLIDWORKS uses the full name of the units instead of only the symbols.

Usually the use of "s" instead of "sec" is preferred for time unit second.

Affects strings presented to the user on the combobox to select unit system.

- The symbol to represent angles on "degree" unit is '°'
- Change imperial velocity to "ft/s" to enforce the use of 's' symbol as second

Also added colons to TODOs to get highlightning.