### PR TITLE
Part/TopoShapeMapper: Add missing PreCompiled include

### DIFF
--- a/src/Mod/Part/App/TopoShapeMapper.cpp
+++ b/src/Mod/Part/App/TopoShapeMapper.cpp
@@ -1,3 +1,5 @@
+#include "PreCompiled.h"
+
 #include "TopoShapeMapper.h"
 
 namespace Part


### PR DESCRIPTION
Required by MSVC.