### PR TITLE
PartDesign: Update Length/Offset when Occurrences changes 

### DIFF
--- a/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
@@ -254,12 +254,14 @@ void LinearPattern::onChanged(const App::Property* prop)
         setReadWriteStatusForMode(mode);
     }
 
-    // Keep Length in sync with Offset
-    if (mode == LinearPatternMode::offset && prop == &Offset && !Length.testStatus(App::Property::Status::Immutable)) {
+    // Keep Length in sync with Offset, catch Occurrences changes
+    if (mode == LinearPatternMode::offset && (prop == &Offset || prop == &Occurrences)
+        && !Length.testStatus(App::Property::Status::Immutable)) {
         Length.setValue(Offset.getValue() * (Occurrences.getValue() - 1));
     }
 
-    if (mode == LinearPatternMode::length && prop == &Length && !Offset.testStatus(App::Property::Status::Immutable)) {
+    if (mode == LinearPatternMode::length && (prop == &Length || prop == &Occurrences)
+        && !Offset.testStatus(App::Property::Status::Immutable)) {
         Offset.setValue(Length.getValue() / (Occurrences.getValue() - 1));
     }
 

--- a/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
@@ -221,7 +221,7 @@ const std::list<gp_Trsf> LinearPattern::getTransformations(const std::vector<App
     gp_Trsf trans;
     transformations.push_back(trans);
 
-    // Note: The original feature is already included in the list of transformations!
+    // NOTE: The original feature is already included in the list of transformations!
     // Therefore we start with occurrence number 1
     for (int i = 1; i < occurrences; i++) {
         trans.SetTranslation(offset * i);

--- a/src/Mod/PartDesign/WizardShaft/WizardShaft.py
+++ b/src/Mod/PartDesign/WizardShaft/WizardShaft.py
@@ -169,7 +169,7 @@ class TaskWizardShaft:
     def isAllowedAlterDocument(self):
         return False
 
-# Workaround to allow a callback
+# HACK: Workaround to allow a callback
 # Problem: From the FemConstraint ViewProvider, we need to tell the Shaft instance that the user finished editing the constraint
 # We can find the Shaft Wizard dialog object from C++, but there is no way to reach the Shaft instance
 # Also it seems to be impossible to access the active dialog from Python, so Gui::Command::runCommand() is not an option either


### PR DESCRIPTION
I tested on my local machine at worked fine. There is something more I should care?

For example the `pre-coomit` hook didn't change the length of the line, 145 char width.
```pre-commit
clang-format.........................................(no files to check)Skipped
```

Fix https://github.com/FreeCAD/FreeCAD/issues/12068