### PR TITLE
Sketcher: Apply styling to elements and constraints UI

### DIFF
--- a/src/Gui/Stylesheets/images_dark-light/check_dark_disabled.svg
+++ b/src/Gui/Stylesheets/images_dark-light/check_dark_disabled.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="30"
+   height="30"
+   id="svg2"
+   version="1.1"
+   viewBox="0 0 30 29.999999"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Pablo Gil</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>SVG</rdf:li>
+            <rdf:li>template</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(-1074.0663,-326.59799)">
+    <path
+       id="path8685"
+       d="m 1081.0663,345.09799 3.9999,4 12.0001,-12"
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:0.600939;stroke:#1b0909;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.117647" />
+    <path
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#555555;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 1081.0663,342.59799 3.9999,4 12.0001,-12"
+       id="path7899" />
+  </g>
+</svg>

--- a/src/Gui/Stylesheets/images_dark-light/check_light_disabled.svg
+++ b/src/Gui/Stylesheets/images_dark-light/check_light_disabled.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="30"
+   height="30"
+   id="svg2"
+   version="1.1"
+   viewBox="0 0 30 29.999999"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Pablo Gil</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>SVG</rdf:li>
+            <rdf:li>template</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(-1074.0663,-326.59799)">
+    <path
+       id="path8685"
+       d="m 1081.0663,345.09799 3.9999,4 12.0001,-12"
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:0.600939;stroke:#1b0909;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.117647" />
+    <path
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#aaaaaa;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 1081.0663,342.59799 3.9999,4 12.0001,-12"
+       id="path7899" />
+  </g>
+</svg>

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -262,12 +262,12 @@ public:
             static QIcon snell_driven(
                 Gui::BitmapFactory().iconFromTheme("Constraint_SnellsLaw_Driven"));
 
-            auto selicon = [](const Sketcher::Constraint* constr,
+            auto selicon = [this](const Sketcher::Constraint* constr,
                               const QIcon& normal,
                               const QIcon& driven) -> QIcon {
                 if (!constr->isActive) {
                     QIcon darkIcon;
-                    int w = QApplication::style()->pixelMetric(QStyle::PM_ListViewIconSize);
+                    int w = listWidget()->style()->pixelMetric(QStyle::PM_ListViewIconSize);
                     darkIcon.addPixmap(normal.pixmap(w, w, QIcon::Disabled, QIcon::Off),
                                        QIcon::Normal,
                                        QIcon::Off);
@@ -466,7 +466,7 @@ protected:
         QStyleOptionViewItem options = option;
         initStyleOption(&options, index);
 
-        options.widget->style()->drawControl(QStyle::CE_ItemViewItem, &options, painter);
+        options.widget->style()->drawControl(QStyle::CE_ItemViewItem, &options, painter, option.widget);
 
         ConstraintItem* item = dynamic_cast<ConstraintItem*>(view->item(index.row()));
         if (!item || item->sketch->Constraints.getSize() <= item->ConstraintNbr)

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.h
@@ -109,6 +109,7 @@ Q_SIGNALS:
 
 private:
     void changeLayer(int layer);
+    void changeLayer(ElementItem* item, int layer);
 };
 
 class ElementFilterList;


### PR DESCRIPTION
This ensures that checkboxes drawn in the Elements UI of the sketcher can be styled using the correct style.

Three changes are introduced:
1. paint() method uses style provided by the widget, not application.
2. Indicator is drawn using `PE_IndicatorCheckBox` not `CE_CheckBox` - it allows to use `::indicator` in qss to style it properly. This works the same as TreeView.
3. Fix for minor issues with text alignment and extension of selected items background to cover checkbox. This is how other controls of this kind work.

It also completely refactors the rendering delegate introducing dedicated method for calculating rects of each element and method for rendering each sub control. Thanks to this refactor we can be sure that areas drawn are the same as areas checked for events in `editorEvent`.

I also changed logic on highlighting selected elements - now elements that are not selected are semi-transparent (40% - 80% when preselected). Current solution would not work as from paint method I don't have access to the stylesheet properties. This is certainly up for debate.

Fixes:  #11942 - @grudir - if you could test if it works now? I was not able to reproduce this issue, but it should work now.
Fixes: #11766
Fixes: #8814

After (this is only proposal of how it could look - it is controlled via stylsheet and now random stuff got applied)
![image](https://github.com/FreeCAD/FreeCAD/assets/747404/18857cd8-cf1e-4d65-8967-67c6be261aed)

Before:
![image](https://github.com/FreeCAD/FreeCAD/assets/747404/f0528633-a628-440c-a7c1-e1ca41d939f2)
