### PR TITLE
Change the description of the default 'Toggle active object' command

### DIFF
--- a/src/Gui/ViewProviderPart.cpp
+++ b/src/Gui/ViewProviderPart.cpp
@@ -68,35 +68,20 @@ void ViewProviderPart::onChanged(const App::Property* prop) {
 
 void ViewProviderPart::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {
-    App::DocumentObject* activePart = nullptr;
-    auto activeDoc = Gui::Application::Instance->activeDocument();
-    if(!activeDoc)
-        activeDoc = getDocument();
-    auto activeView = activeDoc->setActiveView(this);
-    activePart = activeView->getActiveObject<App::DocumentObject*> (PARTKEY);
-
     auto func = new Gui::ActionFunction(menu);
 
-    if (activePart == this->getObject()){
-        QAction* act = menu->addAction(QObject::tr("Unset active object"));
-        func->trigger(act, [this](){
-        this->doubleClicked();
+    QAction* act = menu->addAction(QObject::tr("Active object"));
+    act->setCheckable(true);
+    act->setChecked(isActivePart());
+    func->trigger(act, [this](){
+    this->toggleActivePart();
     });
-    } else {
-        QAction* act = menu->addAction(QObject::tr("Set active object"));
-        func->trigger(act, [this](){
-        this->doubleClicked();
-    });
-    }
 
     ViewProviderDragger::setupContextMenu(menu, receiver, member);
 }
 
-bool ViewProviderPart::doubleClicked()
+bool ViewProviderPart::isActivePart()
 {
-    //make the part the active one
-
-    //first, check if the part is already active.
     App::DocumentObject* activePart = nullptr;
     auto activeDoc = Gui::Application::Instance->activeDocument();
     if(!activeDoc)
@@ -108,6 +93,16 @@ bool ViewProviderPart::doubleClicked()
     activePart = activeView->getActiveObject<App::DocumentObject*> (PARTKEY);
 
     if (activePart == this->getObject()){
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void ViewProviderPart::toggleActivePart()
+{
+    //make the part the active one
+    if (isActivePart()){
         //active part double-clicked. Deactivate.
         Gui::Command::doCommand(Gui::Command::Gui,
                 "Gui.ActiveDocument.ActiveView.setActiveObject('%s', None)",
@@ -120,7 +115,11 @@ bool ViewProviderPart::doubleClicked()
                 this->getObject()->getDocument()->getName(),
                 this->getObject()->getNameInDocument());
     }
+}
 
+bool ViewProviderPart::doubleClicked()
+{
+    toggleActivePart();
     return true;
 }
 

--- a/src/Gui/ViewProviderPart.cpp
+++ b/src/Gui/ViewProviderPart.cpp
@@ -68,11 +68,26 @@ void ViewProviderPart::onChanged(const App::Property* prop) {
 
 void ViewProviderPart::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {
+    App::DocumentObject* activePart = nullptr;
+    auto activeDoc = Gui::Application::Instance->activeDocument();
+    if(!activeDoc)
+        activeDoc = getDocument();
+    auto activeView = activeDoc->setActiveView(this);
+    activePart = activeView->getActiveObject<App::DocumentObject*> (PARTKEY);
+
     auto func = new Gui::ActionFunction(menu);
-    QAction* act = menu->addAction(QObject::tr("Toggle active part"));
-    func->trigger(act, [this](){
+
+    if (activePart == this->getObject()){
+        QAction* act = menu->addAction(QObject::tr("Unset active object"));
+        func->trigger(act, [this](){
         this->doubleClicked();
     });
+    } else {
+        QAction* act = menu->addAction(QObject::tr("Set active object"));
+        func->trigger(act, [this](){
+        this->doubleClicked();
+    });
+    }
 
     ViewProviderDragger::setupContextMenu(menu, receiver, member);
 }

--- a/src/Gui/ViewProviderPart.h
+++ b/src/Gui/ViewProviderPart.h
@@ -43,6 +43,8 @@ public:
 
     bool doubleClicked() override;
     void setupContextMenu(QMenu* menu, QObject* receiver, const char* member) override;
+    bool isActivePart();
+    void toggleActivePart();
 
     /// deliver the icon shown in the tree view
     /// override from ViewProvider.h

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -132,10 +132,23 @@ void ViewProviderBody::setupContextMenu(QMenu* menu, QObject* receiver, const ch
     Q_UNUSED(receiver);
     Q_UNUSED(member);
     Gui::ActionFunction* func = new Gui::ActionFunction(menu);
-    QAction* act = menu->addAction(tr("Toggle active body"));
+
+    auto activeDoc = Gui::Application::Instance->activeDocument();
+    if(!activeDoc)
+        activeDoc = getDocument();
+    auto activeView = activeDoc->setActiveView(this);
+
+     if (activeView->isActiveObject(getObject(),PDBODYKEY)) {
+        QAction* act = menu->addAction(tr("Unset active body"));
     func->trigger(act, [this]() {
         this->doubleClicked();
     });
+    } else {
+        QAction* act = menu->addAction(tr("Set active body"));
+    func->trigger(act, [this]() {
+        this->doubleClicked();
+    });
+    }
 
     Gui::ViewProviderGeometryObject::setupContextMenu(menu, receiver, member); // clazy:exclude=skipped-base-method
 }

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.h
@@ -58,6 +58,8 @@ public:
 
     bool doubleClicked() override;
     void setupContextMenu(QMenu* menu, QObject* receiver, const char* member) override;
+    bool isActiveBody();
+    void toggleActiveBody();
 
     std::vector< std::string > getDisplayModes() const override;
     void setDisplayMode(const char* ModeName) override;


### PR DESCRIPTION
Change the description of the default 'Toggle active object' command in the right click menu based on the current state of the selected object.
Currently it always says "Toggle active object".
The PR would say "Active object" and displays a checkbox as icon. If the object is currently not the active object the checkbox is unchecked, otherwise the checkbox is checked.
The code previously called the double click function which was now refactored in two new functions.

Before:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/e612a221-78ae-40e9-b265-8b265211adb0)

After:

https://github.com/FreeCAD/FreeCAD/assets/6246609/2b237541-f1e3-4b16-9cb3-3e9cb10e0ee1

