### PR TITLE
GUI: Follow the widget indications when docking them

### DIFF
--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -989,11 +989,23 @@ public:
     {
         OverlayTitleBar *widget = new OverlayTitleBar(parent);
         widget->setObjectName(QStringLiteral("OverlayTitle"));
+
         QList<QAction*> actions;
         if (auto tabWidget = qobject_cast<OverlayTabWidget*>(parent))
             actions = tabWidget->actions();
+        else if (auto dockWidget = qobject_cast<QDockWidget*>(parent))
+        {
+            const QDockWidget::DockWidgetFeatures features = dockWidget->features();
+
+            actions.append(&_actOverlay);
+            if (features.testFlag(QDockWidget::DockWidgetFloatable))
+                actions.append(&_actFloat);
+            if (features.testFlag(QDockWidget::DockWidgetClosable))
+                actions.append(&_actClose);
+        }
         else
             actions = _actions;
+
         widget->setTitleItem(OverlayTabWidget::prepareTitleWidget(widget, actions));
         return widget;
     }
@@ -1528,6 +1540,8 @@ void OverlayManager::initDockWidget(QDockWidget *dw)
             this, &OverlayManager::onToggleDockWidget);
     QObject::connect(dw, &QDockWidget::visibilityChanged,
             this, &OverlayManager::onDockVisibleChange);
+    QObject::connect(dw, &QDockWidget::featuresChanged,
+            this, &OverlayManager::onDockFeaturesChange);
     if (auto widget = dw->widget()) {
         QObject::connect(widget, &QWidget::windowTitleChanged,
                 this, &OverlayManager::onDockWidgetTitleChange);
@@ -1575,6 +1589,20 @@ void OverlayManager::onDockVisibleChange(bool visible)
         return;
     FC_TRACE("dock " << dock->objectName().toUtf8().constData()
             << " visible change " << visible << ", " << dock->isVisible());
+}
+
+void OverlayManager::onDockFeaturesChange(QDockWidget::DockWidgetFeatures features)
+{
+    auto dw = qobject_cast<QDockWidget*>(sender());
+    if (!dw)
+        return;
+
+    // Rebuild the title widget as it may have a different set of buttons shown.
+    if (QWidget *titleBarWidget = dw->titleBarWidget()) {
+        dw->setTitleBarWidget(nullptr);
+        delete titleBarWidget;
+    }
+    setupTitleBar(dw);
 }
 
 void OverlayManager::onTaskViewUpdate()

--- a/src/Gui/OverlayManager.h
+++ b/src/Gui/OverlayManager.h
@@ -174,6 +174,7 @@ protected:
 private:
     void onToggleDockWidget(bool checked);
     void onDockVisibleChange(bool visible);
+    void onDockFeaturesChange(QDockWidget::DockWidgetFeatures features);
     void onDockWidgetTitleChange(const QString &);
     void onTaskViewUpdate();
     void onFocusChanged(QWidget *, QWidget *);


### PR DESCRIPTION
The overlay manager handles the creation and drawing of the title bars for the docked widgets. When adding a QDockWidget the manager ignored the set of features (closable, movable, floatable) provided by the widget and always showed all the actions.

Amend the code to take into account the features specified by the widget.

Closes #11944

This commit makes the dockbars show the same set of buttons with and without the overlay mode enabled.

Random concern, should the "overlay" button be displayed unconditionally?