### PR TITLE
Fix warning in DlgMacroExecute.ui

### DIFF
--- a/src/Gui/DlgMacroExecute.ui
+++ b/src/Gui/DlgMacroExecute.ui
@@ -94,7 +94,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QLabel" name="label">
+           <widget class="QLabel" name="label1">
             <property name="text">
              <string>Find in files:</string>
             </property>


### PR DESCRIPTION
Fix warning about already existing `QLabel` with name "label"