### PR TITLE
Stop tests from leaving files around after execution

### DIFF
--- a/src/Mod/AddonManager/AddonManagerTest/app/test_utilities.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_utilities.py
@@ -43,6 +43,12 @@ class TestUtilities(unittest.TestCase):
         self.test_dir = os.path.join(
             FreeCAD.getHomePath(), "Mod", "AddonManager", "AddonManagerTest", "data"
         )
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            os.remove("AM_INSTALLATION_DIGEST.txt")
+        except FileNotFoundError:
+            pass
 
     def test_recognized_git_location(self):
         recognized_urls = [

--- a/src/Mod/AddonManager/AddonManagerTest/app/test_utilities.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_utilities.py
@@ -43,6 +43,7 @@ class TestUtilities(unittest.TestCase):
         self.test_dir = os.path.join(
             FreeCAD.getHomePath(), "Mod", "AddonManager", "AddonManagerTest", "data"
         )
+
     @classmethod
     def tearDownClass(cls):
         try:

--- a/src/Mod/Path/PathTests/TestCentroidPost.py
+++ b/src/Mod/Path/PathTests/TestCentroidPost.py
@@ -93,7 +93,7 @@ class TestCentroidPost(PathTestUtils.PathTestBase):
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
         args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertTrue(len(gcode.splitlines()) == 16)
 
         # Test without header
@@ -115,7 +115,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
         # test without comments
@@ -131,7 +131,7 @@ M99
 
         args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
     def test010(self):
@@ -144,13 +144,13 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.0000 Y20.0000 Z30.0000"
         self.assertEqual(result, expected)
 
         args = "--no-header --axis-precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
@@ -165,7 +165,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "N150  G0 X10.0000 Y20.0000 Z30.0000"
         self.assertEqual(result, expected)
@@ -183,7 +183,7 @@ M99
         # --preamble option.  We end up with the default preamble.
         #
         args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[1]
         self.assertEqual(result, "G53 G00 G17")
 
@@ -198,7 +198,7 @@ M99
         # --postamble option.  We end up with the default postamble.
         #
         args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[-1], "M99")
 
     def test050(self):
@@ -211,7 +211,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[3], "G20")
 
         result = gcode.splitlines()[5]
@@ -219,7 +219,7 @@ M99
         self.assertEqual(result, expected)
 
         args = "--no-header --inches --axis-precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X0.39 Y0.79 Z1.18"
         self.assertEqual(result, expected)
@@ -240,7 +240,7 @@ M99
         # --modal option.  We end up with the original gcode.
         #
         args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "G0 X10.0000 Y30.0000 Z30.0000"
         self.assertEqual(result, expected)
@@ -261,7 +261,7 @@ M99
         # --axis-modal option.  We end up with the original gcode.
         #
         args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "G0 X10.0000 Y30.0000 Z30.0000"
         self.assertEqual(result, expected)
@@ -276,7 +276,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[5], "M6 T2")
         self.assertEqual(gcode.splitlines()[6], "M3 S3000")
 
@@ -286,7 +286,7 @@ M99
         # --no-tlo option.  We end up with the original gcode.
         #
         args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[6], "M3 S3000")
 
     def test090(self):
@@ -300,7 +300,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = ";comment"
         self.assertEqual(result, expected)

--- a/src/Mod/Path/PathTests/TestGrblPost.py
+++ b/src/Mod/Path/PathTests/TestGrblPost.py
@@ -91,7 +91,7 @@ class TestGrblPost(PathTestUtils.PathTestBase):
         # Header contains a time stamp that messes up unit testing.  Only test
         # length of result.
         args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertTrue(len(gcode.splitlines()) == 13)
 
         # Test without header
@@ -112,7 +112,7 @@ M2
 
         args = "--no-header --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
         # test without comments
@@ -125,7 +125,7 @@ M2
 
         args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
     def test010(self):
@@ -139,13 +139,13 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
         args = "--no-header --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
@@ -160,7 +160,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "N150 G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
@@ -174,7 +174,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-comments --preamble='G18 G55\n' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[0]
         self.assertEqual(result, "G18 G55")
 
@@ -185,7 +185,7 @@ M2
         self.docobj.Path = Path.Path([])
         postables = [self.docobj]
         args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -200,7 +200,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[2], "G20")
 
         result = gcode.splitlines()[5]
@@ -211,7 +211,7 @@ M2
         # with imperial units.
 
         # args = ("--no-header --inches --precision=2")
-        # gcode = postprocessor.export(postables, "gcode.tmp", args)
+        # gcode = postprocessor.export(postables, "-", args)
         # result = gcode.splitlines()[5]
         # expected = "G0 X0.39 Y0.78 Z1.18 "
         # self.assertEqual(result, expected)
@@ -231,7 +231,7 @@ M2
         # The grbl postprocessor does not have a --modal option.
         #
         # args = "--no-header --modal --no-show-editor"
-        # gcode = postprocessor.export(postables, "gcode.tmp", args)
+        # gcode = postprocessor.export(postables, "-", args)
         # result = gcode.splitlines()[6]
         # expected = "X10.000 Y30.000 Z30.000 "
         # self.assertEqual(result, expected)
@@ -251,7 +251,7 @@ M2
         # The grbl postprocessor does not have a --axis-modal option.
         #
         # args = "--no-header --axis-modal --no-show-editor"
-        # gcode = postprocessor.export(postables, "gcode.tmp", args)
+        # gcode = postprocessor.export(postables, "-", args)
         # result = gcode.splitlines()[6]
         # expected = "G0 Y30.000 "
         # self.assertEqual(result, expected)
@@ -266,7 +266,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[6], "( M6 T2 )")
         self.assertEqual(gcode.splitlines()[7], "M3 S3000")
 
@@ -275,7 +275,7 @@ M2
         # The grbl postprocessor does not have a --no-tlo option.
         #
         # args = "--no-header --no-tlo --no-show-editor"
-        # gcode = postprocessor.export(postables, "gcode.tmp", args)
+        # gcode = postprocessor.export(postables, "-", args)
         # self.assertEqual(gcode.splitlines()[7], "M3 S3000 ")
 
     def test090(self):
@@ -289,7 +289,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "(comment)"
         self.assertEqual(result, expected)

--- a/src/Mod/Path/PathTests/TestLinuxCNCPost.py
+++ b/src/Mod/Path/PathTests/TestLinuxCNCPost.py
@@ -90,7 +90,7 @@ class TestLinuxCNCPost(PathTestUtils.PathTestBase):
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
         args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertTrue(len(gcode.splitlines()) == 13)
 
         # Test without header
@@ -111,7 +111,7 @@ M2
 
         args = "--no-header --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
         # test without comments
@@ -124,7 +124,7 @@ M2
 
         args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
     def test010(self):
@@ -138,13 +138,13 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.000 Y20.000 Z30.000 "
         self.assertEqual(result, expected)
 
         args = "--no-header --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.00 Y20.00 Z30.00 "
         self.assertEqual(result, expected)
@@ -159,7 +159,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "N160  G0 X10.000 Y20.000 Z30.000 "
         self.assertEqual(result, expected)
@@ -173,7 +173,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[0]
         self.assertEqual(result, "G18 G55")
 
@@ -184,7 +184,7 @@ M2
         self.docobj.Path = Path.Path([])
         postables = [self.docobj]
         args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -199,7 +199,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[2], "G20")
 
         result = gcode.splitlines()[5]
@@ -210,7 +210,7 @@ M2
         # with imperial units.
 
         # args = ("--no-header --inches --precision=2")
-        # gcode = postprocessor.export(postables, "gcode.tmp", args)
+        # gcode = postprocessor.export(postables, "-", args)
         # result = gcode.splitlines()[5]
         # expected = "G0 X0.39 Y0.78 Z1.18 "
         # self.assertEqual(result, expected)
@@ -227,7 +227,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "X10.000 Y30.000 Z30.000 "
         self.assertEqual(result, expected)
@@ -244,7 +244,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "G0 Y30.000 "
         self.assertEqual(result, expected)
@@ -259,7 +259,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[5], "M5")
         self.assertEqual(gcode.splitlines()[6], "M6 T2 ")
         self.assertEqual(gcode.splitlines()[7], "G43 H2 ")
@@ -267,7 +267,7 @@ M2
 
         # suppress TLO
         args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[7], "M3 S3000 ")
 
     def test090(self):
@@ -281,7 +281,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "(comment) "
         self.assertEqual(result, expected)

--- a/src/Mod/Path/PathTests/TestMach3Mach4Post.py
+++ b/src/Mod/Path/PathTests/TestMach3Mach4Post.py
@@ -93,7 +93,7 @@ class TestMach3Mach4Post(PathTestUtils.PathTestBase):
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
         args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertTrue(len(gcode.splitlines()) == 13)
 
         # Test without header
@@ -114,7 +114,7 @@ M2
 
         args = "--no-header --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
         # test without comments
@@ -127,7 +127,7 @@ M2
 
         args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
     def test010(self):
@@ -140,13 +140,13 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
         args = "--no-header --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
@@ -161,7 +161,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "N160  G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
@@ -175,7 +175,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[0]
         self.assertEqual(result, "G18 G55")
 
@@ -186,7 +186,7 @@ M2
         self.docobj.Path = Path.Path([])
         postables = [self.docobj]
         args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -201,7 +201,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[2], "G20")
 
         result = gcode.splitlines()[5]
@@ -212,7 +212,7 @@ M2
         # with imperial units.
 
         # args = ("--no-header --inches --precision=2 --no-show-editor")
-        # gcode = postprocessor.export(postables, "gcode.tmp", args)
+        # gcode = postprocessor.export(postables, "-", args)
         # result = gcode.splitlines()[5]
         # expected = "G0 X0.39 Y0.79 Z1.18"
         # self.assertEqual(result, expected)
@@ -229,7 +229,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "X10.000 Y30.000 Z30.000"
         self.assertEqual(result, expected)
@@ -246,7 +246,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "G0 Y30.000"
         self.assertEqual(result, expected)
@@ -261,7 +261,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[5], "M5")
         self.assertEqual(gcode.splitlines()[6], "M6 T2 ")
         self.assertEqual(gcode.splitlines()[7], "G43 H2")
@@ -269,7 +269,7 @@ M2
 
         # suppress TLO
         args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[7], "M3 S3000")
 
     def test090(self):
@@ -283,7 +283,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "(comment)"
         self.assertEqual(result, expected)

--- a/src/Mod/Path/PathTests/TestRefactoredCentroidPost.py
+++ b/src/Mod/Path/PathTests/TestRefactoredCentroidPost.py
@@ -93,7 +93,7 @@ class TestRefactoredCentroidPost(PathTestUtils.PathTestBase):
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
         args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertTrue(len(gcode.splitlines()) == 16)
 
         # Test without header
@@ -115,7 +115,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
         # test without comments
@@ -131,7 +131,7 @@ M99
 
         args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
     def test010(self):
@@ -144,13 +144,13 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.0000 Y20.0000 Z30.0000"
         self.assertEqual(result, expected)
 
         args = "--no-header --axis-precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
@@ -165,7 +165,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "N150 G0 X10.0000 Y20.0000 Z30.0000"
         self.assertEqual(result, expected)
@@ -179,7 +179,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[1]
         self.assertEqual(result, "G18 G55")
 
@@ -190,7 +190,7 @@ M99
         self.docobj.Path = Path.Path([])
         postables = [self.docobj]
         args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -205,7 +205,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[3], "G20")
 
         result = gcode.splitlines()[5]
@@ -213,7 +213,7 @@ M99
         self.assertEqual(result, expected)
 
         args = "--no-header --inches --axis-precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X0.39 Y0.79 Z1.18"
         self.assertEqual(result, expected)
@@ -230,7 +230,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "X10.0000 Y30.0000 Z30.0000"
         self.assertEqual(result, expected)
@@ -247,7 +247,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "G0 Y30.0000"
         self.assertEqual(result, expected)
@@ -262,13 +262,13 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[6], "M6 T2")
         self.assertEqual(gcode.splitlines()[7], "M3 S3000")
 
         # suppress TLO
         args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[7], "M3 S3000")
 
     def test090(self):
@@ -282,7 +282,7 @@ M99
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = ";comment"
         self.assertEqual(result, expected)

--- a/src/Mod/Path/PathTests/TestRefactoredGrblPost.py
+++ b/src/Mod/Path/PathTests/TestRefactoredGrblPost.py
@@ -93,7 +93,7 @@ class TestRefactoredGrblPost(PathTestUtils.PathTestBase):
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
         args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertTrue(len(gcode.splitlines()) == 14)
 
         # Test without header
@@ -114,7 +114,7 @@ M2
 
         args = "--no-header --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
         # test without comments
@@ -127,7 +127,7 @@ M2
 
         args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
     def test010(self):
@@ -140,13 +140,13 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
         args = "--no-header --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
@@ -161,7 +161,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "N150 G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
@@ -175,7 +175,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[0]
         self.assertEqual(result, "G18 G55")
 
@@ -186,7 +186,7 @@ M2
         self.docobj.Path = Path.Path([])
         postables = [self.docobj]
         args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -201,7 +201,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[2], "G20")
 
         result = gcode.splitlines()[5]
@@ -209,7 +209,7 @@ M2
         self.assertEqual(result, expected)
 
         args = "--no-header --inches --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X0.39 Y0.79 Z1.18"
         self.assertEqual(result, expected)
@@ -226,7 +226,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "X10.000 Y30.000 Z30.000"
         self.assertEqual(result, expected)
@@ -243,7 +243,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "G0 Y30.000"
         self.assertEqual(result, expected)
@@ -258,13 +258,13 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[6], "( M6 T2 )")
         self.assertEqual(gcode.splitlines()[7], "M3 S3000")
 
         # suppress TLO
         args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[7], "M3 S3000")
 
     def test090(self):
@@ -278,7 +278,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "(comment)"
         self.assertEqual(result, expected)

--- a/src/Mod/Path/PathTests/TestRefactoredLinuxCNCPost.py
+++ b/src/Mod/Path/PathTests/TestRefactoredLinuxCNCPost.py
@@ -93,7 +93,7 @@ class TestRefactoredLinuxCNCPost(PathTestUtils.PathTestBase):
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
         args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertTrue(len(gcode.splitlines()) == 14)
 
         # Test without header
@@ -114,7 +114,7 @@ M2
 
         args = "--no-header --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
         # test without comments
@@ -127,7 +127,7 @@ M2
 
         args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
     def test010(self):
@@ -140,13 +140,13 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
         args = "--no-header --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
@@ -161,7 +161,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "N150 G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
@@ -175,7 +175,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[0]
         self.assertEqual(result, "G18 G55")
 
@@ -186,7 +186,7 @@ M2
         self.docobj.Path = Path.Path([])
         postables = [self.docobj]
         args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -201,7 +201,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[2], "G20")
 
         result = gcode.splitlines()[5]
@@ -209,7 +209,7 @@ M2
         self.assertEqual(result, expected)
 
         args = "--no-header --inches --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X0.39 Y0.79 Z1.18"
         self.assertEqual(result, expected)
@@ -226,7 +226,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "X10.000 Y30.000 Z30.000"
         self.assertEqual(result, expected)
@@ -243,7 +243,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "G0 Y30.000"
         self.assertEqual(result, expected)
@@ -258,7 +258,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[6], "M5")
         self.assertEqual(gcode.splitlines()[7], "M6 T2")
         self.assertEqual(gcode.splitlines()[8], "G43 H2")
@@ -266,7 +266,7 @@ M2
 
         # suppress TLO
         args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[8], "M3 S3000")
 
     def test090(self):
@@ -280,7 +280,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "(comment)"
         self.assertEqual(result, expected)

--- a/src/Mod/Path/PathTests/TestRefactoredMach3Mach4Post.py
+++ b/src/Mod/Path/PathTests/TestRefactoredMach3Mach4Post.py
@@ -92,7 +92,7 @@ class TestRefactoredMach3Mach4Post(PathTestUtils.PathTestBase):
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
         args = "--no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertTrue(len(gcode.splitlines()) == 14)
 
         # Test without header
@@ -113,7 +113,7 @@ M2
 
         args = "--no-header --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
         # test without comments
@@ -126,7 +126,7 @@ M2
 
         args = "--no-header --no-comments --no-show-editor"
         # args = ("--no-header --no-comments --no-show-editor --precision=2")
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode, expected)
 
     def test010(self):
@@ -139,13 +139,13 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
 
         args = "--no-header --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X10.00 Y20.00 Z30.00"
         self.assertEqual(result, expected)
@@ -160,7 +160,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --line-numbers --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "N150 G0 X10.000 Y20.000 Z30.000"
         self.assertEqual(result, expected)
@@ -174,7 +174,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-comments --preamble='G18 G55' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[0]
         self.assertEqual(result, "G18 G55")
 
@@ -185,7 +185,7 @@ M2
         self.docobj.Path = Path.Path([])
         postables = [self.docobj]
         args = "--no-header --no-comments --postamble='G0 Z50\nM2' --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[-2]
         self.assertEqual(result, "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -200,7 +200,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --inches --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[2], "G20")
 
         result = gcode.splitlines()[5]
@@ -208,7 +208,7 @@ M2
         self.assertEqual(result, expected)
 
         args = "--no-header --inches --precision=2 --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "G0 X0.39 Y0.79 Z1.18"
         self.assertEqual(result, expected)
@@ -225,7 +225,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "X10.000 Y30.000 Z30.000"
         self.assertEqual(result, expected)
@@ -242,7 +242,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --axis-modal --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[6]
         expected = "G0 Y30.000"
         self.assertEqual(result, expected)
@@ -257,7 +257,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[6], "M5")
         self.assertEqual(gcode.splitlines()[7], "M6 T2")
         self.assertEqual(gcode.splitlines()[8], "G43 H2")
@@ -265,7 +265,7 @@ M2
 
         # suppress TLO
         args = "--no-header --no-tlo --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         self.assertEqual(gcode.splitlines()[8], "M3 S3000")
 
     def test090(self):
@@ -279,7 +279,7 @@ M2
         postables = [self.docobj]
 
         args = "--no-header --no-show-editor"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         result = gcode.splitlines()[5]
         expected = "(comment)"
         self.assertEqual(result, expected)

--- a/src/Mod/Path/PathTests/TestRefactoredTestPost.py
+++ b/src/Mod/Path/PathTests/TestRefactoredTestPost.py
@@ -91,7 +91,7 @@ class TestRefactoredTestPost(PathTestUtils.PathTestBase):
         nl = "\n"
         self.docobj.Path = Path.Path(path)
         postables = [self.docobj]
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         if debug:
             print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
@@ -104,7 +104,7 @@ class TestRefactoredTestPost(PathTestUtils.PathTestBase):
         else:
             self.docobj.Path = Path.Path([])
         postables = [self.docobj]
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         if debug:
             print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[2], expected)
@@ -132,12 +132,12 @@ class TestRefactoredTestPost(PathTestUtils.PathTestBase):
         postables = [self.docobj]
 
         args = "--axis-modal"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[3], "G0 Y30.000")
 
         args = "--no-axis-modal"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[3], "G0 X10.000 Y30.000 Z30.000")
 
@@ -182,7 +182,7 @@ G21
         self.docobj.Path = Path.Path([c])
         postables = [self.docobj]
         args = "--comments"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[4], "(comment)")
 
@@ -197,14 +197,14 @@ G21
         postables = [self.docobj]
 
         args = ""
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         # Note:  The "internal" F speed is in mm/s,
         #        while the output F speed is in mm/min.
         self.assertEqual(gcode.splitlines()[2], "G1 X10.000 Y20.000 Z30.000 F7387.407")
 
         args = "--feed-precision=2"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         # Note:  The "internal" F speed is in mm/s,
         #        while the output F speed is in mm/min.
@@ -224,7 +224,7 @@ G21
         # The header contains a time stamp that messes up unit testing.
         # Only test the length of the line that contains the time.
         args = "--comments --header"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[0], "(Exported by FreeCAD)")
         self.assertEqual(
@@ -250,13 +250,13 @@ G21
 (Begin postamble)
 """
         args = "--comments --no-header"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode, expected)
 
         # Test without comments with header.
         args = "--no-comments --header"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[0], "(Exported by FreeCAD)")
         self.assertEqual(
@@ -274,7 +274,7 @@ G21
 G21
 """
         args = "--no-comments --no-header"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode, expected)
 
@@ -296,7 +296,7 @@ G21
         self.docobj.Path = Path.Path([c])
         postables = [self.docobj]
         args = "--inches"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[1], "G20")
         self.assertEqual(
@@ -316,11 +316,11 @@ G21
         self.docobj.Path = Path.Path([c, c1])
         postables = [self.docobj]
         args = "--modal"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[3], "X10.000 Y30.000 Z30.000")
         args = "--no-modal"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[3], "G0 X10.000 Y30.000 Z30.000")
 
@@ -395,7 +395,7 @@ G21
         self.docobj.Path = Path.Path([])
         postables = [self.docobj]
         gcode: str = postprocessor.export(
-            postables, "gcode.tmp", "--output_all_arguments"
+            postables, "-", "--output_all_arguments"
         )
         # The argparse help routine turns out to be sensitive to the
         # number of columns in the terminal window that the tests
@@ -421,7 +421,7 @@ G21
         self.docobj.Path = Path.Path([])
         postables = [self.docobj]
         args = "--postamble='G0 Z50\nM2'"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[-2], "G0 Z50")
         self.assertEqual(gcode.splitlines()[-1], "M2")
@@ -433,7 +433,7 @@ G21
         self.docobj.Path = Path.Path([])
         postables = [self.docobj]
         args = "--preamble='G18 G55'"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[0], "G18 G55")
 
@@ -467,14 +467,14 @@ G21
         self.docobj.Path = Path.Path([c, c2])
         postables = [self.docobj]
         args = "--tlo"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[2], "M6 T2")
         self.assertEqual(gcode.splitlines()[3], "G43 H2")
         self.assertEqual(gcode.splitlines()[4], "M3 S3000")
         # suppress TLO
         args = "--no-tlo"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[2], "M6 T2")
         self.assertEqual(gcode.splitlines()[3], "M3 S3000")
@@ -488,12 +488,12 @@ G21
         self.docobj.Path = Path.Path([c, c2])
         postables = [self.docobj]
         args = "--tool_change"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[2], "M6 T2")
         self.assertEqual(gcode.splitlines()[3], "M3 S3000")
         args = "--comments --no-tool_change"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[5], "( M6 T2 )")
         self.assertEqual(gcode.splitlines()[6], "M3 S3000")
@@ -506,11 +506,11 @@ G21
         self.docobj.Path = Path.Path([c])
         postables = [self.docobj]
         args = ""
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[2], "M3 S3000")
         args = "--wait-for-spindle=1.23456"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[2], "M3 S3000")
         self.assertEqual(gcode.splitlines()[3], "G4 P1.23456")
@@ -520,11 +520,11 @@ G21
         # This also tests that the default for --wait-for-spindle
         # goes back to 0.0 (no wait)
         args = ""
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[2], "M4 S3000")
         args = "--wait-for-spindle=1.23456"
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         # print("--------\n" + gcode + "--------\n")
         self.assertEqual(gcode.splitlines()[2], "M4 S3000")
         self.assertEqual(gcode.splitlines()[3], "G4 P1.23456")

--- a/src/Mod/Path/PathTests/TestRefactoredTestPostGCodes.py
+++ b/src/Mod/Path/PathTests/TestRefactoredTestPostGCodes.py
@@ -92,7 +92,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
         nl = "\n"
         self.docobj.Path = Path.Path(path)
         postables = [self.docobj]
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         if debug:
             print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
@@ -105,7 +105,7 @@ class TestRefactoredTestPostGCodes(PathTestUtils.PathTestBase):
         else:
             self.docobj.Path = Path.Path([])
         postables = [self.docobj]
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         if debug:
             print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[2], expected)
@@ -597,7 +597,7 @@ G52 X0.0000 Y0.0000 Z0.0000 A0.0000 B0.0000 C0.0000 U0.0000 V0.0000 W0.0000
     # G53 G0 X10.000 Y20.000 Z30.000 A40.000 B50.000 C60.000 U70.000 V80.000 W90.000
     # """
     #         args = ""
-    #         gcode = postprocessor.export(postables, "gcode.tmp", args)
+    #         gcode = postprocessor.export(postables, "-", args)
     #         print("--------\n" + gcode + "--------\n")
     #         self.assertEqual(gcode, expected)
 

--- a/src/Mod/Path/PathTests/TestRefactoredTestPostMCodes.py
+++ b/src/Mod/Path/PathTests/TestRefactoredTestPostMCodes.py
@@ -92,7 +92,7 @@ class TestRefactoredTestPostMCodes(PathTestUtils.PathTestBase):
         nl = "\n"
         self.docobj.Path = Path.Path(path)
         postables = [self.docobj]
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         if debug:
             print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode, expected)
@@ -105,7 +105,7 @@ class TestRefactoredTestPostMCodes(PathTestUtils.PathTestBase):
         else:
             self.docobj.Path = Path.Path([])
         postables = [self.docobj]
-        gcode = postprocessor.export(postables, "gcode.tmp", args)
+        gcode = postprocessor.export(postables, "-", args)
         if debug:
             print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[2], expected)


### PR DESCRIPTION
Never really noticed this until a CLion switch had me building in a subdirectory of the source tree, instead of one adjacent to it.  Suddenly I was seeing a gcode.txt and AM_INSTALLATION_DIGEST.txt show up pretty much ever time I went to commit, because I run the tests as part of my workflow.

This fixes this; the Path is a cleanly removing generating a test file that was never actually used - the contents are tested separately.  The AddonManager part is a bit more failsafe / heavy handed as I didn't find a clear place to address the generation of the file.