### PR TITLE
Draft: Draft_Edit: restore Relative checkbox

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -474,7 +474,6 @@ class Edit(gui_base_original.Modifier):
                                  + str(node_idx) + "\n")
 
         self.ui.lineUi(title=translate("draft", "Edit node"), icon="Draft_Edit")
-        self.ui.isRelative.hide()
         self.ui.continueCmd.hide()
         self.editing = node_idx
         self.trackers[obj.Name][node_idx].off()


### PR DESCRIPTION
The relative checkbox was hidden by mistake.
