### PR TITLE
[Materials] Correct PreCompiled.h inclusions

### DIFF
--- a/src/Mod/Material/App/MaterialConfigLoader.cpp
+++ b/src/Mod/Material/App/MaterialConfigLoader.cpp
@@ -24,18 +24,17 @@
 #include <QDirIterator>
 #include <QFileInfo>
 #include <QString>
-#endif
-
-#include <memory>
-
 #include <QFile>
 #include <QIODevice>
 #include <QTextStream>
 #include <QUuid>
+#include <memory>
+#include <fstream>
+#endif
+
 
 #include <App/Application.h>
 #include <Base/Interpreter.h>
-#include <fstream>
 
 
 #include "Exceptions.h"

--- a/src/Mod/Material/App/MaterialLibrary.cpp
+++ b/src/Mod/Material/App/MaterialLibrary.cpp
@@ -22,10 +22,10 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 #include <QVector>
-#endif
-
 #include <QDirIterator>
 #include <QFileInfo>
+#endif
+
 
 #include <App/Application.h>
 

--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -21,10 +21,10 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#endif
-
 #include <QMetaType>
 #include <QUuid>
+#endif
+
 
 #include <App/Application.h>
 #include <Gui/MetaTypes.h>

--- a/src/Mod/Material/App/Model.cpp
+++ b/src/Mod/Material/App/Model.cpp
@@ -21,9 +21,8 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#endif
-
 #include <string>
+#endif
 
 #include <App/Application.h>
 

--- a/src/Mod/Material/App/ModelLibrary.cpp
+++ b/src/Mod/Material/App/ModelLibrary.cpp
@@ -21,9 +21,8 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#endif
-
 #include <string>
+#endif
 
 #include <App/Application.h>
 

--- a/src/Mod/Material/App/ModelLoader.cpp
+++ b/src/Mod/Material/App/ModelLoader.cpp
@@ -22,13 +22,13 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 #include <QString>
+#include <QDirIterator>
+#include <QFileInfo>
 #endif
 
 #include <App/Application.h>
 #include <Base/Interpreter.h>
 
-#include <QDirIterator>
-#include <QFileInfo>
 
 #include "Model.h"
 #include "ModelLoader.h"

--- a/src/Mod/Material/App/PreCompiled.h
+++ b/src/Mod/Material/App/PreCompiled.h
@@ -47,14 +47,26 @@
 
 // STL
 #include <algorithm>
+#include <fstream>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
 
 // Qt
 #include <QtGlobal>
+#include <QDirIterator>
+#include <QFileInfo>
+#include <QIODevice>
+#include <QList>
+#include <QMetaType>
+#include <QMetaType>
 #include <QRegularExpression>
+#include <QString>
+#include <QTextStream>
+#include <QUuid>
+#include <QVector>
 
 #endif  //_PreComp_
 

--- a/src/Mod/Material/Gui/Array2D.cpp
+++ b/src/Mod/Material/Gui/Array2D.cpp
@@ -21,10 +21,9 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
+#include <QMenu>
 #include <QMessageBox>
 #endif
-
-#include <QMenu>
 
 #include <Gui/MainWindow.h>
 

--- a/src/Mod/Material/Gui/Array3D.cpp
+++ b/src/Mod/Material/Gui/Array3D.cpp
@@ -21,11 +21,10 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
+#include <QMenu>
 #include <QMessageBox>
 #include <QPushButton>
 #endif
-
-#include <QMenu>
 
 #include <Gui/MainWindow.h>
 

--- a/src/Mod/Material/Gui/ArrayDelegate.cpp
+++ b/src/Mod/Material/Gui/ArrayDelegate.cpp
@@ -30,9 +30,8 @@
 #include <QStringList>
 #include <QTextStream>
 #include <QVariant>
-#endif
-
 #include <limits>
+#endif
 
 #include <App/Application.h>
 #include <Base/Interpreter.h>

--- a/src/Mod/Material/Gui/ArrayModel.cpp
+++ b/src/Mod/Material/Gui/ArrayModel.cpp
@@ -21,10 +21,9 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#endif
-
 #include <QList>
 #include <QMetaType>
+#endif
 
 #include <Base/Console.h>
 #include <Gui/MainWindow.h>

--- a/src/Mod/Material/Gui/BaseDelegate.cpp
+++ b/src/Mod/Material/Gui/BaseDelegate.cpp
@@ -31,9 +31,8 @@
 #include <QSvgRenderer>
 #include <QTextStream>
 #include <QVariant>
-#endif
-
 #include <limits>
+#endif
 
 #include <App/Application.h>
 #include <Base/Interpreter.h>

--- a/src/Mod/Material/Gui/ImageEdit.cpp
+++ b/src/Mod/Material/Gui/ImageEdit.cpp
@@ -21,17 +21,16 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#include <QMessageBox>
-#endif
-
 #include <QBuffer>
 #include <QFile>
 #include <QMenu>
+#include <QMessageBox>
 #include <QPainter>
 #include <QPixmap>
 #include <QString>
 #include <QSvgRenderer>
 #include <QTextStream>
+#endif
 
 #include <Gui/FileDialog.h>
 #include <Gui/MainWindow.h>

--- a/src/Mod/Material/Gui/ListDelegate.cpp
+++ b/src/Mod/Material/Gui/ListDelegate.cpp
@@ -30,9 +30,8 @@
 #include <QStringList>
 #include <QTextStream>
 #include <QVariant>
-#endif
-
 #include <limits>
+#endif
 
 #include <App/Application.h>
 #include <Base/Interpreter.h>

--- a/src/Mod/Material/Gui/ListEdit.cpp
+++ b/src/Mod/Material/Gui/ListEdit.cpp
@@ -21,10 +21,9 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
+#include <QMenu>
 #include <QMessageBox>
 #endif
-
-#include <QMenu>
 
 #include <Gui/MainWindow.h>
 

--- a/src/Mod/Material/Gui/ListModel.cpp
+++ b/src/Mod/Material/Gui/ListModel.cpp
@@ -21,9 +21,8 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#endif
-
 #include <QMetaType>
+#endif
 
 #include <Base/Console.h>
 #include <Gui/MainWindow.h>

--- a/src/Mod/Material/Gui/MaterialDelegate.cpp
+++ b/src/Mod/Material/Gui/MaterialDelegate.cpp
@@ -31,9 +31,8 @@
 #include <QSvgRenderer>
 #include <QTextStream>
 #include <QVariant>
-#endif
-
 #include <limits>
+#endif
 
 #include <App/Application.h>
 #include <Base/Interpreter.h>

--- a/src/Mod/Material/Gui/MaterialsEditor.cpp
+++ b/src/Mod/Material/Gui/MaterialsEditor.cpp
@@ -31,9 +31,8 @@
 #include <QStringList>
 #include <QTextStream>
 #include <QVariant>
-#endif
-
 #include <limits>
+#endif
 
 #include <App/Application.h>
 #include <App/License.h>

--- a/src/Mod/Material/Gui/PreCompiled.h
+++ b/src/Mod/Material/Gui/PreCompiled.h
@@ -44,6 +44,7 @@
 // standard
 #include <cfloat>
 #include <cmath>
+#include <limits>
 
 // STL
 #include <algorithm>

--- a/src/Mod/Material/Gui/TextEdit.cpp
+++ b/src/Mod/Material/Gui/TextEdit.cpp
@@ -21,10 +21,9 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
+#include <QMenu>
 #include <QMessageBox>
 #endif
-
-#include <QMenu>
 
 #include <Gui/MainWindow.h>
 


### PR DESCRIPTION
PreCompiled.h had fallen out-of-date, and some files that it included were being re-included later outside the checks.