### PR TITLE
Path: fix wire midpoint calculation

### DIFF
--- a/src/Mod/Path/Path/Op/Profile.py
+++ b/src/Mod/Path/Path/Op/Profile.py
@@ -1449,8 +1449,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         wL = wire.Length
         midW = wL / 2
 
-        for e in range(0, len(wire.Edges)):
-            E = wire.Edges[e]
+        for E in Part.sortEdges(wire.Edges)[0]:
             elen = E.Length
             d_ = dist + elen
             if dist < midW and midW <= d_:


### PR DESCRIPTION
The calculated midpoint of a wire (coordinate at half the path length) was sometimes wrong because the edges were not sorted.

This will fix #11922.
