### PR TITLE
[App] Fix segfault due to missing Py_Initialize in StringIDRefTest

### DIFF
--- a/tests/src/App/StringHasher.cpp
+++ b/tests/src/App/StringHasher.cpp
@@ -1006,6 +1006,7 @@ TEST_F(StringIDRefTest, toBytes)  // NOLINT
 
 TEST_F(StringIDRefTest, getPyObject)  // NOLINT
 {
+    Py_Initialize();
     // Arrange
     auto ref = App::StringIDRef(createStringID());
     auto empty = App::StringIDRef();


### PR DESCRIPTION
The PyObject desctructor requires an initialized interpreter, otherwise PyGILState_Ensure crashes.

Fixes #11878