### PR TITLE
Gui: Add easing to navigation animations

### DIFF
--- a/src/Gui/NavigationAnimation.cpp
+++ b/src/Gui/NavigationAnimation.cpp
@@ -44,7 +44,7 @@ void NavigationAnimation::onStop([[maybe_unused]] bool finished)
 
 FixedTimeAnimation::FixedTimeAnimation(NavigationStyle* navigation, const SbRotation& orientation,
                                        const SbVec3f& rotationCenter, const SbVec3f& translation,
-                                       int duration)
+                                       int duration, const QEasingCurve::Type easingCurve)
     : NavigationAnimation(navigation)
     , targetOrientation(orientation)
     , targetTranslation(translation)
@@ -53,6 +53,7 @@ FixedTimeAnimation::FixedTimeAnimation(NavigationStyle* navigation, const SbRota
     setDuration(duration);
     setStartValue(0.0);
     setEndValue(duration * 1.0);
+    setEasingCurve(easingCurve);
 }
 
 void FixedTimeAnimation::initialize()

--- a/src/Gui/NavigationAnimation.h
+++ b/src/Gui/NavigationAnimation.h
@@ -60,7 +60,7 @@ class GuiExport FixedTimeAnimation : public NavigationAnimation
 public:
     explicit FixedTimeAnimation(NavigationStyle* navigation, const SbRotation& orientation,
                                 const SbVec3f& rotationCenter, const SbVec3f& translation,
-                                int duration);
+                                int duration, const QEasingCurve::Type easingCurve);
 
 private:
     float angularVelocity; // [rad/ms]

--- a/src/Gui/PreferencePackTemplates/View.cfg
+++ b/src/Gui/PreferencePackTemplates/View.cfg
@@ -35,7 +35,7 @@
           <FCBool Name="ShowSelectionBoundingBox" Value="0"/>
           <FCBool Name="UseNavigationAnimations" Value="1"/>
           <FCBool Name="UseSpinningAnimations" Value="0"/>
-          <FCFloat Name="AnimationDuration" Value="0.25"/>
+          <FCFloat Name="AnimationDuration" Value="500"/>
           <FCBool Name="UseVBO" Value="0"/>
           <FCFloat Name="ViewScalingFactor" Value="1.0"/>
           <FCBool Name="ZoomAtCursor" Value="1"/>

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.ui
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.ui
@@ -773,7 +773,7 @@ Mouse tilting is not disabled by this setting.</string>
          <number>50</number>
         </property>
         <property name="value">
-         <number>250</number>
+         <number>500</number>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>AnimationDuration</cstring>

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3406,7 +3406,7 @@ void View3DInventorViewer::startAnimation(const SbRotation& orientation,
     if (duration < 0) {
         duration = App::GetApplication()
                        .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
-                       ->GetInt("AnimationDuration", 250);
+                       ->GetInt("AnimationDuration", 500);
     }
 
     auto animation = std::make_shared<FixedTimeAnimation>(

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3409,8 +3409,12 @@ void View3DInventorViewer::startAnimation(const SbRotation& orientation,
                        ->GetInt("AnimationDuration", 500);
     }
 
+    QEasingCurve::Type easingCurve = static_cast<QEasingCurve::Type>(App::GetApplication()
+                         .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+                         ->GetInt("NavigationAnimationEasingCurve", QEasingCurve::Type::InOutCubic));
+
     auto animation = std::make_shared<FixedTimeAnimation>(
-        navigation, orientation, rotationCenter, translation, duration);
+        navigation, orientation, rotationCenter, translation, duration, easingCurve);
 
     navigation->startAnimating(animation, wait);
 }


### PR DESCRIPTION
This adds an option (enabled by default) to use the InOutCubic easing function in navigation animations. By using this, the start and end of the animations are more smooth instead of directly going to the max speed or 0.