### PR TITLE
[Path] Rest machining from gcode

### DIFF
--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -628,7 +628,7 @@ private:
     }
 };
 
-std::shared_ptr<Area> Area::getClearedAreaFromPath(const Toolpath *path, double diameter, double zmax) {
+std::shared_ptr<Area> Area::getClearedArea(const Toolpath *path, double diameter, double zmax) {
     build();
 
     // Precision losses in arc/segment conversions (multiples of Accuracy):
@@ -646,7 +646,7 @@ std::shared_ptr<Area> Area::getClearedAreaFromPath(const Toolpath *path, double 
     CAreaConfig conf(params, /*no_fit_arcs*/ true);
 
     Base::Vector3d pos = Base::Vector3d(0, 0, zmax + 1);
-    printf("getClearedAreaFromPath(path, diameter=%g, zmax=%g:\n", diameter, zmax);
+    printf("getClearedArea(path, diameter=%g, zmax=%g:\n", diameter, zmax);
     // printf("Gcode:\n");
     for (auto c : path->getCommands()) {
         // printf("\t%s ", c->Name.c_str());
@@ -725,7 +725,7 @@ std::shared_ptr<Area> Area::getRestArea(std::vector<std::shared_ptr<Area>> clear
     remaining.Clip(toClipperOp(Area::OperationDifference), &*(clearedAreasInPlane.myArea), SubjectFill, ClipFill);
 
     // rest = intersect(clearable, offset(remaining, dTool))
-    // add buffer to dTool to compensate for oversizing in getClearedAreaFromPath
+    // add buffer to dTool to compensate for oversizing in getClearedArea
     printf("Compute rest\n");
     CArea restCArea(remaining);
     restCArea.OffsetWithClipper(diameter + buffer, JoinType, EndType, params.MiterLimit, roundPrecision);

--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -662,7 +662,6 @@ std::shared_ptr<Area> Area::getClearedAreaFromPath(const Toolpath *path, double 
 
     const double roundPrecision = myParams.Accuracy;
     const double buffer = 2 * roundPrecision;
-    (void)buffer;
     (void)JoinType;
     (void)EndType;
 
@@ -679,7 +678,7 @@ std::shared_ptr<Area> Area::getClearedAreaFromPath(const Toolpath *path, double 
 
     printf("\n");
     printf("GCode walker:\n");
-    ClearedAreaSegmentVisitor visitor(zmax, diameter);
+    ClearedAreaSegmentVisitor visitor(zmax, diameter + buffer);
     PathSegmentWalker walker(*path);
     walker.walk(visitor, Base::Vector3d(0, 0, zmax + 1));
     printf("Count: %d\n", visitor.count);

--- a/src/Mod/Path/App/Area.h
+++ b/src/Mod/Path/App/Area.h
@@ -242,7 +242,7 @@ public:
         const std::vector<double>& heights = std::vector<double>(),
         const TopoDS_Shape& plane = TopoDS_Shape());
 
-    std::shared_ptr<Area> getClearedArea(const Toolpath *path, double diameter, double zmax);
+    std::shared_ptr<Area> getClearedArea(const Toolpath *path, double diameter, double zmax, Base::BoundBox3d bbox);
     std::shared_ptr<Area> getRestArea(std::vector<std::shared_ptr<Area>> clearedAreas, double diameter);
     TopoDS_Shape toTopoShape();
 

--- a/src/Mod/Path/App/Area.h
+++ b/src/Mod/Path/App/Area.h
@@ -242,7 +242,7 @@ public:
         const std::vector<double>& heights = std::vector<double>(),
         const TopoDS_Shape& plane = TopoDS_Shape());
 
-    std::shared_ptr<Area> getClearedAreaFromPath(const Toolpath *path, double diameter, double zmax);
+    std::shared_ptr<Area> getClearedArea(const Toolpath *path, double diameter, double zmax);
     std::shared_ptr<Area> getRestArea(std::vector<std::shared_ptr<Area>> clearedAreas, double diameter);
     TopoDS_Shape toTopoShape();
 

--- a/src/Mod/Path/App/Area.h
+++ b/src/Mod/Path/App/Area.h
@@ -243,6 +243,7 @@ public:
         const TopoDS_Shape& plane = TopoDS_Shape());
 
     std::shared_ptr<Area> getClearedArea(double tipDiameter, double diameter);
+    std::shared_ptr<Area> getClearedAreaFromPath(const Toolpath *path, double diameter, double zmax);
     std::shared_ptr<Area> getRestArea(std::vector<std::shared_ptr<Area>> clearedAreas, double diameter);
     TopoDS_Shape toTopoShape();
 

--- a/src/Mod/Path/App/Area.h
+++ b/src/Mod/Path/App/Area.h
@@ -242,7 +242,6 @@ public:
         const std::vector<double>& heights = std::vector<double>(),
         const TopoDS_Shape& plane = TopoDS_Shape());
 
-    std::shared_ptr<Area> getClearedArea(double tipDiameter, double diameter);
     std::shared_ptr<Area> getClearedAreaFromPath(const Toolpath *path, double diameter, double zmax);
     std::shared_ptr<Area> getRestArea(std::vector<std::shared_ptr<Area>> clearedAreas, double diameter);
     TopoDS_Shape toTopoShape();

--- a/src/Mod/Path/App/AreaPy.xml
+++ b/src/Mod/Path/App/AreaPy.xml
@@ -62,7 +62,7 @@ same algorithm</UserDocu>
           <UserDocu></UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="getClearedAreaFromPath">
+    <Methode Name="getClearedArea">
       <Documentation>
           <UserDocu></UserDocu>
       </Documentation>

--- a/src/Mod/Path/App/AreaPy.xml
+++ b/src/Mod/Path/App/AreaPy.xml
@@ -67,6 +67,11 @@ same algorithm</UserDocu>
           <UserDocu></UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="getClearedAreaFromPath">
+      <Documentation>
+          <UserDocu></UserDocu>
+      </Documentation>
+    </Methode>
     <Methode Name="getRestArea">
       <Documentation>
           <UserDocu></UserDocu>

--- a/src/Mod/Path/App/AreaPy.xml
+++ b/src/Mod/Path/App/AreaPy.xml
@@ -62,11 +62,6 @@ same algorithm</UserDocu>
           <UserDocu></UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="getClearedArea">
-      <Documentation>
-          <UserDocu></UserDocu>
-      </Documentation>
-    </Methode>
     <Methode Name="getClearedAreaFromPath">
       <Documentation>
           <UserDocu></UserDocu>

--- a/src/Mod/Path/App/AreaPyImp.cpp
+++ b/src/Mod/Path/App/AreaPyImp.cpp
@@ -464,6 +464,9 @@ PyObject* AreaPy::getRestArea(PyObject *args)
         }
 
         std::shared_ptr<Area> restArea = getAreaPtr()->getRestArea(clearedAreas, diameter);
+        if (!restArea) {
+            return Py_None;
+        }
         auto pyRestArea = Py::asObject(new AreaPy(new Area(*restArea, true)));
         return Py::new_reference_to(pyRestArea);
     } PY_CATCH_OCC

--- a/src/Mod/Path/App/AreaPyImp.cpp
+++ b/src/Mod/Path/App/AreaPyImp.cpp
@@ -149,8 +149,8 @@ static const PyMethodDef areaOverrides[] = {
         "of this Area is used if section mode is 'Workplane'.",
     },
     {
-        "getClearedAreaFromPath",nullptr,0,
-        "getClearedAreaFromPath(path, diameter, zmax):\n"
+        "getClearedArea",nullptr,0,
+        "getClearedArea(path, diameter, zmax):\n"
         "Gets the area cleared when a tool of the specified diameter follows the gcode represented in the path, ignoring cleared space above zmax.\n",
     },
     {
@@ -404,7 +404,7 @@ PyObject* AreaPy::makeSections(PyObject *args, PyObject *keywds)
     } PY_CATCH_OCC
 }
 
-PyObject* AreaPy::getClearedAreaFromPath(PyObject *args)
+PyObject* AreaPy::getClearedArea(PyObject *args)
 {
     PY_TRY {
         PyObject *pyPath;
@@ -416,7 +416,7 @@ PyObject* AreaPy::getClearedAreaFromPath(PyObject *args)
 		return nullptr;
 	}
 	const PathPy *path = static_cast<PathPy*>(pyPath);
-        std::shared_ptr<Area> clearedArea = getAreaPtr()->getClearedAreaFromPath(path->getToolpathPtr(), diameter, zmax);
+        std::shared_ptr<Area> clearedArea = getAreaPtr()->getClearedArea(path->getToolpathPtr(), diameter, zmax);
         auto pyClearedArea = Py::asObject(new AreaPy(new Area(*clearedArea, true)));
         return Py::new_reference_to(pyClearedArea);
     } PY_CATCH_OCC

--- a/src/Mod/Path/App/AreaPyImp.cpp
+++ b/src/Mod/Path/App/AreaPyImp.cpp
@@ -152,7 +152,7 @@ static const PyMethodDef areaOverrides[] = {
     {
         "getClearedArea",nullptr,0,
         "getClearedArea(path, diameter, zmax, bbox):\n"
-        "Gets the area cleared when a tool of the specified diameter follows the gcode represented in the path, ignoring cleared space above zmax and path segments that don't affect space within bbox.\n",
+        "Gets the area cleared when a tool of the specified diameter follows the gcode represented in the path, ignoring cleared space above zmax and path segments that don't affect space within the x/y space of bbox.\n",
     },
     {
         "getRestArea",nullptr,0,

--- a/src/Mod/Path/App/AreaPyImp.cpp
+++ b/src/Mod/Path/App/AreaPyImp.cpp
@@ -149,11 +149,6 @@ static const PyMethodDef areaOverrides[] = {
         "of this Area is used if section mode is 'Workplane'.",
     },
     {
-        "getClearedArea",nullptr,0,
-        "getClearedArea(tipDiameter, diameter):\n"
-        "Gets the area cleared when a tool maximally clears this area. This method assumes a tool tip diameter 'tipDiameter' traces the full area, and that (perhaps at a different height on the tool) this clears a different region with tool diameter 'diameter'.\n",
-    },
-    {
         "getClearedAreaFromPath",nullptr,0,
         "getClearedAreaFromPath(path, diameter, zmax):\n"
         "Gets the area cleared when a tool of the specified diameter follows the gcode represented in the path, ignoring cleared space above zmax.\n",
@@ -406,18 +401,6 @@ PyObject* AreaPy::makeSections(PyObject *args, PyObject *keywds)
         for(auto &area : sections)
             ret.append(Py::asObject(new AreaPy(new Area(*area,true))));
         return Py::new_reference_to(ret);
-    } PY_CATCH_OCC
-}
-
-PyObject* AreaPy::getClearedArea(PyObject *args)
-{
-    PY_TRY {
-        double tipDiameter, diameter;
-        if (!PyArg_ParseTuple(args, "dd", &tipDiameter, &diameter))
-            return nullptr;
-        std::shared_ptr<Area> clearedArea = getAreaPtr()->getClearedArea(tipDiameter, diameter);
-        auto pyClearedArea = Py::asObject(new AreaPy(new Area(*clearedArea, true)));
-        return Py::new_reference_to(pyClearedArea);
     } PY_CATCH_OCC
 }
 

--- a/src/Mod/Path/Path/Op/Area.py
+++ b/src/Mod/Path/Path/Op/Area.py
@@ -253,7 +253,8 @@ class ObjectOp(PathOp.ObjectOp):
                     if hasattr(op, "Active") and op.Active and op.Path:
                         tool = op.Proxy.tool if hasattr(op.Proxy, "tool") else op.ToolController.Proxy.getTool(op.ToolController)
                         diameter = tool.Diameter.getValueAs("mm")
-                        sectionClearedAreas.append(section.getClearedArea(op.Path, diameter, z+0.001, bbox))
+                        dz = 0 if not hasattr(tool, "TipAngle") else -PathUtils.drillTipLength(tool)  # for drills, dz moves to the full width part of the tool
+                        sectionClearedAreas.append(section.getClearedArea(op.Path, diameter, z+dz+0.001, bbox))
                         # debugZ = -1.5
                         # if debugZ -.1 < z and z < debugZ + .1:
                         #     debugObj = obj.Document.addObject("Part::Feature", "Debug_{}_{}".format(debugZ, op.Name))

--- a/src/Mod/Path/Path/Op/Area.py
+++ b/src/Mod/Path/Path/Op/Area.py
@@ -283,14 +283,14 @@ class ObjectOp(PathOp.ObjectOp):
                         tool = op.Proxy.tool if hasattr(op.Proxy, "tool") else op.ToolController.Proxy.getTool(op.ToolController)
                         diameter = tool.Diameter.getValueAs("mm")
                         sectionClearedAreas.append(area.getClearedAreaFromPath(op.Path, diameter, z+0.001))
-                        debugZ = -1.5
-                        if debugZ -.1 < z and z < debugZ + .1:
-                            debugObj = obj.Document.addObject("Part::Feature", "Debug_{}_{}".format(debugZ, op.Name))
-                            debugObj.Label = "Debug_{}_{}".format(debugZ, op.Label)
-                            debugObj.Shape = sectionClearedAreas[-1].getShape()
-                        pass
+                        # debugZ = -1.5
+                        # if debugZ -.1 < z and z < debugZ + .1:
+                        #     debugObj = obj.Document.addObject("Part::Feature", "Debug_{}_{}".format(debugZ, op.Name))
+                        #     debugObj.Label = "Debug_{}_{}".format(debugZ, op.Label)
+                        #     debugObj.Shape = sectionClearedAreas[-1].getShape()
                 restSection = section.getRestArea(sectionClearedAreas, self.tool.Diameter.getValueAs("mm"))
-                restSections.append(restSection)
+                if (restSection is not None):
+                    restSections.append(restSection)
             sections = restSections
 
         shapelist = [sec.getShape() for sec in sections]

--- a/src/Mod/Path/Path/Op/Area.py
+++ b/src/Mod/Path/Path/Op/Area.py
@@ -252,7 +252,7 @@ class ObjectOp(PathOp.ObjectOp):
                         tool = op.Proxy.tool if hasattr(op.Proxy, "tool") else op.ToolController.Proxy.getTool(op.ToolController)
                         diameter = tool.Diameter.getValueAs("mm")
                         dz = 0 if not hasattr(tool, "TipAngle") else -PathUtils.drillTipLength(tool)  # for drills, dz translates to the full width part of the tool
-                        sectionClearedAreas.append(section.getClearedArea(op.Path, diameter, z+dz+0.001, bbox))
+                        sectionClearedAreas.append(section.getClearedArea(op.Path, diameter, z+dz+self.job.GeometryTolerance.getValueAs("mm"), bbox))
                 restSection = section.getRestArea(sectionClearedAreas, self.tool.Diameter.getValueAs("mm"))
                 if (restSection is not None):
                     restSections.append(restSection)

--- a/src/Mod/Path/Path/Op/Area.py
+++ b/src/Mod/Path/Path/Op/Area.py
@@ -240,39 +240,9 @@ class ObjectOp(PathOp.ObjectOp):
         # Rest machining
         self.sectionShapes = self.sectionShapes + [section.toTopoShape() for section in sections]
         if hasattr(obj, "UseRestMachining") and obj.UseRestMachining:
-            # Loop through prior operations
-            clearedAreas = []
-            foundSelf = False
-            for op in self.job.Operations.Group:
-                if foundSelf:
-                    break
-                oplist = [op] + op.OutListRecursive
-                oplist = list(filter(lambda op: hasattr(op, "Active"), oplist))
-                for op in oplist:
-                    if op.Proxy == self:
-                        # Ignore self, and all later operations
-                        foundSelf = True
-                        break
-                    if hasattr(op, "RestMachiningRegions") and op.Active:
-                        if hasattr(op, "RestMachiningRegionsNeedRecompute") and op.RestMachiningRegionsNeedRecompute:
-                            Path.Log.warning(
-                                translate("PathAreaOp", "Previous operation %s is required for rest machining, but it has no stored rest machining metadata. Recomputing to generate this metadata...") % op.Label
-                            )
-                            op.recompute()
-
-                        tool = op.Proxy.tool if hasattr(op.Proxy, "tool") else op.ToolController.Proxy.getTool(op.ToolController)
-                        diameter = tool.Diameter.getValueAs("mm")
-                        def shapeToArea(shape):
-                            area = Path.Area()
-                            area.setPlane(PathUtils.makeWorkplane(shape))
-                            area.add(shape)
-                            return area
-                        opClearedAreas = [shapeToArea(pa).getClearedArea(diameter, diameter) for pa in op.RestMachiningRegions.SubShapes]
-                        clearedAreas.extend(opClearedAreas)
             restSections = []
             for section in sections:
                 z = section.getShape().BoundBox.ZMin
-                # sectionClearedAreas = [a for a in clearedAreas if a.getShape().BoundBox.ZMax <= z]
                 sectionClearedAreas = []
                 for op in self.job.Operations.Group:
                     print(op.Name)
@@ -497,10 +467,6 @@ class ObjectOp(PathOp.ObjectOp):
                     )
                 )
 
-        if hasattr(obj, "RestMachiningRegions"):
-            obj.RestMachiningRegions = Part.makeCompound(self.sectionShapes)
-        if hasattr(obj, "RestMachiningRegionsNeedRecompute"):
-            obj.RestMachiningRegionsNeedRecompute = False
         Path.Log.debug("obj.Name: " + str(obj.Name) + "\n\n")
         return sims
 

--- a/src/Mod/Path/Path/Op/Area.py
+++ b/src/Mod/Path/Path/Op/Area.py
@@ -246,20 +246,13 @@ class ObjectOp(PathOp.ObjectOp):
                 z = bbox.ZMin
                 sectionClearedAreas = []
                 for op in self.job.Operations.Group:
-                    print(op.Name)
                     if self in [x.Proxy for x in [op] + op.OutListRecursive if hasattr(x, "Proxy")]:
-                        print("found self")
                         break
                     if hasattr(op, "Active") and op.Active and op.Path:
                         tool = op.Proxy.tool if hasattr(op.Proxy, "tool") else op.ToolController.Proxy.getTool(op.ToolController)
                         diameter = tool.Diameter.getValueAs("mm")
-                        dz = 0 if not hasattr(tool, "TipAngle") else -PathUtils.drillTipLength(tool)  # for drills, dz moves to the full width part of the tool
+                        dz = 0 if not hasattr(tool, "TipAngle") else -PathUtils.drillTipLength(tool)  # for drills, dz translates to the full width part of the tool
                         sectionClearedAreas.append(section.getClearedArea(op.Path, diameter, z+dz+0.001, bbox))
-                        # debugZ = -1.5
-                        # if debugZ -.1 < z and z < debugZ + .1:
-                        #     debugObj = obj.Document.addObject("Part::Feature", "Debug_{}_{}".format(debugZ, op.Name))
-                        #     debugObj.Label = "Debug_{}_{}".format(debugZ, op.Label)
-                        #     debugObj.Shape = sectionClearedAreas[-1].getShape()
                 restSection = section.getRestArea(sectionClearedAreas, self.tool.Diameter.getValueAs("mm"))
                 if (restSection is not None):
                     restSections.append(restSection)

--- a/src/Mod/Path/Path/Op/Area.py
+++ b/src/Mod/Path/Path/Op/Area.py
@@ -242,7 +242,8 @@ class ObjectOp(PathOp.ObjectOp):
         if hasattr(obj, "UseRestMachining") and obj.UseRestMachining:
             restSections = []
             for section in sections:
-                z = section.getShape().BoundBox.ZMin
+                bbox = section.getShape().BoundBox
+                z = bbox.ZMin
                 sectionClearedAreas = []
                 for op in self.job.Operations.Group:
                     print(op.Name)
@@ -252,7 +253,7 @@ class ObjectOp(PathOp.ObjectOp):
                     if hasattr(op, "Active") and op.Active and op.Path:
                         tool = op.Proxy.tool if hasattr(op.Proxy, "tool") else op.ToolController.Proxy.getTool(op.ToolController)
                         diameter = tool.Diameter.getValueAs("mm")
-                        sectionClearedAreas.append(area.getClearedArea(op.Path, diameter, z+0.001))
+                        sectionClearedAreas.append(section.getClearedArea(op.Path, diameter, z+0.001, bbox))
                         # debugZ = -1.5
                         # if debugZ -.1 < z and z < debugZ + .1:
                         #     debugObj = obj.Document.addObject("Part::Feature", "Debug_{}_{}".format(debugZ, op.Name))

--- a/src/Mod/Path/Path/Op/Area.py
+++ b/src/Mod/Path/Path/Op/Area.py
@@ -252,7 +252,7 @@ class ObjectOp(PathOp.ObjectOp):
                     if hasattr(op, "Active") and op.Active and op.Path:
                         tool = op.Proxy.tool if hasattr(op.Proxy, "tool") else op.ToolController.Proxy.getTool(op.ToolController)
                         diameter = tool.Diameter.getValueAs("mm")
-                        sectionClearedAreas.append(area.getClearedAreaFromPath(op.Path, diameter, z+0.001))
+                        sectionClearedAreas.append(area.getClearedArea(op.Path, diameter, z+0.001))
                         # debugZ = -1.5
                         # if debugZ -.1 < z and z < debugZ + .1:
                         #     debugObj = obj.Document.addObject("Part::Feature", "Debug_{}_{}".format(debugZ, op.Name))

--- a/src/Mod/Path/Path/Op/PocketBase.py
+++ b/src/Mod/Path/Path/Op/PocketBase.py
@@ -194,16 +194,6 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                 "Skips machining regions that have already been cleared by previous operations.",
             ),
         )
-        obj.addProperty(
-            "Part::PropertyPartShape",
-            "RestMachiningRegions",
-            "Pocket",
-            QT_TRANSLATE_NOOP(
-                "App::Property",
-                "The areas cleared by this operation, one area per height, stored as a compound part. Used internally for rest machining.",
-            ),
-        )
-        obj.setEditorMode("RestMachiningRegions", 2)  # hide
 
         for n in self.pocketPropertyEnumerations():
             setattr(obj, n[0], n[1])
@@ -277,29 +267,10 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                 ),
             )
 
-        if not hasattr(obj, "RestMachiningRegions"):
-            obj.addProperty(
-                "Part::PropertyPartShape",
-                "RestMachiningRegions",
-                "Pocket",
-                QT_TRANSLATE_NOOP(
-                    "App::Property",
-                "The areas cleared by this operation, one area per height, stored as a compound part. Used internally for rest machining.",
-                ),
-            )
-            obj.setEditorMode("RestMachiningRegions", 2)  # hide
-
-            obj.addProperty(
-                "App::PropertyBool",
-                "RestMachiningRegionsNeedRecompute",
-                "Pocket",
-                QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "Flag to indicate that the rest machining regions have never been computed, and must be recomputed before being used.",
-                ),
-            )
-            obj.setEditorMode("RestMachiningRegionsNeedRecompute", 2)  # hide
-            obj.RestMachiningRegionsNeedRecompute = True
+        if hasattr(obj, "RestMachiningRegions"):
+            obj.removeProperty("RestMachiningRegions")
+        if hasattr(obj, "RestMachiningRegionsNeedRecompute"):
+            obj.removeProperty("RestMachiningRegionsNeedRecompute")
 
         Path.Log.track()
 

--- a/src/Mod/Path/libarea/AreaClipper.cpp
+++ b/src/Mod/Path/libarea/AreaClipper.cpp
@@ -252,14 +252,14 @@ static void MakeObround(const Point &pt0, const CVertex &vt1, double radius)
 static void OffsetSpansWithObrounds(const CArea& area, TPolyPolygon &pp_new, double radius)
 {
 	Clipper c;
-    c.StrictlySimple(CArea::m_clipper_simple);
+	c.StrictlySimple(CArea::m_clipper_simple);
 	pp_new.clear();
 
 	for(std::list<CCurve>::const_iterator It = area.m_curves.begin(); It != area.m_curves.end(); It++)
 	{
-                c.Clear();
-                c.AddPaths(pp_new, ptSubject, true);
-                pp_new.clear();
+		c.Clear();
+		c.AddPaths(pp_new, ptSubject, true);
+		pp_new.clear();
 		pts_for_AddVertex.clear();
 
 		const CCurve& curve = *It;
@@ -282,7 +282,7 @@ static void OffsetSpansWithObrounds(const CArea& area, TPolyPolygon &pp_new, dou
 			}
 			prev_vertex = &vertex;
 		}
-                c.Execute(ctUnion, pp_new, pftNonZero, pftNonZero);
+		c.Execute(ctUnion, pp_new, pftNonZero, pftNonZero);
 	}
 
 

--- a/src/Mod/Path/libarea/AreaClipper.cpp
+++ b/src/Mod/Path/libarea/AreaClipper.cpp
@@ -253,11 +253,15 @@ static void OffsetSpansWithObrounds(const CArea& area, TPolyPolygon &pp_new, dou
 {
 	Clipper c;
     c.StrictlySimple(CArea::m_clipper_simple);
-
+	pp_new.clear();
 
 	for(std::list<CCurve>::const_iterator It = area.m_curves.begin(); It != area.m_curves.end(); It++)
 	{
+                c.Clear();
+                c.AddPaths(pp_new, ptSubject, true);
+                pp_new.clear();
 		pts_for_AddVertex.clear();
+
 		const CCurve& curve = *It;
 		const CVertex* prev_vertex = NULL;
 		for(std::list<CVertex>::const_iterator It2 = curve.m_vertices.begin(); It2 != curve.m_vertices.end(); It2++)
@@ -278,10 +282,9 @@ static void OffsetSpansWithObrounds(const CArea& area, TPolyPolygon &pp_new, dou
 			}
 			prev_vertex = &vertex;
 		}
+                c.Execute(ctUnion, pp_new, pftNonZero, pftNonZero);
 	}
 
-	pp_new.clear();
-	c.Execute(ctUnion, pp_new, pftNonZero, pftNonZero);
 
 	// reverse all the resulting polygons
 	TPolyPolygon copy = pp_new;


### PR DESCRIPTION
[Forum post](https://forum.freecad.org/viewtopic.php?t=78773&sid=5fa0a750380e7bd8c78aa626592c5bb5&start=30)

This PR is my next iteration of rest machining for FreeCAD. It discards the old approach of using internals of the Area class to determine previously cleared regions, and instead computes those regions by processing the gcode from earlier operations. This is trickier, but comes with the advantage of being more flexible: in this version of the rest machining feature, any operation (most notably Adaptive operations) can be the source tool path for rest machining.

Even with the improvements from this iteration, only Area operations (Pocket, Pocket3D, Profile) can take advantage of rest machining. I hope to implement rest machining for Adaptive tool paths in my next pass improving this feature.

Here is [the FreeCAD file](https://github.com/FreeCAD/FreeCAD/files/13868014/test_rectangle3.zip) I've been using to test this feature. It contains 3 parts with test tool paths:

The first part is the part I used to test my initial implementation of rest machining. There are 3 operations. The first operation is a Pocket on the right side, 6mm tool, with no special features. The second operation is a Pocket covering the full top area with a 1.5mm tool, with rest machining enabled. The third operation is a Pocket3D on the entire volume with the same 1.5mm tool, with rest machining enabled. The implementation producing these results is new, but this functionality already exists in the version of rest machining currently in FreeCAD.

![Part 1](https://github.com/FreeCAD/FreeCAD/assets/1409130/322ff384-bc86-4bcf-af06-f8f13108fb15)

The second part tests rest machining after an adaptive operation. The first operation is an Adaptive operation in the top region with a 6mm tool. The second operation is a Pocket3D on the full volume with a 1.5mm tool.

![Part 2](https://github.com/FreeCAD/FreeCAD/assets/1409130/36195190-714d-41a5-874a-912f13ae3a73)

The third part tests speed optimizations and drilling. It has an absurdly dense Adaptive operation on the left region (visibility limited to the first 50k segments as a necessity to improve rendering performance). After that there is a drilling operation on the right side, then a Pocket operation on the right side with rest machining enabled. In addition to demonstrating that rest machining can process drilling gcode commands, this part demonstrates that bounding box filtering of far-away gcode commands works correctly (without that, generating the Pocket would be _very_ slow).

![20240108_20h57m23s_grim](https://github.com/FreeCAD/FreeCAD/assets/1409130/96d3750c-09c6-4a5e-b5a7-8862d989dea6)



Todo:
- [ ] squash commits, and label the full commit with [Path]
