### PR TITLE
Conda: Pin Python to prevent automatically downgrading without error.

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -87,7 +87,7 @@ dependencies:
 - pre-commit
 - pybind11
 - pyside2
-- python
+- python==3.11.*
 - pyyaml
 - qt
 - qt-main


### PR DESCRIPTION
Python is pinned in `conda/conda-env.yaml` to the desired version.  This commit also pins the Python version in `conda/environment.devenv.yml` to prevent Python to be downgraded unexpectedly to satisfy dependency constraints.