### PR TITLE
Fem: Fix restoring old Tie constraint and add support for cyclic symmetry - fixes #12155

### DIFF
--- a/src/Mod/Fem/femobjects/base_fempythonobject.py
+++ b/src/Mod/Fem/femobjects/base_fempythonobject.py
@@ -47,3 +47,19 @@ class BaseFemPythonObject(object):
 
     def loads(self, state):
         return None
+
+
+class _PropHelper:
+    """
+    Helper class to manage property data inside proxy objects.
+    Initialization keywords are the same used with PropertyContainer
+    to add dynamics properties plus "value" for the initial value.
+    """
+    def __init__(self, **kwds):
+        self.value = kwds.pop("value")
+        self.info = kwds
+        self.name = kwds["name"]
+
+    def add_to_object(self, obj):
+        obj.addProperty(**self.info)
+        setattr(obj, self.name, self.value)

--- a/src/Mod/Fem/femobjects/constraint_tie.py
+++ b/src/Mod/Fem/femobjects/constraint_tie.py
@@ -31,6 +31,10 @@ __url__ = "https://www.freecad.org"
 
 from . import base_fempythonobject
 
+import FreeCAD
+
+_PropHelper = base_fempythonobject._PropHelper
+
 
 class ConstraintTie(base_fempythonobject.BaseFemPythonObject):
     """
@@ -42,18 +46,68 @@ class ConstraintTie(base_fempythonobject.BaseFemPythonObject):
     def __init__(self, obj):
         super(ConstraintTie, self).__init__(obj)
 
-        obj.addProperty(
-            "App::PropertyLength",
-            "Tolerance",
-            "Geometry",
-            "Set max gap between tied faces"
-        )
-        obj.Tolerance = "0.0 mm"
+        for prop in self._get_properties():
+            prop.add_to_object(obj)
 
-        obj.addProperty(
-            "App::PropertyBool",
-            "Adjust",
-            "Geometry",
-            "Adjust connected nodes"
+    def _get_properties(self):
+        prop = []
+
+        prop.append(_PropHelper(
+            type  = "App::PropertyLength",
+            name  = "Tolerance",
+            group = "Geometry",
+            doc   = "Set max gap between tied faces",
+            value = "0.0 mm"
+            )
         )
-        obj.Adjust = False
+        prop.append(_PropHelper(
+            type  = "App::PropertyBool",
+            name  = "Adjust",
+            group = "Geometry",
+            doc   = "Adjust connected nodes",
+            value = False
+            )
+        )
+        prop.append(_PropHelper(
+            type  = "App::PropertyBool",
+            name  = "CyclicSymmetry",
+            group = "Geometry",
+            doc   = "Define cyclic symmetry model",
+            value = False
+            )
+        )
+        prop.append(_PropHelper(
+            type  = "App::PropertyPlacement",
+            name  = "SymmetryAxis",
+            group = "Geometry",
+            doc   = "Placement of axis of symmetry",
+            value = FreeCAD.Placement()
+            )
+        )
+        prop.append(_PropHelper(
+            type  = "App::PropertyInteger",
+            name  = "Sectors",
+            group = "Geometry",
+            doc   = "Number of sectors",
+            value = 0
+            )
+        )
+        prop.append(_PropHelper(
+            type  = "App::PropertyInteger",
+            name  = "ConnectedSectors",
+            group = "Geometry",
+            doc   = "Number of connected sectors",
+            value = 1
+            )
+        )
+
+        return prop
+
+
+    def onDocumentRestored(self, obj):
+        # update old proyect with new properties
+        for prop in self._get_properties():
+            try:
+                obj.getPropertyByName(prop.name)
+            except:
+                prop.add_to_object(obj)


### PR DESCRIPTION
Add support for cyclic symmetry.
This also fixes the loading of the old Tie constraint object prior to #12133 since in that commit the existence check for the `Adjust` property was not added when restoring the object (currently old files are loaded without adding this property).
Normally I would have generated two pull requests, one for the correction and another to add the cyclic symmetry, but since some helper functions are added for use in creating properties and restoring the `DocumentObject`, I decided to put it together in a single commit.
The idea of the helper functions is to avoid code duplication and string comparison that usually occurs in `onDocumentRestored` when modifications are made to the properties.

The location of the axis of symmetry is obtained by applying the placement transformation to the `Z versor` (similar to what is done with the lines in `Part` module).

Still is needed add some view providers, options to task panel and automatically calculate the axis of symmetry from the planes defined by the surfaces that define the sector angle.

@FEA-eng
