### PR TITLE
Arch: Arch_Window: wrong value for Frame property

### DIFF
--- a/src/Mod/Arch/ArchWindowPresets.py
+++ b/src/Mod/Arch/ArchWindowPresets.py
@@ -501,7 +501,7 @@ def makeWindowPreset(windowtype,width,height,h1,h2,h3,w1,w2,o1,o2,placement=None
                 FreeCAD.ActiveDocument.recompute()
             obj = ArchWindow.makeWindow(default[0],width,height,default[1])
             obj.Preset = WindowPresets.index(windowtype)+1
-            obj.Frame = h1
+            obj.Frame = w2
             obj.Offset = o1
             obj.Placement = FreeCAD.Placement() # unable to find where this bug comes from...
             if "door" in windowtype:


### PR DESCRIPTION
The Frame property controls the extrusion of the window components. It should receive the w2 instead of the h1 value.
