### PR TITLE
[Import]fix linkage warning on linux/gcc

### DIFF
--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -173,7 +173,11 @@ struct LWPolyDataOut
     std::vector<double> Bulge;
     point3D Extr;
 };
-using eDXFGroupCode_t = enum {
+
+
+    // "using" for enums is not supported by all platforms
+    // https://stackoverflow.com/questions/41167119/how-to-fix-a-wsubobject-linkage-warning
+enum eDXFGroupCode_t {
     eObjectType = 0,
     ePrimaryText = 1,
     eName = 2,
@@ -211,7 +215,7 @@ using eDXFGroupCode_t = enum {
     eYOffset = 10,
     eZOffset = 20
 };
-using eDXFVersion_t = enum {
+enum eDXFVersion_t {
     RUnknown,
     ROlder,
     R10,
@@ -226,7 +230,7 @@ using eDXFVersion_t = enum {
     R2018,
     RNewer,
 };
-using eDimensionType_t = enum {
+enum eDimensionType_t {
     eLinear = 0,  // Rotated, Horizontal, or Vertical
     eAligned = 1,
     eAngular = 2,
@@ -431,6 +435,7 @@ class ImportExport CDxfRead
 private:
     // Low-level reader members
     std::ifstream* m_ifs;  // TODO: gsl::owner<ifstream>
+    // https://stackoverflow.com/questions/41167119/how-to-fix-a-wsubobject-linkage-warning
     eDXFGroupCode_t m_record_type = eObjectType;
     std::string m_record_data;
     bool m_not_eof = true;

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -175,9 +175,10 @@ struct LWPolyDataOut
 };
 
 
-    // "using" for enums is not supported by all platforms
-    // https://stackoverflow.com/questions/41167119/how-to-fix-a-wsubobject-linkage-warning
-enum eDXFGroupCode_t {
+// "using" for enums is not supported by all platforms
+// https://stackoverflow.com/questions/41167119/how-to-fix-a-wsubobject-linkage-warning
+enum eDXFGroupCode_t
+{
     eObjectType = 0,
     ePrimaryText = 1,
     eName = 2,
@@ -215,7 +216,8 @@ enum eDXFGroupCode_t {
     eYOffset = 10,
     eZOffset = 20
 };
-enum eDXFVersion_t {
+enum eDXFVersion_t
+{
     RUnknown,
     ROlder,
     R10,
@@ -230,7 +232,8 @@ enum eDXFVersion_t {
     R2018,
     RNewer,
 };
-enum eDimensionType_t {
+enum eDimensionType_t
+{
     eLinear = 0,  // Rotated, Horizontal, or Vertical
     eAligned = 1,
     eAngular = 2,


### PR DESCRIPTION
This PR implements a fix for warning messages in dxf.cpp.    

These warnings appear to have been introduced  by commit 2c0bc89f62.  The warnings appear on linux/gcc.  It appears MS compiler (and possibly clang) allow this construct.

The construct "using eDXFGroupCode_t = enum {" causes a number of warning messages of the form: 

/home/wile/Source/FreeCAD/src/Mod/Import/App/dxf/dxf.h:429: warning: ‘CDxfRead’ has a field ‘CDxfRead::m_record_type’ whose type has no linkage [-Wsubobject-linkage]
In file included from /home/wile/Source/FreeCAD/src/Mod/Import/App/dxf/ImpExpDxf.h:32,
                 from /home/wile/Source/FreeCAD/src/Mod/Import/App/AppImportPy.cpp:53:
/home/wile/Source/FreeCAD/src/Mod/Import/App/dxf/dxf.h:429:20: warning: ‘CDxfRead’ has a field ‘CDxfRead::m_record_type’ whose type has no linkage [-Wsubobject-linkage]
  429 | class ImportExport CDxfRead
      |                    ^~~~~~~~

The issue is discussed here: 
https://stackoverflow.com/questions/41167119/how-to-fix-a-wsubobject-linkage-warning