### PR TITLE
Show the normal vector of datum planes

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderDatumPlane.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatumPlane.h
@@ -44,8 +44,15 @@ public:
     void setExtents (Base::BoundBox3d bbox) override;
     void setExtents(double l, double w);
 
+    bool setEdit(int ModNum) override;
+    void unsetEdit(int ModNum) override;
+
 private:
     SoCoordinate3 *pCoords;
+    SoCoordinate3 *pArrowCoords;
+    SoTransform *pTransform;
+    SoSwitch *pArrowSwitch;
+
 };
 
 } // namespace PartDesignGui


### PR DESCRIPTION
Preliminary PR to see if there's some interest in this feature.

In order to let the user know the plane orientation draw the normal vector in the center.
The vector is only drawn when the edit panel is open to avoid cluttering the 3D view.

Much inspiration was drawn from Solidworks.