### PR TITLE
Sketcher: Fix sketcher_Copy bug when a single geometry was copied

### DIFF
--- a/src/Mod/Sketcher/App/PythonConverter.cpp
+++ b/src/Mod/Sketcher/App/PythonConverter.cpp
@@ -169,7 +169,7 @@ std::string PythonConverter::convert(const std::string& doc,
                                      GeoIdMode geoIdMode)
 {
     if (constraints.size() == 1) {
-        auto cg = convert(constraints[0]);
+        auto cg = convert(constraints[0], geoIdMode);
 
         return boost::str(boost::format("%s.%s\n") % doc % cg);
     }


### PR DESCRIPTION
Fix sketcher_Copy bug when a single geometry was copied, geoId was not correct in constraints.
Bug reported by @Roy-043 in https://github.com/FreeCAD/FreeCAD/pull/11537