### PR TITLE
[Core] Introduce Tab-Bar workbench selector

### DIFF
--- a/src/Gui/Action.h
+++ b/src/Gui/Action.h
@@ -153,7 +153,6 @@ public:
     int checkedAction() const;
     void setCheckedAction(int);
 
-protected:
     QActionGroup* groupAction() const {
         return _group;
     }
@@ -180,22 +179,6 @@ private:
     Q_DISABLE_COPY(ActionGroup)
 };
 
-// --------------------------------------------------------------------
-class GuiExport WorkbenchComboBox : public QComboBox
-{
-    Q_OBJECT
-
-public:
-    explicit WorkbenchComboBox(QWidget* parent=nullptr);
-    void showPopup() override;
-
-public Q_SLOTS:
-    void refreshList(QList<QAction*>);
-
-private:
-    Q_DISABLE_COPY(WorkbenchComboBox)
-};
-
 /**
  * The WorkbenchGroup class represents a list of workbenches. When it is added
  * to a menu a submenu gets created, if added to a toolbar a combo box gets created.
@@ -216,6 +199,9 @@ public:
 
     void slotActivateWorkbench(const char*);
 
+    QList<QAction*> getEnabledWbActions() const;
+    QList<QAction*> getDisabledWbActions() const;
+
 Q_SIGNALS:
     void workbenchListRefreshed(QList<QAction*>);
 
@@ -223,6 +209,9 @@ protected Q_SLOTS:
     void onWorkbenchActivated(const QString&);
 
 private:
+    QList<QAction*> enabledWbsActions;
+    QList<QAction*> disabledWbsActions;
+
     Q_DISABLE_COPY(WorkbenchGroup)
 };
 

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1041,6 +1041,7 @@ SET(Widget_CPP_SRCS
     WidgetFactory.cpp
     Widgets.cpp
     Window.cpp
+    WorkbenchSelector.cpp
 )
 SET(Widget_HPP_SRCS
     FileDialog.h
@@ -1061,6 +1062,7 @@ SET(Widget_HPP_SRCS
     WidgetFactory.h
     Widgets.h
     Window.h
+    WorkbenchSelector.h
 )
 SET(Widget_SRCS
     ${Widget_CPP_SRCS}

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenches.ui
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenches.ui
@@ -92,6 +92,39 @@ after FreeCAD launches</string>
       <number>0</number>
      </property>
      <item>
+      <widget class="QLabel" name="WorkbenchSelectorTypeLabel">
+       <property name="text">
+        <string>Workbench selector type:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="WorkbenchSelectorType">
+       <property name="toolTip">
+        <string>Choose the workbench selector widget type (restart required).</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0">
+    <layout class="QHBoxLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
       <widget class="QLabel" name="WorkbenchSelectorPositionLabel">
        <property name="text">
         <string>Workbench selector position:</string>
@@ -111,7 +144,40 @@ after FreeCAD launches</string>
      </item>
     </layout>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
+    <layout class="QHBoxLayout">
+     <property name="spacing">
+      <number>6</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="WorkbenchSelectorItemLabel">
+       <property name="text">
+        <string>Workbench selector items style:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="WorkbenchSelectorItem">
+       <property name="toolTip">
+        <string>Customize how the items are displayed.</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="6" column="0">
     <widget class="Gui::PrefCheckBox" name="CheckBox_WbByTab">
      <property name="toolTip">
       <string>If checked, application will remember which workbench is active for each tab of the viewport</string>

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.h
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.h
@@ -56,7 +56,6 @@ public:
 protected Q_SLOTS:
     void wbToggled(const QString& wbName, bool enabled);
     void wbItemMoved();
-    void onWbSelectorChanged(int index);
     void onStartWbChanged(int index);
     void onWbByTabToggled(bool val);
 

--- a/src/Gui/WorkbenchManager.cpp
+++ b/src/Gui/WorkbenchManager.cpp
@@ -127,6 +127,15 @@ Workbench* WorkbenchManager::active() const
     return _activeWorkbench;
 }
 
+std::string WorkbenchManager::activeName() const
+{
+    std::string activeWbName = "";
+    if (_activeWorkbench) {
+        activeWbName = _activeWorkbench->name();
+    }
+    return activeWbName;
+}
+
 std::list<std::string> WorkbenchManager::workbenches() const
 {
     std::list<std::string> wb;

--- a/src/Gui/WorkbenchManager.h
+++ b/src/Gui/WorkbenchManager.h
@@ -61,6 +61,8 @@ public:
     bool activate(const std::string& name, const std::string& className);
     /** Returns the active workbench. */
     Workbench* active() const;
+    /** Returns the name of the active workbench. */
+    std::string activeName() const;
     /** Returns a list of all created workbench objects. */
     std::list<std::string> workbenches() const;
 

--- a/src/Gui/WorkbenchSelector.cpp
+++ b/src/Gui/WorkbenchSelector.cpp
@@ -1,0 +1,248 @@
+/***************************************************************************
+ *   Copyright (c) 2024 Pierre-Louis Boyer <development[at]Ondsel.com>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <QAbstractItemView>
+# include <QActionGroup>
+# include <QApplication>
+# include <QScreen>
+# include <QToolBar>
+#endif
+
+#include "Action.h"
+#include "BitmapFactory.h"
+#include "Command.h"
+#include "PreferencePages/DlgSettingsWorkbenchesImp.h"
+#include "DlgPreferencesImp.h"
+#include "MainWindow.h"
+#include "WorkbenchManager.h"
+#include "WorkbenchSelector.h"
+
+
+using namespace Gui;
+
+WorkbenchComboBox::WorkbenchComboBox(WorkbenchGroup* aGroup, QWidget* parent) : QComboBox(parent)
+{
+    setIconSize(QSize(16, 16));
+    setToolTip(aGroup->toolTip());
+    setStatusTip(aGroup->action()->statusTip());
+    setWhatsThis(aGroup->action()->whatsThis());
+    refreshList(aGroup->getEnabledWbActions());
+    connect(aGroup, &WorkbenchGroup::workbenchListRefreshed, this, &WorkbenchComboBox::refreshList);
+    connect(aGroup->groupAction(), &QActionGroup::triggered, this, [this, aGroup](QAction* action) {
+        setCurrentIndex(aGroup->actions().indexOf(action));
+    });
+    connect(this, qOverload<int>(&WorkbenchComboBox::activated), aGroup, [aGroup](int index) {
+        aGroup->actions()[index]->trigger();
+    });
+}
+
+void WorkbenchComboBox::showPopup()
+{
+    int rows = count();
+    if (rows > 0) {
+        int height = view()->sizeHintForRow(0);
+        int maxHeight = QApplication::primaryScreen()->size().height();
+        view()->setMinimumHeight(qMin(height * rows, maxHeight/2));
+    }
+
+    QComboBox::showPopup();
+}
+
+void WorkbenchComboBox::refreshList(QList<QAction*> actionList)
+{
+    clear();
+
+    ParameterGrp::handle hGrp;
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
+    int itemStyleIndex = hGrp->GetInt("WorkbenchSelectorItem", 0);
+
+    for (QAction* action : actionList) {
+        QIcon icon = action->icon();
+        if (icon.isNull() || itemStyleIndex == 2) {
+            addItem(action->text());
+        }
+        else if (itemStyleIndex == 1) {
+            addItem(icon, QString::fromLatin1(""));
+        }
+        else {
+            addItem(icon, action->text());
+        }
+
+        if (action->isChecked()) {
+            this->setCurrentIndex(this->count() - 1);
+        }
+    }
+}
+
+
+WorkbenchTabWidget::WorkbenchTabWidget(WorkbenchGroup* aGroup, QWidget* parent) 
+    : QTabBar(parent)
+    , wbActionGroup(aGroup)
+{
+    setToolTip(aGroup->toolTip());
+    setStatusTip(aGroup->action()->statusTip());
+    setWhatsThis(aGroup->action()->whatsThis());
+
+    QAction* moreAction = new QAction(this);
+    menu = new QMenu(this);
+    moreAction->setMenu(menu);
+    connect(moreAction, &QAction::triggered, [this]() {
+        menu->popup(QCursor::pos());
+    });
+    connect(menu, &QMenu::aboutToHide, this, [this]() {
+        // if the more tab did not triggered a disabled workbench, make sure we reselect the correct tab.
+        std::string activeWbName = WorkbenchManager::instance()->activeName();
+        for (int i = 0; i < count(); ++i) {
+            if (wbActionGroup->actions()[i]->objectName().toStdString() == activeWbName) {
+                setCurrentIndex(i);
+                break;
+            }
+        }
+    });
+
+    if (parent->inherits("QToolBar")) {
+        // set the initial orientation. We cannot do updateLayoutAndTabOrientation(false); 
+        // because on init the toolbar area is always TopToolBarArea.
+        ParameterGrp::handle hGrp;
+        hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
+        std::string orientation = hGrp->GetASCII("TabBarOrientation", "North");
+
+        this->setShape(orientation == "North" ? QTabBar::RoundedNorth :
+            orientation == "South" ? QTabBar::RoundedSouth :
+            orientation == "East" ? QTabBar::RoundedEast :
+            QTabBar::RoundedWest);
+    }
+
+    setDocumentMode(true);
+    setUsesScrollButtons(true);
+    setDrawBase(true);
+    setObjectName(QString::fromLatin1("WbTabBar"));
+    setIconSize(QSize(16, 16));
+
+    refreshList(aGroup->getEnabledWbActions());
+    connect(aGroup, &WorkbenchGroup::workbenchListRefreshed, this, &WorkbenchTabWidget::refreshList);
+    connect(aGroup->groupAction(), &QActionGroup::triggered, this, [this, aGroup](QAction* action) {
+        int index = std::min(aGroup->actions().indexOf(action), this->count() - 1);
+        setCurrentIndex(index);
+    });
+    connect(this, qOverload<int>(&QTabBar::tabBarClicked), aGroup, [aGroup, moreAction](int index) {
+        if (index < aGroup->getEnabledWbActions().size()) {
+            aGroup->actions()[index]->trigger();
+        }
+        else {
+            moreAction->trigger();
+        }
+    });
+
+    if (parent->inherits("QToolBar")) {
+        // Connect toolbar orientation changed
+        QToolBar* tb = qobject_cast<QToolBar*>(parent);
+        connect(tb, &QToolBar::topLevelChanged, this, &WorkbenchTabWidget::updateLayoutAndTabOrientation);
+    }
+}
+
+void WorkbenchTabWidget::refreshList(QList<QAction*> actionList)
+{
+    // tabs->clear() (QTabBar has no clear)
+    for (int i = count() - 1; i >= 0; --i) {
+        removeTab(i);
+    }
+
+    ParameterGrp::handle hGrp;
+    hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
+    int itemStyleIndex = hGrp->GetInt("WorkbenchSelectorItem", 0);
+
+    for (QAction* action : actionList) {
+        QIcon icon = action->icon();
+        if (icon.isNull() || itemStyleIndex == 2) {
+            addTab(action->text());
+        }
+        else if (itemStyleIndex == 1) {
+            addTab(icon, QString::fromLatin1(""));
+        }
+        else {
+            addTab(icon, action->text());
+        }
+
+        if (action->isChecked()) {
+            setCurrentIndex(count() - 1);
+        }
+    }
+
+    QIcon icon = Gui::BitmapFactory().iconFromTheme("list-add");
+    if (itemStyleIndex == 2) {
+        addTab(tr("More"));
+    }
+    else if (itemStyleIndex == 1) {
+        addTab(icon, QString::fromLatin1(""));
+    }
+    else {
+        addTab(icon, tr("More"));
+    }
+    
+    buildPrefMenu();
+}
+
+void WorkbenchTabWidget::updateLayoutAndTabOrientation(bool floating)
+{
+    if (!parentWidget()->inherits("QToolBar") || floating) {
+        return;
+    }
+
+    ParameterGrp::handle hGrp = App::GetApplication()
+        .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
+
+    QToolBar* tb = qobject_cast<QToolBar*>(parentWidget());
+    Qt::ToolBarArea area = getMainWindow()->toolBarArea(tb);
+
+    if (area == Qt::LeftToolBarArea || area == Qt::RightToolBarArea) {
+        setShape(area == Qt::LeftToolBarArea ? QTabBar::RoundedWest : QTabBar::RoundedEast);
+        hGrp->SetASCII("TabBarOrientation", area == Qt::LeftToolBarArea ? "West" : "East");
+    }
+    else {
+        setShape(area == Qt::TopToolBarArea ? QTabBar::RoundedNorth : QTabBar::RoundedSouth);
+        hGrp->SetASCII("TabBarOrientation", area == Qt::TopToolBarArea ? "North" : "South");
+    }
+}
+
+void WorkbenchTabWidget::buildPrefMenu()
+{
+    menu->clear();
+
+    // Add disabled workbenches, sorted alphabetically.
+    menu->addActions(wbActionGroup->getDisabledWbActions());
+
+    menu->addSeparator();
+
+    QAction* preferencesAction = menu->addAction(tr("Preferences"));
+    connect(preferencesAction, &QAction::triggered, this, [this]() {
+        Gui::Dialog::DlgPreferencesImp cDlg(getMainWindow());
+        cDlg.activateGroupPage(QString::fromUtf8("Workbenches"), 0);
+        cDlg.exec();
+    });
+}
+
+#include "moc_WorkbenchSelector.cpp"

--- a/src/Gui/WorkbenchSelector.h
+++ b/src/Gui/WorkbenchSelector.h
@@ -1,0 +1,74 @@
+/***************************************************************************
+ *   Copyright (c) 2024 Pierre-Louis Boyer <development[at]Ondsel.com>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_WORKBENCHSELECTOR_H
+#define GUI_WORKBENCHSELECTOR_H
+
+#include <QComboBox>
+#include <QTabBar>
+#include <QMenu>
+#include <FCGlobal.h>
+
+namespace Gui
+{
+class WorkbenchGroup;
+
+class GuiExport WorkbenchComboBox : public QComboBox
+{
+    Q_OBJECT
+
+public:
+    explicit WorkbenchComboBox(WorkbenchGroup* aGroup, QWidget* parent = nullptr);
+    void showPopup() override;
+
+public Q_SLOTS:
+    void refreshList(QList<QAction*>);
+
+private:
+    Q_DISABLE_COPY(WorkbenchComboBox)
+};
+
+
+class GuiExport WorkbenchTabWidget : public QTabBar
+{
+    Q_OBJECT
+
+public:
+    explicit WorkbenchTabWidget(WorkbenchGroup* aGroup, QWidget* parent = nullptr);
+    
+    void updateLayoutAndTabOrientation(bool);
+    void buildPrefMenu();
+
+public Q_SLOTS:
+    void refreshList(QList<QAction*>);
+
+private:
+    WorkbenchGroup* wbActionGroup;
+    QMenu* menu;
+};
+
+
+
+} // namespace Gui
+
+#endif // GUI_WORKBENCHSELECTOR_H


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/8692
Introduce Tab-Bar workbench selector (inspired by triplus' addon)
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/9bd89874-eb9f-4da2-b24b-7c7c139a0a1b)

Can go on any side (north/south/west/east) : 
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/91293b6f-c31e-4e8c-8cf1-8d3a423757b0)

Preferences : 
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/4b363c53-2bf4-40f3-9c19-375fffe16074)

You can configure text / icon or both. (for combobox too btw)
Can be put on the corner widget same as the combobox:
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/8bd5acab-a4e4-4d6c-bcdf-f345077011fa)

**The default is not changed : ComboBox as a toolbar with text & icons.**