### PR TITLE
[PD] Implement symmetric linear/polar patterns

### DIFF
--- a/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
@@ -63,7 +63,7 @@ LinearPattern::LinearPattern()
     ADD_PROPERTY(Length,(100.0));
     ADD_PROPERTY(Offset,(10.0));
     ADD_PROPERTY(Occurrences,(3));
-    ADD_PROPERTY(Symmetric,(0));
+    ADD_PROPERTY(Mirrored,(0));
     Occurrences.setConstraints(&intOccurrences);
     Mode.setEnums(ModeEnums);
     setReadWriteStatusForMode(initialMode);
@@ -78,7 +78,7 @@ short LinearPattern::mustExecute() const
         Length.isTouched() || 
         Offset.isTouched() || 
         Occurrences.isTouched() ||
-        Symmetric.isTouched())
+        Mirrored.isTouched())
         return 1;
     return Transformed::mustExecute();
 }
@@ -87,7 +87,6 @@ void LinearPattern::setReadWriteStatusForMode(LinearPatternMode mode)
 {
     Length.setReadOnly(mode != LinearPatternMode::length);
     Offset.setReadOnly(mode != LinearPatternMode::offset);
-    Symmetric.setReadOnly(mode != LinearPatternMode::offset);
 }
 
 const std::list<gp_Trsf> LinearPattern::getTransformations(const std::vector<App::DocumentObject*>)
@@ -103,7 +102,7 @@ const std::list<gp_Trsf> LinearPattern::getTransformations(const std::vector<App
     if (distance < Precision::Confusion())
         throw Base::ValueError("Pattern length too small");
     bool reversed = Reversed.getValue();
-    bool symmetric = Symmetric.getValue();
+    bool mirrored = Mirrored.getValue();
 
     App::DocumentObject* refObject = Direction.getValue();
     if (!refObject)
@@ -230,7 +229,7 @@ const std::list<gp_Trsf> LinearPattern::getTransformations(const std::vector<App
     for (int i = 1; i < occurrences; i++) {
         trans.SetTranslation(offset * i);
         transformations.push_back(trans);
-        if (symmetric) {
+        if (mirrored) {
             trans.SetTranslation(-offset * i);
             transformations.push_back(trans);
         }
@@ -260,9 +259,6 @@ void LinearPattern::onChanged(const App::Property* prop)
 
     if (prop == &Mode) {
         setReadWriteStatusForMode(mode);
-        // Reset to the default value
-        if (mode != LinearPatternMode::offset)
-            Symmetric.setValue(0);
     }
 
     // Keep Length in sync with Offset, catch Occurrences changes

--- a/src/Mod/PartDesign/App/FeatureLinearPattern.h
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.h
@@ -47,7 +47,7 @@ public:
     App::PropertyLength      Length;
     App::PropertyLength      Offset;
     App::PropertyIntegerConstraint Occurrences;
-    App::PropertyBool        Symmetric;
+    App::PropertyBool        Mirrored;
 
    /** @name methods override feature */
     //@{
@@ -75,7 +75,7 @@ public:
       * 
       * If Reversed is true, the direction of transformation will be opposite
       *
-      * If Symmetric is true, the transformations are duplicated in the opposite
+      * If Mirrored is true, the transformations are duplicated in the opposite
       * direction.
       */
     const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*> ) override;

--- a/src/Mod/PartDesign/App/FeatureLinearPattern.h
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.h
@@ -47,6 +47,7 @@ public:
     App::PropertyLength      Length;
     App::PropertyLength      Offset;
     App::PropertyIntegerConstraint Occurrences;
+    App::PropertyBool        Symmetric;
 
    /** @name methods override feature */
     //@{
@@ -73,6 +74,9 @@ public:
       *   transformation direction will be parallel to the given edge, which must be linear
       * 
       * If Reversed is true, the direction of transformation will be opposite
+      *
+      * If Symmetric is true, the transformations are duplicated in the opposite
+      * direction.
       */
     const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*> ) override;
 

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -67,7 +67,7 @@ PolarPattern::PolarPattern()
     Offset.setConstraints(&floatAngle);
     ADD_PROPERTY(Occurrences, (3));
     Occurrences.setConstraints(&intOccurrences);
-    ADD_PROPERTY(Symmetric,(0));
+    ADD_PROPERTY(Mirrored,(0));
 
     setReadWriteStatusForMode(initialMode);
 }
@@ -81,7 +81,7 @@ short PolarPattern::mustExecute() const
         Angle.isTouched() || 
         Offset.isTouched() || 
         Occurrences.isTouched() ||
-        Symmetric.isTouched())
+        Mirrored.isTouched())
         return 1;
     return Transformed::mustExecute();
 }
@@ -96,7 +96,7 @@ const std::list<gp_Trsf> PolarPattern::getTransformations(const std::vector<App:
         return {gp_Trsf()};
 
     bool reversed = Reversed.getValue();
-    bool symmetric = Symmetric.getValue();
+    bool mirrored = Mirrored.getValue();
 
     App::DocumentObject* refObject = Axis.getValue();
     if (!refObject)
@@ -207,7 +207,7 @@ const std::list<gp_Trsf> PolarPattern::getTransformations(const std::vector<App:
     for (int i = 1; i < occurrences; i++) {
         trans.SetRotation(axis.Axis(), i * offset);
         transformations.push_back(trans);
-        if (symmetric) {
+        if (mirrored) {
             trans.SetRotation(axis.Axis(), -offset * i);
             transformations.push_back(trans);
         }
@@ -237,9 +237,6 @@ void PolarPattern::onChanged(const App::Property* prop)
     if (prop == &Mode) {
         auto mode = static_cast<PolarPatternMode>(Mode.getValue());
         setReadWriteStatusForMode(mode);
-        // Reset to the default value
-        if (mode != PolarPatternMode::offset)
-            Symmetric.setValue(0);
     }
 
     Transformed::onChanged(prop);
@@ -249,7 +246,6 @@ void PolarPattern::setReadWriteStatusForMode(PolarPatternMode mode)
 {
     Offset.setReadOnly(mode != PolarPatternMode::offset);
     Angle.setReadOnly(mode != PolarPatternMode::angle);
-    Symmetric.setReadOnly(mode != PolarPatternMode::offset);
 }
 
 }

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.h
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.h
@@ -49,6 +49,7 @@ public:
     App::PropertyAngle       Angle;
     App::PropertyAngle       Offset;
     App::PropertyIntegerConstraint Occurrences;
+    App::PropertyBool        Symmetric;
 
    /** @name methods override feature */
     //@{
@@ -78,6 +79,9 @@ public:
       * the given edge, which must be linear.
       * 
       * If Reversed is true, the direction of rotation will be opposite.
+      *
+      * If Symmetric is true, the transformations are duplicated in the opposite
+      * direction.
       */
     const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*>) override;
 

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.h
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.h
@@ -49,7 +49,7 @@ public:
     App::PropertyAngle       Angle;
     App::PropertyAngle       Offset;
     App::PropertyIntegerConstraint Occurrences;
-    App::PropertyBool        Symmetric;
+    App::PropertyBool        Mirrored;
 
    /** @name methods override feature */
     //@{
@@ -80,7 +80,7 @@ public:
       * 
       * If Reversed is true, the direction of rotation will be opposite.
       *
-      * If Symmetric is true, the transformations are duplicated in the opposite
+      * If Mirrored is true, the transformations are duplicated in the opposite
       * direction.
       */
     const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*>) override;

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -127,8 +127,8 @@ void TaskLinearPatternParameters::connectSignals()
             this, &TaskLinearPatternParameters::onDirectionChanged);
     connect(ui->checkReverse, &QCheckBox::toggled,
             this, &TaskLinearPatternParameters::onCheckReverse);
-    connect(ui->checkSymmetric, &QCheckBox::toggled,
-            this, &TaskLinearPatternParameters::onCheckSymmetric);
+    connect(ui->checkMirrored, &QCheckBox::toggled,
+            this, &TaskLinearPatternParameters::onCheckMirrored);
     connect(ui->comboMode, qOverload<int>(&QComboBox::activated),
             this, &TaskLinearPatternParameters::onModeChanged);
     connect(ui->spinLength, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
@@ -166,7 +166,7 @@ void TaskLinearPatternParameters::setupUI()
 
     ui->comboDirection->setEnabled(true);
     ui->checkReverse->setEnabled(true);
-    ui->checkSymmetric->setEnabled(false);
+    ui->checkMirrored->setEnabled(true);
     ui->comboMode->setEnabled(true);
     ui->spinLength->blockSignals(true);
     ui->spinLength->setEnabled(true);
@@ -214,7 +214,7 @@ void TaskLinearPatternParameters::updateUI()
     PartDesign::LinearPatternMode mode = static_cast<PartDesign::LinearPatternMode>(pcLinearPattern->Mode.getValue());
 
     bool reverse = pcLinearPattern->Reversed.getValue();
-    bool symmetric = pcLinearPattern->Symmetric.getValue();
+    bool mirrored = pcLinearPattern->Mirrored.getValue();
     double length = pcLinearPattern->Length.getValue();
     double offset = pcLinearPattern->Offset.getValue();
     unsigned occurrences = pcLinearPattern->Occurrences.getValue();
@@ -226,12 +226,10 @@ void TaskLinearPatternParameters::updateUI()
         dirLinks.setCurrentLink(pcLinearPattern->Direction);
     }
 
-    ui->checkSymmetric->setEnabled(mode == PartDesign::LinearPatternMode::offset);
-
     // Note: This block of code would trigger change signal handlers (e.g. onOccurrences())
     // and another updateUI() if we didn't check for blockUpdate
     ui->checkReverse->setChecked(reverse);
-    ui->checkSymmetric->setChecked(symmetric);
+    ui->checkMirrored->setChecked(mirrored);
     ui->comboMode->setCurrentIndex((long)mode);
     ui->spinLength->setValue(length);
     ui->spinOffset->setValue(offset);
@@ -326,11 +324,11 @@ void TaskLinearPatternParameters::onCheckReverse(const bool on) {
     kickUpdateViewTimer();
 }
 
-void TaskLinearPatternParameters::onCheckSymmetric(const bool on) {
+void TaskLinearPatternParameters::onCheckMirrored(const bool on) {
     if (blockUpdate)
         return;
     PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
-    pcLinearPattern->Symmetric.setValue(on);
+    pcLinearPattern->Mirrored.setValue(on);
 
     exitSelectionMode();
     kickUpdateViewTimer();
@@ -415,7 +413,7 @@ void TaskLinearPatternParameters::onUpdateView(bool on)
         getDirection(obj, directions);
         pcLinearPattern->Direction.setValue(obj,directions);
         pcLinearPattern->Reversed.setValue(getReverse());
-        pcLinearPattern->Symmetric.setValue(getSymmetric());
+        pcLinearPattern->Mirrored.setValue(getMirrored());
         pcLinearPattern->Length.setValue(getLength());
         pcLinearPattern->Offset.setValue(getOffset());
         pcLinearPattern->Occurrences.setValue(getOccurrences());
@@ -452,9 +450,9 @@ bool TaskLinearPatternParameters::getReverse() const
     return ui->checkReverse->isChecked();
 }
 
-bool TaskLinearPatternParameters::getSymmetric() const
+bool TaskLinearPatternParameters::getMirrored() const
 {
-    return ui->checkSymmetric->isChecked();
+    return ui->checkMirrored->isChecked();
 }
 
 int TaskLinearPatternParameters::getMode() const
@@ -516,8 +514,8 @@ void TaskLinearPatternParameters::apply()
     PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(TransformedView->getObject());
     FCMD_OBJ_CMD(tobj,"Direction = " << direction);
     FCMD_OBJ_CMD(tobj,"Reversed = " << getReverse());
-    if (!pcLinearPattern->Symmetric.isReadOnly())
-        FCMD_OBJ_CMD(tobj, "Symmetric = " << getSymmetric());
+    if (!pcLinearPattern->Mirrored.isReadOnly())
+        FCMD_OBJ_CMD(tobj, "Mirrored = " << getMirrored());
 
     ui->spinLength->apply();
     ui->spinOffset->apply();

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -59,6 +59,7 @@ private Q_SLOTS:
     void onUpdateViewTimer();
     void onDirectionChanged(int num);
     void onCheckReverse(const bool on);
+    void onCheckSymmetric(const bool on);
     void onModeChanged(const int mode);
     void onLength(const double l);
     void onOffset(const double o);
@@ -74,6 +75,7 @@ protected:
     void clearButtons() override;
     void getDirection(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
     bool getReverse() const;
+    bool getSymmetric() const;
     int getMode() const;
     double getLength() const;
     double getOffset() const;

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -59,7 +59,7 @@ private Q_SLOTS:
     void onUpdateViewTimer();
     void onDirectionChanged(int num);
     void onCheckReverse(const bool on);
-    void onCheckSymmetric(const bool on);
+    void onCheckMirrored(const bool on);
     void onModeChanged(const int mode);
     void onLength(const double l);
     void onOffset(const double o);
@@ -75,7 +75,7 @@ protected:
     void clearButtons() override;
     void getDirection(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
     bool getReverse() const;
-    bool getSymmetric() const;
+    bool getMirrored() const;
     int getMode() const;
     double getLength() const;
     double getOffset() const;

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.ui
@@ -70,13 +70,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkSymmetric">
-     <property name="text">
-      <string>Symmetric</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout">
      <item>
       <widget class="QLabel" name="labelMode">
@@ -201,6 +194,13 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkMirrored">
+     <property name="text">
+      <string>Mirrored</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QCheckBox" name="checkBoxUpdateView">

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.ui
@@ -70,6 +70,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="checkSymmetric">
+     <property name="text">
+      <string>Symmetric</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout">
      <item>
       <widget class="QLabel" name="labelMode">

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -135,8 +135,8 @@ void TaskPolarPatternParameters::connectSignals()
             this, &TaskPolarPatternParameters::onModeChanged);
     connect(ui->checkReverse, &QCheckBox::toggled,
             this, &TaskPolarPatternParameters::onCheckReverse);
-    connect(ui->checkSymmetric, &QCheckBox::toggled,
-            this, &TaskPolarPatternParameters::onCheckSymmetric);
+    connect(ui->checkMirrored, &QCheckBox::toggled,
+            this, &TaskPolarPatternParameters::onCheckMirrored);
     connect(ui->polarAngle, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
             this, &TaskPolarPatternParameters::onAngle);
     connect(ui->angleOffset, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
@@ -174,7 +174,7 @@ void TaskPolarPatternParameters::setupUI()
     ui->comboAxis->setEnabled(true);
     ui->comboMode->setEnabled(true);
     ui->checkReverse->setEnabled(true);
-    ui->checkSymmetric->setEnabled(false);
+    ui->checkMirrored->setEnabled(true);
     ui->polarAngle->setEnabled(true);
     ui->spinOccurrences->setEnabled(true);
 
@@ -215,7 +215,7 @@ void TaskPolarPatternParameters::updateUI()
 
     PartDesign::PolarPatternMode mode = static_cast<PartDesign::PolarPatternMode>(pcPolarPattern->Mode.getValue());
     bool reverse = pcPolarPattern->Reversed.getValue();
-    bool symmetric = pcPolarPattern->Symmetric.getValue();
+    bool mirrored = pcPolarPattern->Mirrored.getValue();
     double angle = pcPolarPattern->Angle.getValue();
     double offset = pcPolarPattern->Offset.getValue();
     unsigned occurrences = pcPolarPattern->Occurrences.getValue();
@@ -226,14 +226,10 @@ void TaskPolarPatternParameters::updateUI()
         axesLinks.setCurrentLink(pcPolarPattern->Axis);
     }
 
-    Base::Console().Log("mode is %d\n", (int)mode);
-
-    ui->checkSymmetric->setEnabled(mode == PartDesign::PolarPatternMode::offset);
-
     // Note: This block of code would trigger change signal handlers (e.g. onOccurrences())
     // and another updateUI() if we didn't check for blockUpdate
     ui->checkReverse->setChecked(reverse);
-    ui->checkSymmetric->setChecked(symmetric);
+    ui->checkMirrored->setChecked(mirrored);
     ui->comboMode->setCurrentIndex((long)mode);
     ui->polarAngle->setValue(angle);
     ui->angleOffset->setValue(offset);
@@ -323,11 +319,11 @@ void TaskPolarPatternParameters::onCheckReverse(const bool on) {
     kickUpdateViewTimer();
 }
 
-void TaskPolarPatternParameters::onCheckSymmetric(const bool on) {
+void TaskPolarPatternParameters::onCheckMirrored(const bool on) {
     if (blockUpdate)
         return;
     PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
-    pcPolarPattern->Symmetric.setValue(on);
+    pcPolarPattern->Mirrored.setValue(on);
 
     exitSelectionMode();
     kickUpdateViewTimer();
@@ -413,7 +409,7 @@ void TaskPolarPatternParameters::onUpdateView(bool on)
         getAxis(obj, axes);
         pcPolarPattern->Axis.setValue(obj,axes);
         pcPolarPattern->Reversed.setValue(getReverse());
-        pcPolarPattern->Symmetric.setValue(getSymmetric());
+        pcPolarPattern->Mirrored.setValue(getMirrored());
         pcPolarPattern->Angle.setValue(getAngle());
         pcPolarPattern->Occurrences.setValue(getOccurrences());
 
@@ -449,9 +445,9 @@ bool TaskPolarPatternParameters::getReverse() const
     return ui->checkReverse->isChecked();
 }
 
-bool TaskPolarPatternParameters::getSymmetric() const
+bool TaskPolarPatternParameters::getMirrored() const
 {
-    return ui->checkSymmetric->isChecked();
+    return ui->checkMirrored->isChecked();
 }
 
 double TaskPolarPatternParameters::getAngle() const
@@ -503,8 +499,8 @@ void TaskPolarPatternParameters::apply()
     PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(TransformedView->getObject());
     FCMD_OBJ_CMD(tobj,"Axis = " << axis.c_str());
     FCMD_OBJ_CMD(tobj,"Reversed = " << getReverse());
-    if (!pcPolarPattern->Symmetric.isReadOnly())
-        FCMD_OBJ_CMD(tobj, "Symmetric = " << getSymmetric());
+    if (!pcPolarPattern->Mirrored.isReadOnly())
+        FCMD_OBJ_CMD(tobj, "Mirrored = " << getMirrored());
 
     ui->polarAngle->apply();
     ui->spinOccurrences->apply();

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -60,6 +60,7 @@ private Q_SLOTS:
     void onAxisChanged(int num);
     void onModeChanged(const int mode);
     void onCheckReverse(const bool on);
+    void onCheckSymmetric(const bool on);
     void onAngle(const double a);
     void onOffset(const double a);
     void onOccurrences(const uint n);
@@ -76,6 +77,7 @@ protected:
     const std::string getStdAxis() const;
     const std::string getAxis() const;
     bool getReverse() const;
+    bool getSymmetric() const;
     double getAngle() const;
     unsigned getOccurrences() const;
 

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -60,7 +60,7 @@ private Q_SLOTS:
     void onAxisChanged(int num);
     void onModeChanged(const int mode);
     void onCheckReverse(const bool on);
-    void onCheckSymmetric(const bool on);
+    void onCheckMirrored(const bool on);
     void onAngle(const double a);
     void onOffset(const double a);
     void onOccurrences(const uint n);
@@ -77,7 +77,7 @@ protected:
     const std::string getStdAxis() const;
     const std::string getAxis() const;
     bool getReverse() const;
-    bool getSymmetric() const;
+    bool getMirrored() const;
     double getAngle() const;
     unsigned getOccurrences() const;
 

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.ui
@@ -70,13 +70,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkSymmetric">
-     <property name="text">
-      <string>Symmetric</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout">
      <item>
       <widget class="QLabel" name="label">
@@ -213,6 +206,13 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkMirrored">
+     <property name="text">
+      <string>Mirrored</string>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QCheckBox" name="checkBoxUpdateView">

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.ui
@@ -70,6 +70,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="checkSymmetric">
+     <property name="text">
+      <string>Symmetric</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout">
      <item>
       <widget class="QLabel" name="label">


### PR DESCRIPTION
Add a boolean option that's only active when the user specifies the pattern in terms of offset and occurrences. The pattern is symmetrically replicated around the main datum, creating 2n copies in total.

Closes #10442