### PR TITLE
Add an icon to toggle the visibility of items in the tree view

### DIFF
--- a/src/Gui/Icons/TreeItemInvisible.svg
+++ b/src/Gui/Icons/TreeItemInvisible.svg
@@ -1,0 +1,598 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg2816"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="TreeItemInvisible.svg">
+  <defs
+     id="defs2818">
+    <linearGradient
+       id="linearGradient4513">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3681">
+      <stop
+         id="stop3697"
+         offset="0"
+         style="stop-color:#fff110;stop-opacity:1;" />
+      <stop
+         style="stop-color:#cf7008;stop-opacity:1;"
+         offset="1"
+         id="stop3685" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective2824" />
+    <inkscape:perspective
+       id="perspective3622"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3622-9"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3653"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3675"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3697"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3720"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3742"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3764"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3785"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3806"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3806-3"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3835"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3614"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3614-8"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3643"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3643-3"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3672"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3672-5"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3701"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3701-8"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3746"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       patternTransform="matrix(0.67643728,-0.81829155,2.4578314,1.8844554,-26.450606,18.294947)"
+       id="pattern5231"
+       xlink:href="#Strips1_1-4"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5224"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-4"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-4"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <inkscape:perspective
+       id="perspective5224-9"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,39.618381,8.9692804)"
+       id="pattern5231-4"
+       xlink:href="#Strips1_1-6"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5224-3"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-6"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-0"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <pattern
+       patternTransform="matrix(0.66513382,-1.0631299,2.4167603,2.4482973,-49.762569,2.9546807)"
+       id="pattern5296"
+       xlink:href="#pattern5231-3"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5288"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,-26.336284,10.887197)"
+       id="pattern5231-3"
+       xlink:href="#Strips1_1-4-3"
+       inkscape:collect="always" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-4-3"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-4-6"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <pattern
+       patternTransform="matrix(0.42844886,-0.62155849,1.5567667,1.431396,27.948414,13.306456)"
+       id="pattern5330"
+       xlink:href="#Strips1_1-9"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5323"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-9"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-3"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <inkscape:perspective
+       id="perspective5361"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5383"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5411"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3681"
+       id="linearGradient3687"
+       x1="37.89756"
+       y1="41.087898"
+       x2="4.0605712"
+       y2="40.168594"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(127.27273,-51.272729)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3681"
+       id="linearGradient3695"
+       x1="37.894287"
+       y1="40.484772"
+       x2="59.811455"
+       y2="43.558987"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(127.27273,-51.272729)" />
+    <linearGradient
+       id="linearGradient3681-3">
+      <stop
+         id="stop3697-3"
+         offset="0"
+         style="stop-color:#fff110;stop-opacity:1;" />
+      <stop
+         style="stop-color:#cf7008;stop-opacity:1;"
+         offset="1"
+         id="stop3685-4" />
+    </linearGradient>
+    <linearGradient
+       y2="43.558987"
+       x2="59.811455"
+       y1="40.484772"
+       x1="37.894287"
+       gradientTransform="translate(-37.00068,-20.487365)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3608"
+       xlink:href="#linearGradient3681-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-2" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-4" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="7.9319997"
+       fx="32.151962"
+       cy="7.9319997"
+       cx="32.151962"
+       gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4538"
+       xlink:href="#linearGradient4513-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-8" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-6" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="7.9319997"
+       fx="32.151962"
+       cy="7.9319997"
+       cx="32.151962"
+       gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4538-6"
+       xlink:href="#linearGradient4513-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-1-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-8-7" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-6-5" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="35.869175"
+       fx="32.151962"
+       cy="35.869175"
+       cx="32.151962"
+       gradientTransform="matrix(0.39497909,0,0,1.1841158,-2.716491,-26.067007)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3069"
+       xlink:href="#linearGradient4513-1-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-1-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-8-6" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-6-6" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="35.869175"
+       fx="32.151962"
+       cy="35.869175"
+       cx="32.151962"
+       gradientTransform="matrix(0.39497909,0,0,1.1841158,-2.716491,-26.067007)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3102"
+       xlink:href="#linearGradient4513-1-2"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4513-1"
+       id="radialGradient3132"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.39497909,0,0,1.1841158,64.952609,-7.0541574)"
+       cx="32.151962"
+       cy="27.950663"
+       fx="32.151962"
+       fy="27.950663"
+       r="23.634638" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4031"
+       id="linearGradient4055"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(71.494719,-3.1982556)"
+       x1="30.000002"
+       y1="14"
+       x2="36"
+       y2="54.227272" />
+    <linearGradient
+       id="linearGradient4031">
+      <stop
+         id="stop4033"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1" />
+      <stop
+         id="stop4035"
+         offset="1"
+         style="stop-color:#888a85;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="35.267952"
+     inkscape:cy="19.835481"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:window-width="1301"
+     inkscape:window-height="744"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3234"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2821">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+        <dc:title>Path-FaceProfile</dc:title>
+        <dc:date>2016-01-19</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Path/Gui/Resources/icons/Path-</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g4783"
+       transform="matrix(0.9691016,0,0,0.87415975,6.6067169,15.530249)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 26.202906,1.6813301 c -9.673905,0 -20.9601314,6.2397496 -25.79708379,18.7192689 C 5.2427746,29.76025 14.916679,36 26.202906,36 37.489143,36 47.163048,29.76025 52,20.400599 47.163048,7.9210797 35.876821,1.6813301 26.202906,1.6813301 Z m 0,31.1987859 c -9.673905,0 -17.7354897,-6.23975 -19.3478099,-12.479517 C 8.4674163,14.160848 16.529001,7.9210797 26.202906,7.9210797 c 9.673915,0 17.7355,6.2397683 19.34782,12.4795193 -1.61232,6.239767 -9.673905,12.479517 -19.34782,12.479517 z m 0,-21.839152 c -1.007692,0 -1.914621,0.194993 -2.821549,0.438734 1.662698,0.731222 2.821549,2.339912 2.821549,4.241091 0,2.583655 -2.166544,4.67981 -4.836953,4.67981 -1.965006,0 -3.627715,-1.121208 -4.383483,-2.729881 -0.251923,0.877467 -0.453469,1.754917 -0.453469,2.729881 0,5.167306 4.333107,9.359651 9.673905,9.359651 5.340808,0 9.673915,-4.192345 9.673915,-9.359651 0,-5.167292 -4.333107,-9.359635 -9.673915,-9.359635 z"
+         id="path3599"
+         style="fill:#808080;fill-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3630"
+         d="M 24.513492,32.743549 C 20.158618,32.279756 16.320657,30.874437 13.101873,28.565038 10.565128,26.744986 8.0555748,23.645238 7.240207,21.324834 6.9310922,20.445146 6.9319596,20.410993 7.289147,19.39655 c 1.39318,-3.956736 5.894877,-8.025327 10.97742,-9.9212893 2.388118,-0.8908503 4.189049,-1.243432 6.954324,-1.3615029 3.700832,-0.1580165 6.748099,0.3948804 10.068295,1.8267941 4.509958,1.9450261 8.541022,5.8276231 9.860413,9.4972421 l 0.343034,0.954079 -0.406823,1.087884 c -1.903008,5.08883 -8.045412,9.656313 -14.648854,10.892867 -1.533211,0.287106 -4.793511,0.491266 -5.923465,0.370925 z m 3.944714,-3.168696 c 3.268532,-0.752696 6.040924,-3.250309 7.009108,-6.314414 0.74188,-2.347903 0.609807,-4.448295 -0.422862,-6.724951 -1.727573,-3.808655 -5.799065,-6.000195 -10.098702,-5.435771 -0.713226,0.09362 -1.36028,0.238742 -1.437897,0.322477 -0.07761,0.08374 0.205724,0.373163 0.629646,0.643172 2.40184,1.529797 2.621108,4.930323 0.448249,6.951712 -2.087088,1.941597 -5.735326,1.528636 -7.161292,-0.810623 -0.190194,-0.312008 -0.397714,-0.56753 -0.461157,-0.567826 -0.184558,-8.66e-4 -0.490195,1.808374 -0.485585,2.874447 0.0097,2.22833 0.762415,4.123494 2.376571,5.983168 2.345137,2.701835 6.063739,3.893862 9.603921,3.078609 z"
+         style="opacity:0.8479996;fill:#ffffff;stroke:none;stroke-width:0.18025407;stroke-opacity:1" />
+    </g>
+    <rect
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:#ffffff;stroke-width:2.00000024;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4909"
+       width="6.1190372"
+       height="59.347763"
+       x="-1.1544952"
+       y="15.539548"
+       transform="matrix(0.73670431,-0.67621503,0.67671401,0.73624598,0,0)" />
+  </g>
+</svg>

--- a/src/Gui/Icons/TreeItemVisible.svg
+++ b/src/Gui/Icons/TreeItemVisible.svg
@@ -1,0 +1,590 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg2816"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="TreeItemVisible.svg">
+  <defs
+     id="defs2818">
+    <linearGradient
+       id="linearGradient4513">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3681">
+      <stop
+         id="stop3697"
+         offset="0"
+         style="stop-color:#fff110;stop-opacity:1;" />
+      <stop
+         style="stop-color:#cf7008;stop-opacity:1;"
+         offset="1"
+         id="stop3685" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective2824" />
+    <inkscape:perspective
+       id="perspective3622"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3622-9"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3653"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3675"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3697"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3720"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3742"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3764"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3785"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3806"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3806-3"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3835"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3614"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3614-8"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3643"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3643-3"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3672"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3672-5"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3701"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3701-8"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3746"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       patternTransform="matrix(0.67643728,-0.81829155,2.4578314,1.8844554,-26.450606,18.294947)"
+       id="pattern5231"
+       xlink:href="#Strips1_1-4"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5224"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-4"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-4"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <inkscape:perspective
+       id="perspective5224-9"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,39.618381,8.9692804)"
+       id="pattern5231-4"
+       xlink:href="#Strips1_1-6"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5224-3"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-6"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-0"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <pattern
+       patternTransform="matrix(0.66513382,-1.0631299,2.4167603,2.4482973,-49.762569,2.9546807)"
+       id="pattern5296"
+       xlink:href="#pattern5231-3"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5288"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,-26.336284,10.887197)"
+       id="pattern5231-3"
+       xlink:href="#Strips1_1-4-3"
+       inkscape:collect="always" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-4-3"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-4-6"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <pattern
+       patternTransform="matrix(0.42844886,-0.62155849,1.5567667,1.431396,27.948414,13.306456)"
+       id="pattern5330"
+       xlink:href="#Strips1_1-9"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective5323"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <pattern
+       inkscape:stockid="Stripes 1:1"
+       id="Strips1_1-9"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       height="1"
+       width="2"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <rect
+         id="rect4483-3"
+         height="2"
+         width="1"
+         y="-0.5"
+         x="0"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <inkscape:perspective
+       id="perspective5361"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5383"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5411"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3681"
+       id="linearGradient3687"
+       x1="37.89756"
+       y1="41.087898"
+       x2="4.0605712"
+       y2="40.168594"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(127.27273,-51.272729)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3681"
+       id="linearGradient3695"
+       x1="37.894287"
+       y1="40.484772"
+       x2="59.811455"
+       y2="43.558987"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(127.27273,-51.272729)" />
+    <linearGradient
+       id="linearGradient3681-3">
+      <stop
+         id="stop3697-3"
+         offset="0"
+         style="stop-color:#fff110;stop-opacity:1;" />
+      <stop
+         style="stop-color:#cf7008;stop-opacity:1;"
+         offset="1"
+         id="stop3685-4" />
+    </linearGradient>
+    <linearGradient
+       y2="43.558987"
+       x2="59.811455"
+       y1="40.484772"
+       x1="37.894287"
+       gradientTransform="translate(-37.00068,-20.487365)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3608"
+       xlink:href="#linearGradient3681-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-2" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-4" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="7.9319997"
+       fx="32.151962"
+       cy="7.9319997"
+       cx="32.151962"
+       gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4538"
+       xlink:href="#linearGradient4513-2"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-8" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-6" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="7.9319997"
+       fx="32.151962"
+       cy="7.9319997"
+       cx="32.151962"
+       gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4538-6"
+       xlink:href="#linearGradient4513-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-1-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-8-7" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-6-5" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="35.869175"
+       fx="32.151962"
+       cy="35.869175"
+       cx="32.151962"
+       gradientTransform="matrix(0.39497909,0,0,1.1841158,-2.716491,-26.067007)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3069"
+       xlink:href="#linearGradient4513-1-3"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4513-1-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4515-8-6" />
+      <stop
+         style="stop-color:#999999;stop-opacity:1;"
+         offset="1"
+         id="stop4517-6-6" />
+    </linearGradient>
+    <radialGradient
+       r="23.634638"
+       fy="35.869175"
+       fx="32.151962"
+       cy="35.869175"
+       cx="32.151962"
+       gradientTransform="matrix(0.39497909,0,0,1.1841158,-2.716491,-26.067007)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3102"
+       xlink:href="#linearGradient4513-1-2"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4513-1"
+       id="radialGradient3132"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.39497909,0,0,1.1841158,64.952609,-7.0541574)"
+       cx="32.151962"
+       cy="27.950663"
+       fx="32.151962"
+       fy="27.950663"
+       r="23.634638" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4031"
+       id="linearGradient4055"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(71.494719,-3.1982556)"
+       x1="30.000002"
+       y1="14"
+       x2="36"
+       y2="54.227272" />
+    <linearGradient
+       id="linearGradient4031">
+      <stop
+         id="stop4033"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1" />
+      <stop
+         id="stop4035"
+         offset="1"
+         style="stop-color:#888a85;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="21.263997"
+     inkscape:cy="29.668329"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:window-width="1301"
+     inkscape:window-height="744"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3234"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2821">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+        <dc:title>Path-FaceProfile</dc:title>
+        <dc:date>2016-01-19</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Path/Gui/Resources/icons/Path-</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g4783"
+       transform="matrix(0.9691016,0,0,0.87415975,6.6067169,15.530249)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 26.202906,1.6813301 c -9.673905,0 -20.9601314,6.2397496 -25.79708379,18.7192689 C 5.2427746,29.76025 14.916679,36 26.202906,36 37.489143,36 47.163048,29.76025 52,20.400599 47.163048,7.9210797 35.876821,1.6813301 26.202906,1.6813301 Z m 0,31.1987859 c -9.673905,0 -17.7354897,-6.23975 -19.3478099,-12.479517 C 8.4674163,14.160848 16.529001,7.9210797 26.202906,7.9210797 c 9.673915,0 17.7355,6.2397683 19.34782,12.4795193 -1.61232,6.239767 -9.673905,12.479517 -19.34782,12.479517 z m 0,-21.839152 c -1.007692,0 -1.914621,0.194993 -2.821549,0.438734 1.662698,0.731222 2.821549,2.339912 2.821549,4.241091 0,2.583655 -2.166544,4.67981 -4.836953,4.67981 -1.965006,0 -3.627715,-1.121208 -4.383483,-2.729881 -0.251923,0.877467 -0.453469,1.754917 -0.453469,2.729881 0,5.167306 4.333107,9.359651 9.673905,9.359651 5.340808,0 9.673915,-4.192345 9.673915,-9.359651 0,-5.167292 -4.333107,-9.359635 -9.673915,-9.359635 z"
+         id="path3599"
+         style="fill:#000000;fill-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3630"
+         d="M 24.513492,32.743549 C 20.158618,32.279756 16.320657,30.874437 13.101873,28.565038 10.565128,26.744986 8.0555748,23.645238 7.240207,21.324834 6.9310922,20.445146 6.9319596,20.410993 7.289147,19.39655 c 1.39318,-3.956736 5.894877,-8.025327 10.97742,-9.9212893 2.388118,-0.8908503 4.189049,-1.243432 6.954324,-1.3615029 3.700832,-0.1580165 6.748099,0.3948804 10.068295,1.8267941 4.509958,1.9450261 8.541022,5.8276231 9.860413,9.4972421 l 0.343034,0.954079 -0.406823,1.087884 c -1.903008,5.08883 -8.045412,9.656313 -14.648854,10.892867 -1.533211,0.287106 -4.793511,0.491266 -5.923465,0.370925 z m 3.944714,-3.168696 c 3.268532,-0.752696 6.040924,-3.250309 7.009108,-6.314414 0.74188,-2.347903 0.609807,-4.448295 -0.422862,-6.724951 -1.727573,-3.808655 -5.799065,-6.000195 -10.098702,-5.435771 -0.713226,0.09362 -1.36028,0.238742 -1.437897,0.322477 -0.07761,0.08374 0.205724,0.373163 0.629646,0.643172 2.40184,1.529797 2.621108,4.930323 0.448249,6.951712 -2.087088,1.941597 -5.735326,1.528636 -7.161292,-0.810623 -0.190194,-0.312008 -0.397714,-0.56753 -0.461157,-0.567826 -0.184558,-8.66e-4 -0.490195,1.808374 -0.485585,2.874447 0.0097,2.22833 0.762415,4.123494 2.376571,5.983168 2.345137,2.701835 6.063739,3.893862 9.603921,3.078609 z"
+         style="opacity:0.8479996;fill:#ffffff;stroke:none;stroke-width:0.18025407;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -133,6 +133,8 @@
         <file>Tree_Annotation.svg</file>
         <file>Tree_Dimension.svg</file>
         <file>Tree_Python.svg</file>
+        <file>TreeItemVisible.svg</file>
+        <file>TreeItemInvisible.svg</file>
         <file>dagViewVisible.svg</file>
         <file>dagViewPass.svg</file>
         <file>dagViewFail.svg</file>

--- a/src/Gui/PreferencePages/DlgSettingsUI.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsUI.cpp
@@ -93,49 +93,56 @@ DlgSettingsUI::DlgSettingsUI(QWidget* parent)
     ResizableColumn->setParamGrpPath("TreeView");
 
     // Auto generated code (Tools/params_utils.py:433)
+    VisibilityIcon = new Gui::PrefCheckBox(this);
+    layoutTreeview->addWidget(VisibilityIcon, 3, 0);
+    VisibilityIcon->setChecked(Gui::TreeParams::defaultVisibilityIcon());
+    VisibilityIcon->setEntryName("VisibilityIcon");
+    VisibilityIcon->setParamGrpPath("TreeView");
+
+    // Auto generated code (Tools/params_utils.py:433)
     HideColumn = new Gui::PrefCheckBox(this);
-    layoutTreeview->addWidget(HideColumn, 3, 0);
+    layoutTreeview->addWidget(HideColumn, 4, 0);
     HideColumn->setChecked(Gui::TreeParams::defaultHideColumn());
     HideColumn->setEntryName("HideColumn");
     HideColumn->setParamGrpPath("TreeView");
 
     // Auto generated code (Tools/params_utils.py:433)
     HideScrollBar = new Gui::PrefCheckBox(this);
-    layoutTreeview->addWidget(HideScrollBar, 4, 0);
+    layoutTreeview->addWidget(HideScrollBar, 5, 0);
     HideScrollBar->setChecked(Gui::TreeParams::defaultHideScrollBar());
     HideScrollBar->setEntryName("HideScrollBar");
     HideScrollBar->setParamGrpPath("TreeView");
 
     // Auto generated code (Tools/params_utils.py:433)
     HideHeaderView = new Gui::PrefCheckBox(this);
-    layoutTreeview->addWidget(HideHeaderView, 5, 0);
+    layoutTreeview->addWidget(HideHeaderView, 6, 0);
     HideHeaderView->setChecked(Gui::TreeParams::defaultHideHeaderView());
     HideHeaderView->setEntryName("HideHeaderView");
     HideHeaderView->setParamGrpPath("TreeView");
 
     // Auto generated code (Tools/params_utils.py:433)
     labelIconSize = new QLabel(this);
-    layoutTreeview->addWidget(labelIconSize, 6, 0);
+    layoutTreeview->addWidget(labelIconSize, 7, 0);
     IconSize = new Gui::PrefSpinBox(this);
-    layoutTreeview->addWidget(IconSize, 6, 1);
+    layoutTreeview->addWidget(IconSize, 7, 1);
     IconSize->setValue(Gui::TreeParams::defaultIconSize());
     IconSize->setEntryName("IconSize");
     IconSize->setParamGrpPath("TreeView");
 
     // Auto generated code (Tools/params_utils.py:433)
     labelFontSize = new QLabel(this);
-    layoutTreeview->addWidget(labelFontSize, 7, 0);
+    layoutTreeview->addWidget(labelFontSize, 8, 0);
     FontSize = new Gui::PrefSpinBox(this);
-    layoutTreeview->addWidget(FontSize, 7, 1);
+    layoutTreeview->addWidget(FontSize, 8, 1);
     FontSize->setValue(Gui::TreeParams::defaultFontSize());
     FontSize->setEntryName("FontSize");
     FontSize->setParamGrpPath("TreeView");
 
     // Auto generated code (Tools/params_utils.py:433)
     labelItemSpacing = new QLabel(this);
-    layoutTreeview->addWidget(labelItemSpacing, 8, 0);
+    layoutTreeview->addWidget(labelItemSpacing, 9, 0);
     ItemSpacing = new Gui::PrefSpinBox(this);
-    layoutTreeview->addWidget(ItemSpacing, 8, 1);
+    layoutTreeview->addWidget(ItemSpacing, 9, 1);
     ItemSpacing->setValue(Gui::TreeParams::defaultItemSpacing());
     ItemSpacing->setEntryName("ItemSpacing");
     ItemSpacing->setParamGrpPath("TreeView");
@@ -442,6 +449,7 @@ void DlgSettingsUI::saveSettings()
     ItemBackground->onSave();
     ItemBackgroundPadding->onSave();
     ResizableColumn->onSave();
+    VisibilityIcon->onSave();
     HideColumn->onSave();
     HideScrollBar->onSave();
     HideHeaderView->onSave();
@@ -482,6 +490,7 @@ void DlgSettingsUI::loadSettings()
     ItemBackground->onRestore();
     ItemBackgroundPadding->onRestore();
     ResizableColumn->onRestore();
+    VisibilityIcon->onRestore();
     HideColumn->onRestore();
     HideScrollBar->onRestore();
     HideHeaderView->onRestore();
@@ -528,6 +537,8 @@ void DlgSettingsUI::retranslateUi()
     labelItemBackgroundPadding->setToolTip(ItemBackgroundPadding->toolTip());
     ResizableColumn->setToolTip(QApplication::translate("TreeParams", Gui::TreeParams::docResizableColumn()));
     ResizableColumn->setText(QObject::tr("Resizable columns"));
+    VisibilityIcon->setToolTip(QApplication::translate("TreeParams", Gui::TreeParams::docVisibilityIcon()));
+    VisibilityIcon->setText(QObject::tr("Show visibility icon"));
     HideColumn->setToolTip(QApplication::translate("TreeParams", Gui::TreeParams::docHideColumn()));
     HideColumn->setText(QObject::tr("Hide extra column"));
     HideScrollBar->setToolTip(QApplication::translate("TreeParams", Gui::TreeParams::docHideScrollBar()));

--- a/src/Gui/PreferencePages/DlgSettingsUI.h
+++ b/src/Gui/PreferencePages/DlgSettingsUI.h
@@ -78,6 +78,7 @@ private:
     QLabel *labelItemBackgroundPadding = nullptr;
     Gui::PrefSpinBox *ItemBackgroundPadding = nullptr;
     Gui::PrefCheckBox *ResizableColumn = nullptr;
+    Gui::PrefCheckBox *VisibilityIcon = nullptr;
     Gui::PrefCheckBox *HideColumn = nullptr;
     Gui::PrefCheckBox *HideScrollBar = nullptr;
     Gui::PrefCheckBox *HideHeaderView = nullptr;

--- a/src/Gui/PreferencePages/DlgSettingsUI.py
+++ b/src/Gui/PreferencePages/DlgSettingsUI.py
@@ -48,6 +48,7 @@ ParamGroup = (
         'ItemBackground',
         'ItemBackgroundPadding',
         'ResizableColumn',
+        'VisibilityIcon',
         'HideColumn',
         'HideScrollBar',
         'HideHeaderView',

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -94,7 +94,7 @@ static bool _DraggingActive;
 static bool _DragEventFilter;
 
 static bool isVisibilityIconEnabled() {
-    return true;
+    return TreeParams::getVisibilityIcon();
 }
 
 static bool isSelectionCheckBoxesEnabled() {

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -3199,6 +3199,20 @@ void TreeWidget::synchronizeSelectionCheckBoxes() {
     }
 }
 
+void TreeWidget::updateVisibilityIcons() {
+    for (auto tree : TreeWidget::Instances) {
+        QSignalBlocker blocker(tree);
+        for (QTreeWidgetItemIterator it(tree); *it; ++it) {
+            auto item = *it;
+            if (item->type() == ObjectType) {
+                auto objitem = static_cast<DocumentObjectItem*>(item);
+                objitem->testStatus(true);
+            }
+        }
+        tree->resizeColumnToContents(0);
+    }
+}
+
 QList<QTreeWidgetItem*> TreeWidget::childrenOfItem(const QTreeWidgetItem& item) const {
     QList children = QList<QTreeWidgetItem*>();
 

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -122,6 +122,7 @@ public:
     void itemSearch(const QString &text, bool select);
 
     static void synchronizeSelectionCheckBoxes();
+    static void updateVisibilityIcons();
 
     QList<QTreeWidgetItem *> childrenOfItem(const QTreeWidgetItem &item) const;
 

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -143,6 +143,7 @@ protected:
     //@}
     bool event(QEvent *e) override;
     void keyPressEvent(QKeyEvent *event) override;
+    void mousePressEvent(QMouseEvent * event) override;
     void mouseDoubleClickEvent(QMouseEvent * event) override;
 
 protected:

--- a/src/Gui/TreeParams.cpp
+++ b/src/Gui/TreeParams.cpp
@@ -78,6 +78,7 @@ public:
     long ColumnSize1;
     long ColumnSize2;
     bool TreeToolTipIcon;
+    bool VisibilityIcon;
 
     // Auto generated code (Tools/params_utils.py:203)
     TreeParamsP() {
@@ -156,6 +157,8 @@ public:
         funcs["ColumnSize2"] = &TreeParamsP::updateColumnSize2;
         TreeToolTipIcon = handle->GetBool("TreeToolTipIcon", false);
         funcs["TreeToolTipIcon"] = &TreeParamsP::updateTreeToolTipIcon;
+        VisibilityIcon = handle->GetBool("VisibilityIcon", false);
+        funcs["VisibilityIcon"] = &TreeParamsP::updateVisibilityIcon;
     }
 
     // Auto generated code (Tools/params_utils.py:217)
@@ -388,6 +391,14 @@ public:
     // Auto generated code (Tools/params_utils.py:238)
     static void updateTreeToolTipIcon(TreeParamsP *self) {
         self->TreeToolTipIcon = self->handle->GetBool("TreeToolTipIcon", false);
+    }
+    // Auto generated code (Tools/params_utils.py:296)
+    static void updateVisibilityIcon(TreeParamsP *self) {
+        auto v = self->handle->GetBool("VisibilityIcon", false);
+        if (self->VisibilityIcon != v) {
+            self->VisibilityIcon = v;
+            TreeParams::onVisibilityIconChanged();
+        }
     }
 };
 
@@ -1381,6 +1392,34 @@ void TreeParams::setTreeToolTipIcon(const bool &v) {
 void TreeParams::removeTreeToolTipIcon() {
     instance()->handle->RemoveBool("TreeToolTipIcon");
 }
+
+// Auto generated code (Tools/params_utils.py:350)
+const char *TreeParams::docVisibilityIcon() {
+    return QT_TRANSLATE_NOOP("TreeParams",
+"If enabled, show an eye icon before the tree view items, showing the items visibility status. When clicked the visibility is toggled");
+}
+
+// Auto generated code (Tools/params_utils.py:358)
+const bool & TreeParams::getVisibilityIcon() {
+    return instance()->VisibilityIcon;
+}
+
+// Auto generated code (Tools/params_utils.py:366)
+const bool & TreeParams::defaultVisibilityIcon() {
+    const static bool def = false;
+    return def;
+}
+
+// Auto generated code (Tools/params_utils.py:375)
+void TreeParams::setVisibilityIcon(const bool &v) {
+    instance()->handle->SetBool("VisibilityIcon",v);
+    instance()->VisibilityIcon = v;
+}
+
+// Auto generated code (Tools/params_utils.py:384)
+void TreeParams::removeVisibilityIcon() {
+    instance()->handle->RemoveBool("VisibilityIcon");
+}
 //[[[end]]]
 
 void TreeParams::onSyncSelectionChanged() {
@@ -1481,4 +1520,9 @@ void TreeParams::onHideColumnChanged()
 {
     for(auto tree : TreeWidget::Instances)
         tree->setColumnHidden(1, TreeParams::getHideColumn());
+}
+
+void TreeParams::onVisibilityIconChanged()
+{
+    TreeWidget::updateVisibilityIcons();
 }

--- a/src/Gui/TreeParams.cpp
+++ b/src/Gui/TreeParams.cpp
@@ -28,14 +28,14 @@ import TreeParams
 TreeParams.define()
 ]]]*/
 
-// Auto generated code (Tools/params_utils.py:166)
+// Auto generated code (Tools/params_utils.py:196)
 #include <unordered_map>
 #include <App/Application.h>
 #include <App/DynamicProperty.h>
 #include "TreeParams.h"
 using namespace Gui;
 
-// Auto generated code (Tools/params_utils.py:175)
+// Auto generated code (Tools/params_utils.py:207)
 namespace {
 class TreeParamsP: public ParameterGrp::ObserverType {
 public:
@@ -80,7 +80,7 @@ public:
     bool TreeToolTipIcon;
     bool VisibilityIcon;
 
-    // Auto generated code (Tools/params_utils.py:203)
+    // Auto generated code (Tools/params_utils.py:245)
     TreeParamsP() {
         handle = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/TreeView");
         handle->Attach(this);
@@ -161,22 +161,23 @@ public:
         funcs["VisibilityIcon"] = &TreeParamsP::updateVisibilityIcon;
     }
 
-    // Auto generated code (Tools/params_utils.py:217)
-    ~TreeParamsP() override = default;
+    // Auto generated code (Tools/params_utils.py:263)
+    ~TreeParamsP() {
+    }
 
-    // Auto generated code (Tools/params_utils.py:222)
-    void OnChange(Base::Subject<const char*> &, const char* sReason) override {
+    // Auto generated code (Tools/params_utils.py:270)
+    void OnChange(Base::Subject<const char*> &, const char* sReason) {
         if(!sReason)
             return;
         auto it = funcs.find(sReason);
         if(it == funcs.end())
             return;
         it->second(this);
-
+        
     }
 
 
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateSyncSelection(TreeParamsP *self) {
         auto v = self->handle->GetBool("SyncSelection", true);
         if (self->SyncSelection != v) {
@@ -184,7 +185,7 @@ public:
             TreeParams::onSyncSelectionChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateCheckBoxesSelection(TreeParamsP *self) {
         auto v = self->handle->GetBool("CheckBoxesSelection", false);
         if (self->CheckBoxesSelection != v) {
@@ -192,23 +193,23 @@ public:
             TreeParams::onCheckBoxesSelectionChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateSyncView(TreeParamsP *self) {
         self->SyncView = self->handle->GetBool("SyncView", true);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updatePreSelection(TreeParamsP *self) {
         self->PreSelection = self->handle->GetBool("PreSelection", true);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateSyncPlacement(TreeParamsP *self) {
         self->SyncPlacement = self->handle->GetBool("SyncPlacement", false);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateRecordSelection(TreeParamsP *self) {
         self->RecordSelection = self->handle->GetBool("RecordSelection", true);
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateDocumentMode(TreeParamsP *self) {
         auto v = self->handle->GetInt("DocumentMode", 2);
         if (self->DocumentMode != v) {
@@ -216,39 +217,39 @@ public:
             TreeParams::onDocumentModeChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateStatusTimeout(TreeParamsP *self) {
         self->StatusTimeout = self->handle->GetInt("StatusTimeout", 100);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateSelectionTimeout(TreeParamsP *self) {
         self->SelectionTimeout = self->handle->GetInt("SelectionTimeout", 100);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updatePreSelectionTimeout(TreeParamsP *self) {
         self->PreSelectionTimeout = self->handle->GetInt("PreSelectionTimeout", 500);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updatePreSelectionDelay(TreeParamsP *self) {
         self->PreSelectionDelay = self->handle->GetInt("PreSelectionDelay", 700);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updatePreSelectionMinDelay(TreeParamsP *self) {
         self->PreSelectionMinDelay = self->handle->GetInt("PreSelectionMinDelay", 200);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateRecomputeOnDrop(TreeParamsP *self) {
         self->RecomputeOnDrop = self->handle->GetBool("RecomputeOnDrop", true);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateKeepRootOrder(TreeParamsP *self) {
         self->KeepRootOrder = self->handle->GetBool("KeepRootOrder", true);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateTreeActiveAutoExpand(TreeParamsP *self) {
         self->TreeActiveAutoExpand = self->handle->GetBool("TreeActiveAutoExpand", true);
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateTreeActiveColor(TreeParamsP *self) {
         auto v = self->handle->GetUnsigned("TreeActiveColor", 3873898495);
         if (self->TreeActiveColor != v) {
@@ -256,7 +257,7 @@ public:
             TreeParams::onTreeActiveColorChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateTreeEditColor(TreeParamsP *self) {
         auto v = self->handle->GetUnsigned("TreeEditColor", 2459042047);
         if (self->TreeEditColor != v) {
@@ -264,7 +265,7 @@ public:
             TreeParams::onTreeEditColorChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateSelectingGroupColor(TreeParamsP *self) {
         auto v = self->handle->GetUnsigned("SelectingGroupColor", 1082163711);
         if (self->SelectingGroupColor != v) {
@@ -272,7 +273,7 @@ public:
             TreeParams::onSelectingGroupColorChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateTreeActiveBold(TreeParamsP *self) {
         auto v = self->handle->GetBool("TreeActiveBold", true);
         if (self->TreeActiveBold != v) {
@@ -280,7 +281,7 @@ public:
             TreeParams::onTreeActiveBoldChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateTreeActiveItalic(TreeParamsP *self) {
         auto v = self->handle->GetBool("TreeActiveItalic", false);
         if (self->TreeActiveItalic != v) {
@@ -288,7 +289,7 @@ public:
             TreeParams::onTreeActiveItalicChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateTreeActiveUnderlined(TreeParamsP *self) {
         auto v = self->handle->GetBool("TreeActiveUnderlined", false);
         if (self->TreeActiveUnderlined != v) {
@@ -296,7 +297,7 @@ public:
             TreeParams::onTreeActiveUnderlinedChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateTreeActiveOverlined(TreeParamsP *self) {
         auto v = self->handle->GetBool("TreeActiveOverlined", false);
         if (self->TreeActiveOverlined != v) {
@@ -304,7 +305,7 @@ public:
             TreeParams::onTreeActiveOverlinedChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateIndentation(TreeParamsP *self) {
         auto v = self->handle->GetInt("Indentation", 0);
         if (self->Indentation != v) {
@@ -312,11 +313,11 @@ public:
             TreeParams::onIndentationChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateLabelExpression(TreeParamsP *self) {
         self->LabelExpression = self->handle->GetBool("LabelExpression", false);
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateIconSize(TreeParamsP *self) {
         auto v = self->handle->GetInt("IconSize", 0);
         if (self->IconSize != v) {
@@ -324,7 +325,7 @@ public:
             TreeParams::onIconSizeChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateFontSize(TreeParamsP *self) {
         auto v = self->handle->GetInt("FontSize", 0);
         if (self->FontSize != v) {
@@ -332,7 +333,7 @@ public:
             TreeParams::onFontSizeChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateItemSpacing(TreeParamsP *self) {
         auto v = self->handle->GetInt("ItemSpacing", 0);
         if (self->ItemSpacing != v) {
@@ -340,7 +341,7 @@ public:
             TreeParams::onItemSpacingChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateItemBackground(TreeParamsP *self) {
         auto v = self->handle->GetUnsigned("ItemBackground", 0x00000000);
         if (self->ItemBackground != v) {
@@ -348,7 +349,7 @@ public:
             TreeParams::onItemBackgroundChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateItemBackgroundPadding(TreeParamsP *self) {
         auto v = self->handle->GetInt("ItemBackgroundPadding", 0);
         if (self->ItemBackgroundPadding != v) {
@@ -356,7 +357,7 @@ public:
             TreeParams::onItemBackgroundPaddingChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateHideColumn(TreeParamsP *self) {
         auto v = self->handle->GetBool("HideColumn", true);
         if (self->HideColumn != v) {
@@ -364,15 +365,15 @@ public:
             TreeParams::onHideColumnChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateHideScrollBar(TreeParamsP *self) {
         self->HideScrollBar = self->handle->GetBool("HideScrollBar", true);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateHideHeaderView(TreeParamsP *self) {
         self->HideHeaderView = self->handle->GetBool("HideHeaderView", true);
     }
-    // Auto generated code (Tools/params_utils.py:244)
+    // Auto generated code (Tools/params_utils.py:296)
     static void updateResizableColumn(TreeParamsP *self) {
         auto v = self->handle->GetBool("ResizableColumn", false);
         if (self->ResizableColumn != v) {
@@ -380,15 +381,15 @@ public:
             TreeParams::onResizableColumnChanged();
         }
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateColumnSize1(TreeParamsP *self) {
         self->ColumnSize1 = self->handle->GetInt("ColumnSize1", 0);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateColumnSize2(TreeParamsP *self) {
         self->ColumnSize2 = self->handle->GetInt("ColumnSize2", 0);
     }
-    // Auto generated code (Tools/params_utils.py:238)
+    // Auto generated code (Tools/params_utils.py:288)
     static void updateTreeToolTipIcon(TreeParamsP *self) {
         self->TreeToolTipIcon = self->handle->GetBool("TreeToolTipIcon", false);
     }
@@ -402,7 +403,7 @@ public:
     }
 };
 
-// Auto generated code (Tools/params_utils.py:256)
+// Auto generated code (Tools/params_utils.py:310)
 TreeParamsP *instance() {
     static TreeParamsP *inst = new TreeParamsP;
     return inst;
@@ -410,985 +411,985 @@ TreeParamsP *instance() {
 
 } // Anonymous namespace
 
-// Auto generated code (Tools/params_utils.py:265)
+// Auto generated code (Tools/params_utils.py:321)
 ParameterGrp::handle TreeParams::getHandle() {
     return instance()->handle;
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docSyncSelection() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getSyncSelection() {
     return instance()->SyncSelection;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultSyncSelection() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setSyncSelection(const bool &v) {
     instance()->handle->SetBool("SyncSelection",v);
     instance()->SyncSelection = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeSyncSelection() {
     instance()->handle->RemoveBool("SyncSelection");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docCheckBoxesSelection() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getCheckBoxesSelection() {
     return instance()->CheckBoxesSelection;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultCheckBoxesSelection() {
     const static bool def = false;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setCheckBoxesSelection(const bool &v) {
     instance()->handle->SetBool("CheckBoxesSelection",v);
     instance()->CheckBoxesSelection = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeCheckBoxesSelection() {
     instance()->handle->RemoveBool("CheckBoxesSelection");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docSyncView() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getSyncView() {
     return instance()->SyncView;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultSyncView() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setSyncView(const bool &v) {
     instance()->handle->SetBool("SyncView",v);
     instance()->SyncView = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeSyncView() {
     instance()->handle->RemoveBool("SyncView");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docPreSelection() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getPreSelection() {
     return instance()->PreSelection;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultPreSelection() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setPreSelection(const bool &v) {
     instance()->handle->SetBool("PreSelection",v);
     instance()->PreSelection = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removePreSelection() {
     instance()->handle->RemoveBool("PreSelection");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docSyncPlacement() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getSyncPlacement() {
     return instance()->SyncPlacement;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultSyncPlacement() {
     const static bool def = false;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setSyncPlacement(const bool &v) {
     instance()->handle->SetBool("SyncPlacement",v);
     instance()->SyncPlacement = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeSyncPlacement() {
     instance()->handle->RemoveBool("SyncPlacement");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docRecordSelection() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getRecordSelection() {
     return instance()->RecordSelection;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultRecordSelection() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setRecordSelection(const bool &v) {
     instance()->handle->SetBool("RecordSelection",v);
     instance()->RecordSelection = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeRecordSelection() {
     instance()->handle->RemoveBool("RecordSelection");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docDocumentMode() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getDocumentMode() {
     return instance()->DocumentMode;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultDocumentMode() {
     const static long def = 2;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setDocumentMode(const long &v) {
     instance()->handle->SetInt("DocumentMode",v);
     instance()->DocumentMode = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeDocumentMode() {
     instance()->handle->RemoveInt("DocumentMode");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docStatusTimeout() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getStatusTimeout() {
     return instance()->StatusTimeout;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultStatusTimeout() {
     const static long def = 100;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setStatusTimeout(const long &v) {
     instance()->handle->SetInt("StatusTimeout",v);
     instance()->StatusTimeout = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeStatusTimeout() {
     instance()->handle->RemoveInt("StatusTimeout");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docSelectionTimeout() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getSelectionTimeout() {
     return instance()->SelectionTimeout;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultSelectionTimeout() {
     const static long def = 100;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setSelectionTimeout(const long &v) {
     instance()->handle->SetInt("SelectionTimeout",v);
     instance()->SelectionTimeout = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeSelectionTimeout() {
     instance()->handle->RemoveInt("SelectionTimeout");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docPreSelectionTimeout() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getPreSelectionTimeout() {
     return instance()->PreSelectionTimeout;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultPreSelectionTimeout() {
     const static long def = 500;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setPreSelectionTimeout(const long &v) {
     instance()->handle->SetInt("PreSelectionTimeout",v);
     instance()->PreSelectionTimeout = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removePreSelectionTimeout() {
     instance()->handle->RemoveInt("PreSelectionTimeout");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docPreSelectionDelay() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getPreSelectionDelay() {
     return instance()->PreSelectionDelay;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultPreSelectionDelay() {
     const static long def = 700;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setPreSelectionDelay(const long &v) {
     instance()->handle->SetInt("PreSelectionDelay",v);
     instance()->PreSelectionDelay = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removePreSelectionDelay() {
     instance()->handle->RemoveInt("PreSelectionDelay");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docPreSelectionMinDelay() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getPreSelectionMinDelay() {
     return instance()->PreSelectionMinDelay;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultPreSelectionMinDelay() {
     const static long def = 200;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setPreSelectionMinDelay(const long &v) {
     instance()->handle->SetInt("PreSelectionMinDelay",v);
     instance()->PreSelectionMinDelay = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removePreSelectionMinDelay() {
     instance()->handle->RemoveInt("PreSelectionMinDelay");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docRecomputeOnDrop() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getRecomputeOnDrop() {
     return instance()->RecomputeOnDrop;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultRecomputeOnDrop() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setRecomputeOnDrop(const bool &v) {
     instance()->handle->SetBool("RecomputeOnDrop",v);
     instance()->RecomputeOnDrop = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeRecomputeOnDrop() {
     instance()->handle->RemoveBool("RecomputeOnDrop");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docKeepRootOrder() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getKeepRootOrder() {
     return instance()->KeepRootOrder;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultKeepRootOrder() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setKeepRootOrder(const bool &v) {
     instance()->handle->SetBool("KeepRootOrder",v);
     instance()->KeepRootOrder = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeKeepRootOrder() {
     instance()->handle->RemoveBool("KeepRootOrder");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docTreeActiveAutoExpand() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getTreeActiveAutoExpand() {
     return instance()->TreeActiveAutoExpand;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultTreeActiveAutoExpand() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setTreeActiveAutoExpand(const bool &v) {
     instance()->handle->SetBool("TreeActiveAutoExpand",v);
     instance()->TreeActiveAutoExpand = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeTreeActiveAutoExpand() {
     instance()->handle->RemoveBool("TreeActiveAutoExpand");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docTreeActiveColor() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const unsigned long & TreeParams::getTreeActiveColor() {
     return instance()->TreeActiveColor;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const unsigned long & TreeParams::defaultTreeActiveColor() {
     const static unsigned long def = 3873898495;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setTreeActiveColor(const unsigned long &v) {
     instance()->handle->SetUnsigned("TreeActiveColor",v);
     instance()->TreeActiveColor = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeTreeActiveColor() {
     instance()->handle->RemoveUnsigned("TreeActiveColor");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docTreeEditColor() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const unsigned long & TreeParams::getTreeEditColor() {
     return instance()->TreeEditColor;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const unsigned long & TreeParams::defaultTreeEditColor() {
     const static unsigned long def = 2459042047;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setTreeEditColor(const unsigned long &v) {
     instance()->handle->SetUnsigned("TreeEditColor",v);
     instance()->TreeEditColor = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeTreeEditColor() {
     instance()->handle->RemoveUnsigned("TreeEditColor");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docSelectingGroupColor() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const unsigned long & TreeParams::getSelectingGroupColor() {
     return instance()->SelectingGroupColor;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const unsigned long & TreeParams::defaultSelectingGroupColor() {
     const static unsigned long def = 1082163711;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setSelectingGroupColor(const unsigned long &v) {
     instance()->handle->SetUnsigned("SelectingGroupColor",v);
     instance()->SelectingGroupColor = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeSelectingGroupColor() {
     instance()->handle->RemoveUnsigned("SelectingGroupColor");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docTreeActiveBold() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getTreeActiveBold() {
     return instance()->TreeActiveBold;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultTreeActiveBold() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setTreeActiveBold(const bool &v) {
     instance()->handle->SetBool("TreeActiveBold",v);
     instance()->TreeActiveBold = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeTreeActiveBold() {
     instance()->handle->RemoveBool("TreeActiveBold");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docTreeActiveItalic() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getTreeActiveItalic() {
     return instance()->TreeActiveItalic;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultTreeActiveItalic() {
     const static bool def = false;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setTreeActiveItalic(const bool &v) {
     instance()->handle->SetBool("TreeActiveItalic",v);
     instance()->TreeActiveItalic = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeTreeActiveItalic() {
     instance()->handle->RemoveBool("TreeActiveItalic");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docTreeActiveUnderlined() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getTreeActiveUnderlined() {
     return instance()->TreeActiveUnderlined;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultTreeActiveUnderlined() {
     const static bool def = false;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setTreeActiveUnderlined(const bool &v) {
     instance()->handle->SetBool("TreeActiveUnderlined",v);
     instance()->TreeActiveUnderlined = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeTreeActiveUnderlined() {
     instance()->handle->RemoveBool("TreeActiveUnderlined");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docTreeActiveOverlined() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getTreeActiveOverlined() {
     return instance()->TreeActiveOverlined;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultTreeActiveOverlined() {
     const static bool def = false;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setTreeActiveOverlined(const bool &v) {
     instance()->handle->SetBool("TreeActiveOverlined",v);
     instance()->TreeActiveOverlined = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeTreeActiveOverlined() {
     instance()->handle->RemoveBool("TreeActiveOverlined");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docIndentation() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getIndentation() {
     return instance()->Indentation;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultIndentation() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setIndentation(const long &v) {
     instance()->handle->SetInt("Indentation",v);
     instance()->Indentation = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeIndentation() {
     instance()->handle->RemoveInt("Indentation");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docLabelExpression() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getLabelExpression() {
     return instance()->LabelExpression;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultLabelExpression() {
     const static bool def = false;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setLabelExpression(const bool &v) {
     instance()->handle->SetBool("LabelExpression",v);
     instance()->LabelExpression = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeLabelExpression() {
     instance()->handle->RemoveBool("LabelExpression");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docIconSize() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getIconSize() {
     return instance()->IconSize;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultIconSize() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setIconSize(const long &v) {
     instance()->handle->SetInt("IconSize",v);
     instance()->IconSize = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeIconSize() {
     instance()->handle->RemoveInt("IconSize");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docFontSize() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getFontSize() {
     return instance()->FontSize;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultFontSize() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setFontSize(const long &v) {
     instance()->handle->SetInt("FontSize",v);
     instance()->FontSize = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeFontSize() {
     instance()->handle->RemoveInt("FontSize");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docItemSpacing() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getItemSpacing() {
     return instance()->ItemSpacing;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultItemSpacing() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setItemSpacing(const long &v) {
     instance()->handle->SetInt("ItemSpacing",v);
     instance()->ItemSpacing = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeItemSpacing() {
     instance()->handle->RemoveInt("ItemSpacing");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docItemBackground() {
     return QT_TRANSLATE_NOOP("TreeParams",
 "Tree view item background. Only effective in overlay.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const unsigned long & TreeParams::getItemBackground() {
     return instance()->ItemBackground;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const unsigned long & TreeParams::defaultItemBackground() {
     const static unsigned long def = 0x00000000;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setItemBackground(const unsigned long &v) {
     instance()->handle->SetUnsigned("ItemBackground",v);
     instance()->ItemBackground = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeItemBackground() {
     instance()->handle->RemoveUnsigned("ItemBackground");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docItemBackgroundPadding() {
     return QT_TRANSLATE_NOOP("TreeParams",
 "Tree view item background padding.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getItemBackgroundPadding() {
     return instance()->ItemBackgroundPadding;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultItemBackgroundPadding() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setItemBackgroundPadding(const long &v) {
     instance()->handle->SetInt("ItemBackgroundPadding",v);
     instance()->ItemBackgroundPadding = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeItemBackgroundPadding() {
     instance()->handle->RemoveInt("ItemBackgroundPadding");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docHideColumn() {
     return QT_TRANSLATE_NOOP("TreeParams",
 "Hide extra tree view column for item description.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getHideColumn() {
     return instance()->HideColumn;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultHideColumn() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setHideColumn(const bool &v) {
     instance()->handle->SetBool("HideColumn",v);
     instance()->HideColumn = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeHideColumn() {
     instance()->handle->RemoveBool("HideColumn");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docHideScrollBar() {
     return QT_TRANSLATE_NOOP("TreeParams",
 "Hide tree view scroll bar in dock overlay.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getHideScrollBar() {
     return instance()->HideScrollBar;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultHideScrollBar() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setHideScrollBar(const bool &v) {
     instance()->handle->SetBool("HideScrollBar",v);
     instance()->HideScrollBar = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeHideScrollBar() {
     instance()->handle->RemoveBool("HideScrollBar");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docHideHeaderView() {
     return QT_TRANSLATE_NOOP("TreeParams",
 "Hide tree view header view in dock overlay.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getHideHeaderView() {
     return instance()->HideHeaderView;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultHideHeaderView() {
     const static bool def = true;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setHideHeaderView(const bool &v) {
     instance()->handle->SetBool("HideHeaderView",v);
     instance()->HideHeaderView = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeHideHeaderView() {
     instance()->handle->RemoveBool("HideHeaderView");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docResizableColumn() {
     return QT_TRANSLATE_NOOP("TreeParams",
 "Allow tree view columns to be manually resized.");
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getResizableColumn() {
     return instance()->ResizableColumn;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultResizableColumn() {
     const static bool def = false;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setResizableColumn(const bool &v) {
     instance()->handle->SetBool("ResizableColumn",v);
     instance()->ResizableColumn = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeResizableColumn() {
     instance()->handle->RemoveBool("ResizableColumn");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docColumnSize1() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getColumnSize1() {
     return instance()->ColumnSize1;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultColumnSize1() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setColumnSize1(const long &v) {
     instance()->handle->SetInt("ColumnSize1",v);
     instance()->ColumnSize1 = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeColumnSize1() {
     instance()->handle->RemoveInt("ColumnSize1");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docColumnSize2() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const long & TreeParams::getColumnSize2() {
     return instance()->ColumnSize2;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const long & TreeParams::defaultColumnSize2() {
     const static long def = 0;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setColumnSize2(const long &v) {
     instance()->handle->SetInt("ColumnSize2",v);
     instance()->ColumnSize2 = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeColumnSize2() {
     instance()->handle->RemoveInt("ColumnSize2");
 }
 
-// Auto generated code (Tools/params_utils.py:288)
+// Auto generated code (Tools/params_utils.py:350)
 const char *TreeParams::docTreeToolTipIcon() {
     return "";
 }
 
-// Auto generated code (Tools/params_utils.py:294)
+// Auto generated code (Tools/params_utils.py:358)
 const bool & TreeParams::getTreeToolTipIcon() {
     return instance()->TreeToolTipIcon;
 }
 
-// Auto generated code (Tools/params_utils.py:300)
+// Auto generated code (Tools/params_utils.py:366)
 const bool & TreeParams::defaultTreeToolTipIcon() {
     const static bool def = false;
     return def;
 }
 
-// Auto generated code (Tools/params_utils.py:307)
+// Auto generated code (Tools/params_utils.py:375)
 void TreeParams::setTreeToolTipIcon(const bool &v) {
     instance()->handle->SetBool("TreeToolTipIcon",v);
     instance()->TreeToolTipIcon = v;
 }
 
-// Auto generated code (Tools/params_utils.py:314)
+// Auto generated code (Tools/params_utils.py:384)
 void TreeParams::removeTreeToolTipIcon() {
     instance()->handle->RemoveBool("TreeToolTipIcon");
 }

--- a/src/Gui/TreeParams.h
+++ b/src/Gui/TreeParams.h
@@ -28,11 +28,11 @@ import TreeParams
 TreeParams.declare_begin()
 ]]]*/
 
-// Auto generated code (Tools/params_utils.py:72)
+// Auto generated code (Tools/params_utils.py:82)
 #include <Base/Parameter.h>
 
 
-// Auto generated code (Tools/params_utils.py:78)
+// Auto generated code (Tools/params_utils.py:90)
 namespace Gui {
 /** Convenient class to obtain tree view related parameters
 
@@ -68,7 +68,7 @@ class GuiExport TreeParams {
 public:
     static ParameterGrp::handle getHandle();
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter SyncSelection
     static const bool & getSyncSelection();
@@ -79,7 +79,7 @@ public:
     static void onSyncSelectionChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter CheckBoxesSelection
     static const bool & getCheckBoxesSelection();
@@ -90,7 +90,7 @@ public:
     static void onCheckBoxesSelectionChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter SyncView
     static const bool & getSyncView();
@@ -100,7 +100,7 @@ public:
     static const char *docSyncView();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter PreSelection
     static const bool & getPreSelection();
@@ -110,7 +110,7 @@ public:
     static const char *docPreSelection();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter SyncPlacement
     static const bool & getSyncPlacement();
@@ -120,7 +120,7 @@ public:
     static const char *docSyncPlacement();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter RecordSelection
     static const bool & getRecordSelection();
@@ -130,7 +130,7 @@ public:
     static const char *docRecordSelection();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter DocumentMode
     static const long & getDocumentMode();
@@ -141,7 +141,7 @@ public:
     static void onDocumentModeChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter StatusTimeout
     static const long & getStatusTimeout();
@@ -151,7 +151,7 @@ public:
     static const char *docStatusTimeout();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter SelectionTimeout
     static const long & getSelectionTimeout();
@@ -161,7 +161,7 @@ public:
     static const char *docSelectionTimeout();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter PreSelectionTimeout
     static const long & getPreSelectionTimeout();
@@ -171,7 +171,7 @@ public:
     static const char *docPreSelectionTimeout();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter PreSelectionDelay
     static const long & getPreSelectionDelay();
@@ -181,7 +181,7 @@ public:
     static const char *docPreSelectionDelay();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter PreSelectionMinDelay
     static const long & getPreSelectionMinDelay();
@@ -191,7 +191,7 @@ public:
     static const char *docPreSelectionMinDelay();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter RecomputeOnDrop
     static const bool & getRecomputeOnDrop();
@@ -201,7 +201,7 @@ public:
     static const char *docRecomputeOnDrop();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter KeepRootOrder
     static const bool & getKeepRootOrder();
@@ -211,7 +211,7 @@ public:
     static const char *docKeepRootOrder();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter TreeActiveAutoExpand
     static const bool & getTreeActiveAutoExpand();
@@ -221,7 +221,7 @@ public:
     static const char *docTreeActiveAutoExpand();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter TreeActiveColor
     static const unsigned long & getTreeActiveColor();
@@ -232,7 +232,7 @@ public:
     static void onTreeActiveColorChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter TreeEditColor
     static const unsigned long & getTreeEditColor();
@@ -243,7 +243,7 @@ public:
     static void onTreeEditColorChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter SelectingGroupColor
     static const unsigned long & getSelectingGroupColor();
@@ -254,7 +254,7 @@ public:
     static void onSelectingGroupColorChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter TreeActiveBold
     static const bool & getTreeActiveBold();
@@ -265,7 +265,7 @@ public:
     static void onTreeActiveBoldChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter TreeActiveItalic
     static const bool & getTreeActiveItalic();
@@ -276,7 +276,7 @@ public:
     static void onTreeActiveItalicChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter TreeActiveUnderlined
     static const bool & getTreeActiveUnderlined();
@@ -287,7 +287,7 @@ public:
     static void onTreeActiveUnderlinedChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter TreeActiveOverlined
     static const bool & getTreeActiveOverlined();
@@ -298,7 +298,7 @@ public:
     static void onTreeActiveOverlinedChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter Indentation
     static const long & getIndentation();
@@ -309,7 +309,7 @@ public:
     static void onIndentationChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter LabelExpression
     static const bool & getLabelExpression();
@@ -319,7 +319,7 @@ public:
     static const char *docLabelExpression();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter IconSize
     static const long & getIconSize();
@@ -330,7 +330,7 @@ public:
     static void onIconSizeChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter FontSize
     static const long & getFontSize();
@@ -341,7 +341,7 @@ public:
     static void onFontSizeChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter ItemSpacing
     static const long & getItemSpacing();
@@ -352,7 +352,7 @@ public:
     static void onItemSpacingChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter ItemBackground
     ///
@@ -365,7 +365,7 @@ public:
     static void onItemBackgroundChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter ItemBackgroundPadding
     ///
@@ -378,7 +378,7 @@ public:
     static void onItemBackgroundPaddingChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter HideColumn
     ///
@@ -391,7 +391,7 @@ public:
     static void onHideColumnChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter HideScrollBar
     ///
@@ -403,7 +403,7 @@ public:
     static const char *docHideScrollBar();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter HideHeaderView
     ///
@@ -415,7 +415,7 @@ public:
     static const char *docHideHeaderView();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter ResizableColumn
     ///
@@ -428,7 +428,7 @@ public:
     static void onResizableColumnChanged();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter ColumnSize1
     static const long & getColumnSize1();
@@ -438,7 +438,7 @@ public:
     static const char *docColumnSize1();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter ColumnSize2
     static const long & getColumnSize2();
@@ -448,7 +448,7 @@ public:
     static const char *docColumnSize2();
     //@}
 
-    // Auto generated code (Tools/params_utils.py:122)
+    // Auto generated code (Tools/params_utils.py:138)
     //@{
     /// Accessor for parameter TreeToolTipIcon
     static const bool & getTreeToolTipIcon();
@@ -478,7 +478,7 @@ public:
 TreeParams.declare_end()
 ]]]*/
 
-// Auto generated code (Tools/params_utils.py:150)
+// Auto generated code (Tools/params_utils.py:178)
 }; // class TreeParams
 } // namespace Gui
 //[[[end]]]

--- a/src/Gui/TreeParams.h
+++ b/src/Gui/TreeParams.h
@@ -457,6 +457,19 @@ public:
     static void setTreeToolTipIcon(const bool &v);
     static const char *docTreeToolTipIcon();
     //@}
+
+    // Auto generated code (Tools/params_utils.py:138)
+    //@{
+    /// Accessor for parameter VisibilityIcon
+    ///
+    /// If enabled, show an eye icon before the tree view items, showing the items visibility status. When clicked the visibility is toggled
+    static const bool & getVisibilityIcon();
+    static const bool & defaultVisibilityIcon();
+    static void removeVisibilityIcon();
+    static void setVisibilityIcon(const bool &v);
+    static const char *docVisibilityIcon();
+    static void onVisibilityIconChanged();
+    //@}
 //[[[end]]]
 
     static void refreshTreeViews();

--- a/src/Gui/TreeParams.py
+++ b/src/Gui/TreeParams.py
@@ -80,6 +80,8 @@ Params = [
     ParamInt('ColumnSize1', 0),
     ParamInt('ColumnSize2', 0),
     ParamBool('TreeToolTipIcon', False, title='Show icon in tool tip'),
+    ParamBool('VisibilityIcon', False, on_change=True, title='Show visibility icon',
+        doc = "If enabled, show an eye icon before the tree view items, showing the items visibility status. When clicked the visibility is toggled"),
 ]
 
 def declare_begin():


### PR DESCRIPTION
### User story
In the preferences under Display->UI a user can enable a checkbox to show an additonal icon (eye) before the normal tree view icon. This icon shows the visiblity status of the item and when the user clicks this icon the visibility of the item is toggled. This is a faster alternative to selecting the item and then pressing the space bar.
<img src="https://github.com/FreeCAD/FreeCAD/assets/8003824/9c2389b2-861d-4418-af5b-13f938d39d61" width="200"/>

### Implementation rational
When working with PartDesign I often switch between the different features to see what my moddeling steps are and this also helps with debugging. I find it annyoung that I always have to click on the feature and then press space. With this icon I just have to click once to switch between the features.

### Implementation info
This is a feature from @realthunder LinkMerge branch. This is not a port but a small bare bones implementation.

I hope this is something that can be added to the official version.
I only tested it on my pc with Arch Linux. I would appreciate it if someone is able to test it on a different OS.

Some points that are up for discussion:
* Should items still be grayed out if the icon is enabled? Currently not, same as in LinkMerge
* The check for the icon click area feels a bit hackish. Are there any cases that might brake? Realthunder uses a more involved but also more generic method, that looks like it would need a lot of refactoring.
