### PR TITLE
Arch: Bring back Axis bubbles and show annotation DrawStyle in ArchView

### DIFF
--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -336,7 +336,7 @@ def getSVG(source,
     for o in objs:
         if Draft.getType(o) == "Space":
             spaces.append(o)
-        elif Draft.getType(o) in ["Dimension","AngularDimension","LinearDimension","Annotation","Label","Text","DraftText"]:
+        elif Draft.getType(o) in ["Dimension","AngularDimension","LinearDimension","Annotation","Label","Text","DraftText","Axis"]:
             if isOriented(o,cutplane):
                 drafts.append(o)
         elif o.isDerivedFrom("App::DocumentObjectGroup"):
@@ -511,7 +511,8 @@ def getSVG(source,
                                  direction=direction,
                                  color=lineColor,
                                  techdraw=techdraw,
-                                 rotation=rotation)
+                                 rotation=rotation,
+                                 override=False)
         if not techdraw:
             svg += '</g>'
 


### PR DESCRIPTION
* Restores Arch_Axis bubbles in a TechDraw_ArchView. This fixes a regression in V0.21 and 0.22, I suspect an unwanted side-effect of a previous PR of mine (#8688).
* Also fixes the linetype of axes and other annotation objects in a TechDraw_ArchView.
