### PR TITLE
Arch: importIFC fix clone placement

### DIFF
--- a/src/Mod/Arch/importIFC.py
+++ b/src/Mod/Arch/importIFC.py
@@ -641,7 +641,7 @@ def insert(srcfile, docname, skip=[], only=[], root=None, preferences=None):
                         if clone.Shape.Solids:
                             s2 = clone.Shape.Solids[0]
                         else:
-                            s1 = clone.Shape
+                            s2 = clone.Shape
                         if hasattr(s1,"CenterOfMass") and hasattr(s2,"CenterOfMass"):
                             v = s1.CenterOfMass.sub(s2.CenterOfMass)
                             if product.Representation:
@@ -671,10 +671,13 @@ def insert(srcfile, docname, skip=[], only=[], root=None, preferences=None):
                         obj.Width = 0
                         obj.Length = 0
                     if (freecadtype in ["Rebar"]) and baseobj:
-                        # TODO rebars don't keep link to their baee object - we can remove it
+                        # TODO rebars don't keep link to their base object - we can remove it
                         bn = baseobj.Name
                         doc.removeObject(bn)
                     if store:
+                        # Recompute required otherwise obj has a null shape and then
+                        # cloning distances cannot be determined in the next loop.
+                        obj.recompute()
                         sharedobjects[store] = obj
 
                 # set the placement from the storey's elevation property


### PR DESCRIPTION
Objects in `sharedobjects` were not recomputed during the import process. They had a null shape preventing the correct calculation of clone placements.

Forum topic:
https://forum.freecad.org/viewtopic.php?p=738864#p739039
