### PR TITLE
Release GIL while meshing in MeshPart.meshFromShape (2nd proposal)

### DIFF
--- a/src/Mod/MeshPart/App/AppMeshPartPy.cpp
+++ b/src/Mod/MeshPart/App/AppMeshPartPy.cpp
@@ -474,6 +474,15 @@ private:
     {
         PyObject *shape;
 
+        auto runMesher = [](const MeshPart::Mesher& mesher) {
+            Mesh::MeshObject* mesh;
+            {
+                Base::PyGILStateRelease releaser{};
+                mesh = mesher.createMesh();
+            }
+            return Py::asObject(new Mesh::MeshPy(mesh));
+        };
+
         static const std::array<const char *, 7> kwds_lindeflection{"Shape", "LinearDeflection", "AngularDeflection",
                                                                     "Relative", "Segments", "GroupColors", nullptr};
         PyErr_Clear();
@@ -509,7 +518,7 @@ private:
                 }
                 mesher.setColors(colors);
             }
-            return Py::asObject(new Mesh::MeshPy(mesher.createMesh()));
+            return runMesher(mesher);
         }
 
         static const std::array<const char *, 3> kwds_maxLength{"Shape", "MaxLength", nullptr};
@@ -521,7 +530,7 @@ private:
             mesher.setMethod(MeshPart::Mesher::Mefisto);
             mesher.setMaxLength(maxLength);
             mesher.setRegular(true);
-            return Py::asObject(new Mesh::MeshPy(mesher.createMesh()));
+            return runMesher(mesher);
         }
 
         static const std::array<const char *, 3> kwds_maxArea{"Shape", "MaxArea", nullptr};
@@ -533,7 +542,7 @@ private:
             mesher.setMethod(MeshPart::Mesher::Mefisto);
             mesher.setMaxArea(maxArea);
             mesher.setRegular(true);
-            return Py::asObject(new Mesh::MeshPy(mesher.createMesh()));
+            return runMesher(mesher);
         }
 
         static const std::array<const char *, 3> kwds_localLen{"Shape", "LocalLength", nullptr};
@@ -545,7 +554,7 @@ private:
             mesher.setMethod(MeshPart::Mesher::Mefisto);
             mesher.setLocalLength(localLen);
             mesher.setRegular(true);
-            return Py::asObject(new Mesh::MeshPy(mesher.createMesh()));
+            return runMesher(mesher);
         }
 
         static const std::array<const char *, 3> kwds_deflection{"Shape", "Deflection", nullptr};
@@ -557,7 +566,7 @@ private:
             mesher.setMethod(MeshPart::Mesher::Mefisto);
             mesher.setDeflection(deflection);
             mesher.setRegular(true);
-            return Py::asObject(new Mesh::MeshPy(mesher.createMesh()));
+            return runMesher(mesher);
         }
 
         static const std::array<const char *, 4> kwds_minmaxLen{"Shape", "MinLength", "MaxLength", nullptr};
@@ -569,7 +578,7 @@ private:
             mesher.setMethod(MeshPart::Mesher::Mefisto);
             mesher.setMinMaxLengths(minLen, maxLen);
             mesher.setRegular(true);
-            return Py::asObject(new Mesh::MeshPy(mesher.createMesh()));
+            return runMesher(mesher);
         }
 
         static const std::array<const char *, 8> kwds_fineness{"Shape", "Fineness", "SecondOrder", "Optimize",
@@ -587,7 +596,7 @@ private:
             mesher.setOptimize(optimize != 0);
             mesher.setQuadAllowed(allowquad != 0);
             mesher.setMinMaxLengths(minLen, maxLen);
-            return Py::asObject(new Mesh::MeshPy(mesher.createMesh()));
+            return runMesher(mesher);
 #else
             throw Py::RuntimeError("SMESH was built without NETGEN support");
 #endif
@@ -612,7 +621,7 @@ private:
             mesher.setOptimize(optimize != 0);
             mesher.setQuadAllowed(allowquad != 0);
             mesher.setMinMaxLengths(minLen, maxLen);
-            return Py::asObject(new Mesh::MeshPy(mesher.createMesh()));
+            return runMesher(mesher);
 #else
             throw Py::RuntimeError("SMESH was built without NETGEN support");
 #endif
@@ -627,7 +636,7 @@ private:
             mesher.setMethod(MeshPart::Mesher::Mefisto);
             mesher.setRegular(true);
 #endif
-            return Py::asObject(new Mesh::MeshPy(mesher.createMesh()));
+            return runMesher(mesher);
         }
 
         throw Py::TypeError("Wrong arguments");


### PR DESCRIPTION
This commit enables multithreading use when exporting large quantities of objects (for instance for external rendering).
GIL release is only applied to mesher call, which is pure C / no Python, and only if explicitely required via a new parameter.
In case this new parameter is not set, the previous behavior remains (hold GIL), thus ensuring ascendant compatibility.

This PR replaces https://github.com/FreeCAD/FreeCAD/pull/12241 (@marioalexis84)