### PR TITLE
[TD]fix fail when dropping onto corrupt object

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingViewExtension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingViewExtension.cpp
@@ -58,9 +58,24 @@ void ViewProviderDrawingViewExtension::extensionDragObject(App::DocumentObject* 
 //extension to try to drop on us and cause problems
 bool ViewProviderDrawingViewExtension::extensionCanDropObjects() const { return true; }
 
-//let the page have any drops we receive
+//let the page have any drops we receive.
 bool ViewProviderDrawingViewExtension::extensionCanDropObject(App::DocumentObject* obj) const
 {
+    // it can happen that if the tree gets badly corrupted, there can be loose
+    // objects that have no page or view provider, so we need to check that
+    // all these objects exist.
+    auto vpdv = getViewProviderDrawingView();
+    if (!vpdv) {
+        return false;
+    }
+    auto vpp  = vpdv->getViewProviderPage();
+    if (!vpp) {
+        return false;
+    }
+    auto vppEx = vpp->getVPPExtension();
+    if (!vppEx) {
+        return false;
+    }
     return getViewProviderDrawingView()
         ->getViewProviderPage()
         ->getVPPExtension()


### PR DESCRIPTION
This PR implements a fix for an unusual situation reported here: https://forum.freecad.org/viewtopic.php?t=83825

If a TechDraw object somehow becomes disconnected from its parent or page, then there can be a crash when the ViewProvider attempts to handle a drop operation.  It is not clear how the situation in the forum thread was created.