### PR TITLE
Avoid overriding ImagePlane size during import

### DIFF
--- a/src/Gui/ViewProviderImagePlane.cpp
+++ b/src/Gui/ViewProviderImagePlane.cpp
@@ -200,7 +200,9 @@ void ViewProviderImagePlane::setPlaneSize(const QSizeF& size, const QImage& img)
 {
     if (!img.isNull()) {
         Image::ImagePlane* imagePlane = static_cast<Image::ImagePlane*>(pcObject);
-        if (!isRestoring()) {
+        // When restoring the document or importing a ImagePlane by eg. pasting it
+        // preserve the X and Y size.
+        if (!isRestoring() && !pcObject->testStatus(App::ObjectStatus::ObjImporting)) {
             imagePlane->XSize.setValue(size.width());
             imagePlane->YSize.setValue(size.height());
         }


### PR DESCRIPTION
When copying&pasting an ImagePlane whose ImageFile property is a PropertyFile we'd get two updateData notifications, one when the property value is restored (which doesn't do much as the file doesn't exist yet) and another when the RestoreDocFile method is invoked.

The solution is simple, do not set Xsize and Ysize when importing the object as we expect the properties to already have the correct values.

Closes #11036