### PR TITLE
Navicube : Add missing view menu entries.

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1226,6 +1226,7 @@ QMenu* NaviCubeImplementation::createNaviCubeMenu() {
         commands.emplace_back("Std_ViewIsometric");
         commands.emplace_back("Separator");
         commands.emplace_back("Std_ViewFitAll");
+        commands.emplace_back("Std_ViewFitSelection");
         commands.emplace_back("Separator");
         commands.emplace_back("NaviCubeDraggableCmd");
     }


### PR DESCRIPTION
Edit: now this PR only adds 'fit selection'

Fixes https://github.com/FreeCAD/FreeCAD/issues/12317

This adds menu entries to the navicube button. The idea is to make the menu more complete so that users can hide the view toolbar and still have access to all its functionality.

![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/56bd894e-0726-4373-bab4-de13c8233336)
Before left, after right
Remarks : 
- Yes I have put front/top... even though the cube provide this already. My reasoning is that sometimes I use the view toolbar because I don't want to analyze the cube to find top view. So I still like to have quick access to those.
- I have not added the Std_TreeViewActions because they feel out of context here. And not very useful so feel ok only in the main menu. Thoughts ?