### PR TITLE
Assembly: Add ${PYTHON_INCLUDE_DIRS} to CMakeLists.txt

### DIFF
--- a/src/Mod/Assembly/Gui/CMakeLists.txt
+++ b/src/Mod/Assembly/Gui/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${COIN3D_INCLUDE_DIRS}
     ${OCC_INCLUDE_DIR}
+    ${PYTHON_INCLUDE_DIRS}
 )
 
 set(AssemblyGui_LIBS


### PR DESCRIPTION
Assembly Gui is including <Base/PyObjectBase.h> which in turn includes <Python.h>, so path to Python includes is needed.