### PR TITLE
Gui: Prohibit dragging using LMB in sketch mode for OpenSCAD style

### DIFF
--- a/src/Gui/OpenSCADNavigationStyle.cpp
+++ b/src/Gui/OpenSCADNavigationStyle.cpp
@@ -189,7 +189,7 @@ SbBool OpenSCADNavigationStyle::processSoEvent(const SoEvent * const ev)
     if (type.isDerivedFrom(SoLocation2Event::getClassTypeId())) {
         this->lockrecenter = true;
         const auto event = (const SoLocation2Event *) ev;
-        if (curmode == NavigationStyle::SELECTION) {
+        if (!viewer->isEditing() && curmode == NavigationStyle::SELECTION) {
             newmode = NavigationStyle::DRAGGING;
             saveCursorPosition(ev);
             this->centerTime = ev->getTime();


### PR DESCRIPTION
Fixes #10623.

Best I could come up with is to prohibit dragging using left mouse button when in sketch/editing mode. Dragging is still possible using middle mouse button + right mouse button. Left mouse button keeps working when not in editing mode.