### PR TITLE
Property editor: Hide header and enable resizing on all cells.

### DIFF
--- a/src/Gui/propertyeditor/PropertyEditor.h
+++ b/src/Gui/propertyeditor/PropertyEditor.h
@@ -100,6 +100,7 @@ protected Q_SLOTS:
     void onRowsRemoved(const QModelIndex &parent, int start, int end);
 
 protected:
+    bool eventFilter(QObject* object, QEvent* event);
     void closeEditor (QWidget * editor, QAbstractItemDelegate::EndEditHint hint) override;
     void commitData (QWidget * editor) override;
     void editorDestroyed (QObject * editor) override;
@@ -120,6 +121,10 @@ private:
     void closeTransaction();
     void recomputeDocument(App::Document*);
 
+    // check if mouse_pos is around right or bottom side of a cell 
+    // and return the index of that cell if found
+    QModelIndex indexResizable(QPoint mouse_pos);
+
 private:
     PropertyItemDelegate *delegate;
     PropertyModel* propertyModel;
@@ -133,6 +138,12 @@ private:
     bool binding;
     bool checkDocument;
     bool closingEditor;
+    bool dragInProgress;
+
+    //max distance between mouse and a cell, small enough to trigger resize
+    int dragSensibility = 5; // NOLINT
+    int dragSection = 0;
+    int dragPreviousPos = 0;
 
     int transactionID = 0;
 


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/11794

Hide headers of property view as they are self explanatory: 
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/442fdd76-0cdb-429c-a503-1278db19c708)

And enable resizing on all cells (as before you could resize only on headers, which was a problem if you hide headers).