### PR TITLE
Part: Add BRepFill_Generator to the OpenCascadeAll.h

### DIFF
--- a/src/Mod/Part/App/OpenCascadeAll.h
+++ b/src/Mod/Part/App/OpenCascadeAll.h
@@ -150,6 +150,7 @@
 #include <BRepFeat_SplitShape.hxx>
 #include <BRepFill.hxx>
 #include <BRepFill_Filling.hxx>
+#include <BRepFill_Generator.hxx>
 #include <BRepFilletAPI_MakeChamfer.hxx>
 #include <BRepFilletAPI_MakeFillet.hxx>
 #include <BRepGProp.hxx>


### PR DESCRIPTION
Fix master not compiling with precompiled. https://forum.freecad.org/viewtopic.php?t=84835
@chennes 