### PR TITLE
Fem: Remove pipeline node from analysis view provider - fixes #11175

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -85,6 +85,13 @@ void ViewProviderFemHighlighter::highlightView(Gui::ViewProviderDocumentObject* 
     }
 }
 
+void ViewProviderFemHighlighter::removeView(Gui::ViewProviderDocumentObject* view)
+{
+    if (view) {
+        annotate->removeChild(view->getRoot());
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 /* TRANSLATOR FemGui::ViewProviderFemAnalysis */
@@ -113,6 +120,11 @@ void ViewProviderFemAnalysis::attach(App::DocumentObject* obj)
 void ViewProviderFemAnalysis::highlightView(Gui::ViewProviderDocumentObject* view)
 {
     extension.highlightView(view);
+}
+
+void ViewProviderFemAnalysis::removeView(Gui::ViewProviderDocumentObject* view)
+{
+    extension.removeView(view);
 }
 
 bool ViewProviderFemAnalysis::doubleClicked()

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.h
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.h
@@ -41,6 +41,7 @@ public:
 
     void attach(ViewProviderFemAnalysis*);
     void highlightView(Gui::ViewProviderDocumentObject*);
+    void removeView(Gui::ViewProviderDocumentObject*);
 
 private:
     SoSeparator* annotate;
@@ -87,6 +88,8 @@ public:
     void show() override;
 
     void highlightView(Gui::ViewProviderDocumentObject*);
+
+    void removeView(Gui::ViewProviderDocumentObject*);
 
     /** @name Drag and drop */
     //@{

--- a/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
@@ -107,18 +107,35 @@ void ViewProviderFemPostPipeline::updateFunctionSize()
     }
 }
 
+namespace
+{
+// Function to get the analysis container related to the object
+ViewProviderFemAnalysis* getAnalyzeView(App::DocumentObject* obj)
+{
+    ViewProviderFemAnalysis* analyzeView = nullptr;
+    App::DocumentObject* grp = App::GroupExtension::getGroupOfObject(obj);
+
+    if (Fem::FemAnalysis* analyze = Base::freecad_dynamic_cast<Fem::FemAnalysis>(grp)) {
+        analyzeView = Base::freecad_dynamic_cast<ViewProviderFemAnalysis>(
+            Gui::Application::Instance->getViewProvider(analyze));
+    }
+
+    return analyzeView;
+};
+}  // namespace
+
+bool ViewProviderFemPostPipeline::onDelete(const std::vector<std::string>& objs)
+{
+    ViewProviderFemAnalysis* analyzeView = getAnalyzeView(this->getObject());
+    if (analyzeView) {
+        analyzeView->removeView(this);
+    }
+
+    return ViewProviderFemPostObject::onDelete(objs);
+}
+
 void ViewProviderFemPostPipeline::onSelectionChanged(const Gui::SelectionChanges& sel)
 {
-    auto getAnalyzeView = [](App::DocumentObject* obj) {
-        ViewProviderFemAnalysis* analyzeView = nullptr;
-        App::DocumentObject* grp = App::GroupExtension::getGroupOfObject(obj);
-        if (Fem::FemAnalysis* analyze = Base::freecad_dynamic_cast<Fem::FemAnalysis>(grp)) {
-            analyzeView = Base::freecad_dynamic_cast<ViewProviderFemAnalysis>(
-                Gui::Application::Instance->getViewProvider(analyze));
-        }
-        return analyzeView;
-    };
-
     // If a FemPostObject is selected in the document tree we must refresh its
     // color bar.
     // But don't do this if the object is invisible because other objects with a

--- a/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.h
@@ -45,6 +45,7 @@ public:
     std::vector<App::DocumentObject*> claimChildren() const override;
     std::vector<App::DocumentObject*> claimChildren3D() const override;
     void updateData(const App::Property* prop) override;
+    bool onDelete(const std::vector<std::string>& objs) override;
     void onSelectionChanged(const Gui::SelectionChanges& sel) override;
     void updateColorBars();
     void transformField(char* FieldName, double FieldFactor);


### PR DESCRIPTION
If a pipeline is selected, its `SoNode` is added to the Analysis object node.
With these changes the pipeline node is removed when the pipeline is deleted.  