### PR TITLE
[Sketcher] planegcs: Fix issue in arc-B-spline tangent test

### DIFF
--- a/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -85,13 +85,15 @@ TEST_F(ConstraintsTest, tangentBSplineAndArc)  // NOLINT
     }
     std::vector<double> weights(bSplineControlPoints.size(), 1.0);
     std::vector<double*> weightsAsPtr;
-    std::vector<double> knots(bSplineControlPoints.size());
+    std::vector<double> knots(bSplineControlPoints.size() - 2);  // Hardcoded for cubic
     std::vector<double*> knotsAsPtr;
-    std::vector<int> mult(bSplineControlPoints.size(), 1);
-    mult.front() = 4;  // Hardcoded for cubic
-    mult.back() = 4;   // Hardcoded for cubic
+    std::vector<int> mult(bSplineControlPoints.size() - 2, 1);  // Hardcoded for cubic
+    mult.front() = 4;                                           // Hardcoded for cubic
+    mult.back() = 4;                                            // Hardcoded for cubic
     for (size_t i = 0; i < bSplineControlPoints.size(); ++i) {
         weightsAsPtr.push_back(&weights[i]);
+    }
+    for (size_t i = 0; i < knots.size(); ++i) {
         knots[i] = i;
         knotsAsPtr.push_back(&knots[i]);
     }


### PR DESCRIPTION
Correct the size of the knot vector used (described here with knots and multiplicities).