### PR TITLE
Gui: add explicit transparency specification

### DIFF
--- a/src/Gui/ViewProviderOriginFeature.cpp
+++ b/src/Gui/ViewProviderOriginFeature.cpp
@@ -51,6 +51,7 @@ ViewProviderOriginFeature::ViewProviderOriginFeature () {
     QT_TRANSLATE_NOOP("App::Property", "Visual size of the feature"));
 
     ShapeColor.setValue ( ViewProviderOrigin::defaultColor ); // Set default color for origin (light-blue)
+    Transparency.setValue(0);
     BoundingBox.setStatus(App::Property::Hidden, true); // Hide Boundingbox from the user due to it doesn't make sense
 
     // Create node for scaling the origin

--- a/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
@@ -197,6 +197,7 @@ ViewProviderFemMesh::ViewProviderFemMesh()
     LineWidth.setConstraints(&floatRange);
 
     ShapeColor.setValue(App::Color(1.0f, 0.7f, 0.0f));
+    Transparency.setValue(0);
     ADD_PROPERTY(BackfaceCulling, (true));
     ADD_PROPERTY(ShowInner, (false));
     ADD_PROPERTY(MaxFacesShowInner, (50000));

--- a/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
+++ b/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
@@ -82,6 +82,7 @@ void ImpExpDxfReadGui::ApplyGuiStyles(Part::Feature* object)
     view->LineColor.setValue(color);
     view->PointColor.setValue(color);
     view->ShapeColor.setValue(color);
+    view->Transparency.setValue(0);
 }
 
 void ImpExpDxfReadGui::ApplyGuiStyles(App::FeaturePython* object)

--- a/src/Mod/Part/CMakeLists.txt
+++ b/src/Mod/Part/CMakeLists.txt
@@ -69,6 +69,7 @@ set(Part_tests
     parttests/regression_tests.py
     parttests/TopoShapeListTest.py
     parttests/ColorPerFaceTest.py
+    parttests/ColorTransparencyTest.py
 )
 
 add_custom_target(PartScripts ALL SOURCES

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -638,6 +638,7 @@ void PartGui::DlgProjectionOnSurface::show_projected_shapes(const std::vector<SS
     vp->LineColor.setValue(0x8ae23400);
     vp->ShapeColor.setValue(0x8ae23400);
     vp->PointColor.setValue(0x8ae23400);
+    vp->Transparency.setValue(0);
   }
 }
 

--- a/src/Mod/Part/TestPartGui.py
+++ b/src/Mod/Part/TestPartGui.py
@@ -44,6 +44,7 @@ def findDockWidget(name):
 #---------------------------------------------------------------------------
 """
 from parttests.ColorPerFaceTest import ColorPerFaceTest
+from parttests.ColorTransparencyTest import ColorTransparencyTest
 
 
 #class PartGuiTestCases(unittest.TestCase):

--- a/src/Mod/Part/parttests/ColorTransparencyTest.py
+++ b/src/Mod/Part/parttests/ColorTransparencyTest.py
@@ -1,0 +1,58 @@
+import unittest
+
+import FreeCAD as App
+
+
+class ColorTransparencyTest(unittest.TestCase):
+
+    def setUp(self):
+        self._doc = App.newDocument()
+        self._pg = App.ParamGet('User parameter:BaseApp/Preferences/View')
+        self._backup_default_transparency = self._pg.GetInt('DefaultShapeTransparency')
+        self._backup_default_shapecolor = self._pg.GetUnsigned('DefaultShapeColor')
+
+
+    def tearDown(self):
+        App.closeDocument(self._doc.Name)
+        self._pg.SetInt('DefaultShapeTransparency', self._backup_default_transparency)
+        self._pg.SetUnsigned('DefaultShapeColor', self._backup_default_shapecolor)
+
+
+    def test_default_shape_transparency(self):
+        """
+        related: https://github.com/FreeCAD/FreeCAD/pull/11866
+        related: https://github.com/FreeCAD/FreeCAD/pull/11586
+        """
+        transparency = 70
+        self._pg.SetInt('DefaultShapeTransparency', transparency)
+        obj = self._doc.addObject('Part::Box')
+        assert obj.ViewObject.Transparency == transparency
+        obj.ViewObject.ShapeColor = (0.5, 0.0, 0.0)
+
+        self.assertEqual(obj.ViewObject.Transparency, transparency,
+            'transparency was unexpectedly changed to {} when changing the color.'.format(
+            obj.ViewObject.Transparency))
+
+
+    def test_default_shape_color(self):
+        """
+        related: https://github.com/FreeCAD/FreeCAD/pull/11866
+        """
+        self._pg.SetUnsigned('DefaultShapeColor', 0xff000000)  # red
+        obj = self._doc.addObject('Part::Box')
+
+        self.assertEqual(obj.ViewObject.ShapeColor, (1.0, 0.0, 0.0, 0.0),
+            'default shape color was not set correctly')
+
+
+    def test_app_plane_transparency(self):
+        """
+        related: https://github.com/FreeCAD/FreeCAD/pull/12064
+        """
+        self._pg.SetInt('DefaultShapeTransparency', 70)
+        obj = self._doc.addObject('App::Origin')
+        t = self._doc.findObjects('App::Plane')[0].ViewObject.Transparency
+
+        self.assertEqual(t, 0,
+            'transparency of App::Plane object is {} instead of 0'.format(t))
+


### PR DESCRIPTION
As described in the [forum](https://forum.freecad.org/viewtopic.php?p=734688#p734688), the transparency value of an App::Plane object is set to the default transparency instead of zero after creation.

During creation, the App::Plane object is assigned the specified default shape color and then the color is set (again) to a fixed color for the plane (light-blue). But the transparency was not set to a fixed value and therefore kept the default transparency value.

This PR also adds the missing transparency specification to some other objects.

To test the changes, the following Python code can be executed:
```python3
doc = App.newDocument()

pg = App.ParamGet('User parameter:BaseApp/Preferences/View')
backup_default_transparency = pg.GetInt('DefaultShapeTransparency')

pg.SetInt('DefaultShapeTransparency', 70)

obj = doc.addObject('App::Origin')
t = doc.findObjects('App::Plane')[0].ViewObject.Transparency
if t != 0:
    print('WARNING: transparency of App::Plane object is {} instead of 0'.format(t))
else:
    print('transparency of App::Plane object is ok')

pg.SetInt('DefaultShapeTransparency', backup_default_transparency)
```