### PR TITLE
Material: Return new reference to Python boolean and change format unit to parse path

### DIFF
--- a/src/Mod/Material/App/MaterialManagerPyImpl.cpp
+++ b/src/Mod/Material/App/MaterialManagerPyImpl.cpp
@@ -71,17 +71,20 @@ PyObject* MaterialManagerPy::getMaterial(PyObject* args)
 
 PyObject* MaterialManagerPy::getMaterialByPath(PyObject* args)
 {
-    char* path {};
+    char* path;
     const char* lib = "";
-    if (!PyArg_ParseTuple(args, "s|s", &path, &lib)) {
+    if (!PyArg_ParseTuple(args, "et|s", "utf-8", &path, &lib)) {
         return nullptr;
     }
+
+    std::string utf8Path = std::string(path);
+    PyMem_Free(path);
 
     QString libPath(QString::fromStdString(lib));
     if (!libPath.isEmpty()) {
         try {
             auto material =
-                getMaterialManagerPtr()->getMaterialByPath(QString::fromStdString(path), libPath);
+                getMaterialManagerPtr()->getMaterialByPath(QString::fromUtf8(utf8Path.c_str()), libPath);
             return new MaterialPy(new Material(*material));
         }
         catch (const MaterialNotFound&) {
@@ -95,7 +98,7 @@ PyObject* MaterialManagerPy::getMaterialByPath(PyObject* args)
     }
 
     try {
-        auto material = getMaterialManagerPtr()->getMaterialByPath(QString::fromStdString(path));
+        auto material = getMaterialManagerPtr()->getMaterialByPath(QString::fromUtf8(utf8Path.c_str()));
         return new MaterialPy(new Material(*material));
     }
     catch (const MaterialNotFound&) {

--- a/src/Mod/Material/App/MaterialPyImpl.cpp
+++ b/src/Mod/Material/App/MaterialPyImpl.cpp
@@ -222,7 +222,7 @@ PyObject* MaterialPy::hasPhysicalModel(PyObject* args)
     }
 
     bool hasProperty = getMaterialPtr()->hasPhysicalModel(QString::fromStdString(uuid));
-    return hasProperty ? Py_True : Py_False;
+    return PyBool_FromLong(hasProperty ? 1 : 0);
 }
 
 PyObject* MaterialPy::hasAppearanceModel(PyObject* args)
@@ -233,7 +233,7 @@ PyObject* MaterialPy::hasAppearanceModel(PyObject* args)
     }
 
     bool hasProperty = getMaterialPtr()->hasAppearanceModel(QString::fromStdString(uuid));
-    return hasProperty ? Py_True : Py_False;
+    return PyBool_FromLong(hasProperty ? 1 : 0);
 }
 
 PyObject* MaterialPy::isPhysicalModelComplete(PyObject* args)
@@ -244,7 +244,7 @@ PyObject* MaterialPy::isPhysicalModelComplete(PyObject* args)
     }
 
     bool isComplete = getMaterialPtr()->isPhysicalModelComplete(QString::fromStdString(name));
-    return isComplete ? Py_True : Py_False;
+    return PyBool_FromLong(isComplete ? 1 : 0);
 }
 
 PyObject* MaterialPy::isAppearanceModelComplete(PyObject* args)
@@ -255,7 +255,7 @@ PyObject* MaterialPy::isAppearanceModelComplete(PyObject* args)
     }
 
     bool isComplete = getMaterialPtr()->isAppearanceModelComplete(QString::fromStdString(name));
-    return isComplete ? Py_True : Py_False;
+    return PyBool_FromLong(isComplete ? 1 : 0);
 }
 
 PyObject* MaterialPy::hasPhysicalProperty(PyObject* args)
@@ -266,7 +266,7 @@ PyObject* MaterialPy::hasPhysicalProperty(PyObject* args)
     }
 
     bool hasProperty = getMaterialPtr()->hasPhysicalProperty(QString::fromStdString(name));
-    return hasProperty ? Py_True : Py_False;
+    return PyBool_FromLong(hasProperty ? 1 : 0);
 }
 
 PyObject* MaterialPy::hasAppearanceProperty(PyObject* args)
@@ -277,7 +277,7 @@ PyObject* MaterialPy::hasAppearanceProperty(PyObject* args)
     }
 
     bool hasProperty = getMaterialPtr()->hasAppearanceProperty(QString::fromStdString(name));
-    return hasProperty ? Py_True : Py_False;
+    return PyBool_FromLong(hasProperty ? 1 : 0);
 }
 
 Py::Dict MaterialPy::getProperties() const


### PR DESCRIPTION
`Py_False` or `Py_True` should not be used directly on function return without increasing the reference count