### PR TITLE
Toponaming shapeprotector Nullify() check

### DIFF
--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -3911,7 +3911,9 @@ TopoDS_Shape TopoShape::makeShell(const TopoDS_Shape& input) const
 
 TopoShape &TopoShape::makeWires(const TopoShape &shape, const char *op, bool fix, double tol)
 {
-    _Shape.Nullify();
+    if (!_Shape.IsNull()) {
+        _Shape.Nullify();
+    }
 
     if(shape.isNull())
         HANDLE_NULL_INPUT;
@@ -3983,7 +3985,9 @@ TopoShape &TopoShape::makeWires(const TopoShape &shape, const char *op, bool fix
 TopoShape &TopoShape::makeCompound(const std::vector<TopoShape> &shapes, const char *op, bool force)
 {
     (void)op;
-    _Shape.Nullify();
+    if (!_Shape.IsNull()) {
+        _Shape.Nullify();
+    }
 
     if(shapes.empty())
         HANDLE_NULL_INPUT;
@@ -4025,7 +4029,9 @@ TopoShape &TopoShape::makeFace(const TopoShape &shape, const char *op, const cha
 TopoShape &TopoShape::makeFace(const std::vector<TopoShape> &shapes, const char *op, const char *maker)
 {
     (void)op;
-    _Shape.Nullify();
+    if (!_Shape.IsNull()) {
+        _Shape.Nullify();
+    }
 
     if(!maker || !maker[0])
         maker = "Part::FaceMakerBullseye";
@@ -4042,9 +4048,13 @@ TopoShape &TopoShape::makeFace(const std::vector<TopoShape> &shapes, const char 
     return *this;
 }
 
-TopoShape &TopoShape::makeRefine(const TopoShape &shape, const char *op, bool no_fail) {
+TopoShape &TopoShape::makeRefine(const TopoShape &shape, const char *op, bool no_fail)
+{
     (void)op;
-    _Shape.Nullify();
+    if (!_Shape.IsNull()) {
+        _Shape.Nullify();
+    }
+
     if(shape.isNull()) {
         if(!no_fail)
             HANDLE_NULL_SHAPE;

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -3911,9 +3911,7 @@ TopoDS_Shape TopoShape::makeShell(const TopoDS_Shape& input) const
 
 TopoShape &TopoShape::makeWires(const TopoShape &shape, const char *op, bool fix, double tol)
 {
-    if (!_Shape.IsNull()) {
-        _Shape.Nullify();
-    }
+    _Shape.Nullify();
 
     if(shape.isNull())
         HANDLE_NULL_INPUT;
@@ -3985,9 +3983,7 @@ TopoShape &TopoShape::makeWires(const TopoShape &shape, const char *op, bool fix
 TopoShape &TopoShape::makeCompound(const std::vector<TopoShape> &shapes, const char *op, bool force)
 {
     (void)op;
-    if (!_Shape.IsNull()) {
-        _Shape.Nullify();
-    }
+    _Shape.Nullify();
 
     if(shapes.empty())
         HANDLE_NULL_INPUT;
@@ -4029,9 +4025,7 @@ TopoShape &TopoShape::makeFace(const TopoShape &shape, const char *op, const cha
 TopoShape &TopoShape::makeFace(const std::vector<TopoShape> &shapes, const char *op, const char *maker)
 {
     (void)op;
-    if (!_Shape.IsNull()) {
-        _Shape.Nullify();
-    }
+    _Shape.Nullify();
 
     if(!maker || !maker[0])
         maker = "Part::FaceMakerBullseye";
@@ -4051,9 +4045,7 @@ TopoShape &TopoShape::makeFace(const std::vector<TopoShape> &shapes, const char 
 TopoShape &TopoShape::makeRefine(const TopoShape &shape, const char *op, bool no_fail)
 {
     (void)op;
-    if (!_Shape.IsNull()) {
-        _Shape.Nullify();
-    }
+    _Shape.Nullify();
 
     if(shape.isNull()) {
         if(!no_fail)

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -851,9 +851,11 @@ private:
 
         void Nullify()
         {
-            _owner->resetElementMap();
-            _owner->_cache.reset();
-            _owner->_parentCache.reset();
+            if (!this->IsNull()) {
+                _owner->resetElementMap();
+                _owner->_cache.reset();
+                _owner->_parentCache.reset();
+            }
         }
 
         const TopLoc_Location& Location() const


### PR DESCRIPTION
related to comment in https://github.com/FreeCAD/FreeCAD/commit/a74c6b339160c48b26b8bc191138a583a6a2aee4#comments of https://github.com/FreeCAD/FreeCAD/pull/11896

This PR adds a check on objects of class `ShapeProtector` before performing `Nullify()`

as reported in https://forum.freecad.org/viewtopic.php?t=84536 the lack of this check causes a segfault when the `Nullify()` method is called
