### PR TITLE
[Arch] Always use a default IFC type

### DIFF
--- a/src/Mod/Arch/exportIFC.py
+++ b/src/Mod/Arch/exportIFC.py
@@ -1711,7 +1711,7 @@ def getIfcTypeFromObj(obj):
     if "::" in ifctype:
         # it makes no sense to return IfcPart::Cylinder for a Part::Cylinder
         # this is not a ifctype at all
-        ifctype = None
+        ifctype = "IfcBuildingElementPRoxy"
 
     # print("Return value of getIfcTypeFromObj: {}".format(ifctype))
     return ifctype


### PR DESCRIPTION
Some objects had their IFC class set to "None" which we decided many epochs ago to prevent because the class is an enum

Fixes yorikvanhavre/FreeCAD-NativeIFC#60
Fixes yorikvanhavre/FreeCAD-NativeIFC#59