### PR TITLE
Gui: Fix disappearing element handles in sketcher

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1058,6 +1058,7 @@ void View3DInventorViewer::setEditingViewProvider(Gui::ViewProvider* vp, int Mod
 {
     this->editViewProvider = vp;
     this->editViewProvider->setEditViewer(this, ModNum);
+    this->navigation->findBoundingSphere();
     addEventCallback(SoEvent::getClassTypeId(), Gui::ViewProvider::eventCallback,this->editViewProvider);
 }
 


### PR DESCRIPTION
Finds the bounding sphere when the editing view provider is set. This ensures the right bounding sphere is used for finding the near and far clipping plane

Fixes #12288