### PR TITLE
[Import]fix rounding errors in dxf export

### DIFF
--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -63,6 +63,10 @@ CDxfWrite::CDxfWrite(const char* filepath)
         return;
     }
     m_ofs->imbue(std::locale("C"));
+
+    // use lots of digits to avoid rounding errors
+    m_ssEntity->setf(std::ios::fixed);
+    m_ssEntity->precision(9);
 }
 
 CDxfWrite::~CDxfWrite()


### PR DESCRIPTION
This PR implements a fix for an issue with the number of digits being used in dxf exports as reported here: https://forum.freecad.org/viewtopic.php?t=84416&sid=5b37fcf9562b8d514d927baa290cd3ab