### PR TITLE
[Material] Adjust default material appearance

### DIFF
--- a/src/App/Material.cpp
+++ b/src/App/Material.cpp
@@ -36,7 +36,7 @@ using namespace App;
 // Material
 //===========================================================================
 Material::Material()
-  : shininess{0.2000f}
+  : shininess{0.9000f}
   , transparency{}
 {
     setType(STEEL);
@@ -44,14 +44,14 @@ Material::Material()
 }
 
 Material::Material(const char* MatName)
-  : shininess{0.2000f}
+  : shininess{0.9000f}
   , transparency{}
 {
     set(MatName);
 }
 
 Material::Material(const MaterialType MatType)
-  : shininess{0.2000f}
+  : shininess{0.9000f}
   , transparency{}
 {
     setType(MatType);
@@ -326,11 +326,11 @@ void Material::setType(const MaterialType MatType)
     case USER_DEFINED:
         break;
     default:
-        ambientColor .set(0.2000f,0.2000f,0.2000f);
-        diffuseColor .set(0.8000f,0.8000f,0.8000f);
-        specularColor.set(0.0000f,0.0000f,0.0000f);
+        ambientColor.set(0.8000f, 0.8000f, 0.8000f);
+        diffuseColor .set(0.8000f,0.8000f,0.9000f);
+        specularColor.set(0.8000f, 0.8000f, 0.8000f);
         emissiveColor.set(0.0000f,0.0000f,0.0000f);
-        shininess    = 0.2000f;
+        shininess = 0.9000f;
         transparency = 0.0000f;
         break;
     }

--- a/src/App/Material.cpp
+++ b/src/App/Material.cpp
@@ -326,9 +326,9 @@ void Material::setType(const MaterialType MatType)
     case USER_DEFINED:
         break;
     default:
-        ambientColor.set(0.8000f, 0.8000f, 0.8000f);
+        ambientColor.set(0.3333f, 0.3333f, 0.3333f);
         diffuseColor .set(0.8000f,0.8000f,0.9000f);
-        specularColor.set(0.8000f, 0.8000f, 0.8000f);
+        specularColor.set(0.5333f, 0.5333f, 0.5333f);
         emissiveColor.set(0.0000f,0.0000f,0.0000f);
         shininess = 0.9000f;
         transparency = 0.0000f;

--- a/src/Mod/Material/Resources/Materials/Appearance/Default.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Default.FCMat
@@ -9,9 +9,9 @@ General:
 AppearanceModels:
   BasicRendering:
     UUID: 'f006c7e4-35b7-43d5-bbf9-c5d572309e6e'
-    AmbientColor: "(0.8000, 0.8000, 0.8000, 1.0)"
+    AmbientColor: "(0.3333, 0.3333, 0.3333, 1.0)"
     DiffuseColor: "(0.8000, 0.8000, 0.9000, 1.0)"
     EmissiveColor: "(0.0000, 0.0000, 0.0000, 1.0)"
     Shininess: "0.9000"
-    SpecularColor: "(0.8000, 0.8000, 0.8000, 1.0)"
+    SpecularColor: "(0.5333, 0.5333, 0.5333, 1.0)"
     Transparency: "0.0"

--- a/src/Mod/Material/Resources/Materials/Appearance/Default.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Default.FCMat
@@ -9,9 +9,9 @@ General:
 AppearanceModels:
   BasicRendering:
     UUID: 'f006c7e4-35b7-43d5-bbf9-c5d572309e6e'
-    AmbientColor: "(0.2000, 0.2000, 0.2000, 1.0)"
-    DiffuseColor: "(0.8000, 0.8000, 0.8000, 1.0)"
+    AmbientColor: "(0.8000, 0.8000, 0.8000, 1.0)"
+    DiffuseColor: "(0.8000, 0.8000, 0.9000, 1.0)"
     EmissiveColor: "(0.0000, 0.0000, 0.0000, 1.0)"
-    Shininess: "0.2000"
-    SpecularColor: "(0.0000, 0.0000, 0.0000, 1.0)"
+    Shininess: "0.9000"
+    SpecularColor: "(0.8000, 0.8000, 0.8000, 1.0)"
     Transparency: "0.0"

--- a/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
+++ b/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
@@ -44,7 +44,7 @@
            <color>
             <red>204</red>
             <green>204</green>
-            <blue>204</blue>
+            <blue>230</blue>
            </color>
           </property>
           <property name="prefEntry" stdset="0">


### PR DESCRIPTION
As discussed with @davesrocketshop the default material appearance is adjusted to better grasp the objects shape (surfaces and contours) with specular highlights and a low ambient color. 
In the long run, this will be replaced with the new material system and the corresponding material pickers / shape appearance preferences.