### PR TITLE
Base: escape quotes in Quantity::getSafeUserString

### DIFF
--- a/src/Base/Quantity.cpp
+++ b/src/Base/Quantity.cpp
@@ -28,6 +28,7 @@
 #include <array>
 #endif
 
+#include <Base/Tools.h>
 #include "Quantity.h"
 #include "Exception.h"
 #include "UnitsApi.h"
@@ -255,6 +256,8 @@ QString Quantity::getSafeUserString() const
             retString = QStringLiteral("%1 %2").arg(this->myValue).arg(this->getUnit().getString());
         }
     }
+    retString =
+        QString::fromStdString(Base::Tools::escapeQuotesFromString(retString.toStdString()));
     return retString;
 }
 

--- a/tests/src/Base/Quantity.cpp
+++ b/tests/src/Base/Quantity.cpp
@@ -226,5 +226,21 @@ TEST_F(Quantity, TestSafeUserString)
     QString result = quantity.getSafeUserString();
 
     EXPECT_EQ(result.toStdString(), "1 mm");
+
+    Base::UnitsApi::setSchema(Base::UnitSystem::Imperial1);
+
+    quantity = Base::Quantity {304.8, Base::Unit::Length};
+    quantity.setFormat(format);
+
+    result = quantity.getSafeUserString();
+
+    EXPECT_EQ(result.toStdString(), "1.0 \\'");
+
+    quantity = Base::Quantity {25.4, Base::Unit::Length};
+    quantity.setFormat(format);
+
+    result = quantity.getSafeUserString();
+
+    EXPECT_EQ(result.toStdString(), "1.0 \\\"");
 }
 // NOLINTEND


### PR DESCRIPTION
fix #12204 and fix #12206

All uses I found of this function where to construct python commands