### PR TITLE
Fem: Improve self weight constraint - fixes #11652

### DIFF
--- a/src/Mod/Fem/femexamples/constraint_selfweight_cantilever.py
+++ b/src/Mod/Fem/femexamples/constraint_selfweight_cantilever.py
@@ -124,7 +124,7 @@ def setup(doc=None, solvertype="ccxtools"):
 
     # constraint selfweight
     con_selfweight = ObjectsFem.makeConstraintSelfWeight(doc, "ConstraintSelfWeight")
-    con_selfweight.Gravity_z = -1.00
+    con_selfweight.GravityDirection = (0, 0, -1)
     analysis.addObject(con_selfweight)
 
     # mesh

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_selfweight.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_selfweight.py
@@ -52,10 +52,10 @@ def write_constraint(f, femobj, selwei_obj, ccxwriter):
         "{},GRAV,{:.13G},{:.13G},{:.13G},{:.13G}\n"
         .format(
             ccxwriter.ccx_eall,
-            ccxwriter.gravity,  # actual magnitude of gravity vector
-            selwei_obj.Gravity_x,  # coordinate x of normalized gravity vector
-            selwei_obj.Gravity_y,  # y
-            selwei_obj.Gravity_z  # z
+            selwei_obj.GravityAcceleration.getValueAs("mm/s^2").Value,  # actual magnitude of gravity vector
+            selwei_obj.GravityDirection.x,  # coordinate x of normalized gravity vector
+            selwei_obj.GravityDirection.y,  # y
+            selwei_obj.GravityDirection.z  # z
         )
     )
     f.write("\n")

--- a/src/Mod/Fem/femsolver/elmer/equations/deformation_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/deformation_writer.py
@@ -148,7 +148,7 @@ class DeformationWriter:
         obj = self.write.getSingleMember("Fem::ConstraintSelfWeight")
         if obj is not None:
             for name in bodies:
-                gravity = self.write.convert(self.write.constsdef["Gravity"], "L/T^2")
+                gravity = self.write.convert(obj.GravityAcceleration.toStr(), "L/T^2")
                 if self.write.getBodyMaterial(name) is None:
                     raise general_writer.WriteError(
                         "The body {} is not referenced in any material.\n\n".format(name)
@@ -164,9 +164,9 @@ class DeformationWriter:
                     dimension = "M/L^2"
                 density = self.write.convert(densityQuantity, dimension)
 
-                force1 = gravity * obj.Gravity_x * density
-                force2 = gravity * obj.Gravity_y * density
-                force3 = gravity * obj.Gravity_z * density
+                force1 = gravity * obj.GravityDirection.x * density
+                force2 = gravity * obj.GravityDirection.y * density
+                force3 = gravity * obj.GravityDirection.z * density
                 self.write.bodyForce(name, "Stress Bodyforce 1", force1)
                 self.write.bodyForce(name, "Stress Bodyforce 2", force2)
                 self.write.bodyForce(name, "Stress Bodyforce 3", force3)

--- a/src/Mod/Fem/femsolver/elmer/equations/elasticity_writer.py
+++ b/src/Mod/Fem/femsolver/elmer/equations/elasticity_writer.py
@@ -364,7 +364,7 @@ class ElasticityWriter:
         obj = self.write.getSingleMember("Fem::ConstraintSelfWeight")
         if obj is not None:
             for name in bodies:
-                gravity = self.write.convert(self.write.constsdef["Gravity"], "L/T^2")
+                gravity = self.write.convert(obj.GravityAcceleration.toStr(), "L/T^2")
                 if self.write.getBodyMaterial(name) is None:
                     raise general_writer.WriteError(
                         "The body {} is not referenced in any material.\n\n".format(name)
@@ -380,9 +380,9 @@ class ElasticityWriter:
                     dimension = "M/L^2"
                 density = self.write.convert(densityQuantity, dimension)
 
-                force1 = gravity * obj.Gravity_x * density
-                force2 = gravity * obj.Gravity_y * density
-                force3 = gravity * obj.Gravity_z * density
+                force1 = gravity * obj.GravityDirection.x * density
+                force2 = gravity * obj.GravityDirection.y * density
+                force3 = gravity * obj.GravityDirection.z * density
                 self.write.bodyForce(name, "Stress Bodyforce 1", force1)
                 self.write.bodyForce(name, "Stress Bodyforce 2", force2)
                 self.write.bodyForce(name, "Stress Bodyforce 3", force3)

--- a/src/Mod/Fem/femtest/data/calculix/constraint_selfweight_cantilever.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_selfweight_cantilever.inp
@@ -2170,7 +2170,7 @@ ConstraintFixed,3
 ** Self weight Constraint
 ** ConstraintSelfWeight
 *DLOAD
-Eall,GRAV,9806,0,0,-1
+Eall,GRAV,9806.65,0,0,-1
 
 
 ***********************************************************


### PR DESCRIPTION
The self-weight constraint now supports modifying the gravity value.
A `PropertyAcceleration` and a `PropertyVector`  are used to control the gravity module and (normalized) direction.   
Previous `PropertyFloat` used to represent the gravity direction are removed.

Now, both CalculiX and Elmer solvers can use customized gravity values.