### PR TITLE
Sketcher: change tool description of rotate and polygon tool

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -302,8 +302,9 @@ template<>
 void DSHPolygonController::configureToolWidget()
 {
 
-    toolWidget->setParameterLabel(OnViewParameter::First,
-                                  QApplication::translate("ToolWidgetManager_p4", "Sides 'U'/'J'"));
+    toolWidget->setParameterLabel(
+        OnViewParameter::First,
+        QApplication::translate("ToolWidgetManager_p4", "Sides (+'U'/ -'J')"));
     toolWidget->setParameter(OnViewParameter::First,
                              handler->numberOfCorners);  // unconditionally set
     toolWidget->configureParameterUnit(OnViewParameter::First, Base::Unit());

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -490,11 +490,12 @@ void DSHRotateController::configureToolWidget()
             QApplication::translate("TaskSketcherTool_c1_offset", "Clone constraints"));
         toolWidget->setCheckboxToolTip(
             WCheckbox::FirstBox,
-            QApplication::translate(
-                "TaskSketcherTool_c1_offset",
-                "This concerns the datum constraints like distances. If you activate Clone, "
-                "then the tool will copy the datum. Else it will try to replace them with "
-                "equalities between the initial geometries and the new copies."));
+            QString::fromLatin1("<p>")
+                + QApplication::translate("TaskSketcherTool_c1_offset",
+                                          "This concerns the datum constraints (e.g. distance)."
+                                          "If you activate Clone, the tool will copy the datum."
+                                          "Else it will try to replace them with equalities.")
+                + QString::fromLatin1("</p>"));
     }
 
     onViewParameters[OnViewParameter::First]->setLabelType(Gui::SoDatumLabel::DISTANCEX);
@@ -508,7 +509,7 @@ void DSHRotateController::configureToolWidget()
 
     toolWidget->setParameterLabel(
         WParameter::First,
-        QApplication::translate("TaskSketcherTool_p4_rotate", "Copies 'U'/'J'"));
+        QApplication::translate("TaskSketcherTool_p4_rotate", "Copies (+'U'/ -'J')"));
     toolWidget->setParameter(OnViewParameter::First, 0.0);
     toolWidget->configureParameterUnit(OnViewParameter::First, Base::Unit());
     toolWidget->configureParameterMin(OnViewParameter::First, 0.0);     // NOLINT


### PR DESCRIPTION
Change the tool description of polar pattern (rotate) and polygon in the Sketcher WB to better hint users to modify with U and J key. Added line breaks to the copy constraints tooltip.
@PaddleStroke fixing https://github.com/FreeCAD/FreeCAD/pull/11264#issuecomment-1868324482


Before:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/243745f9-e644-4df4-8054-13d40f09eec1)

After:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/2c33fc16-60f3-4a70-94e2-60d40932fa6f)
