### PR TITLE
Assembly: Add ${COIN3D_INCLUDE_DIRS} to CMakeLists.txt

### DIFF
--- a/src/Mod/Assembly/Gui/CMakeLists.txt
+++ b/src/Mod/Assembly/Gui/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${COIN3D_INCLUDE_DIRS} 
     ${OCC_INCLUDE_DIR}
 )
 

--- a/src/Mod/Assembly/Gui/CMakeLists.txt
+++ b/src/Mod/Assembly/Gui/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(
     ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${COIN3D_INCLUDE_DIRS} 
+    ${COIN3D_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
 )
 


### PR DESCRIPTION
Builds are broken on some platforms without this line.