### PR TITLE
Always show auto HorVer tool command in the toolbar (like auto dimension) when concise option is enabled

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -2610,6 +2610,7 @@ public:
         eType = ForEdit;
 
         setCheckable(false);
+        setRememberLast(false);
 
         addCommand("Sketcher_ConstrainHorVer");
         addCommand("Sketcher_ConstrainHorizontal");


### PR DESCRIPTION
https://github.com/FreeCAD/FreeCAD/pull/11745#issuecomment-1870435624
Always show auto HorVer tool command in the toolbar when the tool is present (concise toolbar option by @obelisk79 )
Currently the last used tool is shown as command in the toolbar, this PR makes the auto tool not remember the last sub tool, like currently also implemented in the auto dimension tool.
![293062926-bb05611e-72f8-404e-97d5-e9b013739f4d](https://github.com/FreeCAD/FreeCAD/assets/6246609/ba17ac58-537e-4bd2-8b78-ac656000b139)

