### PR TITLE
Fem: Prevent stop CalculiX immediately - fixes #12448

### DIFF
--- a/src/Mod/Fem/femtaskpanels/task_solver_ccxtools.py
+++ b/src/Mod/Fem/femtaskpanels/task_solver_ccxtools.py
@@ -98,15 +98,17 @@ class _TaskPanel:
             QtCore.SIGNAL("clicked()"),
             self.editCalculixInputFile
         )
-        QtCore.QObject.connect(
-            self.form.pb_run_ccx,
-            QtCore.SIGNAL("clicked()"),
-            self.runCalculix
-        )
+        # connect stopCalculix before runCalculix
+        # see https://github.com/FreeCAD/FreeCAD/issues/12448
         QtCore.QObject.connect(
             self.form.pb_run_ccx,
             QtCore.SIGNAL("clicked()"),
             self.stopCalculix
+        )
+        QtCore.QObject.connect(
+            self.form.pb_run_ccx,
+            QtCore.SIGNAL("clicked()"),
+            self.runCalculix
         )
         QtCore.QObject.connect(
             self.form.rb_static_analysis,


### PR DESCRIPTION
According to the Qt docs, on some platforms (Windows) QProcess::start emits the started signal before the function returns.

With the current implementation of run/stop Calculix, this involves stopping the process immediately after starting it.
To solve this, stopCalculix is connected before runCalculix, so that on the first click the call to stopCalculix is irrelevant.

@FEA-eng can you confirm that this solves the issue on Windows?