### PR TITLE
Gui: fix ignored default shape color

### DIFF
--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -84,6 +84,7 @@ ViewProviderGeometryObject::ViewProviderGeometryObject()
     ADD_PROPERTY_TYPE(Transparency, (initialTransparency), osgroup, App::Prop_None, "Set object transparency");
     Transparency.setConstraints(&intPercent);
     App::Material mat(App::Material::DEFAULT);
+    mat.transparency = (float)initialTransparency / 100.0f;
     ADD_PROPERTY_TYPE(ShapeMaterial,(mat), osgroup, App::Prop_None, "Shape material");
     ADD_PROPERTY_TYPE(BoundingBox, (false), dogroup, App::Prop_None, "Display object bounding box");
     ADD_PROPERTY_TYPE(Selectable, (true), sgroup, App::Prop_None, "Set if the object is selectable in the 3d view");
@@ -94,7 +95,6 @@ ViewProviderGeometryObject::ViewProviderGeometryObject()
     pcShapeMaterial = new SoMaterial;
     pcShapeMaterial->diffuseColor.setValue(r, g, b);
     pcShapeMaterial->transparency = float(initialTransparency);
-    ShapeMaterial.setTransparency((float)initialTransparency / 100.0f);
     pcShapeMaterial->ref();
 
     pcBoundingBox = new Gui::SoFCBoundingBox;


### PR DESCRIPTION
With PR #11586 I introduced a bug that caused the default shape color setting to be ignored.
This PR will fix that.

see also:
https://forum.freecad.org/viewtopic.php?t=83924
https://forum.freecad.org/viewtopic.php?t=83066

Code to test the old and new behavior:
```python3
import Part

doc = App.newDocument()


## check transparency

pg = App.ParamGet('User parameter:BaseApp/Preferences/View')
backup_default_transparency = pg.GetInt('DefaultShapeTransparency')

pg.SetInt('DefaultShapeTransparency', 70)

obj = doc.addObject('Part::Box')
assert obj.ViewObject.Transparency == 70

obj.ViewObject.ShapeColor = (0.5, 0.0, 0.0)

if obj.ViewObject.Transparency != 70:
    # behavior before PR 11586
    print('WARNING: transparency was changed to',
            obj.ViewObject.Transparency, 'when changing the color.')
else:
    # new behavior after PR 11586 (and still after this PR)
    print('transparency is still ok after changing color')

pg.SetInt('DefaultShapeTransparency', backup_default_transparency)


## check color

backup_default_shapecolor = pg.GetUnsigned('DefaultShapeColor')

pg.SetUnsigned('DefaultShapeColor', 0xff000000)  # red

obj = doc.addObject('Part::Box')

if obj.ViewObject.ShapeColor != (1.0, 0.0, 0.0, 0.0):  # red
    # buggy behavior introduced by PR 11586
    print('WARNING: default shape color was not set correctly')
else:
    # new behavior after this PR (and before PR 11586)
    print('default shape color is ok')

pg.SetUnsigned('DefaultShapeColor', backup_default_shapecolor)



doc.recompute()
```