### PR TITLE
Sketcher: Infinite axes

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -87,6 +87,7 @@
 #include <Base/Sequencer.h>
 #include <Base/Tools.h>
 #include <Base/UnitsApi.h>
+#include <Base/Tools2D.h>
 #include <Quarter/devices/InputDevice.h>
 #include <Quarter/eventhandlers/EventFilter.h>
 
@@ -2645,6 +2646,75 @@ SbVec2f View3DInventorViewer::getNormalizedPosition(const SbVec2s& pnt) const
     // NOLINTEND
 
     return {pX, pY};
+}
+
+Base::BoundBox2d View3DInventorViewer::getViewportOnXYPlaneOfPlacement(Base::Placement& plc) const
+{
+    auto projBBox = Base::BoundBox3d();
+    projBBox.SetVoid();
+
+    SoCamera* pCam = this->getSoRenderManager()->getCamera();
+
+    if (!pCam) {
+        // Return empty box.
+        return Base::BoundBox2d(0, 0, 0, 0);
+    }
+
+    Base::Vector3d pos = plc.getPosition();
+    Base::Rotation rot = plc.getRotation();
+
+    // Transform the plane LCS into the global one.
+    Base::Vector3d zAxis(0, 0, 1);
+    rot.multVec(zAxis, zAxis);
+
+    // Get the position and convert Base::Vector3d to SbVec3f
+    SbVec3f planeNormal(zAxis.x, zAxis.y, zAxis.z);
+    SbVec3f planePosition(pos.x, pos.y, pos.z);
+    SbPlane xyPlane(planeNormal, planePosition);
+
+    const SbViewportRegion& vp = this->getSoRenderManager()->getViewportRegion();
+    SbViewVolume vol = pCam->getViewVolume();
+
+    float fRatio = vp.getViewportAspectRatio();
+    float dX, dY;
+    vp.getViewportSize().getValue(dX, dY);
+
+    // Projects a pair of normalized coordinates on the XY plane.
+    auto projectPoint =
+            [&](float x, float y) {
+                if (fRatio > 1.f) {
+                    x = (x - 0.5f * dX) * fRatio + 0.5f * dX;
+                }
+                else if (fRatio < 1.f) {
+                    y = (y - 0.5f * dY) / fRatio + 0.5f * dY;
+                }
+
+                SbLine line;
+                vol.projectPointToLine(SbVec2f(x, y), line);
+
+                SbVec3f pt;
+                // Intersection point on the XY plane.
+                if (!xyPlane.intersect(line, pt)) {
+                    return;
+                }
+
+                projBBox.Add(Base::convertTo<Base::Vector3d>(pt));
+            };
+
+    // Project the four corners of the viewport plane.
+    projectPoint(0.f, 0.f);
+    projectPoint(1.f, 0.f);
+    projectPoint(0.f, 1.f);
+    projectPoint(1.f, 1.f);
+
+    if (!projBBox.IsValid()) {
+        // Return empty box.
+        return Base::BoundBox2d(0, 0, 0, 0);
+    }
+
+    plc.invert();
+    Base::ViewOrthoProjMatrix proj(plc.toMatrix());
+    return projBBox.ProjectBox(&proj);
 }
 
 SbVec3f View3DInventorViewer::getPointOnXYPlaneOfPlacement(const SbVec2s& pnt, Base::Placement& plc) const

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -67,6 +67,10 @@ class SoClipPlane;
 
 namespace Quarter = SIM::Coin3D::Quarter;
 
+namespace Base {
+    class BoundBox2d;
+}
+
 namespace Gui {
 
 class ViewProvider;
@@ -323,6 +327,8 @@ public:
 
     /** Returns the 3d point on the XY plane of a placement to the given 2d point. */
     SbVec3f getPointOnXYPlaneOfPlacement(const SbVec2s&, Base::Placement&) const;
+
+    Base::BoundBox2d View3DInventorViewer::getViewportOnXYPlaneOfPlacement(Base::Placement& plc) const;
 
     /** Returns the 2d coordinates on the viewport to the given 3d point. */
     SbVec2s getPointOnViewport(const SbVec3f&) const;

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -328,7 +328,8 @@ public:
     /** Returns the 3d point on the XY plane of a placement to the given 2d point. */
     SbVec3f getPointOnXYPlaneOfPlacement(const SbVec2s&, Base::Placement&) const;
 
-    Base::BoundBox2d View3DInventorViewer::getViewportOnXYPlaneOfPlacement(Base::Placement& plc) const;
+    /** Returns the bounding box on the XY plane of a placement to the given 2d point. */
+    Base::BoundBox2d getViewportOnXYPlaneOfPlacement(Base::Placement& plc) const;
 
     /** Returns the 2d coordinates on the viewport to the given 3d point. */
     SbVec2s getPointOnViewport(const SbVec3f&) const;

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -866,18 +866,10 @@ void EditModeCoinManager::updateAxesLength(double minX, double minY, double maxX
 {
     auto zCrossH = ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider)
         * drawingParameters.zCross;
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
-        0,
-        SbVec3f(minX, 0.0f, zCrossH));
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
-        1,
-        SbVec3f(maxX, 0.0f, zCrossH));
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
-        2,
-        SbVec3f(0.0f, minY, zCrossH));
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
-        3,
-        SbVec3f(0.0f, maxY, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(0, SbVec3f(minX, 0.0f, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(1, SbVec3f(maxX, 0.0f, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(2, SbVec3f(0.0f, minY, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(3, SbVec3f(0.0f, maxY, zCrossH));
 }
 
 void EditModeCoinManager::updateAxesLength()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -862,18 +862,14 @@ void EditModeCoinManager::updateAxesLength(const Base::BoundBox2d& bb)
 {
     auto zCrossH = ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider)
         * drawingParameters.zCross;
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
-        0,
-        SbVec3f(bb.MinX, 0.0f, zCrossH));
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
-        1,
-        SbVec3f(bb.MaxX, 0.0f, zCrossH));
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
-        2,
-        SbVec3f(0.0f, bb.MinY, zCrossH));
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
-        3,
-        SbVec3f(0.0f, bb.MaxY, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(0,
+                                                                 SbVec3f(bb.MinX, 0.0f, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(1,
+                                                                 SbVec3f(bb.MaxX, 0.0f, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(2,
+                                                                 SbVec3f(0.0f, bb.MinY, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(3,
+                                                                 SbVec3f(0.0f, bb.MaxY, zCrossH));
 }
 
 void EditModeCoinManager::updateColor()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -816,10 +816,6 @@ void EditModeCoinManager::processGeometryConstraintsInformationOverlay(
 
     processGeometryInformationOverlay(geolistfacade);
 
-#if 0
-    updateAxesLength();
-#endif
-
     pEditModeConstraintCoinManager->processConstraints(geolistfacade);
 }
 
@@ -862,32 +858,22 @@ void EditModeCoinManager::processGeometryInformationOverlay(const GeoListFacade&
     overlayParameters.visibleInformationChanged = false;  // just updated
 }
 
-void EditModeCoinManager::updateAxesLength(double minX, double minY, double maxX, double maxY)
-{
-    auto zCrossH = ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider)
-        * drawingParameters.zCross;
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(0, SbVec3f(minX, 0.0f, zCrossH));
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(1, SbVec3f(maxX, 0.0f, zCrossH));
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(2, SbVec3f(0.0f, minY, zCrossH));
-    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(3, SbVec3f(0.0f, maxY, zCrossH));
-}
-
-void EditModeCoinManager::updateAxesLength()
+void EditModeCoinManager::updateAxesLength(const Base::BoundBox2d& bb)
 {
     auto zCrossH = ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider)
         * drawingParameters.zCross;
     editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
         0,
-        SbVec3f(-analysisResults.boundingBoxMagnitudeOrder, 0.0f, zCrossH));
+        SbVec3f(bb.MinX, 0.0f, zCrossH));
     editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
         1,
-        SbVec3f(analysisResults.boundingBoxMagnitudeOrder, 0.0f, zCrossH));
+        SbVec3f(bb.MaxX, 0.0f, zCrossH));
     editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
         2,
-        SbVec3f(0.0f, -analysisResults.boundingBoxMagnitudeOrder, zCrossH));
+        SbVec3f(0.0f, bb.MinY, zCrossH));
     editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
         3,
-        SbVec3f(0.0f, analysisResults.boundingBoxMagnitudeOrder, zCrossH));
+        SbVec3f(0.0f, bb.MaxY, zCrossH));
 }
 
 void EditModeCoinManager::updateColor()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -816,7 +816,9 @@ void EditModeCoinManager::processGeometryConstraintsInformationOverlay(
 
     processGeometryInformationOverlay(geolistfacade);
 
+#if 0
     updateAxesLength();
+#endif
 
     pEditModeConstraintCoinManager->processConstraints(geolistfacade);
 }
@@ -858,6 +860,24 @@ void EditModeCoinManager::processGeometryInformationOverlay(const GeoListFacade&
 
 
     overlayParameters.visibleInformationChanged = false;  // just updated
+}
+
+void EditModeCoinManager::updateAxesLength(double minX, double minY, double maxX, double maxY)
+{
+    auto zCrossH = ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider)
+        * drawingParameters.zCross;
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
+        0,
+        SbVec3f(minX, 0.0f, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
+        1,
+        SbVec3f(maxX, 0.0f, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
+        2,
+        SbVec3f(0.0f, minY, zCrossH));
+    editModeScenegraphNodes.RootCrossCoordinate->point.set1Value(
+        3,
+        SbVec3f(0.0f, maxY, zCrossH));
 }
 
 void EditModeCoinManager::updateAxesLength()

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -256,6 +256,8 @@ public:
     void setConstraintSelectability(bool enabled = true);
     //@}
 
+    void updateAxesLength(double minX, double minY, double maxX, double maxY);
+
 private:
     // This function populates the coin nodes with the information of the current geometry
     void processGeometry(const GeoListFacade& geolistfacade);

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -44,6 +44,8 @@ class Vector3;
 
 class Vector2d;
 
+class BoundBox2d;
+
 class Placement;
 }  // namespace Base
 
@@ -256,7 +258,8 @@ public:
     void setConstraintSelectability(bool enabled = true);
     //@}
 
-    void updateAxesLength(double minX, double minY, double maxX, double maxY);
+    // Updates the Axes extension to span the specified area.
+    void updateAxesLength(const Base::BoundBox2d& bb);
 
 private:
     // This function populates the coin nodes with the information of the current geometry
@@ -266,9 +269,6 @@ private:
     // information gathered during the processGeometry step, so it is not possible to run both in
     // parallel.
     void processGeometryInformationOverlay(const GeoListFacade& geolistfacade);
-
-    // updates the Axes length to extend beyond the calculated bounding box magnitude
-    void updateAxesLength();
 
     // updates the parameters to be used for the Overlay information layer
     void updateOverlayParameters();

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3315,8 +3315,10 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
 
     viewer->setupEditingRoot();
 
-    cameraSensor.setData(new VPRender {this, viewer->getSoRenderManager()});
-    cameraSensor.attach(viewer->getSoRenderManager()->getSceneGraph());
+    auto *camSensorData = new VPRender {this, viewer->getSoRenderManager()};
+    cameraSensor.setData(camSensorData);
+    cameraSensor.setDeleteCallback(&ViewProviderSketch::camSensDeleteCB, camSensorData);
+    cameraSensor.attach(viewer->getCamera());
 }
 
 void ViewProviderSketch::unsetEditViewer(Gui::View3DInventorViewer* viewer)
@@ -3324,11 +3326,28 @@ void ViewProviderSketch::unsetEditViewer(Gui::View3DInventorViewer* viewer)
     auto dataPtr = static_cast<VPRender*>(cameraSensor.getData());
     delete dataPtr;
     cameraSensor.setData(nullptr);
+    cameraSensor.setDeleteCallback(nullptr, nullptr);
     cameraSensor.detach();
 
     viewer->removeGraphicsItem(rubberband.get());
     viewer->setEditing(false);
     viewer->setSelectionEnabled(true);
+}
+
+void ViewProviderSketch::camSensDeleteCB(void* data, SoSensor *s)
+{
+    auto *proxyVPrdr = static_cast<VPRender*>(data);
+    if (!proxyVPrdr)
+        return;
+
+    // The camera object the observer was attached to is gone, try to re-attach the sensor
+    // to the new camera.
+    // This happens i.e. when the user switches the camera type from orthographic to
+    // perspective.
+    SoCamera *camera = proxyVPrdr->renderMgr->getCamera();
+    if (camera) {
+        static_cast<SoNodeSensor *>(s)->attach(camera);
+    }
 }
 
 void ViewProviderSketch::camSensCB(void* data, SoSensor*)

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3316,7 +3316,7 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
     viewer->setupEditingRoot();
 
     cameraSensor.setData(new VPRender {this, viewer->getSoRenderManager()});
-    cameraSensor.attach(viewer->getSoRenderManager()->getSceneGraph());
+    cameraSensor.attach(camera);
 }
 
 void ViewProviderSketch::unsetEditViewer(Gui::View3DInventorViewer* viewer)

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3369,10 +3369,9 @@ void ViewProviderSketch::onCameraChanged(SoCamera* cam)
         Base::Interpreter().runStringObject(cmdStr.toLatin1());
     }
 
-    Gui::MDIView* mdi =
-        Gui::Application::Instance->editViewOfNode(editCoinManager->getRootEditNode());
-    if (mdi && mdi->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
-        Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(mdi)->getViewer();
+    Gui::View3DInventor* view = qobject_cast<Gui::View3DInventor*>(this->getActiveView());
+    if (view) {
+        Gui::View3DInventorViewer* viewer = view->getViewer();
 
         // Add 50% to be sure the whole viewport is covered.
         float axesLength = 1.5f * viewer->getMaxDimension();

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3369,6 +3369,22 @@ void ViewProviderSketch::onCameraChanged(SoCamera* cam)
         Base::Interpreter().runStringObject(cmdStr.toLatin1());
     }
 
+    Gui::MDIView* mdi =
+        Gui::Application::Instance->editViewOfNode(editCoinManager->getRootEditNode());
+    if (mdi && mdi->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
+        Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(mdi)->getViewer();
+
+        // Add 50% to be sure the whole viewport is covered.
+        float axesLength = 1.5f * viewer->getMaxDimension();
+        // Project the camera focus onto the sketch plane.
+        float x, y, z;
+        viewer->getCenterPointOnFocalPlane().getValue(x, y, z);
+
+        editCoinManager->updateAxesLength(
+                x - axesLength / 2, y - axesLength / 2,
+                x + axesLength / 2, y + axesLength / 2);
+    }
+
     drawGrid(true);
 }
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3391,8 +3391,9 @@ void ViewProviderSketch::onCameraChanged(SoCamera* cam)
     // Stretch the axes to cover the whole viewport.
     Gui::View3DInventor* view = qobject_cast<Gui::View3DInventor*>(this->getActiveView());
     if (view) {
+        Base::Placement plc = getEditingPlacement();
         const Base::BoundBox2d vpBBox = view->getViewer()
-                ->getViewportOnXYPlaneOfPlacement(getEditingPlacement());
+                ->getViewportOnXYPlaneOfPlacement(plc);
         editCoinManager->updateAxesLength(vpBBox);
     }
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -765,8 +765,7 @@ private:
     /// give projecting line of position
     void getProjectingLine(const SbVec2s&, const Gui::View3DInventorViewer* viewer, SbLine&) const;
 
-    Base::Vector3d getCamCenterInSketchCoordinates(
-        const Gui::View3DInventorViewer* viewer) const;
+    Base::Vector3d getCamCenterInSketchCoordinates(const Gui::View3DInventorViewer* viewer) const;
     //@}
 
     /** @name preselection functions */

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -712,6 +712,7 @@ protected:
     void setEditViewer(Gui::View3DInventorViewer*, int ModNum) override;
     void unsetEditViewer(Gui::View3DInventorViewer*) override;
     static void camSensCB(void* data, SoSensor*);  // camera sensor callback
+    static void camSensDeleteCB(void* data, SoSensor*);  // camera sensor callback
     void onCameraChanged(SoCamera* cam);
     //@}
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -765,7 +765,7 @@ private:
     /// give projecting line of position
     void getProjectingLine(const SbVec2s&, const Gui::View3DInventorViewer* viewer, SbLine&) const;
 
-    Base::Vector3d ViewProviderSketch::getCamCenterInSketchCoordinates(
+    Base::Vector3d getCamCenterInSketchCoordinates(
         const Gui::View3DInventorViewer* viewer) const;
     //@}
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -765,7 +765,8 @@ private:
     /// give projecting line of position
     void getProjectingLine(const SbVec2s&, const Gui::View3DInventorViewer* viewer, SbLine&) const;
 
-    Base::Vector3d ViewProviderSketch::getCamCenterInSketchCoordinates(const Gui::View3DInventorViewer* viewer) const;
+    Base::Vector3d ViewProviderSketch::getCamCenterInSketchCoordinates(
+        const Gui::View3DInventorViewer* viewer) const;
     //@}
 
     /** @name preselection functions */

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -764,6 +764,8 @@ private:
 
     /// give projecting line of position
     void getProjectingLine(const SbVec2s&, const Gui::View3DInventorViewer* viewer, SbLine&) const;
+
+    Base::Vector3d ViewProviderSketch::getCamCenterInSketchCoordinates(const Gui::View3DInventorViewer* viewer) const;
     //@}
 
     /** @name preselection functions */

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -764,8 +764,6 @@ private:
 
     /// give projecting line of position
     void getProjectingLine(const SbVec2s&, const Gui::View3DInventorViewer* viewer, SbLine&) const;
-
-    Base::Vector3d getCamCenterInSketchCoordinates(const Gui::View3DInventorViewer* viewer) const;
     //@}
 
     /** @name preselection functions */

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -711,7 +711,7 @@ protected:
     void unsetEdit(int ModNum) override;
     void setEditViewer(Gui::View3DInventorViewer*, int ModNum) override;
     void unsetEditViewer(Gui::View3DInventorViewer*) override;
-    static void camSensCB(void* data, SoSensor*);  // camera sensor callback
+    static void camSensCB(void* data, SoSensor*);        // camera sensor callback
     static void camSensDeleteCB(void* data, SoSensor*);  // camera sensor callback
     void onCameraChanged(SoCamera* cam);
     //@}


### PR DESCRIPTION
Resize the axes according to the viewport size so that they appear as infinite.

The implementation is trivial, let me know if I've overlooked something.

The previous auto-resizing behaviour is now gone for good, the machinery to compute the sketch BB is still there so re-adding this option is easily done if needed.