### PR TITLE
Arch: Revised preference ui files, remove WindowColor

### DIFF
--- a/src/Mod/Arch/ArchCommands.py
+++ b/src/Mod/Arch/ArchCommands.py
@@ -84,7 +84,7 @@ def getDefaultColor(objectType):
         c = params.get_param("constructioncolor")
         transparency = 0.80
     else:
-        c = params.get_param_arch("WindowColor")
+        c = params.get_param_view("DefaultShapeColor")
     r, g, b, _ = Draft.get_rgba_tuple(c)
     return (r, g, b, transparency)
 

--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -1174,9 +1174,7 @@ class _ViewProviderWindow(ArchComponent.ViewProviderComponent):
                 typeidx = (i*5)+1
                 if typeidx < len(obj.WindowParts):
                     typ = obj.WindowParts[typeidx]
-                    if typ == WindowPartTypes[0]:  # "Frame"
-                        ccol = ArchCommands.getDefaultColor("")
-                    elif typ == WindowPartTypes[2]:  # "Glass panel"
+                    if typ == WindowPartTypes[2]:  # "Glass panel"
                         ccol = ArchCommands.getDefaultColor("WindowGlass")
             if not ccol:
                 ccol = base

--- a/src/Mod/Arch/Resources/ui/preferences-arch.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-arch.ui
@@ -13,21 +13,15 @@
   <property name="windowTitle">
    <string>General settings</string>
   </property>
-  <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <property name="margin">
-    <number>9</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout_1">
    <item>
-    <widget class="QGroupBox" name="groupBox_4">
+    <widget class="QGroupBox" name="groupBox_1">
      <property name="title">
       <string>Object creation</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_4">
-      <item>
-       <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_5">
+     <layout class="QGridLayout" name="gridLayout_1">
+      <item row="0" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_autoJoinWalls">
         <property name="text">
          <string>Auto-join walls</string>
         </property>
@@ -42,13 +36,13 @@
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_8">
+      <item row="1" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_joinWallSketches">
         <property name="toolTip">
          <string>If this is checked, when 2 similar walls are being connected, their underlying sketches will be joined into one, and the two walls will become one</string>
         </property>
         <property name="text">
-         <string>Join walls base sketches when possible</string>
+         <string>Join base sketches of walls if possible</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>joinWallSketches</cstring>
@@ -58,13 +52,13 @@
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox">
+      <item row="2" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_archRemoveExternal">
         <property name="toolTip">
          <string>Two possible strategies to avoid circular dependencies: Create one more object (unchecked) or remove external geometry of base sketch (checked)</string>
         </property>
         <property name="text">
-         <string>Remove external geometry of base sketches when needed</string>
+         <string>Remove external geometry of base sketches if needed</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>archRemoveExternal</cstring>
@@ -74,151 +68,8 @@
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_7">
-        <property name="toolTip">
-         <string>If this is checked, when an object becomes Subtraction or Addition of an Arch object, it will receive the Draft Construction color.</string>
-        </property>
-        <property name="text">
-         <string>Apply Draft construction style to subcomponents</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>applyconstructionStyle</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_14">
-        <item>
-         <spacer name="horizontalSpacer_9">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Do not compute areas for object with more than:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox">
-          <property name="suffix">
-           <string> faces</string>
-          </property>
-          <property name="value">
-           <number>20</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>MaxComputeAreas</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_17">
-        <item>
-         <spacer name="horizontalSpacer_10">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_8">
-          <property name="text">
-           <string>Interval between file checks for references</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox_2">
-          <property name="suffix">
-           <string> seconds</string>
-          </property>
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>9999</number>
-          </property>
-          <property name="value">
-           <number>60</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ReferenceCheckInterval</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_4">
-        <property name="toolTip">
-         <string>By default, new objects will have their "Move with host" property set to False, which means they won't move when their host object is moved.</string>
-        </property>
-        <property name="text">
-         <string>Set "Move with host" property to True by default</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>MoveWithHost</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_5">
-        <property name="text">
-         <string>Set "Move base" property to True by default</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>MoveBase</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_6">
+      <item row="3" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_UseMaterialColor">
         <property name="toolTip">
          <string>If this is checked, when an Arch object has a material, the object will take the color of the material. This can be overridden for each object.</string>
         </property>
@@ -236,68 +87,151 @@
         </property>
        </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item row="4" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_applyconstructionStyle">
+        <property name="toolTip">
+         <string>If this is checked, when an object becomes Subtraction or Addition of an Arch object, it will receive the Draft Construction color.</string>
+        </property>
+        <property name="text">
+         <string>Apply Draft construction style to subcomponents</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>applyconstructionStyle</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_MoveWithHost">
+        <property name="toolTip">
+         <string>By default, new objects will have their "Move with host" property set to False, which means they won't move when their host object is moved.</string>
+        </property>
+        <property name="text">
+         <string>Set "Move with host" property to True by default</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>MoveWithHost</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_MoveBase">
+        <property name="text">
+         <string>Set "Move base" property to True by default</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>MoveBase</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_MaxComputeAreas">
+        <property name="text">
+         <string>Do not compute areas for objects with more than</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_MaxComputeAreas">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="suffix">
+         <string> faces</string>
+        </property>
+        <property name="value">
+         <number>20</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>MaxComputeAreas</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="2">
+       <spacer name="horizontalSpacer_1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_ReferenceCheckInterval">
+        <property name="text">
+         <string>Interval between file checks for references</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_ReferenceCheckInterval">
+        <property name="suffix">
+         <string> seconds</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>9999</number>
+        </property>
+        <property name="value">
+         <number>60</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ReferenceCheckInterval</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_IfcVersion">
+        <property name="text">
+         <string>IFC version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="Gui::PrefComboBox" name="comboBox_IfcVersion">
+        <property name="toolTip">
+         <string>The IFC version will change which attributes and products are supported</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>IfcVersion</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
         <item>
-         <spacer name="horizontalSpacer_11">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
+         <property name="text">
+          <string>IFC4</string>
+         </property>
         </item>
         <item>
-         <widget class="QLabel" name="label_9">
-          <property name="text">
-           <string>IFC version</string>
-          </property>
-         </widget>
+         <property name="text">
+          <string>IFC2X3</string>
+         </property>
         </item>
-        <item>
-         <spacer name="horizontalSpacer_12">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefComboBox" name="comboBox">
-          <property name="toolTip">
-           <string>The IFC version will change which attributes and products are supported</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>IfcVersion</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>IFC4</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>IFC2X3</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -307,101 +241,114 @@
      <property name="title">
       <string>Mesh to Shape Conversion</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox">
-          <property name="toolTip">
-           <string>If this is checked, conversion is faster but the result might still contain triangulated faces</string>
-          </property>
-          <property name="text">
-           <string>Fast conversion</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ConversionFast</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Tolerance:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="gui::prefdoublespinbox_12">
-          <property name="toolTip">
-           <string>Tolerance value to use when checking if 2 adjacent faces as planar</string>
-          </property>
-          <property name="decimals">
-           <number>4</number>
-          </property>
-          <property name="value">
-           <double>0.001000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ConversionTolerance</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_ConversionFast">
+        <property name="toolTip">
+         <string>If this is checked, conversion is faster but the result might still contain triangulated faces</string>
+        </property>
+        <property name="text">
+         <string>Fast conversion</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ConversionFast</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_2">
-          <property name="toolTip">
-           <string>If this is checked, flat groups of faces will be force-flattened, resulting in possible gaps and non-solid results</string>
-          </property>
-          <property name="text">
-           <string>Force flat faces</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ConversionFlat</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="1" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_ConversionFlat">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>If this is checked, flat groups of faces will be force-flattened, resulting in possible gaps and non-solid results</string>
+        </property>
+        <property name="text">
+         <string>Force flat faces</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ConversionFlat</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_3">
-          <property name="toolTip">
-           <string>If this is checked, holes in faces will be performed by subtraction rather than using wires orientation</string>
-          </property>
-          <property name="text">
-           <string>Cut method</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ConversionCut</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="2" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_ConversionCut">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>If this is checked, holes in faces will be performed by subtraction rather than using wires orientation</string>
+        </property>
+        <property name="text">
+         <string>Cut method</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ConversionCut</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_ConversionTolerance">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Tolerance</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefDoubleSpinBox" name="spinBox_ConversionTolerance">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Tolerance value to use when checking if 2 adjacent faces as planar</string>
+        </property>
+        <property name="decimals">
+         <number>4</number>
+        </property>
+        <property name="singleStep">
+         <double>0.0001</double>
+        </property>
+        <property name="value">
+         <double>0.001</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ConversionTolerance</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>
@@ -411,362 +358,221 @@
      <property name="title">
       <string>2D rendering</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_4">
-          <property name="toolTip">
-           <string>Show debug information during 2D rendering</string>
-          </property>
-          <property name="text">
-           <string>Show renderer debug messages</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ShowVRMDebug</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_ShowVRMDebug">
+        <property name="toolTip">
+         <string>Show debug information during 2D rendering</string>
+        </property>
+        <property name="text">
+         <string>Show renderer debug messages</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowVRMDebug</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Cut areas line thickness ratio</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="gui::prefdoublespinbox">
-          <property name="toolTip">
-           <string>Specifies how many times the viewed line thickness must be applied to cut lines</string>
-          </property>
-          <property name="value">
-           <double>2.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>CutLineThickness</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_CutLineThickness">
+        <property name="text">
+         <string>Cut areas line thickness ratio</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_16">
-        <item>
-         <spacer name="horizontalSpacer_8">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_6">
-          <property name="text">
-           <string>Symbol line thickness ratio</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_7">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox_2">
-          <property name="value">
-           <double>0.600000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SymbolLineThickness</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="1" column="1">
+       <widget class="Gui::PrefDoubleSpinBox" name="spinBox_CutLineThickness">
+        <property name="toolTip">
+         <string>Specifies how many times the viewed line thickness must be applied to cut lines</string>
+        </property>
+        <property name="value">
+         <double>2.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>CutLineThickness</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Hidden geometry pattern</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefLineEdit" name="lineEdit">
-          <property name="toolTip">
-           <string>This is the SVG stroke-dasharray property to apply
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_SymbolLineThickness">
+        <property name="text">
+         <string>Symbol line thickness ratio</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefDoubleSpinBox" name="spinBox_SymbolLineThickness">
+        <property name="value">
+         <double>0.6</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SymbolLineThickness</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_archHiddenPattern">
+        <property name="text">
+         <string>Hidden geometry pattern</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_archHiddenPattern">
+        <property name="maximumSize">
+         <size>
+          <width>140</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>This is the SVG stroke-dasharray property to apply
 to projections of hidden objects.</string>
-          </property>
-          <property name="text">
-           <string notr="true">30, 10</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>archHiddenPattern</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </property>
+        <property name="text">
+         <string notr="true">30, 10</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>archHiddenPattern</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_15">
-        <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Pattern scale</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_6">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox">
-          <property name="toolTip">
-           <string>Scaling factor for patterns used by object that have
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_patternScale">
+        <property name="text">
+         <string>Pattern scale</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefDoubleSpinBox" name="spinBox_patternScale">
+        <property name="toolTip">
+         <string>Scaling factor for patterns used by object that have
 a Footprint display mode</string>
-          </property>
-          <property name="decimals">
-           <number>4</number>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="value">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>patternScale</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </property>
+        <property name="decimals">
+         <number>4</number>
+        </property>
+        <property name="singleStep">
+         <double>0.001</double>
+        </property>
+        <property name="maximum">
+         <double>9999.989999999999782</double>
+        </property>
+        <property name="value">
+         <double>0.01</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>patternScale</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_6">
+    <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
       <string>Bim server</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_6">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Address</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefLineEdit" name="lineEdit_2">
-          <property name="toolTip">
-           <string>The URL of a bim server instance (www.bimserver.org) to connect to.</string>
-          </property>
-          <property name="text">
-           <string>http://localhost:8082</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>BimServerUrl</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_BimServerUrl">
+        <property name="text">
+         <string>Address</string>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_13">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_3">
-          <property name="toolTip">
-           <string>If this is selected, the "Open BimServer in browser"
+      <item row="0" column="1">
+       <widget class="Gui::PrefLineEdit" name="lineEdit_BimServerUrl">
+        <property name="toolTip">
+         <string>The URL of a bim server instance (www.bimserver.org) to connect to.</string>
+        </property>
+        <property name="text">
+         <string notr="true">http://localhost:8082</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>BimServerUrl</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="Gui::PrefCheckBox" name="checkBox_BimServerBrowser">
+        <property name="toolTip">
+         <string>If this is selected, the "Open BimServer in browser"
 button will open the Bim Server interface in an external browser
 instead of the FreeCAD web workbench</string>
-          </property>
-          <property name="text">
-           <string>Open in external browser</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>BimServerBrowser</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        </property>
+        <property name="text">
+         <string>Open in external browser</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>BimServerBrowser</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_5">
      <property name="title">
       <string>Survey</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_12">
-        <item>
-         <widget class="Gui::PrefCheckBox" name="checkBox_2">
-          <property name="toolTip">
-           <string>If this is checked, the text that gets placed in the clipboard will include the unit. Otherwise, it will be a simple number expressed in internal units (millimeters)</string>
-          </property>
-          <property name="text">
-           <string>Include unit when sending measurements to clipboard</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>surveyUnits</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="Gui::PrefCheckBox" name="checkBox_surveyUnits">
+        <property name="toolTip">
+         <string>If this is checked, the text that gets placed in the clipboard will include the unit. Otherwise, it will be a simple number expressed in internal units (millimeters)</string>
+        </property>
+        <property name="text">
+         <string>Include unit when sending measurements to clipboard</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>surveyUnits</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
+    <spacer name="verticalSpacer_1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
      </property>
     </spacer>
    </item>
@@ -776,13 +582,13 @@ instead of the FreeCAD web workbench</string>
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
-   <class>Gui::PrefSpinBox</class>
-   <extends>QSpinBox</extends>
+   <class>Gui::PrefCheckBox</class>
+   <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefCheckBox</class>
-   <extends>QCheckBox</extends>
+   <class>Gui::PrefLineEdit</class>
+   <extends>QLineEdit</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
@@ -791,8 +597,8 @@ instead of the FreeCAD web workbench</string>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefLineEdit</class>
-   <extends>QLineEdit</extends>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
@@ -802,5 +608,30 @@ instead of the FreeCAD web workbench</string>
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>checkBox_ConversionFast</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>checkBox_ConversionFlat</receiver>
+   <slot>setDisabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>checkBox_ConversionFast</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>checkBox_ConversionCut</receiver>
+   <slot>setDisabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>checkBox_ConversionFast</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_ConversionTolerance</receiver>
+   <slot>setDisabled(bool)</slot>
+  </connection>
+  <connection>
+   <sender>checkBox_ConversionFast</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spinBox_ConversionTolerance</receiver>
+   <slot>setDisabled(bool)</slot>
+  </connection>
+ </connections>
 </ui>

--- a/src/Mod/Arch/Resources/ui/preferences-archdefaults.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-archdefaults.ui
@@ -13,60 +13,22 @@
   <property name="windowTitle">
    <string>Defaults</string>
   </property>
-  <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <property name="margin">
-    <number>9</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout_1">
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_1">
      <property name="title">
-      <string>Walls</string>
+      <string>Visual</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox">
+     <layout class="QGridLayout" name="gridLayout_1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_WallColor">
         <property name="text">
-         <string>Use sketches</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>WallSketches</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
+         <string>Wall color</string>
         </property>
        </widget>
       </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefColorButton" name="gui::prefcolorbutton">
-        <property name="toolTip">
-         <string>This is the default color for new Wall objects</string>
-        </property>
+      <item row="0" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_WallColor">
         <property name="color">
          <color>
           <red>214</red>
@@ -82,40 +44,22 @@
         </property>
        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Structures</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5">
-      <item>
-       <spacer name="horizontalSpacer_2">
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_1">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
        </spacer>
       </item>
-      <item>
-       <widget class="QLabel" name="label_11">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_StructureColor">
         <property name="text">
-         <string>Color:</string>
+         <string>Structure color</string>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="Gui::PrefColorButton" name="gui::prefcolorbutton_2">
-        <property name="toolTip">
-         <string>This is the default color for new Structure objects</string>
-        </property>
+      <item row="1" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_StructureColor">
         <property name="color">
          <color>
           <red>150</red>
@@ -131,156 +75,51 @@
         </property>
        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Rebars</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QLabel" name="label_18">
-          <property name="text">
-           <string>Diameter</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="gui::prefdoublespinbox_8">
-          <property name="suffix">
-           <string> mm</string>
-          </property>
-          <property name="maximum">
-           <double>999.990000000000009</double>
-          </property>
-          <property name="value">
-           <double>6.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>RebarDiameter</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_8">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_19">
-          <property name="text">
-           <string>Offset</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="gui::prefdoublespinbox_7">
-          <property name="suffix">
-           <string> mm</string>
-          </property>
-          <property name="maximum">
-           <double>999.990000000000009</double>
-          </property>
-          <property name="value">
-           <double>30.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>RebarOffset</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_17">
-          <property name="text">
-           <string>Color:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefColorButton" name="gui::prefcolorbutton_5">
-          <property name="color">
-           <color>
-            <red>185</red>
-            <green>117</green>
-            <blue>90</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>RebarColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_4">
-     <property name="title">
-      <string>Windows</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_14">
-      <item>
-       <spacer name="horizontalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QLabel" name="label">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_RebarColor">
         <property name="text">
-         <string>Transparency:</string>
+         <string>Rebar color</string>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="Gui::PrefSpinBox" name="spinBox">
+      <item row="2" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_RebarColor">
+        <property name="color">
+         <color>
+          <red>185</red>
+          <green>117</green>
+          <blue>90</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>RebarColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_WindowTransparency">
+        <property name="text">
+         <string>Window glass transparency</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_WindowTransparency">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="suffix">
+         <string> %</string>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
         <property name="value">
          <number>85</number>
         </property>
@@ -292,39 +131,15 @@
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QLabel" name="label_6">
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_WindowGlassColor">
         <property name="text">
-         <string>Frame color:</string>
+         <string>Window glass color</string>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="Gui::PrefColorButton" name="gui::prefcolorbutton_3">
-        <property name="color">
-         <color>
-          <red>33</red>
-          <green>45</green>
-          <blue>66</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>WindowColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_15">
-        <property name="text">
-         <string>Glass color:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefColorButton" name="gui::prefcolorbutton_4">
+      <item row="4" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_WindowGlassColor">
         <property name="color">
          <color>
           <red>93</red>
@@ -340,194 +155,15 @@
         </property>
        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_5">
-     <property name="title">
-      <string>Stairs</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_5">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Length:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox">
-          <property name="suffix">
-           <string> mm</string>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="value">
-           <double>4500.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>StairsLength</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_11">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Width:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox_2">
-          <property name="suffix">
-           <string> mm</string>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="value">
-           <double>1000.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>StairsWidth</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_12">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Height:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox_3">
-          <property name="suffix">
-           <string> mm</string>
-          </property>
-          <property name="maximum">
-           <double>9999.989999999999782</double>
-          </property>
-          <property name="value">
-           <double>3000.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>StairsHeight</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <spacer name="horizontalSpacer_13">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Number of steps:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox_2">
-          <property name="maximum">
-           <number>99</number>
-          </property>
-          <property name="value">
-           <number>17</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>StairsSteps</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_6">
-     <property name="title">
-      <string>Panels</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_11">
-      <item>
-       <spacer name="horizontalSpacer_16">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_24">
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_PanelColor">
         <property name="text">
-         <string>Color:</string>
+         <string>Panel color</string>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="Gui::PrefColorButton" name="colorButton">
+      <item row="5" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_PanelColor">
         <property name="color">
          <color>
           <red>203</red>
@@ -543,92 +179,15 @@
         </property>
        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_7">
-     <property name="title">
-      <string>Pipes</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_7">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_12">
-        <item>
-         <widget class="QLabel" name="label_25">
-          <property name="text">
-           <string>Diameter:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox_7">
-          <property name="suffix">
-           <string>mm</string>
-          </property>
-          <property name="decimals">
-           <number>2</number>
-          </property>
-          <property name="maximum">
-           <double>999999.989999999990687</double>
-          </property>
-          <property name="value">
-           <double>50.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>PipeDiameter</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_17">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_8">
-     <property name="title">
-      <string>Helpers (grids, axes, etc...)</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_13">
-      <item>
-       <spacer name="horizontalSpacer_18">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_26">
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_ColorHelpers">
         <property name="text">
-         <string>Color:</string>
+         <string>Helper color (grids, axes, etc.)</string>
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="Gui::PrefColorButton" name="colorButton_2">
+      <item row="6" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_ColorHelpers">
         <property name="color">
          <color>
           <red>40</red>
@@ -644,121 +203,309 @@
         </property>
        </widget>
       </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_defaultSpaceTransparency">
+        <property name="text">
+         <string>Space transparency</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_defaultSpaceTransparency">
+        <property name="suffix">
+         <string> %</string>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="value">
+         <number>85</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>defaultSpaceTransparency</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_defaultSpaceStyle">
+        <property name="text">
+         <string>Space line style</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="Gui::PrefComboBox" name="comboBox_defaultSpaceStyle">
+        <property name="currentIndex">
+         <number>2</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>defaultSpaceStyle</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+        <item>
+         <property name="text">
+          <string>Solid</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Dashed</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Dotted</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Dashdot</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_defaultSpaceColor">
+        <property name="text">
+         <string>Space line color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_defaultSpaceColor">
+        <property name="color">
+         <color>
+          <red>255</red>
+          <green>29</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>defaultSpaceColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_9">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Spaces</string>
+      <string>Other</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_8">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_15">
-        <item>
-         <widget class="QLabel" name="label_27">
-          <property name="text">
-           <string>Transparency:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox_3">
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="singleStep">
-           <number>1</number>
-          </property>
-          <property name="value">
-           <number>85</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>defaultSpaceTransparency</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_19">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_30">
-          <property name="text">
-           <string>Line style:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefComboBox" name="comboBox">
-          <property name="currentIndex">
-           <number>2</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>defaultSpaceStyle</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>Solid</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Dashed</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Dotted</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Dashdot</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_28">
-          <property name="text">
-           <string>Line color</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefColorButton" name="colorButton_3">
-          <property name="color">
-           <color>
-            <red>255</red>
-            <green>29</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>defaultSpaceColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0" colspan="3">
+       <widget class="Gui::PrefCheckBox" name="checkBox_WallSketches">
+        <property name="text">
+         <string>Use sketches for walls</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>WallSketches</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_PipeDiameter">
+        <property name="text">
+         <string>Pipe diameter</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_PipeDiameter">
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="minimum">
+         <number>0.0</number>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>50.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>PipeDiameter</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_RebarDiameter">
+        <property name="text">
+         <string>Rebar diameter</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_RebarDiameter">
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="minimum">
+         <number>0.0</number>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>6.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>RebarDiameter</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_RebarOffset">
+        <property name="text">
+         <string>Rebar offset</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_RebarOffset">
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="minimum">
+         <number>0.0</number>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>30.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>RebarOffset</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_StairsLength">
+        <property name="text">
+         <string>Stair length</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_StairsLength">
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="minimum">
+         <number>0.0</number>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>4500.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>StairsLength</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_StairsWidth">
+        <property name="text">
+         <string>Stair width</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_StairsWidth">
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="minimum">
+         <number>0.0</number>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>1000.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>StairsWidth</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_StairsHeight">
+        <property name="text">
+         <string>Stair height</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="Gui::PrefUnitSpinBox" name="spinBox_StairsHeight">
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="minimum">
+         <number>0.0</number>
+        </property>
+        <property name="rawValue" stdset="0">
+         <double>3000.0</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>StairsHeight</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_StairsSteps">
+        <property name="text">
+         <string>Number of stair steps</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox_StairsSteps">
+        <property name="value">
+         <number>17</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>StairsSteps</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -776,21 +523,6 @@
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
   <customwidget>
-   <class>Gui::ColorButton</class>
-   <extends>QPushButton</extends>
-   <header>Gui/Widgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefColorButton</class>
-   <extends>Gui::ColorButton</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
@@ -801,8 +533,28 @@
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefUnitSpinBox</class>
+   <extends>Gui::QuantitySpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header>Gui/Widgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefColorButton</class>
+   <extends>Gui::ColorButton</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
Follow-up PR of #11940.

* The new ui layout follows that of the Draft preferences.
* The ConversionFast checkbox enables/disables the 3  preferences listed below it.
* The WindowColor preference was removed. It is not a per-object, or even a per-file setting. The fix in #11940 would change windows in existing projects when they are recomputed. It is therefore better to keep the V0.21 solution where the glass is colored according to the preferences and the rest of the window receives a color based on its ShapeColor. Users who want to apply specific colors can use a multi-material.
