### PR TITLE
Fem: Move constraint properties to base class and expose symbol node to Python

### DIFF
--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -91,6 +91,19 @@ Constraint::Constraint()
                       App::PropertyType(App::Prop_Output),
                       "Scale used for drawing constraints");  // OvG: Add scale parameter inherited
                                                               // by all derived constraints
+    ADD_PROPERTY_TYPE(Points,
+                      (Base::Vector3d()),
+                      "Constraint",
+                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output | App::Prop_Hidden),
+                      "Points where symbols are drawn");
+    ADD_PROPERTY_TYPE(Normals,
+                      (Base::Vector3d()),
+                      "Constraint",
+                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output | App::Prop_Hidden),
+                      "Normals where symbols are drawn");
+
+    Points.setValues(std::vector<Base::Vector3d>());
+    Normals.setValues(std::vector<Base::Vector3d>());
 
     References.setScope(App::LinkScope::Global);
 }
@@ -164,6 +177,16 @@ void Constraint::onChanged(const App::Property* prop)
                     break;
                 }
             }
+        }
+
+        std::vector<Base::Vector3d> points;
+        std::vector<Base::Vector3d> normals;
+        int scale = 1;
+        if (getPoints(points, normals, &scale)) {
+            Points.setValues(points);
+            Normals.setValues(normals);
+            Scale.setValue(scale);
+            Points.touch();
         }
     }
 

--- a/src/Mod/Fem/App/FemConstraint.h
+++ b/src/Mod/Fem/App/FemConstraint.h
@@ -102,6 +102,10 @@ public:
      */
     App::PropertyInteger Scale;
 
+    // Read-only (calculated values). These trigger changes in the ViewProvider
+    App::PropertyVectorList Points;
+    App::PropertyVectorList Normals;
+
     /**
      * @brief Updates @ref NormalDirection.
      *

--- a/src/Mod/Fem/App/FemConstraintContact.cpp
+++ b/src/Mod/Fem/App/FemConstraintContact.cpp
@@ -58,20 +58,6 @@ ConstraintContact::ConstraintContact()
                       "ConstraintContact",
                       App::PropertyType(App::Prop_None),
                       "Stick slope");
-
-    ADD_PROPERTY_TYPE(Points,
-                      (Base::Vector3d()),
-                      "ConstraintContact",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Points where symbols are drawn");
-    ADD_PROPERTY_TYPE(Normals,
-                      (Base::Vector3d()),
-                      "ConstraintContact",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Normals where symbols are drawn");
-    /* */
-    Points.setValues(std::vector<Base::Vector3d>());
-    Normals.setValues(std::vector<Base::Vector3d>());
 }
 
 App::DocumentObjectExecReturn* ConstraintContact::execute()
@@ -87,18 +73,6 @@ const char* ConstraintContact::getViewProviderName() const
 void ConstraintContact::onChanged(const App::Property* prop)
 {
     Constraint::onChanged(prop);
-
-    if (prop == &References) {
-        std::vector<Base::Vector3d> points;
-        std::vector<Base::Vector3d> normals;
-        int scale = 1;  // OvG: Enforce use of scale
-        if (getPoints(points, normals, &scale)) {
-            Points.setValues(points);
-            Normals.setValues(normals);
-            Scale.setValue(scale);  // OvG: Scale
-            Points.touch();         // This triggers ViewProvider::updateData()
-        }
-    }
 }
 
 void ConstraintContact::handleChangedPropertyType(Base::XMLReader& reader,

--- a/src/Mod/Fem/App/FemConstraintContact.h
+++ b/src/Mod/Fem/App/FemConstraintContact.h
@@ -38,10 +38,6 @@ public:
     /// Constructor
     ConstraintContact();
 
-    // Read-only (calculated values). These trigger changes in the ViewProvider
-    App::PropertyVectorList Points;
-    App::PropertyVectorList Normals;
-
     /*Note*/
     // Constraint parameters
     /******

--- a/src/Mod/Fem/App/FemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/App/FemConstraintDisplacement.cpp
@@ -78,20 +78,6 @@ ConstraintDisplacement::ConstraintDisplacement()
     ADD_PROPERTY(rotzFix, (false));
     ADD_PROPERTY(rotzFree, (true));
     ADD_PROPERTY(zRotation, (0.0));
-
-    ADD_PROPERTY_TYPE(Points,
-                      (Base::Vector3d()),
-                      "ConstraintFixed",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Points where symbols are drawn");
-    ADD_PROPERTY_TYPE(Normals,
-                      (Base::Vector3d()),
-                      "ConstraintFixed",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Normals where symbols are drawn");
-
-    Points.setValues(std::vector<Base::Vector3d>());
-    Normals.setValues(std::vector<Base::Vector3d>());
 }
 
 App::DocumentObjectExecReturn* ConstraintDisplacement::execute()
@@ -148,19 +134,5 @@ void ConstraintDisplacement::handleChangedPropertyType(Base::XMLReader& reader,
 
 void ConstraintDisplacement::onChanged(const App::Property* prop)
 {
-    // Note: If we call this at the end, then the arrows are not oriented correctly initially
-    // because the NormalDirection has not been calculated yet
     Constraint::onChanged(prop);
-
-    if (prop == &References) {
-        std::vector<Base::Vector3d> points;
-        std::vector<Base::Vector3d> normals;
-        int scale = 1;  // OvG: Enforce use of scale
-        if (getPoints(points, normals, &scale)) {
-            Points.setValues(points);
-            Normals.setValues(normals);
-            Scale.setValue(scale);  // OvG: Scale
-            Points.touch();         // This triggers ViewProvider::updateData()
-        }
-    }
 }

--- a/src/Mod/Fem/App/FemConstraintDisplacement.h
+++ b/src/Mod/Fem/App/FemConstraintDisplacement.h
@@ -40,10 +40,6 @@ public:
     /// Constructor
     ConstraintDisplacement();
 
-    // Read-only (calculated values). These trigger changes in the ViewProvider
-    App::PropertyVectorList Points;
-    App::PropertyVectorList Normals;
-
     // Displacement parameters
     App::PropertyDistance xDisplacement;
     App::PropertyDistance yDisplacement;

--- a/src/Mod/Fem/App/FemConstraintFixed.cpp
+++ b/src/Mod/Fem/App/FemConstraintFixed.cpp
@@ -31,20 +31,7 @@ using namespace Fem;
 PROPERTY_SOURCE(Fem::ConstraintFixed, Fem::Constraint)
 
 ConstraintFixed::ConstraintFixed()
-{
-    ADD_PROPERTY_TYPE(Points,
-                      (Base::Vector3d()),
-                      "ConstraintFixed",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Points where symbols are drawn");
-    ADD_PROPERTY_TYPE(Normals,
-                      (Base::Vector3d()),
-                      "ConstraintFixed",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Normals where symbols are drawn");
-    Points.setValues(std::vector<Base::Vector3d>());
-    Normals.setValues(std::vector<Base::Vector3d>());
-}
+{}
 
 App::DocumentObjectExecReturn* ConstraintFixed::execute()
 {
@@ -53,19 +40,5 @@ App::DocumentObjectExecReturn* ConstraintFixed::execute()
 
 void ConstraintFixed::onChanged(const App::Property* prop)
 {
-    // Note: If we call this at the end, then the symbols are not oriented correctly initially
-    // because the NormalDirection has not been calculated yet
     Constraint::onChanged(prop);
-
-    if (prop == &References) {
-        std::vector<Base::Vector3d> points;
-        std::vector<Base::Vector3d> normals;
-        int scale = 1;  // OvG: Enforce use of scale
-        if (getPoints(points, normals, &scale)) {
-            Points.setValues(points);
-            Normals.setValues(normals);
-            Scale.setValue(scale);  // OvG: Scale
-            Points.touch();         // This triggers ViewProvider::updateData()
-        }
-    }
 }

--- a/src/Mod/Fem/App/FemConstraintFixed.h
+++ b/src/Mod/Fem/App/FemConstraintFixed.h
@@ -38,10 +38,6 @@ public:
     /// Constructor
     ConstraintFixed();
 
-    // Read-only (calculated values). These trigger changes in the ViewProvider
-    App::PropertyVectorList Points;
-    App::PropertyVectorList Normals;
-
     /// recalculate the object
     App::DocumentObjectExecReturn* execute() override;
 

--- a/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
@@ -96,17 +96,9 @@ ConstraintFluidBoundary::ConstraintFluidBoundary()
                       "Heat flux value for thermal boundary condition");
     ADD_PROPERTY_TYPE(HTCoeffValue,(0.0),"HeatTransfer",(App::PropertyType)(App::Prop_None),
                       "Heat transfer coefficient for convective boundary condition");
-    /// geometry rendering related properties
-    ADD_PROPERTY_TYPE(Points,(Base::Vector3d()),"FluidBoundary",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
-                      "Points where arrows are drawn");
-    Points.setValues(std::vector<Base::Vector3d>());
     ADD_PROPERTY_TYPE(DirectionVector,(Base::Vector3d(0,0,1)),"FluidBoundary",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
                       "Direction of arrows");
     naturalDirectionVector = Base::Vector3d(0,0,0); // by default use the null vector to indicate an invalid value
-    // property from: FemConstraintFixed object
-    ADD_PROPERTY_TYPE(Normals,(Base::Vector3d()),"FluidBoundary",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
-                      "Normals where symbols are drawn");
-    Normals.setValues(std::vector<Base::Vector3d>());
     // clang-format on
 }
 
@@ -146,19 +138,6 @@ void ConstraintFluidBoundary::onChanged(const App::Property* prop)
         // must set a default (0 or 1) as freestream has only 2 subtypes
         Subtype.setValue(1);
         // need to trigger ViewProvider::updateData() for redraw in 3D view after this method
-    }
-
-    // naturalDirectionVector is a private member of this class
-    if (prop == &References) {
-        std::vector<Base::Vector3d> points;
-        std::vector<Base::Vector3d> normals;
-        int scale = 1;  // OvG: Enforce use of scale
-        if (getPoints(points, normals, &scale)) {
-            Points.setValues(points);
-            Normals.setValues(normals);
-            Scale.setValue(scale);  // OvG: Scale
-            Points.touch();         // This triggers ViewProvider::updateData()
-        }
     }
     else if (prop == &Direction) {
         Base::Vector3d direction = getDirection(Direction);

--- a/src/Mod/Fem/App/FemConstraintFluidBoundary.h
+++ b/src/Mod/Fem/App/FemConstraintFluidBoundary.h
@@ -54,8 +54,6 @@ public:
 
     App::PropertyBool Reversed;
     // Read-only (calculated values). These trigger changes in the ViewProvider
-    App::PropertyVectorList Points;
-    App::PropertyVectorList Normals;  // needed to draw diff BoundaryType
     App::PropertyVector DirectionVector;
 
     /// recalculate the object

--- a/src/Mod/Fem/App/FemConstraintForce.cpp
+++ b/src/Mod/Fem/App/FemConstraintForce.cpp
@@ -46,11 +46,6 @@ ConstraintForce::ConstraintForce()
     Direction.setScope(App::LinkScope::Global);
 
     ADD_PROPERTY(Reversed, (0));
-    ADD_PROPERTY_TYPE(Points,
-                      (Base::Vector3d()),
-                      "ConstraintForce",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Points where arrows are drawn");
     ADD_PROPERTY_TYPE(DirectionVector,
                       (Base::Vector3d(0, 0, 1)),
                       "ConstraintForce",
@@ -59,7 +54,6 @@ ConstraintForce::ConstraintForce()
 
     // by default use the null vector to indicate an invalid value
     naturalDirectionVector = Base::Vector3d(0, 0, 0);
-    Points.setValues(std::vector<Base::Vector3d>());
 }
 
 App::DocumentObjectExecReturn* ConstraintForce::execute()
@@ -91,19 +85,7 @@ void ConstraintForce::onChanged(const App::Property* prop)
     // because the NormalDirection has not been calculated yet
     Constraint::onChanged(prop);
 
-    if (prop == &References) {
-        std::vector<Base::Vector3d> points;
-        std::vector<Base::Vector3d> normals;
-        int scale = 1;  // OvG: Enforce use of scale
-        if (getPoints(points, normals, &scale)) {
-            // We don't use the normals because all arrows should have
-            // the same direction
-            Points.setValues(points);
-            Scale.setValue(scale);
-            Points.touch();
-        }
-    }
-    else if (prop == &Direction) {
+    if (prop == &Direction) {
         Base::Vector3d direction = getDirection(Direction);
         if (direction.Length() < Precision::Confusion()) {
             return;

--- a/src/Mod/Fem/App/FemConstraintForce.h
+++ b/src/Mod/Fem/App/FemConstraintForce.h
@@ -41,8 +41,6 @@ public:
     App::PropertyForce Force;
     App::PropertyLinkSub Direction;
     App::PropertyBool Reversed;
-    // Read-only (calculated values). These trigger changes in the ViewProvider
-    App::PropertyVectorList Points;
     App::PropertyVector DirectionVector;
 
     /// recalculate the object

--- a/src/Mod/Fem/App/FemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.cpp
@@ -45,19 +45,6 @@ ConstraintHeatflux::ConstraintHeatflux()
                       (App::PropertyType)(App::Prop_None),
                       "Type of constraint, surface convection or surface heat flux");
     ConstraintType.setEnums(ConstraintTypes);
-
-    ADD_PROPERTY_TYPE(Points,
-                      (Base::Vector3d()),
-                      "ConstraintHeatflux",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Points where symbols are drawn");
-    ADD_PROPERTY_TYPE(Normals,
-                      (Base::Vector3d()),
-                      "ConstraintHeatflux",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Normals where symbols are drawn");
-    Points.setValues(std::vector<Base::Vector3d>());
-    Normals.setValues(std::vector<Base::Vector3d>());
 }
 
 App::DocumentObjectExecReturn* ConstraintHeatflux::execute()
@@ -72,19 +59,5 @@ const char* ConstraintHeatflux::getViewProviderName() const
 
 void ConstraintHeatflux::onChanged(const App::Property* prop)
 {
-    // Note: If we call this at the end, then the arrows are not oriented correctly initially
-    // because the NormalDirection has not been calculated yet
     Constraint::onChanged(prop);
-
-    if (prop == &References) {
-        std::vector<Base::Vector3d> points;
-        std::vector<Base::Vector3d> normals;
-        int scale = 1;  // OvG: Enforce use of scale
-        if (getPoints(points, normals, &scale)) {
-            Points.setValues(points);
-            Normals.setValues(normals);
-            Scale.setValue(scale);  // OvG: Scale
-            Points.touch();         // This triggers ViewProvider::updateData()
-        }
-    }
 }

--- a/src/Mod/Fem/App/FemConstraintHeatflux.h
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.h
@@ -45,9 +45,6 @@ public:
     App::PropertyFloat DFlux;
     App::PropertyEnumeration ConstraintType;
 
-    App::PropertyVectorList Points;
-    App::PropertyVectorList Normals;
-
     /// recalculate the object
     App::DocumentObjectExecReturn* execute() override;
 

--- a/src/Mod/Fem/App/FemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/App/FemConstraintInitialTemperature.cpp
@@ -36,19 +36,6 @@ ConstraintInitialTemperature::ConstraintInitialTemperature()
 {
     ADD_PROPERTY(initialTemperature, (300.0));
 
-    ADD_PROPERTY_TYPE(Points,
-                      (Base::Vector3d()),
-                      "ConstraintInitialTemperature",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Points where symbols are drawn");
-    ADD_PROPERTY_TYPE(Normals,
-                      (Base::Vector3d()),
-                      "ConstraintInitialTemperature",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Normals where symbols are drawn");
-    Points.setValues(std::vector<Base::Vector3d>());
-    Normals.setValues(std::vector<Base::Vector3d>());
-
     References.setStatus(App::Property::ReadOnly, true);
     References.setStatus(App::Property::Hidden, true);
 }
@@ -81,19 +68,5 @@ void ConstraintInitialTemperature::handleChangedPropertyType(Base::XMLReader& re
 
 void ConstraintInitialTemperature::onChanged(const App::Property* prop)
 {
-    // Note: If we call this at the end, then the arrows are not oriented correctly initially
-    // because the NormalDirection has not been calculated yet
     Constraint::onChanged(prop);
-
-    if (prop == &References) {
-        std::vector<Base::Vector3d> points;
-        std::vector<Base::Vector3d> normals;
-        int scale = 1;  // OvG: Enforce use of scale
-        if (getPoints(points, normals, &scale)) {
-            Points.setValues(points);
-            Normals.setValues(normals);
-            Scale.setValue(scale);  // OvG: Scale
-            Points.touch();         // This triggers ViewProvider::updateData()
-        }
-    }
 }

--- a/src/Mod/Fem/App/FemConstraintInitialTemperature.h
+++ b/src/Mod/Fem/App/FemConstraintInitialTemperature.h
@@ -40,10 +40,6 @@ public:
     /// Constructor
     ConstraintInitialTemperature();
 
-    // Read-only (calculated values). These trigger changes in the ViewProvider
-    App::PropertyVectorList Points;
-    App::PropertyVectorList Normals;
-
     // Temperature parameters
     App::PropertyTemperature initialTemperature;
 

--- a/src/Mod/Fem/App/FemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/App/FemConstraintPlaneRotation.cpp
@@ -31,21 +31,7 @@ using namespace Fem;
 PROPERTY_SOURCE(Fem::ConstraintPlaneRotation, Fem::Constraint)
 
 ConstraintPlaneRotation::ConstraintPlaneRotation()
-{
-
-    ADD_PROPERTY_TYPE(Points,
-                      (Base::Vector3d()),
-                      "ConstraintPlaneRotation",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Points where symbols are drawn");
-    ADD_PROPERTY_TYPE(Normals,
-                      (Base::Vector3d()),
-                      "ConstraintPlaneRotation",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Normals where symbols are drawn");
-    Points.setValues(std::vector<Base::Vector3d>());
-    Normals.setValues(std::vector<Base::Vector3d>());
-}
+{}
 
 App::DocumentObjectExecReturn* ConstraintPlaneRotation::execute()
 {
@@ -60,16 +46,4 @@ const char* ConstraintPlaneRotation::getViewProviderName() const
 void ConstraintPlaneRotation::onChanged(const App::Property* prop)
 {
     Constraint::onChanged(prop);
-
-    if (prop == &References) {
-        std::vector<Base::Vector3d> points;
-        std::vector<Base::Vector3d> normals;
-        int scale = 1;  // OvG: Enforce use of scale
-        if (getPoints(points, normals, &scale)) {
-            Points.setValues(points);
-            Normals.setValues(normals);
-            Scale.setValue(scale);  // OvG: Scale
-            Points.touch();         // This triggers ViewProvider::updateData()
-        }
-    }
 }

--- a/src/Mod/Fem/App/FemConstraintPlaneRotation.h
+++ b/src/Mod/Fem/App/FemConstraintPlaneRotation.h
@@ -38,11 +38,6 @@ public:
     /// Constructor
     ConstraintPlaneRotation();
 
-    // Read-only (calculated values). These trigger changes in the ViewProvider
-    App::PropertyVectorList Points;
-    App::PropertyVectorList Normals;
-
-
     /// recalculate the object
     App::DocumentObjectExecReturn* execute() override;
 

--- a/src/Mod/Fem/App/FemConstraintPressure.cpp
+++ b/src/Mod/Fem/App/FemConstraintPressure.cpp
@@ -34,18 +34,6 @@ ConstraintPressure::ConstraintPressure()
 {
     ADD_PROPERTY(Pressure, (0.0));
     ADD_PROPERTY(Reversed, (0));
-    ADD_PROPERTY_TYPE(Points,
-                      (Base::Vector3d()),
-                      "ConstraintPressure",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Points where arrows are drawn");
-    ADD_PROPERTY_TYPE(Normals,
-                      (Base::Vector3d()),
-                      "ConstraintPressure",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Normals where symbols are drawn");
-    Points.setValues(std::vector<Base::Vector3d>());
-    Normals.setValues(std::vector<Base::Vector3d>());
 }
 
 App::DocumentObjectExecReturn* ConstraintPressure::execute()
@@ -80,18 +68,7 @@ void ConstraintPressure::onChanged(const App::Property* prop)
 {
     Constraint::onChanged(prop);
 
-    if (prop == &References) {
-        std::vector<Base::Vector3d> points;
-        std::vector<Base::Vector3d> normals;
-        int scale = Scale.getValue();
-        if (getPoints(points, normals, &scale)) {
-            Points.setValues(points);
-            Normals.setValues(normals);
-            Scale.setValue(scale);
-            Points.touch();
-        }
-    }
-    else if (prop == &Reversed) {
+    if (prop == &Reversed) {
         Points.touch();
     }
 }

--- a/src/Mod/Fem/App/FemConstraintPressure.h
+++ b/src/Mod/Fem/App/FemConstraintPressure.h
@@ -39,8 +39,6 @@ public:
 
     App::PropertyPressure Pressure;
     App::PropertyBool Reversed;
-    App::PropertyVectorList Points;
-    App::PropertyVectorList Normals;
 
     /// recalculate the object
     App::DocumentObjectExecReturn* execute() override;

--- a/src/Mod/Fem/App/FemConstraintSpring.cpp
+++ b/src/Mod/Fem/App/FemConstraintSpring.cpp
@@ -37,20 +37,8 @@ ConstraintSpring::ConstraintSpring()
     ADD_PROPERTY(NormalStiffness, (0.0));
     ADD_PROPERTY(TangentialStiffness, (0.0));
     ADD_PROPERTY(ElmerStiffness, (1));
-    ADD_PROPERTY_TYPE(Points,
-                      (Base::Vector3d()),
-                      "ConstraintSpring",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Points where arrows are drawn");
-    ADD_PROPERTY_TYPE(Normals,
-                      (Base::Vector3d()),
-                      "ConstraintSpring",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Normals where symbols are drawn");
 
     ElmerStiffness.setEnums(Stiffnesses);
-    Points.setValues(std::vector<Base::Vector3d>());
-    Normals.setValues(std::vector<Base::Vector3d>());
 }
 
 App::DocumentObjectExecReturn* ConstraintSpring::execute()
@@ -66,16 +54,4 @@ const char* ConstraintSpring::getViewProviderName() const
 void ConstraintSpring::onChanged(const App::Property* prop)
 {
     Constraint::onChanged(prop);
-
-    if (prop == &References) {
-        std::vector<Base::Vector3d> points;
-        std::vector<Base::Vector3d> normals;
-        int scale = Scale.getValue();
-        if (getPoints(points, normals, &scale)) {
-            Points.setValues(points);
-            Normals.setValues(normals);
-            Scale.setValue(scale);
-            Points.touch();
-        }
-    }
 }

--- a/src/Mod/Fem/App/FemConstraintSpring.h
+++ b/src/Mod/Fem/App/FemConstraintSpring.h
@@ -40,8 +40,6 @@ public:
     App::PropertyStiffness NormalStiffness;
     App::PropertyStiffness TangentialStiffness;
     App::PropertyEnumeration ElmerStiffness;
-    App::PropertyVectorList Points;
-    App::PropertyVectorList Normals;
 
     /// recalculate the object
     App::DocumentObjectExecReturn* execute() override;

--- a/src/Mod/Fem/App/FemConstraintTemperature.cpp
+++ b/src/Mod/Fem/App/FemConstraintTemperature.cpp
@@ -44,19 +44,6 @@ ConstraintTemperature::ConstraintTemperature()
                       (App::PropertyType)(App::Prop_None),
                       "Type of constraint, temperature or concentrated heat flux");
     ConstraintType.setEnums(ConstraintTypes);
-
-    ADD_PROPERTY_TYPE(Points,
-                      (Base::Vector3d()),
-                      "ConstraintTemperature",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Points where symbols are drawn");
-    ADD_PROPERTY_TYPE(Normals,
-                      (Base::Vector3d()),
-                      "ConstraintTemperature",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Normals where symbols are drawn");
-    Points.setValues(std::vector<Base::Vector3d>());
-    Normals.setValues(std::vector<Base::Vector3d>());
 }
 
 App::DocumentObjectExecReturn* ConstraintTemperature::execute()
@@ -93,19 +80,5 @@ void ConstraintTemperature::handleChangedPropertyType(Base::XMLReader& reader,
 
 void ConstraintTemperature::onChanged(const App::Property* prop)
 {
-    // Note: If we call this at the end, then the arrows are not oriented correctly initially
-    // because the NormalDirection has not been calculated yet
     Constraint::onChanged(prop);
-
-    if (prop == &References) {
-        std::vector<Base::Vector3d> points;
-        std::vector<Base::Vector3d> normals;
-        int scale = 1;  // OvG: Enforce use of scale
-        if (getPoints(points, normals, &scale)) {
-            Points.setValues(points);
-            Normals.setValues(normals);
-            Scale.setValue(scale);  // OvG: Scale
-            Points.touch();         // This triggers ViewProvider::updateData()
-        }
-    }
 }

--- a/src/Mod/Fem/App/FemConstraintTemperature.h
+++ b/src/Mod/Fem/App/FemConstraintTemperature.h
@@ -40,10 +40,6 @@ public:
     /// Constructor
     ConstraintTemperature();
 
-    // Read-only (calculated values). These trigger changes in the ViewProvider
-    App::PropertyVectorList Points;
-    App::PropertyVectorList Normals;
-
     // Temperature parameters
     App::PropertyTemperature Temperature;
     App::PropertyPower CFlux;

--- a/src/Mod/Fem/App/FemConstraintTransform.cpp
+++ b/src/Mod/Fem/App/FemConstraintTransform.cpp
@@ -66,18 +66,6 @@ ConstraintTransform::ConstraintTransform()
                       "ConstraintTransform",
                       App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
                       "Axis of cylindrical surface");
-    ADD_PROPERTY_TYPE(Points,
-                      (Base::Vector3d()),
-                      "ConstraintTransform",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Points where symbols are drawn");
-    ADD_PROPERTY_TYPE(Normals,
-                      (Base::Vector3d()),
-                      "ConstraintTransform",
-                      App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
-                      "Normals where symbols are drawn");
-    Points.setValues(std::vector<Base::Vector3d>());
-    Normals.setValues(std::vector<Base::Vector3d>());
 }
 
 App::DocumentObjectExecReturn* ConstraintTransform::execute()
@@ -124,10 +112,6 @@ void ConstraintTransform::onChanged(const App::Property* prop)
         std::vector<Base::Vector3d> normals;
         int scale = 1;  // OvG: Enforce use of scale
         if (getPoints(points, normals, &scale)) {
-            Points.setValues(points);
-            Normals.setValues(normals);
-            Scale.setValue(scale);  // OvG: Scale
-            Points.touch();         // This triggers ViewProvider::updateData()
             std::string transform_type = TransformType.getValueAsString();
             if (transform_type == "Cylindrical") {
                 // Find data of cylinder

--- a/src/Mod/Fem/App/FemConstraintTransform.h
+++ b/src/Mod/Fem/App/FemConstraintTransform.h
@@ -40,8 +40,6 @@ public:
     // Read-only (calculated values). These trigger changes in the ViewProvider
     App::PropertyLinkSubList RefDispl;
     App::PropertyLinkList NameDispl;
-    App::PropertyVectorList Points;
-    App::PropertyVectorList Normals;
     App::PropertyVector BasePoint;
     App::PropertyVector Axis;
     App::PropertyAngle X_rot;

--- a/src/Mod/Fem/Gui/CMakeLists.txt
+++ b/src/Mod/Fem/Gui/CMakeLists.txt
@@ -35,10 +35,13 @@ set(FemGui_LIBS
     PartGui
 )
 
+generate_from_xml(ViewProviderFemConstraintPy)
 generate_from_xml(ViewProviderFemMeshPy)
 generate_from_xml(ViewProviderFemPostPipelinePy)
 
 SET(Python_SRCS
+    ViewProviderFemConstraintPy.xml
+    ViewProviderFemConstraintPyImp.cpp
     ViewProviderFemMeshPy.xml
     ViewProviderFemMeshPyImp.cpp
     ViewProviderFemPostPipelinePy.xml

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
@@ -47,6 +47,7 @@
 
 #include "TaskFemConstraint.h"
 #include "ViewProviderFemConstraint.h"
+#include "ViewProviderFemConstraintPy.h"
 
 
 using namespace FemGui;
@@ -214,6 +215,15 @@ void ViewProviderFemConstraint::unsetEdit(int ModNum)
             ViewProviderGeometryObject::unsetEdit(ModNum);
         }
     }
+}
+
+PyObject* ViewProviderFemConstraint::getPyObject()
+{
+    if (!pyViewObject) {
+        pyViewObject = new ViewProviderFemConstraintPy(this);
+    }
+    pyViewObject->IncRef();
+    return pyViewObject;
 }
 /*
 // Create a local coordinate system with the z-axis given in dir

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
@@ -72,9 +72,16 @@ public:
     std::vector<App::DocumentObject*> claimChildren() const override;
     void setupContextMenu(QMenu*, QObject*, const char*) override;
 
+    PyObject* getPyObject() override;
+
     /// Highlight the references that have been selected
     virtual void highlightReferences(const bool /* on */)
     {}
+
+    SoSeparator* getSymbolSeparator() const
+    {
+        return pShapeSep;
+    }
 
     static std::string gethideMeshShowPartStr();
     static std::string gethideMeshShowPartStr(const std::string showConstr);

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPy.xml
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPy.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
+    <PythonExport
+        Father="ViewProviderDocumentObjectPy"
+        Name="ViewProviderFemConstraintPy"
+        Twin="ViewProviderFemConstraint"
+        TwinPointer="ViewProviderFemConstraint"
+        Include="Mod/Fem/Gui/ViewProviderFemConstraint.h"
+        Namespace="FemGui"
+        FatherInclude="Gui/ViewProviderDocumentObjectPy.h"
+        FatherNamespace="Gui">
+        <Documentation>
+            <Author Licence="LGPL" Name="Mario Passaglia" EMail="mpassaglia@cbc.ub.ar" />
+            <UserDocu>This is the ViewProviderFemConstraint class</UserDocu>
+        </Documentation>
+        <Attribute Name="SymbolNode" ReadOnly="true">
+            <Documentation>
+                <UserDocu>A pivy SoSeparator with the nodes of the constraint symbols</UserDocu>
+            </Documentation>
+            <Parameter Name="SymbolNode" Type="Object" />
+        </Attribute>
+    </PythonExport>
+</GenerateModel>

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPyImp.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPyImp.cpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2024 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+#include <Inventor/nodes/SoSeparator.h>
+#endif
+
+#include <Base/Interpreter.h>
+
+#include "ViewProviderFemConstraintPy.h"
+#include "ViewProviderFemConstraintPy.cpp"
+
+
+using namespace FemGui;
+
+// returns a string which represent the object e.g. when printed in python
+std::string ViewProviderFemConstraintPy::representation() const
+{
+    std::stringstream str;
+    str << "<View provider FemConstraint object at " << getViewProviderFemConstraintPtr() << ">";
+
+    return str.str();
+}
+
+
+Py::Object ViewProviderFemConstraintPy::getSymbolNode() const
+{
+    try {
+        SoSeparator* sep = getViewProviderFemConstraintPtr()->getSymbolSeparator();
+        PyObject* Ptr =
+            Base::Interpreter().createSWIGPointerObj("pivy.coin", "_p_SoSeparator", sep, 1);
+
+        sep->ref();
+
+        return Py::Object(Ptr, true);
+    }
+    catch (const Base::Exception& e) {
+        throw Py::RuntimeError(e.what());
+    }
+}
+
+PyObject* ViewProviderFemConstraintPy::getCustomAttributes(const char* /*attr*/) const
+{
+    return nullptr;
+}
+
+int ViewProviderFemConstraintPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0;
+}


### PR DESCRIPTION
The `Points` and `Normals` properties are used to draw the constraint symbols in the 3D view at specific positions.
Currently, these properties are implemented in every class that inherits from `Fem::Constraint`, so it is best to move them to the base class.
But more importantly than avoiding code duplication, these properties are now inherited by the Python constraint objects.

The second commit exposes the node where constraint symbols are drawn to the constraint view provider's Python object, so we can now add symbols to pure Python constraint objects in the same way as C++ objects.