### PR TITLE
Fem: Improve contact and tie constraints - fixes #11653

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2027,6 +2027,7 @@ void Application::initTypes()
     App::PropertySpecificHeat               ::init();
     App::PropertySpeed                      ::init();
     App::PropertyStiffness                  ::init();
+    App::PropertyStiffnessDensity           ::init();
     App::PropertyStress                     ::init();
     App::PropertyTemperature                ::init();
     App::PropertyThermalConductivity        ::init();

--- a/src/App/PropertyUnits.cpp
+++ b/src/App/PropertyUnits.cpp
@@ -622,6 +622,17 @@ PropertyStiffness::PropertyStiffness()
 }
 
 //**************************************************************************
+// PropertyStiffnessDensity
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+TYPESYSTEM_SOURCE(App::PropertyStiffnessDensity, App::PropertyQuantity)
+
+PropertyStiffnessDensity::PropertyStiffnessDensity()
+{
+    setUnit(Base::Unit::StiffnessDensity);
+}
+
+//**************************************************************************
 // PropertyTemperature
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/src/App/PropertyUnits.h
+++ b/src/App/PropertyUnits.h
@@ -620,7 +620,7 @@ public:
 
 /** Stiffness property
  * This is a property for representing stiffness. It is basically a float
- * property. On the Gui it has a quantity like m/s^2.
+ * property. On the Gui it has a quantity like N/m.
  */
 class AppExport PropertyStiffness: public PropertyQuantity
 {
@@ -631,8 +631,21 @@ public:
     ~PropertyStiffness() override = default;
 };
 
+/** StiffnessDensity property
+ * This is a property for representing stiffness per area unit. It is basically a float
+ * property. On the Gui it has a quantity like Pa/m.
+ */
+class AppExport PropertyStiffnessDensity: public PropertyQuantity
+{
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
+
+public:
+    PropertyStiffnessDensity();
+    ~PropertyStiffnessDensity() override = default;
+};
+
 /** Stress property
- * This is a property for representing . It is basically a float
+ * This is a property for representing stress. It is basically a float
  * property. On the Gui it has a quantity like Pa.
  */
 class AppExport PropertyStress: public PropertyQuantity

--- a/src/Base/Unit.cpp
+++ b/src/Base/Unit.cpp
@@ -575,6 +575,9 @@ QString Unit::getTypeString() const
     if (*this == Unit::Stiffness) {
         return QString::fromLatin1("Stiffness");
     }
+    if (*this == Unit::StiffnessDensity) {
+        return QString::fromLatin1("StiffnessDensity");
+    }
     if (*this == Unit::Stress) {
         return QString::fromLatin1("Stress");
     }
@@ -667,6 +670,7 @@ const Unit Unit::ShearModulus               (-1,1,-2);
 const Unit Unit::SpecificEnergy             (2, 0, -2);
 const Unit Unit::SpecificHeat               (2, 0, -2, 0, -1);
 const Unit Unit::Stiffness                  (0, 1, -2);
+const Unit Unit::StiffnessDensity           (-2, 1, -2);
 const Unit Unit::Stress                     (-1,1,-2);
 const Unit Unit::ThermalConductivity        (1, 1, -3, 0, -1);
 const Unit Unit::ThermalExpansionCoefficient(0, 0, 0, 0, -1);

--- a/src/Base/Unit.h
+++ b/src/Base/Unit.h
@@ -150,6 +150,7 @@ public:
     static const Unit YoungsModulus;
 
     static const Unit Stiffness;
+    static const Unit StiffnessDensity;
 
     static const Unit Force;
     static const Unit Work;

--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -223,7 +223,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, QStr
             unitString = QString::fromLatin1("mN/m");
             factor = 1e-3;
         }
-        if (UnitValue < 1e3) {
+        else if (UnitValue < 1e3) {
             unitString = QString::fromLatin1("N/m");
             factor = 1.0;
         }
@@ -234,6 +234,24 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, QStr
         else {
             unitString = QString::fromLatin1("MN/m");
             factor = 1e6;
+        }
+    }
+    else if ((unit == Unit::StiffnessDensity)) {
+        if (UnitValue < 1e-3) {
+            unitString = QString::fromLatin1("Pa/m");
+            factor = 1e-6;
+        }
+        else if (UnitValue < 1) {
+            unitString = QString::fromLatin1("kPa/m");
+            factor = 1e-3;
+        }
+        else if (UnitValue < 1e3) {
+            unitString = QString::fromLatin1("MPa/m");
+            factor = 1.0;
+        }
+        else {
+            unitString = QString::fromLatin1("GPa/m");
+            factor = 1e3;
         }
     }
     else if (unit == Unit::Force) {

--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -174,7 +174,7 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, Q
             unitString = QString::fromLatin1("mN/m");
             factor = 1e-3;
         }
-        if (UnitValue < 1e3) {
+        else if (UnitValue < 1e3) {
             unitString = QString::fromLatin1("N/m");
             factor = 1.0;
         }
@@ -185,6 +185,24 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, Q
         else {
             unitString = QString::fromLatin1("MN/m");
             factor = 1e6;
+        }
+    }
+    else if ((unit == Unit::StiffnessDensity)) {
+        if (UnitValue < 1e-3) {
+            unitString = QString::fromLatin1("Pa/m");
+            factor = 1e-6;
+        }
+        else if (UnitValue < 1) {
+            unitString = QString::fromLatin1("kPa/m");
+            factor = 1e-3;
+        }
+        else if (UnitValue < 1e3) {
+            unitString = QString::fromLatin1("MPa/m");
+            factor = 1.0;
+        }
+        else {
+            unitString = QString::fromLatin1("GPa/m");
+            factor = 1e3;
         }
     }
     else if (unit == Unit::ThermalConductivity) {

--- a/src/Mod/Fem/App/FemConstraintContact.h
+++ b/src/Mod/Fem/App/FemConstraintContact.h
@@ -50,8 +50,11 @@ public:
      * This is only the definitions of the variables
      ******/
     // ex.
-    App::PropertyFloat Slope;
-    App::PropertyFloat Friction;
+    App::PropertyStiffnessDensity Slope;
+    App::PropertyLength Adjust;
+    App::PropertyBool Friction;
+    App::PropertyFloat FrictionCoefficient;
+    App::PropertyStiffnessDensity StickSlope;
 
     // etc
     /* */
@@ -64,6 +67,9 @@ public:
 
 protected:
     void onChanged(const App::Property* prop) override;
+    void handleChangedPropertyType(Base::XMLReader& reader,
+                                   const char* typeName,
+                                   App::Property* prop) override;
 };
 
 }  // namespace Fem

--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -250,10 +250,19 @@ void CmdFemConstraintContact::activated(int)
               "App.activeDocument().addObject(\"Fem::ConstraintContact\",\"%s\")",
               FeatName.c_str());
     doCommand(Doc,
-              "App.activeDocument().%s.Slope = 1000000.00",
+              "App.activeDocument().%s.Slope = \"1e6 GPa/m\"",
               FeatName.c_str());  // OvG: set default not equal to 0
     doCommand(Doc,
-              "App.activeDocument().%s.Friction = 0.0",
+              "App.activeDocument().%s.Adjust = 0.0",
+              FeatName.c_str());  // OvG: set default equal to 0
+    doCommand(Doc,
+              "App.activeDocument().%s.Friction = False",
+              FeatName.c_str());  // OvG: set default equal to 0
+    doCommand(Doc,
+              "App.activeDocument().%s.FrictionCoefficient = 0.0",
+              FeatName.c_str());  // OvG: set default equal to 0
+    doCommand(Doc,
+              "App.activeDocument().%s.StickSlope = \"1e4 GPa/m\"",
               FeatName.c_str());  // OvG: set default not equal to 0
     doCommand(Doc,
               "App.activeDocument().%s.Scale = 1",

--- a/src/Mod/Fem/Gui/Resources/ui/ConstraintTie.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ConstraintTie.ui
@@ -28,40 +28,19 @@
      <layout class="QVBoxLayout" name="verticalLayout_5">
       <item>
        <layout class="QFormLayout" name="formLayout_1">
-        <property name="fieldGrowthPolicy">
-         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-        </property>
         <item row="1" column="1">
-         <widget class="Gui::InputField" name="if_tolerance">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+         <widget class="Gui::QuantitySpinBox" name="spb_tolerance">
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
           </property>
-          <property name="minimumSize">
-           <size>
-            <width>80</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="layoutDirection">
-           <enum>Qt::LeftToRight</enum>
-          </property>
-          <property name="text">
-           <string>0 mm</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          <property name="value" stdset="0">
+           <double>0.000000000000000</double>
           </property>
           <property name="singleStep">
            <double>1.000000000000000</double>
           </property>
           <property name="maximum">
            <double>1000000000.000000000000000</double>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true">mm</string>
           </property>
           <property name="decimals" stdset="0">
            <number>2</number>
@@ -74,7 +53,14 @@
         <item row="1" column="0">
          <widget class="QLabel" name="l_tolerance">
           <property name="text">
-           <string>Tolerance:     </string>
+           <string>Tolerance</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="ckb_adjust">
+          <property name="text">
+           <string>Enable Adjust</string>
           </property>
          </widget>
         </item>
@@ -87,9 +73,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::InputField</class>
-   <extends>QLineEdit</extends>
-   <header>Gui/InputField.h</header>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.h
@@ -46,8 +46,11 @@ public:
                                       QWidget* parent = nullptr);
     ~TaskFemConstraintContact() override;
     const std::string getReferences() const override;
-    double get_Slope() const;
-    double get_Friction() const;
+    const std::string getAdjust() const;
+    const std::string getSlope() const;
+    bool getFriction() const;
+    const std::string getStickSlope() const;
+    double getFrictionCoeff() const;
 
 private Q_SLOTS:
     void onReferenceDeletedSlave();
@@ -56,12 +59,12 @@ private Q_SLOTS:
     void removeFromSelectionSlave();
     void addToSelectionMaster();
     void removeFromSelectionMaster();
+    void onFrictionChanged(bool);
 
 protected:
     void changeEvent(QEvent* e) override;
 
 private:
-    // void onSelectionChanged(const Gui::SelectionChanges& msg);
     void updateUI();
     std::unique_ptr<Ui_TaskFemConstraintContact> ui;
 };

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.ui
@@ -135,56 +135,123 @@
      </property>
     </widget>
    </item>
+
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Contact Stiffness</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="Gui::InputField" name="spSlope">
-       <property name="singleStep">
-        <double>1.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>1000000000.000000000000000</double>
-       </property>
-       <property name="unit" stdset="0">
-        <string notr="true">Pa</string>
-       </property>
-       <property name="value" stdset="0">
-        <double>1000000.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Friction coefficient</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDoubleSpinBox" name="spFriction">
-       <property name="decimals">
-        <number>2</number>
-       </property>
-       <property name="maximum">
-        <double>1.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QGroupBox" name="gpbParameter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="title">
+      <string>Parameters</string>
+     </property>
+     <layout class="QFormLayout" name="fltParameters">
+      <item row="0" column="0">
+       <widget class="QLabel" name="lblSlope">
+        <property name="text">
+         <string>Contact Stiffness</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::QuantitySpinBox" name="spbSlope">
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000.000000000000000</double>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">GPa/m</string>
+        </property>
+        <property name="value" stdset="0">
+         <double>100.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lblAdjust">
+        <property name="text">
+         <string>Clearance Adjustment</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::QuantitySpinBox" name="spbAdjust">
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">mm</string>
+        </property>
+        <property name="value" stdset="0">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="ckbFriction">
+        <property name="text">
+         <string>Enable Friction</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="lblFrictionCoeff">
+        <property name="text">
+         <string>Friction Coefficient</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::DoubleSpinBox" name="spbFrictionCoeff">
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="lblStickSlope">
+        <property name="text">
+         <string>Stick Slope</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::QuantitySpinBox" name="spbStickSlope">
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000000.000000000000000</double>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">GPa/m</string>
+        </property>
+        <property name="value" stdset="0">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
   <zorder>lbl_info_2</zorder>
@@ -194,9 +261,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::InputField</class>
-   <extends>QLineEdit</extends>
-   <header>Gui/InputField.h</header>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::DoubleSpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/SpinBox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/Mod/Fem/femexamples/constraint_contact_shell_shell.py
+++ b/src/Mod/Fem/femexamples/constraint_contact_shell_shell.py
@@ -193,9 +193,8 @@ def setup(doc=None, solvertype="ccxtools"):
         (lower_tube, "Face1"),
         (upper_tube, "Face1"),
     ]
-    con_contact.Friction = 0.0
-    # con_contact.Slope = "1000000.0 kg/(mm*s^2)"  # contact stiffness
-    con_contact.Slope = 1000000.0  # should be 1000000.0 kg/(mm*s^2)
+    con_contact.Friction = False
+    con_contact.Slope = "1000000.0 GPa/m"
     analysis.addObject(con_contact)
 
     # mesh

--- a/src/Mod/Fem/femexamples/constraint_contact_solid_solid.py
+++ b/src/Mod/Fem/femexamples/constraint_contact_solid_solid.py
@@ -177,8 +177,8 @@ def setup(doc=None, solvertype="ccxtools"):
         (geom_obj, "Face7"),  # first seams slave face, TODO proof in writer code!
         (geom_obj, "Face3"),  # second seams master face, TODO proof in writer code!
     ]
-    con_contact.Friction = 0.0
-    con_contact.Slope = 1000000.0  # contact stiffness 1000000.0 kg/(mm*s^2)
+    con_contact.Friction = False
+    con_contact.Slope = "1000000.0 GPa/m"
     analysis.addObject(con_contact)
 
     # mesh

--- a/src/Mod/Fem/femobjects/constraint_tie.py
+++ b/src/Mod/Fem/femobjects/constraint_tie.py
@@ -46,5 +46,14 @@ class ConstraintTie(base_fempythonobject.BaseFemPythonObject):
             "App::PropertyLength",
             "Tolerance",
             "Geometry",
-            "set max gap between tied faces"
+            "Set max gap between tied faces"
         )
+        obj.Tolerance = "0.0 mm"
+
+        obj.addProperty(
+            "App::PropertyBool",
+            "Adjust",
+            "Geometry",
+            "Adjust connected nodes"
+        )
+        obj.Adjust = False

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_contact.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_contact.py
@@ -68,20 +68,24 @@ def write_meshdata_constraint(f, femobj, contact_obj, ccxwriter):
 def write_constraint(f, femobj, contact_obj, ccxwriter):
 
     # floats read from ccx should use {:.13G}, see comment in writer module
+    adjust = ""
+    if contact_obj.Adjust.Value > 0:
+        adjust = ", ADJUST={:.13G}".format(
+            contact_obj.Adjust.getValueAs("mm").Value)
 
     f.write(
-        "*CONTACT PAIR, INTERACTION=INT{},TYPE=SURFACE TO SURFACE\n"
-        .format(contact_obj.Name)
+        "*CONTACT PAIR, INTERACTION=INT{}, TYPE=SURFACE TO SURFACE{}\n"
+        .format(contact_obj.Name, adjust)
     )
     ind_surf = "IND" + contact_obj.Name
     dep_surf = "DEP" + contact_obj.Name
-    f.write("{},{}\n".format(dep_surf, ind_surf))
+    f.write("{}, {}\n".format(dep_surf, ind_surf))
     f.write("*SURFACE INTERACTION, NAME=INT{}\n".format(contact_obj.Name))
-    f.write("*SURFACE BEHAVIOR,PRESSURE-OVERCLOSURE=LINEAR\n")
-    slope = contact_obj.Slope
+    f.write("*SURFACE BEHAVIOR, PRESSURE-OVERCLOSURE=LINEAR\n")
+    slope = contact_obj.Slope.getValueAs("MPa/mm").Value
     f.write("{:.13G}\n".format(slope))
-    friction = contact_obj.Friction
-    if friction > 0:
-        f.write("*FRICTION \n")
-        stick = (slope / 10.0)
+    if contact_obj.Friction:
+        f.write("*FRICTION\n")
+        friction = contact_obj.FrictionCoefficient
+        stick = contact_obj.StickSlope.getValueAs("MPa/mm").Value
         f.write("{:.13G}, {:.13G}\n".format(friction, stick))

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_tie.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_tie.py
@@ -70,10 +70,13 @@ def write_constraint(f, femobj, tie_obj, ccxwriter):
     # floats read from ccx should use {:.13G}, see comment in writer module
 
     tolerance = tie_obj.Tolerance.getValueAs("mm").Value
+    adjust = ""
+    if not tie_obj.Adjust:
+        adjust = ", ADJUST=NO"
     f.write(
-        "*TIE, POSITION TOLERANCE={:.13G}, ADJUST=NO, NAME=TIE{}\n"
-        .format(tolerance, tie_obj.Name)
+        "*TIE, POSITION TOLERANCE={:.13G}{}, NAME=TIE{}\n"
+        .format(tolerance, adjust, tie_obj.Name)
     )
     ind_surf = "TIE_IND{}".format(tie_obj.Name)
     dep_surf = "TIE_DEP{}".format(tie_obj.Name)
-    f.write("{},{}\n".format(dep_surf, ind_surf))
+    f.write("{}, {}\n".format(dep_surf, ind_surf))

--- a/src/Mod/Fem/femtaskpanels/task_constraint_tie.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_tie.py
@@ -52,9 +52,14 @@ class _TaskPanel:
             FreeCAD.getHomePath() + "Mod/Fem/Resources/ui/ConstraintTie.ui"
         )
         QtCore.QObject.connect(
-            self.parameterWidget.if_tolerance,
+            self.parameterWidget.spb_tolerance,
             QtCore.SIGNAL("valueChanged(Base::Quantity)"),
             self.tolerance_changed
+        )
+        QtCore.QObject.connect(
+            self.parameterWidget.ckb_adjust,
+            QtCore.SIGNAL("toggled(bool)"),
+            self.adjust_changed
         )
         self.init_parameter_widget()
 
@@ -67,7 +72,7 @@ class _TaskPanel:
         )
 
         # form made from param and selection widget
-        self.form = [self.parameterWidget, self.selectionWidget]
+        self.form = [self.selectionWidget, self.parameterWidget]
 
     def accept(self):
         # check values
@@ -94,6 +99,7 @@ class _TaskPanel:
             elif msgBox.clickedButton() == ignoreButton:
                 pass
         self.obj.Tolerance = self.tolerance
+        self.obj.Adjust = self.adjust
         self.obj.References = self.selectionWidget.references
         self.recompute_and_set_back_all()
         return True
@@ -112,7 +118,12 @@ class _TaskPanel:
 
     def init_parameter_widget(self):
         self.tolerance = self.obj.Tolerance
-        self.parameterWidget.if_tolerance.setText(self.tolerance.UserString)
+        self.adjust = self.obj.Adjust
+        self.parameterWidget.spb_tolerance.setProperty("value", self.tolerance)
+        self.parameterWidget.ckb_adjust.setChecked(self.adjust)
 
     def tolerance_changed(self, base_quantity_value):
         self.tolerance = base_quantity_value
+
+    def adjust_changed(self, bool_value):
+        self.adjust = bool_value

--- a/src/Mod/Fem/femtest/data/calculix/constraint_contact_shell_shell.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_contact_shell_shell.inp
@@ -38365,10 +38365,10 @@ Efaces
 ***********************************************************
 ** Contact Constraints
 ** ConstraintContact
-*CONTACT PAIR, INTERACTION=INTConstraintContact,TYPE=SURFACE TO SURFACE
-DEPConstraintContact,INDConstraintContact
+*CONTACT PAIR, INTERACTION=INTConstraintContact, TYPE=SURFACE TO SURFACE
+DEPConstraintContact, INDConstraintContact
 *SURFACE INTERACTION, NAME=INTConstraintContact
-*SURFACE BEHAVIOR,PRESSURE-OVERCLOSURE=LINEAR
+*SURFACE BEHAVIOR, PRESSURE-OVERCLOSURE=LINEAR
 1000000
 
 ***********************************************************

--- a/src/Mod/Fem/femtest/data/calculix/constraint_contact_solid_solid.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_contact_solid_solid.inp
@@ -5572,10 +5572,10 @@ Evolumes
 ***********************************************************
 ** Contact Constraints
 ** ConstraintContact
-*CONTACT PAIR, INTERACTION=INTConstraintContact,TYPE=SURFACE TO SURFACE
+*CONTACT PAIR, INTERACTION=INTConstraintContact, TYPE=SURFACE TO SURFACE
 DEPConstraintContact,INDConstraintContact
 *SURFACE INTERACTION, NAME=INTConstraintContact
-*SURFACE BEHAVIOR,PRESSURE-OVERCLOSURE=LINEAR
+*SURFACE BEHAVIOR, PRESSURE-OVERCLOSURE=LINEAR
 1000000
 
 ***********************************************************

--- a/src/Mod/Fem/femtest/data/calculix/constraint_tie.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_tie.inp
@@ -18608,7 +18608,7 @@ Evolumes
 ** Tie Constraints
 ** ConstraintTie
 *TIE, POSITION TOLERANCE=25, ADJUST=NO, NAME=TIEConstraintTie
-TIE_DEPConstraintTie,TIE_INDConstraintTie
+TIE_DEPConstraintTie, TIE_INDConstraintTie
 
 ***********************************************************
 ** At least one step is needed to run an CalculiX analysis of FreeCAD


### PR DESCRIPTION
* Add new unit `StiffnessDensity` ($\text{Force/Lenght}^3 \equiv \text{Pressure/Lenght}$)  and the corresponding `App::PropertyStiffnessDensity`, basically a spring stiffness per unit area needed to use in contact stiffness and the stick slope value used by the `*FRICTION` keyword. (currrently it is said that the unit should be Pressure like the elastic modulus, but this is incorrect).
* Add support for `ADJUST` parameter on the `CONTACT PAIR` card  for contact constraint.
* Add support for specifying stick slope value in `*FRICTION` keyword.
* Add support for `ADJUST` parameter in tie constraint.
* Use quantity spin box in both constraint task dialogs.

@FEA-eng Do you want to test this?

Some links:
http://www.dhondt.de/ccx_2.21.pdf#subsubsection.6.7.5
http://www.dhondt.de/ccx_2.21.pdf#subsubsection.6.7.6
https://calculix.discourse.group/t/contact-stiffness-setting/455/2
https://www.mdpi.com/2075-4442/7/7/56

