### PR TITLE
Draft: Fix messages that only worked for objects supplied as strings

### DIFF
--- a/src/Mod/Draft/draftmake/make_circulararray.py
+++ b/src/Mod/Draft/draftmake/make_circulararray.py
@@ -120,13 +120,9 @@ def make_circular_array(base_object,
     """
     _name = "make_circular_array"
 
-    if isinstance(base_object, str):
-        base_object_str = base_object
-
-    found, base_object = utils.find_object(base_object,
-                                           doc=App.activeDocument())
+    found, base_object = utils.find_object(base_object, doc=App.activeDocument())
     if not found:
-        _err(translate("draft","Wrong input: base_object {} not in document.").format(base_object_str))
+        _err(translate("draft","Wrong input: base_object not in document."))
         return None
 
     try:

--- a/src/Mod/Draft/draftmake/make_dimension.py
+++ b/src/Mod/Draft/draftmake/make_dimension.py
@@ -301,16 +301,13 @@ def make_linear_dimension_obj(edge_object, i1=1, i2=2, dim_line=None):
         _err(translate("draft","No active document. Aborting."))
         return None
 
-    if isinstance(edge_object, str):
-        edge_object_str = edge_object
-
     if isinstance(edge_object, (list, tuple)):
-        _err(translate("draft","Wrong input: edge_object {} must not be a list or tuple.").format(edge_object))
+        _err(translate("draft","Wrong input: edge_object must not be a list or tuple."))
         return None
 
     found, edge_object = utils.find_object(edge_object, doc)
     if not found:
-        _err(translate("draft","Wrong input: edge_object {} not in document.").format(edge_object_str))
+        _err(translate("draft","Wrong input: edge_object not in document."))
         return None
 
     if not hasattr(edge_object, "Shape"):
@@ -424,12 +421,9 @@ def make_radial_dimension_obj(edge_object, index=1, mode="radius",
         _err(translate("draft","No active document. Aborting."))
         return None
 
-    if isinstance(edge_object, str):
-        edge_object_str = edge_object
-
     found, edge_object = utils.find_object(edge_object, doc)
     if not found:
-        _err(translate("draft","Wrong input: edge_object {} not in document.").format(edge_object_str))
+        _err(translate("draft","Wrong input: edge_object not in document."))
         return None
 
     if not hasattr(edge_object, "Shape"):

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -218,19 +218,14 @@ def make_label(target_point=App.Vector(0, 0, 0),
     elif isinstance(placement, App.Rotation):
         placement = App.Placement(App.Vector(), placement)
 
-    if isinstance(target_object, str):
-        target_object_str = target_object
+    if isinstance(target_object, (list, tuple)):
+        _err(translate("draft","Wrong input: target_object must not be a list."))
+        return None
 
-    if target_object:
-        if isinstance(target_object, (list, tuple)):
-            _err(translate("draft","Wrong input: target_object {} must not be a list.").format(target_object))
-            return None
-
-        found, target_object = utils.find_object(target_object, doc)
-        if not found:
-            _err(translate("draft","Wrong input: target_object {} not in document.").format(target_object_str))
-            return None
-
+    found, target_object = utils.find_object(target_object, doc)
+    if not found:
+        _err(translate("draft","Wrong input: target_object not in document."))
+        return None
 
     if target_object and subelements:
         try:

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -217,15 +217,16 @@ def make_label(target_point=App.Vector(0, 0, 0),
         placement = App.Placement(placement, App.Rotation())
     elif isinstance(placement, App.Rotation):
         placement = App.Placement(App.Vector(), placement)
+        
+    if target_object:
+        if isinstance(target_object, (list, tuple)):
+            _err(translate("draft","Wrong input: target_object must not be a list."))
+            return None
 
-    if isinstance(target_object, (list, tuple)):
-        _err(translate("draft","Wrong input: target_object must not be a list."))
-        return None
-
-    found, target_object = utils.find_object(target_object, doc)
-    if not found:
-        _err(translate("draft","Wrong input: target_object not in document."))
-        return None
+        found, target_object = utils.find_object(target_object, doc)
+        if not found:
+            _err(translate("draft","Wrong input: target_object not in document."))
+            return None
 
     if target_object and subelements:
         try:

--- a/src/Mod/Draft/draftmake/make_orthoarray.py
+++ b/src/Mod/Draft/draftmake/make_orthoarray.py
@@ -140,17 +140,11 @@ def _are_numbers(d_x, d_y, d_z=None, name="Unknown"):
 
 def _find_object_in_doc(base_object, doc=None):
     """Check that a document is available and the object exists."""
-    FOUND = True
-    if isinstance(base_object, str):
-        base_object_str = base_object
-
-    found, base_object = utils.find_object(base_object,
-                                           doc=doc)
+    found, base_object = utils.find_object(base_object, doc=doc)
     if not found:
-        _err(translate("draft","Wrong input: base_object {} not in document.").format(base_object_str))
-        return not FOUND, base_object
+        _err(translate("draft","Wrong input: base_object not in document."))
 
-    return FOUND, base_object
+    return found, base_object
 
 
 def make_ortho_array(base_object,

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -170,20 +170,14 @@ def make_path_array(base_object, path_object, count=4,
         _err(translate("draft","No active document. Aborting."))
         return None
 
-    if isinstance(base_object, str):
-        base_object_str = base_object
-
     found, base_object = utils.find_object(base_object, doc)
     if not found:
-        _err(translate("draft","Wrong input: base_object {} not in document.").format(base_object_str))
+        _err(translate("draft","Wrong input: base_object not in document."))
         return None
-
-    if isinstance(path_object, str):
-        path_object_str = path_object
 
     found, path_object = utils.find_object(path_object, doc)
     if not found:
-        _err(translate("draft","Wrong input: path_object not in document.").format(path_object_str))
+        _err(translate("draft","Wrong input: path_object not in document."))
         return None
 
     try:
@@ -338,20 +332,14 @@ def make_path_twisted_array(base_object, path_object,
         _err(translate("draft","No active document. Aborting."))
         return None
 
-    if isinstance(base_object, str):
-        base_object_str = base_object
-
     found, base_object = utils.find_object(base_object, doc)
     if not found:
-        _err(translate("draft","Wrong input: base_object not in document.").format(base_object_str))
+        _err(translate("draft","Wrong input: base_object not in document."))
         return None
-
-    if isinstance(path_object, str):
-        path_object_str = path_object
 
     found, path_object = utils.find_object(path_object, doc)
     if not found:
-        _err(translate("draft","Wrong input: path_object not in document.").format(path_object_str))
+        _err(translate("draft","Wrong input: path_object not in document."))
         return None
     try:
         utils.type_check([(count, (int, float))],

--- a/src/Mod/Draft/draftmake/make_pointarray.py
+++ b/src/Mod/Draft/draftmake/make_pointarray.py
@@ -90,20 +90,14 @@ def make_point_array(base_object, point_object, extra=None, use_link=True):
         _err(translate("draft", "No active document. Aborting."))
         return None
 
-    if isinstance(base_object, str):
-        base_object_str = base_object
-
     found, base_object = utils.find_object(base_object, doc)
     if not found:
-        _err(translate("draft", "Wrong input: base_object {} not in document.").format(base_object_str))
+        _err(translate("draft", "Wrong input: base_object not in document."))
         return None
-
-    if isinstance(point_object, str):
-        point_object_str = point_object
 
     found, point_object = utils.find_object(point_object, doc)
     if not found:
-        _err(translate("draft", "Wrong input: point_object {} not in document.").format(point_object_str))
+        _err(translate("draft", "Wrong input: point_object not in document."))
         return None
 
     if not ((hasattr(point_object, "Shape") and hasattr(point_object.Shape, "Vertexes"))

--- a/src/Mod/Draft/draftmake/make_polararray.py
+++ b/src/Mod/Draft/draftmake/make_polararray.py
@@ -92,13 +92,9 @@ def make_polar_array(base_object,
     """
     _name = "make_polar_array"
 
-    if isinstance(base_object, str):
-        base_object_str = base_object
-
-    found, base_object = utils.find_object(base_object,
-                                           doc=App.activeDocument())
+    found, base_object = utils.find_object(base_object, doc=App.activeDocument())
     if not found:
-        _err(translate("draft","Wrong input: base_object {} not in document.").format(base_object_str))
+        _err(translate("draft","Wrong input: base_object not in document."))
         return None
 
     try:


### PR DESCRIPTION
Some error messages would only work if objects were supplied as strings. These would fail if objects were passed (as objects) that had already been deleted.
