### PR TITLE
Fix compilation failures in TopoShapeExpansion and TopoShapeMapper.

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -41,7 +41,6 @@
 #include <utility>
 #endif
 
-#include "modelRefine.h"
 #include "TopoShape.h"
 #include "TopoShapeCache.h"
 #include "TopoShapeMapper.h"

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -27,7 +27,6 @@
 #ifndef _PreComp_
 
 #include <BRepBuilderAPI_MakeWire.hxx>
-#include <modelRefine.h>
 #include <BRepCheck_Analyzer.hxx>
 #include <BRepFill_Generator.hxx>
 #include <BRepTools.hxx>
@@ -41,6 +40,7 @@
 #include <utility>
 #endif
 
+#include "modelRefine.h"
 #include "TopoShape.h"
 #include "TopoShapeCache.h"
 #include "TopoShapeMapper.h"

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -41,6 +41,7 @@
 #include <utility>
 #endif
 
+#include "modelRefine.h"
 #include "TopoShape.h"
 #include "TopoShapeCache.h"
 #include "TopoShapeMapper.h"

--- a/src/Mod/Part/App/TopoShapeMapper.cpp
+++ b/src/Mod/Part/App/TopoShapeMapper.cpp
@@ -21,6 +21,8 @@
  *                                                                          *
  ***************************************************************************/
 
+#include "PreCompiled.h"
+
 #include <BRep_Tool.hxx>
 #include <TopoDS_Edge.hxx>
 

--- a/src/Mod/Part/App/TopoShapeMapper.cpp
+++ b/src/Mod/Part/App/TopoShapeMapper.cpp
@@ -23,8 +23,10 @@
 
 #include "PreCompiled.h"
 
+#ifndef _PreComp_
 #include <BRep_Tool.hxx>
 #include <TopoDS_Edge.hxx>
+#endif
 
 #include "TopoShapeMapper.h"
 #include "Geometry.h"


### PR DESCRIPTION
Main does not build following #12237
Please be careful about precompiled includes @chennes @bgbsww 