### PR TITLE
Toponaming/Part: Remove makeElementShape and cleanup opcode code

### DIFF
--- a/src/Mod/Part/App/FeaturePartBoolean.h
+++ b/src/Mod/Part/App/FeaturePartBoolean.h
@@ -58,6 +58,7 @@ public:
 
 protected:
     virtual BRepAlgoAPI_BooleanOperation* makeOperation(const TopoDS_Shape&, const TopoDS_Shape&) const = 0;
+    virtual const char *opCode() const = 0;
 };
 
 }

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -45,6 +45,11 @@ PROPERTY_SOURCE(Part::Common, Part::Boolean)
 
 Common::Common() = default;
 
+const char *Common::opCode() const
+{
+    return Part::OpCodes::Common;
+}
+
 BRepAlgoAPI_BooleanOperation* Common::makeOperation(const TopoDS_Shape& base, const TopoDS_Shape& tool) const
 {
     // Let's call algorithm computing a section operation:

--- a/src/Mod/Part/App/FeaturePartCommon.h
+++ b/src/Mod/Part/App/FeaturePartCommon.h
@@ -41,6 +41,7 @@ public:
     /// recalculate the Feature
 protected:
     BRepAlgoAPI_BooleanOperation* makeOperation(const TopoDS_Shape&, const TopoDS_Shape&) const override;
+    const char *opCode() const override;
     //@}
 };
 

--- a/src/Mod/Part/App/FeaturePartCut.cpp
+++ b/src/Mod/Part/App/FeaturePartCut.cpp
@@ -26,7 +26,7 @@
 #endif
 
 #include "FeaturePartCut.h"
-
+#include "TopoShapeOpCode.h"
 
 using namespace Part;
 
@@ -34,6 +34,11 @@ PROPERTY_SOURCE(Part::Cut, Part::Boolean)
 
 
 Cut::Cut() = default;
+
+const char *Cut::opCode() const
+{
+    return Part::OpCodes::Cut;
+}
 
 BRepAlgoAPI_BooleanOperation* Cut::makeOperation(const TopoDS_Shape& base, const TopoDS_Shape& tool) const
 {

--- a/src/Mod/Part/App/FeaturePartCut.h
+++ b/src/Mod/Part/App/FeaturePartCut.h
@@ -41,6 +41,7 @@ public:
     /// recalculate the Feature
 protected:
     BRepAlgoAPI_BooleanOperation* makeOperation(const TopoDS_Shape&, const TopoDS_Shape&) const override;
+    const char *opCode() const override;
     //@}
 };
 

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -35,6 +35,7 @@
 
 #include "FeaturePartFuse.h"
 #include "modelRefine.h"
+#include "TopoShapeOpCode.h"
 
 
 using namespace Part;
@@ -48,6 +49,11 @@ BRepAlgoAPI_BooleanOperation* Fuse::makeOperation(const TopoDS_Shape& base, cons
 {
     // Let's call algorithm computing a fuse operation:
     return new BRepAlgoAPI_Fuse(base, tool);
+}
+
+const char *Fuse::opCode() const
+{
+    return Part::OpCodes::Fuse;
 }
 
 // ----------------------------------------------------
@@ -97,9 +103,9 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
         compoundOfArguments = s[0];
         if (compoundOfArguments.ShapeType() == TopAbs_COMPOUND){
             s.clear();
-            TopoDS_Iterator it(compoundOfArguments);
-            for (; it.More(); it.Next()) {
-                const TopoDS_Shape& aChild = it.Value();
+            TopoDS_Iterator it2(compoundOfArguments);
+            for (; it2.More(); it2.Next()) {
+                const TopoDS_Shape& aChild = it2.Value();
                 s.push_back(aChild);
             }
             argumentsAreInCompound = true;
@@ -116,10 +122,10 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
                 throw Base::RuntimeError("Input shape is null");
             shapeArguments.Append(shape);
 
-            for (std::vector<TopoDS_Shape>::iterator it = s.begin()+1; it != s.end(); ++it) {
-                if (it->IsNull())
+            for (auto it2 = s.begin()+1; it2 != s.end(); ++it2) {
+                if (it2->IsNull())
                     throw Base::RuntimeError("Input shape is null");
-                shapeTools.Append(*it);
+                shapeTools.Append(*it2);
             }
 
             mkFuse.SetArguments(shapeArguments);
@@ -129,8 +135,8 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
                 throw Base::RuntimeError("MultiFusion failed");
 
             TopoDS_Shape resShape = mkFuse.Shape();
-            for (const auto & it : s) {
-                history.push_back(buildHistory(mkFuse, TopAbs_FACE, resShape, it));
+            for (const auto & it2 : s) {
+                history.push_back(buildHistory(mkFuse, TopAbs_FACE, resShape, it2));
             }
             if (resShape.IsNull())
                 throw Base::RuntimeError("Resulting shape is null");
@@ -173,7 +179,7 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
                     for(std::pair<const int,ShapeHistory::List> &histitem: history[iChild].shapeMap){ //loop over elements of history - that is - over faces of the child of source compound
                         int iFaceInChild = histitem.first;
                         ShapeHistory::List &iFacesInResult = histitem.second;
-                        TopoDS_Shape srcFace = facesOfChild(iFaceInChild + 1); //+1 to convert our 0-based to OCC 1-bsed conventions
+                        const TopoDS_Shape& srcFace = facesOfChild(iFaceInChild + 1); //+1 to convert our 0-based to OCC 1-bsed conventions
                         int iFaceInCompound = facesOfCompound.FindIndex(srcFace)-1;
                         overallHist.shapeMap[iFaceInCompound] = iFacesInResult; //this may overwrite existing info if the same face is used in several children of compound. This shouldn't be a problem, because the histories should match anyway...
                     }

--- a/src/Mod/Part/App/FeaturePartFuse.h
+++ b/src/Mod/Part/App/FeaturePartFuse.h
@@ -41,6 +41,7 @@ public:
     /// recalculate the Feature
 protected:
     BRepAlgoAPI_BooleanOperation* makeOperation(const TopoDS_Shape&, const TopoDS_Shape&) const override;
+    const char *opCode() const override;
     //@}
 };
 

--- a/src/Mod/Part/App/FeaturePartSection.cpp
+++ b/src/Mod/Part/App/FeaturePartSection.cpp
@@ -27,7 +27,7 @@
 #endif
 
 #include "FeaturePartSection.h"
-
+#include "TopoShapeOpCode.h"
 
 using namespace Part;
 
@@ -44,6 +44,12 @@ short Section::mustExecute() const
     if (Approximation.isTouched())
         return 1;
     return 0;
+}
+
+
+const char *Section::opCode() const
+{
+    return Part::OpCodes::Section;
 }
 
 BRepAlgoAPI_BooleanOperation* Section::makeOperation(const TopoDS_Shape& base, const TopoDS_Shape& tool) const

--- a/src/Mod/Part/App/FeaturePartSection.h
+++ b/src/Mod/Part/App/FeaturePartSection.h
@@ -46,6 +46,7 @@ public:
     short mustExecute() const override;
 protected:
     BRepAlgoAPI_BooleanOperation* makeOperation(const TopoDS_Shape&, const TopoDS_Shape&) const override;
+    virtual const char *opCode() const;
     //@}
 };
 

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -1396,172 +1396,15 @@ public:
         return TopoShape(0, Hasher).makeElementShape(mkShape, *this, op);
     }
 
-    /** Specialized shape making for BRepBuilderAPI_Sewing with mapped element name
-     *
-     * @param mkShape: OCCT shape maker.
-     * @param sources: list of source shapes.
-     * @param op: optional string to be encoded into topo naming for indicating
-     *            the operation
-     *
-     * @return The original content of this TopoShape is discarded and replaced
-     *         with the new shape built by the shape maker. The function
-     *         returns the TopoShape itself as a self reference so that
-     *         multiple operations can be carried out for the same shape in the
-     *         same line of code.
-     */
-    TopoShape& makeElementShape(BRepBuilderAPI_Sewing& mkShape,
-                                const std::vector<TopoShape>& sources,
-                                const char* op = nullptr);
-    /** Specialized shape making for BRepBuilderAPI_Sewing with mapped element name
-     *
-     * @param mkShape: OCCT shape maker.
-     * @param source: source shape.
-     * @param op: optional string to be encoded into topo naming for indicating
-     *            the operation
-     *
-     * @return The original content of this TopoShape is discarded and replaced
-     *         with the new shape built by the shape maker. The function
-     *         returns the TopoShape itself as a self reference so that
-     *         multiple operations can be carried out for the same shape in the
-     *         same line of code.
-     */
-    TopoShape& makeElementShape(BRepBuilderAPI_Sewing& mkShape,
-                                const TopoShape& source,
-                                const char* op = nullptr);
-    /** Specialized shape making for BRepBuilderAPI_Sewing with mapped element name
-     *
-     * @param mkShape: OCCT shape maker.
-     * @param op: optional string to be encoded into topo naming for indicating
-     *            the operation
-     *
-     * @return Returns the new shape built by the shape maker with mappend element
-     *         name generated using this shape as the source. The shape itself
-     *         is not modified.
-     */
-    TopoShape makeElementShape(BRepBuilderAPI_Sewing& mkShape, const char* op = nullptr) const
-    {
-        return TopoShape(0, Hasher).makeElementShape(mkShape, *this, op);
-    }
-
-    /** Specialized shape making for BRepBuilderAPI_ThruSections with mapped element name
-     *
-     * @param mkShape: OCCT shape maker.
-     * @param sources: list of source shapes.
-     * @param op: optional string to be encoded into topo naming for indicating
-     *            the operation
-     *
-     * @return The original content of this TopoShape is discarded and replaced
-     *         with the new shape built by the shape maker. The function
-     *         returns the TopoShape itself as a self reference so that
-     *         multiple operations can be carried out for the same shape in the
-     *         same line of code.
-     */
-    TopoShape& makeElementShape(BRepOffsetAPI_ThruSections& mkShape,
-                                const std::vector<TopoShape>& sources,
-                                const char* op = nullptr);
-    /** Specialized shape making for BRepBuilderAPI_Sewing with mapped element name
-     *
-     * @param mkShape: OCCT shape maker.
-     * @param source: source shape.
-     * @param op: optional string to be encoded into topo naming for indicating
-     *            the operation
-     *
-     * @return The original content of this TopoShape is discarded and replaced
-     *         with the new shape built by the shape maker. The function
-     *         returns the TopoShape itself as a self reference so that
-     *         multiple operations can be carried out for the same shape in the
-     *         same line of code.
-     */
-    TopoShape& makeElementShape(BRepOffsetAPI_ThruSections& mkShape,
-                                const TopoShape& source,
-                                const char* op = nullptr);
-    /** Specialized shape making for BRepBuilderAPI_Sewing with mapped element name
-     *
-     * @param mkShape: OCCT shape maker.
-     * @param op: optional string to be encoded into topo naming for indicating
-     *            the operation
-     *
-     * @return Returns the new shape built by the shape maker with mappend element
-     *         name generated using this shape as the source. The shape itself
-     *         is not modified.
-     */
-    TopoShape makeElementShape(BRepOffsetAPI_ThruSections& mkShape, const char* op = nullptr) const
-    {
-        return TopoShape(0, Hasher).makeElementShape(mkShape, *this, op);
-    }
-
-    /** Specialized shape making for BRepBuilderAPI_MakePipeShell with mapped element name
-     *
-     * @param mkShape: OCCT shape maker.
-     * @param sources: list of source shapes.
-     * @param op: optional string to be encoded into topo naming for indicating
-     *            the operation
-     *
-     * @return The original content of this TopoShape is discarded and replaced
-     *         with the new shape built by the shape maker. The function
-     *         returns the TopoShape itself as a self reference so that
-     *         multiple operations can be carried out for the same shape in the
-     *         same line of code.
-     */
-    TopoShape& makeElementShape(BRepOffsetAPI_MakePipeShell& mkShape,
-                                const std::vector<TopoShape>& sources,
-                                const char* op = nullptr);
-
-    /** Specialized shape making for BRepBuilderAPI_MakeHalfSpace with mapped element name
-     *
-     * @param mkShape: OCCT shape maker.
-     * @param source: source shape.
-     * @param op: optional string to be encoded into topo naming for indicating
-     *            the operation
-     *
-     * @return The original content of this TopoShape is discarded and replaced
-     *         with the new shape built by the shape maker. The function
-     *         returns the TopoShape itself as a self reference so that
-     *         multiple operations can be carried out for the same shape in the
-     *         same line of code.
-     */
-    TopoShape& makeElementShape(BRepPrimAPI_MakeHalfSpace& mkShape,
-                                const TopoShape& source,
-                                const char* op = nullptr);
-    /** Specialized shape making for BRepBuilderAPI_MakeHalfSpace with mapped element name
-     *
-     * @param mkShape: OCCT shape maker.
-     * @param op: optional string to be encoded into topo naming for indicating
-     *            the operation
-     *
-     * @return Returns the new shape built by the shape maker with mappend element
-     *         name generated using this shape as the source. The shape itself
-     *         is not modified.
-     */
-    TopoShape makeElementShape(BRepPrimAPI_MakeHalfSpace& mkShape, const char* op = nullptr) const
-    {
-        return TopoShape(0, Hasher).makeElementShape(mkShape, *this, op);
-    }
-
-    /** Specialized shape making for BRepBuilderAPI_MakePrism with mapped element name
-     *
-     * @param mkShape: OCCT shape maker.
-     * @param sources: list of source shapes.
-     * @param op: optional string to be encoded into topo naming for indicating
-     *            the operation
-     *
-     * @return The original content of this TopoShape is discarded and replaced
-     *         with the new shape built by the shape maker. The function
-     *         returns the TopoShape itself as a self reference so that
-     *         multiple operations can be carried out for the same shape in the
-     *         same line of code.
-     */
-    TopoShape& makeElementShape(BRepFeat_MakePrism& mkShape,
-                                const std::vector<TopoShape>& sources,
-                                const TopoShape& uptoface,
-                                const char* op);
-
-    /** Helper class to return the generated and modified shape given an input shape
-     *
-     * Shape history information is extracted using OCCT APIs
-     * BRepBuilderAPI_MakeShape::Generated/Modified(). However, there is often
-     * some glitches in various derived class. So we use this class as an
-     * abstraction, and create various derived classes to deal with the glitches.
+    /* Toponaming migration, February 2014:
+     * Note that the specialized versions of makeElementShape for operations that do not
+     * inherit from BRepBuilderAPI_MakeShape  ( like BRepBuilderAPI_Sewing ) have been removed.
+     * Rather than restore them, code that calls them should be changed to call
+     * makeShapeWithElementMap directly.  For example:
+     * makeElementShape(sewer, sources)
+     * makeShapeWithElementMap(sewer.SewedShape(), MapperSewing(sewer), sources, OpCodes::Sewing);
+     * Note that if op exists in the method, it should be checked for null and overriden with
+     * the appropriate operation if so.
      */
 
     friend class TopoShapeCache;
@@ -1727,6 +1570,15 @@ struct PartExport MapperMaker: TopoShape::Mapper
     {}
     const std::vector<TopoDS_Shape>& modified(const TopoDS_Shape& s) const override;
     const std::vector<TopoDS_Shape>& generated(const TopoDS_Shape& s) const override;
+};
+
+struct PartExport MapperSewing: TopoShape::Mapper
+{
+    BRepBuilderAPI_Sewing& maker;
+    explicit MapperSewing(BRepBuilderAPI_Sewing& maker)
+        : maker(maker)
+    {}
+    const std::vector<TopoDS_Shape>& modified(const TopoDS_Shape& s) const override;
 };
 
 /** Shape mapper for BRepTools_History

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -2403,35 +2403,28 @@ TopoShape::makeElementCopy(const TopoShape& shape, const char* op, bool copyGeom
     return *this;
 }
 
-struct MapperSewing: Part::TopoShape::Mapper
+const std::vector<TopoDS_Shape>& MapperSewing::modified(const TopoDS_Shape& s) const
 {
-    BRepBuilderAPI_Sewing& maker;
-    explicit MapperSewing(BRepBuilderAPI_Sewing& maker)
-        : maker(maker)
-    {}
-    const std::vector<TopoDS_Shape>& modified(const TopoDS_Shape& s) const override
-    {
-        _res.clear();
-        try {
-            const auto& shape = maker.Modified(s);
-            if (!shape.IsNull() && !shape.IsSame(s)) {
-                _res.push_back(shape);
-            }
-            else {
-                const auto& sshape = maker.ModifiedSubShape(s);
-                if (!sshape.IsNull() && !sshape.IsSame(s)) {
-                    _res.push_back(sshape);
-                }
+    _res.clear();
+    try {
+        const auto& shape = maker.Modified(s);
+        if (!shape.IsNull() && !shape.IsSame(s)) {
+            _res.push_back(shape);
+        }
+        else {
+            const auto& sshape = maker.ModifiedSubShape(s);
+            if (!sshape.IsNull() && !sshape.IsSame(s)) {
+                _res.push_back(sshape);
             }
         }
-        catch (const Standard_Failure& e) {
-            if (FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG)) {
-                FC_WARN("Exception on shape mapper: " << e.GetMessageString());
-            }
-        }
-        return _res;
     }
-};
+    catch (const Standard_Failure& e) {
+        if (FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG)) {
+            FC_WARN("Exception on shape mapper: " << e.GetMessageString());
+        }
+    }
+    return _res;
+}
 
 struct MapperThruSections: MapperMaker
 {
@@ -2476,7 +2469,6 @@ struct MapperThruSections: MapperMaker
     }
 };
 
-
 TopoShape& TopoShape::makeElementShape(BRepBuilderAPI_MakeShape& mkShape,
                                        const TopoShape& source,
                                        const char* op)
@@ -2490,64 +2482,6 @@ TopoShape& TopoShape::makeElementShape(BRepBuilderAPI_MakeShape& mkShape,
                                        const char* op)
 {
     return makeShapeWithElementMap(mkShape.Shape(), MapperMaker(mkShape), shapes, op);
-}
-
-TopoShape&
-TopoShape::makeElementShape(BRepOffsetAPI_ThruSections& mk, const TopoShape& source, const char* op)
-{
-    if (!op) {
-        op = Part::OpCodes::ThruSections;
-    }
-    return makeElementShape(mk, std::vector<TopoShape>(1, source), op);
-}
-
-TopoShape& TopoShape::makeElementShape(BRepOffsetAPI_ThruSections& mk,
-                                       const std::vector<TopoShape>& sources,
-                                       const char* op)
-{
-    if (!op) {
-        op = Part::OpCodes::ThruSections;
-    }
-    return makeShapeWithElementMap(mk.Shape(), MapperThruSections(mk, sources), sources, op);
-}
-
-TopoShape& TopoShape::makeElementShape(BRepBuilderAPI_Sewing& mk,
-                                       const std::vector<TopoShape>& shapes,
-                                       const char* op)
-{
-    if (!op) {
-        op = Part::OpCodes::Sewing;
-    }
-    return makeShapeWithElementMap(mk.SewedShape(), MapperSewing(mk), shapes, op);
-}
-
-TopoShape&
-TopoShape::makeElementShape(BRepBuilderAPI_Sewing& mkShape, const TopoShape& source, const char* op)
-{
-    if (!op) {
-        op = Part::OpCodes::Sewing;
-    }
-    return makeElementShape(mkShape, std::vector<TopoShape>(1, source), op);
-}
-
-TopoShape& TopoShape::makeElementShape(BRepPrimAPI_MakeHalfSpace& mkShape,
-                                       const TopoShape& source,
-                                       const char* op)
-{
-    if (!op) {
-        op = Part::OpCodes::HalfSpace;
-    }
-    return makeShapeWithElementMap(mkShape.Solid(), MapperMaker(mkShape), {source}, op);
-}
-
-TopoShape& TopoShape::makeElementShape(BRepOffsetAPI_MakePipeShell& mkShape,
-                                       const std::vector<TopoShape>& source,
-                                       const char* op)
-{
-    if (!op) {
-        op = Part::OpCodes::PipeShell;
-    }
-    return makeShapeWithElementMap(mkShape.Shape(), MapperMaker(mkShape), source, op);
 }
 
 TopoShape& TopoShape::makeElementLoft(const std::vector<TopoShape>& shapes,

--- a/tests/src/Mod/Part/App/TopoShapeMakeShape.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeMakeShape.cpp
@@ -7,6 +7,7 @@
 #include "src/App/InitApplication.h"
 #include "PartTestHelpers.h"
 #include <Mod/Part/App/TopoShape.h>
+#include <Mod/Part/App/TopoShapeOpCode.h>
 
 using namespace Data;
 using namespace Part;
@@ -92,7 +93,8 @@ TEST_F(TopoShapeMakeShapeTests, thruSections)
     thruMaker.AddWire(wire2);
     TopoShape topoShape {};
     // Act
-    TopoShape& result = topoShape.makeElementShape(thruMaker, {wire1ts, wire2ts});
+    TopoShape& result =
+        topoShape.makeElementShape(thruMaker, {wire1ts, wire2ts}, OpCodes::ThruSections);
     auto elements = elementMap(result);
     // Assert
     EXPECT_EQ(elements.size(), 24);
@@ -116,7 +118,11 @@ TEST_F(TopoShapeMakeShapeTests, sewing)
     std::vector<TopoShape> sources {{face1, 1L}, {face2, 2L}};
     TopoShape topoShape {};
     // Act
-    TopoShape& result = topoShape.makeElementShape(sewer, sources);
+    TopoShape& result = topoShape.makeShapeWithElementMap(sewer.SewedShape(),
+                                                          MapperSewing(sewer),
+                                                          sources,
+                                                          OpCodes::Sewing);
+
     auto elements = elementMap(result);
     // Assert
     EXPECT_EQ(&result, &topoShape);


### PR DESCRIPTION
Get rid of the unnecessary versions of makeElementShape.

Bring over the opCode definitions in the boolean operations.

Fix an issue with incorrect TNP branch boolean code before we flip over.

Some mild delinting.