### PR TITLE
Draft: DraftGui.py make type of self.facecolor consistent

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -163,10 +163,8 @@ class DraftToolBar:
         self.pointcallback = None
 
         # OBSOLETE BUT STILL USED BY SOME ADDONS AND MACROS
-        self.paramcolor = utils.rgba_to_argb(params.get_param_view("DefaultShapeLineColor"))
-        self.color = QtGui.QColor(self.paramcolor)
-        # ToDo: in setStyleButton() self.facecolor is assigned a QColor
-        self.facecolor = utils.rgba_to_argb(params.get_param_view("DefaultShapeColor"))
+        self.color = QtGui.QColor(utils.rgba_to_argb(params.get_param_view("DefaultShapeLineColor")))
+        self.facecolor = QtGui.QColor(utils.rgba_to_argb(params.get_param_view("DefaultShapeColor")))
         self.linewidth = params.get_param_view("DefaultShapeLineWidth")
         self.fontsize = params.get_param("textheight")
 


### PR DESCRIPTION
Since V0.19 self.facecolor had two types: integer (initial value) or QColor. With this PR it is again always a QColor.
