### PR TITLE
Arch: add subvolume property for ArchRoof (for roof based on solid shape)

### DIFF
--- a/src/Mod/Arch/ArchRoof.py
+++ b/src/Mod/Arch/ArchRoof.py
@@ -308,6 +308,11 @@ class _Roof(ArchComponent.Component):
                             "Flip",
                             "Roof",
                             QT_TRANSLATE_NOOP("App::Property", "Specifies if the direction of the roof should be flipped"))
+        if not "Subvolume" in pl:
+            obj.addProperty("App::PropertyLink",
+                            "Subvolume",
+                            "Roof",
+                            QT_TRANSLATE_NOOP("App::Property", "An optional object that defines a volume to be subtracted from walls. If field is set - it has a priority over auto-generated subvolume"))
         self.Type = "Roof"
 
     def onDocumentRestored(self, obj):
@@ -825,6 +830,10 @@ class _Roof(ArchComponent.Component):
 
     def getSubVolume(self, obj):
         '''returns a volume to be subtracted'''
+        custom_subvolume = getattr(obj, 'Subvolume', None)
+        if custom_subvolume:
+            return custom_subvolume.Shape
+
         if not obj.Base:
             return None
 

--- a/src/Mod/Arch/ArchRoof.py
+++ b/src/Mod/Arch/ArchRoof.py
@@ -825,21 +825,22 @@ class _Roof(ArchComponent.Component):
 
     def getSubVolume(self, obj):
         '''returns a volume to be subtracted'''
-        if obj.Base:
-            if hasattr(obj.Base, "Shape"):
-                if obj.Base.Shape.Solids:
-                    return obj.Shape
-                else :
-                    if hasattr(self, "sub"):
-                        if self.sub:
-                            return self.sub
-                        else :
-                            self.execute(obj)
-                            return self.sub
-                    else :
-                        self.execute(obj)
-                        return self.sub
-        return None
+        if not obj.Base:
+            return None
+
+        if not hasattr(obj.Base, "Shape"):
+            return None
+
+        if obj.Base.Shape.Solids:
+            return obj.Shape
+
+        # self.sub is auto-generated subvolume for wire-based roof
+        sub_field = getattr(self, 'sub', None)
+        if not sub_field:
+            self.execute(obj)
+
+        return self.sub
+
 
     def computeAreas(self, obj):
         '''computes border and ridge roof edges length'''


### PR DESCRIPTION
Hi ! 

I'm author of following [topic](https://forum.freecad.org/viewtopic.php?p=733834). 

In current implementation ArchRoof subvolume generated properly only for wire-based roof.
For solid-base roof it uses given shape as-is. But proper implementation will be 'extrude given shape horizontally up'.
This can be done via macros, [that i showed in topic](https://forum.freecad.org/viewtopic.php?p=738858#p738858).
I didn't sure that my macros code is valid and work in all cases, but if you also check it, maybe we can include this behaviour as default for solid-roof case (in future PR, if code will be correct)

---

In this PR, i just want to give user ability, to override default behaviour and set custom subvolume.
I add new field, and also i refactor getSubvolume method, because in current implementation it has a lot of nested if conditions.

Original Idea is suggested by yorik [here](https://forum.freecad.org/viewtopic.php?p=733834#p733834)