### PR TITLE
Gui: remember user closed overlay panel

### DIFF
--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -813,28 +813,16 @@ public:
             setOverlayMode(OverlayManager::OverlayMode::TransparentAll);
             return;
         case OverlayManager::OverlayMode::ToggleLeft:
-            if (OverlayTabWidget::_LeftOverlay->isVisible())
-                OverlayTabWidget::_LeftOverlay->setState(OverlayTabWidget::State::Hidden);
-            else
-                OverlayTabWidget::_LeftOverlay->setState(OverlayTabWidget::State::Showing);
+            toggleOverlayTab(OverlayTabWidget::_LeftOverlay);
             break;
         case OverlayManager::OverlayMode::ToggleRight:
-            if (OverlayTabWidget::_RightOverlay->isVisible())
-                OverlayTabWidget::_RightOverlay->setState(OverlayTabWidget::State::Hidden);
-            else
-                OverlayTabWidget::_RightOverlay->setState(OverlayTabWidget::State::Showing);
+            toggleOverlayTab(OverlayTabWidget::_RightOverlay);
             break;
         case OverlayManager::OverlayMode::ToggleTop:
-            if (OverlayTabWidget::_TopOverlay->isVisible())
-                OverlayTabWidget::_TopOverlay->setState(OverlayTabWidget::State::Hidden);
-            else
-                OverlayTabWidget::_TopOverlay->setState(OverlayTabWidget::State::Showing);
+            toggleOverlayTab(OverlayTabWidget::_TopOverlay);
             break;
         case OverlayManager::OverlayMode::ToggleBottom:
-            if (OverlayTabWidget::_BottomOverlay->isVisible())
-                OverlayTabWidget::_BottomOverlay->setState(OverlayTabWidget::State::Hidden);
-            else
-                OverlayTabWidget::_BottomOverlay->setState(OverlayTabWidget::State::Showing);
+            toggleOverlayTab(OverlayTabWidget::_BottomOverlay);
             break;
         default:
             break;
@@ -880,6 +868,15 @@ public:
         toggleOverlay(dock, m);
     }
 
+    static void toggleOverlayTab(OverlayTabWidget* tab)
+    {
+        auto toggledState = tab->isVisible()
+            ? OverlayTabWidget::State::Hidden
+            : OverlayTabWidget::State::Showing;
+
+        tab->setState(toggledState, OverlayTabWidget::StateChangeSource::User);
+    }
+    
     void onToggleDockWidget(QDockWidget *dock, int checked)
     {
         if(!dock)

--- a/src/Gui/OverlayWidgets.cpp
+++ b/src/Gui/OverlayWidgets.cpp
@@ -783,8 +783,14 @@ void OverlayTabWidget::restore(ParameterGrp::handle handle)
         setAutoMode(AutoMode::EditShow);
     else if (handle->GetBool("TaskShow", false))
         setAutoMode(AutoMode::TaskShow);
-    else
+    else {
         setAutoMode(AutoMode::NoAutoMode);
+        if (handle->GetBool("Closed", false)) {
+            setState(State::Hidden);
+        } else if (!isVisible() && !checkAutoHide()) {
+            setState(State::Showing);
+        }
+    }
 
     setTransparent(handle->GetBool("Transparent", false));
 
@@ -923,7 +929,7 @@ void OverlayTabWidget::onAction(QAction *action)
     OverlayManager::instance()->refresh(this);
 }
 
-void OverlayTabWidget::setState(State state)
+void OverlayTabWidget::setState(State state, StateChangeSource source)
 {
     if (_state == state)
         return;
@@ -939,6 +945,11 @@ void OverlayTabWidget::setState(State state)
         }
         // fall through
     case State::Showing:
+        if (source == StateChangeSource::User && !_saving) {
+            Base::StateLocker lock(_saving);
+            hGrp->SetBool("Closed", false);
+        }
+
         _state = state;
         hide();
         if (dockArea == Qt::RightDockWidgetArea)
@@ -980,10 +991,16 @@ void OverlayTabWidget::setState(State state)
         hide();
         _graphicsEffectTab->setEnabled(true);
         break;
+
     case State::Hidden:
+        if (source == StateChangeSource::User && !_saving) {
+            Base::StateLocker lock(_saving);
+            hGrp->SetBool("Closed", true);
+        }
         startHide();
         _state = state;
         break;
+
     default:
         break;
     }

--- a/src/Gui/OverlayWidgets.h
+++ b/src/Gui/OverlayWidgets.h
@@ -281,8 +281,17 @@ public:
         /// The tab widget is explicitly hidden by user
         Hidden,
     };
+    /// Source for the change of tab state
+    enum class StateChangeSource {
+        /// Event originating from the internal source code
+        Internal,
+        /// Event triggered explicitly by the user
+        User,
+    };
     /// Set state of the tab widget
-    void setState(State);
+    /// @params state: the new state
+    /// @params source: source responsible for triggering change
+    void setState(State state, StateChangeSource source = StateChangeSource::Internal);
     /// Get the state of the widget
     State getState() const {return _state;}
 


### PR DESCRIPTION
This ensures that after overlay area is hidden using "X" button it stays closed even after restart.

Replaces #11837 