### PR TITLE
Gui: add missing setup code to FreeCADGui started via Gui.showMainWindow()

### DIFF
--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -31,6 +31,7 @@
 #define  putpix()
 
 #include <App/Application.h>
+#include "GuiApplication.h"
 
 class QCloseEvent;
 class SoNode;
@@ -46,6 +47,11 @@ class MenuItem;
 class PreferencePackManager;
 class ViewProvider;
 class ViewProviderDocumentObject;
+
+
+GuiExport void initGuiAppPreMainWindow(bool calledByGuiPy);
+GuiExport void initGuiAppPostMainWindow(bool calledByGuiPy, QApplication &mApp, MainWindow &mw, GUIApplicationNativeEventAware *pmAppNativeEventAware);
+
 
 /** The Application main class
  * This is the central class of the GUI


### PR DESCRIPTION
Since the added support for transparent overlay docking widget, FreeCAD reports errors such as
```
Cannot find icon: qss:overlay/close.svg
Cannot find icon: qss:overlay/overlay.svg
Cannot find icon: qss:overlay/mode.svg
...
```
during start-up via `Gui.showMainWindow()` when having FreeCAD imported as a Python module.

To fix that, I copied the necessary code from src/Gui/Application.cpp and adapted it accordingly. I also copied other code parts to make other features such as StyleSheets work in the FreeCAD Gui when it was started from an imported module.

I am aware that duplicated code should be avoided, but my C++ skills and my knowledge of the FreeCAD code base are too limited to come up with a cleaner solution. Any hints from experienced FreeCAD developers are welcome.