### PR TITLE
Display current active document in main window title

### DIFF
--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -453,7 +453,10 @@ QString MDIView::buildWindowTitle()
     QString windowTitle;
     if (Gui::Document* document = getGuiDocument()) {
         if (document->isModified()) {
-            windowTitle = QString::fromUtf8("* ");
+            getMainWindow()->setWindowModified(TRUE);
+        }
+        else {
+            getMainWindow()->setWindowModified(FALSE);
         }
 
         windowTitle.append(QString::fromUtf8(getAppDocument()->getName()));

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -448,4 +448,18 @@ void MDIView::setCurrentViewMode(ViewMode mode)
     }
 }
 
+QString MDIView::buildWindowTitle()
+{
+    QString windowTitle;
+    if (Gui::Document* document = getGuiDocument()) {
+        if (document->isModified()) {
+            windowTitle = QString::fromUtf8("* ");
+        }
+
+        windowTitle.append(QString::fromUtf8(getAppDocument()->getName()));
+    }
+
+    return windowTitle;
+}
+
 #include "moc_MDIView.cpp"

--- a/src/Gui/MDIView.h
+++ b/src/Gui/MDIView.h
@@ -74,6 +74,9 @@ public:
     void onRelabel(Gui::Document *pDoc) override;
     virtual void viewAll();
 
+    /// build window title
+    QString buildWindowTitle();
+
     /// Message handler
     bool onMsg(const char* pMsg,const char** ppReturn) override;
     /// Message handler test

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1270,6 +1270,7 @@ void MainWindow::tabChanged(MDIView* view)
 {
     Q_UNUSED(view);
     updateActions();
+    getMainWindow()->setWindowTitle(view->buildWindowTitle());
 }
 
 void MainWindow::tabCloseRequested(int index)
@@ -1665,6 +1666,7 @@ void MainWindow::_updateActions()
         Application::Instance->commandManager().testActive();
     }
     d->actionUpdateDelay = 0;
+    getMainWindow()->setWindowTitle(activeWindow()->buildWindowTitle());
 }
 
 void MainWindow::updateEditorActions()
@@ -2368,6 +2370,7 @@ void MainWindow::changeEvent(QEvent *e)
                     d->activeView = view;
                     Application::Instance->viewActivated(view);
                 }
+                getMainWindow()->setWindowTitle(view->buildWindowTitle());
             }
         }
     }
@@ -2509,97 +2512,132 @@ QMdiArea *MainWindow::getMdiArea() const
     return d->mdiArea;
 }
 
-// ----------------------------------------------------------
-
-StatusBarObserver::StatusBarObserver()
-  : WindowParameter("OutputWindow")
+void MainWindow::setWindowTitle(const QString& string)
 {
-    msg = QString::fromLatin1("#statusBar{color: #000000}"); // black
-    wrn = QString::fromLatin1("#statusBar{color: #ffaa00}"); // orange
-    err = QString::fromLatin1("#statusBar{color: #ff0000}"); // red
-    Base::Console().AttachObserver(this);
-    getWindowParameter()->Attach(this);
-    getWindowParameter()->NotifyAll();
-}
+    QString title;
+    QString appname =
+        QString(static_cast<QApplication*>(QCoreApplication::instance())->applicationName());
 
-StatusBarObserver::~StatusBarObserver()
-{
-    getWindowParameter()->Detach(this);
-    Base::Console().DetachObserver(this);
-}
+    // allow to disable version number
+    ParameterGrp::handle hGen = +App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/General");
+    bool showVersion = hGen->GetBool("ShowVersionInTitle", true);
 
-void StatusBarObserver::OnChange(Base::Subject<const char*> &rCaller, const char * sReason)
-{
-    ParameterGrp& rclGrp = ((ParameterGrp&)rCaller);
-    auto format = QString::fromLatin1("#statusBar{color: %1}");
-    if (strcmp(sReason, "colorText") == 0) {
-        unsigned long col = rclGrp.GetUnsigned( sReason );
-        this->msg = format.arg(App::Color::fromPackedRGB<QColor>(col).name());
+    if (showVersion) {
+        // set main window title with FreeCAD Version
+        auto config = App::Application::Config();
+        QString major = QString::fromUtf8(config["BuildVersionMajor"].c_str());
+        QString minor = QString::fromUtf8(config["BuildVersionMinor"].c_str());
+        QString point = QString::fromUtf8(config["BuildVersionPoint"].c_str());
+        QString suffix = QString::fromUtf8(config["BuildVersionSuffix"].c_str());
+        title = QString::fromUtf8("%1 %2.%3.%4%5").arg(appname, major, minor, point, suffix);
     }
-    else if (strcmp(sReason, "colorWarning") == 0) {
-        unsigned long col = rclGrp.GetUnsigned( sReason );
-        this->wrn = format.arg(App::Color::fromPackedRGB<QColor>(col).name());
-    }
-    else if (strcmp(sReason, "colorError") == 0) {
-        unsigned long col = rclGrp.GetUnsigned( sReason );
-        this->err = format.arg(App::Color::fromPackedRGB<QColor>(col).name());
-    }
-    else if (strcmp(sReason, "colorCritical") == 0) {
-        unsigned long col = rclGrp.GetUnsigned( sReason );
-        this->critical = format.arg(QColor((col >> 24) & 0xff,(col >> 16) & 0xff,(col >> 8) & 0xff).name());
-    }
-}
-
-void StatusBarObserver::SendLog(const std::string& notifiername, const std::string& msg, Base::LogStyle level,
-                                Base::IntendedRecipient recipient, Base::ContentType content)
-{
-    (void) notifiername;
-
-    // Do not log untranslated messages, or messages intended only to a developer to status bar
-    if( recipient == Base::IntendedRecipient::Developer ||
-        content == Base::ContentType::Untranslated ||
-        content == Base::ContentType::Untranslatable )
-        return;
-
-    int messageType = -1;
-    switch(level){
-        case Base::LogStyle::Warning:
-            messageType = MainWindow::Wrn;
-            break;
-        case Base::LogStyle::Message:
-            messageType = MainWindow::Msg;
-            break;
-        case Base::LogStyle::Error:
-            messageType = MainWindow::Err;
-            break;
-        case Base::LogStyle::Log:
-            messageType = MainWindow::Log;
-            break;
-        case Base::LogStyle::Critical:
-            messageType = MainWindow::Critical;
-            break;
-        default:
-            break;
+    else {
+        title = appname;
     }
 
-    // Send the event to the main window to allow thread-safety. Qt will delete it when done.
-    auto ev = new CustomMessageEvent(messageType, QString::fromUtf8(msg.c_str()));
-    QApplication::postEvent(getMainWindow(), ev);
+    if (!string.isEmpty()) {
+        title = QString::fromUtf8("%1 - %2").arg(string, title);
+    }
+
+    QMainWindow::setWindowTitle(title);
 }
 
-// -------------------------------------------------------------
+    // ----------------------------------------------------------
 
-int ActionStyleEvent::EventType = -1;
+    StatusBarObserver::StatusBarObserver()
+        : WindowParameter("OutputWindow")
+    {
+        msg = QString::fromLatin1("#statusBar{color: #000000}");  // black
+        wrn = QString::fromLatin1("#statusBar{color: #ffaa00}");  // orange
+        err = QString::fromLatin1("#statusBar{color: #ff0000}");  // red
+        Base::Console().AttachObserver(this);
+        getWindowParameter()->Attach(this);
+        getWindowParameter()->NotifyAll();
+    }
 
-ActionStyleEvent::ActionStyleEvent(Style type)
-  : QEvent(QEvent::Type(EventType)), type(type)
-{
-}
+    StatusBarObserver::~StatusBarObserver()
+    {
+        getWindowParameter()->Detach(this);
+        Base::Console().DetachObserver(this);
+    }
 
-ActionStyleEvent::Style ActionStyleEvent::getType() const
-{
-    return type;
-}
+    void StatusBarObserver::OnChange(Base::Subject<const char*> & rCaller, const char* sReason)
+    {
+        ParameterGrp& rclGrp = ((ParameterGrp&)rCaller);
+        auto format = QString::fromLatin1("#statusBar{color: %1}");
+        if (strcmp(sReason, "colorText") == 0) {
+            unsigned long col = rclGrp.GetUnsigned(sReason);
+            this->msg = format.arg(App::Color::fromPackedRGB<QColor>(col).name());
+        }
+        else if (strcmp(sReason, "colorWarning") == 0) {
+            unsigned long col = rclGrp.GetUnsigned(sReason);
+            this->wrn = format.arg(App::Color::fromPackedRGB<QColor>(col).name());
+        }
+        else if (strcmp(sReason, "colorError") == 0) {
+            unsigned long col = rclGrp.GetUnsigned(sReason);
+            this->err = format.arg(App::Color::fromPackedRGB<QColor>(col).name());
+        }
+        else if (strcmp(sReason, "colorCritical") == 0) {
+            unsigned long col = rclGrp.GetUnsigned(sReason);
+            this->critical = format.arg(
+                QColor((col >> 24) & 0xff, (col >> 16) & 0xff, (col >> 8) & 0xff).name());
+        }
+    }
+
+    void StatusBarObserver::SendLog(const std::string& notifiername,
+                                    const std::string& msg,
+                                    Base::LogStyle level,
+                                    Base::IntendedRecipient recipient,
+                                    Base::ContentType content)
+    {
+        (void)notifiername;
+
+        // Do not log untranslated messages, or messages intended only to a developer to status bar
+        if (recipient == Base::IntendedRecipient::Developer
+            || content == Base::ContentType::Untranslated
+            || content == Base::ContentType::Untranslatable)
+            return;
+
+        int messageType = -1;
+        switch (level) {
+            case Base::LogStyle::Warning:
+                messageType = MainWindow::Wrn;
+                break;
+            case Base::LogStyle::Message:
+                messageType = MainWindow::Msg;
+                break;
+            case Base::LogStyle::Error:
+                messageType = MainWindow::Err;
+                break;
+            case Base::LogStyle::Log:
+                messageType = MainWindow::Log;
+                break;
+            case Base::LogStyle::Critical:
+                messageType = MainWindow::Critical;
+                break;
+            default:
+                break;
+        }
+
+        // Send the event to the main window to allow thread-safety. Qt will delete it when done.
+        auto ev = new CustomMessageEvent(messageType, QString::fromUtf8(msg.c_str()));
+        QApplication::postEvent(getMainWindow(), ev);
+    }
+
+    // -------------------------------------------------------------
+
+    int ActionStyleEvent::EventType = -1;
+
+    ActionStyleEvent::ActionStyleEvent(Style type)
+        : QEvent(QEvent::Type(EventType))
+        , type(type)
+    {}
+
+    ActionStyleEvent::Style ActionStyleEvent::getType() const
+    {
+        return type;
+    }
 
 
 #include "moc_MainWindow.cpp"

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2537,7 +2537,7 @@ void MainWindow::setWindowTitle(const QString& string)
     }
 
     if (!string.isEmpty()) {
-        title = QString::fromUtf8("%1 - %2").arg(string, title);
+        title = QString::fromUtf8("[*] %1 - %2").arg(string, title);
     }
 
     QMainWindow::setWindowTitle(title);

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -266,6 +266,9 @@ public Q_SLOTS:
 
     void showMessage (const QString & message, int timeout = 0);
 
+    // Set main window title
+    void setWindowTitle(const QString& string);
+
 protected:
     /**
      * This method checks if the main window can be closed by checking all open documents and views.

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -237,30 +237,8 @@ void StartupPostProcess::execute()
 
 void StartupPostProcess::setWindowTitle()
 {
-    // allow to disable version number
-    ParameterGrp::handle hGen =
-        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/General");
-    bool showVersion = hGen->GetBool("ShowVersionInTitle", true);
-
-    QString appName = QCoreApplication::applicationName();
-    if (appName.isEmpty()) {
-        appName = QString::fromLatin1(App::Application::Config()["ExeName"].c_str());
-    }
-    if (showVersion) {
-        // set main window title with FreeCAD Version
-        std::map<std::string, std::string>& config = App::Application::Config();
-        QString major  = QString::fromLatin1(config["BuildVersionMajor"].c_str());
-        QString minor  = QString::fromLatin1(config["BuildVersionMinor"].c_str());
-        QString point = QString::fromLatin1(config["BuildVersionPoint"].c_str());
-        QString suffix = QString::fromLatin1(config["BuildVersionSuffix"].c_str());
-        QString title = QString::fromLatin1("%1 %2.%3.%4%5").arg(
-            appName, major, minor, point, suffix
-        );
-        mainWindow->setWindowTitle(title);
-    }
-    else {
-        mainWindow->setWindowTitle(appName);
-    }
+    // empty window title QString sets default title (app + version)
+    mainWindow->setWindowTitle(QString());
 }
 
 void StartupPostProcess::setProcessMessages()


### PR DESCRIPTION
fixes #11858 
current active document is shown in the main window title bar. An asterisk is displayed in front, if unsaved changes exist.

current, always static:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/611210c7-8313-45ee-9eed-678a6d2d326a)

new:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/383131e6-8d80-4079-b90b-dc483e08b06a)
