### PR TITLE
Provide a default axis for polar patterns in multitransformation

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -370,6 +370,10 @@ void TaskMultiTransformParameters::onTransformAddPolarPattern()
     App::DocumentObject* sketch = getSketchObject();
     if (sketch)
         FCMD_OBJ_CMD(Feat, "Axis = ("<<Gui::Command::getObjectCmd(sketch)<<",['N_Axis'])");
+    else {
+        App::Origin* orig = pcActiveBody->getOrigin();
+        FCMD_OBJ_CMD(Feat, "Axis = ("<<Gui::Command::getObjectCmd(orig->getX())<<",[''])");
+    }
     FCMD_OBJ_CMD(Feat, "Angle = 360");
     FCMD_OBJ_CMD(Feat, "Occurrences = 2");
 


### PR DESCRIPTION
Fix #11801.