### PR TITLE
[Core] Wb selector : adds "Toolbar icons" mode

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -688,11 +688,20 @@ void WorkbenchGroup::addTo(QWidget *widget)
         qobject_cast<QToolBar*>(widget)->addWidget(box);
     }
     else if (widget->inherits("QMenuBar")) {
-        auto* box = new WorkbenchComboBox(widget);
-        setupBox(box);
+        bool leftCorner = WorkbenchSwitcher::isLeftCorner(WorkbenchSwitcher::getValue());
+        bool rightCorner = WorkbenchSwitcher::isLeftCorner(WorkbenchSwitcher::getValue());
+        QMenuBar* menuBar = qobject_cast<QMenuBar*>(widget);
 
-        bool left = WorkbenchSwitcher::isLeftCorner(WorkbenchSwitcher::getValue());
-        qobject_cast<QMenuBar*>(widget)->setCornerWidget(box, left ? Qt::TopLeftCorner : Qt::TopRightCorner);
+        if (leftCorner || rightCorner) { // corner widget
+            auto* box = new WorkbenchComboBox(widget);
+            setupBox(box);
+            menuBar->setCornerWidget(box, leftCorner ? Qt::TopLeftCorner : Qt::TopRightCorner);
+        }
+        else { // QMenuBar icons
+            for (auto* action : actions()) {
+                menuBar->addAction(action);
+            }
+        }
     }
     else if (widget->inherits("QMenu")) {
         auto menu = qobject_cast<QMenu*>(widget);

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -517,6 +517,7 @@ void DlgSettingsWorkbenchesImp::loadWorkbenchSelector()
     ui->WorkbenchSelectorPosition->addItem(tr("Toolbar"));
     ui->WorkbenchSelectorPosition->addItem(tr("Left corner"));
     ui->WorkbenchSelectorPosition->addItem(tr("Right corner"));
+    ui->WorkbenchSelectorPosition->addItem(tr("Menu bar icons"));
     ui->WorkbenchSelectorPosition->setCurrentIndex(WorkbenchSwitcher::getIndex());
 }
 

--- a/src/Gui/UserSettings.cpp
+++ b/src/Gui/UserSettings.cpp
@@ -55,6 +55,11 @@ bool WorkbenchSwitcher::isRightCorner(const std::string& value)
     return (value == "WSRightCorner");
 }
 
+bool WorkbenchSwitcher::isMenuBarIcons(const std::string& value)
+{
+    return (value == "WSMenuBarIcons");
+}
+
 bool WorkbenchSwitcher::isToolbar(const std::string& value)
 {
     return (value == "WSToolbar");
@@ -63,7 +68,7 @@ bool WorkbenchSwitcher::isToolbar(const std::string& value)
 QVector<std::string> WorkbenchSwitcher::values()
 {
     QVector<std::string> wsPositions;
-    wsPositions << "WSToolbar" << "WSLeftCorner" << "WSRightCorner";
+    wsPositions << "WSToolbar" << "WSLeftCorner" << "WSRightCorner" << "WSMenuBarIcons";
     return wsPositions;
 }
 

--- a/src/Gui/UserSettings.h
+++ b/src/Gui/UserSettings.h
@@ -34,6 +34,7 @@ class GuiExport WorkbenchSwitcher
 public:
     static bool isLeftCorner(const std::string&);
     static bool isRightCorner(const std::string&);
+    static bool isMenuBarIcons(const std::string&);
     static bool isToolbar(const std::string&);
     static std::string getValue();
     static int getIndex();


### PR DESCRIPTION
Workbench selector : adds "Toolbar icons" mode.
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/2868ba00-9ddd-4421-bba5-bcd5f4d0da0d)

This is adding menu entries with the icon of the workbenches directly on the QMenuBar. Inspired from Triplus' Selector toolbar. (https://forum.freecad.org/viewtopic.php?t=21403)

If someone on linux and on MacOS can feedback if it works properly?

Ideas and feedback welcome.