### PR TITLE
[TechDraw] Add Owner property to Symbols

### DIFF
--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -375,6 +375,11 @@ bool DrawView::isInClip()
     return false;
 }
 
+DrawView *DrawView::claimParent() const
+{
+    return nullptr;
+}
+
 DrawViewClip* DrawView::getClipGroup()
 {
     std::vector<App::DocumentObject*> parent = getInList();

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -84,6 +84,8 @@ public:
 
     virtual DrawPage* findParentPage() const;
     virtual std::vector<DrawPage*> findAllParentPages() const;
+    virtual DrawView *claimParent() const;
+
     virtual int countParentPages() const;
     virtual QRectF getRect() const;                      //must be overridden by derived class
     QRectF getRectAligned() const;

--- a/src/Mod/TechDraw/App/DrawViewSymbol.h
+++ b/src/Mod/TechDraw/App/DrawViewSymbol.h
@@ -48,7 +48,9 @@ public:
 
     App::PropertyString       Symbol;
     App::PropertyStringList   EditableTexts;
+    App::PropertyLink         Owner;
 
+    short mustExecute() const override;
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
@@ -59,6 +61,7 @@ public:
     const char* getViewProviderName() const override {
         return "TechDrawGui::ViewProviderSymbol";
     }
+    DrawView *claimParent(void) const override;
     QRectF getRect() const override;
     bool checkFit(TechDraw::DrawPage* p) const override;
 
@@ -66,6 +69,8 @@ public:
     PyObject *getPyObject() override;
 
 protected:
+    void touchTreeOwner();
+    void onBeforeChange(const App::Property* prop) override;
     void onChanged(const App::Property* prop) override;
     Base::BoundBox3d bbox;
 

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -36,6 +36,7 @@
 # include <BRepBuilderAPI_MakeVertex.hxx>
 # include <BRepBuilderAPI_MakeWire.hxx>
 # include <BRepExtrema_DistShapeShape.hxx>
+# include <BRepGProp.hxx>
 # include <BRepLib.hxx>
 # include <BRepLProp_CLProps.hxx>
 # include <BRepTools.hxx>
@@ -43,6 +44,7 @@
 # include <GC_MakeEllipse.hxx>
 # include <gce_MakeCirc.hxx>
 # include <GCPnts_AbscissaPoint.hxx>
+# include <GProp_GProps.hxx>
 # include <Geom_BSplineCurve.hxx>
 # include <Geom_BezierCurve.hxx>
 # include <Geom_Circle.hxx>
@@ -156,6 +158,14 @@ TopoDS_Face Face::toOccFace() const
         return mkFace.Face();
     }
     return TopoDS_Face();
+}
+
+//**** Face
+Base::Vector3d Face::getCenter() const {
+    GProp_GProps faceProps;
+    BRepGProp::SurfaceProperties(toOccFace(), faceProps);
+
+    return DrawUtil::toVector3d(faceProps.CentreOfMass());
 }
 
 Face::~Face()

--- a/src/Mod/TechDraw/App/Geometry.h
+++ b/src/Mod/TechDraw/App/Geometry.h
@@ -347,6 +347,8 @@ class TechDrawExport Face
         ~Face();
         TopoDS_Face toOccFace() const;
         std::vector<Wire *> wires;
+
+        Base::Vector3d getCenter() const;
 };
 using FacePtr = std::shared_ptr<Face>;
 

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -663,6 +663,26 @@ void QGIView::addArbitraryItem(QGraphicsItem* qgi)
     }
 }
 
+void QGIView::switchParentItem(QGIView *targetParent)
+{
+    auto currentParent = dynamic_cast<QGIView *>(this->parentItem());
+    if (currentParent != targetParent) {
+        if (targetParent) {
+            targetParent->addToGroup(this);
+        }
+        else {
+            currentParent->removeFromGroup(this);
+        }
+
+        if (currentParent) {
+            currentParent->updateView();
+        }
+        if (targetParent) {
+            targetParent->updateView();
+        }
+    }
+}
+
 void QGIView::setStack(int z)
 {
     m_zOrder = z;

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -155,8 +155,8 @@ public:
     static int exactFontSize(std::string fontFamily, double nominalSize);
 
     virtual void removeChild(QGIView* child);
-
     virtual void addArbitraryItem(QGraphicsItem* qgi);
+    virtual void switchParentItem(QGIView *targetParent);
 
     // Mouse handling
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -448,8 +448,15 @@ QGIView* QGSPage::addDrawViewAnnotation(TechDraw::DrawViewAnnotation* annoFeat)
 QGIView* QGSPage::addDrawViewSymbol(TechDraw::DrawViewSymbol* symbolFeat)
 {
     auto qview(new QGIViewSymbol);
-
     qview->setViewFeature(symbolFeat);
+
+    auto owner = dynamic_cast<TechDraw::DrawView *>(symbolFeat->Owner.getValue());
+    if (owner) {
+        auto parent = dynamic_cast<QGIView *>(findQViewForDocObj(owner));
+        if (parent) {
+            qview->switchParentItem(parent);
+        }
+    }
 
     addQView(qview);
     return qview;

--- a/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.h
+++ b/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.h
@@ -78,7 +78,7 @@ class TaskSurfaceFinishSymbols : public QWidget
     Q_OBJECT
 
 public:
-    explicit TaskSurfaceFinishSymbols(TechDraw::DrawViewPart* view);
+    explicit TaskSurfaceFinishSymbols(const std::string &ownerName);
     ~TaskSurfaceFinishSymbols() override = default;
 
     virtual bool accept();
@@ -89,12 +89,14 @@ protected:
     void changeEvent(QEvent *event) override;
     void setUiEdit();
 
+    App::DocumentObject *owner;
+    Base::Vector3d placement;
+
 private:
     enum symbolType {anyMethod=0, removeProhibit, removeRequired,
                      anyMethodAll, removeProhibitAll, removeRequiredAll};
     QPixmap baseSymbol(symbolType type);
     std::string completeSymbol();
-    TechDraw::DrawViewPart* selectedView;
     QGraphicsScene* symbolScene;     //note this is not QGSPage, but another scene only used to
                                      //display symbols in this task's ui
     std::vector<std::string> raValues, laySymbols, roughGrades;
@@ -117,7 +119,7 @@ class TaskDlgSurfaceFinishSymbols : public Gui::TaskView::TaskDialog
     Q_OBJECT
 
 public:
-    explicit TaskDlgSurfaceFinishSymbols(TechDraw::DrawViewPart* view);
+    explicit TaskDlgSurfaceFinishSymbols(const std::string &ownerName);
     ~TaskDlgSurfaceFinishSymbols() override;
 
     /// is called the TaskView when the dialog is opened

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -442,3 +442,23 @@ TechDraw::DrawView* ViewProviderDrawingView::getViewObject() const
 {
     return dynamic_cast<TechDraw::DrawView*>(pcObject);
 }
+
+void ViewProviderDrawingView::switchOwnerProperty(App::PropertyLink &prop)
+{
+    QGIView *qv = getQView();
+    if (!qv) {
+        return;
+    }
+
+    QGIView *targetParent = nullptr;
+    auto owner = dynamic_cast<TechDraw::DrawView *>(prop.getValue());
+    if (owner) {
+        auto vp = dynamic_cast<ViewProviderDrawingView *>(QGIView::getViewProvider(owner));
+        if (vp) {
+            targetParent = vp->getQView();
+        }
+    }
+
+    qv->switchParentItem(targetParent);
+    qv->updateView();
+}

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
@@ -99,6 +99,8 @@ public:
 
     const char* whoAmI() const;
 
+    void switchOwnerProperty(App::PropertyLink &prop);
+
 private:
     void multiParentPaint(std::vector<TechDraw::DrawPage*>& pages);
     void singleParentPaint(const TechDraw::DrawView* dv);

--- a/src/Mod/TechDraw/Gui/ViewProviderLeader.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderLeader.cpp
@@ -142,6 +142,12 @@ std::vector<App::DocumentObject*> ViewProviderLeader::claimChildren() const
     const std::vector<App::DocumentObject *> &views = getFeature()->getInList();
     try {
        for(std::vector<App::DocumentObject *>::const_iterator it = views.begin(); it != views.end(); ++it) {
+            auto view = dynamic_cast<TechDraw::DrawView *>(*it);
+            if (view && view->claimParent() == getViewObject()) {
+                temp.push_back(view);
+                continue;
+            }
+
            if ((*it)->isDerivedFrom<TechDraw::DrawRichAnno>()) {
                 temp.push_back((*it));
            } else if ((*it)->isDerivedFrom<TechDraw::DrawWeldSymbol>()) {

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -405,6 +405,12 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
         for (std::vector<App::DocumentObject*>::const_iterator it = views.begin();
              it != views.end(); ++it) {
             TechDraw::DrawView* featView = dynamic_cast<TechDraw::DrawView*>(*it);
+
+            // If the child view appoints a parent, skip it
+            if (featView && featView->claimParent()) {
+                continue;
+            }
+
             App::DocumentObject* docObj = *it;
             //DrawRichAnno with no parent is child of Page
             TechDraw::DrawRichAnno* dra = dynamic_cast<TechDraw::DrawRichAnno*>(*it);

--- a/src/Mod/TechDraw/Gui/ViewProviderSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderSymbol.cpp
@@ -44,15 +44,17 @@ ViewProviderSymbol::~ViewProviderSymbol()
 
 void ViewProviderSymbol::updateData(const App::Property* prop)
 {
-    if (prop == &getViewObject()->Scale) {
-        onGuiRepaint(getViewObject());
-    } else if (prop == &getViewObject()->Rotation) {
-        onGuiRepaint(getViewObject());
-    } else if (prop == &getViewObject()->Symbol) {
-        onGuiRepaint(getViewObject());
-    } else if (prop == &getViewObject()->EditableTexts) {
-        onGuiRepaint(getViewObject());
+    TechDraw::DrawViewSymbol *obj = getViewObject();
+    if (prop == &obj->Scale
+        || prop == &obj->Rotation
+        || prop == &obj->Symbol
+        || prop == &obj->EditableTexts) {
+        onGuiRepaint(obj);
     }
+    else if (prop == &obj->Owner) {
+        switchOwnerProperty(obj->Owner);
+    }
+
     ViewProviderDrawingView::updateData(prop);
 }
 

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -217,6 +217,12 @@ std::vector<App::DocumentObject*> ViewProviderViewPart::claimChildren() const
     const std::vector<App::DocumentObject *> &views = getViewPart()->getInList();
     try {
       for(std::vector<App::DocumentObject *>::const_iterator it = views.begin(); it != views.end(); ++it) {
+          auto view = dynamic_cast<TechDraw::DrawView *>(*it);
+          if (view && view->claimParent() == getViewPart()) {
+              temp.push_back(view);
+              continue;
+          }
+
           if((*it)->isDerivedFrom<TechDraw::DrawViewDimension>()) {
               //TODO: make a list, then prune it.  should be faster?
               bool skip = false;


### PR DESCRIPTION
This pull request aims to implement issue #11684 by adding "Owner" property to all Symbols (i.e. not only Surface Finish symbols). This new property specifies the drawing view to which the Symbol is attached so once the owner view is moved, the attached symbol is moved as well. The Owner property can be freely changed to another view or left completely blank, in which case the "owner" becomes the whole page.

The Surface Finish Symbol can be now attached  to any Part View, Leader Line or (if nothing is selected) to a page. There is also a small improvement in case a Part View subitem is seleted. In this case the Surface Finish Symbol is placed in the center of given subitem. 

The pull request contains some generic code infrastructure for implementing the parent/owner switching for other views which need to be attached e.g. Rich Annotation, Leader Line etc. For these I will try to implement the functional parent/owner switching in future separate pull requests.

I hope you will find this addition useful, in case of any problems or issues please let me know.