### PR TITLE
 Fem: Prevent selection of partially attached object - fixes #12163

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -110,11 +110,6 @@ void ViewProviderFemAnalysis::attach(App::DocumentObject* obj)
 {
     Gui::ViewProviderDocumentObjectGroup::attach(obj);
     extension.attach(this);
-    // activate analysis if currently active workbench is FEM
-    auto* workbench = Gui::WorkbenchManager::instance()->active();
-    if (workbench->name() == "FemWorkbench") {
-        doubleClicked();
-    }
 }
 
 void ViewProviderFemAnalysis::highlightView(Gui::ViewProviderDocumentObject* view)

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.h
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.h
@@ -50,7 +50,7 @@ private:
 class FemGuiExport ViewProviderFemAnalysis: public Gui::ViewProviderDocumentObjectGroup
 {
     Q_DECLARE_TR_FUNCTIONS(FemGui::ViewProviderFemAnalysis)
-    PROPERTY_HEADER_WITH_OVERRIDE(FemGui::ViewProviderAnalysis);
+    PROPERTY_HEADER_WITH_OVERRIDE(FemGui::ViewProviderFemAnalysis);
 
 public:
     /// constructor


### PR DESCRIPTION
Calling `doubleClicked` method implies an attempt to add the currently partially attached object to the list of selected objects, which generates the reported bug.
The activation of the analysis object is already done by executing the `FEM_Analysis` command.