### PR TITLE
Dim the Navigation Cube when not active

### DIFF
--- a/src/Gui/NaviCube.h
+++ b/src/Gui/NaviCube.h
@@ -65,6 +65,7 @@ public:
     void setHiliteColor(QColor HiliteColor);
     void setBorderWidth(double BorderWidth);
     void setShowCS(bool showCS);
+    void setInactiveOpacity(float opacity);
     // Label order: front, top, right, rear, bottom, left
     void setNaviCubeLabels(const std::vector<std::string>& labels);
     static void setNaviCubeCommands(const std::vector<std::string>& cmd);

--- a/src/Gui/PreferencePackTemplates/View.cfg
+++ b/src/Gui/PreferencePackTemplates/View.cfg
@@ -10,6 +10,7 @@
           <FCInt Name="CornerNaviCube" Value="1"/>
           <FCInt Name="CubeSize" Value="132"/>
           <FCBool Name="NaviRotateToNearest" Value="1"/>
+          <FCBool Name="InactiveOpacity" Value="0.5"/>
         </FCParamGroup>
         <FCParamGroup Name="View">
           <FCInt Name="AntiAliasing" Value="0"/>

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
@@ -96,6 +96,7 @@ void DlgSettingsNavigation::saveSettings()
     ui->naviCubeToNearest->onSave();
     ui->prefCubeSize->onSave();
     ui->naviCubeBaseColor->onSave();
+    ui->naviCubeInactiveOpacity->onSave();
 
     bool showNaviCube = ui->groupBoxNaviCube->isChecked();
     hGrp->SetBool("ShowNaviCube", showNaviCube);
@@ -141,6 +142,7 @@ void DlgSettingsNavigation::loadSettings()
     ui->naviCubeToNearest->onRestore();
     ui->prefCubeSize->onRestore();
     ui->naviCubeBaseColor->onRestore();
+    ui->naviCubeInactiveOpacity->onRestore();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath
         ("User parameter:BaseApp/Preferences/View");

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.ui
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.ui
@@ -199,6 +199,47 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="3">
+       <widget class="QLabel" name="inactiveOpacityLabel">
+        <property name="text">
+         <string>Opacity when inactive</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="4">
+       <widget class="Gui::PrefSpinBox" name="naviCubeInactiveOpacity">
+        <property name="maximumSize">
+         <size>
+          <width>60</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Opacity of the navigation cube when not focused</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="value">
+         <number>50</number>
+        </property>
+        <property name="suffix">
+         <string notr="true">%</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>InactiveOpacity</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>NaviCube</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="0">
        <widget class="QLabel" name="BaseColorLabel">
         <property name="text">

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -479,6 +479,7 @@ void NaviCubeSettings::applySettings()
     parameterChanged("FontWeight");
     parameterChanged("FontStretch");
     parameterChanged("ShowCS");
+    parameterChanged("InactiveOpacity");
     parameterChanged("TextFront"); // Updates all labels
 }
 
@@ -538,6 +539,10 @@ void NaviCubeSettings::parameterChanged(const char* Name)
     }
     else if (strcmp(Name, "ShowCS") == 0) {
         nc->setShowCS(hGrp->GetBool("ShowCS", true));
+    }
+    else if (strcmp(Name, "InactiveOpacity") == 0) {
+        float opacity = static_cast<float>(hGrp->GetInt("InactiveOpacity", 50)) / 100;
+        nc->setInactiveOpacity(opacity);
     }
     else if (strcmp(Name, "TextTop") == 0 || strcmp(Name, "TextBottom") == 0
              || strcmp(Name, "TextFront") == 0 || strcmp(Name, "TextRear") == 0


### PR DESCRIPTION
Implement the InactiveOpacity option, allowing the user to dim the navigation cube when not focused by making it transparent.

This feature is present in many CAD softwares and IMO is quite useful to make the cube slightly less noticeable when working on the model.