### PR TITLE
Draft: Improve layer functions

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -379,8 +379,7 @@ if App.GuiUp:
 from draftobjects.layer import (Layer,
                                 _VisGroup)
 
-from draftmake.make_layer import (make_layer,
-                                  makeLayer)
+from draftmake.make_layer import make_layer
 
 if App.GuiUp:
     from draftviewproviders.view_layer import (ViewProviderLayer,

--- a/src/Mod/Draft/draftguitools/gui_layers.py
+++ b/src/Mod/Draft/draftguitools/gui_layers.py
@@ -37,6 +37,7 @@ import Draft
 import Draft_rc
 from draftguitools import gui_base
 from draftutils import params
+from draftutils import utils
 from draftutils.translate import translate
 
 # The module is used to prevent complaints from code checkers (flake8)
@@ -76,8 +77,8 @@ class Layer(gui_base.GuiCommandSimplest):
 
         self.doc.openTransaction("Create Layer")
         Gui.addModule("Draft")
-        Gui.doCommand('_layer_ = Draft.make_layer()')
-        Gui.doCommand('FreeCAD.ActiveDocument.recompute()')
+        Gui.doCommand("_layer_ = Draft.make_layer(name=None, line_color=None, shape_color=None, line_width=None, draw_style=None, transparency=None)")
+        Gui.doCommand("FreeCAD.ActiveDocument.recompute()")
         self.doc.commitTransaction()
 
 
@@ -170,7 +171,8 @@ class LayerManager:
                 if not changed:
                     FreeCAD.ActiveDocument.openTransaction("Layers change")
                     changed = True
-                obj = Draft.make_layer()
+                obj = Draft.make_layer(name=None, line_color=None, shape_color=None,
+                                       line_width=None, draw_style=None, transparency=None)
 
             # visibility
             checked = True if self.model.item(row,0).checkState() == QtCore.Qt.Checked else False
@@ -303,7 +305,7 @@ class LayerManager:
         nameItem = QtGui.QStandardItem(translate("Draft", "New Layer"))
         widthItem = QtGui.QStandardItem()
         widthItem.setData(params.get_param_view("DefaultShapeLineWidth"), QtCore.Qt.DisplayRole)
-        styleItem = QtGui.QStandardItem("Solid")
+        styleItem = QtGui.QStandardItem(utils.DRAW_STYLES[params.get_param("DefaultDrawStyle")])
         lineColorItem = QtGui.QStandardItem()
         lineColorItem.setData(
             utils.get_rgba_tuple(params.get_param_view("DefaultShapeLineColor"))[:3],
@@ -315,7 +317,10 @@ class LayerManager:
             QtCore.Qt.UserRole
         )
         transparencyItem = QtGui.QStandardItem()
-        transparencyItem.setData(0, QtCore.Qt.DisplayRole)
+        transparencyItem.setData(
+            params.get_param_view("DefaultShapeTransparency"),
+            QtCore.Qt.DisplayRole
+        )
         linePrintColorItem = QtGui.QStandardItem()
         linePrintColorItem.setData(
             utils.get_rgba_tuple(params.get_param("DefaultPrintColor"))[:3],
@@ -428,7 +433,7 @@ if FreeCAD.GuiUp:
                 editor.setMaximum(99)
             elif index.column() == 3: # Line style
                 editor = QtGui.QComboBox(parent)
-                editor.addItems(["Solid","Dashed","Dotted","Dashdot"])
+                editor.addItems(utils.DRAW_STYLES)
             elif index.column() == 4: # Line color
                 editor = QtGui.QLineEdit(parent)
                 self.first = True
@@ -452,7 +457,7 @@ if FreeCAD.GuiUp:
             elif index.column() == 2: # Line width
                 editor.setValue(index.data())
             elif index.column() == 3: # Line style
-                editor.setCurrentIndex(["Solid","Dashed","Dotted","Dashdot"].index(index.data()))
+                editor.setCurrentIndex(utils.DRAW_STYLES.index(index.data()))
             elif index.column() == 4: # Line color
                 editor.setText(str(index.data(QtCore.Qt.UserRole)))
                 if self.first:
@@ -486,7 +491,7 @@ if FreeCAD.GuiUp:
             elif index.column() == 2: # Line width
                 model.setData(index,editor.value())
             elif index.column() == 3: # Line style
-                model.setData(index,["Solid","Dashed","Dotted","Dashdot"][editor.currentIndex()])
+                model.setData(index,utils.DRAW_STYLES[editor.currentIndex()])
             elif index.column() == 4: # Line color
                 model.setData(index,eval(editor.text()),QtCore.Qt.UserRole)
                 model.itemFromIndex(index).setIcon(getColorIcon(eval(editor.text())))

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -586,6 +586,7 @@ def _create_objects(doc=None,
                              line_color=(0.33, 0.0, 0.49),
                              shape_color=(0.56, 0.89, 0.56),
                              line_width=4,
+                             draw_style="Solid",
                              transparency=50)
     box = doc.addObject("Part::Box", "Box")
     box.Length = 200

--- a/src/Mod/Draft/draftviewproviders/view_layer.py
+++ b/src/Mod/Draft/draftviewproviders/view_layer.py
@@ -557,7 +557,8 @@ class ViewProviderLayerContainer:
         doc = App.ActiveDocument
         doc.openTransaction(translate("draft", "Add new layer"))
 
-        Draft.make_layer()
+        Draft.make_layer(name=None, line_color=None, shape_color=None,
+                         line_width=None, draw_style=None, transparency=None)
 
         doc.recompute()
         doc.commitTransaction()


### PR DESCRIPTION
The current make_layer function has a `None` default for the shape color and the line color. With that value the current preference is used. This, and how the function is called, results in some confusing behaviors:
* Newly created layers will only use 2 values from the preferences when they might use 5. The latter makes more sense for the end-user IMO.
* Layers created during DXF import (for example) will have a different shape color depending on the current preferences.
* The make_layer function may reapply colors that have already been set by the view provider.

To solve this all view property related function parameter have been changed to a not None value. If a None value is supplied the view property as set by the view provider is not changed. The Layer Manager has been updated accordingly.
I realize that calling a function with 6 None values is not very convenient, but think it is the solution that is least likely to break other exiting code.

Additionally:
* Removed the makeLayer function. Layers were introduced in V0.19 when the naming scheme was changed to "make_*". Maybe it was created by mistake, or before the actual renaming operation started, but it is safe to remove it now.
* Removed overly verbose messages.
* gui_layers.py had a missing import (result of a previous V0.22 PR): `from draftutils import utils`.
