### PR TITLE
fix build for python 3.12: remove usage of _Py_PackageContext in 3.12+

### DIFF
--- a/src/CXX/IndirectPythonInterface.cxx
+++ b/src/CXX/IndirectPythonInterface.cxx
@@ -128,7 +128,9 @@ static int *ptr_Py_OptimizeFlag = NULL;
 static int *ptr_Py_NoSiteFlag = NULL;
 static int *ptr_Py_VerboseFlag = NULL;
 
-#   if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7
+#   if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 12
+// NOTE: No _PyPackageContext in 3.12
+#   elif PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7
 static const char **ptr__Py_PackageContext = NULL;
 #   else
 static char **ptr__Py_PackageContext = NULL;
@@ -248,7 +250,9 @@ bool InitialisePythonIndirectInterface()
     ptr_Py_NoSiteFlag           = GetInt_as_IntPointer( "Py_NoSiteFlag" );
     ptr_Py_VerboseFlag          = GetInt_as_IntPointer( "Py_VerboseFlag" );
 
-#    if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7
+#    if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 12
+    // NOTE: No _PyPackageContext in 3.12+
+#    elif PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7
     ptr__Py_PackageContext      = GetConstCharPointer_as_ConstCharPointerPointer( "_Py_PackageContext" );
 #    else
     ptr__Py_PackageContext      = GetCharPointer_as_CharPointerPointer( "_Py_PackageContext" );
@@ -404,7 +408,9 @@ PYCXX_EXPORT int &_Py_NoSiteFlag()                   { return *ptr_Py_NoSiteFlag
 PYCXX_EXPORT int &_Py_VerboseFlag()                  { return *ptr_Py_VerboseFlag; }
 #  endif
 
-#  if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7
+#  if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 12
+// NOTE: No _Py_PackageContext in 3.12+
+#  elif PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7
 PYCXX_EXPORT const char *__Py_PackageContext()       { return *ptr__Py_PackageContext; }
 #  else
 PYCXX_EXPORT char *__Py_PackageContext()             { return *ptr__Py_PackageContext; }
@@ -523,7 +529,9 @@ PYCXX_EXPORT int &_Py_InteractiveFlag()              { return Py_InteractiveFlag
 PYCXX_EXPORT int &_Py_OptimizeFlag()                 { return Py_OptimizeFlag; }
 PYCXX_EXPORT int &_Py_NoSiteFlag()                   { return Py_NoSiteFlag; }
 PYCXX_EXPORT int &_Py_VerboseFlag()                  { return Py_VerboseFlag; }
-#  if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7
+#  if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 12
+// NOTE: No _Py_PackageContext in 3.12+
+#  elif PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7
 PYCXX_EXPORT const char *__Py_PackageContext()       { return _Py_PackageContext; }
 #  else
 PYCXX_EXPORT char *__Py_PackageContext()             { return _Py_PackageContext; }

--- a/src/CXX/Python3/IndirectPythonInterface.hxx
+++ b/src/CXX/Python3/IndirectPythonInterface.hxx
@@ -149,7 +149,9 @@ PYCXX_EXPORT int &_Py_NoSiteFlag();
 PYCXX_EXPORT int &_Py_TabcheckFlag();
 PYCXX_EXPORT int &_Py_VerboseFlag();
 
-#  if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7
+#  if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 12
+// NOTE: No _Py_PackageContext in 3.12+
+#  elif PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7
 PYCXX_EXPORT const char *__Py_PackageContext();
 #  else
 PYCXX_EXPORT char *__Py_PackageContext();

--- a/src/CXX/Python3/cxx_extensions.cxx
+++ b/src/CXX/Python3/cxx_extensions.cxx
@@ -152,7 +152,7 @@ PyMethodDef *MethodTable::table()
 //================================================================================
 ExtensionModuleBase::ExtensionModuleBase( const char *name )
 : m_module_name( name )
-#if defined( Py_LIMITED_API )
+#if defined( Py_LIMITED_API ) || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 12)
 , m_full_module_name( m_module_name )
 #else
 , m_full_module_name( __Py_PackageContext() != NULL ? std::string( __Py_PackageContext() ) : m_module_name )


### PR DESCRIPTION
_Py_PackageContext was removed from cpython in https://github.com/python/cpython/commit/5f55067e238c21de25f09ece9bb24ae8c42d02b4, and I'm not seeing an obvious way to replace this functionality.

I'm not sure if this would regress any behavior, but it at least matches what the Limited API version does, so if that's a supported way to link against Python then it should be fine.

Came across this trying to build on Fedora 39. I wasn't actually able to test it as I wasn't able to get pyside6 to build properly unfortunately, but since I already made these changes to get it to build I figured I'd open a PR.
