### PR TITLE
Draft: Avoid draftToolBar.getDefaultColor outside DraftGui.py

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -54,15 +54,15 @@ from draftguitools import gui_trackers as trackers
 
 
 COLORS = {
-    "default": Gui.draftToolBar.getDefaultColor("snap"),
-    "black":  (0., 0., 0.),
-    "white":  (1., 1., 1.),
-    "grey":   (.5, .5, .5),
-    "red":    (1., 0., 0.),
-    "green":  (0., 1., 0.),
-    "blue":   (0., 0., 1.),
-    "yellow": (1., 1., 0.),
-    "cyan":   (0., 1., 1.),
+    "default": utils.get_rgba_tuple(params.get_param("snapcolor"))[:3],
+    "black":   (0., 0., 0.),
+    "white":   (1., 1., 1.),
+    "grey":    (.5, .5, .5),
+    "red":     (1., 0., 0.),
+    "green":   (0., 1., 0.),
+    "blue":    (0., 0., 1.),
+    "yellow":  (1., 1., 0.),
+    "cyan":    (0., 1., 1.),
     "magenta": (1., 0., 1.)
 }
 

--- a/src/Mod/Draft/draftguitools/gui_groups.py
+++ b/src/Mod/Draft/draftguitools/gui_groups.py
@@ -316,8 +316,7 @@ class AddToConstruction(gui_base.GuiCommandNeedsSelection):
         if not hasattr(Gui, "draftToolBar"):
             return
 
-        col = Gui.draftToolBar.getDefaultColor("constr")
-        col = (float(col[0]), float(col[1]), float(col[2]), 0.0)
+        col = params.get_param("constructioncolor") & 0xFFFFFF00
 
         # Get the construction group or create it if it doesn't exist
         grp = self.doc.getObject("Draft_Construction")

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -147,11 +147,11 @@ class Tracker:
             self.color.rgb = color
         elif hasattr(FreeCAD, "activeDraftCommand") \
                 and FreeCAD.activeDraftCommand is not None \
+                and hasattr(FreeCAD.activeDraftCommand, "featureName") \
                 and FreeCAD.activeDraftCommand.featureName in ("Dimension", "Label", "Text"):
-            color = utils.get_rgba_tuple(params.get_param("DefaultAnnoLineColor"))[:3]
-            self.color.rgb = color
+            self.color.rgb = utils.get_rgba_tuple(params.get_param("DefaultAnnoLineColor"))[:3]
         else:
-            self.color.rgb = FreeCADGui.draftToolBar.getDefaultColor("line")
+            self.color.rgb = utils.get_rgba_tuple(params.get_param_view("DefaultShapeLineColor"))[:3]
 
     def _get_wp(self):
         return FreeCAD.DraftWorkingPlane
@@ -178,7 +178,7 @@ class snapTracker(Tracker):
     def setColor(self, color=None):
         """Set the color."""
         if color is None:
-            self.color.rgb = FreeCADGui.draftToolBar.getDefaultColor("snap")
+            self.color.rgb = utils.get_rgba_tuple(params.get_param("snapcolor"))[:3]
         else:
             self.color.rgb = color
 
@@ -714,7 +714,7 @@ class ghostTracker(Tracker):
     def setColor(self, color=None):
         """Set the color."""
         if color is None:
-            self.color.rgb = FreeCADGui.draftToolBar.getDefaultColor("snap")
+            self.color.rgb = utils.get_rgba_tuple(params.get_param("snapcolor"))[:3]
         else:
             self.color.rgb = color
 
@@ -898,7 +898,7 @@ class editTracker(Tracker):
     def setColor(self, color=None):
         """Set the color."""
         if color is None:
-            self.color.rgb = FreeCADGui.draftToolBar.getDefaultColor("snap")
+            self.color.rgb = utils.get_rgba_tuple(params.get_param("snapcolor"))[:3]
         else:
             self.color.rgb = color
 
@@ -1399,7 +1399,7 @@ class archDimTracker(Tracker):
         p2node = coin.SbVec3f([p2.x, p2.y, p2.z])
         self.dimnode.pnts.setValues([p1node, p2node])
         self.dimnode.lineWidth = 1
-        color = FreeCADGui.draftToolBar.getDefaultColor("snap")
+        color = utils.get_rgba_tuple(params.get_param("snapcolor"))[:3]
         self.dimnode.textColor.setValue(coin.SbVec3f(color))
         self.dimnode.size = 11
         self.size_pixel = self.dimnode.size.getValue()*96/72

--- a/src/Mod/Draft/draftmake/make_point.py
+++ b/src/Mod/Draft/draftmake/make_point.py
@@ -79,10 +79,7 @@ def make_point(X=0, Y=0, Z=0, color=None, name="Point", point_size=5):
 
     if App.GuiUp:
         ViewProviderPoint(obj.ViewObject)
-        if hasattr(Gui,"draftToolBar") and color is None:
-            color = Gui.draftToolBar.getDefaultColor("line")
-        if color is not None:
-            obj.ViewObject.PointColor = (float(color[0]), float(color[1]), float(color[2]))
+        gui_utils.formatObject(obj)
         obj.ViewObject.PointSize = point_size
         gui_utils.select(obj)
 

--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -527,7 +527,7 @@ def format_object(target, origin=None):
                 obrep.DisplayMode = dm
     if Gui.draftToolBar.isConstructionMode():
         doc = App.ActiveDocument
-        col = Gui.draftToolBar.getDefaultColor("constr") + (0.0,)
+        col = params.get_param("constructioncolor") & 0xFFFFFF00
         grp = doc.getObject("Draft_Construction")
         if not grp:
             grp = doc.addObject("App::DocumentObjectGroup", "Draft_Construction")


### PR DESCRIPTION
The draftToolBar.getDefaultColor() function is an indirect way of retreiving a parameter. It is better to avoid it where possible.
