### PR TITLE
Resolve #11965 (A) no proper execute() for cross-property references

### DIFF
--- a/src/Base/QuantityPyImp.cpp
+++ b/src/Base/QuantityPyImp.cpp
@@ -22,6 +22,8 @@
 
 #include "PreCompiled.h"
 
+#include <QString>
+
 // inclusion of the generated files (generated out of QuantityPy.xml)
 #include "QuantityPy.h"
 #include "UnitPy.h"
@@ -333,6 +335,9 @@ static Quantity& pyToQuantity(Quantity& q, PyObject* pyobj)
     }
     else if (PyLong_Check(pyobj)) {
         q = Quantity(PyLong_AsLong(pyobj));
+    }
+    else if (PyUnicode_Check(pyobj)) {
+        q = Quantity::parse(QString::fromUtf8(PyUnicode_AsUTF8(pyobj)));
     }
     else {
         PyErr_Format(PyExc_TypeError, "Cannot convert %s to Quantity", Py_TYPE(pyobj)->tp_name);

--- a/tests/src/App/CMakeLists.txt
+++ b/tests/src/App/CMakeLists.txt
@@ -13,5 +13,6 @@ target_sources(
             ${CMAKE_CURRENT_SOURCE_DIR}/MappedName.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Metadata.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Property.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/PropertyExpressionEngine.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/StringHasher.cpp
 )

--- a/tests/src/App/PropertyExpressionEngine.cpp
+++ b/tests/src/App/PropertyExpressionEngine.cpp
@@ -1,0 +1,91 @@
+#include "gtest/gtest.h"
+
+#include "Base/Quantity.h"
+
+#include "App/Application.h"
+#include "App/Document.h"
+#include "App/DocumentObject.h"
+#include "App/Expression.h"
+#include "App/ObjectIdentifier.h"
+#include "App/PropertyExpressionEngine.h"
+
+#include "src/App/InitApplication.h"
+
+// clang-format off
+
+class PropertyExpressionEngine: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        _doc_name = App::GetApplication().getUniqueDocumentName("test");
+        _this_doc = App::GetApplication().newDocument(_doc_name.c_str(), "testUser");
+        _this_obj = _this_doc -> addObject("Sketcher::SketchObject");
+        _source_name = std::string("this_origin");
+        _source_prop = _this_obj -> addDynamicProperty("App::PropertyString", _source_name.c_str()); // property with length as string
+        _target_name = std::string("this_length");
+        _target_prop = _this_obj -> addDynamicProperty("App::PropertyLength", _target_name.c_str()); // property with reference to source
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(_doc_name.c_str());
+    }
+
+    std::string doc_name() { return _doc_name; }
+    App::Document* this_doc() { return _this_doc; }
+    App::DocumentObject* this_obj() { return _this_obj; }
+    std::string source_name() { return _source_name; }
+    App::Property* source_prop() { return _source_prop; }
+    std::string target_name() { return _target_name; }
+    App::Property* target_prop() { return _target_prop; }
+
+private:
+    std::string _doc_name;
+    App::Document* _this_doc {};
+    App::DocumentObject* _this_obj {};
+    std::string _source_name;
+    App::Property* _source_prop {};
+    std::string _target_name;
+    App::Property* _target_prop {};
+};
+
+// https://github.com/FreeCAD/FreeCAD/issues/11965
+TEST_F(PropertyExpressionEngine, executeCrossPropertyReference)
+{
+    auto source_text = std::string("1.5 m"); // provided in source
+    auto target_text = std::string("1500 mm"); // expected in target
+
+    auto source_path = App::ObjectIdentifier::parse(this_obj(), source_name());
+    source_prop()->setPathValue(source_path, source_text);
+
+    auto target_expr = source_name() + "+0mm"; // Solution A: "magic reference syntax"
+
+    auto target_path = App::ObjectIdentifier::parse(this_obj(), target_name());
+    std::shared_ptr<App::Expression> target_rule(App::Expression::parse(this_obj(), target_expr));
+    this_obj()->setExpression(target_path, target_rule);
+
+    this_obj() -> ExpressionEngine.execute();
+
+    auto source_entry = source_prop() -> getPathValue(source_path);
+    ASSERT_TRUE(source_entry.type() == typeid(std::string));
+    auto source_value = App::any_cast<std::string>(source_entry);
+
+    auto target_entry = target_prop() -> getPathValue(target_path);
+    ASSERT_TRUE(target_entry.type() == typeid(Base::Quantity));
+    auto target_quant = App::any_cast<Base::Quantity>(target_entry);
+    auto target_value = target_quant.getValue();
+    auto target_unit = target_quant.getUnit().getString().toStdString();
+
+    EXPECT_EQ(target_quant, App::parseQuantityFromText(target_text)) << ""
+        "expecting equal: source_text='" + source_text + "' target_text='" + target_text + "'"
+        "instead produced: target_value='" + std::to_string(target_value) + "' target_unit='" + target_unit + "'"
+    ;
+}
+
+// clang-format on


### PR DESCRIPTION
Resolve #11965 : Solution A: magic reference syntax: `prop_name + 0mm`
