### PR TITLE
Material: fix Qt6 build failure

### DIFF
--- a/src/Mod/Material/App/MaterialLoader.cpp
+++ b/src/Mod/Material/App/MaterialLoader.cpp
@@ -21,16 +21,12 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#include <QString>
-#endif
-
 #include <QDirIterator>
 #include <QFileInfo>
 #include <QList>
 #include <QMetaType>
-
-#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
-#include <QtCore5Compat/QRegExp>
+#include <QRegularExpression>
+#include <QString>
 #endif
 
 #include <App/Application.h>
@@ -85,7 +81,7 @@ std::shared_ptr<QList<QVariant>> MaterialYamlEntry::readList(const YAML::Node& n
         QVariant nodeValue;
         if (isImageList) {
             nodeValue = QString::fromStdString(it->as<std::string>())
-                            .remove(QRegExp(QString::fromStdString("[\r\n]")));
+                            .remove(QRegularExpression(QString::fromStdString("[\r\n]")));
         }
         else {
             nodeValue = QString::fromStdString(it->as<std::string>());
@@ -247,7 +243,7 @@ void MaterialYamlEntry::addToTree(
                                 QString::fromStdString((itp->second).as<std::string>());
                             if (type == MaterialValue::Image) {
                                 propertyValue =
-                                    propertyValue.remove(QRegExp(QString::fromStdString("[\r\n]")));
+                                    propertyValue.remove(QRegularExpression(QString::fromStdString("[\r\n]")));
                             }
                             finalModel->setPhysicalValue(QString::fromStdString(propertyName),
                                                          propertyValue);
@@ -314,7 +310,7 @@ void MaterialYamlEntry::addToTree(
                                 QString::fromStdString((itp->second).as<std::string>());
                             if (type == MaterialValue::Image) {
                                 propertyValue =
-                                    propertyValue.remove(QRegExp(QString::fromStdString("[\r\n]")));
+                                    propertyValue.remove(QRegularExpression(QString::fromStdString("[\r\n]")));
                             }
                             finalModel->setAppearanceValue(QString::fromStdString(propertyName),
                                                            propertyValue);

--- a/src/Mod/Material/App/MaterialValue.cpp
+++ b/src/Mod/Material/App/MaterialValue.cpp
@@ -21,10 +21,9 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
+#include <QMetaType>
 #include <QRegularExpression>
 #endif
-
-#include <QMetaType>
 
 #include <App/Application.h>
 #include <Base/QtTools.h>
@@ -264,7 +263,7 @@ QString MaterialValue::getYAMLStringMultiLine() const
     QString yaml;
     yaml = QString::fromStdString(" |2");
     auto list =
-        getValue().toString().split(QRegExp(QString::fromStdString("[\r\n]")), Qt::SkipEmptyParts);
+        getValue().toString().split(QRegularExpression(QString::fromStdString("[\r\n]")), Qt::SkipEmptyParts);
     for (auto& it : list) {
         yaml += QString::fromStdString("\n      ") + it;
     }

--- a/src/Mod/Material/App/ModelLibrary.cpp
+++ b/src/Mod/Material/App/ModelLibrary.cpp
@@ -55,7 +55,7 @@ QString LibraryBase::getLocalPath(const QString& path) const
     QString prefix = QString::fromStdString("/") + getName();
     if (cleanPath.startsWith(prefix)) {
         // Remove the library name from the path
-        filePath += cleanPath.rightRef(cleanPath.length() - prefix.length());
+        filePath += cleanPath.right(cleanPath.length() - prefix.length());
     }
     else {
         filePath += cleanPath;


### PR DESCRIPTION
QRegExp has been replaced with QRegularExpression and isn't part of the base of Qt6 any more