### PR TITLE
Part/TopoShapeMapper: Add missing PreCompiled include

### DIFF
--- a/src/Mod/Part/App/TopoShapeMapper.cpp
+++ b/src/Mod/Part/App/TopoShapeMapper.cpp
@@ -1,3 +1,5 @@
+#include "PreCompiled.h"
+
 #include "TopoShapeMapper.h"
 
 namespace Part


### PR DESCRIPTION
PR for https://github.com/FreeCAD/FreeCAD/commit/7a259e8c98b6d1ed3d805e909b82896de0dbf9c2 by @chennes, redo of https://github.com/FreeCAD/FreeCAD/pull/12182 due to a mistake done in that PR

I checked other `.cpp` files added/modified for the [Toponaming Project](https://github.com/orgs/FreeCAD/projects/2/views/1) and haven't found others with missing `#include "PreCompiled.h"`