### PR TITLE
Fem: Call base class handleChangedProperyType function

### DIFF
--- a/src/Mod/Fem/App/FemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/App/FemConstraintDisplacement.cpp
@@ -141,6 +141,9 @@ void ConstraintDisplacement::handleChangedPropertyType(Base::XMLReader& reader,
         zRotationProperty.Restore(reader);
         zRotation.setValue(zRotationProperty.getValue());
     }
+    else {
+        Constraint::handleChangedPropertyType(reader, TypeName, prop);
+    }
 }
 
 void ConstraintDisplacement::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemConstraintForce.cpp
+++ b/src/Mod/Fem/App/FemConstraintForce.cpp
@@ -80,6 +80,9 @@ void ConstraintForce::handleChangedPropertyType(Base::XMLReader& reader,
         // e.g. "2.5" must become 2500 to result in 2.5 N
         Force.setValue(ForceProperty.getValue() * 1000);
     }
+    else {
+        Constraint::handleChangedPropertyType(reader, TypeName, prop);
+    }
 }
 
 void ConstraintForce::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/App/FemConstraintInitialTemperature.cpp
@@ -74,6 +74,9 @@ void ConstraintInitialTemperature::handleChangedPropertyType(Base::XMLReader& re
         initialTemperatureProperty.Restore(reader);
         initialTemperature.setValue(initialTemperatureProperty.getValue());
     }
+    else {
+        Constraint::handleChangedPropertyType(reader, TypeName, prop);
+    }
 }
 
 void ConstraintInitialTemperature::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemConstraintPressure.cpp
+++ b/src/Mod/Fem/App/FemConstraintPressure.cpp
@@ -71,6 +71,9 @@ void ConstraintPressure::handleChangedPropertyType(Base::XMLReader& reader,
         // therefore we must convert the value with a factor 1000
         Pressure.setValue(PressureProperty.getValue() * 1000.0);
     }
+    else {
+        Constraint::handleChangedPropertyType(reader, TypeName, prop);
+    }
 }
 
 void ConstraintPressure::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemConstraintTemperature.cpp
+++ b/src/Mod/Fem/App/FemConstraintTemperature.cpp
@@ -86,6 +86,9 @@ void ConstraintTemperature::handleChangedPropertyType(Base::XMLReader& reader,
         CFluxProperty.Restore(reader);
         CFlux.setValue(CFluxProperty.getValue());
     }
+    else {
+        Constraint::handleChangedPropertyType(reader, TypeName, prop);
+    }
 }
 
 void ConstraintTemperature::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemConstraintTransform.cpp
+++ b/src/Mod/Fem/App/FemConstraintTransform.cpp
@@ -110,6 +110,9 @@ void ConstraintTransform::handleChangedPropertyType(Base::XMLReader& reader,
         Z_rotProperty.Restore(reader);
         Z_rot.setValue(Z_rotProperty.getValue());
     }
+    else {
+        Constraint::handleChangedPropertyType(reader, TypeName, prop);
+    }
 }
 
 void ConstraintTransform::onChanged(const App::Property* prop)

--- a/src/Mod/Fem/App/FemPostFilter.cpp
+++ b/src/Mod/Fem/App/FemPostFilter.cpp
@@ -217,6 +217,9 @@ void FemPostDataAlongLineFilter::handleChangedPropertyType(Base::XMLReader& read
         Point2Property.Restore(reader);
         Point2.setValue(Point2Property.getValue());
     }
+    else {
+        FemPostFilter::handleChangedPropertyType(reader, TypeName, prop);
+    }
 }
 
 void FemPostDataAlongLineFilter::onChanged(const Property* prop)


### PR DESCRIPTION
Functions to handle property changes should also call the corresponding function of the base class.