### PR TITLE
PD: Exclude the grid group from bbox computation

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -271,7 +271,9 @@ void GridExtensionP::createGrid(bool cameraUpdate)
 
 void GridExtensionP::createGridPart(int numberSubdiv, bool subDivLines, bool divLines, int pattern, SoBaseColor* color, int lineWidth)
 {
-    SoGroup* parent = new Gui::SoSkipBoundingGroup();
+    auto* parent = new Gui::SoSkipBoundingGroup();
+    parent->mode = Gui::SoSkipBoundingGroup::EXCLUDE_BBOX;
+
     GridRoot->addChild(parent);
     SoVertexProperty* vts;
 


### PR DESCRIPTION
Fixes the problem where View_FitAll would compute a huge bounding box when the infinite grid is enabled.

Closes #11570