### PR TITLE
[base] Extend Python class App.Vector by isParallel function

### DIFF
--- a/src/Base/Vector3D.cpp
+++ b/src/Base/Vector3D.cpp
@@ -228,6 +228,25 @@ bool Vector3<float_type>::IsEqual(const Vector3<float_type>& rclPnt, float_type 
 }
 
 template<class float_type>
+bool Vector3<float_type>::IsParallel(const Vector3<float_type>& rclPnt, float_type tol) const
+{
+    Vector3<float_type> v1 = *this;
+    Vector3<float_type> v2 = rclPnt;
+    double dot = abs(v1 * v2);
+    double mag = v1.Length() * v2.Length();
+    return (abs(dot - mag) < tol);
+}
+
+template<class float_type>
+bool Vector3<float_type>::IsNormal(const Vector3<float_type>& rclPnt, float_type tol) const
+{
+    Vector3<float_type> v1 = *this;
+    Vector3<float_type> v2 = rclPnt;
+    double dot = abs(v1 * v2);
+    return (dot < tol);
+}
+
+template<class float_type>
 Vector3<float_type>& Vector3<float_type>::ProjectToPlane(const Vector3<float_type>& rclBase,
                                                          const Vector3<float_type>& rclNorm)
 {

--- a/src/Base/Vector3D.h
+++ b/src/Base/Vector3D.h
@@ -210,6 +210,10 @@ public:
      * equal.
      */
     bool IsEqual(const Vector3& rclPnt, float_type tol) const;
+    /// Returns true if two vectors are parallel within the tol
+    bool IsParallel(const Vector3& rclPnt, float_type tol) const;
+    /// Returns true if two vectors are normal within the tol
+    bool IsNormal(const Vector3& rclPnt, float_type tol) const;
     /// Projects this point onto the plane given by the base \a rclBase and the normal \a rclNorm.
     Vector3& ProjectToPlane(const Vector3& rclBase, const Vector3& rclNorm);
     /**

--- a/src/Base/VectorPy.xml
+++ b/src/Base/VectorPy.xml
@@ -158,6 +158,17 @@ vector2 : Base.Vector
 tol : float</UserDocu>
             </Documentation>
         </Methode>
+        <Methode Name="isNormal" Const="true">
+            <Documentation>
+                <UserDocu>isNormal(vector2, tol=0) -> bool
+
+Checks if this vector and `vector2` are
+normal less or equal to the given tolerance.
+
+vector2 : Base.Vector
+tol : float</UserDocu>
+            </Documentation>
+        </Methode>
         <Methode Name="projectToLine">
             <Documentation>
                 <UserDocu>projectToLine(point, dir) -> Base.Vector

--- a/src/Base/VectorPy.xml
+++ b/src/Base/VectorPy.xml
@@ -147,6 +147,17 @@ vector2 : Base.Vector
 tol : float</UserDocu>
             </Documentation>
         </Methode>
+        <Methode Name="isParallel" Const="true">
+            <Documentation>
+                <UserDocu>isParallel(vector2, tol=0) -> bool
+
+Checks if this vector and `vector2` are
+parallel less or equal to the given tolerance.
+
+vector2 : Base.Vector
+tol : float</UserDocu>
+            </Documentation>
+        </Methode>
         <Methode Name="projectToLine">
             <Documentation>
                 <UserDocu>projectToLine(point, dir) -> Base.Vector

--- a/src/Base/VectorPyImp.cpp
+++ b/src/Base/VectorPyImp.cpp
@@ -389,7 +389,7 @@ PyObject* VectorPy::isParallel(PyObject* args)
 
     VectorPy::PointerType v1_ptr = getVectorPtr();
     VectorPy::PointerType v2_ptr = vec->getVectorPtr();
-    
+
     Py::Boolean parallel((*v1_ptr).IsParallel(*v2_ptr, tolerance));
     return Py::new_reference_to(parallel);
 }
@@ -406,7 +406,7 @@ PyObject* VectorPy::isNormal(PyObject* args)
 
     VectorPy::PointerType v1_ptr = getVectorPtr();
     VectorPy::PointerType v2_ptr = vec->getVectorPtr();
-    
+
     Py::Boolean normal((*v1_ptr).IsNormal(*v2_ptr, tolerance));
     return Py::new_reference_to(normal);
 }

--- a/src/Base/VectorPyImp.cpp
+++ b/src/Base/VectorPyImp.cpp
@@ -390,11 +390,25 @@ PyObject* VectorPy::isParallel(PyObject* args)
     VectorPy::PointerType v1_ptr = getVectorPtr();
     VectorPy::PointerType v2_ptr = vec->getVectorPtr();
     
-    double dot = abs((*v1_ptr)*(*v2_ptr));
-    double mag = v1_ptr->Length()*v2_ptr->Length();
-    
-    Py::Boolean parallel(abs(dot-mag) < tolerance);
+    Py::Boolean parallel((*v1_ptr).IsParallel(*v2_ptr, tolerance));
     return Py::new_reference_to(parallel);
+}
+
+PyObject* VectorPy::isNormal(PyObject* args)
+{
+    PyObject* obj = nullptr;
+    double tolerance = 0;
+    if (!PyArg_ParseTuple(args, "O!d", &(VectorPy::Type), &obj, &tolerance)) {
+        return nullptr;
+    }
+
+    VectorPy* vec = static_cast<VectorPy*>(obj);
+
+    VectorPy::PointerType v1_ptr = getVectorPtr();
+    VectorPy::PointerType v2_ptr = vec->getVectorPtr();
+    
+    Py::Boolean normal((*v1_ptr).IsNormal(*v2_ptr, tolerance));
+    return Py::new_reference_to(normal);
 }
 
 PyObject* VectorPy::scale(PyObject* args)

--- a/src/Base/VectorPyImp.cpp
+++ b/src/Base/VectorPyImp.cpp
@@ -377,6 +377,26 @@ PyObject* VectorPy::isEqual(PyObject* args)
     return Py::new_reference_to(eq);
 }
 
+PyObject* VectorPy::isParallel(PyObject* args)
+{
+    PyObject* obj = nullptr;
+    double tolerance = 0;
+    if (!PyArg_ParseTuple(args, "O!d", &(VectorPy::Type), &obj, &tolerance)) {
+        return nullptr;
+    }
+
+    VectorPy* vec = static_cast<VectorPy*>(obj);
+
+    VectorPy::PointerType v1_ptr = getVectorPtr();
+    VectorPy::PointerType v2_ptr = vec->getVectorPtr();
+    
+    double dot = abs((*v1_ptr)*(*v2_ptr));
+    double mag = v1_ptr->Length()*v2_ptr->Length();
+    
+    Py::Boolean parallel(abs(dot-mag) < tolerance);
+    return Py::new_reference_to(parallel);
+}
+
 PyObject* VectorPy::scale(PyObject* args)
 {
     double factorX = 0.0;


### PR DESCRIPTION
Extend Python class App.Vector by a boolean function `isParallel`.

Usage: 
```python
       vec1 = App.Vector(...)
       vec2 = App.Vector(...)
       tol = 0.01
       if vec1.isParallel(vec2,tol):
          ....
```
Returns True if the two vectors are parallel, otherwise returns False.