### PR TITLE
App: fix PropertyPythonObject persistence backward compatibility

### DIFF
--- a/src/App/PropertyPythonObject.cpp
+++ b/src/App/PropertyPythonObject.cpp
@@ -92,14 +92,17 @@ std::string PropertyPythonObject::toString() const
             Py::Callable state(this->object.getAttr("dumps"));
             dump = state.apply(args);
         }
-#if PY_VERSION_HEX < 0x030b0000
         // support add-ons that use the old method names
-        else if (this->object.hasAttr("__getstate__")) {
+        else if (this->object.hasAttr("__getstate__")
+#if PY_VERSION_HEX >= 0x030b0000
+                && this->object.getAttr("__getstate__").hasAttr("__func__")
+#endif
+                )
+        {
             Py::Tuple args;
             Py::Callable state(this->object.getAttr("__getstate__"));
             dump = state.apply(args);
         }
-#endif
         else if (this->object.hasAttr("__dict__")) {
             dump = this->object.getAttr("__dict__");
         }
@@ -143,15 +146,18 @@ void PropertyPythonObject::fromString(const std::string& repr)
             Py::Callable state(this->object.getAttr("loads"));
             state.apply(args);
         }
-#if PY_VERSION_HEX < 0x030b0000
         // support add-ons that use the old method names
-        else if (this->object.hasAttr("__setstate__")) {
+        else if (this->object.hasAttr("__setstate__")
+#if PY_VERSION_HEX >= 0x030b0000
+                && this->object.getAttr("__setstate__").hasAttr("__func__")
+#endif
+                )
+        {
             Py::Tuple args(1);
             args.setItem(0, res);
             Py::Callable state(this->object.getAttr("__setstate__"));
             state.apply(args);
         }
-#endif
         else if (this->object.hasAttr("__dict__")) {
             if (!res.isNone()) {
                 this->object.setAttr("__dict__", res);


### PR DESCRIPTION
Related #10460

Amendment to 83d4080f.

Check for attribute `__func__` for Python >= 3.11 to avoid calling built-in `__getstate__/__setstate__`.