### PR TITLE
Toponaming: makeElementCompound

### DIFF
--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -184,6 +184,11 @@ bool ComplexGeoData::getCenterOfGravity(Base::Vector3d& unused) const
     return false;
 }
 
+const std::string &ComplexGeoData::elementMapPrefix() {
+    static std::string prefix(";");
+    return prefix;
+}
+
 size_t ComplexGeoData::getElementMapSize(bool flush) const
 {
     if (flush) {
@@ -619,6 +624,25 @@ unsigned int ComplexGeoData::getMemSize() const
         return _elementMap->size() * multiplier;
     }
     return 0;
+}
+
+
+void ComplexGeoData::setMappedChildElements(const std::vector<Data::ElementMap::MappedChildElements> & children)
+{
+    // DO NOT reset element map if there is one. Because we allow mixing child
+    // mapping and normal mapping
+    if (!_elementMap) {
+        resetElementMap(std::make_shared<Data::ElementMap>());
+    }
+    _elementMap->addChildElements(Tag, children);
+}
+
+std::vector<Data::ElementMap::MappedChildElements> ComplexGeoData::getMappedChildElements() const
+{
+    if (!_elementMap) {
+        return {};
+    }
+    return _elementMap->getChildElements();
 }
 
 void ComplexGeoData::beforeSave() const

--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -185,7 +185,7 @@ bool ComplexGeoData::getCenterOfGravity(Base::Vector3d& unused) const
 }
 
 const std::string &ComplexGeoData::elementMapPrefix() {
-    static std::string prefix(";");
+    static std::string prefix(ELEMENT_MAP_PREFIX);
     return prefix;
 }
 

--- a/src/App/ComplexGeoData.h
+++ b/src/App/ComplexGeoData.h
@@ -176,6 +176,7 @@ public:
     virtual bool getCenterOfGravity(Base::Vector3d& center) const;
     //@}
 
+    static const std::string &elementMapPrefix();
 
     /** @name Element name mapping */
     //@{
@@ -246,6 +247,9 @@ public:
     }
 
     // NOTE: getElementHistory is now in ElementMap
+
+    void setMappedChildElements(const std::vector<Data::ElementMap::MappedChildElements> & children);
+    std::vector<Data::ElementMap::MappedChildElements> getMappedChildElements() const;
 
     char elementType(const Data::MappedName &) const;
     char elementType(const Data::IndexedName &) const;

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -606,6 +606,29 @@ public:
     //                                      double tol=1e-7, double atol=1e-12) const;
     //@}
 
+    void copyElementMap(const TopoShape &other, const char *op=nullptr);
+    bool canMapElement(const TopoShape &other) const;
+    void mapSubElement(const TopoShape &other,const char *op=nullptr, bool forceHasher=false);
+    void mapSubElement(const std::vector<TopoShape> &shapes, const char *op);
+    bool hasPendingElementMap() const;
+
+
+    /** Make a compound shape
+     *
+     * @param shapes: input shapes
+     * @param op: optional string to be encoded into topo naming for indicating
+     *            the operation
+     * @param force: if true and there is only one input shape, then return
+     *               that shape instead.  If false, then always return a
+     *               compound, even if there is no input shape.
+     *
+     * @return The original content of this TopoShape is discarded and replaced
+     *         with the new shape. The function returns the TopoShape itself as
+     *         a reference so that multiple operations can be carried out for
+     *         the same shape in the same line of code.
+     */
+    TopoShape &makeElementCompound(const std::vector<TopoShape> &shapes, const char *op=nullptr, bool force=true);
+
     friend class TopoShapeCache;
 
 private:

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -606,7 +606,7 @@ public:
     //                                      double tol=1e-7, double atol=1e-12) const;
     //@}
 
-    void copyElementMap(const TopoShape &other, const char *op=nullptr);
+    void copyElementMap(const TopoShape & topoShape, const char *op=nullptr);
     bool canMapElement(const TopoShape &other) const;
     void mapSubElement(const TopoShape &other,const char *op=nullptr, bool forceHasher=false);
     void mapSubElement(const std::vector<TopoShape> &shapes, const char *op);
@@ -741,6 +741,26 @@ private:
     };
 
     ShapeProtector _Shape;
+
+private:
+    // Helper methods
+    static std::vector<Data::ElementMap::MappedChildElements>
+    createChildMap(size_t count, const std::vector<TopoShape>& shapes, const char* op);
+
+    void setupChild(Data::ElementMap::MappedChildElements& child,
+                    TopAbs_ShapeEnum elementType,
+                    const TopoShape& topoShape,
+                    size_t shapeCount,
+                    const char* op);
+    void mapSubElementForShape(const TopoShape& other, const char* op);
+    void mapSubElementTypeForShape(const TopoShape& other,
+                                   TopAbs_ShapeEnum type,
+                                   const char* op,
+                                   int count,
+                                   bool forward,
+                                   bool& warned);
+    void mapCompoundSubElements(const std::vector<TopoShape>& shapes, const char* op);
+
 };
 
 }  // namespace Part

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -22,8 +22,12 @@
  *                                                                          *
  ***************************************************************************/
 
-#include <BRep_Tool.hxx>
+
 #include "PreCompiled.h"
+#ifndef _PreComp_
+#include <BRep_Builder.hxx>
+#include <BRep_Tool.hxx>
+#endif
 
 #include "TopoShape.h"
 #include "TopoShapeCache.h"
@@ -194,6 +198,214 @@ std::vector<TopoDS_Shape> TopoShape::findAncestorsShapes(const TopoDS_Shape& sub
     std::vector<TopoDS_Shape> shapes;
     _cache->findAncestor(_Shape, subshape, type, &shapes);
     return shapes;
+}
+
+#define _HANDLE_NULL_SHAPE(_msg,_throw) do {\
+    if(_throw) {\
+        FC_THROWM(NullShapeException,_msg);\
+    }\
+    FC_WARN(_msg);\
+}while(0)
+
+#define HANDLE_NULL_SHAPE _HANDLE_NULL_SHAPE("Null shape",true)
+#define HANDLE_NULL_INPUT _HANDLE_NULL_SHAPE("Null input shape",true)
+#define WARN_NULL_INPUT _HANDLE_NULL_SHAPE("Null input shape",false)
+
+bool TopoShape::hasPendingElementMap() const
+{
+    return !elementMap(false)
+        && this->_cache
+        && (this->_parentCache || this->_cache->cachedElementMap);
+}
+
+bool TopoShape::canMapElement(const TopoShape &other) const {
+    if(isNull() || other.isNull() || this == &other || other.Tag == -1 || Tag == -1)
+        return false;
+    if(!other.Tag
+        && !other.elementMap(false)
+        && !other.hasPendingElementMap())
+        return false;
+    initCache();
+    other.initCache();
+    _cache->relations.clear();
+    return true;
+}
+
+void TopoShape::mapSubElement(const TopoShape &other, const char *op, bool forceHasher) {
+#ifdef FC_NO_ELEMENT_MAP
+    return;
+#endif
+
+    if(!canMapElement(other))
+        return;
+
+    if (!getElementMapSize(false) && this->_Shape.IsPartner(other._Shape)) {
+        if (!this->Hasher)
+            this->Hasher = other.Hasher;
+        copyElementMap(other, op);
+        return;
+    }
+
+    bool warned = false;
+    static const std::array<TopAbs_ShapeEnum, 3> types = {TopAbs_VERTEX, TopAbs_EDGE, TopAbs_FACE};
+
+    auto checkHasher = [this](const TopoShape &other) {
+        if(Hasher) {
+            if(other.Hasher!=Hasher) {
+                if(!getElementMapSize(false)) {
+                    if(FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG))
+                        FC_WARN("hasher mismatch");
+                }else {
+                    // FC_THROWM(Base::RuntimeError, "hasher mismatch");
+                    FC_ERR("hasher mismatch");
+                }
+                Hasher = other.Hasher;
+            }
+        }else
+            Hasher = other.Hasher;
+    };
+
+    for(auto type : types) {
+        auto &shapeMap = _cache->getAncestry(type);
+        auto &otherMap = other._cache->getAncestry(type);
+        if(!shapeMap.count() || !otherMap.count())
+            continue;
+        if(!forceHasher && other.Hasher) {
+            forceHasher = true;
+            checkHasher(other);
+        }
+        const char *shapetype = shapeName(type).c_str();
+        std::ostringstream ss;
+
+        bool forward;
+        int count;
+        if(otherMap.count()<=shapeMap.count()) {
+            forward = true;
+            count = otherMap.count();
+        }else{
+            forward = false;
+            count = shapeMap.count();
+        }
+        for(int k=1;k<=count;++k) {
+            int i,idx;
+            if(forward) {
+                i = k;
+                idx = shapeMap.find(_Shape,otherMap.find(other._Shape,k));
+                if(!idx) continue;
+            } else {
+                idx = k;
+                i = otherMap.find(other._Shape,shapeMap.find(_Shape,k));
+                if(!i) continue;
+            }
+            Data::IndexedName element = Data::IndexedName::fromConst(shapetype, idx);
+            for(auto &v : other.getElementMappedNames(
+                     Data::IndexedName::fromConst(shapetype,i),true))
+            {
+                auto &name = v.first;
+                auto &sids = v.second;
+                if(sids.size()) {
+                    if (!Hasher)
+                        Hasher = sids[0].getHasher();
+                    else if (!sids[0].isFromSameHasher(Hasher)) {
+                        if (!warned) {
+                            warned = true;
+                            FC_WARN("hasher mismatch");
+                        }
+                        sids.clear();
+                    }
+                }
+                ss.str("");
+                elementMap()->encodeElementName(shapetype[0],name,ss,&sids,Tag,op,other.Tag);
+                elementMap()->setElementName(element,name,Tag, &sids);
+            }
+        }
+    }
+}
+
+void TopoShape::mapSubElement(const std::vector<TopoShape> &shapes, const char *op) {
+#ifdef FC_NO_ELEMENT_MAP
+    return;
+#endif
+
+    if (shapes.empty())
+        return;
+
+    if (shapeType(true) == TopAbs_COMPOUND) {
+        int count = 0;
+        for (auto & s : shapes) {
+            if (s.isNull())
+                continue;
+            if (!getSubShape(TopAbs_SHAPE, ++count, true).IsPartner(s._Shape)) {
+                count = 0;
+                break;
+            }
+        }
+        if (count) {
+            std::vector<Data::ElementMap::MappedChildElements> children;
+            children.reserve(count*3);
+            TopAbs_ShapeEnum types[] = {TopAbs_VERTEX, TopAbs_EDGE, TopAbs_FACE};
+            for (unsigned i=0; i<sizeof(types)/sizeof(types[0]); ++i) {
+                int offset = 0;
+                for (auto & s : shapes) {
+                    if (s.isNull())
+                        continue;
+                    int count = s.countSubShapes(types[i]);
+                    if (!count)
+                        continue;
+                    children.emplace_back();
+                    auto & child = children.back();
+                    child.indexedName = Data::IndexedName::fromConst(shapeName(types[i]).c_str(), 1);
+                    child.offset = offset;
+                    offset += count;
+                    child.count = count;
+                    child.elementMap = s.elementMap();
+                    child.tag = s.Tag;
+                    if (op)
+                        child.postfix = op;
+                }
+            }
+            elementMap()->addChildElements(Tag, children);  // Replaces the original line below
+            //setMappedChildElements(children);
+            return;
+        }
+    }
+
+    for(auto &shape : shapes)
+        mapSubElement(shape,op);
+}
+
+TopoShape &TopoShape::makeElementCompound(const std::vector<TopoShape> &shapes, const char *op, bool force)
+{
+    if(!force && shapes.size()==1) {
+        *this = shapes[0];
+        return *this;
+    }
+
+    BRep_Builder builder;
+    TopoDS_Compound comp;
+    builder.MakeCompound(comp);
+
+    if(shapes.empty()) {
+        setShape(comp);
+        return *this;
+    }
+
+    int count = 0;
+    for(auto &s : shapes) {
+        if(s.isNull()) {
+            WARN_NULL_INPUT;
+            continue;
+        }
+        builder.Add(comp,s.getShape());
+        ++count;
+    }
+    if(!count)
+        HANDLE_NULL_SHAPE;
+    setShape(comp);
+    initCache();
+
+    mapSubElement(shapes,op);
+    return *this;
 }
 
 }  // namespace Part

--- a/tests/src/Mod/Part/App/CMakeLists.txt
+++ b/tests/src/Mod/Part/App/CMakeLists.txt
@@ -2,7 +2,6 @@
 target_sources(
     Part_tests_run
         PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/TopoShape.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/FeatureChamfer.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/FeatureCompound.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/FeatureExtrusion.cpp
@@ -13,10 +12,7 @@ target_sources(
             ${CMAKE_CURRENT_SOURCE_DIR}/FeaturePartFuse.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/FeatureRevolution.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/PartTestHelpers.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/TopoShape.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/TopoShapeCache.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/FeaturePartCommon.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/FeaturePartCut.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/FeaturePartFuse.cpp
-            # ${CMAKE_CURRENT_SOURCE_DIR}/FeatureFillet.cpp
-            ${CMAKE_CURRENT_SOURCE_DIR}/PartTestHelpers.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/TopoShapeExpansion.cpp
 )

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4,7 +4,9 @@
 #include "src/App/InitApplication.h"
 #include <Mod/Part/App/TopoShape.h>
 
+#include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
 #include <TopoDS_Edge.hxx>
 #include <BRep_Builder.hxx>
 
@@ -113,6 +115,50 @@ TEST_F(TopoShapeExpansionTest, makeElementCompoundTwoShapesGeneratesMap)
 
     // Assert
     EXPECT_EQ(4, topoShape.getMappedChildElements().size());  // two vertices and two edges
+}
+
+namespace
+{
+
+std::pair<TopoDS_Shape, TopoDS_Shape> CreateTwoCubes()
+{
+    auto boxMaker1 = BRepPrimAPI_MakeBox(1.0, 1.0, 1.0);
+    boxMaker1.Build();
+    auto box1 = boxMaker1.Shape();
+
+    auto boxMaker2 = BRepPrimAPI_MakeBox(1.0, 1.0, 1.0);
+    boxMaker2.Build();
+    auto box2 = boxMaker2.Shape();
+    auto transform = gp_Trsf();
+    transform.SetTranslation(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+    box2.Location(TopLoc_Location(transform));
+
+    return {box1, box2};
+}
+}  // namespace
+
+TEST_F(TopoShapeExpansionTest, makeElementCompoundTwoCubes)
+{
+    // Arrange
+    auto [cube1, cube2] = CreateTwoCubes();
+    Part::TopoShape cube1TS {cube1};
+    cube1TS.Tag = 1;
+    Part::TopoShape cube2TS {cube2};
+    cube2TS.Tag = 2;
+
+    // Act
+    Part::TopoShape topoShape;
+    topoShape.makeElementCompound({cube1TS, cube2TS});
+
+    // Assert
+    auto elementMap = topoShape.getElementMap();
+    EXPECT_EQ(52, elementMap.size());
+    // Two cubes, each consisting of:
+    // 8 Vertices
+    // 12 Edges
+    // 6 Faces
+    // ----------
+    // 26 subshapes each
 }
 
 // NOLINTEND(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1,3 +1,118 @@
-//
-// Created by Chris Hennes on 1/11/24.
-//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "gtest/gtest.h"
+#include "src/App/InitApplication.h"
+#include <Mod/Part/App/TopoShape.h>
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <TopoDS_Edge.hxx>
+#include <BRep_Builder.hxx>
+
+// NOLINTBEGIN(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+
+class TopoShapeExpansionTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        _docName = App::GetApplication().getUniqueDocumentName("test");
+        App::GetApplication().newDocument(_docName.c_str(), "testUser");
+        _sids = &_sid;
+        _hasher = Base::Reference<App::StringHasher>(new App::StringHasher);
+        ASSERT_EQ(_hasher.getRefCount(), 1);
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(_docName.c_str());
+    }
+
+private:
+    std::string _docName;
+    Data::ElementIDRefs _sid;
+    QVector<App::StringIDRef>* _sids = nullptr;
+    App::StringHasherRef _hasher;
+};
+
+TEST_F(TopoShapeExpansionTest, makeElementCompoundOneShapeReturnsShape)
+{
+    // Arrange
+    auto edge = BRepBuilderAPI_MakeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0)).Edge();
+    Part::TopoShape topoShape {edge};
+    std::vector<Part::TopoShape> shapes {topoShape};
+
+    // Act
+    topoShape.makeElementCompound(shapes, "C", false /*Don't force the creation*/);
+
+    // Assert
+    EXPECT_EQ(edge.ShapeType(), topoShape.getShape().ShapeType());  // NOT a Compound
+}
+
+TEST_F(TopoShapeExpansionTest, makeElementCompoundOneShapeForceReturnsCompound)
+{
+    // Arrange
+    auto edge = BRepBuilderAPI_MakeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0)).Edge();
+    Part::TopoShape topoShape {edge};
+    std::vector<Part::TopoShape> shapes {topoShape};
+
+    // Act
+    topoShape.makeElementCompound(shapes, "C", true /*Force the creation*/);
+
+    // Assert
+    EXPECT_NE(edge.ShapeType(), topoShape.getShape().ShapeType());  // No longer the same thing
+}
+
+TEST_F(TopoShapeExpansionTest, makeElementCompoundTwoShapesReturnsCompound)
+{
+    // Arrange
+    auto edge1 = BRepBuilderAPI_MakeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0)).Edge();
+    auto edge2 = BRepBuilderAPI_MakeEdge(gp_Pnt(1.0, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0)).Edge();
+    Part::TopoShape topoShape {edge1};
+    std::vector<Part::TopoShape> shapes {edge1, edge2};
+
+    // Act
+    topoShape.makeElementCompound(shapes);
+
+    // Assert
+    EXPECT_EQ(TopAbs_ShapeEnum::TopAbs_COMPOUND, topoShape.getShape().ShapeType());
+}
+
+TEST_F(TopoShapeExpansionTest, makeElementCompoundEmptyShapesReturnsEmptyCompound)
+{
+    // Arrange
+    auto edge = BRepBuilderAPI_MakeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0)).Edge();
+    Part::TopoShape topoShape {edge};
+    std::vector<Part::TopoShape> shapes;
+
+    // Act
+    topoShape.makeElementCompound(shapes);
+
+    // Assert
+    EXPECT_EQ(TopAbs_ShapeEnum::TopAbs_COMPOUND, topoShape.getShape().ShapeType());
+    EXPECT_TRUE(topoShape.getMappedChildElements().empty());
+#if OCC_VERSION_HEX >= 0x070400
+    EXPECT_EQ(0, topoShape.getShape().TShape()->NbChildren());
+#endif
+}
+
+TEST_F(TopoShapeExpansionTest, makeElementCompoundTwoShapesGeneratesMap)
+{
+    // Arrange
+    auto edge1 = BRepBuilderAPI_MakeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0)).Edge();
+    auto edge2 = BRepBuilderAPI_MakeEdge(gp_Pnt(1.0, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0)).Edge();
+    Part::TopoShape topoShape {edge1};
+    std::vector<Part::TopoShape> shapes {edge1, edge2};
+
+    // Act
+    topoShape.makeElementCompound(shapes);
+
+    // Assert
+    EXPECT_EQ(4, topoShape.getMappedChildElements().size());  // two vertices and two edges
+}
+
+// NOLINTEND(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1,0 +1,3 @@
+//
+// Created by Chris Hennes on 1/11/24.
+//


### PR DESCRIPTION
This implements the method originally called `makECompound` (and now called `makeElementCompound`) as well as all auxiliary methods required by it. This is the first of the toponaming-aware object creation methods being added to the TopoShape class.

There is some follow-on work to be done refactoring the `mapSubElement`, which has very high complexity and requires some additional tests before it can be refactored safely.