### PR TITLE
Sketcher: Add check for handler's existence

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -454,7 +454,7 @@ public:
     /// triggered by the controllable DSH after a mode change has been effected
     virtual void afterHandlerModeChanged()
     {
-        if (!handler->isState(SelectModeT::End) || handler->continuousMode) {
+        if (handler && (!handler->isState(SelectModeT::End) || handler->continuousMode)) {
             handler->mouseMove(prevCursorPosition);
         }
     }


### PR DESCRIPTION
Asynchronous events on MacOS seemed to trigger a change after the handler's deletion.