### PR TITLE
Gui: Mouse navigation fixes

### DIFF
--- a/src/Gui/BlenderNavigationStyle.cpp
+++ b/src/Gui/BlenderNavigationStyle.cpp
@@ -278,15 +278,17 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent * const ev)
         break;
     }
 
+    // If the selection button is pressed together with another button
+    // and the other button is released, don't switch to selection mode.
+    // Process when selection button is pressed together with other buttons that could trigger different actions.
+    if (this->button1down && (this->button2down || this->button3down)) {
+        this->lockButton1 = true;
+        processed = true;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }
-
-    // If for dragging the buttons 1 and 3 are pressed
-    // but then button 3 is released we shouldn't switch
-    // into selection mode.
-    if (this->button1down && this->button3down)
-        this->lockButton1 = true;
 
     // If not handled in this class, pass on upwards in the inheritance
     // hierarchy.

--- a/src/Gui/BlenderNavigationStyle.cpp
+++ b/src/Gui/BlenderNavigationStyle.cpp
@@ -142,16 +142,17 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent * const ev)
             // If we are in edit mode then simply ignore the RMB events
             // to pass the event to the base class.
             this->lockrecenter = true;
-            if (!viewer->isEditing()) {
-                // If we are in zoom or pan mode ignore RMB events otherwise
-                // the canvas doesn't get any release events
+
+            // Don't show the context menu after dragging, panning or zooming
+            if (!press && (hasDragged || hasPanned || hasZoomed)) {
+                processed = true;
+            }
+            else if (!press && !viewer->isEditing()) {
                 if (this->currentmode != NavigationStyle::ZOOMING &&
                     this->currentmode != NavigationStyle::PANNING &&
                     this->currentmode != NavigationStyle::DRAGGING) {
                     if (this->isPopupMenuEnabled()) {
-                        if (!press) { // release right mouse button
-                            this->openPopupMenu(event->getPosition());
-                        }
+                        this->openPopupMenu(event->getPosition());
                     }
                 }
             }

--- a/src/Gui/BlenderNavigationStyle.cpp
+++ b/src/Gui/BlenderNavigationStyle.cpp
@@ -242,17 +242,15 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent * const ev)
     case 0:
         if (curmode == NavigationStyle::SPINNING) { break; }
         newmode = NavigationStyle::IDLE;
-        // The left mouse button has been released right now but
-        // we want to avoid that the event is processed elsewhere
+        // The left mouse button has been released right now
         if (this->lockButton1) {
             this->lockButton1 = false;
-            processed = true;
         }
         break;
     case BUTTON1DOWN:
     case CTRLDOWN|BUTTON1DOWN:
         // make sure not to change the selection when stopping spinning
-        if (curmode == NavigationStyle::SPINNING || this->lockButton1)
+        if (!viewer->isEditing() && (curmode == NavigationStyle::SPINNING || this->lockButton1))
             newmode = NavigationStyle::IDLE;
         else
             newmode = NavigationStyle::SELECTION;
@@ -284,6 +282,12 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent * const ev)
     if (this->button1down && (this->button2down || this->button3down)) {
         this->lockButton1 = true;
         processed = true;
+    }
+
+    // Prevent interrupting rubber-band selection in sketcher
+    if (viewer->isEditing() && curmode == NavigationStyle::SELECTION && newmode != NavigationStyle::IDLE) {
+        newmode = NavigationStyle::SELECTION;
+        processed = false;
     }
 
     if (newmode != curmode) {

--- a/src/Gui/CADNavigationStyle.cpp
+++ b/src/Gui/CADNavigationStyle.cpp
@@ -144,16 +144,17 @@ SbBool CADNavigationStyle::processSoEvent(const SoEvent * const ev)
             // If we are in edit mode then simply ignore the RMB events
             // to pass the event to the base class.
             this->lockrecenter = true;
-            if (!viewer->isEditing()) {
-                // If we are in zoom or pan mode ignore RMB events otherwise
-                // the canvas doesn't get any release events
+
+            // Don't show the context menu after dragging, panning or zooming
+            if (!press && (hasDragged || hasPanned || hasZoomed)) {
+                processed = true;
+            }
+            if (!press && !viewer->isEditing()) {
                 if (this->currentmode != NavigationStyle::ZOOMING &&
                     this->currentmode != NavigationStyle::PANNING &&
                     this->currentmode != NavigationStyle::DRAGGING) {
                     if (this->isPopupMenuEnabled()) {
-                        if (!press) { // release right mouse button
-                            this->openPopupMenu(event->getPosition());
-                        }
+                        this->openPopupMenu(event->getPosition());
                     }
                 }
             }

--- a/src/Gui/CADNavigationStyle.cpp
+++ b/src/Gui/CADNavigationStyle.cpp
@@ -250,16 +250,14 @@ SbBool CADNavigationStyle::processSoEvent(const SoEvent * const ev)
     case 0:
         if (curmode == NavigationStyle::SPINNING) { break; }
         newmode = NavigationStyle::IDLE;
-        // The left mouse button has been released right now but
-        // we want to avoid that the event is processed elsewhere
+        // The left mouse button has been released right now
         if (this->lockButton1) {
             this->lockButton1 = false;
-            processed = true;
         }
         break;
     case BUTTON1DOWN:
         // make sure not to change the selection when stopping spinning
-        if (curmode == NavigationStyle::SPINNING || this->lockButton1)
+        if (!viewer->isEditing() && (curmode == NavigationStyle::SPINNING || this->lockButton1))
             newmode = NavigationStyle::IDLE;
         else
             newmode = NavigationStyle::SELECTION;
@@ -308,6 +306,12 @@ SbBool CADNavigationStyle::processSoEvent(const SoEvent * const ev)
     if (this->button1down && (this->button2down || this->button3down)) {
         this->lockButton1 = true;
         processed = true;
+    }
+
+    // Prevent interrupting rubber-band selection in sketcher
+    if (viewer->isEditing() && curmode == NavigationStyle::SELECTION && newmode != NavigationStyle::IDLE) {
+        newmode = NavigationStyle::SELECTION;
+        processed = false;
     }
 
     if (newmode != curmode) {

--- a/src/Gui/CADNavigationStyle.cpp
+++ b/src/Gui/CADNavigationStyle.cpp
@@ -302,15 +302,17 @@ SbBool CADNavigationStyle::processSoEvent(const SoEvent * const ev)
         break;
     }
 
+    // If the selection button is pressed together with another button
+    // and the other button is released, don't switch to selection mode.
+    // Process when selection button is pressed together with other buttons that could trigger different actions.
+    if (this->button1down && (this->button2down || this->button3down)) {
+        this->lockButton1 = true;
+        processed = true;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }
-
-    // If for dragging the buttons 1 and 3 are pressed
-    // but then button 3 is released we shouldn't switch
-    // into selection mode.
-    if (this->button1down && this->button3down)
-        this->lockButton1 = true;
 
     // If not handled in this class, pass on upwards in the inheritance
     // hierarchy.

--- a/src/Gui/InventorNavigationStyle.cpp
+++ b/src/Gui/InventorNavigationStyle.cpp
@@ -301,6 +301,12 @@ SbBool InventorNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = true;
     }
 
+    // Prevent interrupting rubber-band selection in sketcher
+    if (viewer->isEditing() && curmode == NavigationStyle::SELECTION && newmode != NavigationStyle::IDLE) {
+        newmode = NavigationStyle::SELECTION;
+        processed = false;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/InventorNavigationStyle.cpp
+++ b/src/Gui/InventorNavigationStyle.cpp
@@ -172,15 +172,17 @@ SbBool InventorNavigationStyle::processSoEvent(const SoEvent * const ev)
             // If we are in edit mode then simply ignore the RMB events
             // to pass the event to the base class.
             this->lockrecenter = true;
-            if (!viewer->isEditing()) {
-                // If we are in zoom or pan mode ignore RMB events otherwise
-                // the canvas doesn't get any release events
+
+            // Don't show the context menu after dragging, panning or zooming
+            if (!press && (hasDragged || hasPanned || hasZoomed)) {
+                processed = true;
+            }
+            else if (!press && !viewer->isEditing()) {
                 if (this->currentmode != NavigationStyle::ZOOMING &&
-                    this->currentmode != NavigationStyle::PANNING) {
+                    this->currentmode != NavigationStyle::PANNING &&
+                    this->currentmode != NavigationStyle::DRAGGING) {
                     if (this->isPopupMenuEnabled()) {
-                        if (!press) { // release right mouse button
-                            this->openPopupMenu(event->getPosition());
-                        }
+                        this->openPopupMenu(event->getPosition());
                     }
                 }
             }
@@ -289,20 +291,7 @@ SbBool InventorNavigationStyle::processSoEvent(const SoEvent * const ev)
         newmode = NavigationStyle::ZOOMING;
         break;
 
-        // There are many cases we don't handle that just falls through to
-        // the default case, like SHIFTDOWN, CTRLDOWN, CTRLDOWN|SHIFTDOWN,
-        // SHIFTDOWN|BUTTON3DOWN, SHIFTDOWN|CTRLDOWN|BUTTON3DOWN, etc.
-        // This is a feature, not a bug. :-)
-        //
-        // mortene.
-
     default:
-        // The default will make a spin stop and otherwise not do
-        // anything.
-        if ((curmode != NavigationStyle::SEEK_WAIT_MODE) &&
-            (curmode != NavigationStyle::SEEK_MODE)) {
-            newmode = NavigationStyle::IDLE;
-        }
         break;
     }
 

--- a/src/Gui/InventorNavigationStyle.cpp
+++ b/src/Gui/InventorNavigationStyle.cpp
@@ -269,6 +269,7 @@ SbBool InventorNavigationStyle::processSoEvent(const SoEvent * const ev)
         }
         break;
     case BUTTON1DOWN:
+        if (curmode == NavigationStyle::SELECTION) { break; }
         if (newmode != NavigationStyle::DRAGGING) {
             saveCursorPosition(ev);
         }
@@ -293,6 +294,11 @@ SbBool InventorNavigationStyle::processSoEvent(const SoEvent * const ev)
 
     default:
         break;
+    }
+
+    // Process when selection button is pressed together with other buttons that could trigger different actions.
+    if (this->button1down && (this->button2down || this->button3down)) {
+        processed = true;
     }
 
     if (newmode != curmode) {

--- a/src/Gui/MayaGestureNavigationStyle.cpp
+++ b/src/Gui/MayaGestureNavigationStyle.cpp
@@ -308,8 +308,40 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
 
     //all mode-dependent stuff is within this switch.
     switch(curmode){
-    case NavigationStyle::IDLE:
     case NavigationStyle::SELECTION:
+        // Prevent interrupting rubber-band selection in sketcher
+        if (viewer->isEditing()) {
+            if (evIsButton) {
+                auto const event = (const SoMouseButtonEvent*)ev;
+                const SbBool press = event->getState() == SoButtonEvent::DOWN;
+                const int button = event->getButton();
+
+                if (!press && button == SoMouseButtonEvent::BUTTON1) {
+                    setViewingMode(NavigationStyle::IDLE);
+                    break;
+                }
+            }
+
+            if (this->button1down) {
+                break;
+            }
+        }
+        [[fallthrough]];
+    case NavigationStyle::IDLE:
+        // Prevent interrupting rubber-band selection in sketcher
+        if (viewer->isEditing()) {
+            if (evIsButton) {
+                auto const event = (const SoMouseButtonEvent*)ev;
+                const SbBool press = event->getState() == SoButtonEvent::DOWN;
+                const int button = event->getButton();
+
+                if (press && button == SoMouseButtonEvent::BUTTON1 && !this->altdown) {
+                    setViewingMode(NavigationStyle::SELECTION);
+                    break;
+                }
+            }
+        }
+        [[fallthrough]];
     case NavigationStyle::INTERACT: {
         //idle and interaction
 

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -260,6 +260,7 @@ void NavigationStyle::initialize()
 
     this->hasDragged = false;
     this->hasPanned = false;
+    this->hasZoomed = false;
 }
 
 void NavigationStyle::finalize()
@@ -586,7 +587,10 @@ void NavigationStyle::panCamera(SoCamera * cam, float aspectratio, const SbPlane
     // Reposition camera according to the vector difference between the
     // projected points.
     cam->position = cam->position.getValue() - (current_planept - old_planept);
-    hasPanned = true;
+
+    if (this->currentmode != NavigationStyle::IDLE) {
+        hasPanned = true;
+    }
 }
 
 void NavigationStyle::pan(SoCamera* camera)
@@ -694,6 +698,10 @@ void NavigationStyle::zoom(SoCamera * cam, float diffvalue)
             cam->position = newpos;
             cam->focalDistance = newfocaldist;
         }
+    }
+
+    if (this->currentmode != NavigationStyle::IDLE) {
+        hasZoomed = true;
     }
 }
 
@@ -900,7 +908,9 @@ void NavigationStyle::spin(const SbVec2f & pointerpos)
     // animation.
     if (this->spinsamplecounter > 3) this->spinsamplecounter = 3;
 
-    hasDragged = true;
+    if (this->currentmode != NavigationStyle::IDLE) {
+        hasDragged = true;
+    }
 }
 
 /*!
@@ -1352,9 +1362,10 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
         return;
     }
 
-    if (newmode != NavigationStyle::IDLE) {
+    if (newmode == NavigationStyle::IDLE) {
         hasPanned = false;
         hasDragged = false;
+        hasZoomed = false;
     }
 
     switch (newmode) {

--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -261,6 +261,7 @@ protected:
     float zoomStep;
     SbBool hasDragged;
     SbBool hasPanned;
+    SbBool hasZoomed;
 
     /** @name Mouse model */
     //@{

--- a/src/Gui/OpenCascadeNavigationStyle.cpp
+++ b/src/Gui/OpenCascadeNavigationStyle.cpp
@@ -264,6 +264,11 @@ SbBool OpenCascadeNavigationStyle::processSoEvent(const SoEvent * const ev)
         break;
     }
 
+    // Process when selection button is pressed together with other buttons that could trigger different actions.
+    if (this->button1down && (this->button2down || this->button3down || this->ctrldown)) {
+        processed = true;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/OpenCascadeNavigationStyle.cpp
+++ b/src/Gui/OpenCascadeNavigationStyle.cpp
@@ -139,16 +139,17 @@ SbBool OpenCascadeNavigationStyle::processSoEvent(const SoEvent * const ev)
             // If we are in edit mode then simply ignore the RMB events
             // to pass the event to the base class.
             this->lockrecenter = true;
-            if (!viewer->isEditing()) {
-                // If we are in zoom or pan mode ignore RMB events otherwise
-                // the canvas doesn't get any release events
+
+            // Don't show the context menu after dragging, panning or zooming
+            if (!press && (hasDragged || hasPanned || hasZoomed)) {
+                processed = true;
+            }
+            else if (!press && !viewer->isEditing()) {
                 if (this->currentmode != NavigationStyle::ZOOMING &&
                     this->currentmode != NavigationStyle::PANNING &&
                     this->currentmode != NavigationStyle::DRAGGING) {
                     if (this->isPopupMenuEnabled()) {
-                        if (!press) { // release right mouse button
-                            this->openPopupMenu(event->getPosition());
-                        }
+                        this->openPopupMenu(event->getPosition());
                     }
                 }
             }

--- a/src/Gui/OpenCascadeNavigationStyle.cpp
+++ b/src/Gui/OpenCascadeNavigationStyle.cpp
@@ -269,6 +269,12 @@ SbBool OpenCascadeNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = true;
     }
 
+    // Prevent interrupting rubber-band selection in sketcher
+    if (viewer->isEditing() && curmode == NavigationStyle::SELECTION && newmode != NavigationStyle::IDLE) {
+        newmode = NavigationStyle::SELECTION;
+        processed = false;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/OpenSCADNavigationStyle.cpp
+++ b/src/Gui/OpenSCADNavigationStyle.cpp
@@ -264,6 +264,12 @@ SbBool OpenSCADNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = true;
     }
 
+    // Prevent interrupting rubber-band selection in sketcher
+    if (viewer->isEditing() && curmode == NavigationStyle::SELECTION && newmode != NavigationStyle::IDLE) {
+        newmode = NavigationStyle::SELECTION;
+        processed = false;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/OpenSCADNavigationStyle.cpp
+++ b/src/Gui/OpenSCADNavigationStyle.cpp
@@ -140,17 +140,16 @@ SbBool OpenSCADNavigationStyle::processSoEvent(const SoEvent * const ev)
             // to pass the event to the base class.
             this->lockrecenter = true;
             this->button2down = press;
-            if (!viewer->isEditing()) {
-                // If we are in zoom or pan mode ignore RMB events otherwise
-                // the canvas doesn't get any release events
-                if ((curmode != NavigationStyle::ZOOMING &&
-                    curmode != NavigationStyle::PANNING &&
-                    curmode != NavigationStyle::DRAGGING) ||
-                    (curmode == NavigationStyle::PANNING && !hasPanned)) {
+
+            // Don't show the context menu after dragging, panning or zooming
+            if (!press && (hasDragged || hasPanned || hasZoomed)) {
+                processed = true;
+            }
+            else if (!press && !viewer->isEditing()) {
+                if (this->currentmode != NavigationStyle::ZOOMING &&
+                    this->currentmode != NavigationStyle::DRAGGING) {
                     if (this->isPopupMenuEnabled()) {
-                        if (!press) { // release right mouse button
-                            this->openPopupMenu(event->getPosition());
-                        }
+                        this->openPopupMenu(event->getPosition());
                     }
                 }
             }
@@ -164,9 +163,6 @@ SbBool OpenSCADNavigationStyle::processSoEvent(const SoEvent * const ev)
             }
             else if (!press && (curmode == NavigationStyle::DRAGGING)) {
                 newmode = NavigationStyle::IDLE;
-                processed = true;
-            }
-            else if (!press && curmode == NavigationStyle::PANNING && hasPanned) {
                 processed = true;
             }
             break;

--- a/src/Gui/OpenSCADNavigationStyle.cpp
+++ b/src/Gui/OpenSCADNavigationStyle.cpp
@@ -259,6 +259,11 @@ SbBool OpenSCADNavigationStyle::processSoEvent(const SoEvent * const ev)
         break;
     }
 
+    // Process when selection button is pressed together with other buttons that could trigger different actions.
+    if (this->button1down && (this->button2down || this->button3down)) {
+        processed = true;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/RevitNavigationStyle.cpp
+++ b/src/Gui/RevitNavigationStyle.cpp
@@ -141,16 +141,17 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent * const ev)
             // If we are in edit mode then simply ignore the RMB events
             // to pass the event to the base class.
             this->lockrecenter = true;
-            if (!viewer->isEditing()) {
-                // If we are in zoom or pan mode ignore RMB events otherwise
-                // the canvas doesn't get any release events
+
+            // Don't show the context menu after dragging, panning or zooming
+            if (!press && (hasDragged || hasPanned || hasZoomed)) {
+                processed = true;
+            }
+            else if (!press && !viewer->isEditing()) {
                 if (this->currentmode != NavigationStyle::ZOOMING &&
                     this->currentmode != NavigationStyle::PANNING &&
                     this->currentmode != NavigationStyle::DRAGGING) {
                     if (this->isPopupMenuEnabled()) {
-                        if (!press) { // release right mouse button
-                            this->openPopupMenu(event->getPosition());
-                        }
+                        this->openPopupMenu(event->getPosition());
                     }
                 }
             }

--- a/src/Gui/RevitNavigationStyle.cpp
+++ b/src/Gui/RevitNavigationStyle.cpp
@@ -280,15 +280,17 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent * const ev)
         break;
     }
 
+    // If the selection button is pressed together with another button
+    // and the other button is released, don't switch to selection mode.
+    // Process when selection button is pressed together with other buttons that could trigger different actions.
+    if (this->button1down && (this->button2down || this->button3down)) {
+        this->lockButton1 = true;
+        processed = true;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }
-
-    // If for dragging the buttons 1 and 3 are pressed
-    // but then button 3 is released we shouldn't switch
-    // into selection mode.
-    if (this->button1down && this->button3down)
-        this->lockButton1 = true;
 
     // If not handled in this class, pass on upwards in the inheritance
     // hierarchy.

--- a/src/Gui/RevitNavigationStyle.cpp
+++ b/src/Gui/RevitNavigationStyle.cpp
@@ -239,17 +239,15 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent * const ev)
     case 0:
         if (curmode == NavigationStyle::SPINNING) { break; }
         newmode = NavigationStyle::IDLE;
-        // The left mouse button has been released right now but
-        // we want to avoid that the event is processed elsewhere
+        // The left mouse button has been released right now
         if (this->lockButton1) {
             this->lockButton1 = false;
-            processed = true;
         }
         break;
     case BUTTON1DOWN:
     case CTRLDOWN|BUTTON1DOWN:
         // make sure not to change the selection when stopping spinning
-        if (curmode == NavigationStyle::SPINNING || this->lockButton1)
+        if (!viewer->isEditing() && (curmode == NavigationStyle::SPINNING || this->lockButton1))
             newmode = NavigationStyle::IDLE;
         else
             newmode = NavigationStyle::SELECTION;
@@ -286,6 +284,12 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent * const ev)
     if (this->button1down && (this->button2down || this->button3down)) {
         this->lockButton1 = true;
         processed = true;
+    }
+
+    // Prevent interrupting rubber-band selection in sketcher
+    if (viewer->isEditing() && curmode == NavigationStyle::SELECTION && newmode != NavigationStyle::IDLE) {
+        newmode = NavigationStyle::SELECTION;
+        processed = false;
     }
 
     if (newmode != curmode) {

--- a/src/Gui/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/TinkerCADNavigationStyle.cpp
@@ -142,15 +142,18 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
                 this->centerTime = ev->getTime();
                 processed = true;
             }
-            else if (!press && curmode == NavigationStyle::DRAGGING && hasDragged) {
+            // Don't show the context menu after dragging, panning or zooming
+            else if (!press && (hasDragged || hasPanned || hasZoomed)) {
                 processed = true;
             }
-            else if (!press && curmode == NavigationStyle::DRAGGING && !hasDragged) {
+            else if (!press) {
                 newmode = NavigationStyle::IDLE;
                 if (!viewer->isEditing()) {
-                    // If we are in drag mode but mouse hasn't been moved open the context-menu
-                    if (this->isPopupMenuEnabled()) {
-                        this->openPopupMenu(event->getPosition());
+                    if (this->currentmode != NavigationStyle::ZOOMING &&
+                        this->currentmode != NavigationStyle::PANNING) {
+                        if (this->isPopupMenuEnabled()) {
+                            this->openPopupMenu(event->getPosition());
+                        }
                     }
                     processed = true;
                 }

--- a/src/Gui/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/TinkerCADNavigationStyle.cpp
@@ -238,6 +238,12 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = true;
     }
 
+    // Prevent interrupting rubber-band selection in sketcher
+    if (viewer->isEditing() && curmode == NavigationStyle::SELECTION && newmode != NavigationStyle::IDLE) {
+        newmode = NavigationStyle::SELECTION;
+        processed = false;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/TinkerCADNavigationStyle.cpp
@@ -233,6 +233,11 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
         break;
     }
 
+    // Process when selection button is pressed together with other buttons that could trigger different actions.
+    if (this->button1down && (this->button2down || this->button3down)) {
+        processed = true;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/TouchpadNavigationStyle.cpp
+++ b/src/Gui/TouchpadNavigationStyle.cpp
@@ -138,16 +138,17 @@ SbBool TouchpadNavigationStyle::processSoEvent(const SoEvent * const ev)
             // If we are in edit mode then simply ignore the RMB events
             // to pass the event to the base class.
             this->lockrecenter = true;
-            if (!viewer->isEditing()) {
-                // If we are in zoom or pan mode ignore RMB events otherwise
-                // the canvas doesn't get any release events
+
+            // Don't show the context menu after dragging, panning or zooming
+            if (!press && (hasDragged || hasPanned || hasZoomed)) {
+                processed = true;
+            }
+            else if (!press && !viewer->isEditing()) {
                 if (this->currentmode != NavigationStyle::ZOOMING &&
                     this->currentmode != NavigationStyle::PANNING &&
                     this->currentmode != NavigationStyle::DRAGGING) {
                     if (this->isPopupMenuEnabled()) {
-                        if (!press) { // release right mouse button
-                            this->openPopupMenu(event->getPosition());
-                        }
+                        this->openPopupMenu(event->getPosition());
                     }
                 }
             }

--- a/src/Gui/TouchpadNavigationStyle.cpp
+++ b/src/Gui/TouchpadNavigationStyle.cpp
@@ -259,6 +259,12 @@ SbBool TouchpadNavigationStyle::processSoEvent(const SoEvent * const ev)
         processed = true;
     }
 
+    // Prevent interrupting rubber-band selection in sketcher
+    if (viewer->isEditing() && curmode == NavigationStyle::SELECTION && newmode != NavigationStyle::IDLE) {
+        newmode = NavigationStyle::SELECTION;
+        processed = false;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }

--- a/src/Gui/TouchpadNavigationStyle.cpp
+++ b/src/Gui/TouchpadNavigationStyle.cpp
@@ -254,6 +254,11 @@ SbBool TouchpadNavigationStyle::processSoEvent(const SoEvent * const ev)
         break;
     }
 
+    // Process when selection button is pressed together with other buttons that could trigger different actions.
+    if (this->button1down && (this->button2down || this->button3down || this->altdown)) {
+        processed = true;
+    }
+
     if (newmode != curmode) {
         this->setViewingMode(newmode);
     }


### PR DESCRIPTION
Fixes #12030.

This PR consists of 3 types of fixes. The first commit makes sure the right click context menu won't be shown after dragging, panning or zooming. The second commit prevents starting the sketcher rubber-band selection while another navigation button is pressed. The third commit prohibits switching to another mode while the rubber-band selection is active.