### PR TITLE
PD: Support for App::Link in loft operation

### DIFF
--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -86,7 +86,8 @@ App::DocumentObjectExecReturn *Loft::execute()
             }
 
             if (!linkedObj->isDerivedFrom<Part::Feature>())
-                throw Base::TypeError("Loft: All sections need to be part features");
+                throw Base::TypeError(QT_TRANSLATE_NOOP("Exception",
+                            "Loft: All sections need to be part features"));
 
             auto subName = subs.empty() ? "" : subs.front();
 


### PR DESCRIPTION
Tested with the attached test case (sketch-sketch) and some other cases (sketch-vertex) and seems to work pretty well.

The type-checking for the object is moved into `getSectionShape`.

Closes #6198