### PR TITLE
AddonManager: Disable README reformatting

### DIFF
--- a/src/Mod/AddonManager/package_details.py
+++ b/src/Mod/AddonManager/package_details.py
@@ -573,7 +573,8 @@ class PackageDetails(QtWidgets.QWidget):
             elif title == "":
                 self.show_error_for(url)
             else:
-                self.run_javascript()
+                pass
+                #self.run_javascript()
         else:
             self.show_error_for(url)
 

--- a/src/Mod/AddonManager/package_details.py
+++ b/src/Mod/AddonManager/package_details.py
@@ -574,7 +574,7 @@ class PackageDetails(QtWidgets.QWidget):
                 self.show_error_for(url)
             else:
                 pass
-                #self.run_javascript()
+                # self.run_javascript()
         else:
             self.show_error_for(url)
 


### PR DESCRIPTION
GitHub has changed their page format: to cope with this quickly, this PR disables the custom format parsing that the Addon Manager was doing, and simply displays the data as sent.