### PR TITLE
Sketcher: contextual right click context menu based on selection

### DIFF
--- a/src/Doc/CONTRIBUTORS
+++ b/src/Doc/CONTRIBUTORS
@@ -129,6 +129,7 @@ Marosh
 Masaya Ootsuki
 Mateusz Skowroński (f3nix)
 Mattis M
+Max Wilfinger (maxwxyz)
 mdinger
 Meme2704
 Michael Hansen

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1167,14 +1167,14 @@ public:
 
         addCommand("Sketcher_Dimension");
         addCommand(); //separator
-        addCommand("Sketcher_ConstrainLock");
         addCommand("Sketcher_ConstrainDistanceX");
         addCommand("Sketcher_ConstrainDistanceY");
         addCommand("Sketcher_ConstrainDistance");
+        addCommand("Sketcher_ConstrainRadiam");
         addCommand("Sketcher_ConstrainRadius");
         addCommand("Sketcher_ConstrainDiameter");
-        addCommand("Sketcher_ConstrainRadiam");
         addCommand("Sketcher_ConstrainAngle");
+        addCommand("Sketcher_ConstrainLock");
     }
 
     void updateAction(int mode) override
@@ -1217,6 +1217,37 @@ public:
     }
 
     const char* className() const override { return "CmdSketcherCompDimensionTools"; }
+};
+
+// Comp for constrain tools =============================================
+
+class CmdSketcherCompConstrainTools : public Gui::GroupCommand
+{
+public:
+    CmdSketcherCompConstrainTools()
+        : GroupCommand("Sketcher_CompConstrainTools")
+    {
+        sAppModule = "Sketcher";
+        sGroup = "Sketcher";
+        sMenuText = QT_TR_NOOP("Constrain");
+        sToolTipText = QT_TR_NOOP("Constrain tools.");
+        sWhatsThis = "Sketcher_CompConstrainTools";
+        sStatusTip = sToolTipText;
+        eType = ForEdit;
+
+        setCheckable(false);
+        setRememberLast(false);
+
+        addCommand("Sketcher_ConstrainCoincidentUnified");
+        addCommand("Sketcher_ConstrainHorVer");
+        addCommand("Sketcher_ConstrainParallel");
+        addCommand("Sketcher_ConstrainPerpendicular");
+        addCommand("Sketcher_ConstrainTangent");
+        addCommand("Sketcher_ConstrainEqual");
+        addCommand("Sketcher_ConstrainSymmetric");
+        addCommand("Sketcher_ConstrainBlock");
+    }
+    const char* className() const override { return "CmdSketcherCompConstrainTools"; }
 };
 
 // Dimension tool =======================================================
@@ -9897,5 +9928,6 @@ void CreateSketcherCommandsConstraints()
     rcCmdMgr.addCommand(new CmdSketcherToggleDrivingConstraint());
     rcCmdMgr.addCommand(new CmdSketcherToggleActiveConstraint());
     rcCmdMgr.addCommand(new CmdSketcherCompDimensionTools());
+    rcCmdMgr.addCommand(new CmdSketcherCompConstrainTools());
 }
 // clang-format on

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -1535,8 +1535,8 @@ Gui::Action* CmdSketcherCompCreateFillets::createAction()
     _pcAction = pcAction;
     languageChange();
 
-    pcAction->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreateFillet"));
-    int defaultId = 0;
+    pcAction->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreatePointFillet"));
+    int defaultId = 1;
     pcAction->setProperty("defaultAction", QVariant(defaultId));
 
     return pcAction;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -567,6 +567,10 @@ public:
     {
         return Mode;
     }
+
+    // create right click context menu based on selection in the 3D view
+    void generateContextMenu();
+
     //@}
 
     /** @name Drawing functions */

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -374,8 +374,8 @@ void SketcherAddWorkspaceFillets(T& geom);
 template<>
 inline void SketcherAddWorkspaceFillets<Gui::MenuItem>(Gui::MenuItem& geom)
 {
-    geom << "Sketcher_CreateFillet"
-         << "Sketcher_CreatePointFillet";
+    geom << "Sketcher_CreatePointFillet"
+         << "Sketcher_CreateFillet";
 }
 
 template<>


### PR DESCRIPTION
fixes #11818 
This PR introduces a *contextual* right click context menu in the Sketcher WB which shows different commands based on the selection of the user (none, one or multiple geometry elements, or constraints).
The current context menu is static and is overloaded with commands which are either greyed out or not working in Sketcher.

New:


https://github.com/FreeCAD/FreeCAD/assets/6246609/49426bf8-56a2-46f5-bd6c-cd768a9386d5



Old:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/23b88749-c410-40f8-9207-61157d73ce86)
