### PR TITLE
[Sketcher] Add contextual BSpline commands in right click menu

### DIFF
--- a/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineApproximate.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineApproximate.svg
@@ -16,6 +16,17 @@
   <defs
      id="defs2871">
     <linearGradient
+       id="linearGradient4">
+      <stop
+         style="stop-color:#3f6fab;stop-opacity:1;"
+         offset="0"
+         id="stop3" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="1"
+         id="stop4" />
+    </linearGradient>
+    <linearGradient
        id="linearGradient62">
       <stop
          style="stop-color:#d3d7cf;stop-opacity:1;"
@@ -417,7 +428,7 @@
        x2="-22"
        y2="5" />
     <linearGradient
-       xlink:href="#linearGradient3836-9-3"
+       xlink:href="#linearGradient4"
        id="linearGradient97"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.82607043,0,0,0.82533448,-4.0098079,1.346708)"
@@ -425,6 +436,15 @@
        y1="18"
        x2="-22"
        y2="5" />
+    <linearGradient
+       y2="131.22015"
+       x2="154.4444"
+       y1="161.22015"
+       x1="164.4444"
+       gradientTransform="translate(-188.44439,-101.22016)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3112"
+       xlink:href="#linearGradient3815" />
   </defs>
   <metadata
      id="metadata2874">
@@ -464,7 +484,8 @@
        transform="matrix(0.1460346,0,0,0.1460346,-220.10298,-55.131225)">
       <g
          transform="translate(-451.94762,54.987483)"
-         id="g4428-3-2">
+         id="g4428-3-2"
+         style="display:inline">
         <path
            style="fill:none;stroke:#151819;stroke-width:8.27355;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:8.27355, 16.5471;stroke-dashoffset:8.27355;stroke-opacity:1"
            id="path3044-28"
@@ -519,7 +540,7 @@
            d="m -24.358888,7.0362241 a 5.782493,5.7773415 0 1 1 8.784093,7.5158349 5.782493,5.7773415 0 0 1 -8.784093,-7.5158349 z" />
       </g>
       <g
-         transform="matrix(5.3322609,0,0,5.33226,1983.4426,601.87102)"
+         transform="matrix(5.3322609,0,0,5.33226,1983.4426,588.17564)"
          id="g95"
          style="stroke-width:1.2842">
         <path
@@ -536,11 +557,11 @@
          id="g97"
          style="stroke-width:1.2842">
         <path
-           style="fill:none;stroke:#2e0000;stroke-width:2.56841;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;stroke:#0b1521;stroke-width:2.56841;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path96"
            d="M -26.310778,5.3580033 A 8.3519646,8.3515832 0.02039876 1 1 -13.623399,16.222662 8.3519646,8.3515832 0.02039876 1 1 -26.310778,5.3580033 Z" />
         <path
-           style="fill:url(#linearGradient97);fill-opacity:1;stroke:#ef2929;stroke-width:2.56842;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:url(#linearGradient97);fill-opacity:1;stroke:#729fcf;stroke-width:2.56842;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path97"
            d="m -24.358888,7.0362241 a 5.782493,5.7773415 0 1 1 8.784093,7.5158349 5.782493,5.7773415 0 0 1 -8.784093,-7.5158349 z" />
       </g>

--- a/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineInsertKnot.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_BSplineInsertKnot.svg
@@ -380,7 +380,7 @@
          id="path3826" />
     </g>
     <g
-       transform="matrix(0.77869459,0,0,0.77869445,66.2831,20.597628)"
+       transform="matrix(0.77869459,0,0,0.77869445,63.903318,22.302657)"
        id="g3"
        style="display:inline;stroke-width:1.2842">
       <path
@@ -392,5 +392,9 @@
          id="path3"
          d="m -24.358888,7.0362241 a 5.782493,5.7773415 0 1 1 8.784093,7.5158349 5.782493,5.7773415 0 0 1 -8.784093,-7.5158349 z" />
     </g>
+    <path
+       id="path1"
+       style="fill:none;fill-opacity:1;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+       d="m 37.956269,30.704899 c 0,-5.743254 4.655691,-10.39908 10.398778,-10.39908 m 10.398777,10.39908 c 0,5.743253 -4.655691,10.399079 -10.398777,10.39908" />
   </g>
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_JoinCurves.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/splines/Sketcher_JoinCurves.svg
@@ -261,11 +261,11 @@
     <linearGradient
        id="linearGradient2">
       <stop
-         style="stop-color:#73d216;stop-opacity:1;"
+         style="stop-color:#d3d7cf;stop-opacity:1;"
          offset="0"
          id="stop1" />
       <stop
-         style="stop-color:#8ae234;stop-opacity:1;"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="1"
          id="stop2" />
     </linearGradient>
@@ -316,6 +316,15 @@
        y1="35.978416"
        x2="25.988253"
        y2="29.916241" />
+    <linearGradient
+       xlink:href="#linearGradient2"
+       id="linearGradient3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.82607043,0,0,0.82533448,-4.0098079,1.346708)"
+       x1="-18"
+       y1="18"
+       x2="-22"
+       y2="5" />
   </defs>
   <metadata
      id="metadata2874">
@@ -368,7 +377,7 @@
     </g>
     <g
        id="g1068-6"
-       transform="matrix(-1,0,0,1,45.987644,0)">
+       transform="matrix(-1,0,0,1,47.987644,0)">
       <path
          style="fill:url(#linearGradient1099);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 13.547502,28.511064 v -7.501616 l -10.4959114,1e-6 V 10.507184 H 13.547502 V 3.005568 l 9.44632,12.752748 z"
@@ -394,6 +403,19 @@
          id="path3266-9-2"
          d="M 138.75945,-0.2767731 C 141.87413,39.053035 101.07195,19.660727 91.353198,47.348227"
          style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       transform="matrix(0.77869459,0,0,0.77869445,39.542061,32.862232)"
+       id="g3"
+       style="display:inline;stroke-width:1.2842">
+      <path
+         style="fill:none;stroke:#151819;stroke-width:2.56841;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path2"
+         d="M -26.310778,5.3580033 A 8.3519646,8.3515832 0.02039876 1 1 -13.623399,16.222662 8.3519646,8.3515832 0.02039876 1 1 -26.310778,5.3580033 Z" />
+      <path
+         style="fill:url(#linearGradient3);fill-opacity:1;stroke:#ffffff;stroke-width:2.56842;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path3"
+         d="m -24.358888,7.0362241 a 5.782493,5.7773415 0 1 1 8.784093,7.5158349 5.782493,5.7773415 0 0 1 -8.784093,-7.5158349 z" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
Add B-Spline commands in the contextual right click menu in the Sketcher WB, depending of the selection of
- B-Splines
- Knots
- BSpline + Points

+fine tuned icons for better identification.
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/6fafd6b6-e739-4856-bcbe-3316fd798554)
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/d3e41ada-76d9-41df-94f8-82ffd30d362f)
