### PR TITLE
Right click context menu fixes

### DIFF
--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -257,6 +257,8 @@ void NavigationStyle::initialize()
         setRotationCenterMode(NavigationStyle::RotationCenterMode::ScenePointAtCursor |
                               NavigationStyle::RotationCenterMode::BoundingBoxCenter);
     }
+
+    this->hasPanned = false;
 }
 
 void NavigationStyle::finalize()
@@ -583,6 +585,7 @@ void NavigationStyle::panCamera(SoCamera * cam, float aspectratio, const SbPlane
     // Reposition camera according to the vector difference between the
     // projected points.
     cam->position = cam->position.getValue() - (current_planept - old_planept);
+    hasPanned = true;
 }
 
 void NavigationStyle::pan(SoCamera* camera)
@@ -1365,6 +1368,7 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
     case PANNING:
         animator->stop();
         pan(viewer->getSoRenderManager()->getCamera());
+        hasPanned = false;
         this->interactiveCountInc();
         break;
 
@@ -1386,8 +1390,12 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
     case SPINNING:
     case DRAGGING:
         viewer->showRotationCenter(false);
-        [[fallthrough]];
+        this->interactiveCountDec();
+        break;
     case PANNING:
+        hasPanned = false;
+        this->interactiveCountDec();
+        break;
     case ZOOMING:
     case BOXZOOM:
         this->interactiveCountDec();

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -258,6 +258,7 @@ void NavigationStyle::initialize()
                               NavigationStyle::RotationCenterMode::BoundingBoxCenter);
     }
 
+    this->hasDragged = false;
     this->hasPanned = false;
 }
 
@@ -898,6 +899,8 @@ void NavigationStyle::spin(const SbVec2f & pointerpos)
     // when the user quickly trigger (as in "click-drag-release") a spin
     // animation.
     if (this->spinsamplecounter > 3) this->spinsamplecounter = 3;
+
+    hasDragged = true;
 }
 
 /*!
@@ -932,6 +935,7 @@ void NavigationStyle::spin_simplified(SoCamera* cam, SbVec2f curpos, SbVec2f pre
     r.invert();
     this->reorientCamera(cam, r);
 
+    hasDragged = true;
 }
 
 SbBool NavigationStyle::doSpin()
@@ -1348,6 +1352,11 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
         return;
     }
 
+    if (newmode != NavigationStyle::IDLE) {
+        hasPanned = false;
+        hasDragged = false;
+    }
+
     switch (newmode) {
     case DRAGGING:
         // Set up initial projection point for the projector object when
@@ -1368,7 +1377,6 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
     case PANNING:
         animator->stop();
         pan(viewer->getSoRenderManager()->getCamera());
-        hasPanned = false;
         this->interactiveCountInc();
         break;
 
@@ -1390,12 +1398,8 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
     case SPINNING:
     case DRAGGING:
         viewer->showRotationCenter(false);
-        this->interactiveCountDec();
-        break;
+        [[fallthrough]];
     case PANNING:
-        hasPanned = false;
-        this->interactiveCountDec();
-        break;
     case ZOOMING:
     case BOXZOOM:
         this->interactiveCountDec();

--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -259,6 +259,7 @@ protected:
     SbBool invertZoom;
     SbBool zoomAtCursor;
     float zoomStep;
+    SbBool hasDragged;
     SbBool hasPanned;
 
     /** @name Mouse model */

--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -259,6 +259,7 @@ protected:
     SbBool invertZoom;
     SbBool zoomAtCursor;
     float zoomStep;
+    SbBool hasPanned;
 
     /** @name Mouse model */
     //@{

--- a/src/Gui/OpenSCADNavigationStyle.cpp
+++ b/src/Gui/OpenSCADNavigationStyle.cpp
@@ -143,9 +143,10 @@ SbBool OpenSCADNavigationStyle::processSoEvent(const SoEvent * const ev)
             if (!viewer->isEditing()) {
                 // If we are in zoom or pan mode ignore RMB events otherwise
                 // the canvas doesn't get any release events
-                if (curmode != NavigationStyle::ZOOMING &&
+                if ((curmode != NavigationStyle::ZOOMING &&
                     curmode != NavigationStyle::PANNING &&
-                    curmode != NavigationStyle::DRAGGING) {
+                    curmode != NavigationStyle::DRAGGING) ||
+                    (curmode == NavigationStyle::PANNING && !hasPanned)) {
                     if (this->isPopupMenuEnabled()) {
                         if (!press) { // release right mouse button
                             this->openPopupMenu(event->getPosition());

--- a/src/Gui/OpenSCADNavigationStyle.cpp
+++ b/src/Gui/OpenSCADNavigationStyle.cpp
@@ -166,6 +166,9 @@ SbBool OpenSCADNavigationStyle::processSoEvent(const SoEvent * const ev)
                 newmode = NavigationStyle::IDLE;
                 processed = true;
             }
+            else if (!press && curmode == NavigationStyle::PANNING && hasPanned) {
+                processed = true;
+            }
             break;
         case SoMouseButtonEvent::BUTTON3:
             this->button3down = press;

--- a/src/Gui/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/TinkerCADNavigationStyle.cpp
@@ -142,6 +142,9 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
                 this->centerTime = ev->getTime();
                 processed = true;
             }
+            else if (!press && curmode == NavigationStyle::DRAGGING && hasDragged) {
+                processed = true;
+            }
             else if (!press && curmode == NavigationStyle::DRAGGING && !hasDragged) {
                 newmode = NavigationStyle::IDLE;
                 if (!viewer->isEditing()) {

--- a/src/Gui/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/TinkerCADNavigationStyle.cpp
@@ -110,7 +110,6 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
         const auto event = (const SoMouseButtonEvent *) ev;
         const int button = event->getButton();
         const SbBool press = event->getState() == SoButtonEvent::DOWN ? true : false;
-        SbBool shortRMBclick = false;
 
         switch (button) {
         case SoMouseButtonEvent::BUTTON1:
@@ -135,14 +134,6 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
                 mouseDownConsumedEvent = *event;
                 mouseDownConsumedEvent.setTime(ev->getTime());
             }
-            else if (mouseDownConsumedEvent.getButton() == SoMouseButtonEvent::BUTTON2) {
-                SbTime tmp = (ev->getTime() - mouseDownConsumedEvent.getTime());
-                float dci = float(QApplication::doubleClickInterval())/1000.0f;
-                // time between press and release event
-                if (tmp.getValue() < dci) {
-                    shortRMBclick = true;
-                }
-            }
 
             // About to start rotating
             if (press && (curmode == NavigationStyle::IDLE)) {
@@ -151,16 +142,14 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
                 this->centerTime = ev->getTime();
                 processed = true;
             }
-            else if (!press && (curmode == NavigationStyle::DRAGGING)) {
-                if (shortRMBclick) {
-                    newmode = NavigationStyle::IDLE;
-                    if (!viewer->isEditing()) {
-                        // If we are in drag mode but mouse hasn't been moved open the context-menu
-                        if (this->isPopupMenuEnabled()) {
-                            this->openPopupMenu(event->getPosition());
-                        }
-                        processed = true;
+            else if (!press && curmode == NavigationStyle::DRAGGING && !hasDragged) {
+                newmode = NavigationStyle::IDLE;
+                if (!viewer->isEditing()) {
+                    // If we are in drag mode but mouse hasn't been moved open the context-menu
+                    if (this->isPopupMenuEnabled()) {
+                        this->openPopupMenu(event->getPosition());
                     }
+                    processed = true;
                 }
             }
             break;


### PR DESCRIPTION
This PR fixes several right click context menu issues.

The OpenSCAD navigation style did not show the context menu when right clicking. Now it does.
The TinkerCAD navigation style showed the context menu after a fast drag. Now it only shows it when right mouse is released and the view was not dragged.

This PR fixes #10624 where the context menu always popped up after a drag in the sketcher. And the same for the OpenSCAD style but then for panning.

To fix these issues I added two variables: `hasDragged` and `hasPanned`. These are used to detect if the view was actually dragged or panned when the mode is/was `DRAGGING` or `PANNING`. The TinkerCAD and OpenSCAD styles check the `hasDragged` and `hasPanned`  variable and set processed to true when the right mouse button is released.
