### PR TITLE
FEM Beam reduced integration

### DIFF
--- a/src/Mod/Fem/femmesh/meshtools.py
+++ b/src/Mod/Fem/femmesh/meshtools.py
@@ -2517,11 +2517,11 @@ def beam_reduced_integration(
     lines = f.readlines()
     f.seek(0)
     for line in lines:
-      if line.find("B32") != -1:
-        line = line.replace("B32", "B32R")
-      if line.find("B31") != -1:
-        line = line.replace("B31", "B31R")
-      f.write(line)
+        if line.find("B32") != -1:
+            line = line.replace("B32", "B32R")
+        if line.find("B31") != -1:
+            line = line.replace("B31", "B31R")
+        f.write(line)
     
     f.truncate()
     f.close()

--- a/src/Mod/Fem/femmesh/meshtools.py
+++ b/src/Mod/Fem/femmesh/meshtools.py
@@ -2508,4 +2508,21 @@ def compact_mesh(
     # may be return another value if the mesh was compacted, just check last map entries
     return (new_mesh, node_map, elem_map)
 
+# ************************************************************************************************
+def beam_reduced_integration(
+    fileName
+):
+    # replace B3x elements with B3xR elements
+    f = open(fileName, "r+")
+    lines = f.readlines()
+    f.seek(0)
+    for line in lines:
+      if line.find("B32") != -1:
+        line = line.replace("B32", "B32R")
+      if line.find("B31") != -1:
+        line = line.replace("B31", "B31R")
+      f.write(line)
+    
+    f.truncate()
+    f.close()
 ##  @}

--- a/src/Mod/Fem/femsolver/calculix/solver.py
+++ b/src/Mod/Fem/femsolver/calculix/solver.py
@@ -372,6 +372,16 @@ def add_attributes(obj, ccx_prefs):
         obj.BeamShellResultOutput3D = dimout
 
 
+    if not hasattr(obj, "BeamReducedIntegration"):
+        obj.addProperty(
+            "App::PropertyBool",
+            "BeamReducedIntegration",
+            "Fem",
+            "Set to True to use beam elements with reduced integration"
+        )
+        red = ccx_prefs.GetBool("BeamReducedIntegration", True)
+        obj.BeamReducedIntegration = red
+
 """
 Should there be some equation object for Calculix too?
 

--- a/src/Mod/Fem/femsolver/calculix/solver.py
+++ b/src/Mod/Fem/femsolver/calculix/solver.py
@@ -379,8 +379,7 @@ def add_attributes(obj, ccx_prefs):
             "Fem",
             "Set to True to use beam elements with reduced integration"
         )
-        red = ccx_prefs.GetBool("BeamReducedIntegration", True)
-        obj.BeamReducedIntegration = red
+        obj.BeamReducedIntegration = True
 
 """
 Should there be some equation object for Calculix too?

--- a/src/Mod/Fem/femsolver/calculix/write_femelement_geometry.py
+++ b/src/Mod/Fem/femsolver/calculix/write_femelement_geometry.py
@@ -77,7 +77,7 @@ def write_femelement_geometry(f, ccxwriter):
                     thickness = beamsec_obj.PipeThickness.getValueAs("mm").Value
                     section_type = ", SECTION=PIPE"
                     section_geo = "{:.13G},{:.13G}\n".format(radius, thickness)
-                    section_def = "*BEAM GENERAL SECTION, {}{}{}\n".format(
+                    section_def = "*BEAM SECTION, {}{}{}\n".format(
                         elsetdef,
                         material,
                         section_type

--- a/src/Mod/Fem/femsolver/calculix/write_mesh.py
+++ b/src/Mod/Fem/femsolver/calculix/write_mesh.py
@@ -51,6 +51,10 @@ def write_mesh(ccxwriter):
         if ccxwriter.member.geos_fluidsection:
             meshtools.write_D_network_element_to_inputfile(ccxwriter.femmesh_file)
 
+        # Use reduced integration beam elements if this option is enabled in ccx solver settings
+        if ccxwriter.solver_obj.BeamReducedIntegration is True:
+            meshtools.beam_reduced_integration(ccxwriter.femmesh_file)
+        
         inpfile = codecs.open(ccxwriter.file_name, "w", encoding="utf-8")
         inpfile.write("{}\n".format(59 * "*"))
         inpfile.write("** {}\n".format(write_name))
@@ -68,6 +72,10 @@ def write_mesh(ccxwriter):
         if ccxwriter.member.geos_fluidsection:
             # inpfile is closed
             meshtools.write_D_network_element_to_inputfile(ccxwriter.femmesh_file)
+
+        # Use reduced integration beam elements if this option is enabled in ccx solver settings
+        if ccxwriter.solver_obj.BeamReducedIntegration is True:
+            meshtools.beam_reduced_integration(ccxwriter.femmesh_file)
 
         # reopen file with "append" to add all the rest
         inpfile = codecs.open(ccxwriter.femmesh_file, "a", encoding="utf-8")

--- a/src/Mod/Fem/femsolver/calculix/write_mesh.py
+++ b/src/Mod/Fem/femsolver/calculix/write_mesh.py
@@ -52,7 +52,7 @@ def write_mesh(ccxwriter):
             meshtools.write_D_network_element_to_inputfile(ccxwriter.femmesh_file)
 
         # Use reduced integration beam elements if this option is enabled in ccx solver settings
-        if ccxwriter.solver_obj.BeamReducedIntegration is True:
+        if ccxwriter.solver_obj.BeamReducedIntegration:
             meshtools.beam_reduced_integration(ccxwriter.femmesh_file)
         
         inpfile = codecs.open(ccxwriter.file_name, "w", encoding="utf-8")
@@ -74,7 +74,7 @@ def write_mesh(ccxwriter):
             meshtools.write_D_network_element_to_inputfile(ccxwriter.femmesh_file)
 
         # Use reduced integration beam elements if this option is enabled in ccx solver settings
-        if ccxwriter.solver_obj.BeamReducedIntegration is True:
+        if ccxwriter.solver_obj.BeamReducedIntegration:
             meshtools.beam_reduced_integration(ccxwriter.femmesh_file)
 
         # reopen file with "append" to add all the rest

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_circle.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_circle.inp
@@ -17,7 +17,7 @@
 
 
 ** Edge elements
-*Element, TYPE=B32, ELSET=Eedges
+*Element, TYPE=B32R, ELSET=Eedges
 1, 1, 7, 3
 2, 3, 8, 4
 3, 4, 9, 5

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_pipe.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_pipe.inp
@@ -17,7 +17,7 @@
 
 
 ** Edge elements
-*Element, TYPE=B32, ELSET=Eedges
+*Element, TYPE=B32R, ELSET=Eedges
 1, 1, 7, 3
 2, 3, 8, 4
 3, 4, 9, 5

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_pipe.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_pipe.inp
@@ -56,7 +56,7 @@ Eedges
 
 ***********************************************************
 ** Sections
-*BEAM GENERAL SECTION, ELSET=M0B0RstdD0, MATERIAL=MechanicalMaterial, SECTION=PIPE
+*BEAM SECTION, ELSET=M0B0RstdD0, MATERIAL=MechanicalMaterial, SECTION=PIPE
 500,100
 -0, 1, 0
 

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_rect.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_rect.inp
@@ -17,7 +17,7 @@
 
 
 ** Edge elements
-*Element, TYPE=B32, ELSET=Eedges
+*Element, TYPE=B32R, ELSET=Eedges
 1, 1, 7, 3
 2, 3, 8, 4
 3, 4, 9, 5

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_seg2.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_seg2.inp
@@ -61,7 +61,7 @@
 
 
 ** Edge elements
-*Element, TYPE=B31, ELSET=Eedges
+*Element, TYPE=B31R, ELSET=Eedges
 1, 1, 3
 2, 3, 4
 3, 4, 5

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_seg3.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_seg3.inp
@@ -17,7 +17,7 @@
 
 
 ** Edge elements
-*Element, TYPE=B32, ELSET=Eedges
+*Element, TYPE=B32R, ELSET=Eedges
 1, 1, 7, 3
 2, 3, 8, 4
 3, 4, 9, 5


### PR DESCRIPTION
replaces #12444 and fixes #12320 (plus adds more versatility as mentioned in the comment under #12444)

This PR adds a new property BeamReducedIntegration to the CalculiX solver. If true (by default), beam elements B31 and B32 are replaced with B31R and B32R, respectively. This way it's possible to use the Pipe beam section and to obtain accurate results when plasticity is involved (mentioned in the comment under #12444).