### PR TITLE
Toponaming: transfer in FeaturePartBoolean

### DIFF
--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -60,33 +60,38 @@ Boolean::Boolean()
 short Boolean::mustExecute() const
 {
     if (Base.getValue() && Tool.getValue()) {
-        if (Base.isTouched())
+        if (Base.isTouched()) {
             return 1;
-        if (Tool.isTouched())
+        }
+        if (Tool.isTouched()) {
             return 1;
+        }
     }
     return 0;
 }
 
-App::DocumentObjectExecReturn *Boolean::execute()
+App::DocumentObjectExecReturn* Boolean::execute()
 {
     try {
-#if defined(__GNUC__) && defined (FC_OS_LINUX)
+#if defined(__GNUC__) && defined(FC_OS_LINUX)
         Base::SignalException se;
 #endif
         auto base = Base.getValue();
         auto tool = Tool.getValue();
 
-        if (!base || !tool)
+        if (!base || !tool) {
             return new App::DocumentObjectExecReturn("Linked object is not a Part object");
+        }
 
         // Now, let's get the TopoDS_Shape
         TopoDS_Shape BaseShape = Feature::getShape(base);
-        if (BaseShape.IsNull())
+        if (BaseShape.IsNull()) {
             throw NullShapeException("Base shape is null");
+        }
         TopoDS_Shape ToolShape = Feature::getShape(tool);
-        if (ToolShape.IsNull())
+        if (ToolShape.IsNull()) {
             throw NullShapeException("Tool shape is null");
+        }
 
         std::unique_ptr<BRepAlgoAPI_BooleanOperation> mkBool(makeOperation(BaseShape, ToolShape));
         if (!mkBool->IsDone()) {
@@ -104,12 +109,15 @@ App::DocumentObjectExecReturn *Boolean::execute()
         if (resShape.IsNull()) {
             return new App::DocumentObjectExecReturn("Resulting shape is null");
         }
-        Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-            .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part/Boolean");
+        Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                                 .GetUserParameter()
+                                                 .GetGroup("BaseApp")
+                                                 ->GetGroup("Preferences")
+                                                 ->GetGroup("Mod/Part/Boolean");
 
         if (hGrp->GetBool("CheckModel", false)) {
             BRepCheck_Analyzer aChecker(resShape);
-            if (! aChecker.IsValid() ) {
+            if (!aChecker.IsValid()) {
                 return new App::DocumentObjectExecReturn("Resulting shape is invalid");
             }
         }
@@ -136,15 +144,17 @@ App::DocumentObjectExecReturn *Boolean::execute()
         this->History.setValues(history);
         return App::DocumentObject::StdReturn;
 #else
-        TopoShape res(0,getDocument()->getStringHasher());
-        res.makeElementShape(*mkBool,shapes,opCode());
-        if (this->Refine.getValue())
+        TopoShape res(0, getDocument()->getStringHasher());
+        res.makeElementShape(*mkBool, shapes, opCode());
+        if (this->Refine.getValue()) {
             res = res.makeElementRefine();
+        }
         this->Shape.setValue(res);
         return Part::Feature::execute();
 #endif
     }
     catch (...) {
-        return new App::DocumentObjectExecReturn("A fatal error occurred when running boolean operation");
+        return new App::DocumentObjectExecReturn(
+            "A fatal error occurred when running boolean operation");
     }
 }

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -113,7 +113,7 @@ App::DocumentObjectExecReturn *Boolean::execute()
                 return new App::DocumentObjectExecReturn("Resulting shape is invalid");
             }
         }
-
+#ifndef FC_USE_TNP_FIX
         std::vector<ShapeHistory> history;
         history.push_back(buildHistory(*mkBool.get(), TopAbs_FACE, resShape, BaseShape));
         history.push_back(buildHistory(*mkBool.get(), TopAbs_FACE, resShape, ToolShape));
@@ -135,6 +135,14 @@ App::DocumentObjectExecReturn *Boolean::execute()
         this->Shape.setValue(resShape);
         this->History.setValues(history);
         return App::DocumentObject::StdReturn;
+#else
+        TopoShape res(0,getDocument()->getStringHasher());
+        res.makeElementShape(*mkBool,shapes,opCode());
+        if (this->Refine.getValue())
+            res = res.makeElementRefine();
+        this->Shape.setValue(res);
+        return Part::Feature::execute();
+#endif
     }
     catch (...) {
         return new App::DocumentObjectExecReturn("A fatal error occurred when running boolean operation");

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -34,6 +34,7 @@
 #include <Base/Parameter.h>
 
 #include "FeaturePartCommon.h"
+#include "TopoShapeOpCode.h"
 #include "modelRefine.h"
 
 

--- a/tests/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -28,6 +28,6 @@ protected:
     Part::Boolean* _boolean;  // NOLINT Can't be private in a test framework
 };
 
-// This is completely tested in the FeaturePartCommon, FeaturePartCut, and FeaturePartFuse
-// subclasses.  This class is unfortunately not usable unless initialized in one of those
-// forms, so no testing at this level.
+// This is completely tested in the FeaturePartCommon, FeaturePartCut, FeaturePartFuse and
+// FeaturePartSection subclasses.  This class is unfortunately not usable unless initialized in one
+// of those forms, so no testing at this level.

--- a/tests/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -199,3 +199,19 @@ TEST_F(FeaturePartCommonTest, testHistory)
     EXPECT_EQ(hist[0].shapeMap, compare2);
     EXPECT_EQ(hist[1].shapeMap, compare1);
 }
+
+TEST_F(FeaturePartCommonTest, testMapping)
+{
+
+    // Arrange
+    _boxes[0]->Shape.getShape().Tag = 1L;
+    _boxes[1]->Shape.getShape().Tag = 2L;
+    _common->Base.setValue(_boxes[0]);
+    _common->Tool.setValue(_boxes[1]);
+    Part::TopoShape ts1 = _common->Shape.getShape();
+#ifndef FC_USE_TNP_FIX
+    EXPECT_EQ(ts1.getElementMap().size(), 0);
+#else
+    EXPECT_EQ(ts1.getElementMap().size(), 26);  // Value and code TBD
+#endif
+}


### PR DESCRIPTION
No tests because they go on the subclasses ( FeaturePartFuse, FeaturePartCut, FeaturePartCommon, FeaturePartSection ).

The non-existent tests are already committed.  Subclasses coming up next.

` _boolean = dynamic_cast<Part::Boolean*>(_doc->addObject("Part::Boolean"));  
`
Doesn't create a useful object, and the UI always just creates the subclass appropriate to the operation you chose.