### PR TITLE
Clear projected shape when changing extrude height

### DIFF
--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -882,20 +882,26 @@ void PartGui::DlgProjectionOnSurface::create_face_extrude(std::vector<SShapeStor
     if (iCurrentShape.empty())
         return;
 
+    auto height = ui->doubleSpinBoxExtrudeHeight->value();
+
     for ( auto &itCurrentShape : iCurrentShape )
     {
       if (itCurrentShape.aProjectedFace.IsNull()) continue;;
-      auto height = ui->doubleSpinBoxExtrudeHeight->value();
-      if (itCurrentShape.exrudeValue == height) continue;;
+      if (itCurrentShape.extrudeValue == height) continue;;
 
-      gp_Vec directionToExtrude(itCurrentShape.aProjectionDir.XYZ());
-      directionToExtrude.Reverse();
+      itCurrentShape.extrudeValue = height;
       if (height == 0)
-          return;
-      directionToExtrude.Multiply(height);
-      BRepPrimAPI_MakePrism extrude(itCurrentShape.aProjectedFace, directionToExtrude);
-      itCurrentShape.aProjectedSolid = extrude.Shape();
-      itCurrentShape.exrudeValue = height;
+      {
+        itCurrentShape.aProjectedSolid.Nullify();
+      }
+      else
+      {
+        gp_Vec directionToExtrude(itCurrentShape.aProjectionDir.XYZ());
+        directionToExtrude.Reverse();
+        directionToExtrude.Multiply(height);
+        BRepPrimAPI_MakePrism extrude(itCurrentShape.aProjectedFace, directionToExtrude);
+        itCurrentShape.aProjectedSolid = extrude.Shape();
+      }
     }
   }
   catch (const Standard_Failure& error)

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.h
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.h
@@ -92,7 +92,7 @@ private:
     std::string partName;
     bool is_selectable = false;
     long transparency = 0;
-    float exrudeValue = 0.0f;
+    float extrudeValue = 0.0f;
   };
 
   //from Gui::SelectionObserver


### PR DESCRIPTION
When the height is zero no solid is produced, the code was thus showing the result of the previously selected projection height.

Closes #12113