### PR TITLE
Improvements to Sketcher context menu

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -795,6 +795,9 @@ private:
     void rmvSelection(const std::string& subNameSuffix);
     bool addSelection(const std::string& subNameSuffix, float x = 0, float y = 0, float z = 0);
     bool addSelection2(const std::string& subNameSuffix, float x = 0, float y = 0, float z = 0);
+    void preselectToSelection(const std::stringstream& ss,
+                              boost::scoped_ptr<SoPickedPoint>& pp,
+                              bool toggle);
     //@}
 
     /** @name miscelanea utilities */


### PR DESCRIPTION
This PR improves the contextual right click menu in the Sketcher WB.
1. Consider preselection: You can now directly right click on an element and pull up the contextual menu for the element you've clicked on. This also works if you already have a selection, then it considers the item you've right clicked on for the contextual commands. For example select a circle and then follow with a right click on a line will pull up the menu with dimension (distance) and tangent. Previously it would only considered the selected elements, so you would need one extra left click. This is also the behavior in other (CAD) software tools. 
2. Add functionality to also consider external geometry.
3. Remove commands which (currently) cannot work with a selection (e.g. fillet, trim). They would need to clear the selection and the elements have to be selected again with the respective tool being active beforehand.
4. Add commands for Sketcher copy, cut and paste.


https://github.com/FreeCAD/FreeCAD/assets/6246609/551ea07f-c24b-4c92-92b7-0382be1d10fe

