### PR TITLE
[Feature Request] [Core] [Preferences] Reset preference pages parameters set without using "PrefWidgets" objects

### DIFF
--- a/src/Gui/DlgPreferencesImp.cpp
+++ b/src/Gui/DlgPreferencesImp.cpp
@@ -861,6 +861,11 @@ void DlgPreferencesImp::restorePageDefaults(PreferencesPageItem* item)
         auto* page = qobject_cast<PreferencePage*>(item->getWidget());
 
         page->resetSettingsToDefaults();
+        /**
+         * Let's save the restart request before the page object is deleted and replaced with
+         * the newPage object (wich has restartRequired initialized to false)
+         */
+        restartRequired = restartRequired || page->isRestartRequired();
         
         std::string pageName = page->property(PageNameProperty).toString().toStdString();
         std::string groupName = page->property(GroupNameProperty).toString().toStdString();

--- a/src/Gui/PreferencePages/DlgSettings3DViewImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettings3DViewImp.cpp
@@ -135,6 +135,21 @@ void DlgSettings3DViewImp::loadSettings()
     ui->boxMarkerSize->setCurrentIndex(index);
 }
 
+void DlgSettings3DViewImp::resetSettingsToDefaults()
+{
+    ParameterGrp::handle hGrp;
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+    //reset "AntiAliasing" parameter
+    hGrp->RemoveInt("AntiAliasing");
+    //reset "RenderCache" parameter
+    hGrp->RemoveInt("RenderCache");
+    //reset "MarkerSize" parameter
+    hGrp->RemoveInt("MarkerSize");
+
+    //finally reset all the parameters associated to Gui::Pref* widgets
+    PreferencePage::resetSettingsToDefaults();
+}
+
 /**
  * Sets the strings of the subwidgets using the current language.
  */

--- a/src/Gui/PreferencePages/DlgSettings3DViewImp.h
+++ b/src/Gui/PreferencePages/DlgSettings3DViewImp.h
@@ -48,6 +48,7 @@ public:
 
     void saveSettings() override;
     void loadSettings() override;
+    void resetSettingsToDefaults() override;
 
 private Q_SLOTS:
     void onAliasingChanged(int);

--- a/src/Gui/PreferencePages/DlgSettingsCacheDirectory.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsCacheDirectory.cpp
@@ -98,6 +98,19 @@ void DlgSettingsCacheDirectory::loadSettings()
     ui->comboBoxLimit->setCurrentIndex(index);
 }
 
+void DlgSettingsCacheDirectory::resetSettingsToDefaults()
+{
+    ParameterGrp::handle hGrp;
+    hGrp = WindowParameter::getDefaultParameter()->GetGroup("CacheDirectory");
+    //reset "Limit" parameter
+    hGrp->RemoveUnsigned("Limit");
+    //reset "Period" parameter
+    hGrp->RemoveInt("Period");
+
+    //finally reset all the parameters associated to Gui::Pref* widgets
+    PreferencePage::resetSettingsToDefaults();
+}
+
 void DlgSettingsCacheDirectory::changeEvent(QEvent *e)
 {
     if (e->type() == QEvent::LanguageChange) {

--- a/src/Gui/PreferencePages/DlgSettingsCacheDirectory.h
+++ b/src/Gui/PreferencePages/DlgSettingsCacheDirectory.h
@@ -46,6 +46,7 @@ public:
 
     void saveSettings() override;
     void loadSettings() override;
+    void resetSettingsToDefaults() override;
 
 protected:
     void changeEvent(QEvent *e) override;

--- a/src/Gui/PreferencePages/DlgSettingsEditor.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.cpp
@@ -327,6 +327,23 @@ void DlgSettingsEditor::loadSettings()
     ui->displayItems->setCurrentItem(ui->displayItems->topLevelItem(0));
 }
 
+void DlgSettingsEditor::resetSettingsToDefaults()
+{
+    ParameterGrp::handle hGrp;
+    hGrp = WindowParameter::getDefaultParameter()->GetGroup("Editor");
+    //reset the parameters in the "Editor" group
+    for (QVector<QPair<QString, unsigned int> >::Iterator it = d->colormap.begin(); it != d->colormap.end(); ++it) {
+        hGrp->RemoveUnsigned((*it).first.toLatin1());
+    }
+    //reset "FontSize" parameter
+    hGrp->RemoveInt("FontSize");
+    //reset "Font" parameter
+    hGrp->RemoveASCII("Font");
+
+    //finally reset all the parameters associated to Gui::Pref* widgets
+    PreferencePage::resetSettingsToDefaults();
+}
+
 /**
  * Sets the strings of the subwidgets using the current language.
  */

--- a/src/Gui/PreferencePages/DlgSettingsEditor.h
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.h
@@ -51,6 +51,7 @@ public:
 public:
     void saveSettings() override;
     void loadSettings() override;
+    void resetSettingsToDefaults() override;
 
 private:
     void setupConnections();

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -341,6 +341,44 @@ void DlgSettingsGeneral::loadSettings()
     loadThemes();
 }
 
+void DlgSettingsGeneral::resetSettingsToDefaults()
+{
+    ParameterGrp::handle hGrp;
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Units");
+    //reset "UserSchema" parameter
+    hGrp->RemoveInt("UserSchema");
+    //reset "Decimals" parameter
+    hGrp->RemoveInt("Decimals");
+    //reset "IgnoreProjectSchema" parameter
+    hGrp->RemoveBool("IgnoreProjectSchema");
+    //reset "FracInch" parameter
+    hGrp->RemoveInt("FracInch");
+
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow");
+    //reset "Theme" parameter
+    hGrp->RemoveASCII("Theme");
+    //reset "TiledBackground" parameter
+    hGrp->RemoveBool("TiledBackground");
+
+
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/DockWindows");
+    //reset "ComboView" parameters
+    hGrp->GetGroup("ComboView")->RemoveBool("Enabled");
+    //reset "TreeView" parameters
+    hGrp->GetGroup("TreeView")->RemoveBool("Enabled");
+    //reset "PropertyView" parameters
+    hGrp->GetGroup("PropertyView")->RemoveBool("Enabled");
+
+    hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");
+    //reset "Language" parameter
+    hGrp->RemoveASCII("Language");
+    //reset "ToolbarIconSize" parameter
+    hGrp->RemoveInt("ToolbarIconSize");
+
+    //finally reset all the parameters associated to Gui::Pref* widgets
+    PreferencePage::resetSettingsToDefaults();
+}
+
 void DlgSettingsGeneral::saveThemes()
 {
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow");

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.h
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.h
@@ -53,6 +53,7 @@ public:
 
     void saveSettings() override;
     void loadSettings() override;
+    void resetSettingsToDefaults() override;
 
     void saveThemes();
     void loadThemes();

--- a/src/Gui/PreferencePages/DlgSettingsMacroImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsMacroImp.cpp
@@ -102,6 +102,17 @@ void DlgSettingsMacroImp::loadSettings()
     ui->ShortcutCount->onRestore();
 }
 
+void DlgSettingsMacroImp::resetSettingsToDefaults()
+{
+    ParameterGrp::handle hGrp;
+    hGrp = WindowParameter::getDefaultParameter()->GetGroup("RecentMacros");
+    //reset "ShortcutModifiers" parameter
+    hGrp->RemoveASCII("ShortcutModifiers");
+
+    //finally reset all the parameters associated to Gui::Pref* widgets
+    PreferencePage::resetSettingsToDefaults();
+}
+
 /**
  * Sets the strings of the subwidgets using the current language.
  */

--- a/src/Gui/PreferencePages/DlgSettingsMacroImp.h
+++ b/src/Gui/PreferencePages/DlgSettingsMacroImp.h
@@ -46,6 +46,7 @@ public:
 
     void saveSettings() override;
     void loadSettings() override;
+    void resetSettingsToDefaults() override;
 
 protected:
     void changeEvent(QEvent *e) override;

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
@@ -208,6 +208,39 @@ void DlgSettingsNavigation::loadSettings()
 
 }
 
+void DlgSettingsNavigation::resetSettingsToDefaults()
+{
+    ParameterGrp::handle hGrp;
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+    //reset "NavigationStyle" parameter
+    hGrp->RemoveASCII("NavigationStyle");
+    //reset "OrbitStyle" parameter
+    hGrp->RemoveInt("OrbitStyle");
+    //reset "RotationMode" parameter
+    hGrp->RemoveInt("RotationMode");
+    //reset "ShowNaviCube" parameter
+    hGrp->RemoveBool("ShowNaviCube");
+    //reset "ShowRotationCenter" parameter
+    hGrp->RemoveBool("ShowRotationCenter");
+    //reset "UseNavigationAnimations" parameter
+    hGrp->RemoveBool("UseNavigationAnimations");
+    //reset "NewDocumentCameraOrientation" parameter
+    hGrp->RemoveASCII("NewDocumentCameraOrientation");
+
+    hGrp = hGrp->GetGroup("Custom");
+    //reset "Q0" parameter
+    hGrp->RemoveFloat("Q0");
+    //reset "Q1" parameter
+    hGrp->RemoveFloat("Q1");
+    //reset "Q2" parameter
+    hGrp->RemoveFloat("Q2");
+    //reset "Q3" parameter
+    hGrp->RemoveFloat("Q3");
+
+    //finally reset all the parameters associated to Gui::Pref* widgets
+    PreferencePage::resetSettingsToDefaults();
+}
+
 void DlgSettingsNavigation::onMouseButtonClicked()
 {
     QDialog dlg(this);

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.h
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.h
@@ -49,6 +49,7 @@ public:
 
     void saveSettings() override;
     void loadSettings() override;
+    void resetSettingsToDefaults() override;
 
 private:
     void onMouseButtonClicked();

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -351,6 +351,37 @@ void DlgSettingsWorkbenchesImp::loadSettings()
     }
 }
 
+void DlgSettingsWorkbenchesImp::resetSettingsToDefaults()
+{
+    ParameterGrp::handle hGrp;
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
+    //reset "Ordered" parameter
+    hGrp->RemoveASCII("Ordered");
+    //reset "Disabled" parameter
+    hGrp->RemoveASCII("Disabled");
+
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/General");
+    //reset "BackgroundAutoloadModules" parameter
+    hGrp->RemoveASCII("BackgroundAutoloadModules");
+    //reset "AutoloadModule" parameter
+    hGrp->RemoveASCII("AutoloadModule");
+
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow");
+    //reset "WSPosition" parameter
+    hGrp->RemoveASCII("WSPosition");
+    if  (ui->WorkbenchSelectorPosition->currentIndex() != WorkbenchSwitcher::getIndex()) {
+        requireRestart();
+    }
+
+    //finally reset all the parameters associated to Gui::Pref* widgets
+    PreferencePage::resetSettingsToDefaults();
+
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+    if  (ui->CheckBox_WbByTab->isChecked() != hGrp->GetBool("SaveWBbyTab", 0)) {
+        requireRestart();
+    }
+}
+
 /**
 Build the list of unloaded workbenches.
 */
@@ -590,7 +621,16 @@ void DlgSettingsWorkbenchesImp::onStartWbChanged(int index)
 void DlgSettingsWorkbenchesImp::onWbSelectorChanged(int index)
 {
     Q_UNUSED(index);
-    requireRestart();
+    /**
+     * TODO: move the following code somewhere else so that the restart request isn't asked
+     * everytime the WorkbenchSwitcher is changed but only when the value that will be saved in
+     * the parameter is actually different from the current one.
+     * The code, as is now, will request the restart even if the use selects again the same value
+     * that is already saved in the parameters
+     */
+    if (ui->WorkbenchSelectorPosition->currentIndex() != WorkbenchSwitcher::getIndex()) {
+        requireRestart();
+    }
 }
 
 void DlgSettingsWorkbenchesImp::onWbByTabToggled(bool val)

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.h
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.h
@@ -29,7 +29,8 @@
 #include <Gui/PropertyPage.h>
 #include <memory>
 
-namespace Gui::Dialog {
+namespace Gui{
+namespace Dialog {
 class Ui_DlgSettingsWorkbenches;
 
 /**
@@ -47,6 +48,7 @@ public:
 
     void saveSettings() override;
     void loadSettings() override;
+    void resetSettingsToDefaults() override;
 
     static QStringList getEnabledWorkbenches();
     static QStringList getDisabledWorkbenches();
@@ -78,6 +80,7 @@ private:
     std::unique_ptr<Ui_DlgSettingsWorkbenches> ui;
 };
 
-} // namespace Gui::Dialog
+} // namespace Dialog
+} // namespace Gui
 
 #endif // GUI_DIALOG_DLGSETTINGSWORKBENCHES_IMP_H


### PR DESCRIPTION
Continues the modifications for #10161

This PR adds the management of the parameters set using Preference Pages Widgets that aren't derived from `PrefWidgets` objects and therefore ignored by the `PreferencePage::resetSettingsToDefaults` method

The Preference Pages subject to this PR are only the ones within the directory `src/Gui/PreferencePages`, no modifications have been made to the Preference Pages of the various Workbenches