### PR TITLE
Draft: Fix Draft_Wire conversion function

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -313,7 +313,7 @@ class Wire(Line):
                 edges.extend(o.Shape.Edges)
             if edges:
                 try:
-                    w = Part.Wire(edges)
+                    w = Part.Wire(Part.__sortEdges__(edges))
                 except Exception:
                     _err(translate("draft",
                                    "Unable to create a Wire "
@@ -333,7 +333,10 @@ class Wire(Line):
                     Gui.addModule("Draft")
                     # The command to run is built as a series of text strings
                     # to be committed through the `draftutils.todo.ToDo` class
-                    _cmd_list = ['wire = Draft.make_wire([' + pts + '])']
+                    _cmd = 'wire = Draft.make_wire('
+                    _cmd += '[' + pts + '], closed=' + str(w.isClosed())
+                    _cmd += ')'
+                    _cmd_list = [_cmd]
                     _cmd_list.extend(rems)
                     _cmd_list.append('Draft.autogroup(wire)')
                     _cmd_list.append('FreeCAD.ActiveDocument.recompute()')


### PR DESCRIPTION
The Draft_Wire command can combine selected Draft_Wires and Draft_Lines into a single wire. This function did not always behave properly.
* Edges were not sorted, the result could have a different shape (with the correct vertexes).
* If edges formed  a closed shape the resultant wire was not closed.
