### PR TITLE
Fem: Fix constraint arrows - fixes #6073

### DIFF
--- a/src/Mod/Fem/App/PreCompiled.h
+++ b/src/Mod/Fem/App/PreCompiled.h
@@ -107,6 +107,7 @@
 
 // Opencascade
 #include <Adaptor3d_IsoCurve.hxx>
+#include <BRepAdaptor_CompCurve.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <BRep_Tool.hxx>
 #include <Bnd_Box.hxx>
@@ -134,6 +135,7 @@
 #include <Geom_Plane.hxx>
 #include <Precision.hxx>
 #include <ShapeAnalysis_ShapeTolerance.hxx>
+#include <ShapeAnalysis_Surface.hxx>
 #include <Standard_Real.hxx>
 #include <Standard_Version.hxx>
 #include <TColgp_Array2OfPnt.hxx>


### PR DESCRIPTION
With some trimmed surfaces, it may happen that the points selected based on the iso-curves used to place the constraint arrows do not coincide with the interior of the surface.
In that case, with this commit, the arrows are placed on the outer wire.
See  #6073.