### PR TITLE
Material: Initialize types

### DIFF
--- a/src/Mod/Material/App/AppMaterial.cpp
+++ b/src/Mod/Material/App/AppMaterial.cpp
@@ -28,6 +28,8 @@
 #include <Base/PyObjectBase.h>
 
 // #include "Model.h"
+#include "MaterialFilter.h"
+
 #include "MaterialManagerPy.h"
 #include "MaterialPy.h"
 #include "ModelManagerPy.h"
@@ -70,6 +72,28 @@ PyMOD_INIT_FUNC(Material)
     Base::Interpreter().addType(&Materials::ModelPropertyPy ::Type, module, "ModelProperty");
     Base::Interpreter().addType(&Materials::ModelPy ::Type, module, "Model");
     Base::Interpreter().addType(&Materials::UUIDsPy ::Type, module, "UUIDs");
+
+
+    // Initialize types
+
+    Materials::Material                 ::init();
+    Materials::MaterialFilter           ::init();
+    Materials::MaterialManager          ::init();
+    Materials::Model                    ::init();
+    Materials::ModelManager             ::init();
+    Materials::ModelUUIDs               ::init();
+
+    Materials::LibraryBase              ::init();
+    Materials::MaterialLibrary          ::init();
+    Materials::ModelLibrary             ::init();
+    Materials::MaterialExternalLibrary  ::init();
+
+    Materials::ModelProperty            ::init();
+    Materials::MaterialProperty         ::init();
+
+    Materials::MaterialValue            ::init();
+    Materials::Material2DArray          ::init();
+    Materials::Material3DArray          ::init();
 
     PyMOD_Return(module);
 }

--- a/src/Mod/Material/App/MaterialLibrary.cpp
+++ b/src/Mod/Material/App/MaterialLibrary.cpp
@@ -41,7 +41,7 @@ using namespace Materials;
 
 /* TRANSLATOR Material::Materials */
 
-TYPESYSTEM_SOURCE(Materials::MaterialLibrary, LibraryBase)
+TYPESYSTEM_SOURCE(Materials::MaterialLibrary, Materials::LibraryBase)
 
 MaterialLibrary::MaterialLibrary(const QString& libraryName,
                                  const QString& dir,
@@ -352,7 +352,7 @@ MaterialLibrary::getMaterialTree(const MaterialFilter* filter) const
     return materialTree;
 }
 
-TYPESYSTEM_SOURCE(Materials::MaterialExternalLibrary, MaterialLibrary::MaterialLibrary)
+TYPESYSTEM_SOURCE(Materials::MaterialExternalLibrary, Materials::MaterialLibrary)
 
 MaterialExternalLibrary::MaterialExternalLibrary(const QString& libraryName,
                                                  const QString& dir,

--- a/src/Mod/Material/App/ModelLibrary.cpp
+++ b/src/Mod/Material/App/ModelLibrary.cpp
@@ -99,7 +99,7 @@ QString LibraryBase::getRelativePath(const QString& path) const
     return filePath;
 }
 
-TYPESYSTEM_SOURCE(Materials::ModelLibrary, LibraryBase)
+TYPESYSTEM_SOURCE(Materials::ModelLibrary, Materials::LibraryBase)
 
 ModelLibrary::ModelLibrary(const QString& libraryName, const QString& dir, const QString& icon)
     : LibraryBase(libraryName, dir, icon)


### PR DESCRIPTION
`Materials` types that inherit from `Base::BaseClass` were not initialized properly.
Not initializing types leads to a lot of crashes and undefined behavior (especially from Python's Material module, which until now was basically unusable) and results in material cards being inaccessible from some workbenches like FEM.