### PR TITLE
Addon Manager: Correct connection check (Part 1)

### DIFF
--- a/src/Mod/AddonManager/addonmanager_workers_utility.py
+++ b/src/Mod/AddonManager/addonmanager_workers_utility.py
@@ -85,7 +85,7 @@ class ConnectionChecker(QtCore.QThread):
             else:
                 FreeCAD.Console.PrintWarning(f"No data received: status returned was {status}\n")
                 self.data = None
-        self.done = True
+            self.done = True
 
     def disconnect_network_manager(self):
         NetworkManager.AM_NETWORK_MANAGER.completed.disconnect(self.connection_data_received)


### PR DESCRIPTION
The connection check code incorrectly handled the case of multiple incoming connections, interpreting them all as connection check signals. This is the first of two connection code fixes incoming.