### PR TITLE
Addon Manager: Allow primary branch name change

### DIFF
--- a/src/Mod/AddonManager/addonmanager_installer.py
+++ b/src/Mod/AddonManager/addonmanager_installer.py
@@ -40,6 +40,7 @@ from PySide import QtCore
 
 from Addon import Addon
 import addonmanager_utilities as utils
+from addonmanager_metadata import get_branch_from_metadata
 from addonmanager_git import initialize_git, GitFailed
 
 if FreeCAD.GuiUp:
@@ -281,7 +282,12 @@ class AddonInstaller(QtCore.QObject):
         install_path = os.path.join(self.installation_path, self.addon_to_install.name)
         try:
             if os.path.isdir(install_path):
-                self.git_manager.update(install_path)
+                old_branch = get_branch_from_metadata(self.addon_to_install.installed_metadata)
+                new_branch = get_branch_from_metadata(self.addon_to_install.metadata)
+                if old_branch != new_branch:
+                    self.git_manager.migrate_branch(install_path, old_branch, new_branch)
+                else:
+                    self.git_manager.update(install_path)
             else:
                 self.git_manager.clone(self.addon_to_install.url, install_path)
             self.git_manager.checkout(install_path, self.addon_to_install.branch)

--- a/src/Mod/AddonManager/addonmanager_metadata.py
+++ b/src/Mod/AddonManager/addonmanager_metadata.py
@@ -234,6 +234,13 @@ def get_first_supported_freecad_version(metadata: Metadata) -> Optional[Version]
     return current_earliest
 
 
+def get_branch_from_metadata(metadata: Metadata) -> str:
+    for url in metadata.url:
+        if url.type == UrlType.repository:
+            return url.branch
+    return "master"  # Legacy default
+
+
 class MetadataReader:
     """Read metadata XML data and construct a Metadata object"""
 

--- a/src/Mod/AddonManager/manage_python_dependencies.py
+++ b/src/Mod/AddonManager/manage_python_dependencies.py
@@ -415,7 +415,6 @@ class PythonPackageManager:
         pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
         known_python_versions_string = pref.GetString("KnownPythonVersions", "[]")
         known_python_versions = json.loads(known_python_versions_string)
-        print(json.dumps(known_python_versions, indent=4))
         return known_python_versions
 
     @classmethod

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -454,11 +454,14 @@ class PackageListItemDelegate(QtWidgets.QStyledItemDelegate):
 
         installed_version_string = ""
         if repo.status() != Addon.Status.NOT_INSTALLED:
-            if repo.installed_version:
+            if repo.installed_version or repo.installed_metadata:
                 installed_version_string = (
                     "<br/>" + translate("AddonsInstaller", "Installed version") + ": "
                 )
-                installed_version_string += str(repo.installed_version)
+                if repo.installed_metadata:
+                    installed_version_string += str(repo.installed_metadata.version)
+                elif repo.installed_version:
+                    installed_version_string += str(repo.installed_version)
             else:
                 installed_version_string = "<br/>" + translate("AddonsInstaller", "Unknown version")
 


### PR DESCRIPTION
Support changing the name of the primary branch. To change your primary branch:
1) Make the change in your primary remote repo
2) Update your package.xml file to list the new repo branch
3) Update .gitmodules file in FreeCAD/FreeCAD-Addons repo

The Addon Manager will recognize this as an available update and automatically switch your installed branch name (if your addon was installed using git -- if it was installed via ZIP this just pulls a new copy of the zip file).

Fixes #12130.