### PR TITLE
[TechDraw] Implement proper selection of subitems

### DIFF
--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -539,3 +539,33 @@ double DrawGuiUtil::roundToDigits(double original, int digits)
     temp = rounded / factor;
     return temp;
 }
+
+// Returns true if the item or any of its descendants is selected
+bool DrawGuiUtil::isSelectedInTree(QGraphicsItem *item)
+{
+    if (item) {
+        if (item->isSelected()) {
+            return true;
+        }
+
+        for (QGraphicsItem *child : item->childItems()) {
+           if (isSelectedInTree(child)) {
+               return true;
+           }
+        }
+    }
+
+    return false;
+}
+
+// Selects or deselects the item and all its descendants
+void DrawGuiUtil::setSelectedTree(QGraphicsItem *item, bool selected)
+{
+    if (item) {
+        item->setSelected(selected);
+
+        for (QGraphicsItem *child : item->childItems()) {
+            setSelectedTree(child, selected);
+        }
+    }
+}

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.h
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <QCoreApplication>
+#include <QGraphicsItem>
 
 #include <Base/Vector3D.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
@@ -77,6 +78,8 @@ class TechDrawGuiExport DrawGuiUtil {
 
     static double roundToDigits(double original, int digits);
 
+    static bool isSelectedInTree(QGraphicsItem *item);
+    static void setSelectedTree(QGraphicsItem *item, bool selected);
 
 };
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -69,7 +69,7 @@ public:
     void preSelectionChanged(const QPoint &pos);
 
     /// QGraphicsScene selection routines
-    void selectQGIView(App::DocumentObject *obj, bool isSelected);
+    void selectQGIView(App::DocumentObject *obj, bool isSelected, const std::vector<std::string> &subNames);
     void clearSceneSelection();
     void blockSceneSelection(bool isBlocked);
 

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -130,11 +130,24 @@ bool QGIView::isVisible()
     return vpdo->Visibility.getValue();
 }
 
+//Gets selection state for this view and/or eventually its children
+bool QGIView::getGroupSelection()
+{
+    return isSelected();
+}
+
 //Set selection state for this and its children
 //required for items like dimensions & balloons
 void QGIView::setGroupSelection(bool isSelected)
 {
     setSelected(isSelected);
+}
+
+// Set selection state of the feature (empty subName) or its sub items
+void QGIView::setGroupSelection(bool isSelected, const std::vector<std::string> &subNames)
+{
+    Q_UNUSED(subNames);
+    setGroupSelection(isSelected);
 }
 
 void QGIView::alignTo(QGraphicsItem*item, const QString &alignment)

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -102,7 +102,9 @@ public:
     virtual void isVisible(bool state);
     virtual bool isVisible();
 
+    virtual bool getGroupSelection();
     virtual void setGroupSelection(bool isSelected);
+    virtual void setGroupSelection(bool isSelected, const std::vector<std::string> &subNames);
 
     virtual void draw();
     virtual void drawCaption();

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -313,6 +313,11 @@ QVariant QGIViewBalloon::itemChange(GraphicsItemChange change, const QVariant& v
     return QGIView::itemChange(change, value);
 }
 
+bool QGIViewBalloon::getGroupSelection()
+{
+    return balloonLabel->isSelected();
+}
+
 //Set selection state for this and its children
 void QGIViewBalloon::setGroupSelection(bool isSelected)
 {

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -193,6 +193,7 @@ public:
     void setPrettySel();
     void setPrettyNormal();
 
+    bool getGroupSelection() override;
     void setGroupSelection(bool isSelected) override;
     virtual QGIBalloonLabel* getBalloonLabel()
     {

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -525,6 +525,11 @@ QVariant QGIViewDimension::itemChange(GraphicsItemChange change, const QVariant&
     return QGIView::itemChange(change, value);
 }
 
+bool QGIViewDimension::getGroupSelection()
+{
+    return datumLabel->isSelected();
+}
+
 //Set selection state for this and its children
 void QGIViewDimension::setGroupSelection(bool isSelected)
 {

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.h
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.h
@@ -176,6 +176,7 @@ public:
     void setPrettySel();
     void setPrettyNormal();
 
+    bool getGroupSelection() override;
     void setGroupSelection(bool isSelected) override;
     virtual QGIDatumLabel* getDatumLabel() const { return datumLabel; }
 

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -109,6 +109,12 @@ public:
                                      double x, double y,
                                      double curx, double cury);
 
+    bool getGroupSelection() override;
+    void setGroupSelection(bool isSelected) override;
+    void setGroupSelection(bool isSelected, const std::vector<std::string> &subNames) override;
+
+    virtual QGraphicsItem *getQGISubItemByName(const std::string &subName) const;
+
 protected:
     QPainterPath drawPainterPath(TechDraw::BaseGeomPtr baseGeom) const;
     void drawViewPart();


### PR DESCRIPTION
As Part View is able to provide sub-items to selection, it is desirable to make the vertices/edges/faces also visually selected, when the current selection is changed e.g. from Python code.

This pull request adds this ability, while trying to respect the subitems selection attitude. This means when nothing is selected:
`Gui.Selection.addSelection('doc', 'View')` adds only the view to the selection, but none of the subitems. The frame and label of the view are highlighted.
`Gui.Selection.addSelection('doc', 'View', 'Edge1')` adds the 1st edge to the selection, highlights it, causes the view item to be selected in the tree, but does not highlight the view frame and label on the TechDraw page.
`Gui.Selection.addSelection('doc','View', '')` adds the view, but none of its subitems. It acts in the very same way as the first code snippet.

`Gui.Selection.removeSelection('doc', 'View')` makes the view and all its selected sub items unselected.
`Gui.Selection.removeSelection('doc', 'View','Edge1')` unselects the 1st edge, but keeps the view frame and label selected if they were selected before. If only the edge was selected (not the view itself), the view item is also unselected in the tree.
`Gui.Selection.removeSelection('doc', 'View','')` behaves in the very same way as the first removal code line does.

`Gui.Selection.clearSelection('doc')` behaves as expected, making all views and their sub-items to become unselected. The current behavior not unselecting the edges etc. is fixed.

I hope this small addition proves useful, if there are any issues caused by the changes, please let me know.