### PR TITLE
Sketcher: minor fixes to 2 prefs ui files

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -17,7 +17,7 @@
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Task Panel Widgets</string>
+      <string>Task panel widgets</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
@@ -209,7 +209,7 @@ Requires to re-enter edit mode to take effect.</string>
       </sizepolicy>
      </property>
      <property name="title">
-      <string>Dimension Constraint</string>
+      <string>Dimension constraint</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_general">
       <item row="0" column="0">
@@ -223,10 +223,10 @@ Requires to re-enter edit mode to take effect.</string>
        <widget class="QComboBox" name="dimensioningMode">
         <property name="toolTip">
          <string>Select the type of dimensioning constraints for your toolbar:
-'Single tool': A single tool for all dimensioning constraints in the toolbar : Distance, Distance X / Y, Angle, Radius. (Others in dropdown)
+'Single tool': A single tool for all dimensioning constraints in the toolbar: Distance, Distance X / Y, Angle, Radius. (Others in dropdown)
 'Separated tools': Individual tools for each dimensioning constraint.
 'Both': You will have both the 'Dimension' tool and the separated tools.
-This setting is only for the toolbar. Whichever you chose, all tools are always available in the menu and through shortcuts.</string>
+This setting is only for the toolbar. Whichever you choose, all tools are always available in the menu and through shortcuts.</string>
         </property>
        </widget>
       </item>
@@ -240,7 +240,7 @@ This setting is only for the toolbar. Whichever you chose, all tools are always 
 	  <item row="1" column="1">
        <widget class="QComboBox" name="radiusDiameterMode">
         <property name="toolTip">
-         <string>While using the Dimension tool you may chose how to handle circles and arcs:
+         <string>While using the Dimension tool you may choose how to handle circles and arcs:
 'Auto': The tool will apply radius to arcs and diameter to circles.
 'Diameter': The tool will apply diameter to both arcs and circles.
 'Radius': The tool will apply radius to both arcs and circles.</string>
@@ -259,13 +259,13 @@ This setting is only for the toolbar. Whichever you chose, all tools are always 
       </sizepolicy>
      </property>
      <property name="title">
-      <string>Tool Parameters</string>
+      <string>Tool parameters</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_vis">
       <item row="0" column="0">
        <widget class="QLabel" name="ovpVisibilityLabel">
         <property name="text">
-         <string> On-View-Parameters :</string>
+         <string>On-View-Parameters:</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
@@ -852,60 +852,14 @@
      <layout class="QGridLayout" name="gridLayout_8">
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_4">
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_17">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Edge</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="Gui::PrefColorButton" name="SketchEdgeColor">
-          <property name="toolTip">
-           <string>Color of edges</string>
-          </property>
-          <property name="color" stdset="0">
-           <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SketchEdgeColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       <item row="3" column="0">
+        <item row="0" column="0">
          <widget class="QLabel" name="label_18">
           <property name="text">
            <string>Vertex</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="0" column="1">
          <widget class="Gui::PrefColorButton" name="SketchVertexColor">
           <property name="toolTip">
            <string>Color of vertices</string>
@@ -925,7 +879,53 @@
           </property>
          </widget>
         </item>
-        </layout>
+        <item row="0" column="2">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_17">
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Edge</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="Gui::PrefColorButton" name="SketchEdgeColor">
+          <property name="toolTip">
+           <string>Color of edges</string>
+          </property>
+          <property name="color" stdset="0">
+           <color>
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SketchEdgeColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>View</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
* Titles in sentence case.
* No space before colon.
* Choose instead of chose.
* Vertex item first in "Colors outside Sketcher" as well.
