### PR TITLE
Conda: Unpin coin3d as the latest bugfix version corrects the build incompatibility.

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -59,7 +59,7 @@ dependencies:
 - boost-cpp
 - ccache
 - cmake
-- coin3d==4.0.0
+- coin3d
 - compilers
 - conda
 - conda-devenv


### PR DESCRIPTION
The dependency `coin3d` has included a necessary bugfix which eliminates the build error that required pinning.