### PR TITLE
Fix build with precompiled headers

### DIFF
--- a/src/App/PreCompiled.h
+++ b/src/App/PreCompiled.h
@@ -49,6 +49,7 @@
 #include <csignal>
 #include <cstdio>
 #include <ctime>
+#include <cfloat>
 
 #ifdef FC_OS_WIN32
 # include <crtdbg.h>

--- a/src/Mod/Mesh/Gui/PreCompiled.h
+++ b/src/Mod/Mesh/Gui/PreCompiled.h
@@ -44,6 +44,7 @@
 
 // standard
 #include <ios>
+#include <cfloat>
 
 // STL
 #include <algorithm>

--- a/src/Mod/Part/Gui/PreCompiled.h
+++ b/src/Mod/Part/Gui/PreCompiled.h
@@ -62,13 +62,8 @@
 #include <boost/regex.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
-// Qt Toolkit
-#ifndef __QtAll__
-# include <Gui/QtAll.h>
-#endif
-
 // GL
-// Include glext before InventorAll
+// Include glext before QtAll/InventorAll
 #ifdef FC_OS_WIN32
 # include <GL/gl.h>
 # include <GL/glext.h>
@@ -86,6 +81,11 @@
 #endif //FC_OS_WIN32
 // Should come after glext.h to avoid warnings
 #include <Inventor/C/glue/gl.h>
+
+// Qt Toolkit
+#ifndef __QtAll__
+# include <Gui/QtAll.h>
+#endif
 
 // Inventor includes OpenGL
 #ifndef __InventorAll__


### PR DESCRIPTION
This PR adds some missing includes when attempting to build with `-DFREECAD_USE_PCH=ON`.

Each commit is split by module. The most notable one is moving inclusion of QtAll after glext, so that we can set GL_GLEXT_PROTOTYPES before it's too late.