### PR TITLE
Refactoring and cleanup of PD Pattern task panels

### DIFF
--- a/src/Mod/PartDesign/Gui/CMakeLists.txt
+++ b/src/Mod/PartDesign/Gui/CMakeLists.txt
@@ -41,6 +41,7 @@ set(PartDesignGui_UIC_SRCS
     TaskHoleParameters.ui
     TaskRevolutionParameters.ui
     TaskTransformedMessages.ui
+    TaskTransformedParameters.ui
     TaskMirroredParameters.ui
     TaskLinearPatternParameters.ui
     TaskPolarPatternParameters.ui

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -97,7 +97,7 @@ void TaskLinearPatternParameters::setupParameterUI(QWidget* widget)
 
     dirLinks.setCombo(*(ui->comboDirection));
     App::DocumentObject* sketch = getSketchObject();
-    if (sketch && sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+    if (sketch && sketch->isDerivedFrom<Part::Part2DObject>()) {
         this->fillAxisCombo(dirLinks, static_cast<Part::Part2DObject*>(sketch));
     }
     else {

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -74,8 +74,7 @@ void TaskLinearPatternParameters::setupParameterUI(QWidget* widget)
     QMetaObject::connectSlotsByName(this);
 
     // Get the feature data
-    PartDesign::LinearPattern* pcLinearPattern =
-        static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
 
     ui->spinLength->bind(pcLinearPattern->Length);
     ui->spinOffset->bind(pcLinearPattern->Offset);
@@ -110,8 +109,7 @@ void TaskLinearPatternParameters::setupParameterUI(QWidget* widget)
     if (body) {
         try {
             App::Origin* origin = body->getOrigin();
-            ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(
+            auto vpOrigin = static_cast<ViewProviderOrigin*>(
                 Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->setTemporaryVisibility(true, false);
         }
@@ -168,10 +166,8 @@ void TaskLinearPatternParameters::updateUI()
     }
     blockUpdate = true;
 
-    PartDesign::LinearPattern* pcLinearPattern =
-        static_cast<PartDesign::LinearPattern*>(getObject());
-    PartDesign::LinearPatternMode mode =
-        static_cast<PartDesign::LinearPatternMode>(pcLinearPattern->Mode.getValue());
+    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    auto mode = static_cast<PartDesign::LinearPatternMode>(pcLinearPattern->Mode.getValue());
 
     bool reverse = pcLinearPattern->Reversed.getValue();
     double length = pcLinearPattern->Length.getValue();
@@ -189,7 +185,7 @@ void TaskLinearPatternParameters::updateUI()
     // Note: This block of code would trigger change signal handlers (e.g. onOccurrences())
     // and another updateUI() if we didn't check for blockUpdate
     ui->checkReverse->setChecked(reverse);
-    ui->comboMode->setCurrentIndex((long)mode);
+    ui->comboMode->setCurrentIndex(static_cast<int>(mode));
     ui->spinLength->setValue(length);
     ui->spinOffset->setValue(offset);
     ui->spinOccurrences->setValue(occurrences);
@@ -230,8 +226,7 @@ void TaskLinearPatternParameters::onSelectionChanged(const Gui::SelectionChanges
             exitSelectionMode();
             std::vector<std::string> directions;
             App::DocumentObject* selObj = nullptr;
-            PartDesign::LinearPattern* pcLinearPattern =
-                static_cast<PartDesign::LinearPattern*>(getObject());
+            auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
             if (pcLinearPattern) {
                 getReferencedSelection(pcLinearPattern, msg, selObj, directions);
 
@@ -257,8 +252,7 @@ void TaskLinearPatternParameters::onCheckReverse(const bool on)
     if (blockUpdate) {
         return;
     }
-    PartDesign::LinearPattern* pcLinearPattern =
-        static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
     pcLinearPattern->Reversed.setValue(on);
 
     exitSelectionMode();
@@ -270,8 +264,7 @@ void TaskLinearPatternParameters::onModeChanged(const int mode)
     if (blockUpdate) {
         return;
     }
-    PartDesign::LinearPattern* pcLinearPattern =
-        static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
     pcLinearPattern->Mode.setValue(mode);
 
     adaptVisibilityToMode();
@@ -280,40 +273,37 @@ void TaskLinearPatternParameters::onModeChanged(const int mode)
     kickUpdateViewTimer();
 }
 
-void TaskLinearPatternParameters::onLength(const double l)
+void TaskLinearPatternParameters::onLength(const double length)
 {
     if (blockUpdate) {
         return;
     }
-    PartDesign::LinearPattern* pcLinearPattern =
-        static_cast<PartDesign::LinearPattern*>(getObject());
-    pcLinearPattern->Length.setValue(l);
+    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    pcLinearPattern->Length.setValue(length);
 
     exitSelectionMode();
     kickUpdateViewTimer();
 }
 
-void TaskLinearPatternParameters::onOffset(const double o)
+void TaskLinearPatternParameters::onOffset(const double offset)
 {
     if (blockUpdate) {
         return;
     }
-    PartDesign::LinearPattern* pcLinearPattern =
-        static_cast<PartDesign::LinearPattern*>(getObject());
-    pcLinearPattern->Offset.setValue(o);
+    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    pcLinearPattern->Offset.setValue(offset);
 
     exitSelectionMode();
     kickUpdateViewTimer();
 }
 
-void TaskLinearPatternParameters::onOccurrences(const uint n)
+void TaskLinearPatternParameters::onOccurrences(const uint number)
 {
     if (blockUpdate) {
         return;
     }
-    PartDesign::LinearPattern* pcLinearPattern =
-        static_cast<PartDesign::LinearPattern*>(getObject());
-    pcLinearPattern->Occurrences.setValue(n);
+    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    pcLinearPattern->Occurrences.setValue(number);
 
     exitSelectionMode();
     kickUpdateViewTimer();
@@ -324,8 +314,7 @@ void TaskLinearPatternParameters::onDirectionChanged(int /*num*/)
     if (blockUpdate) {
         return;
     }
-    PartDesign::LinearPattern* pcLinearPattern =
-        static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
     try {
         if (!dirLinks.getCurrentLink().getValue()) {
             // enter reference selection mode
@@ -353,10 +342,9 @@ void TaskLinearPatternParameters::onUpdateView(bool on)
     blockUpdate = !on;
     if (on) {
         // Do the same like in TaskDlgLinearPatternParameters::accept() but without doCommand
-        PartDesign::LinearPattern* pcLinearPattern =
-            static_cast<PartDesign::LinearPattern*>(getObject());
+        auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
         std::vector<std::string> directions;
-        App::DocumentObject* obj;
+        App::DocumentObject* obj = nullptr;
 
         setupTransaction();
         getDirection(obj, directions);
@@ -410,8 +398,7 @@ TaskLinearPatternParameters::~TaskLinearPatternParameters()
         PartDesign::Body* body = PartDesign::Body::findBodyOf(getObject());
         if (body) {
             App::Origin* origin = body->getOrigin();
-            ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(
+            auto vpOrigin = static_cast<ViewProviderOrigin*>(
                 Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->resetTemporaryVisibility();
         }
@@ -424,7 +411,7 @@ TaskLinearPatternParameters::~TaskLinearPatternParameters()
 void TaskLinearPatternParameters::apply()
 {
     std::vector<std::string> directions;
-    App::DocumentObject* obj;
+    App::DocumentObject* obj = nullptr;
     getDirection(obj, directions);
     std::string direction = buildLinkSingleSubPythonStr(obj, directions);
 

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -24,8 +24,8 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <QMessageBox>
-# include <QTimer>
+#include <QMessageBox>
+#include <QTimer>
 #endif
 
 #include <App/Document.h>
@@ -52,26 +52,30 @@ using namespace Gui;
 
 /* TRANSLATOR PartDesignGui::TaskLinearPatternParameters */
 
-TaskLinearPatternParameters::TaskLinearPatternParameters(ViewProviderTransformed *TransformedView,QWidget *parent)
+TaskLinearPatternParameters::TaskLinearPatternParameters(ViewProviderTransformed* TransformedView,
+                                                         QWidget* parent)
     : TaskTransformedParameters(TransformedView, parent)
     , ui(new Ui_TaskLinearPatternParameters)
 {
     setupUI();
 }
 
-TaskLinearPatternParameters::TaskLinearPatternParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget)
-        : TaskTransformedParameters(parentTask), ui(new Ui_TaskLinearPatternParameters)
+TaskLinearPatternParameters::TaskLinearPatternParameters(TaskMultiTransformParameters* parentTask,
+                                                         QWidget* parameterWidget)
+    : TaskTransformedParameters(parentTask)
+    , ui(new Ui_TaskLinearPatternParameters)
 {
     setupParameterUI(parameterWidget);
 }
 
-void TaskLinearPatternParameters::setupParameterUI(QWidget *widget)
+void TaskLinearPatternParameters::setupParameterUI(QWidget* widget)
 {
     ui->setupUi(widget);
     QMetaObject::connectSlotsByName(this);
 
     // Get the feature data
-    PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    PartDesign::LinearPattern* pcLinearPattern =
+        static_cast<PartDesign::LinearPattern*>(getObject());
 
     ui->spinLength->bind(pcLinearPattern->Length);
     ui->spinOffset->bind(pcLinearPattern->Offset);
@@ -101,16 +105,18 @@ void TaskLinearPatternParameters::setupParameterUI(QWidget *widget)
         this->fillAxisCombo(dirLinks, nullptr);
     }
 
-    //show the parts coordinate system axis for selection
-    PartDesign::Body * body = PartDesign::Body::findBodyOf(getObject());
-    if(body) {
+    // show the parts coordinate system axis for selection
+    PartDesign::Body* body = PartDesign::Body::findBodyOf(getObject());
+    if (body) {
         try {
-            App::Origin *origin = body->getOrigin();
+            App::Origin* origin = body->getOrigin();
             ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin = static_cast<ViewProviderOrigin*>(
+                Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->setTemporaryVisibility(true, false);
-        } catch (const Base::Exception &ex) {
-            Base::Console().Error ("%s\n", ex.what () );
+        }
+        catch (const Base::Exception& ex) {
+            Base::Console().Error("%s\n", ex.what());
         }
     }
 
@@ -119,21 +125,35 @@ void TaskLinearPatternParameters::setupParameterUI(QWidget *widget)
     updateViewTimer = new QTimer(this);
     updateViewTimer->setSingleShot(true);
     updateViewTimer->setInterval(getUpdateViewTimeout());
-    connect(updateViewTimer, &QTimer::timeout,
-            this, &TaskLinearPatternParameters::onUpdateViewTimer);
+    connect(updateViewTimer,
+            &QTimer::timeout,
+            this,
+            &TaskLinearPatternParameters::onUpdateViewTimer);
 
-    connect(ui->comboDirection, qOverload<int>(&QComboBox::activated),
-            this, &TaskLinearPatternParameters::onDirectionChanged);
-    connect(ui->checkReverse, &QCheckBox::toggled,
-            this, &TaskLinearPatternParameters::onCheckReverse);
-    connect(ui->comboMode, qOverload<int>(&QComboBox::activated),
-            this, &TaskLinearPatternParameters::onModeChanged);
-    connect(ui->spinLength, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
-            this, &TaskLinearPatternParameters::onLength);
-    connect(ui->spinOffset, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
-            this, &TaskLinearPatternParameters::onOffset);
-    connect(ui->spinOccurrences, &Gui::UIntSpinBox::unsignedChanged,
-            this, &TaskLinearPatternParameters::onOccurrences);
+    connect(ui->comboDirection,
+            qOverload<int>(&QComboBox::activated),
+            this,
+            &TaskLinearPatternParameters::onDirectionChanged);
+    connect(ui->checkReverse,
+            &QCheckBox::toggled,
+            this,
+            &TaskLinearPatternParameters::onCheckReverse);
+    connect(ui->comboMode,
+            qOverload<int>(&QComboBox::activated),
+            this,
+            &TaskLinearPatternParameters::onModeChanged);
+    connect(ui->spinLength,
+            qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+            this,
+            &TaskLinearPatternParameters::onLength);
+    connect(ui->spinOffset,
+            qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+            this,
+            &TaskLinearPatternParameters::onOffset);
+    connect(ui->spinOccurrences,
+            &Gui::UIntSpinBox::unsignedChanged,
+            this,
+            &TaskLinearPatternParameters::onOccurrences);
 }
 
 void TaskLinearPatternParameters::retranslateParameterUI(QWidget* widget)
@@ -143,22 +163,26 @@ void TaskLinearPatternParameters::retranslateParameterUI(QWidget* widget)
 
 void TaskLinearPatternParameters::updateUI()
 {
-    if (blockUpdate)
+    if (blockUpdate) {
         return;
+    }
     blockUpdate = true;
 
-    PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
-    PartDesign::LinearPatternMode mode = static_cast<PartDesign::LinearPatternMode>(pcLinearPattern->Mode.getValue());
+    PartDesign::LinearPattern* pcLinearPattern =
+        static_cast<PartDesign::LinearPattern*>(getObject());
+    PartDesign::LinearPatternMode mode =
+        static_cast<PartDesign::LinearPatternMode>(pcLinearPattern->Mode.getValue());
 
     bool reverse = pcLinearPattern->Reversed.getValue();
     double length = pcLinearPattern->Length.getValue();
     double offset = pcLinearPattern->Offset.getValue();
     unsigned occurrences = pcLinearPattern->Occurrences.getValue();
 
-    if (dirLinks.setCurrentLink(pcLinearPattern->Direction) == -1){
-        //failed to set current, because the link isn't in the list yet
-        dirLinks.addLink(pcLinearPattern->Direction, getRefStr(pcLinearPattern->Direction.getValue(),
-                                                               pcLinearPattern->Direction.getSubValues()));
+    if (dirLinks.setCurrentLink(pcLinearPattern->Direction) == -1) {
+        // failed to set current, because the link isn't in the list yet
+        dirLinks.addLink(pcLinearPattern->Direction,
+                         getRefStr(pcLinearPattern->Direction.getValue(),
+                                   pcLinearPattern->Direction.getSubValues()));
         dirLinks.setCurrentLink(pcLinearPattern->Direction);
     }
 
@@ -206,16 +230,18 @@ void TaskLinearPatternParameters::onSelectionChanged(const Gui::SelectionChanges
             exitSelectionMode();
             std::vector<std::string> directions;
             App::DocumentObject* selObj = nullptr;
-            PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+            PartDesign::LinearPattern* pcLinearPattern =
+                static_cast<PartDesign::LinearPattern*>(getObject());
             if (pcLinearPattern) {
                 getReferencedSelection(pcLinearPattern, msg, selObj, directions);
 
                 // Note: ReferenceSelection has already checked the selection for validity
-                if (selObj && (selectionMode == SelectionMode::Reference ||
-                               selObj->isDerivedFrom(App::Line::getClassTypeId()) ||
-                               selObj->isDerivedFrom(Part::Feature::getClassTypeId()) ||
-                               selObj->isDerivedFrom(PartDesign::Line::getClassTypeId()) ||
-                               selObj->isDerivedFrom(PartDesign::Plane::getClassTypeId()))) {
+                if (selObj
+                    && (selectionMode == SelectionMode::Reference
+                        || selObj->isDerivedFrom(App::Line::getClassTypeId())
+                        || selObj->isDerivedFrom(Part::Feature::getClassTypeId())
+                        || selObj->isDerivedFrom(PartDesign::Line::getClassTypeId())
+                        || selObj->isDerivedFrom(PartDesign::Plane::getClassTypeId()))) {
                     setupTransaction();
                     pcLinearPattern->Direction.setValue(selObj, directions);
                     recomputeFeature();
@@ -226,20 +252,26 @@ void TaskLinearPatternParameters::onSelectionChanged(const Gui::SelectionChanges
     }
 }
 
-void TaskLinearPatternParameters::onCheckReverse(const bool on) {
-    if (blockUpdate)
+void TaskLinearPatternParameters::onCheckReverse(const bool on)
+{
+    if (blockUpdate) {
         return;
-    PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    }
+    PartDesign::LinearPattern* pcLinearPattern =
+        static_cast<PartDesign::LinearPattern*>(getObject());
     pcLinearPattern->Reversed.setValue(on);
 
     exitSelectionMode();
     kickUpdateViewTimer();
 }
 
-void TaskLinearPatternParameters::onModeChanged(const int mode) {
-    if (blockUpdate)
+void TaskLinearPatternParameters::onModeChanged(const int mode)
+{
+    if (blockUpdate) {
         return;
-    PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    }
+    PartDesign::LinearPattern* pcLinearPattern =
+        static_cast<PartDesign::LinearPattern*>(getObject());
     pcLinearPattern->Mode.setValue(mode);
 
     adaptVisibilityToMode();
@@ -248,30 +280,39 @@ void TaskLinearPatternParameters::onModeChanged(const int mode) {
     kickUpdateViewTimer();
 }
 
-void TaskLinearPatternParameters::onLength(const double l) {
-    if (blockUpdate)
+void TaskLinearPatternParameters::onLength(const double l)
+{
+    if (blockUpdate) {
         return;
-    PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    }
+    PartDesign::LinearPattern* pcLinearPattern =
+        static_cast<PartDesign::LinearPattern*>(getObject());
     pcLinearPattern->Length.setValue(l);
 
     exitSelectionMode();
     kickUpdateViewTimer();
 }
 
-void TaskLinearPatternParameters::onOffset(const double o) {
-    if (blockUpdate)
+void TaskLinearPatternParameters::onOffset(const double o)
+{
+    if (blockUpdate) {
         return;
-    PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    }
+    PartDesign::LinearPattern* pcLinearPattern =
+        static_cast<PartDesign::LinearPattern*>(getObject());
     pcLinearPattern->Offset.setValue(o);
 
     exitSelectionMode();
     kickUpdateViewTimer();
 }
 
-void TaskLinearPatternParameters::onOccurrences(const uint n) {
-    if (blockUpdate)
+void TaskLinearPatternParameters::onOccurrences(const uint n)
+{
+    if (blockUpdate) {
         return;
-    PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    }
+    PartDesign::LinearPattern* pcLinearPattern =
+        static_cast<PartDesign::LinearPattern*>(getObject());
     pcLinearPattern->Occurrences.setValue(n);
 
     exitSelectionMode();
@@ -280,23 +321,28 @@ void TaskLinearPatternParameters::onOccurrences(const uint n) {
 
 void TaskLinearPatternParameters::onDirectionChanged(int /*num*/)
 {
-    if (blockUpdate)
+    if (blockUpdate) {
         return;
-    PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
-    try{
+    }
+    PartDesign::LinearPattern* pcLinearPattern =
+        static_cast<PartDesign::LinearPattern*>(getObject());
+    try {
         if (!dirLinks.getCurrentLink().getValue()) {
             // enter reference selection mode
             hideObject();
             showBase();
             selectionMode = SelectionMode::Reference;
             Gui::Selection().clearSelection();
-            addReferenceSelectionGate(AllowSelection::EDGE | AllowSelection::FACE | AllowSelection::PLANAR);
-        } else {
+            addReferenceSelectionGate(AllowSelection::EDGE | AllowSelection::FACE
+                                      | AllowSelection::PLANAR);
+        }
+        else {
             exitSelectionMode();
             pcLinearPattern->Direction.Paste(dirLinks.getCurrentLink());
         }
-    } catch (Base::Exception &e) {
-        QMessageBox::warning(nullptr,tr("Error"),QApplication::translate("Exception", e.what()));
+    }
+    catch (Base::Exception& e) {
+        QMessageBox::warning(nullptr, tr("Error"), QApplication::translate("Exception", e.what()));
     }
 
     kickUpdateViewTimer();
@@ -307,13 +353,14 @@ void TaskLinearPatternParameters::onUpdateView(bool on)
     blockUpdate = !on;
     if (on) {
         // Do the same like in TaskDlgLinearPatternParameters::accept() but without doCommand
-        PartDesign::LinearPattern* pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+        PartDesign::LinearPattern* pcLinearPattern =
+            static_cast<PartDesign::LinearPattern*>(getObject());
         std::vector<std::string> directions;
         App::DocumentObject* obj;
 
         setupTransaction();
         getDirection(obj, directions);
-        pcLinearPattern->Direction.setValue(obj,directions);
+        pcLinearPattern->Direction.setValue(obj, directions);
         pcLinearPattern->Reversed.setValue(getReverse());
         pcLinearPattern->Length.setValue(getLength());
         pcLinearPattern->Offset.setValue(getOffset());
@@ -323,9 +370,10 @@ void TaskLinearPatternParameters::onUpdateView(bool on)
     }
 }
 
-void TaskLinearPatternParameters::getDirection(App::DocumentObject*& obj, std::vector<std::string>& sub) const
+void TaskLinearPatternParameters::getDirection(App::DocumentObject*& obj,
+                                               std::vector<std::string>& sub) const
 {
-    const App::PropertyLinkSub &lnk = dirLinks.getCurrentLink();
+    const App::PropertyLinkSub& lnk = dirLinks.getCurrentLink();
     obj = lnk.getValue();
     sub = lnk.getSubValues();
 }
@@ -358,17 +406,18 @@ unsigned TaskLinearPatternParameters::getOccurrences() const
 TaskLinearPatternParameters::~TaskLinearPatternParameters()
 {
     try {
-        //hide the parts coordinate system axis for selection
-        PartDesign::Body * body = PartDesign::Body::findBodyOf(getObject());
+        // hide the parts coordinate system axis for selection
+        PartDesign::Body* body = PartDesign::Body::findBodyOf(getObject());
         if (body) {
-            App::Origin *origin = body->getOrigin();
+            App::Origin* origin = body->getOrigin();
             ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin = static_cast<ViewProviderOrigin*>(
+                Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->resetTemporaryVisibility();
         }
     }
-    catch (const Base::Exception &ex) {
-        Base::Console().Error ("%s\n", ex.what () );
+    catch (const Base::Exception& ex) {
+        Base::Console().Error("%s\n", ex.what());
     }
 }
 
@@ -380,9 +429,9 @@ void TaskLinearPatternParameters::doApply()
     std::string direction = buildLinkSingleSubPythonStr(obj, directions);
 
     auto tobj = getObject();
-    FCMD_OBJ_CMD(tobj,"Direction = " << direction);
-    FCMD_OBJ_CMD(tobj,"Reversed = " << getReverse());
-    FCMD_OBJ_CMD(tobj,"Mode = " << getMode());
+    FCMD_OBJ_CMD(tobj, "Direction = " << direction);
+    FCMD_OBJ_CMD(tobj, "Reversed = " << getReverse());
+    FCMD_OBJ_CMD(tobj, "Mode = " << getMode());
     ui->spinLength->apply();
     ui->spinOffset->apply();
     ui->spinOccurrences->apply();
@@ -393,7 +442,8 @@ void TaskLinearPatternParameters::doApply()
 // TaskDialog
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-TaskDlgLinearPatternParameters::TaskDlgLinearPatternParameters(ViewProviderLinearPattern *LinearPatternView)
+TaskDlgLinearPatternParameters::TaskDlgLinearPatternParameters(
+    ViewProviderLinearPattern* LinearPatternView)
     : TaskDlgTransformedParameters(LinearPatternView)
 {
     parameter = new TaskLinearPatternParameters(LinearPatternView);

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -222,27 +222,25 @@ void TaskLinearPatternParameters::onSelectionChanged(const Gui::SelectionChanges
             exitSelectionMode();
         }
         else if (selectionMode == SelectionMode::Reference) {
-            // TODO check if this works correctly (2015-09-01, Fat-Zer)
-            exitSelectionMode();
+            auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+
             std::vector<std::string> directions;
             App::DocumentObject* selObj = nullptr;
-            auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
-            if (pcLinearPattern) {
-                getReferencedSelection(pcLinearPattern, msg, selObj, directions);
-
-                // Note: ReferenceSelection has already checked the selection for validity
-                if (selObj
-                    && (selectionMode == SelectionMode::Reference
-                        || selObj->isDerivedFrom(App::Line::getClassTypeId())
-                        || selObj->isDerivedFrom(Part::Feature::getClassTypeId())
-                        || selObj->isDerivedFrom(PartDesign::Line::getClassTypeId())
-                        || selObj->isDerivedFrom(PartDesign::Plane::getClassTypeId()))) {
-                    setupTransaction();
-                    pcLinearPattern->Direction.setValue(selObj, directions);
-                    recomputeFeature();
-                    updateUI();
-                }
+            getReferencedSelection(pcLinearPattern, msg, selObj, directions);
+            if (!selObj) {
+                return;
             }
+
+            // Note: ReferenceSelection has already checked the selection for validity
+            if (selObj->isDerivedFrom<App::Line>() || selObj->isDerivedFrom<Part::Feature>()
+                || selObj->isDerivedFrom<PartDesign::Line>()
+                || selObj->isDerivedFrom<PartDesign::Plane>()) {
+                setupTransaction();
+                pcLinearPattern->Direction.setValue(selObj, directions);
+                recomputeFeature();
+                updateUI();
+            }
+            exitSelectionMode();
         }
     }
 }

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -372,17 +372,17 @@ TaskLinearPatternParameters::~TaskLinearPatternParameters()
     }
 }
 
-void TaskLinearPatternParameters::apply()
+void TaskLinearPatternParameters::doApply()
 {
     std::vector<std::string> directions;
     App::DocumentObject* obj;
     getDirection(obj, directions);
     std::string direction = buildLinkSingleSubPythonStr(obj, directions);
 
-    auto tobj = TransformedView->getObject();
+    auto tobj = getObject();
     FCMD_OBJ_CMD(tobj,"Direction = " << direction);
     FCMD_OBJ_CMD(tobj,"Reversed = " << getReverse());
-
+    FCMD_OBJ_CMD(tobj,"Mode = " << getMode());
     ui->spinLength->apply();
     ui->spinOffset->apply();
     ui->spinOccurrences->apply();

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -197,11 +197,11 @@ void TaskLinearPatternParameters::kickUpdateViewTimer() const
 
 void TaskLinearPatternParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
-    if (selectionMode != none && msg.Type == Gui::SelectionChanges::AddSelection) {
+    if (selectionMode != SelectionMode::None && msg.Type == Gui::SelectionChanges::AddSelection) {
         if (originalSelected(msg)) {
             exitSelectionMode();
         }
-        else if (selectionMode == reference) {
+        else if (selectionMode == SelectionMode::Reference) {
             // TODO check if this works correctly (2015-09-01, Fat-Zer)
             exitSelectionMode();
             std::vector<std::string> directions;
@@ -211,7 +211,7 @@ void TaskLinearPatternParameters::onSelectionChanged(const Gui::SelectionChanges
                 getReferencedSelection(pcLinearPattern, msg, selObj, directions);
 
                 // Note: ReferenceSelection has already checked the selection for validity
-                if (selObj && (selectionMode == reference ||
+                if (selObj && (selectionMode == SelectionMode::Reference ||
                                selObj->isDerivedFrom(App::Line::getClassTypeId()) ||
                                selObj->isDerivedFrom(Part::Feature::getClassTypeId()) ||
                                selObj->isDerivedFrom(PartDesign::Line::getClassTypeId()) ||
@@ -288,7 +288,7 @@ void TaskLinearPatternParameters::onDirectionChanged(int /*num*/)
             // enter reference selection mode
             hideObject();
             showBase();
-            selectionMode = reference;
+            selectionMode = SelectionMode::Reference;
             Gui::Selection().clearSelection();
             addReferenceSelectionGate(AllowSelection::EDGE | AllowSelection::FACE | AllowSelection::PLANAR);
         } else {

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -421,7 +421,7 @@ TaskLinearPatternParameters::~TaskLinearPatternParameters()
     }
 }
 
-void TaskLinearPatternParameters::doApply()
+void TaskLinearPatternParameters::apply()
 {
     std::vector<std::string> directions;
     App::DocumentObject* obj;

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -84,7 +84,7 @@ private:
 
 private:
     std::unique_ptr<Ui_TaskLinearPatternParameters> ui;
-    QTimer* updateViewTimer;
+    QTimer* updateViewTimer = nullptr;
 
     ComboLinks dirLinks;
 };

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -30,27 +30,31 @@
 class QTimer;
 class Ui_TaskLinearPatternParameters;
 
-namespace App {
+namespace App
+{
 class Property;
 }
 
-namespace Gui {
+namespace Gui
+{
 class ViewProvider;
 }
 
-namespace PartDesignGui {
+namespace PartDesignGui
+{
 
 class TaskMultiTransformParameters;
 
-class TaskLinearPatternParameters : public TaskTransformedParameters
+class TaskLinearPatternParameters: public TaskTransformedParameters
 {
     Q_OBJECT
 
 public:
     /// Constructor for task with ViewProvider
-    explicit TaskLinearPatternParameters(ViewProviderTransformed *TransformedView, QWidget *parent = nullptr);
+    explicit TaskLinearPatternParameters(ViewProviderTransformed* TransformedView,
+                                         QWidget* parent = nullptr);
     /// Constructor for task with parent task (MultiTransform mode)
-    TaskLinearPatternParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
+    TaskLinearPatternParameters(TaskMultiTransformParameters* parentTask, QWidget* parameterWidget);
     ~TaskLinearPatternParameters() override;
 
 protected:
@@ -92,14 +96,14 @@ private:
 
 
 /// simulation dialog for the TaskView
-class TaskDlgLinearPatternParameters : public TaskDlgTransformedParameters
+class TaskDlgLinearPatternParameters: public TaskDlgTransformedParameters
 {
     Q_OBJECT
 
 public:
-    explicit TaskDlgLinearPatternParameters(ViewProviderLinearPattern *LinearPatternView);
+    explicit TaskDlgLinearPatternParameters(ViewProviderLinearPattern* LinearPatternView);
 };
 
-} //namespace PartDesignGui
+}  // namespace PartDesignGui
 
-#endif // GUI_TASKVIEW_TASKAPPERANCE_H
+#endif  // GUI_TASKVIEW_TASKAPPERANCE_H

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -70,7 +70,7 @@ private Q_SLOTS:
     void onLength(double length);
     void onOffset(double offset);
     void onOccurrences(uint number);
-    void onUpdateView(bool /*unsused*/) override;
+    void onUpdateView(bool /*unused*/) override;
 
 private:
     void setupParameterUI(QWidget* widget) override;

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -50,7 +50,7 @@ public:
     /// Constructor for task with ViewProvider
     explicit TaskLinearPatternParameters(ViewProviderTransformed *TransformedView, QWidget *parent = nullptr);
     /// Constructor for task with parent task (MultiTransform mode)
-    TaskLinearPatternParameters(TaskMultiTransformParameters *parentTask, QLayout *layout);
+    TaskLinearPatternParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
     ~TaskLinearPatternParameters() override;
 
     void apply() override;
@@ -64,14 +64,9 @@ private Q_SLOTS:
     void onOffset(const double o);
     void onOccurrences(const uint n);
     void onUpdateView(bool) override;
-    void onFeatureDeleted() override;
 
 protected:
-    void addObject(App::DocumentObject*) override;
-    void removeObject(App::DocumentObject*) override;
-    void changeEvent(QEvent *e) override;
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
-    void clearButtons() override;
     void getDirection(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
     bool getReverse() const;
     int getMode() const;
@@ -80,8 +75,9 @@ protected:
     unsigned getOccurrences() const;
 
 private:
+    void setupParameterUI(QWidget* widget) override;
+    void retranslateParameterUI(QWidget* widget) override;
     void connectSignals();
-    void setupUI();
     void updateUI();
     void adaptVisibilityToMode();
     void kickUpdateViewTimer() const;

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -53,8 +53,6 @@ public:
     TaskLinearPatternParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
     ~TaskLinearPatternParameters() override;
 
-    void apply() override;
-
 protected:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
 
@@ -71,6 +69,7 @@ private Q_SLOTS:
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
+    void doApply() override;
 
     void connectSignals();
     void updateUI();

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -97,7 +97,6 @@ class TaskDlgLinearPatternParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgLinearPatternParameters(ViewProviderLinearPattern *LinearPatternView);
-    ~TaskDlgLinearPatternParameters() override = default;
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -57,6 +57,8 @@ public:
     TaskLinearPatternParameters(TaskMultiTransformParameters* parentTask, QWidget* parameterWidget);
     ~TaskLinearPatternParameters() override;
 
+    void apply() override;
+
 protected:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
 
@@ -73,7 +75,6 @@ private Q_SLOTS:
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
-    void doApply() override;
 
     void connectSignals();
     void updateUI();

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -55,6 +55,9 @@ public:
 
     void apply() override;
 
+protected:
+    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
+
 private Q_SLOTS:
     void onUpdateViewTimer();
     void onDirectionChanged(int num);
@@ -65,22 +68,21 @@ private Q_SLOTS:
     void onOccurrences(const uint n);
     void onUpdateView(bool) override;
 
-protected:
-    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
+private:
+    void setupParameterUI(QWidget* widget) override;
+    void retranslateParameterUI(QWidget* widget) override;
+
+    void connectSignals();
+    void updateUI();
+    void adaptVisibilityToMode();
+    void kickUpdateViewTimer() const;
+
     void getDirection(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
     bool getReverse() const;
     int getMode() const;
     double getLength() const;
     double getOffset() const;
     unsigned getOccurrences() const;
-
-private:
-    void setupParameterUI(QWidget* widget) override;
-    void retranslateParameterUI(QWidget* widget) override;
-    void connectSignals();
-    void updateUI();
-    void adaptVisibilityToMode();
-    void kickUpdateViewTimer() const;
 
 private:
     std::unique_ptr<Ui_TaskLinearPatternParameters> ui;

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.h
@@ -65,12 +65,12 @@ protected:
 private Q_SLOTS:
     void onUpdateViewTimer();
     void onDirectionChanged(int num);
-    void onCheckReverse(const bool on);
-    void onModeChanged(const int mode);
-    void onLength(const double l);
-    void onOffset(const double o);
-    void onOccurrences(const uint n);
-    void onUpdateView(bool) override;
+    void onCheckReverse(bool on);
+    void onModeChanged(int mode);
+    void onLength(double length);
+    void onOffset(double offset);
+    void onOccurrences(uint number);
+    void onUpdateView(bool /*unsused*/) override;
 
 private:
     void setupParameterUI(QWidget* widget) override;

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.ui
@@ -7,47 +7,25 @@
     <x>0</x>
     <y>0</y>
     <width>270</width>
-    <height>339</height>
+    <height>188</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QPushButton" name="buttonAddFeature">
-       <property name="text">
-        <string>Add feature</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonRemoveFeature">
-       <property name="text">
-        <string>Remove feature</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QListWidget" name="listWidgetFeatures">
-     <property name="toolTip">
-      <string>List can be reordered by dragging</string>
-     </property>
-     <property name="dragDropMode">
-      <enum>QAbstractItemView::InternalMove</enum>
-     </property>
-    </widget>
-   </item>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
@@ -184,27 +162,6 @@
      </item>
     </layout>
    </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <widget class="QPushButton" name="buttonOK">
-       <property name="text">
-        <string>OK</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkBoxUpdateView">
-     <property name="text">
-      <string>Update view</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -221,49 +178,11 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>buttonAddFeature</tabstop>
-  <tabstop>buttonRemoveFeature</tabstop>
-  <tabstop>listWidgetFeatures</tabstop>
   <tabstop>comboDirection</tabstop>
   <tabstop>checkReverse</tabstop>
   <tabstop>spinLength</tabstop>
   <tabstop>spinOccurrences</tabstop>
-  <tabstop>buttonOK</tabstop>
-  <tabstop>checkBoxUpdateView</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonAddFeature</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>buttonRemoveFeature</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>70</x>
-     <y>21</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>198</x>
-     <y>21</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonRemoveFeature</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>buttonAddFeature</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>198</x>
-     <y>21</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>70</x>
-     <y>21</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -134,17 +134,17 @@ void TaskMirroredParameters::onSelectionChanged(const Gui::SelectionChanges& msg
         if (originalSelected(msg)) {
             exitSelectionMode();
         }
-        else {
+        else if (selectionMode == SelectionMode::Reference) {
+            auto pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
+
             std::vector<std::string> mirrorPlanes;
             App::DocumentObject* selObj = nullptr;
-            auto pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
             getReferencedSelection(pcMirrored, msg, selObj, mirrorPlanes);
             if (!selObj) {
                 return;
             }
 
-            if (selectionMode == SelectionMode::Reference
-                || selObj->isDerivedFrom(App::Plane::getClassTypeId())) {
+            if (selObj->isDerivedFrom<App::Plane>()) {
                 setupTransaction();
                 pcMirrored->MirrorPlane.setValue(selObj, mirrorPlanes);
                 recomputeFeature();

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -209,7 +209,7 @@ void TaskMirroredParameters::getMirrorPlane(App::DocumentObject*& obj,
     sub = lnk.getSubValues();
 }
 
-void TaskMirroredParameters::doApply()
+void TaskMirroredParameters::apply()
 {
     std::vector<std::string> mirrorPlanes;
     App::DocumentObject* obj;

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -24,7 +24,6 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <QAction>
 # include <QMessageBox>
 #endif
 
@@ -53,82 +52,22 @@ TaskMirroredParameters::TaskMirroredParameters(ViewProviderTransformed *Transfor
     : TaskTransformedParameters(TransformedView, parent)
     , ui(new Ui_TaskMirroredParameters)
 {
-    // we need a separate container widget to add all controls to
-    proxy = new QWidget(this);
-    ui->setupUi(proxy);
-    QMetaObject::connectSlotsByName(this);
-
-    this->groupLayout()->addWidget(proxy);
-
-    ui->buttonOK->hide();
-    ui->checkBoxUpdateView->setEnabled(true);
-
-    selectionMode = none;
-
-    blockUpdate = false; // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
     setupUI();
 }
 
-TaskMirroredParameters::TaskMirroredParameters(TaskMultiTransformParameters *parentTask, QLayout *layout)
+TaskMirroredParameters::TaskMirroredParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget)
         : TaskTransformedParameters(parentTask), ui(new Ui_TaskMirroredParameters)
 {
-    proxy = new QWidget(parentTask);
-    ui->setupUi(proxy);
-    connect(ui->buttonOK, &QToolButton::pressed,
-            parentTask, &TaskMirroredParameters::onSubTaskButtonOK);
-    QMetaObject::connectSlotsByName(this);
-
-    layout->addWidget(proxy);
-
-    ui->buttonOK->setEnabled(true);
-    ui->buttonAddFeature->hide();
-    ui->buttonRemoveFeature->hide();
-    ui->listWidgetFeatures->hide();
-    ui->checkBoxUpdateView->hide();
-
-    selectionMode = none;
-
-    blockUpdate = false; // Hack, sometimes it is NOT false although set to false in Transformed::Transformed()!!
-    setupUI();
+    setupParameterUI(parameterWidget);
 }
 
-void TaskMirroredParameters::setupUI()
+void TaskMirroredParameters::setupParameterUI(QWidget *widget)
 {
-    connect(ui->buttonAddFeature, &QToolButton::toggled, this, &TaskMirroredParameters::onButtonAddFeature);
-    connect(ui->buttonRemoveFeature, &QToolButton::toggled, this, &TaskMirroredParameters::onButtonRemoveFeature);
-
-    // Create context menu
-    QAction* action = new QAction(tr("Remove"), this);
-    action->setShortcut(QKeySequence::Delete);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-    // display shortcut behind the context menu entry
-    action->setShortcutVisibleInContextMenu(true);
-#endif
-    ui->listWidgetFeatures->addAction(action);
-    connect(action, &QAction::triggered, this, &TaskMirroredParameters::onFeatureDeleted);
-    ui->listWidgetFeatures->setContextMenuPolicy(Qt::ActionsContextMenu);
-    connect(ui->listWidgetFeatures->model(), &QAbstractListModel::rowsMoved,
-            this, &TaskMirroredParameters::indexesMoved);
+    ui->setupUi(widget);
+    QMetaObject::connectSlotsByName(this);
 
     connect(ui->comboPlane, qOverload<int>(&QComboBox::activated),
             this, &TaskMirroredParameters::onPlaneChanged);
-    connect(ui->checkBoxUpdateView, &QCheckBox::toggled,
-            this, &TaskMirroredParameters::onUpdateView);
-
-    // Get the feature data
-    PartDesign::Mirrored* pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
-    std::vector<App::DocumentObject*> originals = pcMirrored->Originals.getValues();
-
-    // Fill data into dialog elements
-    for (auto obj : originals) {
-        if (obj) {
-            QListWidgetItem* item = new QListWidgetItem();
-            item->setText(QString::fromUtf8(obj->Label.getValue()));
-            item->setData(Qt::UserRole, QString::fromLatin1(obj->getNameInDocument()));
-            ui->listWidgetFeatures->addItem(item);
-        }
-    }
-    // ---------------------
 
     this->planeLinks.setCombo(*(ui->comboPlane));
     ui->comboPlane->setEnabled(true);
@@ -157,6 +96,11 @@ void TaskMirroredParameters::setupUI()
     updateUI();
 }
 
+void TaskMirroredParameters::retranslateParameterUI(QWidget* widget)
+{
+    ui->retranslateUi(widget);
+}
+
 void TaskMirroredParameters::updateUI()
 {
     if (blockUpdate)
@@ -172,23 +116,6 @@ void TaskMirroredParameters::updateUI()
     }
 
     blockUpdate = false;
-}
-
-void TaskMirroredParameters::addObject(App::DocumentObject* obj)
-{
-    QString label = QString::fromUtf8(obj->Label.getValue());
-    QString objectName = QString::fromLatin1(obj->getNameInDocument());
-
-    QListWidgetItem* item = new QListWidgetItem();
-    item->setText(label);
-    item->setData(Qt::UserRole, objectName);
-    ui->listWidgetFeatures->addItem(item);
-}
-
-void TaskMirroredParameters::removeObject(App::DocumentObject* obj)
-{
-    QString label = QString::fromUtf8(obj->Label.getValue());
-    removeItemFromListWidget(ui->listWidgetFeatures, label);
 }
 
 void TaskMirroredParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -214,12 +141,6 @@ void TaskMirroredParameters::onSelectionChanged(const Gui::SelectionChanges& msg
             exitSelectionMode();
         }
     }
-}
-
-void TaskMirroredParameters::clearButtons()
-{
-    ui->buttonAddFeature->setChecked(false);
-    ui->buttonRemoveFeature->setChecked(false);
 }
 
 void TaskMirroredParameters::onPlaneChanged(int /*num*/)
@@ -264,22 +185,6 @@ void TaskMirroredParameters::onUpdateView(bool on)
     }
 }
 
-void TaskMirroredParameters::onFeatureDeleted()
-{
-    PartDesign::Transformed* pcTransformed = getObject();
-    std::vector<App::DocumentObject*> originals = pcTransformed->Originals.getValues();
-    int currentRow = ui->listWidgetFeatures->currentRow();
-    if (currentRow < 0) {
-        Base::Console().Error("PartDesign MirroredPattern: No feature selected for removing.\n");
-        return; //no current row selected
-    }
-    originals.erase(originals.begin() + currentRow);
-    setupTransaction();
-    pcTransformed->Originals.setValues(originals);
-    ui->listWidgetFeatures->model()->removeRow(currentRow);
-    recomputeFeature();
-}
-
 void TaskMirroredParameters::getMirrorPlane(App::DocumentObject*& obj, std::vector<std::string> &sub) const
 {
     const App::PropertyLinkSub &lnk = planeLinks.getCurrentLink();
@@ -304,17 +209,6 @@ TaskMirroredParameters::~TaskMirroredParameters()
         }
     } catch (const Base::Exception &ex) {
         Base::Console().Error ("%s\n", ex.what () );
-    }
-
-    if (proxy)
-        delete proxy;
-}
-
-void TaskMirroredParameters::changeEvent(QEvent *e)
-{
-    TaskBox::changeEvent(e);
-    if (e->type() == QEvent::LanguageChange) {
-        ui->retranslateUi(proxy);
     }
 }
 

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -90,8 +90,7 @@ void TaskMirroredParameters::setupParameterUI(QWidget* widget)
     if (body) {
         try {
             App::Origin* origin = body->getOrigin();
-            ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(
+            auto vpOrigin = static_cast<ViewProviderOrigin*>(
                 Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->setTemporaryVisibility(false, true);
         }
@@ -115,7 +114,7 @@ void TaskMirroredParameters::updateUI()
     }
     blockUpdate = true;
 
-    PartDesign::Mirrored* pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
+    auto pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
 
     if (planeLinks.setCurrentLink(pcMirrored->MirrorPlane) == -1) {
         // failed to set current, because the link isn't in the list yet
@@ -137,8 +136,8 @@ void TaskMirroredParameters::onSelectionChanged(const Gui::SelectionChanges& msg
         }
         else {
             std::vector<std::string> mirrorPlanes;
-            App::DocumentObject* selObj;
-            PartDesign::Mirrored* pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
+            App::DocumentObject* selObj = nullptr;
+            auto pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
             getReferencedSelection(pcMirrored, msg, selObj, mirrorPlanes);
             if (!selObj) {
                 return;
@@ -162,7 +161,7 @@ void TaskMirroredParameters::onPlaneChanged(int /*num*/)
         return;
     }
     setupTransaction();
-    PartDesign::Mirrored* pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
+    auto pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
     try {
         if (!planeLinks.getCurrentLink().getValue()) {
             // enter reference selection mode
@@ -190,9 +189,9 @@ void TaskMirroredParameters::onUpdateView(bool on)
     if (on) {
         setupTransaction();
         // Do the same like in TaskDlgMirroredParameters::accept() but without doCommand
-        PartDesign::Mirrored* pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
+        auto pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
         std::vector<std::string> mirrorPlanes;
-        App::DocumentObject* obj;
+        App::DocumentObject* obj = nullptr;
 
         getMirrorPlane(obj, mirrorPlanes);
         pcMirrored->MirrorPlane.setValue(obj, mirrorPlanes);
@@ -212,7 +211,7 @@ void TaskMirroredParameters::getMirrorPlane(App::DocumentObject*& obj,
 void TaskMirroredParameters::apply()
 {
     std::vector<std::string> mirrorPlanes;
-    App::DocumentObject* obj;
+    App::DocumentObject* obj = nullptr;
     getMirrorPlane(obj, mirrorPlanes);
     std::string mirrorPlane = buildLinkSingleSubPythonStr(obj, mirrorPlanes);
 
@@ -226,8 +225,7 @@ TaskMirroredParameters::~TaskMirroredParameters()
         PartDesign::Body* body = PartDesign::Body::findBodyOf(getObject());
         if (body) {
             App::Origin* origin = body->getOrigin();
-            ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(
+            auto vpOrigin = static_cast<ViewProviderOrigin*>(
                 Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->resetTemporaryVisibility();
         }

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -24,7 +24,7 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <QMessageBox>
+#include <QMessageBox>
 #endif
 
 #include <App/Document.h>
@@ -48,48 +48,55 @@ using namespace Gui;
 
 /* TRANSLATOR PartDesignGui::TaskMirroredParameters */
 
-TaskMirroredParameters::TaskMirroredParameters(ViewProviderTransformed *TransformedView, QWidget *parent)
+TaskMirroredParameters::TaskMirroredParameters(ViewProviderTransformed* TransformedView,
+                                               QWidget* parent)
     : TaskTransformedParameters(TransformedView, parent)
     , ui(new Ui_TaskMirroredParameters)
 {
     setupUI();
 }
 
-TaskMirroredParameters::TaskMirroredParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget)
-        : TaskTransformedParameters(parentTask), ui(new Ui_TaskMirroredParameters)
+TaskMirroredParameters::TaskMirroredParameters(TaskMultiTransformParameters* parentTask,
+                                               QWidget* parameterWidget)
+    : TaskTransformedParameters(parentTask)
+    , ui(new Ui_TaskMirroredParameters)
 {
     setupParameterUI(parameterWidget);
 }
 
-void TaskMirroredParameters::setupParameterUI(QWidget *widget)
+void TaskMirroredParameters::setupParameterUI(QWidget* widget)
 {
     ui->setupUi(widget);
     QMetaObject::connectSlotsByName(this);
 
-    connect(ui->comboPlane, qOverload<int>(&QComboBox::activated),
-            this, &TaskMirroredParameters::onPlaneChanged);
+    connect(ui->comboPlane,
+            qOverload<int>(&QComboBox::activated),
+            this,
+            &TaskMirroredParameters::onPlaneChanged);
 
     this->planeLinks.setCombo(*(ui->comboPlane));
     ui->comboPlane->setEnabled(true);
 
     App::DocumentObject* sketch = getSketchObject();
     if (sketch && sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
-        this->fillPlanesCombo(planeLinks,static_cast<Part::Part2DObject*>(sketch));
+        this->fillPlanesCombo(planeLinks, static_cast<Part::Part2DObject*>(sketch));
     }
     else {
         this->fillPlanesCombo(planeLinks, nullptr);
     }
 
-    //show the parts coordinate system planes for selection
-    PartDesign::Body * body = PartDesign::Body::findBodyOf ( getObject() );
-    if(body) {
+    // show the parts coordinate system planes for selection
+    PartDesign::Body* body = PartDesign::Body::findBodyOf(getObject());
+    if (body) {
         try {
-            App::Origin *origin = body->getOrigin();
+            App::Origin* origin = body->getOrigin();
             ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin = static_cast<ViewProviderOrigin*>(
+                Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->setTemporaryVisibility(false, true);
-        } catch (const Base::Exception &ex) {
-            Base::Console().Error ("%s\n", ex.what () );
+        }
+        catch (const Base::Exception& ex) {
+            Base::Console().Error("%s\n", ex.what());
         }
     }
 
@@ -103,15 +110,18 @@ void TaskMirroredParameters::retranslateParameterUI(QWidget* widget)
 
 void TaskMirroredParameters::updateUI()
 {
-    if (blockUpdate)
+    if (blockUpdate) {
         return;
+    }
     blockUpdate = true;
 
     PartDesign::Mirrored* pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
 
-    if (planeLinks.setCurrentLink(pcMirrored->MirrorPlane) == -1){
-        //failed to set current, because the link isn't in the list yet
-        planeLinks.addLink(pcMirrored->MirrorPlane, getRefStr(pcMirrored->MirrorPlane.getValue(),pcMirrored->MirrorPlane.getSubValues()));
+    if (planeLinks.setCurrentLink(pcMirrored->MirrorPlane) == -1) {
+        // failed to set current, because the link isn't in the list yet
+        planeLinks.addLink(
+            pcMirrored->MirrorPlane,
+            getRefStr(pcMirrored->MirrorPlane.getValue(), pcMirrored->MirrorPlane.getSubValues()));
         planeLinks.setCurrentLink(pcMirrored->MirrorPlane);
     }
 
@@ -124,15 +134,18 @@ void TaskMirroredParameters::onSelectionChanged(const Gui::SelectionChanges& msg
 
         if (originalSelected(msg)) {
             exitSelectionMode();
-        } else {
+        }
+        else {
             std::vector<std::string> mirrorPlanes;
             App::DocumentObject* selObj;
             PartDesign::Mirrored* pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
             getReferencedSelection(pcMirrored, msg, selObj, mirrorPlanes);
-            if (!selObj)
-                    return;
+            if (!selObj) {
+                return;
+            }
 
-            if ( selectionMode == SelectionMode::Reference || selObj->isDerivedFrom ( App::Plane::getClassTypeId () ) ) {
+            if (selectionMode == SelectionMode::Reference
+                || selObj->isDerivedFrom(App::Plane::getClassTypeId())) {
                 setupTransaction();
                 pcMirrored->MirrorPlane.setValue(selObj, mirrorPlanes);
                 recomputeFeature();
@@ -145,11 +158,12 @@ void TaskMirroredParameters::onSelectionChanged(const Gui::SelectionChanges& msg
 
 void TaskMirroredParameters::onPlaneChanged(int /*num*/)
 {
-    if (blockUpdate)
+    if (blockUpdate) {
         return;
+    }
     setupTransaction();
     PartDesign::Mirrored* pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
-    try{
+    try {
         if (!planeLinks.getCurrentLink().getValue()) {
             // enter reference selection mode
             hideObject();
@@ -157,12 +171,14 @@ void TaskMirroredParameters::onPlaneChanged(int /*num*/)
             selectionMode = SelectionMode::Reference;
             Gui::Selection().clearSelection();
             addReferenceSelectionGate(AllowSelection::FACE | AllowSelection::PLANAR);
-        } else {
+        }
+        else {
             exitSelectionMode();
             pcMirrored->MirrorPlane.Paste(planeLinks.getCurrentLink());
         }
-    } catch (Base::Exception &e) {
-        QMessageBox::warning(nullptr,tr("Error"),QApplication::translate("Exception", e.what()));
+    }
+    catch (Base::Exception& e) {
+        QMessageBox::warning(nullptr, tr("Error"), QApplication::translate("Exception", e.what()));
     }
 
     recomputeFeature();
@@ -179,15 +195,16 @@ void TaskMirroredParameters::onUpdateView(bool on)
         App::DocumentObject* obj;
 
         getMirrorPlane(obj, mirrorPlanes);
-        pcMirrored->MirrorPlane.setValue(obj,mirrorPlanes);
+        pcMirrored->MirrorPlane.setValue(obj, mirrorPlanes);
 
         recomputeFeature();
     }
 }
 
-void TaskMirroredParameters::getMirrorPlane(App::DocumentObject*& obj, std::vector<std::string> &sub) const
+void TaskMirroredParameters::getMirrorPlane(App::DocumentObject*& obj,
+                                            std::vector<std::string>& sub) const
 {
-    const App::PropertyLinkSub &lnk = planeLinks.getCurrentLink();
+    const App::PropertyLinkSub& lnk = planeLinks.getCurrentLink();
     obj = lnk.getValue();
     sub = lnk.getSubValues();
 }
@@ -199,22 +216,24 @@ void TaskMirroredParameters::doApply()
     getMirrorPlane(obj, mirrorPlanes);
     std::string mirrorPlane = buildLinkSingleSubPythonStr(obj, mirrorPlanes);
 
-    FCMD_OBJ_CMD(getObject(),"MirrorPlane = " << mirrorPlane);
+    FCMD_OBJ_CMD(getObject(), "MirrorPlane = " << mirrorPlane);
 }
 
 TaskMirroredParameters::~TaskMirroredParameters()
 {
-    //hide the parts coordinate system axis for selection
+    // hide the parts coordinate system axis for selection
     try {
-        PartDesign::Body * body = PartDesign::Body::findBodyOf ( getObject() );
-        if ( body ) {
-            App::Origin *origin = body->getOrigin();
+        PartDesign::Body* body = PartDesign::Body::findBodyOf(getObject());
+        if (body) {
+            App::Origin* origin = body->getOrigin();
             ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin = static_cast<ViewProviderOrigin*>(
+                Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->resetTemporaryVisibility();
         }
-    } catch (const Base::Exception &ex) {
-        Base::Console().Error ("%s\n", ex.what () );
+    }
+    catch (const Base::Exception& ex) {
+        Base::Console().Error("%s\n", ex.what());
     }
 }
 
@@ -223,7 +242,7 @@ TaskMirroredParameters::~TaskMirroredParameters()
 // TaskDialog
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-TaskDlgMirroredParameters::TaskDlgMirroredParameters(ViewProviderMirrored *MirroredView)
+TaskDlgMirroredParameters::TaskDlgMirroredParameters(ViewProviderMirrored* MirroredView)
     : TaskDlgTransformedParameters(MirroredView)
 {
     parameter = new TaskMirroredParameters(MirroredView);

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -78,7 +78,7 @@ void TaskMirroredParameters::setupParameterUI(QWidget* widget)
     ui->comboPlane->setEnabled(true);
 
     App::DocumentObject* sketch = getSketchObject();
-    if (sketch && sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+    if (sketch && sketch->isDerivedFrom<Part::Part2DObject>()) {
         this->fillPlanesCombo(planeLinks, static_cast<Part::Part2DObject*>(sketch));
     }
     else {

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -120,7 +120,7 @@ void TaskMirroredParameters::updateUI()
 
 void TaskMirroredParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
-    if (selectionMode!=none && msg.Type == Gui::SelectionChanges::AddSelection) {
+    if (selectionMode != SelectionMode::None && msg.Type == Gui::SelectionChanges::AddSelection) {
 
         if (originalSelected(msg)) {
             exitSelectionMode();
@@ -132,7 +132,7 @@ void TaskMirroredParameters::onSelectionChanged(const Gui::SelectionChanges& msg
             if (!selObj)
                     return;
 
-            if ( selectionMode == reference || selObj->isDerivedFrom ( App::Plane::getClassTypeId () ) ) {
+            if ( selectionMode == SelectionMode::Reference || selObj->isDerivedFrom ( App::Plane::getClassTypeId () ) ) {
                 setupTransaction();
                 pcMirrored->MirrorPlane.setValue(selObj, mirrorPlanes);
                 recomputeFeature();
@@ -154,7 +154,7 @@ void TaskMirroredParameters::onPlaneChanged(int /*num*/)
             // enter reference selection mode
             hideObject();
             showBase();
-            selectionMode = reference;
+            selectionMode = SelectionMode::Reference;
             Gui::Selection().clearSelection();
             addReferenceSelectionGate(AllowSelection::FACE | AllowSelection::PLANAR);
         } else {

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -192,8 +192,14 @@ void TaskMirroredParameters::getMirrorPlane(App::DocumentObject*& obj, std::vect
     sub = lnk.getSubValues();
 }
 
-void TaskMirroredParameters::apply()
+void TaskMirroredParameters::doApply()
 {
+    std::vector<std::string> mirrorPlanes;
+    App::DocumentObject* obj;
+    getMirrorPlane(obj, mirrorPlanes);
+    std::string mirrorPlane = buildLinkSingleSubPythonStr(obj, mirrorPlanes);
+
+    FCMD_OBJ_CMD(getObject(),"MirrorPlane = " << mirrorPlane);
 }
 
 TaskMirroredParameters::~TaskMirroredParameters()
@@ -223,20 +229,6 @@ TaskDlgMirroredParameters::TaskDlgMirroredParameters(ViewProviderMirrored *Mirro
     parameter = new TaskMirroredParameters(MirroredView);
 
     Content.push_back(parameter);
-}
-//==== calls from the TaskView ===============================================================
-
-bool TaskDlgMirroredParameters::accept()
-{
-    TaskMirroredParameters* mirrorParameter = static_cast<TaskMirroredParameters*>(parameter);
-    std::vector<std::string> mirrorPlanes;
-    App::DocumentObject* obj;
-    mirrorParameter->getMirrorPlane(obj, mirrorPlanes);
-    std::string mirrorPlane = buildLinkSingleSubPythonStr(obj, mirrorPlanes);
-
-    FCMD_OBJ_CMD(vp->getObject(),"MirrorPlane = " << mirrorPlane);
-
-    return TaskDlgTransformedParameters::accept();
 }
 
 #include "moc_TaskMirroredParameters.cpp"

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
@@ -53,10 +53,6 @@ public:
 
     ~TaskMirroredParameters() override;
 
-    void getMirrorPlane(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
-
-    void apply() override;
-
 protected:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
 
@@ -67,7 +63,9 @@ private Q_SLOTS:
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
+    void doApply() override;
     void updateUI();
+    void getMirrorPlane(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
 
 private:
     ComboLinks planeLinks;
@@ -82,9 +80,6 @@ class TaskDlgMirroredParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgMirroredParameters(ViewProviderMirrored *MirroredView);
-
-    /// is called by the framework if the dialog is accepted (Ok)
-    bool accept() override;
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
@@ -29,27 +29,31 @@
 
 class Ui_TaskMirroredParameters;
 
-namespace App {
+namespace App
+{
 class Property;
 }
 
-namespace Gui {
+namespace Gui
+{
 class ViewProvider;
 }
 
-namespace PartDesignGui {
+namespace PartDesignGui
+{
 
 class TaskMultiTransformParameters;
 
-class TaskMirroredParameters : public TaskTransformedParameters
+class TaskMirroredParameters: public TaskTransformedParameters
 {
     Q_OBJECT
 
 public:
     /// Constructor for task with ViewProvider
-    explicit TaskMirroredParameters(ViewProviderTransformed *TransformedView, QWidget *parent = nullptr);
+    explicit TaskMirroredParameters(ViewProviderTransformed* TransformedView,
+                                    QWidget* parent = nullptr);
     /// Constructor for task with parent task (MultiTransform mode)
-    TaskMirroredParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
+    TaskMirroredParameters(TaskMultiTransformParameters* parentTask, QWidget* parameterWidget);
 
     ~TaskMirroredParameters() override;
 
@@ -74,14 +78,14 @@ private:
 
 
 /// simulation dialog for the TaskView
-class TaskDlgMirroredParameters : public TaskDlgTransformedParameters
+class TaskDlgMirroredParameters: public TaskDlgTransformedParameters
 {
     Q_OBJECT
 
 public:
-    explicit TaskDlgMirroredParameters(ViewProviderMirrored *MirroredView);
+    explicit TaskDlgMirroredParameters(ViewProviderMirrored* MirroredView);
 };
 
-} //namespace PartDesignGui
+}  // namespace PartDesignGui
 
-#endif // GUI_TASKVIEW_TASKAPPERANCE_H
+#endif  // GUI_TASKVIEW_TASKAPPERANCE_H

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
@@ -57,20 +57,20 @@ public:
 
     void apply() override;
 
+protected:
+    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
+
 private Q_SLOTS:
     void onPlaneChanged(int num);
     void onUpdateView(bool) override;
-
-protected:
-    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
 
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
     void updateUI();
-    ComboLinks planeLinks;
 
 private:
+    ComboLinks planeLinks;
     std::unique_ptr<Ui_TaskMirroredParameters> ui;
 };
 
@@ -83,7 +83,6 @@ class TaskDlgMirroredParameters : public TaskDlgTransformedParameters
 public:
     explicit TaskDlgMirroredParameters(ViewProviderMirrored *MirroredView);
 
-public:
     /// is called by the framework if the dialog is accepted (Ok)
     bool accept() override;
 };

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
@@ -82,7 +82,6 @@ class TaskDlgMirroredParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgMirroredParameters(ViewProviderMirrored *MirroredView);
-    ~TaskDlgMirroredParameters() override = default;
 
 public:
     /// is called by the framework if the dialog is accepted (Ok)

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
@@ -64,7 +64,7 @@ protected:
 
 private Q_SLOTS:
     void onPlaneChanged(int num);
-    void onUpdateView(bool) override;
+    void onUpdateView(bool /*unused*/) override;
 
 private:
     void setupParameterUI(QWidget* widget) override;

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
@@ -49,7 +49,7 @@ public:
     /// Constructor for task with ViewProvider
     explicit TaskMirroredParameters(ViewProviderTransformed *TransformedView, QWidget *parent = nullptr);
     /// Constructor for task with parent task (MultiTransform mode)
-    TaskMirroredParameters(TaskMultiTransformParameters *parentTask, QLayout *layout);
+    TaskMirroredParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
 
     ~TaskMirroredParameters() override;
 
@@ -60,17 +60,13 @@ public:
 private Q_SLOTS:
     void onPlaneChanged(int num);
     void onUpdateView(bool) override;
-    void onFeatureDeleted() override;
 
 protected:
-    void addObject(App::DocumentObject*) override;
-    void removeObject(App::DocumentObject*) override;
-    void changeEvent(QEvent *e) override;
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
-    void clearButtons() override;
 
 private:
-    void setupUI();
+    void setupParameterUI(QWidget* widget) override;
+    void retranslateParameterUI(QWidget* widget) override;
     void updateUI();
     ComboLinks planeLinks;
 

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.h
@@ -57,6 +57,8 @@ public:
 
     ~TaskMirroredParameters() override;
 
+    void apply() override;
+
 protected:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
 
@@ -67,7 +69,6 @@ private Q_SLOTS:
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
-    void doApply() override;
     void updateUI();
     void getMirrorPlane(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
 

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.ui
@@ -7,47 +7,25 @@
     <x>0</x>
     <y>0</y>
     <width>253</width>
-    <height>260</height>
+    <height>55</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QPushButton" name="buttonAddFeature">
-       <property name="text">
-        <string>Add feature</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonRemoveFeature">
-       <property name="text">
-        <string>Remove feature</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QListWidget" name="listWidgetFeatures">
-     <property name="toolTip">
-      <string>List can be reordered by dragging</string>
-     </property>
-     <property name="dragDropMode">
-      <enum>QAbstractItemView::InternalMove</enum>
-     </property>
-    </widget>
-   </item>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -62,70 +40,11 @@
      </item>
     </layout>
    </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QPushButton" name="buttonOK">
-       <property name="text">
-        <string>OK</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkBoxUpdateView">
-     <property name="text">
-      <string>Update view</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>buttonAddFeature</tabstop>
-  <tabstop>buttonRemoveFeature</tabstop>
-  <tabstop>listWidgetFeatures</tabstop>
   <tabstop>comboPlane</tabstop>
-  <tabstop>buttonOK</tabstop>
-  <tabstop>checkBoxUpdateView</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonAddFeature</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>buttonRemoveFeature</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>66</x>
-     <y>21</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>186</x>
-     <y>21</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonRemoveFeature</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>buttonAddFeature</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>186</x>
-     <y>21</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>66</x>
-     <y>21</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -530,7 +530,7 @@ void TaskMultiTransformParameters::onUpdateView(bool on)
     }
 }
 
-void TaskMultiTransformParameters::doApply()
+void TaskMultiTransformParameters::apply()
 {
     PartDesign::MultiTransform* pcMultiTransform =
         static_cast<PartDesign::MultiTransform*>(getObject());

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -24,7 +24,7 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <QAction>
+#include <QAction>
 #endif
 
 #include <App/Document.h>
@@ -54,63 +54,80 @@ using namespace Gui;
 
 /* TRANSLATOR PartDesignGui::TaskMultiTransformParameters */
 
-TaskMultiTransformParameters::TaskMultiTransformParameters(ViewProviderTransformed *TransformedView,QWidget *parent)
+TaskMultiTransformParameters::TaskMultiTransformParameters(ViewProviderTransformed* TransformedView,
+                                                           QWidget* parent)
     : TaskTransformedParameters(TransformedView, parent)
     , ui(new Ui_TaskMultiTransformParameters)
 {
     setupUI();
 }
 
-void TaskMultiTransformParameters::setupParameterUI(QWidget *widget)
+void TaskMultiTransformParameters::setupParameterUI(QWidget* widget)
 {
     ui->setupUi(widget);
     QMetaObject::connectSlotsByName(this);
 
     // Create a context menu for the listview of transformation features
     QAction* action = new QAction(tr("Edit"), ui->listTransformFeatures);
-    action->connect(action, &QAction::triggered,
-                    this, &TaskMultiTransformParameters::onTransformEdit);
+    action->connect(action,
+                    &QAction::triggered,
+                    this,
+                    &TaskMultiTransformParameters::onTransformEdit);
     ui->listTransformFeatures->addAction(action);
     action = new QAction(tr("Delete"), ui->listTransformFeatures);
-    action->connect(action, &QAction::triggered,
-                    this, &TaskMultiTransformParameters::onTransformDelete);
+    action->connect(action,
+                    &QAction::triggered,
+                    this,
+                    &TaskMultiTransformParameters::onTransformDelete);
     ui->listTransformFeatures->addAction(action);
     action = new QAction(tr("Add mirrored transformation"), ui->listTransformFeatures);
-    action->connect(action, &QAction::triggered,
-                    this, &TaskMultiTransformParameters::onTransformAddMirrored);
+    action->connect(action,
+                    &QAction::triggered,
+                    this,
+                    &TaskMultiTransformParameters::onTransformAddMirrored);
     ui->listTransformFeatures->addAction(action);
     action = new QAction(tr("Add linear pattern"), ui->listTransformFeatures);
-    action->connect(action, &QAction::triggered,
-                    this, &TaskMultiTransformParameters::onTransformAddLinearPattern);
+    action->connect(action,
+                    &QAction::triggered,
+                    this,
+                    &TaskMultiTransformParameters::onTransformAddLinearPattern);
     ui->listTransformFeatures->addAction(action);
     action = new QAction(tr("Add polar pattern"), ui->listTransformFeatures);
-    action->connect(action, &QAction::triggered,
-                    this, &TaskMultiTransformParameters::onTransformAddPolarPattern);
+    action->connect(action,
+                    &QAction::triggered,
+                    this,
+                    &TaskMultiTransformParameters::onTransformAddPolarPattern);
     ui->listTransformFeatures->addAction(action);
     action = new QAction(tr("Add scaled transformation"), ui->listTransformFeatures);
-    action->connect(action, &QAction::triggered,
-                    this, &TaskMultiTransformParameters::onTransformAddScaled);
+    action->connect(action,
+                    &QAction::triggered,
+                    this,
+                    &TaskMultiTransformParameters::onTransformAddScaled);
     ui->listTransformFeatures->addAction(action);
     action = new QAction(tr("Move up"), ui->listTransformFeatures);
-    action->connect(action, &QAction::triggered,
-                    this, &TaskMultiTransformParameters::onMoveUp);
+    action->connect(action, &QAction::triggered, this, &TaskMultiTransformParameters::onMoveUp);
     ui->listTransformFeatures->addAction(action);
     action = new QAction(tr("Move down"), ui->listTransformFeatures);
-    action->connect(action, &QAction::triggered,
-                    this, &TaskMultiTransformParameters::onMoveDown);
+    action->connect(action, &QAction::triggered, this, &TaskMultiTransformParameters::onMoveDown);
     ui->listTransformFeatures->addAction(action);
     ui->listTransformFeatures->setContextMenuPolicy(Qt::ActionsContextMenu);
 
-    connect(ui->listTransformFeatures, &QListWidget::activated,
-            this, &TaskMultiTransformParameters::onTransformActivated);
+    connect(ui->listTransformFeatures,
+            &QListWidget::activated,
+            this,
+            &TaskMultiTransformParameters::onTransformActivated);
 
-    connect(ui->buttonOK, &QToolButton::pressed,
-            this, &TaskMultiTransformParameters::onSubTaskButtonOK);
+    connect(ui->buttonOK,
+            &QToolButton::pressed,
+            this,
+            &TaskMultiTransformParameters::onSubTaskButtonOK);
     ui->buttonOK->hide();
 
     // Get the transformFeatures data
-    PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
-    std::vector<App::DocumentObject*> transformFeatures = pcMultiTransform->Transformations.getValues();
+    PartDesign::MultiTransform* pcMultiTransform =
+        static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    std::vector<App::DocumentObject*> transformFeatures =
+        pcMultiTransform->Transformations.getValues();
 
     // Fill data into dialog elements
     ui->listTransformFeatures->setEnabled(true);
@@ -123,7 +140,8 @@ void TaskMultiTransformParameters::setupParameterUI(QWidget *widget)
     if (!transformFeatures.empty()) {
         ui->listTransformFeatures->setCurrentRow(0, QItemSelectionModel::ClearAndSelect);
         editHint = false;
-    } else {
+    }
+    else {
         ui->listTransformFeatures->addItem(tr("Right-click to add"));
         editHint = true;
     }
@@ -136,8 +154,9 @@ void TaskMultiTransformParameters::retranslateParameterUI(QWidget* widget)
 
 void TaskMultiTransformParameters::slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj)
 {
-    if (Obj.getObject() == this->subFeature)
+    if (Obj.getObject() == this->subFeature) {
         this->subFeature = nullptr;
+    }
     TaskTransformedParameters::slotDeletedObject(Obj);
 }
 
@@ -150,8 +169,10 @@ void TaskMultiTransformParameters::closeSubTask()
 
         // Remove all parameter ui widgets and layout
         ui->subFeatureWidget->setUpdatesEnabled(false);
-        qDeleteAll(ui->subFeatureWidget->findChildren<QWidget*>(QString(), Qt::FindDirectChildrenOnly));
-        qDeleteAll(ui->subFeatureWidget->findChildren<QLayout*>(QString(), Qt::FindDirectChildrenOnly));
+        qDeleteAll(
+            ui->subFeatureWidget->findChildren<QWidget*>(QString(), Qt::FindDirectChildrenOnly));
+        qDeleteAll(
+            ui->subFeatureWidget->findChildren<QLayout*>(QString(), Qt::FindDirectChildrenOnly));
         ui->subFeatureWidget->setUpdatesEnabled(true);
 
         delete subTask;
@@ -161,15 +182,19 @@ void TaskMultiTransformParameters::closeSubTask()
 
 void TaskMultiTransformParameters::onTransformDelete()
 {
-    if (editHint)
-        return; // Can't delete the hint...
+    if (editHint) {
+        return;  // Can't delete the hint...
+    }
     int row = ui->listTransformFeatures->currentIndex().row();
-    PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
-    std::vector<App::DocumentObject*> transformFeatures = pcMultiTransform->Transformations.getValues();
+    PartDesign::MultiTransform* pcMultiTransform =
+        static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    std::vector<App::DocumentObject*> transformFeatures =
+        pcMultiTransform->Transformations.getValues();
 
     App::DocumentObject* feature = transformFeatures[row];
-    if (feature == this->subFeature)
+    if (feature == this->subFeature) {
         this->subFeature = nullptr;
+    }
 
     setupTransaction();
     pcMultiTransform->getDocument()->removeObject(feature->getNameInDocument());
@@ -177,8 +202,8 @@ void TaskMultiTransformParameters::onTransformDelete()
 
     transformFeatures.erase(transformFeatures.begin() + row);
     pcMultiTransform->Transformations.setValues(transformFeatures);
-    // Note: When the last transformation is deleted, recomputeFeature does nothing, because Transformed::execute()
-    // says: "No transformations defined, exit silently"
+    // Note: When the last transformation is deleted, recomputeFeature does nothing, because
+    // Transformed::execute() says: "No transformations defined, exit silently"
     recomputeFeature();
 
     ui->listTransformFeatures->model()->removeRow(row);
@@ -187,25 +212,34 @@ void TaskMultiTransformParameters::onTransformDelete()
 
 void TaskMultiTransformParameters::onTransformEdit()
 {
-    if (editHint)
-        return; // Can't edit the hint...
-    closeSubTask(); // For example if user is editing one subTask and then double-clicks on another without OK'ing first
+    if (editHint) {
+        return;  // Can't edit the hint...
+    }
+    closeSubTask();  // For example if user is editing one subTask and then double-clicks on another
+                     // without OK'ing first
     ui->listTransformFeatures->currentItem()->setSelected(true);
     int row = ui->listTransformFeatures->currentIndex().row();
-    PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
-    std::vector<App::DocumentObject*> transformFeatures = pcMultiTransform->Transformations.getValues();
+    PartDesign::MultiTransform* pcMultiTransform =
+        static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    std::vector<App::DocumentObject*> transformFeatures =
+        pcMultiTransform->Transformations.getValues();
 
     subFeature = static_cast<PartDesign::Transformed*>(transformFeatures[row]);
-    if (subFeature->is<PartDesign::Mirrored>())
+    if (subFeature->is<PartDesign::Mirrored>()) {
         subTask = new TaskMirroredParameters(this, ui->subFeatureWidget);
-    else if (subFeature->is<PartDesign::LinearPattern>())
+    }
+    else if (subFeature->is<PartDesign::LinearPattern>()) {
         subTask = new TaskLinearPatternParameters(this, ui->subFeatureWidget);
-    else if (subFeature->is<PartDesign::PolarPattern>())
+    }
+    else if (subFeature->is<PartDesign::PolarPattern>()) {
         subTask = new TaskPolarPatternParameters(this, ui->subFeatureWidget);
-    else if (subFeature->is<PartDesign::Scaled>())
+    }
+    else if (subFeature->is<PartDesign::Scaled>()) {
         subTask = new TaskScaledParameters(this, ui->subFeatureWidget);
-    else
-        return; // TODO: Show an error?
+    }
+    else {
+        return;  // TODO: Show an error?
+    }
 
     ui->buttonOK->show();
 
@@ -221,30 +255,38 @@ void TaskMultiTransformParameters::onTransformActivated(const QModelIndex& index
 void TaskMultiTransformParameters::onTransformAddMirrored()
 {
     closeSubTask();
-    std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("Mirrored");
+    std::string newFeatName =
+        TransformedView->getObject()->getDocument()->getUniqueObjectName("Mirrored");
     auto pcActiveBody = PartDesignGui::getBody(false);
-    if (!pcActiveBody)
+    if (!pcActiveBody) {
         return;
+    }
 
-    if (isEnabledTransaction())
+    if (isEnabledTransaction()) {
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Mirrored"));
+    }
 
-    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::Mirrored','"<<newFeatName<<"')");
+    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::Mirrored','" << newFeatName << "')");
     auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
-    if (!Feat)
+    if (!Feat) {
         return;
-    //Gui::Command::updateActive();
+    }
+    // Gui::Command::updateActive();
     App::DocumentObject* sketch = getSketchObject();
-    if (sketch)
-        FCMD_OBJ_CMD(Feat, "MirrorPlane = ("<<Gui::Command::getObjectCmd(sketch)<<",['V_Axis'])");
+    if (sketch) {
+        FCMD_OBJ_CMD(Feat,
+                     "MirrorPlane = (" << Gui::Command::getObjectCmd(sketch) << ",['V_Axis'])");
+    }
     else {
         App::Origin* orig = pcActiveBody->getOrigin();
-        FCMD_OBJ_CMD(Feat, "MirrorPlane = ("<<Gui::Command::getObjectCmd(orig->getXY())<<",[''])");
+        FCMD_OBJ_CMD(Feat,
+                     "MirrorPlane = (" << Gui::Command::getObjectCmd(orig->getXY()) << ",[''])");
     }
     finishAdd(newFeatName);
     // show the new view when no error
-    if (!Feat->isError())
+    if (!Feat->isError()) {
         TransformedView->getObject()->Visibility.setValue(true);
+    }
 }
 
 void TaskMultiTransformParameters::onTransformAddLinearPattern()
@@ -252,29 +294,36 @@ void TaskMultiTransformParameters::onTransformAddLinearPattern()
     // See CmdPartDesignLinearPattern
     //
     closeSubTask();
-    std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("LinearPattern");
+    std::string newFeatName =
+        TransformedView->getObject()->getDocument()->getUniqueObjectName("LinearPattern");
     auto pcActiveBody = PartDesignGui::getBody(false);
-    if (!pcActiveBody)
+    if (!pcActiveBody) {
         return;
+    }
 
-    if (isEnabledTransaction())
+    if (isEnabledTransaction()) {
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Make LinearPattern"));
+    }
 
-    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::LinearPattern','"<<newFeatName<<"')");
+    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::LinearPattern','" << newFeatName << "')");
     auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
-    if (!Feat)
+    if (!Feat) {
         return;
-    //Gui::Command::updateActive();
+    }
+    // Gui::Command::updateActive();
     App::DocumentObject* sketch = getSketchObject();
     if (sketch) {
-        FCMD_OBJ_CMD(Feat, "Direction = ("<<Gui::Command::getObjectCmd(sketch)<<",['H_Axis'])");
+        FCMD_OBJ_CMD(Feat, "Direction = (" << Gui::Command::getObjectCmd(sketch) << ",['H_Axis'])");
     }
     else {
         // set Direction value before filling up the combo box to avoid creating an empty item
         // inside updateUI()
-        PartDesign::Body* body = static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(getObject()));
+        PartDesign::Body* body =
+            static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(getObject()));
         if (body) {
-            FCMD_OBJ_CMD(Feat, "Direction = ("<<Gui::Command::getObjectCmd(body->getOrigin()->getX())<<",[''])");
+            FCMD_OBJ_CMD(Feat,
+                         "Direction = (" << Gui::Command::getObjectCmd(body->getOrigin()->getX())
+                                         << ",[''])");
         }
     }
 
@@ -283,75 +332,90 @@ void TaskMultiTransformParameters::onTransformAddLinearPattern()
 
     finishAdd(newFeatName);
     // show the new view when no error
-    if (!Feat->isError())
+    if (!Feat->isError()) {
         TransformedView->getObject()->Visibility.setValue(true);
+    }
 }
 
 void TaskMultiTransformParameters::onTransformAddPolarPattern()
 {
     closeSubTask();
-    std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("PolarPattern");
+    std::string newFeatName =
+        TransformedView->getObject()->getDocument()->getUniqueObjectName("PolarPattern");
     auto pcActiveBody = PartDesignGui::getBody(false);
-    if (!pcActiveBody)
+    if (!pcActiveBody) {
         return;
+    }
 
-    if (isEnabledTransaction())
+    if (isEnabledTransaction()) {
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "PolarPattern"));
+    }
 
-    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::PolarPattern','"<<newFeatName<<"')");
+    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::PolarPattern','" << newFeatName << "')");
     auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
-    if (!Feat)
+    if (!Feat) {
         return;
-    //Gui::Command::updateActive();
+    }
+    // Gui::Command::updateActive();
     App::DocumentObject* sketch = getSketchObject();
-    if (sketch)
-        FCMD_OBJ_CMD(Feat, "Axis = ("<<Gui::Command::getObjectCmd(sketch)<<",['N_Axis'])");
+    if (sketch) {
+        FCMD_OBJ_CMD(Feat, "Axis = (" << Gui::Command::getObjectCmd(sketch) << ",['N_Axis'])");
+    }
     else {
         App::Origin* orig = pcActiveBody->getOrigin();
-        FCMD_OBJ_CMD(Feat, "Axis = ("<<Gui::Command::getObjectCmd(orig->getX())<<",[''])");
+        FCMD_OBJ_CMD(Feat, "Axis = (" << Gui::Command::getObjectCmd(orig->getX()) << ",[''])");
     }
     FCMD_OBJ_CMD(Feat, "Angle = 360");
     FCMD_OBJ_CMD(Feat, "Occurrences = 2");
 
     finishAdd(newFeatName);
     // show the new view when no error
-    if (!Feat->isError())
+    if (!Feat->isError()) {
         TransformedView->getObject()->Visibility.setValue(true);
+    }
 }
 
 void TaskMultiTransformParameters::onTransformAddScaled()
 {
     closeSubTask();
-    std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("Scaled");
+    std::string newFeatName =
+        TransformedView->getObject()->getDocument()->getUniqueObjectName("Scaled");
     auto pcActiveBody = PartDesignGui::getBody(false);
-    if (!pcActiveBody)
+    if (!pcActiveBody) {
         return;
+    }
 
-    if (isEnabledTransaction())
+    if (isEnabledTransaction()) {
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Scaled"));
+    }
 
-    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::Scaled','"<<newFeatName<<"')");
+    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::Scaled','" << newFeatName << "')");
     auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
-    if (!Feat)
+    if (!Feat) {
         return;
-    //Gui::Command::updateActive();
+    }
+    // Gui::Command::updateActive();
     FCMD_OBJ_CMD(Feat, "Factor = 2");
     FCMD_OBJ_CMD(Feat, "Occurrences = 2");
 
     finishAdd(newFeatName);
     // show the new view when no error
-    if (!Feat->isError())
+    if (!Feat->isError()) {
         TransformedView->getObject()->Visibility.setValue(true);
+    }
 }
 
-void TaskMultiTransformParameters::finishAdd(std::string &newFeatName)
+void TaskMultiTransformParameters::finishAdd(std::string& newFeatName)
 {
-    //Gui::Command::updateActive();
-    //Gui::Command::copyVisual(newFeatName.c_str(), "ShapeColor", getOriginals().front()->getNameInDocument().c_str());
-    //Gui::Command::copyVisual(newFeatName.c_str(), "DisplayMode", getOriginals().front()->getNameInDocument().c_str());
+    // Gui::Command::updateActive();
+    // Gui::Command::copyVisual(newFeatName.c_str(), "ShapeColor",
+    // getOriginals().front()->getNameInDocument().c_str());
+    // Gui::Command::copyVisual(newFeatName.c_str(), "DisplayMode",
+    // getOriginals().front()->getNameInDocument().c_str());
 
     setupTransaction();
-    PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    PartDesign::MultiTransform* pcMultiTransform =
+        static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
     if (editHint) {
         // Remove hint, first feature is being added
         ui->listTransformFeatures->model()->removeRow(0);
@@ -359,24 +423,30 @@ void TaskMultiTransformParameters::finishAdd(std::string &newFeatName)
     int row = ui->listTransformFeatures->currentIndex().row();
     if (row < 0) {
         // Happens when first row (first transformation) is created
-        // Hide all the originals now (hiding them in Command.cpp presents the user with an empty screen!)
+        // Hide all the originals now (hiding them in Command.cpp presents the user with an empty
+        // screen!)
         hideBase();
     }
 
     // Insert new transformation after the selected row
-    // This means that in order to insert at the beginning, the user has to use "Move Up" in the menu
-    App::DocumentObject* newFeature = pcMultiTransform->getDocument()->getObject(newFeatName.c_str());
-    std::vector<App::DocumentObject*> transformFeatures = pcMultiTransform->Transformations.getValues();
+    // This means that in order to insert at the beginning, the user has to use "Move Up" in the
+    // menu
+    App::DocumentObject* newFeature =
+        pcMultiTransform->getDocument()->getObject(newFeatName.c_str());
+    std::vector<App::DocumentObject*> transformFeatures =
+        pcMultiTransform->Transformations.getValues();
     if (row == ui->listTransformFeatures->model()->rowCount() - 1) {
         // Note: Inserts always happen before the specified iterator so in order to append at the
         // end we need to use push_back() and append()
         transformFeatures.push_back(newFeature);
         ui->listTransformFeatures->addItem(QString::fromLatin1(newFeature->Label.getValue()));
-        ui->listTransformFeatures->setCurrentRow(row+1, QItemSelectionModel::ClearAndSelect);
-    } else {
+        ui->listTransformFeatures->setCurrentRow(row + 1, QItemSelectionModel::ClearAndSelect);
+    }
+    else {
         // Note: The feature tree always seems to append to the end, no matter what we say here
         transformFeatures.insert(transformFeatures.begin() + row + 1, newFeature);
-        ui->listTransformFeatures->insertItem(row + 1, QString::fromLatin1(newFeature->Label.getValue()));
+        ui->listTransformFeatures->insertItem(row + 1,
+                                              QString::fromLatin1(newFeature->Label.getValue()));
         ui->listTransformFeatures->setCurrentRow(row + 1, QItemSelectionModel::ClearAndSelect);
     }
     pcMultiTransform->Transformations.setValues(transformFeatures);
@@ -394,11 +464,14 @@ void TaskMultiTransformParameters::moveTransformFeature(const int increment)
 {
     setupTransaction();
     int row = ui->listTransformFeatures->currentIndex().row();
-    PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
-    std::vector<App::DocumentObject*> transformFeatures = pcMultiTransform->Transformations.getValues();
+    PartDesign::MultiTransform* pcMultiTransform =
+        static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    std::vector<App::DocumentObject*> transformFeatures =
+        pcMultiTransform->Transformations.getValues();
 
-    if (transformFeatures.empty())
+    if (transformFeatures.empty()) {
         return;
+    }
 
     App::DocumentObject* feature = transformFeatures[row];
     transformFeatures.erase(transformFeatures.begin() + row);
@@ -408,8 +481,9 @@ void TaskMultiTransformParameters::moveTransformFeature(const int increment)
 
     row += increment;
 
-    if (row < 0)
+    if (row < 0) {
         row = 0;
+    }
 
     if (row >= ui->listTransformFeatures->model()->rowCount()) {
         // Note: Inserts always happen before the specified iterator so in order to append at the
@@ -417,7 +491,8 @@ void TaskMultiTransformParameters::moveTransformFeature(const int increment)
         transformFeatures.push_back(feature);
         ui->listTransformFeatures->addItem(item);
         ui->listTransformFeatures->setCurrentRow(row, QItemSelectionModel::ClearAndSelect);
-    } else {
+    }
+    else {
         transformFeatures.insert(transformFeatures.begin() + row, feature);
         ui->listTransformFeatures->insertItem(row, item);
         ui->listTransformFeatures->setCurrentRow(row, QItemSelectionModel::ClearAndSelect);
@@ -452,8 +527,10 @@ void TaskMultiTransformParameters::onUpdateView(bool on)
 
 void TaskMultiTransformParameters::doApply()
 {
-    PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(getObject());
-    std::vector<App::DocumentObject*> transformFeatures = pcMultiTransform->Transformations.getValues();
+    PartDesign::MultiTransform* pcMultiTransform =
+        static_cast<PartDesign::MultiTransform*>(getObject());
+    std::vector<App::DocumentObject*> transformFeatures =
+        pcMultiTransform->Transformations.getValues();
     std::stringstream str;
     str << Gui::Command::getObjectCmd(TransformedView->getObject()) << ".Transformations = [";
     for (auto it : transformFeatures) {
@@ -462,7 +539,7 @@ void TaskMultiTransformParameters::doApply()
         }
     }
     str << "]";
-    Gui::Command::runCommand(Gui::Command::Doc,str.str().c_str());
+    Gui::Command::runCommand(Gui::Command::Doc, str.str().c_str());
 }
 
 TaskMultiTransformParameters::~TaskMultiTransformParameters()
@@ -471,7 +548,7 @@ TaskMultiTransformParameters::~TaskMultiTransformParameters()
         closeSubTask();
     }
     catch (const Py::Exception&) {
-        Base::PyException e; // extract the Python error text
+        Base::PyException e;  // extract the Python error text
         e.ReportException();
     }
 }
@@ -481,7 +558,8 @@ TaskMultiTransformParameters::~TaskMultiTransformParameters()
 // TaskDialog
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-TaskDlgMultiTransformParameters::TaskDlgMultiTransformParameters(ViewProviderMultiTransform *MultiTransformView)
+TaskDlgMultiTransformParameters::TaskDlgMultiTransformParameters(
+    ViewProviderMultiTransform* MultiTransformView)
     : TaskDlgTransformedParameters(MultiTransformView)
 {
     parameter = new TaskMultiTransformParameters(MultiTransformView);

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -68,7 +68,7 @@ void TaskMultiTransformParameters::setupParameterUI(QWidget* widget)
     QMetaObject::connectSlotsByName(this);
 
     // Create a context menu for the listview of transformation features
-    QAction* action = new QAction(tr("Edit"), ui->listTransformFeatures);
+    auto action = new QAction(tr("Edit"), ui->listTransformFeatures);
     action->connect(action,
                     &QAction::triggered,
                     this,
@@ -124,8 +124,7 @@ void TaskMultiTransformParameters::setupParameterUI(QWidget* widget)
     ui->buttonOK->hide();
 
     // Get the transformFeatures data
-    PartDesign::MultiTransform* pcMultiTransform =
-        static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
     std::vector<App::DocumentObject*> transformFeatures =
         pcMultiTransform->Transformations.getValues();
 
@@ -191,8 +190,7 @@ void TaskMultiTransformParameters::onTransformDelete()
         return;  // Can't delete the hint...
     }
     int row = ui->listTransformFeatures->currentIndex().row();
-    PartDesign::MultiTransform* pcMultiTransform =
-        static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
     std::vector<App::DocumentObject*> transformFeatures =
         pcMultiTransform->Transformations.getValues();
 
@@ -224,8 +222,7 @@ void TaskMultiTransformParameters::onTransformEdit()
                      // without OK'ing first
     ui->listTransformFeatures->currentItem()->setSelected(true);
     int row = ui->listTransformFeatures->currentIndex().row();
-    PartDesign::MultiTransform* pcMultiTransform =
-        static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
     std::vector<App::DocumentObject*> transformFeatures =
         pcMultiTransform->Transformations.getValues();
 
@@ -323,8 +320,7 @@ void TaskMultiTransformParameters::onTransformAddLinearPattern()
     else {
         // set Direction value before filling up the combo box to avoid creating an empty item
         // inside updateUI()
-        PartDesign::Body* body =
-            static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(getObject()));
+        auto body = static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(getObject()));
         if (body) {
             FCMD_OBJ_CMD(Feat,
                          "Direction = (" << Gui::Command::getObjectCmd(body->getOrigin()->getX())
@@ -419,8 +415,7 @@ void TaskMultiTransformParameters::finishAdd(std::string& newFeatName)
     // getOriginals().front()->getNameInDocument().c_str());
 
     setupTransaction();
-    PartDesign::MultiTransform* pcMultiTransform =
-        static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
     if (editHint) {
         // Remove hint, first feature is being added
         ui->listTransformFeatures->model()->removeRow(0);
@@ -469,8 +464,7 @@ void TaskMultiTransformParameters::moveTransformFeature(const int increment)
 {
     setupTransaction();
     int row = ui->listTransformFeatures->currentIndex().row();
-    PartDesign::MultiTransform* pcMultiTransform =
-        static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
     std::vector<App::DocumentObject*> transformFeatures =
         pcMultiTransform->Transformations.getValues();
 
@@ -480,7 +474,7 @@ void TaskMultiTransformParameters::moveTransformFeature(const int increment)
 
     App::DocumentObject* feature = transformFeatures[row];
     transformFeatures.erase(transformFeatures.begin() + row);
-    QListWidgetItem* item = new QListWidgetItem(*(ui->listTransformFeatures->item(row)));
+    auto item = new QListWidgetItem(*(ui->listTransformFeatures->item(row)));
     ui->listTransformFeatures->model()->removeRow(row);
     // After this operation, if we were to insert at index row again, things will remain unchanged
 
@@ -532,8 +526,7 @@ void TaskMultiTransformParameters::onUpdateView(bool on)
 
 void TaskMultiTransformParameters::apply()
 {
-    PartDesign::MultiTransform* pcMultiTransform =
-        static_cast<PartDesign::MultiTransform*>(getObject());
+    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(getObject());
     std::vector<App::DocumentObject*> transformFeatures =
         pcMultiTransform->Transformations.getValues();
     std::stringstream str;
@@ -553,8 +546,8 @@ TaskMultiTransformParameters::~TaskMultiTransformParameters()
         closeSubTask();
     }
     catch (const Py::Exception&) {
-        Base::PyException e;  // extract the Python error text
-        e.ReportException();
+        Base::PyException exc;  // extract the Python error text
+        exc.ReportException();
     }
 }
 

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -165,7 +165,11 @@ void TaskMultiTransformParameters::closeSubTask()
     if (subTask) {
         ui->buttonOK->hide();
         exitSelectionMode();
-        subTask->apply();
+        // The subfeature can already be deleted (e.g. cancel) so we have to check before
+        // calling apply
+        if (subFeature) {
+            subTask->apply();
+        }
 
         // Remove all parameter ui widgets and layout
         ui->subFeatureWidget->setUpdatesEnabled(false);
@@ -177,6 +181,7 @@ void TaskMultiTransformParameters::closeSubTask()
 
         delete subTask;
         subTask = nullptr;
+        subFeature = nullptr;
     }
 }
 

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -504,26 +504,4 @@ bool TaskDlgMultiTransformParameters::accept()
     return TaskDlgFeatureParameters::accept ();
 }
 
-// FIXME: It seems all roll back is finely handled by abortCommand() in parent classes. On the other
-//        hand manual removal of objects may lead to segfault in dialog distructer of subtransformation
-//        due to TaskMultiTransformParameters::getSubFeature() returns already destroid object. So check
-//        that everything is fine and delete the method. (2015-07-31, Fat-Zer)
-//bool TaskDlgMultiTransformParameters::reject()
-//{
-//    // Get objects before view is invalidated
-//    // For the same reason we can't delegate showing the originals to TaskDlgTransformedParameters::reject()
-//    PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(vp->getObject());
-//    std::vector<App::DocumentObject*> transformFeatures = pcMultiTransform->Transformations.getValues();
-//
-//    // Delete the transformation features - must happen before abortCommand()!
-//    for (std::vector<App::DocumentObject*>::const_iterator it = transformFeatures.begin(); it != transformFeatures.end(); ++it)
-//    {
-//        if ((*it) != NULL)
-//            Gui::Command::doCommand(
-//                Gui::Command::Doc,"App.ActiveDocument.removeObject(\"%s\")", (*it)->getNameInDocument());
-//    }
-//
-//    return TaskDlgTransformedParameters::reject();
-//}
-
 #include "moc_TaskMultiTransformParameters.cpp"

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -57,8 +57,6 @@ using namespace Gui;
 TaskMultiTransformParameters::TaskMultiTransformParameters(ViewProviderTransformed *TransformedView,QWidget *parent)
     : TaskTransformedParameters(TransformedView, parent)
     , ui(new Ui_TaskMultiTransformParameters)
-    , subTask(nullptr)
-    , subFeature(nullptr)
 {
     setupUI();
 }

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
@@ -63,11 +63,9 @@ public:
 
     void apply() override;
 
-public Q_SLOTS:
-    /// User finished editing a subFeature
-    void onSubTaskButtonOK() override;
-
 private Q_SLOTS:
+    /// User finished editing a subFeature
+    void onSubTaskButtonOK();
     void onTransformDelete();
     void onTransformEdit();
     void onTransformActivated(const QModelIndex& index);
@@ -80,12 +78,14 @@ private Q_SLOTS:
     // Note: There is no Cancel button because I couldn't work out how to save the state of
     // a subFeature so as to revert the changes of an edit operation
     void onUpdateView(bool) override;
-    /** Notifies when the object is about to be removed. */
-    void slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj) override;
 
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
+
+    /** Notifies when the object is about to be removed. */
+    void slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj) override;
+
     void updateUI();
     void closeSubTask();
     void moveTransformFeature(const int increment);
@@ -108,7 +108,6 @@ class TaskDlgMultiTransformParameters : public TaskDlgTransformedParameters
 public:
     explicit TaskDlgMultiTransformParameters(ViewProviderMultiTransform *MultiTransformView);
 
-public:
     /// is called by the framework if the dialog is accepted (Ok)
     bool accept() override;
     /// is called by the framework if the dialog is rejected (Cancel)

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
@@ -54,14 +54,10 @@ public:
     explicit TaskMultiTransformParameters(ViewProviderTransformed *TransformedView,QWidget *parent = nullptr);
     ~TaskMultiTransformParameters() override;
 
-    const std::vector<App::DocumentObject*> getTransformFeatures() const;
-
     /// Return the currently active subFeature
     PartDesign::Transformed* getSubFeature() {
         return subFeature;
     }
-
-    void apply() override;
 
 private Q_SLOTS:
     /// User finished editing a subFeature
@@ -82,6 +78,7 @@ private Q_SLOTS:
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
+    void doApply() override;
 
     /** Notifies when the object is about to be removed. */
     void slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj) override;
@@ -108,8 +105,6 @@ class TaskDlgMultiTransformParameters : public TaskDlgTransformedParameters
 public:
     explicit TaskDlgMultiTransformParameters(ViewProviderMultiTransform *MultiTransformView);
 
-    /// is called by the framework if the dialog is accepted (Ok)
-    bool accept() override;
     /// is called by the framework if the dialog is rejected (Cancel)
     // virtual bool reject();
 };

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
@@ -58,6 +58,8 @@ public:
                                           QWidget* parent = nullptr);
     ~TaskMultiTransformParameters() override;
 
+    void apply() override;
+
     /// Return the currently active subFeature
     PartDesign::Transformed* getSubFeature()
     {
@@ -83,7 +85,6 @@ private Q_SLOTS:
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
-    void doApply() override;
 
     /** Notifies when the object is about to be removed. */
     void slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj) override;

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
@@ -80,7 +80,7 @@ private Q_SLOTS:
     void onMoveDown();
     // Note: There is no Cancel button because I couldn't work out how to save the state of
     // a subFeature so as to revert the changes of an edit operation
-    void onUpdateView(bool) override;
+    void onUpdateView(bool /*unsused*/) override;
 
 private:
     void setupParameterUI(QWidget* widget) override;
@@ -91,7 +91,7 @@ private:
 
     void updateUI();
     void closeSubTask();
-    void moveTransformFeature(const int increment);
+    void moveTransformFeature(int increment);
     void finishAdd(std::string& newFeatName);
 
 private:

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
@@ -30,32 +30,37 @@
 class Ui_TaskMultiTransformParameters;
 class QModelIndex;
 
-namespace PartDesign {
+namespace PartDesign
+{
 class Transformed;
 }
 
-namespace App {
+namespace App
+{
 class Property;
 }
 
-namespace Gui {
+namespace Gui
+{
 class ViewProvider;
 }
 
-namespace PartDesignGui {
+namespace PartDesignGui
+{
 
 
-
-class TaskMultiTransformParameters : public TaskTransformedParameters
+class TaskMultiTransformParameters: public TaskTransformedParameters
 {
     Q_OBJECT
 
 public:
-    explicit TaskMultiTransformParameters(ViewProviderTransformed *TransformedView,QWidget *parent = nullptr);
+    explicit TaskMultiTransformParameters(ViewProviderTransformed* TransformedView,
+                                          QWidget* parent = nullptr);
     ~TaskMultiTransformParameters() override;
 
     /// Return the currently active subFeature
-    PartDesign::Transformed* getSubFeature() {
+    PartDesign::Transformed* getSubFeature()
+    {
         return subFeature;
     }
 
@@ -86,7 +91,7 @@ private:
     void updateUI();
     void closeSubTask();
     void moveTransformFeature(const int increment);
-    void finishAdd(std::string &newFeatName);
+    void finishAdd(std::string& newFeatName);
 
 private:
     std::unique_ptr<Ui_TaskMultiTransformParameters> ui;
@@ -98,17 +103,17 @@ private:
 
 
 /// simulation dialog for the TaskView
-class TaskDlgMultiTransformParameters : public TaskDlgTransformedParameters
+class TaskDlgMultiTransformParameters: public TaskDlgTransformedParameters
 {
     Q_OBJECT
 
 public:
-    explicit TaskDlgMultiTransformParameters(ViewProviderMultiTransform *MultiTransformView);
+    explicit TaskDlgMultiTransformParameters(ViewProviderMultiTransform* MultiTransformView);
 
     /// is called by the framework if the dialog is rejected (Cancel)
     // virtual bool reject();
 };
 
-} //namespace PartDesignGui
+}  // namespace PartDesignGui
 
-#endif // GUI_TASKVIEW_TASKAPPERANCE_H
+#endif  // GUI_TASKVIEW_TASKAPPERANCE_H

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
@@ -94,9 +94,9 @@ private:
 private:
     std::unique_ptr<Ui_TaskMultiTransformParameters> ui;
     /// The subTask and subFeature currently active in the UI
-    TaskTransformedParameters* subTask;
-    PartDesign::Transformed* subFeature;
-    bool editHint;
+    TaskTransformedParameters* subTask = nullptr;
+    PartDesign::Transformed* subFeature = nullptr;
+    bool editHint = false;
 };
 
 

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
@@ -80,7 +80,7 @@ private Q_SLOTS:
     void onMoveDown();
     // Note: There is no Cancel button because I couldn't work out how to save the state of
     // a subFeature so as to revert the changes of an edit operation
-    void onUpdateView(bool /*unsused*/) override;
+    void onUpdateView(bool /*unused*/) override;
 
 private:
     void setupParameterUI(QWidget* widget) override;

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
@@ -80,18 +80,12 @@ private Q_SLOTS:
     // Note: There is no Cancel button because I couldn't work out how to save the state of
     // a subFeature so as to revert the changes of an edit operation
     void onUpdateView(bool) override;
-    void onFeatureDeleted() override;
     /** Notifies when the object is about to be removed. */
     void slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj) override;
 
-protected:
-    void addObject(App::DocumentObject*) override;
-    void removeObject(App::DocumentObject*) override;
-    void changeEvent(QEvent *e) override;
-    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
-    void clearButtons() override;
-
 private:
+    void setupParameterUI(QWidget* widget) override;
+    void retranslateParameterUI(QWidget* widget) override;
     void updateUI();
     void closeSubTask();
     void moveTransformFeature(const int increment);

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.h
@@ -107,7 +107,6 @@ class TaskDlgMultiTransformParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgMultiTransformParameters(ViewProviderMultiTransform *MultiTransformView);
-    ~TaskDlgMultiTransformParameters() override = default;
 
 public:
     /// is called by the framework if the dialog is accepted (Ok)

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.ui
@@ -6,48 +6,26 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>256</width>
-    <height>266</height>
+    <width>229</width>
+    <height>174</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="buttonAddFeature">
-       <property name="text">
-        <string>Add feature</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonRemoveFeature">
-       <property name="text">
-        <string>Remove feature</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QListWidget" name="listWidgetFeatures">
-     <property name="toolTip">
-      <string>List can be reordered by dragging</string>
-     </property>
-     <property name="dragDropMode">
-      <enum>QAbstractItemView::InternalMove</enum>
-     </property>
-    </widget>
-   </item>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
@@ -66,57 +44,20 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBoxUpdateView">
+    <widget class="QWidget" name="subFeatureWidget" native="true"/>
+   </item>
+   <item>
+    <widget class="QPushButton" name="buttonOK">
      <property name="text">
-      <string>Update view</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
+      <string>OK</string>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>buttonAddFeature</tabstop>
-  <tabstop>buttonRemoveFeature</tabstop>
-  <tabstop>listWidgetFeatures</tabstop>
   <tabstop>listTransformFeatures</tabstop>
-  <tabstop>checkBoxUpdateView</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonAddFeature</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>buttonRemoveFeature</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>67</x>
-     <y>21</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>188</x>
-     <y>21</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonRemoveFeature</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>buttonAddFeature</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>188</x>
-     <y>21</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>67</x>
-     <y>21</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -98,7 +98,7 @@ void TaskPolarPatternParameters::setupParameterUI(QWidget* widget)
 
     this->axesLinks.setCombo(*(ui->comboAxis));
     App::DocumentObject* sketch = getSketchObject();
-    if (sketch && sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+    if (sketch && sketch->isDerivedFrom<Part::Part2DObject>()) {
         this->fillAxisCombo(axesLinks, static_cast<Part::Part2DObject*>(sketch));
     }
     else {

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -196,7 +196,7 @@ void TaskPolarPatternParameters::adaptVisibilityToMode()
 
 void TaskPolarPatternParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
-    if (selectionMode!=none && msg.Type == Gui::SelectionChanges::AddSelection) {
+    if (selectionMode != SelectionMode::None && msg.Type == Gui::SelectionChanges::AddSelection) {
 
         if (originalSelected(msg)) {
             exitSelectionMode();
@@ -209,7 +209,7 @@ void TaskPolarPatternParameters::onSelectionChanged(const Gui::SelectionChanges&
             if(!selObj)
                     return;
 
-            if (selectionMode == reference || selObj->isDerivedFrom ( App::Line::getClassTypeId () ) ) {
+            if (selectionMode == SelectionMode::Reference || selObj->isDerivedFrom ( App::Line::getClassTypeId () ) ) {
                 setupTransaction();
                 pcPolarPattern->Axis.setValue(selObj, axes);
                 recomputeFeature();
@@ -283,7 +283,7 @@ void TaskPolarPatternParameters::onAxisChanged(int /*num*/)
             // enter reference selection mode
             hideObject();
             showBase();
-            selectionMode = reference;
+            selectionMode = SelectionMode::Reference;
             Gui::Selection().clearSelection();
             addReferenceSelectionGate(AllowSelection::EDGE | AllowSelection::CIRCLE);
         } else {

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -81,7 +81,7 @@ void TaskPolarPatternParameters::setupParameterUI(QWidget* widget)
     QMetaObject::connectSlotsByName(this);
 
     // Get the feature data
-    PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
 
     ui->polarAngle->bind(pcPolarPattern->Angle);
     ui->angleOffset->bind(pcPolarPattern->Offset);
@@ -111,8 +111,7 @@ void TaskPolarPatternParameters::setupParameterUI(QWidget* widget)
     if (body) {
         try {
             App::Origin* origin = body->getOrigin();
-            ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(
+            auto vpOrigin = static_cast<ViewProviderOrigin*>(
                 Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->setTemporaryVisibility(true, false);
         }
@@ -169,10 +168,9 @@ void TaskPolarPatternParameters::updateUI()
     }
     blockUpdate = true;
 
-    PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
 
-    PartDesign::PolarPatternMode mode =
-        static_cast<PartDesign::PolarPatternMode>(pcPolarPattern->Mode.getValue());
+    auto mode = static_cast<PartDesign::PolarPatternMode>(pcPolarPattern->Mode.getValue());
     bool reverse = pcPolarPattern->Reversed.getValue();
     double angle = pcPolarPattern->Angle.getValue();
     double offset = pcPolarPattern->Offset.getValue();
@@ -189,7 +187,7 @@ void TaskPolarPatternParameters::updateUI()
     // Note: This block of code would trigger change signal handlers (e.g. onOccurrences())
     // and another updateUI() if we didn't check for blockUpdate
     ui->checkReverse->setChecked(reverse);
-    ui->comboMode->setCurrentIndex((long)mode);
+    ui->comboMode->setCurrentIndex(static_cast<int>(mode));
     ui->polarAngle->setValue(angle);
     ui->angleOffset->setValue(offset);
     ui->spinOccurrences->setValue(occurrences);
@@ -226,9 +224,8 @@ void TaskPolarPatternParameters::onSelectionChanged(const Gui::SelectionChanges&
         }
         else {
             std::vector<std::string> axes;
-            App::DocumentObject* selObj;
-            PartDesign::PolarPattern* pcPolarPattern =
-                static_cast<PartDesign::PolarPattern*>(getObject());
+            App::DocumentObject* selObj = nullptr;
+            auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
             getReferencedSelection(pcPolarPattern, msg, selObj, axes);
             if (!selObj) {
                 return;
@@ -251,7 +248,7 @@ void TaskPolarPatternParameters::onCheckReverse(const bool on)
     if (blockUpdate) {
         return;
     }
-    PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
     pcPolarPattern->Reversed.setValue(on);
 
     exitSelectionMode();
@@ -263,7 +260,7 @@ void TaskPolarPatternParameters::onModeChanged(const int mode)
     if (blockUpdate) {
         return;
     }
-    PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
     pcPolarPattern->Mode.setValue(mode);
 
     adaptVisibilityToMode();
@@ -272,25 +269,25 @@ void TaskPolarPatternParameters::onModeChanged(const int mode)
     kickUpdateViewTimer();
 }
 
-void TaskPolarPatternParameters::onAngle(const double a)
+void TaskPolarPatternParameters::onAngle(const double angle)
 {
     if (blockUpdate) {
         return;
     }
-    PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
-    pcPolarPattern->Angle.setValue(a);
+    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    pcPolarPattern->Angle.setValue(angle);
 
     exitSelectionMode();
     kickUpdateViewTimer();
 }
 
-void TaskPolarPatternParameters::onOffset(const double a)
+void TaskPolarPatternParameters::onOffset(const double offset)
 {
     if (blockUpdate) {
         return;
     }
-    PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
-    pcPolarPattern->Offset.setValue(a);
+    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    pcPolarPattern->Offset.setValue(offset);
 
     exitSelectionMode();
     kickUpdateViewTimer();
@@ -301,7 +298,7 @@ void TaskPolarPatternParameters::onOccurrences(const uint n)
     if (blockUpdate) {
         return;
     }
-    PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
     pcPolarPattern->Occurrences.setValue(n);
 
     exitSelectionMode();
@@ -313,7 +310,7 @@ void TaskPolarPatternParameters::onAxisChanged(int /*num*/)
     if (blockUpdate) {
         return;
     }
-    PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
 
     try {
         if (!axesLinks.getCurrentLink().getValue()) {
@@ -341,10 +338,9 @@ void TaskPolarPatternParameters::onUpdateView(bool on)
     blockUpdate = !on;
     if (on) {
         // Do the same like in TaskDlgPolarPatternParameters::accept() but without doCommand
-        PartDesign::PolarPattern* pcPolarPattern =
-            static_cast<PartDesign::PolarPattern*>(getObject());
+        auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
         std::vector<std::string> axes;
-        App::DocumentObject* obj;
+        App::DocumentObject* obj = nullptr;
 
         setupTransaction();
         getAxis(obj, axes);
@@ -393,8 +389,7 @@ TaskPolarPatternParameters::~TaskPolarPatternParameters()
         PartDesign::Body* body = PartDesign::Body::findBodyOf(getObject());
         if (body) {
             App::Origin* origin = body->getOrigin();
-            ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(
+            auto vpOrigin = static_cast<ViewProviderOrigin*>(
                 Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->resetTemporaryVisibility();
         }
@@ -407,7 +402,7 @@ TaskPolarPatternParameters::~TaskPolarPatternParameters()
 void TaskPolarPatternParameters::apply()
 {
     std::vector<std::string> axes;
-    App::DocumentObject* obj;
+    App::DocumentObject* obj = nullptr;
     getAxis(obj, axes);
     std::string axis = buildLinkSingleSubPythonStr(obj, axes);
 

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -218,21 +218,21 @@ void TaskPolarPatternParameters::adaptVisibilityToMode()
 void TaskPolarPatternParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
     if (selectionMode != SelectionMode::None && msg.Type == Gui::SelectionChanges::AddSelection) {
-
         if (originalSelected(msg)) {
             exitSelectionMode();
         }
-        else {
+        else if (selectionMode == SelectionMode::Reference) {
+            auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+
             std::vector<std::string> axes;
             App::DocumentObject* selObj = nullptr;
-            auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
             getReferencedSelection(pcPolarPattern, msg, selObj, axes);
             if (!selObj) {
                 return;
             }
 
-            if (selectionMode == SelectionMode::Reference
-                || selObj->isDerivedFrom(App::Line::getClassTypeId())) {
+            if (selObj->isDerivedFrom<App::Line>() || selObj->isDerivedFrom<Part::Feature>()
+                || selObj->isDerivedFrom<PartDesign::Line>()) {
                 setupTransaction();
                 pcPolarPattern->Axis.setValue(selObj, axes);
                 recomputeFeature();

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -404,7 +404,7 @@ TaskPolarPatternParameters::~TaskPolarPatternParameters()
     }
 }
 
-void TaskPolarPatternParameters::doApply()
+void TaskPolarPatternParameters::apply()
 {
     std::vector<std::string> axes;
     App::DocumentObject* obj;

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -24,8 +24,8 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <QMessageBox>
-# include <QTimer>
+#include <QMessageBox>
+#include <QTimer>
 #endif
 
 #include <Base/UnitsApi.h>
@@ -59,20 +59,23 @@ using namespace Gui;
 
 /* TRANSLATOR PartDesignGui::TaskPolarPatternParameters */
 
-TaskPolarPatternParameters::TaskPolarPatternParameters(ViewProviderTransformed *TransformedView,QWidget *parent)
+TaskPolarPatternParameters::TaskPolarPatternParameters(ViewProviderTransformed* TransformedView,
+                                                       QWidget* parent)
     : TaskTransformedParameters(TransformedView, parent)
     , ui(new Ui_TaskPolarPatternParameters)
 {
     setupUI();
 }
 
-TaskPolarPatternParameters::TaskPolarPatternParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget)
-        : TaskTransformedParameters(parentTask), ui(new Ui_TaskPolarPatternParameters)
+TaskPolarPatternParameters::TaskPolarPatternParameters(TaskMultiTransformParameters* parentTask,
+                                                       QWidget* parameterWidget)
+    : TaskTransformedParameters(parentTask)
+    , ui(new Ui_TaskPolarPatternParameters)
 {
     setupParameterUI(parameterWidget);
 }
 
-void TaskPolarPatternParameters::setupParameterUI(QWidget *widget)
+void TaskPolarPatternParameters::setupParameterUI(QWidget* widget)
 {
     ui->setupUi(widget);
     QMetaObject::connectSlotsByName(this);
@@ -102,17 +105,19 @@ void TaskPolarPatternParameters::setupParameterUI(QWidget *widget)
         this->fillAxisCombo(axesLinks, nullptr);
     }
 
-    //show the parts coordinate system axis for selection
-    PartDesign::Body * body = PartDesign::Body::findBodyOf ( getObject() );
+    // show the parts coordinate system axis for selection
+    PartDesign::Body* body = PartDesign::Body::findBodyOf(getObject());
 
-    if(body) {
+    if (body) {
         try {
-            App::Origin *origin = body->getOrigin();
+            App::Origin* origin = body->getOrigin();
             ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin = static_cast<ViewProviderOrigin*>(
+                Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->setTemporaryVisibility(true, false);
-        } catch (const Base::Exception &ex) {
-            Base::Console().Error ("%s\n", ex.what () );
+        }
+        catch (const Base::Exception& ex) {
+            Base::Console().Error("%s\n", ex.what());
         }
     }
 
@@ -122,20 +127,34 @@ void TaskPolarPatternParameters::setupParameterUI(QWidget *widget)
     updateViewTimer = new QTimer(this);
     updateViewTimer->setSingleShot(true);
     updateViewTimer->setInterval(getUpdateViewTimeout());
-    connect(updateViewTimer, &QTimer::timeout,
-            this, &TaskPolarPatternParameters::onUpdateViewTimer);
-    connect(ui->comboAxis, qOverload<int>(&QComboBox::activated),
-            this, &TaskPolarPatternParameters::onAxisChanged);
-    connect(ui->comboMode, qOverload<int>(&QComboBox::activated),
-            this, &TaskPolarPatternParameters::onModeChanged);
-    connect(ui->checkReverse, &QCheckBox::toggled,
-            this, &TaskPolarPatternParameters::onCheckReverse);
-    connect(ui->polarAngle, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
-            this, &TaskPolarPatternParameters::onAngle);
-    connect(ui->angleOffset, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
-            this, &TaskPolarPatternParameters::onOffset);
-    connect(ui->spinOccurrences, &Gui::UIntSpinBox::unsignedChanged,
-            this, &TaskPolarPatternParameters::onOccurrences);
+    connect(updateViewTimer,
+            &QTimer::timeout,
+            this,
+            &TaskPolarPatternParameters::onUpdateViewTimer);
+    connect(ui->comboAxis,
+            qOverload<int>(&QComboBox::activated),
+            this,
+            &TaskPolarPatternParameters::onAxisChanged);
+    connect(ui->comboMode,
+            qOverload<int>(&QComboBox::activated),
+            this,
+            &TaskPolarPatternParameters::onModeChanged);
+    connect(ui->checkReverse,
+            &QCheckBox::toggled,
+            this,
+            &TaskPolarPatternParameters::onCheckReverse);
+    connect(ui->polarAngle,
+            qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+            this,
+            &TaskPolarPatternParameters::onAngle);
+    connect(ui->angleOffset,
+            qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+            this,
+            &TaskPolarPatternParameters::onOffset);
+    connect(ui->spinOccurrences,
+            &Gui::UIntSpinBox::unsignedChanged,
+            this,
+            &TaskPolarPatternParameters::onOccurrences);
 }
 
 void TaskPolarPatternParameters::retranslateParameterUI(QWidget* widget)
@@ -145,21 +164,25 @@ void TaskPolarPatternParameters::retranslateParameterUI(QWidget* widget)
 
 void TaskPolarPatternParameters::updateUI()
 {
-    if (blockUpdate)
+    if (blockUpdate) {
         return;
+    }
     blockUpdate = true;
 
     PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
 
-    PartDesign::PolarPatternMode mode = static_cast<PartDesign::PolarPatternMode>(pcPolarPattern->Mode.getValue());
+    PartDesign::PolarPatternMode mode =
+        static_cast<PartDesign::PolarPatternMode>(pcPolarPattern->Mode.getValue());
     bool reverse = pcPolarPattern->Reversed.getValue();
     double angle = pcPolarPattern->Angle.getValue();
     double offset = pcPolarPattern->Offset.getValue();
     unsigned occurrences = pcPolarPattern->Occurrences.getValue();
 
     if (axesLinks.setCurrentLink(pcPolarPattern->Axis) == -1) {
-        //failed to set current, because the link isn't in the list yet
-        axesLinks.addLink(pcPolarPattern->Axis, getRefStr(pcPolarPattern->Axis.getValue(),pcPolarPattern->Axis.getSubValues()));
+        // failed to set current, because the link isn't in the list yet
+        axesLinks.addLink(
+            pcPolarPattern->Axis,
+            getRefStr(pcPolarPattern->Axis.getValue(), pcPolarPattern->Axis.getSubValues()));
         axesLinks.setCurrentLink(pcPolarPattern->Axis);
     }
 
@@ -204,12 +227,15 @@ void TaskPolarPatternParameters::onSelectionChanged(const Gui::SelectionChanges&
         else {
             std::vector<std::string> axes;
             App::DocumentObject* selObj;
-            PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+            PartDesign::PolarPattern* pcPolarPattern =
+                static_cast<PartDesign::PolarPattern*>(getObject());
             getReferencedSelection(pcPolarPattern, msg, selObj, axes);
-            if(!selObj)
-                    return;
+            if (!selObj) {
+                return;
+            }
 
-            if (selectionMode == SelectionMode::Reference || selObj->isDerivedFrom ( App::Line::getClassTypeId () ) ) {
+            if (selectionMode == SelectionMode::Reference
+                || selObj->isDerivedFrom(App::Line::getClassTypeId())) {
                 setupTransaction();
                 pcPolarPattern->Axis.setValue(selObj, axes);
                 recomputeFeature();
@@ -220,9 +246,11 @@ void TaskPolarPatternParameters::onSelectionChanged(const Gui::SelectionChanges&
     }
 }
 
-void TaskPolarPatternParameters::onCheckReverse(const bool on) {
-    if (blockUpdate)
+void TaskPolarPatternParameters::onCheckReverse(const bool on)
+{
+    if (blockUpdate) {
         return;
+    }
     PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
     pcPolarPattern->Reversed.setValue(on);
 
@@ -230,9 +258,11 @@ void TaskPolarPatternParameters::onCheckReverse(const bool on) {
     kickUpdateViewTimer();
 }
 
-void TaskPolarPatternParameters::onModeChanged(const int mode) {
-    if (blockUpdate)
+void TaskPolarPatternParameters::onModeChanged(const int mode)
+{
+    if (blockUpdate) {
         return;
+    }
     PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
     pcPolarPattern->Mode.setValue(mode);
 
@@ -242,9 +272,11 @@ void TaskPolarPatternParameters::onModeChanged(const int mode) {
     kickUpdateViewTimer();
 }
 
-void TaskPolarPatternParameters::onAngle(const double a) {
-    if (blockUpdate)
+void TaskPolarPatternParameters::onAngle(const double a)
+{
+    if (blockUpdate) {
         return;
+    }
     PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
     pcPolarPattern->Angle.setValue(a);
 
@@ -252,9 +284,11 @@ void TaskPolarPatternParameters::onAngle(const double a) {
     kickUpdateViewTimer();
 }
 
-void TaskPolarPatternParameters::onOffset(const double a) {
-    if (blockUpdate)
+void TaskPolarPatternParameters::onOffset(const double a)
+{
+    if (blockUpdate) {
         return;
+    }
     PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
     pcPolarPattern->Offset.setValue(a);
 
@@ -262,9 +296,11 @@ void TaskPolarPatternParameters::onOffset(const double a) {
     kickUpdateViewTimer();
 }
 
-void TaskPolarPatternParameters::onOccurrences(const uint n) {
-    if (blockUpdate)
+void TaskPolarPatternParameters::onOccurrences(const uint n)
+{
+    if (blockUpdate) {
         return;
+    }
     PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
     pcPolarPattern->Occurrences.setValue(n);
 
@@ -274,11 +310,12 @@ void TaskPolarPatternParameters::onOccurrences(const uint n) {
 
 void TaskPolarPatternParameters::onAxisChanged(int /*num*/)
 {
-    if (blockUpdate)
+    if (blockUpdate) {
         return;
+    }
     PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
 
-    try{
+    try {
         if (!axesLinks.getCurrentLink().getValue()) {
             // enter reference selection mode
             hideObject();
@@ -286,12 +323,14 @@ void TaskPolarPatternParameters::onAxisChanged(int /*num*/)
             selectionMode = SelectionMode::Reference;
             Gui::Selection().clearSelection();
             addReferenceSelectionGate(AllowSelection::EDGE | AllowSelection::CIRCLE);
-        } else {
+        }
+        else {
             exitSelectionMode();
             pcPolarPattern->Axis.Paste(axesLinks.getCurrentLink());
         }
-    } catch (Base::Exception &e) {
-        QMessageBox::warning(nullptr,tr("Error"),QApplication::translate("Exception", e.what()));
+    }
+    catch (Base::Exception& e) {
+        QMessageBox::warning(nullptr, tr("Error"), QApplication::translate("Exception", e.what()));
     }
 
     kickUpdateViewTimer();
@@ -302,13 +341,14 @@ void TaskPolarPatternParameters::onUpdateView(bool on)
     blockUpdate = !on;
     if (on) {
         // Do the same like in TaskDlgPolarPatternParameters::accept() but without doCommand
-        PartDesign::PolarPattern* pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+        PartDesign::PolarPattern* pcPolarPattern =
+            static_cast<PartDesign::PolarPattern*>(getObject());
         std::vector<std::string> axes;
         App::DocumentObject* obj;
 
         setupTransaction();
         getAxis(obj, axes);
-        pcPolarPattern->Axis.setValue(obj,axes);
+        pcPolarPattern->Axis.setValue(obj, axes);
         pcPolarPattern->Reversed.setValue(getReverse());
         pcPolarPattern->Angle.setValue(getAngle());
         pcPolarPattern->Occurrences.setValue(getOccurrences());
@@ -317,9 +357,10 @@ void TaskPolarPatternParameters::onUpdateView(bool on)
     }
 }
 
-void TaskPolarPatternParameters::getAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const
+void TaskPolarPatternParameters::getAxis(App::DocumentObject*& obj,
+                                         std::vector<std::string>& sub) const
 {
-    const App::PropertyLinkSub &lnk = axesLinks.getCurrentLink();
+    const App::PropertyLinkSub& lnk = axesLinks.getCurrentLink();
     obj = lnk.getValue();
     sub = lnk.getSubValues();
 }
@@ -347,17 +388,19 @@ unsigned TaskPolarPatternParameters::getOccurrences() const
 
 TaskPolarPatternParameters::~TaskPolarPatternParameters()
 {
-    //hide the parts coordinate system axis for selection
+    // hide the parts coordinate system axis for selection
     try {
-        PartDesign::Body * body = PartDesign::Body::findBodyOf ( getObject() );
-        if ( body ) {
-            App::Origin *origin = body->getOrigin();
+        PartDesign::Body* body = PartDesign::Body::findBodyOf(getObject());
+        if (body) {
+            App::Origin* origin = body->getOrigin();
             ViewProviderOrigin* vpOrigin;
-            vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
-            vpOrigin->resetTemporaryVisibility ();
+            vpOrigin = static_cast<ViewProviderOrigin*>(
+                Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin->resetTemporaryVisibility();
         }
-    } catch (const Base::Exception &ex) {
-        Base::Console().Error ("%s\n", ex.what () );
+    }
+    catch (const Base::Exception& ex) {
+        Base::Console().Error("%s\n", ex.what());
     }
 }
 
@@ -369,9 +412,9 @@ void TaskPolarPatternParameters::doApply()
     std::string axis = buildLinkSingleSubPythonStr(obj, axes);
 
     auto tobj = getObject();
-    FCMD_OBJ_CMD(tobj,"Axis = " << axis.c_str());
-    FCMD_OBJ_CMD(tobj,"Reversed = " << getReverse());
-    FCMD_OBJ_CMD(tobj,"Mode = " << getMode());
+    FCMD_OBJ_CMD(tobj, "Axis = " << axis.c_str());
+    FCMD_OBJ_CMD(tobj, "Reversed = " << getReverse());
+    FCMD_OBJ_CMD(tobj, "Mode = " << getMode());
     ui->polarAngle->apply();
     ui->angleOffset->apply();
     ui->spinOccurrences->apply();
@@ -382,7 +425,8 @@ void TaskPolarPatternParameters::doApply()
 // TaskDialog
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-TaskDlgPolarPatternParameters::TaskDlgPolarPatternParameters(ViewProviderPolarPattern *PolarPatternView)
+TaskDlgPolarPatternParameters::TaskDlgPolarPatternParameters(
+    ViewProviderPolarPattern* PolarPatternView)
     : TaskDlgTransformedParameters(PolarPatternView)
 {
     parameter = new TaskPolarPatternParameters(PolarPatternView);

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -329,6 +329,11 @@ bool TaskPolarPatternParameters::getReverse() const
     return ui->checkReverse->isChecked();
 }
 
+int TaskPolarPatternParameters::getMode() const
+{
+    return ui->comboMode->currentIndex();
+}
+
 double TaskPolarPatternParameters::getAngle() const
 {
     return ui->polarAngle->value().getValue();
@@ -356,17 +361,19 @@ TaskPolarPatternParameters::~TaskPolarPatternParameters()
     }
 }
 
-void TaskPolarPatternParameters::apply()
+void TaskPolarPatternParameters::doApply()
 {
-    auto tobj = TransformedView->getObject();
     std::vector<std::string> axes;
     App::DocumentObject* obj;
     getAxis(obj, axes);
     std::string axis = buildLinkSingleSubPythonStr(obj, axes);
 
+    auto tobj = getObject();
     FCMD_OBJ_CMD(tobj,"Axis = " << axis.c_str());
     FCMD_OBJ_CMD(tobj,"Reversed = " << getReverse());
+    FCMD_OBJ_CMD(tobj,"Mode = " << getMode());
     ui->polarAngle->apply();
+    ui->angleOffset->apply();
     ui->spinOccurrences->apply();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -50,7 +50,7 @@ public:
     /// Constructor for task with ViewProvider
     explicit TaskPolarPatternParameters(ViewProviderTransformed *TransformedView, QWidget *parent = nullptr);
     /// Constructor for task with parent task (MultiTransform mode)
-    TaskPolarPatternParameters(TaskMultiTransformParameters *parentTask, QLayout *layout);
+    TaskPolarPatternParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
     ~TaskPolarPatternParameters() override;
 
     void apply() override;
@@ -64,14 +64,9 @@ private Q_SLOTS:
     void onOffset(const double a);
     void onOccurrences(const uint n);
     void onUpdateView(bool) override;
-    void onFeatureDeleted() override;
 
 protected:
-    void addObject(App::DocumentObject*) override;
-    void removeObject(App::DocumentObject*) override;
-    void changeEvent(QEvent *e) override;
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
-    void clearButtons() override;
     void getAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
     const std::string getStdAxis() const;
     const std::string getAxis() const;
@@ -80,8 +75,9 @@ protected:
     unsigned getOccurrences() const;
 
 private:
+    void setupParameterUI(QWidget* widget) override;
+    void retranslateParameterUI(QWidget* widget) override;
     void connectSignals();
-    void setupUI();
     void updateUI();
     void kickUpdateViewTimer() const;
     void adaptVisibilityToMode();

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -30,27 +30,31 @@
 class QTimer;
 class Ui_TaskPolarPatternParameters;
 
-namespace App {
+namespace App
+{
 class Property;
 }
 
-namespace Gui {
+namespace Gui
+{
 class ViewProvider;
 }
 
-namespace PartDesignGui {
+namespace PartDesignGui
+{
 
 class TaskMultiTransformParameters;
 
-class TaskPolarPatternParameters : public TaskTransformedParameters
+class TaskPolarPatternParameters: public TaskTransformedParameters
 {
     Q_OBJECT
 
 public:
     /// Constructor for task with ViewProvider
-    explicit TaskPolarPatternParameters(ViewProviderTransformed *TransformedView, QWidget *parent = nullptr);
+    explicit TaskPolarPatternParameters(ViewProviderTransformed* TransformedView,
+                                        QWidget* parent = nullptr);
     /// Constructor for task with parent task (MultiTransform mode)
-    TaskPolarPatternParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
+    TaskPolarPatternParameters(TaskMultiTransformParameters* parentTask, QWidget* parameterWidget);
     ~TaskPolarPatternParameters() override;
 
 protected:
@@ -93,14 +97,14 @@ private:
 
 
 /// simulation dialog for the TaskView
-class TaskDlgPolarPatternParameters : public TaskDlgTransformedParameters
+class TaskDlgPolarPatternParameters: public TaskDlgTransformedParameters
 {
     Q_OBJECT
 
 public:
-    explicit TaskDlgPolarPatternParameters(ViewProviderPolarPattern *PolarPatternView);
+    explicit TaskDlgPolarPatternParameters(ViewProviderPolarPattern* PolarPatternView);
 };
 
-} //namespace PartDesignGui
+}  // namespace PartDesignGui
 
-#endif // GUI_TASKVIEW_TASKAPPERANCE_H
+#endif  // GUI_TASKVIEW_TASKAPPERANCE_H

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -70,7 +70,7 @@ private Q_SLOTS:
     void onAngle(double angle);
     void onOffset(double offset);
     void onOccurrences(uint number);
-    void onUpdateView(bool /*unsused*/) override;
+    void onUpdateView(bool /*unused*/) override;
 
 private:
     void setupParameterUI(QWidget* widget) override;

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -65,12 +65,12 @@ protected:
 private Q_SLOTS:
     void onUpdateViewTimer();
     void onAxisChanged(int num);
-    void onModeChanged(const int mode);
-    void onCheckReverse(const bool on);
-    void onAngle(const double a);
-    void onOffset(const double a);
-    void onOccurrences(const uint n);
-    void onUpdateView(bool) override;
+    void onModeChanged(int mode);
+    void onCheckReverse(bool on);
+    void onAngle(double angle);
+    void onOffset(double offset);
+    void onOccurrences(uint number);
+    void onUpdateView(bool /*unsused*/) override;
 
 private:
     void setupParameterUI(QWidget* widget) override;

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -53,8 +53,6 @@ public:
     TaskPolarPatternParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
     ~TaskPolarPatternParameters() override;
 
-    void apply() override;
-
 protected:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
 
@@ -71,6 +69,7 @@ private Q_SLOTS:
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
+    void doApply() override;
 
     void connectSignals();
     void updateUI();
@@ -81,6 +80,7 @@ private:
     const std::string getStdAxis() const;
     const std::string getAxis() const;
     bool getReverse() const;
+    int getMode() const;
     double getAngle() const;
     unsigned getOccurrences() const;
 

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -84,7 +84,7 @@ private:
 
 private:
     std::unique_ptr<Ui_TaskPolarPatternParameters> ui;
-    QTimer* updateViewTimer;
+    QTimer* updateViewTimer = nullptr;
 
     ComboLinks axesLinks;
 };

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -55,6 +55,9 @@ public:
 
     void apply() override;
 
+protected:
+    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
+
 private Q_SLOTS:
     void onUpdateViewTimer();
     void onAxisChanged(int num);
@@ -65,22 +68,21 @@ private Q_SLOTS:
     void onOccurrences(const uint n);
     void onUpdateView(bool) override;
 
-protected:
-    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
+private:
+    void setupParameterUI(QWidget* widget) override;
+    void retranslateParameterUI(QWidget* widget) override;
+
+    void connectSignals();
+    void updateUI();
+    void kickUpdateViewTimer() const;
+    void adaptVisibilityToMode();
+
     void getAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const;
     const std::string getStdAxis() const;
     const std::string getAxis() const;
     bool getReverse() const;
     double getAngle() const;
     unsigned getOccurrences() const;
-
-private:
-    void setupParameterUI(QWidget* widget) override;
-    void retranslateParameterUI(QWidget* widget) override;
-    void connectSignals();
-    void updateUI();
-    void kickUpdateViewTimer() const;
-    void adaptVisibilityToMode();
 
 private:
     std::unique_ptr<Ui_TaskPolarPatternParameters> ui;

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -97,7 +97,6 @@ class TaskDlgPolarPatternParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgPolarPatternParameters(ViewProviderPolarPattern *PolarPatternView);
-    ~TaskDlgPolarPatternParameters() override = default;
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.h
@@ -57,6 +57,8 @@ public:
     TaskPolarPatternParameters(TaskMultiTransformParameters* parentTask, QWidget* parameterWidget);
     ~TaskPolarPatternParameters() override;
 
+    void apply() override;
+
 protected:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
 
@@ -73,7 +75,6 @@ private Q_SLOTS:
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
-    void doApply() override;
 
     void connectSignals();
     void updateUI();

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.ui
@@ -7,47 +7,25 @@
     <x>0</x>
     <y>0</y>
     <width>253</width>
-    <height>339</height>
+    <height>206</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QPushButton" name="buttonAddFeature">
-       <property name="text">
-        <string>Add feature</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonRemoveFeature">
-       <property name="text">
-        <string>Remove feature</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QListWidget" name="listWidgetFeatures">
-     <property name="toolTip">
-      <string>List can be reordered by dragging</string>
-     </property>
-     <property name="dragDropMode">
-      <enum>QAbstractItemView::InternalMove</enum>
-     </property>
-    </widget>
-   </item>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
@@ -196,27 +174,6 @@
      </item>
     </layout>
    </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <item>
-      <widget class="QPushButton" name="buttonOK">
-       <property name="text">
-        <string>OK</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkBoxUpdateView">
-     <property name="text">
-      <string>Update view</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -233,49 +190,11 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>buttonAddFeature</tabstop>
-  <tabstop>buttonRemoveFeature</tabstop>
-  <tabstop>listWidgetFeatures</tabstop>
   <tabstop>comboAxis</tabstop>
   <tabstop>checkReverse</tabstop>
   <tabstop>polarAngle</tabstop>
   <tabstop>spinOccurrences</tabstop>
-  <tabstop>buttonOK</tabstop>
-  <tabstop>checkBoxUpdateView</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonAddFeature</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>buttonRemoveFeature</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>66</x>
-     <y>21</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>186</x>
-     <y>21</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonRemoveFeature</sender>
-   <signal>clicked(bool)</signal>
-   <receiver>buttonAddFeature</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>186</x>
-     <y>21</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>66</x>
-     <y>21</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
@@ -152,7 +152,7 @@ unsigned TaskScaledParameters::getOccurrences() const
     return ui->spinOccurrences->value();
 }
 
-void TaskScaledParameters::doApply()
+void TaskScaledParameters::apply()
 {
     FCMD_OBJ_CMD(getObject(), "Factor = " << getFactor());
     ui->spinOccurrences->apply();

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <App/DocumentObject.h>
+#include <App/Document.h>
 #include <Base/Console.h>
 #include <Gui/Command.h>
 #include <Gui/Selection.h>
@@ -141,11 +142,9 @@ unsigned TaskScaledParameters::getOccurrences() const
     return ui->spinOccurrences->value();
 }
 
-void TaskScaledParameters::apply()
+void TaskScaledParameters::doApply()
 {
-    std::string name = TransformedView->getObject()->getNameInDocument();
-
-    Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.Factor = %f",name.c_str(), getFactor());
+    FCMD_OBJ_CMD(getObject(),"Factor = " << getFactor());
     ui->spinOccurrences->apply();
 }
 
@@ -160,15 +159,6 @@ TaskDlgScaledParameters::TaskDlgScaledParameters(ViewProviderScaled *ScaledView)
     parameter = new TaskScaledParameters(ScaledView);
 
     Content.push_back(parameter);
-}
-//==== calls from the TaskView ===============================================================
-
-bool TaskDlgScaledParameters::accept()
-{
-
-        parameter->apply();
-
-    return TaskDlgTransformedParameters::accept();
 }
 
 #include "moc_TaskScaledParameters.cpp"

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
@@ -75,7 +75,7 @@ void TaskScaledParameters::setupParameterUI(QWidget* widget)
             &TaskScaledParameters::onOccurrences);
 
     // Get the feature data
-    PartDesign::Scaled* pcScaled = static_cast<PartDesign::Scaled*>(getObject());
+    auto pcScaled = static_cast<PartDesign::Scaled*>(getObject());
 
     ui->spinFactor->bind(pcScaled->Factor);
     ui->spinOccurrences->setMaximum(INT_MAX);
@@ -99,7 +99,7 @@ void TaskScaledParameters::updateUI()
     }
     blockUpdate = true;
 
-    PartDesign::Scaled* pcScaled = static_cast<PartDesign::Scaled*>(getObject());
+    auto pcScaled = static_cast<PartDesign::Scaled*>(getObject());
 
     double factor = pcScaled->Factor.getValue();
     unsigned occurrences = pcScaled->Occurrences.getValue();
@@ -110,23 +110,23 @@ void TaskScaledParameters::updateUI()
     blockUpdate = false;
 }
 
-void TaskScaledParameters::onFactor(const double f)
+void TaskScaledParameters::onFactor(const double factor)
 {
     if (blockUpdate) {
         return;
     }
-    PartDesign::Scaled* pcScaled = static_cast<PartDesign::Scaled*>(getObject());
-    pcScaled->Factor.setValue(f);
+    auto pcScaled = static_cast<PartDesign::Scaled*>(getObject());
+    pcScaled->Factor.setValue(factor);
     recomputeFeature();
 }
 
-void TaskScaledParameters::onOccurrences(const uint n)
+void TaskScaledParameters::onOccurrences(const uint number)
 {
     if (blockUpdate) {
         return;
     }
-    PartDesign::Scaled* pcScaled = static_cast<PartDesign::Scaled*>(getObject());
-    pcScaled->Occurrences.setValue(n);
+    auto pcScaled = static_cast<PartDesign::Scaled*>(getObject());
+    pcScaled->Occurrences.setValue(number);
     recomputeFeature();
 }
 
@@ -135,7 +135,7 @@ void TaskScaledParameters::onUpdateView(bool on)
     blockUpdate = !on;
     if (on) {
         // Do the same like in TaskDlgScaledParameters::accept() but without doCommand
-        PartDesign::Scaled* pcScaled = static_cast<PartDesign::Scaled*>(getObject());
+        auto pcScaled = static_cast<PartDesign::Scaled*>(getObject());
         pcScaled->Factor.setValue(getFactor());
         pcScaled->Occurrences.setValue(getOccurrences());
         recomputeFeature();

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
@@ -141,10 +141,6 @@ unsigned TaskScaledParameters::getOccurrences() const
     return ui->spinOccurrences->value();
 }
 
-TaskScaledParameters::~TaskScaledParameters()
-{
-}
-
 void TaskScaledParameters::apply()
 {
     std::string name = TransformedView->getObject()->getNameInDocument();

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
@@ -44,28 +44,35 @@ using namespace Gui;
 
 /* TRANSLATOR PartDesignGui::TaskScaledParameters */
 
-TaskScaledParameters::TaskScaledParameters(ViewProviderTransformed *TransformedView,QWidget *parent)
+TaskScaledParameters::TaskScaledParameters(ViewProviderTransformed* TransformedView,
+                                           QWidget* parent)
     : TaskTransformedParameters(TransformedView, parent)
     , ui(new Ui_TaskScaledParameters)
 {
     setupUI();
 }
 
-TaskScaledParameters::TaskScaledParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget)
-        : TaskTransformedParameters(parentTask), ui(new Ui_TaskScaledParameters)
+TaskScaledParameters::TaskScaledParameters(TaskMultiTransformParameters* parentTask,
+                                           QWidget* parameterWidget)
+    : TaskTransformedParameters(parentTask)
+    , ui(new Ui_TaskScaledParameters)
 {
     setupParameterUI(parameterWidget);
 }
 
-void TaskScaledParameters::setupParameterUI(QWidget *widget)
+void TaskScaledParameters::setupParameterUI(QWidget* widget)
 {
     ui->setupUi(widget);
     QMetaObject::connectSlotsByName(this);
 
-    connect(ui->spinFactor, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
-            this, &TaskScaledParameters::onFactor);
-    connect(ui->spinOccurrences, &Gui::UIntSpinBox::unsignedChanged,
-            this, &TaskScaledParameters::onOccurrences);
+    connect(ui->spinFactor,
+            qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
+            this,
+            &TaskScaledParameters::onFactor);
+    connect(ui->spinOccurrences,
+            &Gui::UIntSpinBox::unsignedChanged,
+            this,
+            &TaskScaledParameters::onOccurrences);
 
     // Get the feature data
     PartDesign::Scaled* pcScaled = static_cast<PartDesign::Scaled*>(getObject());
@@ -75,7 +82,7 @@ void TaskScaledParameters::setupParameterUI(QWidget *widget)
     ui->spinOccurrences->bind(pcScaled->Occurrences);
     ui->spinFactor->setEnabled(true);
     ui->spinOccurrences->setEnabled(true);
-    //ui->spinFactor->setDecimals(Base::UnitsApi::getDecimals());
+    // ui->spinFactor->setDecimals(Base::UnitsApi::getDecimals());
 
     updateUI();
 }
@@ -87,8 +94,9 @@ void TaskScaledParameters::retranslateParameterUI(QWidget* widget)
 
 void TaskScaledParameters::updateUI()
 {
-    if (blockUpdate)
+    if (blockUpdate) {
         return;
+    }
     blockUpdate = true;
 
     PartDesign::Scaled* pcScaled = static_cast<PartDesign::Scaled*>(getObject());
@@ -104,8 +112,9 @@ void TaskScaledParameters::updateUI()
 
 void TaskScaledParameters::onFactor(const double f)
 {
-    if (blockUpdate)
+    if (blockUpdate) {
         return;
+    }
     PartDesign::Scaled* pcScaled = static_cast<PartDesign::Scaled*>(getObject());
     pcScaled->Factor.setValue(f);
     recomputeFeature();
@@ -113,8 +122,9 @@ void TaskScaledParameters::onFactor(const double f)
 
 void TaskScaledParameters::onOccurrences(const uint n)
 {
-    if (blockUpdate)
+    if (blockUpdate) {
         return;
+    }
     PartDesign::Scaled* pcScaled = static_cast<PartDesign::Scaled*>(getObject());
     pcScaled->Occurrences.setValue(n);
     recomputeFeature();
@@ -144,7 +154,7 @@ unsigned TaskScaledParameters::getOccurrences() const
 
 void TaskScaledParameters::doApply()
 {
-    FCMD_OBJ_CMD(getObject(),"Factor = " << getFactor());
+    FCMD_OBJ_CMD(getObject(), "Factor = " << getFactor());
     ui->spinOccurrences->apply();
 }
 
@@ -153,7 +163,7 @@ void TaskScaledParameters::doApply()
 // TaskDialog
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-TaskDlgScaledParameters::TaskDlgScaledParameters(ViewProviderScaled *ScaledView)
+TaskDlgScaledParameters::TaskDlgScaledParameters(ViewProviderScaled* ScaledView)
     : TaskDlgTransformedParameters(ScaledView)
 {
     parameter = new TaskScaledParameters(ScaledView);

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.h
@@ -51,8 +51,6 @@ public:
     /// Constructor for task with parent task (MultiTransform mode)
     TaskScaledParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
 
-    void apply() override;
-
 private Q_SLOTS:
     void onFactor(const double f);
     void onOccurrences(const uint n);
@@ -61,6 +59,7 @@ private Q_SLOTS:
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
+    void doApply() override;
     void updateUI();
 
     double getFactor() const;
@@ -78,9 +77,6 @@ class TaskDlgScaledParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgScaledParameters(ViewProviderScaled *ScaledView);
-
-    /// is called by the framework if the dialog is accepted (Ok)
-    bool accept() override;
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.h
@@ -60,7 +60,8 @@ public:
 private Q_SLOTS:
     void onFactor(double factor);
     void onOccurrences(uint number);
-    void onUpdateView(bool /*unsused*/) override;
+    void onUpdateView(bool /*unused*/) override;
+
 
 private:
     void setupParameterUI(QWidget* widget) override;

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.h
@@ -29,27 +29,31 @@
 
 class Ui_TaskScaledParameters;
 
-namespace App {
+namespace App
+{
 class Property;
 }
 
-namespace Gui {
+namespace Gui
+{
 class ViewProvider;
 }
 
-namespace PartDesignGui {
+namespace PartDesignGui
+{
 
 class TaskMultiTransformParameters;
 
-class TaskScaledParameters : public TaskTransformedParameters
+class TaskScaledParameters: public TaskTransformedParameters
 {
     Q_OBJECT
 
 public:
     /// Constructor for task with ViewProvider
-    explicit TaskScaledParameters(ViewProviderTransformed *TransformedView, QWidget *parent = nullptr);
+    explicit TaskScaledParameters(ViewProviderTransformed* TransformedView,
+                                  QWidget* parent = nullptr);
     /// Constructor for task with parent task (MultiTransform mode)
-    TaskScaledParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
+    TaskScaledParameters(TaskMultiTransformParameters* parentTask, QWidget* parameterWidget);
 
 private Q_SLOTS:
     void onFactor(const double f);
@@ -71,14 +75,14 @@ private:
 
 
 /// simulation dialog for the TaskView
-class TaskDlgScaledParameters : public TaskDlgTransformedParameters
+class TaskDlgScaledParameters: public TaskDlgTransformedParameters
 {
     Q_OBJECT
 
 public:
-    explicit TaskDlgScaledParameters(ViewProviderScaled *ScaledView);
+    explicit TaskDlgScaledParameters(ViewProviderScaled* ScaledView);
 };
 
-} //namespace PartDesignGui
+}  // namespace PartDesignGui
 
-#endif // GUI_TASKVIEW_TASKAPPERANCE_H
+#endif  // GUI_TASKVIEW_TASKAPPERANCE_H

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.h
@@ -58,14 +58,13 @@ private Q_SLOTS:
     void onOccurrences(const uint n);
     void onUpdateView(bool) override;
 
-protected:
-    double getFactor() const;
-    unsigned getOccurrences() const;
-
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
     void updateUI();
+
+    double getFactor() const;
+    unsigned getOccurrences() const;
 
 private:
     std::unique_ptr<Ui_TaskScaledParameters> ui;
@@ -80,7 +79,6 @@ class TaskDlgScaledParameters : public TaskDlgTransformedParameters
 public:
     explicit TaskDlgScaledParameters(ViewProviderScaled *ScaledView);
 
-public:
     /// is called by the framework if the dialog is accepted (Ok)
     bool accept() override;
 };

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.h
@@ -49,7 +49,7 @@ public:
     /// Constructor for task with ViewProvider
     explicit TaskScaledParameters(ViewProviderTransformed *TransformedView, QWidget *parent = nullptr);
     /// Constructor for task with parent task (MultiTransform mode)
-    TaskScaledParameters(TaskMultiTransformParameters *parentTask, QLayout *layout);
+    TaskScaledParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
     ~TaskScaledParameters() override;
 
     void apply() override;
@@ -58,17 +58,14 @@ private Q_SLOTS:
     void onFactor(const double f);
     void onOccurrences(const uint n);
     void onUpdateView(bool) override;
-    void onFeatureDeleted() override;
 
 protected:
-    void changeEvent(QEvent *e) override;
-    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
-    void clearButtons() override;
     double getFactor() const;
     unsigned getOccurrences() const;
 
 private:
-    void setupUI();
+    void setupParameterUI(QWidget* widget) override;
+    void retranslateParameterUI(QWidget* widget) override;
     void updateUI();
 
 private:

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.h
@@ -55,6 +55,8 @@ public:
     /// Constructor for task with parent task (MultiTransform mode)
     TaskScaledParameters(TaskMultiTransformParameters* parentTask, QWidget* parameterWidget);
 
+    void apply() override;
+
 private Q_SLOTS:
     void onFactor(const double f);
     void onOccurrences(const uint n);
@@ -63,7 +65,6 @@ private Q_SLOTS:
 private:
     void setupParameterUI(QWidget* widget) override;
     void retranslateParameterUI(QWidget* widget) override;
-    void doApply() override;
     void updateUI();
 
     double getFactor() const;

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.h
@@ -58,9 +58,9 @@ public:
     void apply() override;
 
 private Q_SLOTS:
-    void onFactor(const double f);
-    void onOccurrences(const uint n);
-    void onUpdateView(bool) override;
+    void onFactor(double factor);
+    void onOccurrences(uint number);
+    void onUpdateView(bool /*unsused*/) override;
 
 private:
     void setupParameterUI(QWidget* widget) override;

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.h
@@ -50,7 +50,6 @@ public:
     explicit TaskScaledParameters(ViewProviderTransformed *TransformedView, QWidget *parent = nullptr);
     /// Constructor for task with parent task (MultiTransform mode)
     TaskScaledParameters(TaskMultiTransformParameters *parentTask, QWidget* parameterWidget);
-    ~TaskScaledParameters() override;
 
     void apply() override;
 
@@ -80,7 +79,6 @@ class TaskDlgScaledParameters : public TaskDlgTransformedParameters
 
 public:
     explicit TaskDlgScaledParameters(ViewProviderScaled *ScaledView);
-    ~TaskDlgScaledParameters() override = default;
 
 public:
     /// is called by the framework if the dialog is accepted (Ok)

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.ui
@@ -7,44 +7,25 @@
     <x>0</x>
     <y>0</y>
     <width>253</width>
-    <height>270</height>
+    <height>85</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QPushButton" name="buttonAddFeature">
-       <property name="text">
-        <string>Add feature</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonRemoveFeature">
-       <property name="text">
-        <string>Remove feature</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QListWidget" name="listWidgetFeatures">
-     <property name="dragDropMode">
-      <enum>QAbstractItemView::InternalMove</enum>
-     </property>
-    </widget>
-   </item>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
@@ -55,7 +36,7 @@
       </widget>
      </item>
      <item>
-      <widget class="Gui::QuantitySpinBox" name="spinFactor"/>
+      <widget class="Gui::QuantitySpinBox" name="spinFactor" native="true"/>
      </item>
     </layout>
    </item>
@@ -73,40 +54,6 @@
      </item>
     </layout>
    </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QPushButton" name="buttonOK">
-       <property name="text">
-        <string>OK</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkBoxUpdateView">
-     <property name="text">
-      <string>Update view</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -123,13 +70,8 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>buttonAddFeature</tabstop>
-  <tabstop>buttonRemoveFeature</tabstop>
-  <tabstop>listWidgetFeatures</tabstop>
   <tabstop>spinFactor</tabstop>
   <tabstop>spinOccurrences</tabstop>
-  <tabstop>buttonOK</tabstop>
-  <tabstop>checkBoxUpdateView</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
@@ -23,8 +23,8 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <QAction>
-# include <QListWidget>
+#include <QAction>
+#include <QListWidget>
 #endif
 
 #include <App/Application.h>
@@ -47,16 +47,19 @@
 #include "ReferenceSelection.h"
 
 
-FC_LOG_LEVEL_INIT("PartDesign",true,true)
+FC_LOG_LEVEL_INIT("PartDesign", true, true)
 
 using namespace PartDesignGui;
 using namespace Gui;
 
 /* TRANSLATOR PartDesignGui::TaskTransformedParameters */
 
-TaskTransformedParameters::TaskTransformedParameters(ViewProviderTransformed *TransformedView, QWidget *parent)
+TaskTransformedParameters::TaskTransformedParameters(ViewProviderTransformed* TransformedView,
+                                                     QWidget* parent)
     : TaskBox(Gui::BitmapFactory().pixmap(TransformedView->featureIcon().c_str()),
-              TransformedView->menuName, true, parent)
+              TransformedView->menuName,
+              true,
+              parent)
     , TransformedView(TransformedView)
     , ui(new Ui_TaskTransformedParameters)
 {
@@ -67,20 +70,20 @@ TaskTransformedParameters::TaskTransformedParameters(ViewProviderTransformed *Tr
     App::GetApplication().getActiveTransaction(&transactionID);
 }
 
-TaskTransformedParameters::TaskTransformedParameters(TaskMultiTransformParameters *parentTask)
-    : TaskBox(QPixmap(), tr(""), true, parentTask),
-      parentTask(parentTask),
-      insideMultiTransform(true)
-{
-}
+TaskTransformedParameters::TaskTransformedParameters(TaskMultiTransformParameters* parentTask)
+    : TaskBox(QPixmap(), tr(""), true, parentTask)
+    , parentTask(parentTask)
+    , insideMultiTransform(true)
+{}
 
 TaskTransformedParameters::~TaskTransformedParameters()
 {
     // make sure to remove selection gate in all cases
     Gui::Selection().rmvSelectionGate();
 
-    if (proxy)
+    if (proxy) {
         delete proxy;
+    }
 }
 
 void TaskTransformedParameters::setupUI()
@@ -90,8 +93,14 @@ void TaskTransformedParameters::setupUI()
     ui->setupUi(proxy);
     QMetaObject::connectSlotsByName(this);
 
-    connect(ui->buttonAddFeature, &QToolButton::toggled, this, &TaskTransformedParameters::onButtonAddFeature);
-    connect(ui->buttonRemoveFeature, &QToolButton::toggled, this, &TaskTransformedParameters::onButtonRemoveFeature);
+    connect(ui->buttonAddFeature,
+            &QToolButton::toggled,
+            this,
+            &TaskTransformedParameters::onButtonAddFeature);
+    connect(ui->buttonRemoveFeature,
+            &QToolButton::toggled,
+            this,
+            &TaskTransformedParameters::onButtonRemoveFeature);
 
     // Create context menu
     QAction* action = new QAction(tr("Remove"), this);
@@ -103,11 +112,15 @@ void TaskTransformedParameters::setupUI()
     ui->listWidgetFeatures->addAction(action);
     connect(action, &QAction::triggered, this, &TaskTransformedParameters::onFeatureDeleted);
     ui->listWidgetFeatures->setContextMenuPolicy(Qt::ActionsContextMenu);
-    connect(ui->listWidgetFeatures->model(), &QAbstractListModel::rowsMoved,
-            this, &TaskTransformedParameters::indexesMoved);
+    connect(ui->listWidgetFeatures->model(),
+            &QAbstractListModel::rowsMoved,
+            this,
+            &TaskTransformedParameters::indexesMoved);
 
-    connect(ui->checkBoxUpdateView, &QCheckBox::toggled,
-            this, &TaskTransformedParameters::onUpdateView);
+    connect(ui->checkBoxUpdateView,
+            &QCheckBox::toggled,
+            this,
+            &TaskTransformedParameters::onUpdateView);
 
     // Get the feature data
     PartDesign::Transformed* pcTransformed = static_cast<PartDesign::Transformed*>(getObject());
@@ -123,17 +136,18 @@ void TaskTransformedParameters::setupUI()
         }
     }
 
-    setupParameterUI(ui->featureUI); // create parameter UI widgets
+    setupParameterUI(ui->featureUI);  // create parameter UI widgets
     this->groupLayout()->addWidget(proxy);
 }
 
 void TaskTransformedParameters::slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj)
 {
-    if (TransformedView == &Obj)
+    if (TransformedView == &Obj) {
         TransformedView = nullptr;
+    }
 }
 
-void TaskTransformedParameters::changeEvent(QEvent *e)
+void TaskTransformedParameters::changeEvent(QEvent* e)
 {
     TaskBox::changeEvent(e);
     if (e->type() == QEvent::LanguageChange && proxy) {
@@ -153,7 +167,8 @@ void TaskTransformedParameters::clearButtons()
 {
     if (insideMultiTransform) {
         parentTask->clearButtons();
-    } else {
+    }
+    else {
         ui->buttonAddFeature->setChecked(false);
         ui->buttonRemoveFeature->setChecked(false);
     }
@@ -183,28 +198,33 @@ void TaskTransformedParameters::removeObject(App::DocumentObject* obj)
 
 bool TaskTransformedParameters::originalSelected(const Gui::SelectionChanges& msg)
 {
-    if (msg.Type == Gui::SelectionChanges::AddSelection && (
-                (selectionMode == SelectionMode::AddFeature) || (selectionMode == SelectionMode::RemoveFeature))) {
+    if (msg.Type == Gui::SelectionChanges::AddSelection
+        && ((selectionMode == SelectionMode::AddFeature)
+            || (selectionMode == SelectionMode::RemoveFeature))) {
 
-        if (strcmp(msg.pDocName, getObject()->getDocument()->getName()) != 0)
+        if (strcmp(msg.pDocName, getObject()->getDocument()->getName()) != 0) {
             return false;
+        }
 
         PartDesign::Transformed* pcTransformed = getObject();
-        App::DocumentObject* selectedObject = pcTransformed->getDocument()->getObject(msg.pObjectName);
+        App::DocumentObject* selectedObject =
+            pcTransformed->getDocument()->getObject(msg.pObjectName);
         if (selectedObject->isDerivedFrom(PartDesign::FeatureAddSub::getClassTypeId())) {
 
             // Do the same like in TaskDlgTransformedParameters::accept() but without doCommand
             std::vector<App::DocumentObject*> originals = pcTransformed->Originals.getValues();
-            std::vector<App::DocumentObject*>::iterator o = std::find(originals.begin(), originals.end(), selectedObject);
+            std::vector<App::DocumentObject*>::iterator o =
+                std::find(originals.begin(), originals.end(), selectedObject);
             if (selectionMode == SelectionMode::AddFeature) {
                 if (o == originals.end()) {
                     originals.push_back(selectedObject);
                     addObject(selectedObject);
                 }
                 else {
-                    return false; // duplicate selection
+                    return false;  // duplicate selection
                 }
-            } else {
+            }
+            else {
                 if (o != originals.end()) {
                     originals.erase(o);
                     removeObject(selectedObject);
@@ -226,17 +246,20 @@ bool TaskTransformedParameters::originalSelected(const Gui::SelectionChanges& ms
 
 void TaskTransformedParameters::setupTransaction()
 {
-    if (!isEnabledTransaction())
+    if (!isEnabledTransaction()) {
         return;
+    }
 
     auto obj = getObject();
-    if (!obj)
+    if (!obj) {
         return;
+    }
 
     int tid = 0;
     App::GetApplication().getActiveTransaction(&tid);
-    if (tid && tid == transactionID)
+    if (tid && tid == transactionID) {
         return;
+    }
 
     // open a transaction if none is active
     std::string n("Edit ");
@@ -261,7 +284,8 @@ void TaskTransformedParameters::onButtonAddFeature(bool checked)
         showBase();
         selectionMode = SelectionMode::AddFeature;
         Gui::Selection().clearSelection();
-    } else {
+    }
+    else {
         exitSelectionMode();
     }
 
@@ -269,19 +293,22 @@ void TaskTransformedParameters::onButtonAddFeature(bool checked)
 }
 
 // Make sure only some feature before the given one is visible
-void TaskTransformedParameters::checkVisibility() {
+void TaskTransformedParameters::checkVisibility()
+{
     auto feat = getObject();
     auto body = feat->getFeatureBody();
-    if(!body)
+    if (!body) {
         return;
+    }
     auto inset = feat->getInListEx(true);
     inset.emplace(feat);
-    for(auto o : body->Group.getValues()) {
-        if(!o->Visibility.getValue()
-                || !o->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
+    for (auto o : body->Group.getValues()) {
+        if (!o->Visibility.getValue() || !o->isDerivedFrom(PartDesign::Feature::getClassTypeId())) {
             continue;
-        if(inset.count(o))
+        }
+        if (inset.count(o)) {
             break;
+        }
         return;
     }
     FCMD_OBJ_SHOW(getBaseObject());
@@ -293,7 +320,8 @@ void TaskTransformedParameters::onButtonRemoveFeature(bool checked)
         checkVisibility();
         selectionMode = SelectionMode::RemoveFeature;
         Gui::Selection().clearSelection();
-    } else {
+    }
+    else {
         exitSelectionMode();
     }
 
@@ -307,7 +335,7 @@ void TaskTransformedParameters::onFeatureDeleted()
     int currentRow = ui->listWidgetFeatures->currentRow();
     if (currentRow < 0) {
         Base::Console().Error("PartDesign Pattern: No feature selected for removing.\n");
-        return; //no current row selected
+        return;  // no current row selected
     }
     originals.erase(originals.begin() + currentRow);
     setupTransaction();
@@ -316,7 +344,8 @@ void TaskTransformedParameters::onFeatureDeleted()
     recomputeFeature();
 }
 
-void TaskTransformedParameters::removeItemFromListWidget(QListWidget* widget, const QString& itemstr)
+void TaskTransformedParameters::removeItemFromListWidget(QListWidget* widget,
+                                                         const QString& itemstr)
 {
     QList<QListWidgetItem*> items = widget->findItems(itemstr, Qt::MatchExactly);
     if (!items.empty()) {
@@ -327,129 +356,142 @@ void TaskTransformedParameters::removeItemFromListWidget(QListWidget* widget, co
     }
 }
 
-void TaskTransformedParameters::fillAxisCombo(ComboLinks &combolinks,
-                                              Part::Part2DObject* sketch)
+void TaskTransformedParameters::fillAxisCombo(ComboLinks& combolinks, Part::Part2DObject* sketch)
 {
     combolinks.clear();
 
-    //add sketch axes
-    if (sketch){
-        combolinks.addLink(sketch, "N_Axis",tr("Normal sketch axis"));
-        combolinks.addLink(sketch,"V_Axis",tr("Vertical sketch axis"));
-        combolinks.addLink(sketch,"H_Axis",tr("Horizontal sketch axis"));
-        for (int i=0; i < sketch->getAxisCount(); i++) {
-            QString itemText = tr("Construction line %1").arg(i+1);
+    // add sketch axes
+    if (sketch) {
+        combolinks.addLink(sketch, "N_Axis", tr("Normal sketch axis"));
+        combolinks.addLink(sketch, "V_Axis", tr("Vertical sketch axis"));
+        combolinks.addLink(sketch, "H_Axis", tr("Horizontal sketch axis"));
+        for (int i = 0; i < sketch->getAxisCount(); i++) {
+            QString itemText = tr("Construction line %1").arg(i + 1);
             std::stringstream sub;
             sub << "Axis" << i;
-            combolinks.addLink(sketch,sub.str(),itemText);
+            combolinks.addLink(sketch, sub.str(), itemText);
         }
     }
 
-    //add part axes
+    // add part axes
     App::DocumentObject* obj = getObject();
-    PartDesign::Body * body = PartDesign::Body::findBodyOf ( obj );
+    PartDesign::Body* body = PartDesign::Body::findBodyOf(obj);
 
     if (body) {
         try {
             App::Origin* orig = body->getOrigin();
-            combolinks.addLink(orig->getX(),"",tr("Base X axis"));
-            combolinks.addLink(orig->getY(),"",tr("Base Y axis"));
-            combolinks.addLink(orig->getZ(),"",tr("Base Z axis"));
-        } catch (const Base::Exception &ex) {
-            Base::Console().Error ("%s\n", ex.what() );
+            combolinks.addLink(orig->getX(), "", tr("Base X axis"));
+            combolinks.addLink(orig->getY(), "", tr("Base Y axis"));
+            combolinks.addLink(orig->getZ(), "", tr("Base Z axis"));
+        }
+        catch (const Base::Exception& ex) {
+            Base::Console().Error("%s\n", ex.what());
         }
     }
 
-    //add "Select reference"
-    combolinks.addLink(nullptr,std::string(),tr("Select reference..."));
+    // add "Select reference"
+    combolinks.addLink(nullptr, std::string(), tr("Select reference..."));
 }
 
-void TaskTransformedParameters::fillPlanesCombo(ComboLinks &combolinks,
-                                                Part::Part2DObject* sketch)
+void TaskTransformedParameters::fillPlanesCombo(ComboLinks& combolinks, Part::Part2DObject* sketch)
 {
     combolinks.clear();
 
-    //add sketch axes
-    if (sketch){
-        combolinks.addLink(sketch,"V_Axis",QObject::tr("Vertical sketch axis"));
-        combolinks.addLink(sketch,"H_Axis",QObject::tr("Horizontal sketch axis"));
-        for (int i=0; i < sketch->getAxisCount(); i++) {
-            QString itemText = tr("Construction line %1").arg(i+1);
+    // add sketch axes
+    if (sketch) {
+        combolinks.addLink(sketch, "V_Axis", QObject::tr("Vertical sketch axis"));
+        combolinks.addLink(sketch, "H_Axis", QObject::tr("Horizontal sketch axis"));
+        for (int i = 0; i < sketch->getAxisCount(); i++) {
+            QString itemText = tr("Construction line %1").arg(i + 1);
             std::stringstream sub;
             sub << "Axis" << i;
-            combolinks.addLink(sketch,sub.str(),itemText);
+            combolinks.addLink(sketch, sub.str(), itemText);
         }
     }
 
-    //add part baseplanes
+    // add part baseplanes
     App::DocumentObject* obj = getObject();
-    PartDesign::Body * body = PartDesign::Body::findBodyOf ( obj );
+    PartDesign::Body* body = PartDesign::Body::findBodyOf(obj);
 
     if (body) {
         try {
             App::Origin* orig = body->getOrigin();
-            combolinks.addLink(orig->getXY(),"",tr("Base XY plane"));
-            combolinks.addLink(orig->getYZ(),"",tr("Base YZ plane"));
-            combolinks.addLink(orig->getXZ(),"",tr("Base XZ plane"));
-        } catch (const Base::Exception &ex) {
-            Base::Console().Error ("%s\n", ex.what() );
+            combolinks.addLink(orig->getXY(), "", tr("Base XY plane"));
+            combolinks.addLink(orig->getYZ(), "", tr("Base YZ plane"));
+            combolinks.addLink(orig->getXZ(), "", tr("Base XZ plane"));
+        }
+        catch (const Base::Exception& ex) {
+            Base::Console().Error("%s\n", ex.what());
         }
     }
 
-    //add "Select reference"
-    combolinks.addLink(nullptr,std::string(),tr("Select reference..."));
+    // add "Select reference"
+    combolinks.addLink(nullptr, std::string(), tr("Select reference..."));
 }
 
-void TaskTransformedParameters::recomputeFeature() {
+void TaskTransformedParameters::recomputeFeature()
+{
     getTopTransformedView()->recomputeFeature();
 }
 
-PartDesignGui::ViewProviderTransformed *TaskTransformedParameters::getTopTransformedView() const {
-    PartDesignGui::ViewProviderTransformed *rv;
+PartDesignGui::ViewProviderTransformed* TaskTransformedParameters::getTopTransformedView() const
+{
+    PartDesignGui::ViewProviderTransformed* rv;
 
     if (insideMultiTransform) {
         rv = parentTask->TransformedView;
-    } else {
+    }
+    else {
         rv = TransformedView;
     }
     return rv;
 }
 
-PartDesign::Transformed *TaskTransformedParameters::getTopTransformedObject() const {
+PartDesign::Transformed* TaskTransformedParameters::getTopTransformedObject() const
+{
     ViewProviderTransformed* vp = getTopTransformedView();
-    if (!vp)
+    if (!vp) {
         return nullptr;
+    }
 
-    App::DocumentObject *transform = vp->getObject();
-    assert (transform->isDerivedFrom(PartDesign::Transformed::getClassTypeId()));
+    App::DocumentObject* transform = vp->getObject();
+    assert(transform->isDerivedFrom(PartDesign::Transformed::getClassTypeId()));
     return static_cast<PartDesign::Transformed*>(transform);
 }
 
-PartDesign::Transformed *TaskTransformedParameters::getObject() const {
-    if (insideMultiTransform)
+PartDesign::Transformed* TaskTransformedParameters::getObject() const
+{
+    if (insideMultiTransform) {
         return parentTask->getSubFeature();
-    else if (TransformedView)
+    }
+    else if (TransformedView) {
         return static_cast<PartDesign::Transformed*>(TransformedView->getObject());
-    else
+    }
+    else {
         return nullptr;
+    }
 }
 
-App::DocumentObject *TaskTransformedParameters::getBaseObject() const {
-    PartDesign::Feature* feature = getTopTransformedObject ();
-    if (!feature)
+App::DocumentObject* TaskTransformedParameters::getBaseObject() const
+{
+    PartDesign::Feature* feature = getTopTransformedObject();
+    if (!feature) {
         return nullptr;
+    }
 
     // NOTE: getBaseObject() throws if there is no base; shouldn't happen here.
-    App::DocumentObject *base = feature->getBaseObject(true);
-    if(!base) {
+    App::DocumentObject* base = feature->getBaseObject(true);
+    if (!base) {
         auto body = feature->getFeatureBody();
-        if(body)
+        if (body) {
             base = body->getPrevSolidFeature(feature);
+        }
     }
     return base;
 }
 
-App::DocumentObject* TaskTransformedParameters::getSketchObject() const {
+App::DocumentObject* TaskTransformedParameters::getSketchObject() const
+{
     PartDesign::Transformed* feature = getTopTransformedObject();
     return feature ? feature->getSketchObject() : nullptr;
 }
@@ -501,23 +543,27 @@ void TaskTransformedParameters::exitSelectionMode()
         selectionMode = SelectionMode::None;
         Gui::Selection().rmvSelectionGate();
         showObject();
-    } catch(Base::Exception &e) {
+    }
+    catch (Base::Exception& e) {
         e.ReportException();
     }
 }
 
 void TaskTransformedParameters::addReferenceSelectionGate(AllowSelectionFlags allow)
 {
-    std::unique_ptr<Gui::SelectionFilterGate> gateRefPtr(new ReferenceSelection(getBaseObject(), allow));
-    std::unique_ptr<Gui::SelectionFilterGate> gateDepPtr(new NoDependentsSelection(getTopTransformedObject()));
+    std::unique_ptr<Gui::SelectionFilterGate> gateRefPtr(
+        new ReferenceSelection(getBaseObject(), allow));
+    std::unique_ptr<Gui::SelectionFilterGate> gateDepPtr(
+        new NoDependentsSelection(getTopTransformedObject()));
     Gui::Selection().addSelectionGate(new CombineSelectionFilterGates(gateRefPtr, gateDepPtr));
 }
 
 void TaskTransformedParameters::indexesMoved()
 {
     QAbstractItemModel* model = qobject_cast<QAbstractItemModel*>(sender());
-    if (!model)
+    if (!model) {
         return;
+    }
 
     PartDesign::Transformed* pcTransformed = getObject();
     std::vector<App::DocumentObject*> originals = pcTransformed->Originals.getValues();
@@ -540,7 +586,8 @@ void TaskTransformedParameters::indexesMoved()
 // TaskDialog
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-TaskDlgTransformedParameters::TaskDlgTransformedParameters(ViewProviderTransformed *TransformedView_)
+TaskDlgTransformedParameters::TaskDlgTransformedParameters(
+    ViewProviderTransformed* TransformedView_)
     : TaskDlgFeatureParameters(TransformedView_)
 {
     assert(vp);
@@ -556,7 +603,7 @@ bool TaskDlgTransformedParameters::accept()
     parameter->exitSelectionMode();
     parameter->apply();
 
-    return TaskDlgFeatureParameters::accept ();
+    return TaskDlgFeatureParameters::accept();
 }
 
 bool TaskDlgTransformedParameters::reject()
@@ -564,74 +611,81 @@ bool TaskDlgTransformedParameters::reject()
     // ensure that we are not in selection mode
     parameter->exitSelectionMode();
 
-    return TaskDlgFeatureParameters::reject ();
+    return TaskDlgFeatureParameters::reject();
 }
 
 
 #include "moc_TaskTransformedParameters.cpp"
 
 
-ComboLinks::ComboLinks(QComboBox &combo)
+ComboLinks::ComboLinks(QComboBox& combo)
     : _combo(&combo)
 {
     _combo->clear();
 }
 
-int ComboLinks::addLink(const App::PropertyLinkSub &lnk, QString itemText)
+int ComboLinks::addLink(const App::PropertyLinkSub& lnk, QString itemText)
 {
-    if(!_combo)
+    if (!_combo) {
         return 0;
+    }
     _combo->addItem(itemText);
     this->linksInList.push_back(new App::PropertyLinkSub());
-    App::PropertyLinkSub &newitem = *(linksInList[linksInList.size()-1]);
+    App::PropertyLinkSub& newitem = *(linksInList[linksInList.size() - 1]);
     newitem.Paste(lnk);
-    if (newitem.getValue() && !this->doc)
+    if (newitem.getValue() && !this->doc) {
         this->doc = newitem.getValue()->getDocument();
-    return linksInList.size()-1;
+    }
+    return linksInList.size() - 1;
 }
 
-int ComboLinks::addLink(App::DocumentObject *linkObj, std::string linkSubname, QString itemText)
+int ComboLinks::addLink(App::DocumentObject* linkObj, std::string linkSubname, QString itemText)
 {
-    if(!_combo)
+    if (!_combo) {
         return 0;
+    }
     _combo->addItem(itemText);
     this->linksInList.push_back(new App::PropertyLinkSub());
-    App::PropertyLinkSub &newitem = *(linksInList[linksInList.size()-1]);
-    newitem.setValue(linkObj,std::vector<std::string>(1,linkSubname));
-    if (newitem.getValue() && !this->doc)
+    App::PropertyLinkSub& newitem = *(linksInList[linksInList.size() - 1]);
+    newitem.setValue(linkObj, std::vector<std::string>(1, linkSubname));
+    if (newitem.getValue() && !this->doc) {
         this->doc = newitem.getValue()->getDocument();
-    return linksInList.size()-1;
+    }
+    return linksInList.size() - 1;
 }
 
 void ComboLinks::clear()
 {
-    for(size_t i = 0  ;  i < this->linksInList.size()  ;  i++){
+    for (size_t i = 0; i < this->linksInList.size(); i++) {
         delete linksInList[i];
     }
-    if(this->_combo)
+    if (this->_combo) {
         _combo->clear();
+    }
 }
 
-App::PropertyLinkSub &ComboLinks::getLink(int index) const
+App::PropertyLinkSub& ComboLinks::getLink(int index) const
 {
-    if (index < 0 || index > static_cast<int>(linksInList.size())-1)
+    if (index < 0 || index > static_cast<int>(linksInList.size()) - 1) {
         throw Base::IndexError("ComboLinks::getLink:Index out of range");
-    if (linksInList[index]->getValue() && doc && !(doc->isIn(linksInList[index]->getValue())))
+    }
+    if (linksInList[index]->getValue() && doc && !(doc->isIn(linksInList[index]->getValue()))) {
         throw Base::ValueError("Linked object is not in the document; it may have been deleted");
+    }
     return *(linksInList[index]);
 }
 
-App::PropertyLinkSub &ComboLinks::getCurrentLink() const
+App::PropertyLinkSub& ComboLinks::getCurrentLink() const
 {
     assert(_combo);
     return getLink(_combo->currentIndex());
 }
 
-int ComboLinks::setCurrentLink(const App::PropertyLinkSub &lnk)
+int ComboLinks::setCurrentLink(const App::PropertyLinkSub& lnk)
 {
-    for(size_t i = 0  ;  i < linksInList.size()  ;  i++) {
-        App::PropertyLinkSub &it = *(linksInList[i]);
-        if(lnk.getValue() == it.getValue() && lnk.getSubValues() == it.getSubValues()){
+    for (size_t i = 0; i < linksInList.size(); i++) {
+        App::PropertyLinkSub& it = *(linksInList[i]);
+        if (lnk.getValue() == it.getValue() && lnk.getSubValues() == it.getSubValues()) {
             bool wasBlocked = _combo->signalsBlocked();
             _combo->blockSignals(true);
             _combo->setCurrentIndex(i);

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
@@ -159,11 +159,6 @@ void TaskTransformedParameters::clearButtons()
     }
 }
 
-bool TaskTransformedParameters::isViewUpdated() const
-{
-    return (blockUpdate == false);
-}
-
 int TaskTransformedParameters::getUpdateViewTimeout() const
 {
     return 500;
@@ -560,7 +555,6 @@ bool TaskDlgTransformedParameters::accept()
 {
     parameter->exitSelectionMode();
 
-    // Continue (usually in virtual method accept())
     return TaskDlgFeatureParameters::accept ();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
@@ -554,6 +554,7 @@ TaskDlgTransformedParameters::TaskDlgTransformedParameters(ViewProviderTransform
 bool TaskDlgTransformedParameters::accept()
 {
     parameter->exitSelectionMode();
+    parameter->apply();
 
     return TaskDlgFeatureParameters::accept ();
 }
@@ -562,6 +563,7 @@ bool TaskDlgTransformedParameters::reject()
 {
     // ensure that we are not in selection mode
     parameter->exitSelectionMode();
+
     return TaskDlgFeatureParameters::reject ();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
@@ -57,11 +57,7 @@ using namespace Gui;
 TaskTransformedParameters::TaskTransformedParameters(ViewProviderTransformed *TransformedView, QWidget *parent)
     : TaskBox(Gui::BitmapFactory().pixmap(TransformedView->featureIcon().c_str()),
               TransformedView->menuName, true, parent)
-    , proxy(nullptr)
     , TransformedView(TransformedView)
-    , parentTask(nullptr)
-    , insideMultiTransform(false)
-    , blockUpdate(false)
     , ui(new Ui_TaskTransformedParameters)
 {
     Gui::Document* doc = TransformedView->getDocument();
@@ -73,11 +69,8 @@ TaskTransformedParameters::TaskTransformedParameters(ViewProviderTransformed *Tr
 
 TaskTransformedParameters::TaskTransformedParameters(TaskMultiTransformParameters *parentTask)
     : TaskBox(QPixmap(), tr(""), true, parentTask),
-      proxy(nullptr),
-      TransformedView(nullptr),
       parentTask(parentTask),
-      insideMultiTransform(true),
-      blockUpdate(false)
+      insideMultiTransform(true)
 {
 }
 
@@ -553,7 +546,7 @@ void TaskTransformedParameters::indexesMoved()
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 TaskDlgTransformedParameters::TaskDlgTransformedParameters(ViewProviderTransformed *TransformedView_)
-    : TaskDlgFeatureParameters(TransformedView_), parameter(nullptr)
+    : TaskDlgFeatureParameters(TransformedView_)
 {
     assert(vp);
     message = new TaskTransformedMessages(getTransformedView());
@@ -583,9 +576,8 @@ bool TaskDlgTransformedParameters::reject()
 
 
 ComboLinks::ComboLinks(QComboBox &combo)
-    : doc(nullptr)
+    : _combo(&combo)
 {
-    this->_combo = &combo;
     _combo->clear();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
@@ -196,7 +196,7 @@ void TaskTransformedParameters::removeObject(App::DocumentObject* obj)
 bool TaskTransformedParameters::originalSelected(const Gui::SelectionChanges& msg)
 {
     if (msg.Type == Gui::SelectionChanges::AddSelection && (
-                (selectionMode == addFeature) || (selectionMode == removeFeature))) {
+                (selectionMode == SelectionMode::AddFeature) || (selectionMode == SelectionMode::RemoveFeature))) {
 
         if (strcmp(msg.pDocName, getObject()->getDocument()->getName()) != 0)
             return false;
@@ -208,7 +208,7 @@ bool TaskTransformedParameters::originalSelected(const Gui::SelectionChanges& ms
             // Do the same like in TaskDlgTransformedParameters::accept() but without doCommand
             std::vector<App::DocumentObject*> originals = pcTransformed->Originals.getValues();
             std::vector<App::DocumentObject*>::iterator o = std::find(originals.begin(), originals.end(), selectedObject);
-            if (selectionMode == addFeature) {
+            if (selectionMode == SelectionMode::AddFeature) {
                 if (o == originals.end()) {
                     originals.push_back(selectedObject);
                     addObject(selectedObject);
@@ -271,7 +271,7 @@ void TaskTransformedParameters::onButtonAddFeature(bool checked)
     if (checked) {
         hideObject();
         showBase();
-        selectionMode = addFeature;
+        selectionMode = SelectionMode::AddFeature;
         Gui::Selection().clearSelection();
     } else {
         exitSelectionMode();
@@ -303,7 +303,7 @@ void TaskTransformedParameters::onButtonRemoveFeature(bool checked)
 {
     if (checked) {
         checkVisibility();
-        selectionMode = removeFeature;
+        selectionMode = SelectionMode::RemoveFeature;
         Gui::Selection().clearSelection();
     } else {
         exitSelectionMode();
@@ -510,7 +510,7 @@ void TaskTransformedParameters::exitSelectionMode()
 {
     try {
         clearButtons();
-        selectionMode = none;
+        selectionMode = SelectionMode::None;
         Gui::Selection().rmvSelectionGate();
         showObject();
     } catch(Base::Exception &e) {

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
@@ -205,7 +205,7 @@ bool TaskTransformedParameters::originalSelected(const Gui::SelectionChanges& ms
         PartDesign::Transformed* pcTransformed = getObject();
         App::DocumentObject* selectedObject =
             pcTransformed->getDocument()->getObject(msg.pObjectName);
-        if (selectedObject->isDerivedFrom(PartDesign::FeatureAddSub::getClassTypeId())) {
+        if (selectedObject->isDerivedFrom<PartDesign::FeatureAddSub>()) {
 
             // Do the same like in TaskDlgTransformedParameters::accept() but without doCommand
             std::vector<App::DocumentObject*> originals = pcTransformed->Originals.getValues();
@@ -298,7 +298,7 @@ void TaskTransformedParameters::checkVisibility()
     auto inset = feat->getInListEx(true);
     inset.emplace(feat);
     for (auto obj : body->Group.getValues()) {
-        if (!obj->Visibility.getValue() || !obj->isDerivedFrom(PartDesign::Feature::getClassTypeId())) {
+        if (!obj->Visibility.getValue() || !obj->isDerivedFrom<PartDesign::Feature>()) {
             continue;
         }
         if (inset.count(obj) > 0) {
@@ -441,7 +441,7 @@ PartDesign::Transformed* TaskTransformedParameters::getTopTransformedObject() co
     }
 
     App::DocumentObject* transform = vp->getObject();
-    assert(transform->isDerivedFrom(PartDesign::Transformed::getClassTypeId()));
+    assert(transform->isDerivedFrom<PartDesign::Transformed>());
     return static_cast<PartDesign::Transformed*>(transform);
 }
 

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -67,7 +67,8 @@ public:
      * will go out of sync, and crashes may result.
      */
     explicit ComboLinks(QComboBox &combo);
-    ComboLinks() {_combo = nullptr; doc = nullptr;}
+    ComboLinks() = default;
+
     void setCombo(QComboBox &combo) {assert(!_combo); this->_combo = &combo; _combo->clear();}
 
     /**
@@ -104,8 +105,8 @@ public:
 
     ~ComboLinks() {_combo = nullptr; clear();}
 private:
-    QComboBox* _combo;
-    App::Document* doc;
+    QComboBox* _combo = nullptr;
+    App::Document* doc = nullptr;
     std::vector<App::PropertyLinkSub*> linksInList;
 };
 
@@ -227,8 +228,8 @@ protected:
     void fillPlanesCombo(ComboLinks &combolinks, Part::Part2DObject *sketch);
 
 protected:
-    QWidget* proxy;
-    ViewProviderTransformed *TransformedView;
+    QWidget* proxy = nullptr;
+    ViewProviderTransformed *TransformedView = nullptr;
     int transactionID = 0;
     bool enableTransaction = true;
 
@@ -241,11 +242,11 @@ protected:
     SelectionMode selectionMode = SelectionMode::None;
 
     /// The MultiTransform parent task of this task
-    TaskMultiTransformParameters* parentTask;
+    TaskMultiTransformParameters* parentTask = nullptr;
     /// Flag indicating whether this object is a container for MultiTransform
-    bool insideMultiTransform;
+    bool insideMultiTransform = false;
     /// Lock updateUI(), applying changes to the underlying feature and calling recomputeFeature()
-    bool blockUpdate;
+    bool blockUpdate = false;
 
 private:
     std::unique_ptr<Ui_TaskTransformedParameters> ui;
@@ -268,9 +269,10 @@ public:
     bool accept() override;
     /// is called by the framework if the dialog is rejected (Cancel)
     bool reject() override;
+
 protected:
-    TaskTransformedParameters  *parameter;
-    TaskTransformedMessages  *message;
+    TaskTransformedParameters  *parameter = nullptr;
+    TaskTransformedMessages  *message = nullptr;
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -205,7 +205,6 @@ protected:
 
     void addReferenceSelectionGate(AllowSelectionFlags);
 
-    bool isViewUpdated() const;
     int getUpdateViewTimeout() const;
 
     void checkVisibility();
@@ -259,7 +258,6 @@ class TaskDlgTransformedParameters : public PartDesignGui::TaskDlgFeatureParamet
 
 public:
     explicit TaskDlgTransformedParameters(ViewProviderTransformed *TransformedView);
-    ~TaskDlgTransformedParameters() override = default;
 
     ViewProviderTransformed* getTransformedView() const
     { return static_cast<ViewProviderTransformed*>(vp); }

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -85,8 +85,8 @@ public:
      * @param itemText
      * @return
      */
-    int addLink(const App::PropertyLinkSub& lnk, QString itemText);
-    int addLink(App::DocumentObject* linkObj, std::string linkSubname, QString itemText);
+    int addLink(const App::PropertyLinkSub& lnk, QString const& itemText);
+    int addLink(App::DocumentObject* linkObj, std::string const& linkSubname, QString const& itemText);
     void clear();
     App::PropertyLinkSub& getLink(int index) const;
 
@@ -158,7 +158,7 @@ public:
      * instance that does it already, e.g. TaskDlgMultiTransformParameters.
      * By default, transactions are enabled.
      */
-    void setEnabledTransaction(bool);
+    void setEnabledTransaction(bool /*unsused*/);
 
     /// Exit the selection mode of the associated task panel
     void exitSelectionMode();
@@ -215,10 +215,10 @@ protected:
     void setupTransaction();
 
 private Q_SLOTS:
-    virtual void onUpdateView(bool) = 0;
+    virtual void onUpdateView(bool /*unsused*/) = 0;
 
-    void onButtonAddFeature(const bool checked);
-    void onButtonRemoveFeature(const bool checked);
+    void onButtonAddFeature(bool checked);
+    void onButtonRemoveFeature(bool checked);
     void onFeatureDeleted();
     void indexesMoved();
 
@@ -255,7 +255,7 @@ private:
      */
     PartDesign::Transformed* getTopTransformedObject() const;
 
-    void changeEvent(QEvent* e) override;
+    void changeEvent(QEvent* event) override;
 
     static void removeItemFromListWidget(QListWidget* widget, const QString& itemstr);
 

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -38,6 +38,8 @@
 
 class QListWidget;
 
+class Ui_TaskTransformedParameters;
+
 namespace Part {
 class Feature;
 }
@@ -177,10 +179,12 @@ protected Q_SLOTS:
     virtual void onSubTaskButtonOK() {}
     void onButtonAddFeature(const bool checked);
     void onButtonRemoveFeature(const bool checked);
-    virtual void onFeatureDeleted() = 0;
+    void onFeatureDeleted();
     void indexesMoved();
 
 protected:
+    void setupUI();
+
     /**
      * Returns the base transformation
      * For stand alone features it will be objects associated with the view provider
@@ -205,14 +209,18 @@ protected:
 
     void checkVisibility();
 
+private:
+    virtual void setupParameterUI(QWidget* widget) = 0;
+    virtual void retranslateParameterUI(QWidget* widget) = 0;
+
 protected:
     virtual void addObject(App::DocumentObject*);
     virtual void removeObject(App::DocumentObject*);
     /** Notifies when the object is about to be removed. */
     void slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj) override;
-    void changeEvent(QEvent *e) override = 0;
-    void onSelectionChanged(const Gui::SelectionChanges& msg) override = 0;
-    virtual void clearButtons()=0;
+    void changeEvent(QEvent *e) override;
+    void onSelectionChanged(const Gui::SelectionChanges& msg) override;
+    void clearButtons();
     static void removeItemFromListWidget(QListWidget* widget, const QString& itemstr);
 
     void fillAxisCombo(ComboLinks &combolinks, Part::Part2DObject *sketch);
@@ -233,6 +241,9 @@ protected:
     bool insideMultiTransform;
     /// Lock updateUI(), applying changes to the underlying feature and calling recomputeFeature()
     bool blockUpdate;
+
+private:
+    std::unique_ptr<Ui_TaskTransformedParameters> ui;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -232,8 +232,13 @@ protected:
     int transactionID = 0;
     bool enableTransaction = true;
 
-    enum selectionModes { none, addFeature, removeFeature, reference };
-    selectionModes selectionMode = none;
+    enum class SelectionMode {
+        None,
+        AddFeature,
+        RemoveFeature,
+        Reference
+    };
+    SelectionMode selectionMode = SelectionMode::None;
 
     /// The MultiTransform parent task of this task
     TaskMultiTransformParameters* parentTask;

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -150,10 +150,7 @@ public:
     ~TaskTransformedParameters() override;
 
     /// Apply changes for python console
-    void apply()
-    {
-        doApply();
-    }
+    virtual void apply() = 0;
 
     /*!
      * \brief setEnabledTransaction
@@ -234,9 +231,6 @@ private:
 
     /// Change translation of the parameter UI
     virtual void retranslateParameterUI(QWidget* widget) = 0;
-
-    /// Implementation for apply()
-    virtual void doApply() = 0;
 
     void addObject(App::DocumentObject*);
     void removeObject(App::DocumentObject*);

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -158,7 +158,7 @@ public:
      * instance that does it already, e.g. TaskDlgMultiTransformParameters.
      * By default, transactions are enabled.
      */
-    void setEnabledTransaction(bool /*unsused*/);
+    void setEnabledTransaction(bool /*unused*/);
 
     /// Exit the selection mode of the associated task panel
     void exitSelectionMode();
@@ -215,7 +215,7 @@ protected:
     void setupTransaction();
 
 private Q_SLOTS:
-    virtual void onUpdateView(bool /*unsused*/) = 0;
+    virtual void onUpdateView(bool /*unused*/) = 0;
 
     void onButtonAddFeature(bool checked);
     void onButtonRemoveFeature(bool checked);

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -131,7 +131,11 @@ public:
     explicit TaskTransformedParameters(TaskMultiTransformParameters *parentTask);
     ~TaskTransformedParameters() override;
 
-    virtual void apply() = 0;
+    /// Apply changes for python console
+    void apply()
+    {
+        doApply();
+    }
 
     /*!
      * \brief setEnabledTransaction
@@ -211,6 +215,9 @@ private:
 
     /// Change translation of the parameter UI
     virtual void retranslateParameterUI(QWidget* widget) = 0;
+
+    /// Implementation for apply()
+    virtual void doApply() = 0;
 
     void addObject(App::DocumentObject*);
     void removeObject(App::DocumentObject*);

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -40,15 +40,18 @@ class QListWidget;
 
 class Ui_TaskTransformedParameters;
 
-namespace Part {
+namespace Part
+{
 class Feature;
 }
 
-namespace PartDesign {
+namespace PartDesign
+{
 class Transformed;
 }
 
-namespace PartDesignGui {
+namespace PartDesignGui
+{
 
 class TaskMultiTransformParameters;
 
@@ -66,10 +69,15 @@ public:
      * remove items from the combo directly, otherwise internal tracking list
      * will go out of sync, and crashes may result.
      */
-    explicit ComboLinks(QComboBox &combo);
+    explicit ComboLinks(QComboBox& combo);
     ComboLinks() = default;
 
-    void setCombo(QComboBox &combo) {assert(!_combo); this->_combo = &combo; _combo->clear();}
+    void setCombo(QComboBox& combo)
+    {
+        assert(!_combo);
+        this->_combo = &combo;
+        _combo->clear();
+    }
 
     /**
      * @brief addLink adds an item to the combo. Doesn't check for duplicates.
@@ -77,7 +85,7 @@ public:
      * @param itemText
      * @return
      */
-    int addLink(const App::PropertyLinkSub &lnk, QString itemText);
+    int addLink(const App::PropertyLinkSub& lnk, QString itemText);
     int addLink(App::DocumentObject* linkObj, std::string linkSubname, QString itemText);
     void clear();
     App::PropertyLinkSub& getLink(int index) const;
@@ -99,11 +107,20 @@ public:
      * @param lnk
      * @return the index of an item that was selected, -1 if link is not in the list yet.
      */
-    int setCurrentLink(const App::PropertyLinkSub &lnk);
+    int setCurrentLink(const App::PropertyLinkSub& lnk);
 
-    QComboBox& combo() const {assert(_combo); return *_combo;}
+    QComboBox& combo() const
+    {
+        assert(_combo);
+        return *_combo;
+    }
 
-    ~ComboLinks() {_combo = nullptr; clear();}
+    ~ComboLinks()
+    {
+        _combo = nullptr;
+        clear();
+    }
+
 private:
     QComboBox* _combo = nullptr;
     App::Document* doc = nullptr;
@@ -118,17 +135,18 @@ private:
   Because in the second case there is no ViewProvider, some special methods are required to
   access the underlying FeatureTransformed object in two different ways.
   **/
-class TaskTransformedParameters : public Gui::TaskView::TaskBox,
-                                  public Gui::SelectionObserver,
-                                  public Gui::DocumentObserver
+class TaskTransformedParameters: public Gui::TaskView::TaskBox,
+                                 public Gui::SelectionObserver,
+                                 public Gui::DocumentObserver
 {
     Q_OBJECT
 
 public:
     /// Constructor for task with ViewProvider
-    explicit TaskTransformedParameters(ViewProviderTransformed *TransformedView, QWidget *parent = nullptr);
+    explicit TaskTransformedParameters(ViewProviderTransformed* TransformedView,
+                                       QWidget* parent = nullptr);
     /// Constructor for task with parent task (MultiTransform mode)
-    explicit TaskTransformedParameters(TaskMultiTransformParameters *parentTask);
+    explicit TaskTransformedParameters(TaskMultiTransformParameters* parentTask);
     ~TaskTransformedParameters() override;
 
     /// Apply changes for python console
@@ -150,8 +168,8 @@ public:
 
 protected:
     /** Setup the standalone UI.
-      * Call this in the derived destructor with ViewProvider.
-      */
+     * Call this in the derived destructor with ViewProvider.
+     */
     void setupUI();
 
     /**
@@ -159,14 +177,15 @@ protected:
      * For stand alone features it will be object associated with the view provider
      * For features inside MultiTransform it will be the parent MultiTransform's sub feature object
      */
-    PartDesign::Transformed *getObject() const;
+    PartDesign::Transformed* getObject() const;
 
-    /// Get the sketch object of the first original either of the object associated with this feature or with the parent feature (MultiTransform mode)
+    /// Get the sketch object of the first original either of the object associated with this
+    /// feature or with the parent feature (MultiTransform mode)
     App::DocumentObject* getSketchObject() const;
 
     /** Handle adding/removing of selected features
-      * Returns true if a selected feature was added/removed.
-      */
+     * Returns true if a selected feature was added/removed.
+     */
     bool originalSelected(const Gui::SelectionChanges& msg);
 
     /// Recompute either this feature or the parent MultiTransform feature
@@ -191,9 +210,9 @@ protected:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
 
     /// Fill combobox with the axis from the sketch and the own bodys origin axis
-    void fillAxisCombo(ComboLinks &combolinks, Part::Part2DObject *sketch);
+    void fillAxisCombo(ComboLinks& combolinks, Part::Part2DObject* sketch);
     /// Fill combobox with the planes from the sketch and the own bodys origin planes
-    void fillPlanesCombo(ComboLinks &combolinks, Part::Part2DObject *sketch);
+    void fillPlanesCombo(ComboLinks& combolinks, Part::Part2DObject* sketch);
 
     bool isEnabledTransaction() const;
     void setupTransaction();
@@ -208,9 +227,9 @@ private Q_SLOTS:
 
 private:
     /** Setup the parameter UI.
-      * This is called to create the parameter UI in the specified widget.
-      * Call this in the derived constructor with MultiTransform parent.
-      */
+     * This is called to create the parameter UI in the specified widget.
+     * Call this in the derived constructor with MultiTransform parent.
+     */
     virtual void setupParameterUI(QWidget* widget) = 0;
 
     /// Change translation of the parameter UI
@@ -226,35 +245,36 @@ private:
 
     /// Return the base object of the base transformed object (see getTopTransformedObject())
     // Either through the ViewProvider or the currently active subFeature of the parentTask
-    App::DocumentObject *getBaseObject() const;
+    App::DocumentObject* getBaseObject() const;
 
     /**
      * Returns the base transformation view provider
      * For stand alone features it will be view provider associated with this object
      * For features inside multitransform it will be the view provider of the multitransform object
      */
-    PartDesignGui::ViewProviderTransformed *getTopTransformedView () const;
+    PartDesignGui::ViewProviderTransformed* getTopTransformedView() const;
 
     /**
      * Returns the base transformed object
      * For stand alone features it will be objects associated with this object
      * For features inside multitransform it will be the base multitransform object
      */
-    PartDesign::Transformed *getTopTransformedObject () const;
+    PartDesign::Transformed* getTopTransformedObject() const;
 
-    void changeEvent(QEvent *e) override;
+    void changeEvent(QEvent* e) override;
 
     static void removeItemFromListWidget(QListWidget* widget, const QString& itemstr);
 
 protected:
-    enum class SelectionMode {
+    enum class SelectionMode
+    {
         None,
         AddFeature,
         RemoveFeature,
         Reference
     };
 
-    ViewProviderTransformed *TransformedView = nullptr;
+    ViewProviderTransformed* TransformedView = nullptr;
     SelectionMode selectionMode = SelectionMode::None;
 
     /// Lock updateUI(), applying changes to the underlying feature and calling recomputeFeature()
@@ -273,15 +293,17 @@ private:
 };
 
 /// simulation dialog for the TaskView
-class TaskDlgTransformedParameters : public PartDesignGui::TaskDlgFeatureParameters
+class TaskDlgTransformedParameters: public PartDesignGui::TaskDlgFeatureParameters
 {
     Q_OBJECT
 
 public:
-    explicit TaskDlgTransformedParameters(ViewProviderTransformed *TransformedView);
+    explicit TaskDlgTransformedParameters(ViewProviderTransformed* TransformedView);
 
     ViewProviderTransformed* getTransformedView() const
-    { return static_cast<ViewProviderTransformed*>(vp); }
+    {
+        return static_cast<ViewProviderTransformed*>(vp);
+    }
 
     /// is called by the framework if the dialog is accepted (Ok)
     bool accept() override;
@@ -289,10 +311,10 @@ public:
     bool reject() override;
 
 protected:
-    TaskTransformedParameters  *parameter = nullptr;
-    TaskTransformedMessages  *message = nullptr;
+    TaskTransformedParameters* parameter = nullptr;
+    TaskTransformedMessages* message = nullptr;
 };
 
-} //namespace PartDesignGui
+}  // namespace PartDesignGui
 
-#endif // GUI_TASKVIEW_TASKAPPERANCE_H
+#endif  // GUI_TASKVIEW_TASKAPPERANCE_H

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.ui
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PartDesignGui::TaskTransformedParameters</class>
+ <widget class="QWidget" name="PartDesignGui::TaskTransformedParameters">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>262</width>
+    <height>207</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="buttonAddFeature">
+       <property name="text">
+        <string>Add feature</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="buttonRemoveFeature">
+       <property name="text">
+        <string>Remove feature</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QListWidget" name="listWidgetFeatures">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>120</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>List can be reordered by dragging</string>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::InternalMove</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="featureUI" native="true"/>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxUpdateView">
+     <property name="text">
+      <string>Update view</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>buttonAddFeature</tabstop>
+  <tabstop>buttonRemoveFeature</tabstop>
+  <tabstop>listWidgetFeatures</tabstop>
+  <tabstop>checkBoxUpdateView</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
The PD Pattern task panels contain a lot of code duplication around the feature list which makes it difficult to work on the
common ui elements.

These commits move the code for the feature list into the base class ``TaskTransformedParameters``. All the duplicated widgets
are removed from the ui files. The pattern specific ui files only contain the widgets for their parameters. These are then added
to a placeholder widget in the common ui files at runtime.
The ui file for the MultiTransform pattern also contains such a placeholder widget.

The command report for the python console was not consisent which is also fixed by refactoring the ``apply()`` function.

The rest is code cleanup:
- Replace ``enum`` with ``enum class``
- Use default member initializers
- Limit member access as much as possible (``private``, ``protected``)
- Reformat with clang-format