### PR TITLE
Conda: Unpin OCCT as FreeCAD now builds with OCCT 7.8.0+.

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -77,7 +77,7 @@ dependencies:
 - matplotlib
 - ninja
 - numpy
-- occt==7.6.3
+- occt
 - openssl
 - pcl==1.13.1
 - pip


### PR DESCRIPTION
FreeCAD can now be built with OCCT 7.8.0, removing the need to be pinned to 7.6.3.