### PR TITLE
Conda: Pin PCL to v1.13.1 to fix build errors on Windows.

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -79,7 +79,7 @@ dependencies:
 - numpy
 - occt==7.6.3
 - openssl
-- pcl
+- pcl==1.13.1
 - pip
 - pivy
 - pkg-config


### PR DESCRIPTION
An update to the `conda-forge` package `pcl` from version `1.13.1` to `1.14.0` resulted in build failures only present on Windows.  Pinning the package to `1.13.1` resolves the build issues.