### PR TITLE
Arch: Arch_Window fix and improve handling of hosts

### DIFF
--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -648,19 +648,26 @@ class _Window(ArchComponent.Component):
 
         if prop in ["Base","WindowParts","Placement","HoleDepth","Height","Width","Hosts"]:
             setattr(self,prop,getattr(obj,prop))
+        if prop in ["Height","Width"]:
+            self.TouchOnShapeChange = True  # touch hosts after next "Shape" change
 
     def onChanged(self,obj,prop):
 
         self.hideSubobjects(obj,prop)
         if not "Restore" in obj.State:
-            if prop in ["Base","WindowParts","Placement","HoleDepth","Height","Width","Hosts"]:
+            if prop in ["Base","WindowParts","Placement","HoleDepth","Height","Width","Hosts","Shape"]:
                 # anti-recursive loops, bc the base sketch will touch the Placement all the time
                 touchhosts = False
-                if hasattr(self,prop):
-                    if getattr(self,prop) != getattr(obj,prop):
+                if prop == "Shape":
+                    if hasattr(self,"TouchOnShapeChange") and self.TouchOnShapeChange:
+                        self.TouchOnShapeChange = False
                         touchhosts = True
-                if touchhosts and hasattr(self, "Hosts") and hasattr(obj, "Hosts"):
-                    for host in set(self.Hosts + obj.Hosts): # use set to remove duplicates
+                elif hasattr(self,prop) and getattr(self,prop) != getattr(obj,prop):
+                    touchhosts = True
+                if touchhosts:
+                    hosts = self.Hosts if hasattr(self, "Hosts") else []
+                    hosts += obj.Hosts if hasattr(obj, "Hosts") else []
+                    for host in set(hosts): # use set to remove duplicates
                         # mark host to recompute so it can detect this object
                         host.touch()
             if prop in ["Width","Height","Frame"]:


### PR DESCRIPTION
Fixes a problem introduced with a previous PR of mine (#7591). Hosts would only be touched if that property of the window was modified. But the hosts of a window should also update if other properties of the window change.

Additionally a width or height change of a window now touches the hosts on the subsequent shape change.
