### PR TITLE
Draft: remove reapply_diffuse_color workaround

### DIFF
--- a/src/Mod/Draft/draftmake/make_array.py
+++ b/src/Mod/Draft/draftmake/make_array.py
@@ -134,8 +134,6 @@ def make_array(base_object,
             ViewProviderDraftArray(new_obj.ViewObject)
             gui_utils.format_object(new_obj, new_obj.Base)
             new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
-            # Workaround to trigger update of DiffuseColor:
-            ToDo.delay(reapply_diffuse_color, new_obj.ViewObject)
         new_obj.Base.ViewObject.hide()
         gui_utils.select(new_obj)
 
@@ -154,12 +152,5 @@ def makeArray(baseobject,
     return make_array(baseobject,
                       arg1, arg2, arg3,
                       arg4, arg5, arg6, use_link)
-
-
-def reapply_diffuse_color(vobj):
-    try:
-        vobj.DiffuseColor = vobj.DiffuseColor
-    except:
-        pass
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_clone.py
+++ b/src/Mod/Draft/draftmake/make_clone.py
@@ -97,8 +97,6 @@ def make_clone(obj, delta=None, forcedraft=False):
                     pass
             if App.GuiUp:
                 gui_utils.format_object(cl, base)
-                # Workaround to trigger update of DiffuseColor:
-                ToDo.delay(reapply_diffuse_color, cl.ViewObject)
                 gui_utils.select(cl)
             return cl
 
@@ -118,17 +116,8 @@ def make_clone(obj, delta=None, forcedraft=False):
     if App.GuiUp:
         ViewProviderClone(cl.ViewObject)
         gui_utils.format_object(cl, obj[0])
-        # Workaround to trigger update of DiffuseColor:
-        ToDo.delay(reapply_diffuse_color, cl.ViewObject)
         gui_utils.select(cl)
     return cl
-
-
-def reapply_diffuse_color(vobj):
-    try:
-        vobj.DiffuseColor = vobj.DiffuseColor
-    except:
-        pass
 
 
 clone = make_clone

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -413,18 +413,9 @@ def make_path_twisted_array(base_object, path_object,
             ViewProviderDraftArray(new_obj.ViewObject)
             gui_utils.formatObject(new_obj, new_obj.Base)
             new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
-            # Workaround to trigger update of DiffuseColor:
-            ToDo.delay(reapply_diffuse_color, new_obj.ViewObject)
         new_obj.Base.ViewObject.hide()
         gui_utils.select(new_obj)
 
     return new_obj
-
-
-def reapply_diffuse_color(vobj):
-    try:
-        vobj.DiffuseColor = vobj.DiffuseColor
-    except:
-        pass
 
 ## @}

--- a/src/Mod/Draft/draftmake/make_pointarray.py
+++ b/src/Mod/Draft/draftmake/make_pointarray.py
@@ -157,8 +157,6 @@ def make_point_array(base_object, point_object, extra=None, use_link=True):
             ViewProviderDraftArray(new_obj.ViewObject)
             gui_utils.format_object(new_obj, new_obj.Base)
             new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
-            # Workaround to trigger update of DiffuseColor:
-            ToDo.delay(reapply_diffuse_color, new_obj.ViewObject)
         new_obj.Base.ViewObject.hide()
         gui_utils.select(new_obj)
 
@@ -170,12 +168,5 @@ def makePointArray(base, ptlst):
     utils.use_instead('make_point_array')
 
     return make_point_array(base, ptlst)
-
-
-def reapply_diffuse_color(vobj):
-    try:
-        vobj.DiffuseColor = vobj.DiffuseColor
-    except:
-        pass
 
 ## @}


### PR DESCRIPTION
The function would trigger the creation of duplicate Draft Polar Arrays (only on Linux and only if the Fuse option is selected and the Link Array option deselected).
Forum topic:
https://forum.freecad.org/viewtopic.php?t=84090

The reapply_diffuse_color function is no longer required anyway as Issue #8340 has been fixed.
