### PR TITLE
Change the calculation of the b parameter of the hyperbolic arc

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -102,8 +102,8 @@ public:
             double angleatpoint = acosh(((onSketchPos.x - centerPoint.x) * cos(phi)
                                          + (onSketchPos.y - centerPoint.y) * sin(phi))
                                         / a);
-            double b = (onSketchPos.y - centerPoint.y - a * cosh(angleatpoint) * sin(phi))
-                / (sinh(angleatpoint) * cos(phi));
+            double b = ((onSketchPos.y - centerPoint.y) * cos(phi) - (onSketchPos.x - centerPoint.x) * sin(phi))
+                / sinh(angleatpoint);
 
             if (!boost::math::isnan(b)) {
                 for (int i = 15; i >= -15; i--) {
@@ -140,8 +140,8 @@ public:
             double angleatstartingpoint = acosh(((startingPoint.x - centerPoint.x) * cos(phi)
                                                  + (startingPoint.y - centerPoint.y) * sin(phi))
                                                 / a);
-            double b = (startingPoint.y - centerPoint.y - a * cosh(angleatstartingpoint) * sin(phi))
-                / (sinh(angleatstartingpoint) * cos(phi));
+            double b = ((startingPoint.y - centerPoint.y) * cos(phi) - (startingPoint.x - centerPoint.x) * sin(phi))
+                / sinh(angleatstartingpoint);
 
             double startAngle = angleatstartingpoint;
 
@@ -240,8 +240,9 @@ public:
             double angleatstartingpoint = acosh(((startingPoint.x - centerPoint.x) * cos(phi)
                                                  + (startingPoint.y - centerPoint.y) * sin(phi))
                                                 / a);
-            double b = (startingPoint.y - centerPoint.y - a * cosh(angleatstartingpoint) * sin(phi))
-                / (sinh(angleatstartingpoint) * cos(phi));
+	    
+            double b = ((startingPoint.y - centerPoint.y) * cos(phi) - (startingPoint.x - centerPoint.x) * sin(phi))
+                / sinh(angleatstartingpoint);
 
             double startAngle = angleatstartingpoint;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -102,7 +102,8 @@ public:
             double angleatpoint = acosh(((onSketchPos.x - centerPoint.x) * cos(phi)
                                          + (onSketchPos.y - centerPoint.y) * sin(phi))
                                         / a);
-            double b = ((onSketchPos.y - centerPoint.y) * cos(phi) - (onSketchPos.x - centerPoint.x) * sin(phi))
+            double b = ((onSketchPos.y - centerPoint.y) * cos(phi)
+                        - (onSketchPos.x - centerPoint.x) * sin(phi))
                 / sinh(angleatpoint);
 
             if (!boost::math::isnan(b)) {
@@ -140,7 +141,8 @@ public:
             double angleatstartingpoint = acosh(((startingPoint.x - centerPoint.x) * cos(phi)
                                                  + (startingPoint.y - centerPoint.y) * sin(phi))
                                                 / a);
-            double b = ((startingPoint.y - centerPoint.y) * cos(phi) - (startingPoint.x - centerPoint.x) * sin(phi))
+            double b = ((startingPoint.y - centerPoint.y) * cos(phi)
+                        - (startingPoint.x - centerPoint.x) * sin(phi))
                 / sinh(angleatstartingpoint);
 
             double startAngle = angleatstartingpoint;
@@ -240,8 +242,9 @@ public:
             double angleatstartingpoint = acosh(((startingPoint.x - centerPoint.x) * cos(phi)
                                                  + (startingPoint.y - centerPoint.y) * sin(phi))
                                                 / a);
-	    
-            double b = ((startingPoint.y - centerPoint.y) * cos(phi) - (startingPoint.x - centerPoint.x) * sin(phi))
+
+            double b = ((startingPoint.y - centerPoint.y) * cos(phi)
+                        - (startingPoint.x - centerPoint.x) * sin(phi))
                 / sinh(angleatstartingpoint);
 
             double startAngle = angleatstartingpoint;


### PR DESCRIPTION
so that it does not give 0/0 when cos(phi) = 0

This gave problems if the first two points defined in the sketcher had the same x-coordinate - e.g. when using snap to grid
See: https://forum.freecad.org/viewtopic.php?t=85224