### PR TITLE
Remove excessive output from Draft object creation and editing

### DIFF
--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -95,8 +95,7 @@ def typecheck(args_and_types, name="?"):
     """
     for v, t in args_and_types:
         if not isinstance(v, t):
-            _msg = "typecheck[{0}]: {1} is not {2}".format(name, v, t)
-            messages._wrn(_msg)
+            messages._wrn("typecheck[{0}]: {1} is not {2}".format(name, v, t))
             raise TypeError("fcvec." + str(name))
 
 

--- a/src/Mod/Draft/draftfunctions/downgrade.py
+++ b/src/Mod/Draft/draftfunctions/downgrade.py
@@ -75,7 +75,6 @@ def downgrade(objects, delete=False, force=None):
     upgrade
     """
     _name = "downgrade"
-    utils.print_header(_name, "Downgrade objects")
 
     if not isinstance(objects, list):
         objects = [objects]

--- a/src/Mod/Draft/draftfunctions/mirror.py
+++ b/src/Mod/Draft/draftfunctions/mirror.py
@@ -78,7 +78,6 @@ def mirror(objlist, p1, p2):
     just use `Part::Mirroring`. It should create a derived object,
     that is, it should work similar to `Draft.offset`.
     """
-    utils.print_header('mirror', "Create mirror")
 
     if not objlist:
         _err(translate("draft","No object given"))

--- a/src/Mod/Draft/draftfunctions/upgrade.py
+++ b/src/Mod/Draft/draftfunctions/upgrade.py
@@ -93,7 +93,6 @@ def upgrade(objects, delete=False, force=None):
     downgrade
     """
     _name = "upgrade"
-    utils.print_header(_name, "Upgrade objects")
 
     if not isinstance(objects, list):
         objects = [objects]

--- a/src/Mod/Draft/draftgeoutils/geo_arrays.py
+++ b/src/Mod/Draft/draftgeoutils/geo_arrays.py
@@ -150,8 +150,6 @@ def create_frames(obj, places):
     len_wires = len(obj.Shape.Wires)
     frames = list()
     profiles = list()
-    # _msg("{}: {} wires".format(obj.Label, len_wires))
-    # _msg("places: {}".format(len(places)))
 
     for i in places:
         frame = obj.Shape.copy()

--- a/src/Mod/Draft/draftguitools/gui_base_original.py
+++ b/src/Mod/Draft/draftguitools/gui_base_original.py
@@ -43,7 +43,7 @@ from draftutils import gui_utils
 from draftutils import params
 from draftutils import todo
 from draftutils import utils
-from draftutils.messages import _log, _msg, _toolmsg
+from draftutils.messages import _log, _toolmsg
 
 
 class DraftTool:

--- a/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
@@ -51,7 +51,7 @@ import DraftVecUtils
 
 from draftutils.translate import translate
 import draftutils.utils as utils
-from draftutils.messages import _msg
+from draftutils.messages import _err
 
 import draftguitools.gui_trackers as trackers
 
@@ -174,8 +174,7 @@ class DraftWireGuiTools(GuiTools):
 
     def delete_point(self, obj, node_idx):
         if len(obj.Points) <= 2:
-            _msg = translate("draft", "Active object must have more than two points/nodes")
-            App.Console.PrintWarning(_msg + "\n")
+            _err(translate("draft", "Active object must have more than two points/nodes"))
             return
 
         pts = obj.Points
@@ -837,8 +836,7 @@ class DraftBezCurveGuiTools(GuiTools):
 
     def delete_point(self, obj, node_idx):
         if len(obj.Points) <= 2:
-            _msg = translate("draft", "Active object must have more than two points/nodes")
-            App.Console.PrintWarning(_msg + "\n")
+            _err(translate("draft", "Active object must have more than two points/nodes"))
             return
 
         pts = obj.Points

--- a/src/Mod/Draft/draftguitools/gui_fillets.py
+++ b/src/Mod/Draft/draftguitools/gui_fillets.py
@@ -43,7 +43,7 @@ import draftutils.utils as utils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 
-from draftutils.messages import _msg, _err, _toolmsg
+from draftutils.messages import _err, _toolmsg
 from draftutils.translate import translate
 
 # The module is used to prevent complaints from code checkers (flake8)

--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -44,7 +44,7 @@ from draftutils import gui_utils
 from draftutils import params
 from draftutils import utils
 from draftutils import todo
-from draftutils.messages import _err, _msg, _toolmsg
+from draftutils.messages import _err, _toolmsg
 from draftutils.translate import translate
 
 

--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -229,7 +229,6 @@ class Offset(gui_base_original.Modifier):
                     copymode = True
                 Gui.addModule("Draft")
                 if self.npts:
-                    # _msg("offset:npts= " + str(self.npts))
                     _cmd = 'Draft.offset'
                     _cmd += '('
                     _cmd += 'FreeCAD.ActiveDocument.'

--- a/src/Mod/Draft/draftguitools/gui_orthoarray.py
+++ b/src/Mod/Draft/draftguitools/gui_orthoarray.py
@@ -36,7 +36,7 @@ import Draft
 import Draft_rc  # include resources, icons, ui files
 import draftutils.todo as todo
 
-from draftutils.messages import _msg, _log
+from draftutils.messages import _log
 from draftutils.translate import translate
 from draftguitools import gui_base
 from drafttaskpanels import task_orthoarray
@@ -72,8 +72,6 @@ class OrthoArray(gui_base.GuiCommandBase):
         the widgets of the task panel.
         """
         _log("GuiCommand: {}".format(self.command_name))
-        #_msg("{}".format(16*"-"))
-        #_msg("GuiCommand: {}".format(self.command_name))
 
         # self.location = coin.SoLocation2Event.getClassTypeId()
         self.mouse_event = coin.SoMouseButtonEvent.getClassTypeId()

--- a/src/Mod/Draft/draftguitools/gui_polararray.py
+++ b/src/Mod/Draft/draftguitools/gui_polararray.py
@@ -36,7 +36,7 @@ import Draft
 import Draft_rc  # include resources, icons, ui files
 import draftutils.todo as todo
 
-from draftutils.messages import _msg, _log
+from draftutils.messages import _log
 from draftutils.translate import translate
 from draftguitools import gui_base
 from drafttaskpanels import task_polararray
@@ -72,8 +72,6 @@ class PolarArray(gui_base.GuiCommandBase):
         the widgets of the task panel.
         """
         _log("GuiCommand: {}".format(self.command_name))
-        #_msg("{}".format(16*"-"))
-        #_msg("GuiCommand: {}".format(self.command_name))
 
         self.location = coin.SoLocation2Event.getClassTypeId()
         self.mouse_event = coin.SoMouseButtonEvent.getClassTypeId()

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -445,7 +445,7 @@ class bsplineTracker(Tracker):
             except Exception:
                 # workaround for pivy SoInput.setBuffer() bug
                 buf = buf.replace("\n", "")
-                pts = re.findall("point \[(.*?)\]", buf)[0]
+                pts = re.findall("point \\[(.*?)\\]", buf)[0]
                 pts = pts.split(",")
                 pc = []
                 for p in pts:
@@ -523,7 +523,7 @@ class bezcurveTracker(Tracker):
                 except Exception:
                     # workaround for pivy SoInput.setBuffer() bug
                     buf = buf.replace("\n","")
-                    pts = re.findall("point \[(.*?)\]", buf)[0]
+                    pts = re.findall("point \\[(.*?)\\]", buf)[0]
                     pts = pts.split(",")
                     pc = []
                     for p in pts:
@@ -652,7 +652,7 @@ class arcTracker(Tracker):
         except Exception:
             # workaround for pivy SoInput.setBuffer() bug
             buf = buf.replace("\n", "")
-            pts = re.findall("point \[(.*?)\]", buf)[0]
+            pts = re.findall("point \\[(.*?)\\]", buf)[0]
             pts = pts.split(",")
             pc = []
             for p in pts:

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -33,7 +33,7 @@ import FreeCAD as App
 import Part
 import Draft
 import draftutils.utils as utils
-from draftutils.messages import _msg, _err
+from draftutils.messages import _err
 from draftutils.translate import translate
 
 import draftutils.gui_utils as gui_utils
@@ -117,7 +117,6 @@ def make_arc_3points(points, placement=None, face=False,
         Returns `None` if there is a problem and the object cannot be created.
     """
     _name = "make_arc_3points"
-    utils.print_header(_name, "Arc by 3 points")
 
     try:
         utils.type_check([(points, (list, tuple))], name=_name)
@@ -141,10 +140,6 @@ def make_arc_3points(points, placement=None, face=False,
 
     p1, p2, p3 = points
 
-    _msg("p1: {}".format(p1))
-    _msg("p2: {}".format(p2))
-    _msg("p3: {}".format(p3))
-
     try:
         utils.type_check([(p1, App.Vector),
                           (p2, App.Vector),
@@ -163,11 +158,7 @@ def make_arc_3points(points, placement=None, face=False,
     radius = edge.Curve.Radius
     center = edge.Curve.Center
 
-    _msg(translate("draft","Radius:") + " " + "{}".format(radius))
-    _msg(translate("draft","Center:") + " " + "{}".format(center))
-
     if primitive:
-        _msg(translate("draft","Create primitive object"))
         obj = App.ActiveDocument.addObject("Part::Feature", "Arc")
         obj.Shape = edge
         return obj
@@ -190,18 +181,11 @@ def make_arc_3points(points, placement=None, face=False,
 
     if placement and not support:
         obj.Placement.Base = placement.Base
-        _msg(translate("draft","Final placement:") + " " + "{}".format(obj.Placement))
-    if face:
-        _msg(translate("draft","Face: True"))
     if support:
-        _msg(translate("draft","Support:") + " " + "{}".format(support))
-        _msg(translate("draft","Map mode:") + " " + "{}".format(map_mode))
         obj.MapMode = map_mode
         if placement:
             obj.AttachmentOffset.Base = placement.Base
             obj.AttachmentOffset.Rotation = original_placement.Rotation
-            _msg(translate("draft","Attachment offset: {}".format(obj.AttachmentOffset)))
-        _msg(translate("draft","Final placement:") + " " + "{}".format(obj.Placement))
 
     return obj
 

--- a/src/Mod/Draft/draftmake/make_circulararray.py
+++ b/src/Mod/Draft/draftmake/make_circulararray.py
@@ -31,7 +31,7 @@ import FreeCAD as App
 import draftmake.make_array as make_array
 import draftutils.utils as utils
 
-from draftutils.messages import _msg, _err
+from draftutils.messages import _err
 from draftutils.translate import translate
 
 
@@ -119,7 +119,6 @@ def make_circular_array(base_object,
     make_ortho_array, make_polar_array, make_path_array, make_point_array
     """
     _name = "make_circular_array"
-    utils.print_header(_name, translate("draft","Circular array"))
 
     if isinstance(base_object, str):
         base_object_str = base_object
@@ -127,14 +126,8 @@ def make_circular_array(base_object,
     found, base_object = utils.find_object(base_object,
                                            doc=App.activeDocument())
     if not found:
-        _msg("base_object: {}".format(base_object_str))
-        _err(translate("draft","Wrong input: object not in document."))
+        _err(translate("draft","Wrong input: base_object {} not in document.").format(base_object_str))
         return None
-
-    _msg("base_object: {}".format(base_object.Label))
-
-    _msg("r_distance: {}".format(r_distance))
-    _msg("tan_distance: {}".format(tan_distance))
 
     try:
         utils.type_check([(r_distance, (int, float, App.Units.Quantity)),
@@ -144,18 +137,12 @@ def make_circular_array(base_object,
         _err(translate("draft","Wrong input: must be a number or quantity."))
         return None
 
-    _msg("number: {}".format(number))
-    _msg("symmetry: {}".format(symmetry))
-
     try:
         utils.type_check([(number, int),
                           (symmetry, int)], name=_name)
     except TypeError:
         _err(translate("draft","Wrong input: must be an integer number."))
         return None
-
-    _msg("axis: {}".format(axis))
-    _msg("center: {}".format(center))
 
     try:
         utils.type_check([(axis, App.Vector),
@@ -165,7 +152,6 @@ def make_circular_array(base_object,
         return None
 
     use_link = bool(use_link)
-    _msg("use_link: {}".format(use_link))
 
     new_obj = make_array.make_array(base_object,
                                     arg1=r_distance, arg2=tan_distance,

--- a/src/Mod/Draft/draftmake/make_dimension.py
+++ b/src/Mod/Draft/draftmake/make_dimension.py
@@ -40,7 +40,7 @@ import WorkingPlane
 
 from draftutils import gui_utils
 from draftutils import utils
-from draftutils.messages import _msg, _wrn, _err
+from draftutils.messages import _wrn, _err
 from draftutils.translate import translate
 
 from draftobjects.dimension import LinearDimension, AngularDimension
@@ -206,28 +206,24 @@ def make_linear_dimension(p1, p2, dim_line=None):
         If there is a problem it will return `None`.
     """
     _name = "make_linear_dimension"
-    utils.print_header(_name, "Linear dimension")
 
     found, doc = utils.find_doc(App.activeDocument())
     if not found:
         _err(translate("draft","No active document. Aborting."))
         return None
 
-    _msg("p1: {}".format(p1))
     try:
         utils.type_check([(p1, App.Vector)], name=_name)
     except TypeError:
         _err(translate("draft","Wrong input: must be a vector."))
         return None
 
-    _msg("p2: {}".format(p2))
     try:
         utils.type_check([(p2, App.Vector)], name=_name)
     except TypeError:
         _err(translate("draft","Wrong input: must be a vector."))
         return None
 
-    _msg("dim_line: {}".format(dim_line))
     if dim_line:
         try:
             utils.type_check([(dim_line, App.Vector)], name=_name)
@@ -299,7 +295,6 @@ def make_linear_dimension_obj(edge_object, i1=1, i2=2, dim_line=None):
         If there is a problem it will return `None`.
     """
     _name = "make_linear_dimension_obj"
-    utils.print_header(_name, "Linear dimension")
 
     found, doc = utils.find_doc(App.activeDocument())
     if not found:
@@ -310,17 +305,14 @@ def make_linear_dimension_obj(edge_object, i1=1, i2=2, dim_line=None):
         edge_object_str = edge_object
 
     if isinstance(edge_object, (list, tuple)):
-        _msg("edge_object: {}".format(edge_object))
-        _err(translate("draft","Wrong input: object must not be a list."))
+        _err(translate("draft","Wrong input: edge_object {} must not be a list or tuple.").format(edge_object))
         return None
 
     found, edge_object = utils.find_object(edge_object, doc)
     if not found:
-        _msg("edge_object: {}".format(edge_object_str))
-        _err(translate("draft","Wrong input: object not in document."))
+        _err(translate("draft","Wrong input: edge_object {} not in document.").format(edge_object_str))
         return None
 
-    _msg("edge_object: {}".format(edge_object.Label))
     if not hasattr(edge_object, "Shape"):
         _err(translate("draft","Wrong input: object doesn't have a 'Shape' to measure."))
         return None
@@ -329,7 +321,6 @@ def make_linear_dimension_obj(edge_object, i1=1, i2=2, dim_line=None):
         _err(translate("draft","Wrong input: object doesn't have at least one element in 'Vertexes' to use for measuring."))
         return None
 
-    _msg("i1: {}".format(i1))
     try:
         utils.type_check([(i1, int)], name=_name)
     except TypeError:
@@ -345,7 +336,6 @@ def make_linear_dimension_obj(edge_object, i1=1, i2=2, dim_line=None):
         _err(translate("draft","Wrong input: vertex not in object."))
         return None
 
-    _msg("i2: {}".format(i2))
     try:
         utils.type_check([(i2, int)], name=_name)
     except TypeError:
@@ -361,7 +351,6 @@ def make_linear_dimension_obj(edge_object, i1=1, i2=2, dim_line=None):
         _err(translate("draft","Wrong input: vertex not in object."))
         return None
 
-    _msg("dim_line: {}".format(dim_line))
     if dim_line:
         try:
             utils.type_check([(dim_line, App.Vector)], name=_name)
@@ -429,7 +418,6 @@ def make_radial_dimension_obj(edge_object, index=1, mode="radius",
         If there is a problem it will return `None`.
     """
     _name = "make_radial_dimension_obj"
-    utils.print_header(_name, "Radial dimension")
 
     found, doc = utils.find_doc(App.activeDocument())
     if not found:
@@ -441,11 +429,9 @@ def make_radial_dimension_obj(edge_object, index=1, mode="radius",
 
     found, edge_object = utils.find_object(edge_object, doc)
     if not found:
-        _msg("edge_object: {}".format(edge_object_str))
-        _err(translate("draft","Wrong input: object not in document."))
+        _err(translate("draft","Wrong input: edge_object {} not in document.").format(edge_object_str))
         return None
 
-    _msg("edge_object: {}".format(edge_object.Label))
     if not hasattr(edge_object, "Shape"):
         _err(translate("draft","Wrong input: object doesn't have a 'Shape' to measure."))
         return None
@@ -454,7 +440,6 @@ def make_radial_dimension_obj(edge_object, index=1, mode="radius",
         _err(translate("draft","Wrong input: object doesn't have at least one element in 'Edges' to use for measuring."))
         return None
 
-    _msg("index: {}".format(index))
     try:
         utils.type_check([(index, int)], name=_name)
     except TypeError:
@@ -474,7 +459,6 @@ def make_radial_dimension_obj(edge_object, index=1, mode="radius",
         _err(translate("draft","Wrong input: index doesn't correspond to a circular edge."))
         return None
 
-    _msg("mode: {}".format(mode))
     try:
         utils.type_check([(mode, str)], name=_name)
     except TypeError:
@@ -485,7 +469,6 @@ def make_radial_dimension_obj(edge_object, index=1, mode="radius",
         _err(translate("draft","Wrong input: must be a string, 'radius' or 'diameter'."))
         return None
 
-    _msg("dim_line: {}".format(dim_line))
     if dim_line:
         try:
             utils.type_check([(dim_line, App.Vector)], name=_name)
@@ -548,7 +531,6 @@ def make_angular_dimension(center=App.Vector(0, 0, 0),
         If there is a problem it will return `None`.
     """
     _name = "make_angular_dimension"
-    utils.print_header(_name, "Angular dimension")
 
     # Prevent later modification of a default parameter by using a placeholder
     if angles is None:
@@ -559,14 +541,12 @@ def make_angular_dimension(center=App.Vector(0, 0, 0),
         _err(translate("draft","No active document. Aborting."))
         return None
 
-    _msg("center: {}".format(center))
     try:
         utils.type_check([(center, App.Vector)], name=_name)
     except TypeError:
         _err(translate("draft","Wrong input: must be a vector."))
         return None
 
-    _msg("angles: {}".format(angles))
     try:
         utils.type_check([(angles, (tuple, list))], name=_name)
 
@@ -587,14 +567,12 @@ def make_angular_dimension(center=App.Vector(0, 0, 0),
         if angles[n] > 360:
             angles[n] = angles[n] - 360
 
-    _msg("dim_line: {}".format(dim_line))
     try:
         utils.type_check([(dim_line, App.Vector)], name=_name)
     except TypeError:
         _err(translate("draft","Wrong input: must be a vector."))
         return None
 
-    _msg("normal: {}".format(normal))
     if normal:
         try:
             utils.type_check([(dim_line, App.Vector)], name=_name)

--- a/src/Mod/Draft/draftmake/make_fillet.py
+++ b/src/Mod/Draft/draftmake/make_fillet.py
@@ -34,7 +34,7 @@ import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
 import draftobjects.fillet as fillet
 
-from draftutils.messages import _msg, _err
+from draftutils.messages import _err
 from draftutils.translate import translate
 
 if App.GuiUp:
@@ -46,17 +46,6 @@ DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
 ## \addtogroup draftmake
 # @{
-
-
-def _print_obj_length(obj, edge, num=1):
-    if hasattr(obj, "Label"):
-        name = obj.Label
-    else:
-        name = num
-
-    _msg("({0}): {1}; {2} {3}".format(num, name,
-                                      translate("draft","length:"), edge.Length))
-
 
 def _extract_edges(objs):
     """Extract the edges from the list of objects, Draft lines or Part.Edges.
@@ -79,8 +68,6 @@ def _extract_edges(objs):
         if o1.ShapeType in "Edge":
             e1 = o1
 
-    _print_obj_length(o1, e1, num=1)
-
     if hasattr(o2, "PropertiesList"):
         if "Proxy" in o2.PropertiesList:
             if hasattr(o2.Proxy, "Type"):
@@ -92,8 +79,6 @@ def _extract_edges(objs):
     elif hasattr(o2, "ShapeType"):
         if o2.ShapeType in "Edge":
             e2 = o2
-
-    _print_obj_length(o2, e2, num=2)
 
     return e1, e2
 
@@ -126,7 +111,6 @@ def make_fillet(objs, radius=100, chamfer=False, delete=False):
         It returns `None` if it fails producing the object.
     """
     _name = "make_fillet"
-    utils.print_header(_name, "Fillet")
 
     if len(objs) != 2:
         _err(translate("draft","Two elements are needed."))
@@ -138,11 +122,6 @@ def make_fillet(objs, radius=100, chamfer=False, delete=False):
     if len(edges) < 3:
         _err(translate("draft","Radius is too large") + ", r={}".format(radius))
         return None
-
-    lengths = [edges[0].Length, edges[1].Length, edges[2].Length]
-    _msg(translate("draft","Segment") + " 1, " + translate("draft","length:") + " {}".format(lengths[0]))
-    _msg(translate("draft","Segment") + " 2, " + translate("draft","length:") + " {}".format(lengths[1]))
-    _msg(translate("draft","Segment") + " 3, " + translate("draft","length:") + " {}".format(lengths[2]))
 
     try:
         wire = Part.Wire(edges)
@@ -162,7 +141,6 @@ def make_fillet(objs, radius=100, chamfer=False, delete=False):
     if delete:
         _doc.removeObject(objs[0].Name)
         _doc.removeObject(objs[1].Name)
-        _msg(translate("draft","Removed original objects."))
 
     if App.GuiUp:
         view_fillet.ViewProviderFillet(obj.ViewObject)

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -35,7 +35,7 @@ from draftobjects import label
 from draftutils import gui_utils
 from draftutils import params
 from draftutils import utils
-from draftutils.messages import _msg, _wrn, _err
+from draftutils.messages import _wrn, _err
 from draftutils.translate import translate
 
 if App.GuiUp:
@@ -188,14 +188,12 @@ def make_label(target_point=App.Vector(0, 0, 0),
         If there is a problem it will return `None`.
     """
     _name = "make_label"
-    utils.print_header(_name, "Label")
 
     found, doc = utils.find_doc(App.activeDocument())
     if not found:
         _err(translate("draft","No active document. Aborting."))
         return None
 
-    _msg("target_point: {}".format(target_point))
     if not target_point:
         target_point = App.Vector(0, 0, 0)
     try:
@@ -204,7 +202,6 @@ def make_label(target_point=App.Vector(0, 0, 0),
         _err(translate("draft","Wrong input: must be a vector."))
         return None
 
-    _msg("placement: {}".format(placement))
     if not placement:
         placement = App.Placement()
     try:
@@ -226,20 +223,16 @@ def make_label(target_point=App.Vector(0, 0, 0),
 
     if target_object:
         if isinstance(target_object, (list, tuple)):
-            _msg("target_object: {}".format(target_object))
-            _err(translate("draft","Wrong input: object must not be a list."))
+            _err(translate("draft","Wrong input: target_object {} must not be a list.").format(target_object))
             return None
 
         found, target_object = utils.find_object(target_object, doc)
         if not found:
-            _msg("target_object: {}".format(target_object_str))
-            _err(translate("draft","Wrong input: object not in document."))
+            _err(translate("draft","Wrong input: target_object {} not in document.").format(target_object_str))
             return None
 
-        _msg("target_object: {}".format(target_object.Label))
 
     if target_object and subelements:
-        _msg("subelements: {}".format(subelements))
         try:
             # Make a list
             if isinstance(subelements, str):
@@ -248,7 +241,7 @@ def make_label(target_point=App.Vector(0, 0, 0),
             utils.type_check([(subelements, (list, tuple, str))],
                              name=_name)
         except TypeError:
-            _err(translate("draft","Wrong input: must be a list or tuple of strings, or a single string."))
+            _err(translate("draft","Wrong input: subelements must be a list or tuple of strings, or a single string."))
             return None
 
         # The subelements list is used to build a special list
@@ -259,11 +252,9 @@ def make_label(target_point=App.Vector(0, 0, 0),
         for sub in subelements:
             _sub = target_object.getSubObject(sub)
             if not _sub:
-                _err("subelement: {}".format(sub))
-                _err(translate("draft","Wrong input: subelement not in object."))
+                _err(translate("draft","Wrong input: subelement {} not in object.").format(sub))
                 return None
 
-    _msg("label_type: {}".format(label_type))
     if not label_type:
         label_type = "Custom"
     try:
@@ -277,7 +268,6 @@ def make_label(target_point=App.Vector(0, 0, 0),
         _err(translate("draft", "Wrong input: label_type must be one of the following: ") + str(types).strip("[]"))
         return None
 
-    _msg("custom_text: {}".format(custom_text))
     if not custom_text:
         custom_text = "Label"
     try:
@@ -291,7 +281,6 @@ def make_label(target_point=App.Vector(0, 0, 0),
         _err(translate("draft","Wrong input: must be a list of strings or a single string."))
         return None
 
-    _msg("direction: {}".format(direction))
     if not direction:
         direction = "Horizontal"
     try:
@@ -304,7 +293,6 @@ def make_label(target_point=App.Vector(0, 0, 0),
         _err(translate("draft","Wrong input: must be a string, 'Horizontal', 'Vertical', or 'Custom'."))
         return None
 
-    _msg("distance: {}".format(distance))
     if not distance:
         distance = 1
     try:
@@ -314,9 +302,7 @@ def make_label(target_point=App.Vector(0, 0, 0),
         return None
 
     if points:
-        _msg("points: {}".format(points))
-
-        _err_msg = translate("draft","Wrong input: must be a list of at least two vectors.")
+        _err_msg = translate("draft","Wrong input: points {} must be a list of at least two vectors.").format(points)
         try:
             utils.type_check([(points, (tuple, list))], name=_name)
         except TypeError:

--- a/src/Mod/Draft/draftmake/make_layer.py
+++ b/src/Mod/Draft/draftmake/make_layer.py
@@ -31,7 +31,7 @@
 import FreeCAD as App
 from draftobjects.layer import Layer, LayerContainer
 from draftutils import utils
-from draftutils.messages import _msg, _err
+from draftutils.messages import _err
 from draftutils.translate import translate
 
 if App.GuiUp:

--- a/src/Mod/Draft/draftmake/make_orthoarray.py
+++ b/src/Mod/Draft/draftmake/make_orthoarray.py
@@ -31,7 +31,7 @@ import FreeCAD as App
 import draftutils.utils as utils
 import draftmake.make_array as make_array
 
-from draftutils.messages import _msg, _wrn, _err
+from draftutils.messages import _wrn, _err
 from draftutils.translate import translate
 
 
@@ -57,7 +57,6 @@ def _make_ortho_array(base_object,
     This should be handled by the subfunctions that use this one.
     """
     _name = "_make_ortho_array"
-    utils.print_header(_name, translate("draft","Internal orthogonal array"), debug=False)
 
     new_obj = make_array.make_array(base_object,
                                     arg1=v_x, arg2=v_y, arg3=v_z,
@@ -68,11 +67,6 @@ def _make_ortho_array(base_object,
 
 def _are_vectors(v_x, v_y, v_z=None, name="Unknown"):
     """Check that the vectors are numbers."""
-    _msg("v_x: {}".format(v_x))
-    _msg("v_y: {}".format(v_y))
-    if v_z:
-        _msg("v_z: {}".format(v_z))
-
     try:
         if v_z:
             utils.type_check([(v_x, (int, float, App.Vector)),
@@ -102,11 +96,6 @@ def _are_vectors(v_x, v_y, v_z=None, name="Unknown"):
 
 def _are_integers(n_x, n_y, n_z=None, name="Unknown"):
     """Check that the numbers are integers, with minimum value of 1."""
-    _msg("n_x: {}".format(n_x))
-    _msg("n_y: {}".format(n_y))
-    if n_z:
-        _msg("n_z: {}".format(n_z))
-
     try:
         if n_z:
             utils.type_check([(n_x, int),
@@ -134,11 +123,6 @@ def _are_integers(n_x, n_y, n_z=None, name="Unknown"):
 
 def _are_numbers(d_x, d_y, d_z=None, name="Unknown"):
     """Check that the numbers are numbers."""
-    _msg("d_x: {}".format(d_x))
-    _msg("d_y: {}".format(d_y))
-    if d_z:
-        _msg("d_z: {}".format(d_z))
-
     try:
         if d_z:
             utils.type_check([(d_x, (int, float)),
@@ -163,11 +147,8 @@ def _find_object_in_doc(base_object, doc=None):
     found, base_object = utils.find_object(base_object,
                                            doc=doc)
     if not found:
-        _msg("base_object: {}".format(base_object_str))
-        _err(translate("draft","Wrong input: object not in document."))
+        _err(translate("draft","Wrong input: base_object {} not in document.").format(base_object_str))
         return not FOUND, base_object
-
-    _msg("base_object: {}".format(base_object.Label))
 
     return FOUND, base_object
 
@@ -272,7 +253,6 @@ def make_ortho_array(base_object,
     make_circular_array, make_path_array, make_point_array
     """
     _name = "make_ortho_array"
-    utils.print_header(_name, translate("draft","Orthogonal array"))
 
     found, base_object = _find_object_in_doc(base_object,
                                              doc=App.activeDocument())
@@ -288,7 +268,6 @@ def make_ortho_array(base_object,
         return None
 
     use_link = bool(use_link)
-    _msg("use_link: {}".format(use_link))
 
     new_obj = _make_ortho_array(base_object,
                                 v_x=v_x, v_y=v_y, v_z=v_z,
@@ -347,7 +326,6 @@ def make_ortho_array2d(base_object,
     make_circular_array, make_path_array, make_point_array
     """
     _name = "make_ortho_array2d"
-    utils.print_header(_name, translate("draft","Orthogonal array 2D"))
 
     found, base_object = _find_object_in_doc(base_object,
                                              doc=App.activeDocument())
@@ -363,7 +341,6 @@ def make_ortho_array2d(base_object,
         return None
 
     use_link = bool(use_link)
-    _msg("use_link: {}".format(use_link))
 
     new_obj = _make_ortho_array(base_object,
                                 v_x=v_x, v_y=v_y,
@@ -421,7 +398,6 @@ def make_rect_array(base_object,
     make_circular_array, make_path_array, make_point_array
     """
     _name = "make_rect_array"
-    utils.print_header(_name, translate("draft","Rectangular array"))
 
     found, base_object = _find_object_in_doc(base_object,
                                              doc=App.activeDocument())
@@ -437,7 +413,6 @@ def make_rect_array(base_object,
         return None
 
     use_link = bool(use_link)
-    _msg("use_link: {}".format(use_link))
 
     new_obj = _make_ortho_array(base_object,
                                 v_x=App.Vector(d_x, 0, 0),
@@ -498,7 +473,6 @@ def make_rect_array2d(base_object,
     make_circular_array, make_path_array, make_point_array
     """
     _name = "make_rect_array2d"
-    utils.print_header(_name, translate("draft","Rectangular array 2D"))
 
     found, base_object = _find_object_in_doc(base_object,
                                              doc=App.activeDocument())
@@ -514,7 +488,6 @@ def make_rect_array2d(base_object,
         return None
 
     use_link = bool(use_link)
-    _msg("use_link: {}".format(use_link))
 
     new_obj = _make_ortho_array(base_object,
                                 v_x=App.Vector(d_x, 0, 0),

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -40,7 +40,7 @@ import FreeCAD as App
 import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
 
-from draftutils.messages import _msg, _err
+from draftutils.messages import _err
 from draftutils.translate import translate
 from draftobjects.patharray import PathArray
 from draftobjects.pathtwistedarray import PathTwistedArray
@@ -164,7 +164,6 @@ def make_path_array(base_object, path_object, count=4,
         If there is a problem it will return `None`.
     """
     _name = "make_path_array"
-    utils.print_header(_name, "Path array")
 
     found, doc = utils.find_doc(App.activeDocument())
     if not found:
@@ -176,24 +175,17 @@ def make_path_array(base_object, path_object, count=4,
 
     found, base_object = utils.find_object(base_object, doc)
     if not found:
-        _msg("base_object: {}".format(base_object_str))
-        _err(translate("draft","Wrong input: object not in document."))
+        _err(translate("draft","Wrong input: base_object {} not in document.").format(base_object_str))
         return None
-
-    _msg("base_object: {}".format(base_object.Label))
 
     if isinstance(path_object, str):
         path_object_str = path_object
 
     found, path_object = utils.find_object(path_object, doc)
     if not found:
-        _msg("path_object: {}".format(path_object_str))
-        _err(translate("draft","Wrong input: object not in document."))
+        _err(translate("draft","Wrong input: path_object not in document.").format(path_object_str))
         return None
 
-    _msg("path_object: {}".format(path_object.Label))
-
-    _msg("count: {}".format(count))
     try:
         utils.type_check([(count, (int, float))],
                          name=_name)
@@ -202,7 +194,6 @@ def make_path_array(base_object, path_object, count=4,
         return None
     count = int(count)
 
-    _msg("extra: {}".format(extra))
     try:
         utils.type_check([(extra, App.Vector)],
                          name=_name)
@@ -210,7 +201,6 @@ def make_path_array(base_object, path_object, count=4,
         _err(translate("draft","Wrong input: must be a vector."))
         return None
 
-    _msg("subelements: {}".format(subelements))
     if subelements:
         try:
             # Make a list
@@ -243,9 +233,7 @@ def make_path_array(base_object, path_object, count=4,
         sub_list = None
 
     align = bool(align)
-    _msg("align: {}".format(align))
 
-    _msg("align_mode: {}".format(align_mode))
     try:
         utils.type_check([(align_mode, str)],
                          name=_name)
@@ -256,7 +244,6 @@ def make_path_array(base_object, path_object, count=4,
         _err(translate("draft","Wrong input: must be 'Original', 'Frenet', or 'Tangent'."))
         return None
 
-    _msg("tan_vector: {}".format(tan_vector))
     try:
         utils.type_check([(tan_vector, App.Vector)],
                          name=_name)
@@ -265,9 +252,6 @@ def make_path_array(base_object, path_object, count=4,
         return None
 
     force_vertical = bool(force_vertical)
-    _msg("force_vertical: {}".format(force_vertical))
-
-    _msg("vertical_vector: {}".format(vertical_vector))
     try:
         utils.type_check([(vertical_vector, App.Vector)],
                          name=_name)
@@ -275,7 +259,6 @@ def make_path_array(base_object, path_object, count=4,
         _err(translate("draft","Wrong input: must be a vector."))
         return None
 
-    _msg("start_offset: {}".format(start_offset))
     try:
         utils.type_check([(start_offset, (int, float))],
                          name=_name)
@@ -284,7 +267,6 @@ def make_path_array(base_object, path_object, count=4,
         return None
     start_offset = float(start_offset)
 
-    _msg("end_offset: {}".format(end_offset))
     try:
         utils.type_check([(end_offset, (int, float))],
                          name=_name)
@@ -294,7 +276,6 @@ def make_path_array(base_object, path_object, count=4,
     end_offset = float(end_offset)
 
     use_link = bool(use_link)
-    _msg("use_link: {}".format(use_link))
 
     if use_link:
         # The PathArray class must be called in this special way
@@ -351,7 +332,6 @@ def make_path_twisted_array(base_object, path_object,
                             use_link=True):
     """Create a Path twisted array."""
     _name = "make_path_twisted_array"
-    utils.print_header(_name, "Path twisted array")
 
     found, doc = utils.find_doc(App.activeDocument())
     if not found:
@@ -363,24 +343,16 @@ def make_path_twisted_array(base_object, path_object,
 
     found, base_object = utils.find_object(base_object, doc)
     if not found:
-        _msg("base_object: {}".format(base_object_str))
-        _err(translate("draft","Wrong input: object not in document."))
+        _err(translate("draft","Wrong input: base_object not in document.").format(base_object_str))
         return None
-
-    _msg("base_object: {}".format(base_object.Label))
 
     if isinstance(path_object, str):
         path_object_str = path_object
 
     found, path_object = utils.find_object(path_object, doc)
     if not found:
-        _msg("path_object: {}".format(path_object_str))
-        _err(translate("draft","Wrong input: object not in document."))
+        _err(translate("draft","Wrong input: path_object not in document.").format(path_object_str))
         return None
-
-    _msg("path_object: {}".format(path_object.Label))
-
-    _msg("count: {}".format(count))
     try:
         utils.type_check([(count, (int, float))],
                          name=_name)
@@ -390,8 +362,6 @@ def make_path_twisted_array(base_object, path_object,
     count = int(count)
 
     use_link = bool(use_link)
-    _msg("use_link: {}".format(use_link))
-
     if use_link:
         # The PathTwistedArray class must be called in this special way
         # to make it a PathTwistLinkArray

--- a/src/Mod/Draft/draftmake/make_pointarray.py
+++ b/src/Mod/Draft/draftmake/make_pointarray.py
@@ -38,7 +38,7 @@ import FreeCAD as App
 import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
 
-from draftutils.messages import _msg, _err
+from draftutils.messages import _err
 from draftutils.translate import translate
 from draftobjects.pointarray import PointArray
 
@@ -84,7 +84,6 @@ def make_point_array(base_object, point_object, extra=None, use_link=True):
         If there is a problem it will return `None`.
     """
     _name = "make_point_array"
-    utils.print_header(_name, "Point array")
 
     found, doc = utils.find_doc(App.activeDocument())
     if not found:
@@ -96,31 +95,26 @@ def make_point_array(base_object, point_object, extra=None, use_link=True):
 
     found, base_object = utils.find_object(base_object, doc)
     if not found:
-        _msg("base_object: {}".format(base_object_str))
-        _err(translate("draft", "Wrong input: object not in document."))
+        _err(translate("draft", "Wrong input: base_object {} not in document.").format(base_object_str))
         return None
-
-    _msg("base_object: {}".format(base_object.Label))
 
     if isinstance(point_object, str):
         point_object_str = point_object
 
     found, point_object = utils.find_object(point_object, doc)
     if not found:
-        _msg("point_object: {}".format(point_object_str))
-        _err(translate("draft", "Wrong input: object not in document."))
+        _err(translate("draft", "Wrong input: point_object {} not in document.").format(point_object_str))
         return None
 
-    _msg("point_object: {}".format(point_object.Label))
     if not ((hasattr(point_object, "Shape") and hasattr(point_object.Shape, "Vertexes"))
             or hasattr(point_object, "Mesh")
             or hasattr(point_object, "Points")):
         _err(translate("draft", "Wrong input: object has the wrong type."))
         return None
 
-    _msg("extra: {}".format(extra))
     if not extra:
         extra = App.Placement()
+
     try:
         utils.type_check([(extra, (App.Placement,
                                    App.Vector,

--- a/src/Mod/Draft/draftmake/make_polararray.py
+++ b/src/Mod/Draft/draftmake/make_polararray.py
@@ -31,7 +31,7 @@ import FreeCAD as App
 import draftutils.utils as utils
 import draftmake.make_array as make_array
 
-from draftutils.messages import _msg, _err
+from draftutils.messages import _err
 from draftutils.translate import translate
 
 
@@ -91,7 +91,6 @@ def make_polar_array(base_object,
     make_ortho_array, make_circular_array, make_path_array, make_point_array
     """
     _name = "make_polar_array"
-    utils.print_header(_name, translate("draft","Polar array"))
 
     if isinstance(base_object, str):
         base_object_str = base_object
@@ -99,27 +98,21 @@ def make_polar_array(base_object,
     found, base_object = utils.find_object(base_object,
                                            doc=App.activeDocument())
     if not found:
-        _msg("base_object: {}".format(base_object_str))
-        _err(translate("draft","Wrong input: object not in document."))
+        _err(translate("draft","Wrong input: base_object {} not in document.").format(base_object_str))
         return None
 
-    _msg("base_object: {}".format(base_object.Label))
-
-    _msg("number: {}".format(number))
     try:
         utils.type_check([(number, int)], name=_name)
     except TypeError:
         _err(translate("draft","Wrong input: must be an integer number."))
         return None
 
-    _msg("angle: {}".format(angle))
     try:
         utils.type_check([(angle, (int, float))], name=_name)
     except TypeError:
         _err(translate("draft","Wrong input: must be a number."))
         return None
 
-    _msg("center: {}".format(center))
     try:
         utils.type_check([(center, App.Vector)], name=_name)
     except TypeError:
@@ -127,8 +120,6 @@ def make_polar_array(base_object,
         return None
 
     use_link = bool(use_link)
-    _msg("use_link: {}".format(use_link))
-
     new_obj = make_array.make_array(base_object,
                                     arg1=center, arg2=angle, arg3=number,
                                     use_link=use_link)

--- a/src/Mod/Draft/draftmake/make_text.py
+++ b/src/Mod/Draft/draftmake/make_text.py
@@ -33,7 +33,7 @@ import FreeCAD as App
 import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
 
-from draftutils.messages import _msg, _err
+from draftutils.messages import _err
 from draftutils.translate import translate
 from draftobjects.text import Text
 
@@ -86,14 +86,12 @@ def make_text(string, placement=None, screen=False, height=None, line_spacing=1)
         If there is a problem it will return `None`.
     """
     _name = "make_text"
-    utils.print_header(_name, "Text")
 
     found, doc = utils.find_doc(App.activeDocument())
     if not found:
         _err(translate("draft","No active document. Aborting."))
         return None
 
-    _msg("string: {}".format(string))
     try:
         utils.type_check([(string, (str, list))], name=_name)
     except TypeError:
@@ -105,7 +103,6 @@ def make_text(string, placement=None, screen=False, height=None, line_spacing=1)
         _err(translate("draft","Wrong input: must be a list of strings or a single string."))
         return None
 
-    _msg("placement: {}".format(placement))
     if not placement:
         placement = App.Placement()
     try:
@@ -175,7 +172,6 @@ def convert_draft_texts(textslist=None):
         If it is `None` it will convert all objects in the current document.
     """
     _name = "convert_draft_texts"
-    utils.print_header(_name, "Convert Draft texts")
 
     found, doc = utils.find_doc(App.activeDocument())
     if not found:

--- a/src/Mod/Draft/draftobjects/fillet.py
+++ b/src/Mod/Draft/draftobjects/fillet.py
@@ -30,7 +30,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 import draftobjects.base as base
 
-from draftutils.messages import _msg
+from draftutils.messages import _err
 
 
 class Fillet(base.DraftObject):
@@ -110,11 +110,10 @@ class Fillet(base.DraftObject):
             obj.End = obj.Shape.Vertexes[-1].Point
 
     def _update_radius(self, obj, radius):
-        if (hasattr(obj, "Line1") and hasattr(obj, "Line2")
-                and obj.Line1 and obj.Line2):
-            _msg("Recalculate the radius with objects.")
-
-        _msg("Update radius currently not implemented: r={}".format(radius))
+        #if (hasattr(obj, "Line1") and hasattr(obj, "Line2")
+        #        and obj.Line1 and obj.Line2):
+        # do the unimplemented work
+        _err("Update radius currently not implemented: r={}".format(radius))
 
     def onChanged(self, obj, prop):
         """Change the radius of fillet. NOT IMPLEMENTED.

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -67,7 +67,7 @@ import FreeCAD as App
 import DraftVecUtils
 import lazy_loader.lazy_loader as lz
 
-from draftutils.messages import _msg, _wrn, _err
+from draftutils.messages import _wrn, _err
 from draftutils.translate import translate
 def QT_TRANSLATE_NOOP(ctx,txt): return txt
 from draftobjects.base import DraftObject
@@ -578,7 +578,7 @@ def calculate_placement(globalRotation,
         newRot = App.Rotation(t, n, nullv, "XYZ") # priority = "XYZ"
 
     else:
-        _msg(translate("draft", "AlignMode {} is not implemented").format(mode))
+        _err(translate("draft", "AlignMode {} is not implemented").format(mode))
         return placement
 
     placement.Rotation = newRot.multiply(globalRotation)

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -191,7 +191,6 @@ class TaskPanelCircularArray:
         if self.valid_input:
             self.create_object()
             # The internal function already displays messages
-            # self.print_messages()
             self.finish()
 
     def validate_input(self, selection,
@@ -326,10 +325,6 @@ class TaskPanelCircularArray:
         self.form.input_c_z.setProperty('rawValue', 0)
 
         self.center = self.get_center()
-        _msg(translate("draft","Center reset:")
-             + " ({0}, {1}, {2})".format(self.center.x,
-                                         self.center.y,
-                                         self.center.z))
 
     def print_fuse_state(self, fuse):
         """Print the fuse state translated."""
@@ -342,7 +337,6 @@ class TaskPanelCircularArray:
     def set_fuse(self):
         """Execute as a callback when the fuse checkbox changes."""
         self.fuse = self.form.checkbox_fuse.isChecked()
-        self.print_fuse_state(self.fuse)
         params.set_param("Draft_array_fuse", self.fuse)
 
     def print_link_state(self, use_link):
@@ -356,8 +350,8 @@ class TaskPanelCircularArray:
     def set_link(self):
         """Execute as a callback when the link checkbox changes."""
         self.use_link = self.form.checkbox_link.isChecked()
-        self.print_link_state(self.use_link)
         params.set_param("Draft_array_Link", self.use_link)
+
 
     def print_messages(self):
         """Print messages about the operation."""
@@ -475,7 +469,6 @@ class TaskPanelCircularArray:
 
     def reject(self):
         """Execute when clicking the Cancel button or pressing Escape."""
-        _msg(translate("draft","Aborted:") + " {}".format(translate("draft","Circular array")))
         self.finish()
 
     def finish(self):

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -185,7 +185,6 @@ class TaskPanelOrthoArray:
         if self.valid_input:
             self.create_object()
             # The internal function already displays messages
-            # self.print_messages()
             self.finish()
 
     def validate_input(self, selection,
@@ -311,28 +310,16 @@ class TaskPanelOrthoArray:
             self.form.input_X_y.setProperty('rawValue', 0)
             self.form.input_X_z.setProperty('rawValue', 0)
             self.v_x, self.v_y, self.v_z = self.get_intervals()
-            _msg(translate("draft","Interval X reset:")
-                 + " ({0}, {1}, {2})".format(self.v_x.x,
-                                             self.v_x.y,
-                                             self.v_x.z))
         elif interval == "Y":
             self.form.input_Y_x.setProperty('rawValue', 0)
             self.form.input_Y_y.setProperty('rawValue', 100)
             self.form.input_Y_z.setProperty('rawValue', 0)
             self.v_x, self.v_y, self.v_z = self.get_intervals()
-            _msg(translate("draft","Interval Y reset:")
-                 + " ({0}, {1}, {2})".format(self.v_y.x,
-                                             self.v_y.y,
-                                             self.v_y.z))
         elif interval == "Z":
             self.form.input_Z_x.setProperty('rawValue', 0)
             self.form.input_Z_y.setProperty('rawValue', 0)
             self.form.input_Z_z.setProperty('rawValue', 100)
             self.v_x, self.v_y, self.v_z = self.get_intervals()
-            _msg(translate("draft","Interval Z reset:")
-                 + " ({0}, {1}, {2})".format(self.v_z.x,
-                                             self.v_z.y,
-                                             self.v_z.z))
 
     def print_fuse_state(self, fuse):
         """Print the fuse state translated."""
@@ -345,7 +332,6 @@ class TaskPanelOrthoArray:
     def set_fuse(self):
         """Execute as a callback when the fuse checkbox changes."""
         self.fuse = self.form.checkbox_fuse.isChecked()
-        self.print_fuse_state(self.fuse)
         params.set_param("Draft_array_fuse", self.fuse)
 
     def print_link_state(self, use_link):
@@ -359,7 +345,6 @@ class TaskPanelOrthoArray:
     def set_link(self):
         """Execute as a callback when the link checkbox changes."""
         self.use_link = self.form.checkbox_link.isChecked()
-        self.print_link_state(self.use_link)
         params.set_param("Draft_array_Link", self.use_link)
 
     def print_messages(self):
@@ -392,7 +377,6 @@ class TaskPanelOrthoArray:
 
     def reject(self):
         """Execute when clicking the Cancel button or pressing Escape."""
-        _msg(translate("draft","Aborted:") + " {}".format(translate("draft","Orthogonal array")))
         self.finish()
 
     def finish(self):

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -281,10 +281,6 @@ class TaskPanelPolarArray:
         self.form.input_c_z.setProperty('rawValue', 0)
 
         self.center = self.get_center()
-        _msg(translate("draft","Center reset:")
-             + " ({0}, {1}, {2})".format(self.center.x,
-                                         self.center.y,
-                                         self.center.z))
 
     def print_fuse_state(self, fuse):
         """Print the fuse state translated."""
@@ -297,7 +293,6 @@ class TaskPanelPolarArray:
     def set_fuse(self):
         """Execute as a callback when the fuse checkbox changes."""
         self.fuse = self.form.checkbox_fuse.isChecked()
-        self.print_fuse_state(self.fuse)
         params.set_param("Draft_array_fuse", self.fuse)
 
     def print_link_state(self, use_link):
@@ -311,7 +306,6 @@ class TaskPanelPolarArray:
     def set_link(self):
         """Execute as a callback when the link checkbox changes."""
         self.use_link = self.form.checkbox_link.isChecked()
-        self.print_link_state(self.use_link)
         params.set_param("Draft_array_Link", self.use_link)
 
     def print_messages(self):
@@ -428,7 +422,6 @@ class TaskPanelPolarArray:
 
     def reject(self):
         """Execute when clicking the Cancel button or pressing Escape."""
-        _msg(translate("draft","Aborted:") + " {}".format(translate("draft","Polar array")))
         self.finish()
 
     def finish(self):

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -35,7 +35,7 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Draft_rc
 from draftguitools import gui_tool_utils
-from draftutils.messages import _err, _msg
+from draftutils.messages import _err
 from draftutils.params import get_param
 from draftutils.translate import translate
 from DraftVecUtils import toString

--- a/src/Mod/Draft/draftutils/groups.py
+++ b/src/Mod/Draft/draftutils/groups.py
@@ -38,7 +38,7 @@ import FreeCAD as App
 import draftutils.utils as utils
 
 from draftutils.translate import translate
-from draftutils.messages import _msg, _err
+from draftutils.messages import _err
 
 
 def is_group(obj):
@@ -128,8 +128,7 @@ def ungroup(obj):
 
     found, obj = utils.find_object(obj, doc=App.activeDocument())
     if not found:
-        _msg("obj: {}".format(obj_str))
-        _err(translate("draft", "Wrong input: object not in document."))
+        _err(translate("draft", "Wrong input: object {} not in document.").format(obj_str))
         return None
 
     doc = obj.Document

--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -42,7 +42,7 @@ import os
 import FreeCAD as App
 from draftutils import params
 from draftutils import utils
-from draftutils.messages import _err, _msg, _wrn
+from draftutils.messages import _err, _wrn
 from draftutils.translate import translate
 
 if App.GuiUp:
@@ -328,7 +328,6 @@ def remove_hidden(objectslist):
         if obj.ViewObject:
             if not obj.ViewObject.isVisible():
                 newlist.remove(obj)
-                _msg(translate("draft", "Visibility off; removed from list: ") + obj.Label)
     return newlist
 
 
@@ -821,7 +820,6 @@ def get_bbox(obj, debug=False):
         If there is a problem it will return `None`.
     """
     _name = "get_bbox"
-    utils.print_header(_name, "Bounding box", debug=debug)
 
     found, doc = utils.find_doc(App.activeDocument())
     if not found:
@@ -833,12 +831,8 @@ def get_bbox(obj, debug=False):
 
     found, obj = utils.find_object(obj, doc)
     if not found:
-        _msg("obj: {}".format(obj_str))
-        _err(translate("draft", "Wrong input: object not in document."))
+        _err(translate("draft", "Wrong input: object {} not in document.").format(obj_str))
         return None
-
-    if debug:
-        _msg("obj: {}".format(obj.Label))
 
     if (not hasattr(obj, "ViewObject")
             or not obj.ViewObject

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -40,7 +40,7 @@ import PySide.QtCore as QtCore
 
 import FreeCAD as App
 from draftutils import params
-from draftutils.messages import _msg, _wrn, _err, _log
+from draftutils.messages import  _wrn, _err, _log
 from draftutils.translate import translate
 
 # TODO: move the functions that require the graphical interface
@@ -1029,8 +1029,7 @@ def find_doc(doc=None):
         try:
             doc = App.getDocument(doc)
         except NameError:
-            _msg("document: {}".format(doc))
-            _err(translate("draft", "Wrong input: unknown document."))
+            _err(translate("draft", "Wrong input: unknown document {}").format(doc))
             return not FOUND, None
 
     return FOUND, doc

--- a/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
+++ b/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
@@ -50,7 +50,6 @@ import FreeCAD as App
 import FreeCADGui as Gui
 from draftutils import params
 from draftutils import utils
-from draftutils.messages import _msg
 from draftutils.translate import translate
 
 
@@ -196,8 +195,6 @@ class ViewProviderDraftAnnotation(object):
         if prop == "AnnotationStyle" and "AnnotationStyle" in properties:
             if not vobj.AnnotationStyle or vobj.AnnotationStyle == "":
                 # unset style
-                _msg(16 * "-")
-                _msg("Unset style")
                 for visprop in utils.get_default_annotation_style().keys():
                     if visprop in properties:
                         # make property writable
@@ -210,8 +207,6 @@ class ViewProviderDraftAnnotation(object):
                         styles[key[12:]] = json.loads(value)
 
                 if vobj.AnnotationStyle in styles:
-                    _msg(16 * "-")
-                    _msg("Style: {}".format(vobj.AnnotationStyle))
                     style = styles[vobj.AnnotationStyle]
                     for visprop in style.keys():
                         if visprop in properties:
@@ -222,7 +217,6 @@ class ViewProviderDraftAnnotation(object):
                                 if vobj.getTypeIdOfProperty(visprop) == "App::PropertyColor":
                                     value = value & 0xFFFFFF00
                                 setattr(vobj, visprop, value)
-                                _msg("setattr: '{}', '{}'".format(visprop, value))
                             except:
                                 pass
 

--- a/src/Mod/Draft/draftviewproviders/view_layer.py
+++ b/src/Mod/Draft/draftviewproviders/view_layer.py
@@ -39,7 +39,6 @@ import FreeCADGui as Gui
 from draftobjects.layer import Layer
 from draftutils import params
 from draftutils import utils
-from draftutils.messages import _msg
 from draftutils.translate import translate
 
 
@@ -539,12 +538,9 @@ class ViewProviderLayerContainer:
                     base.Group = base_group
                 to_delete.append(layer)
             elif layer.Label != base_label:
-                _msg(translate("draft", "Relabeling layer:")
-                        + " '{}' -> '{}'".format(layer.Label, base_label))
                 layer.Label = base_label
 
         for layer in to_delete:
-            _msg(translate("draft", "Merging layer:") + " '{}'".format(layer.Label))
             doc.removeObject(layer.Name)
 
         doc.recompute()

--- a/src/Mod/Draft/draftviewproviders/view_wire.py
+++ b/src/Mod/Draft/draftviewproviders/view_wire.py
@@ -44,7 +44,6 @@ from draftgeoutils import wires
 from draftutils import gui_utils
 from draftutils import params
 from draftutils import utils
-from draftutils.messages import _msg
 from draftutils.translate import translate
 from draftviewproviders.view_base import ViewProviderDraft
 

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -223,9 +223,9 @@ def deformat(text):
     # t = re.sub('{([^!}]([^}]|\n)*)}', '', text)
     # print("input text: ",text)
     t = text.strip("{}")
-    t = re.sub("\\\.*?;", "", t)
+    t = re.sub("\\\\.*?;", "", t)
     # replace UTF codes by utf chars
-    sts = re.split("\\\\(U\+....)", t)
+    sts = re.split("\\\\(U\\+....)", t)
     t = u"".join(sts)
     # replace degrees, diameters chars
     t = re.sub('%%d', u'°', t)
@@ -3925,7 +3925,7 @@ def exportPage(page, filename):
     blocks = ""
     entities = ""
     r12 = False
-    ver = re.findall("\$ACADVER\n.*?\n(.*?)\n", template)
+    ver = re.findall("\\$ACADVER\n.*?\n(.*?)\n", template)
     if ver:
         # at the moment this is not used.
         # TODO: if r12, do not print ellipses or splines

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -415,7 +415,7 @@ def getsize(length, mode='discard', base=1):
         }
 
     # Extract a number from a string like '+56215.14565E+6mm'
-    _num = '([-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)'
+    _num = '([-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?)'
     _unit = '(px|pt|pc|mm|cm|in|em|ex|%)?'
     _full_num = _num + _unit
     number, exponent, unit = re.findall(_full_num, length)[0]
@@ -725,7 +725,7 @@ class svgHandler(xml.sax.ContentHandler):
             if 'inkscape:version' in data:
                 inks_doc_name = attrs.getValue('sodipodi:docname')
                 inks_full_ver = attrs.getValue('inkscape:version')
-                inks_ver_pars = re.search("\d+\.\d+", inks_full_ver)
+                inks_ver_pars = re.search("\\d+\\.\\d+", inks_full_ver)
                 if inks_ver_pars is not None:
                     inks_ver_f = float(inks_ver_pars.group(0))
                 else:
@@ -928,10 +928,10 @@ class svgHandler(xml.sax.ContentHandler):
 
             _op = '([mMlLhHvVaAcCqQsStTzZ])'
             _op2 = '([^mMlLhHvVaAcCqQsStTzZ]*)'
-            _command = '\s*?' + _op + '\s*?' + _op2 + '\s*?'
+            _command = '\\s*?' + _op + '\\s*?' + _op2 + '\\s*?'
             pathcommandsre = re.compile(_command, re.DOTALL)
 
-            _num = '[-+]?[0-9]*\.?[0-9]+'
+            _num = '[-+]?[0-9]*\\.?[0-9]+'
             _exp = '([eE][-+]?[0-9]+)?'
             _point = '(' + _num + _exp + ')'
             pointsre = re.compile(_point, re.DOTALL)
@@ -1613,8 +1613,8 @@ class svgHandler(xml.sax.ContentHandler):
             The translated matrix.
         """
         _op = '(matrix|translate|scale|rotate|skewX|skewY)'
-        _val = '\((.*?)\)'
-        _transf = _op + '\s*?' + _val
+        _val = '\\((.*?)\\)'
+        _transf = _op + '\\s*?' + _val
         transformre = re.compile(_transf, re.DOTALL)
         m = FreeCAD.Matrix()
         for transformation, arguments in transformre.findall(tr):


### PR DESCRIPTION
Remove unnecessary calls to _msg, and combine others with the immediately subsequent call to _err so the entire message appears as a single error message.

Correct deprecated escape sequences in ImportSVG.py, ImportDXF.py, and gui_trackers.py

Fixes #11876