### PR TITLE
Add placement command to context menu

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -595,7 +595,7 @@ void StdWorkbench::setupContextMenu(const char* recipient, MenuItem* item) const
         *measure << "View_Measure_Toggle_All" << "View_Measure_Clear_All";
 
 
-        *item << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_DrawStyle" 
+        *item << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_DrawStyle"
               << StdViews << measure << "Separator"
               << "Std_ViewDockUndockFullscreen";
 
@@ -603,13 +603,13 @@ void StdWorkbench::setupContextMenu(const char* recipient, MenuItem* item) const
             *item << "Separator" << "Std_SetAppearance" << "Std_ToggleVisibility"
                   << "Std_ToggleSelectability" << "Std_TreeSelection"
                   << "Std_RandomColor" << "Std_ToggleTransparency" << "Separator" << "Std_Delete"
-                  << "Std_SendToPythonConsole" << "Std_TransformManip";
+                  << "Std_SendToPythonConsole" << "Std_TransformManip" << "Std_Placement";
         }
     }
     else if (strcmp(recipient,"Tree") == 0)
     {
         if (Gui::Selection().countObjectsOfType(App::DocumentObject::getClassTypeId()) > 0) {
-            *item << "Std_ToggleVisibility" << "Std_ShowSelection" << "Std_HideSelection"
+            *item << "Std_Placement" << "Std_ToggleVisibility" << "Std_ShowSelection" << "Std_HideSelection"
                   << "Std_ToggleSelectability" << "Std_TreeSelectAllInstances" << "Separator"
                   << "Std_SetAppearance" << "Std_RandomColor" << "Std_ToggleTransparency" << "Separator"
                   << "Std_Cut" << "Std_Copy" << "Std_Paste" << "Std_Delete"

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -233,7 +233,8 @@ void Workbench::setupContextMenu(const char* recipient, Gui::MenuItem* item) con
                 *item << "PartDesign_MultiTransform";
 
             if (Gui::Selection().countObjectsOfType(App::DocumentObject::getClassTypeId()) > 0) {
-                *item << "Std_SetAppearance"
+                *item << "Std_Placement"
+                      << "Std_SetAppearance"
                       << "Std_RandomColor"
                       << "Std_Cut"
                       << "Std_Copy"


### PR DESCRIPTION
Fixes parts of #11355
Placement command is added to the context menu in the tree and view if objects are selected which can be "placed"
