### PR TITLE
[TD]Fix asme section line

### DIFF
--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -522,3 +522,8 @@ int Preferences::LineCapIndex()
     return getPreferenceGroup("General")->GetInt("EdgeCapStyle", 0x20);
 }
 
+//! returns 0 (use ANSI style section cut line) or 1 (use ISO style section cut line)
+int Preferences::sectionLineConvention()
+{
+    return getPreferenceGroup("Standards")->GetInt("SectionLineStandard", 1);
+}

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -124,6 +124,8 @@ public:
 
     static std::string currentLineDefFile();
     static std::string currentElementDefFile();
+
+    static int sectionLineConvention();
 };
 
 

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -156,19 +156,6 @@ double PreferencesGui::edgeFuzz()
     return Preferences::getPreferenceGroup("General")->GetFloat("EdgeFuzz", 10.0);
 }
 
-
-// this is for the iso vs ansi positioning of arrows and text.  rename to sectionLineConvention?
-Qt::PenStyle PreferencesGui::sectionLineStyle()
-{
-    Qt::PenStyle sectStyle = static_cast<Qt::PenStyle> (Preferences::getPreferenceGroup("Decorations")->GetInt("SectionLine", 2));
-    return sectStyle;
-}
-
-bool PreferencesGui::sectionLineMarks()
-{
-    return Preferences::getPreferenceGroup("Decorations")->GetBool("SectionLineMarks", true);
-}
-
 QString PreferencesGui::weldingDirectory()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Symbols/Welding/AWS/";

--- a/src/Mod/TechDraw/Gui/PreferencesGui.h
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.h
@@ -63,9 +63,6 @@ static double      dimArrowSize();
 
 static double      edgeFuzz();
 
-static Qt::PenStyle  sectionLineStyle();
-static bool          sectionLineMarks();
-
 static QString     weldingDirectory();
 
 static bool showGrid();

--- a/src/Mod/TechDraw/Gui/QGIHighlight.cpp
+++ b/src/Mod/TechDraw/Gui/QGIHighlight.cpp
@@ -173,12 +173,6 @@ QColor QGIHighlight::getHighlightColor()
     return PreferencesGui::sectionLineQColor();
 }
 
-//obs??
-Qt::PenStyle QGIHighlight::getHighlightStyle()
-{
-    return PreferencesGui::sectionLineStyle();
-}
-
 int QGIHighlight::getHoleStyle()
 {
     return TechDraw::Preferences::mattingStyle();

--- a/src/Mod/TechDraw/Gui/QGIHighlight.h
+++ b/src/Mod/TechDraw/Gui/QGIHighlight.h
@@ -67,7 +67,6 @@ public:
 
 protected:
     QColor getHighlightColor();
-    Qt::PenStyle getHighlightStyle();
     void makeHighlight();
     void makeReference();
     void setTools();

--- a/src/Mod/TechDraw/Gui/QGISectionLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.cpp
@@ -33,6 +33,8 @@
 #include <Base/Parameter.h>
 #include <Base/Tools.h>
 
+#include <Mod/TechDraw/App/Preferences.h>
+
 #include "QGISectionLine.h"
 #include "PreferencesGui.h"
 #include "QGIArrow.h"
@@ -73,7 +75,6 @@ QGISectionLine::QGISectionLine() :
     addToGroup(m_symbol2);
 
     setWidth(Rez::guiX(0.75));          //a default?
-    setStyle(getSectionStyle());
     setColor(getSectionColor());
 
 }
@@ -81,7 +82,7 @@ QGISectionLine::QGISectionLine() :
 void QGISectionLine::draw()
 {
     prepareGeometryChange();
-    int format = getPrefSectionStandard();
+    int format = Preferences::sectionLineConvention();
     if (format == ANSISTANDARD) {                           //"ASME"/"ANSI"
         extensionEndsTrad();
     } else {
@@ -128,7 +129,7 @@ void QGISectionLine::makeSectionLine()
 
 void QGISectionLine::makeArrows()
 {
-    int format = getPrefSectionStandard();
+    int format = Preferences::sectionLineConvention();
     if (format == ANSISTANDARD) {
         makeArrowsTrad();
     } else {
@@ -193,7 +194,7 @@ void QGISectionLine::makeArrowsTrad()
 
 void QGISectionLine::makeSymbols()
 {
-    int format = getPrefSectionStandard();
+    int format = Preferences::sectionLineConvention();
     if (format == ANSISTANDARD) {
         makeSymbolsTrad();
     } else {
@@ -470,25 +471,6 @@ QColor QGISectionLine::getSectionColor()
 {
     return PreferencesGui::sectionLineQColor();
 }
-
-//SectionLineStyle
-void QGISectionLine::setSectionStyle(int style)
-{
-    Qt::PenStyle sectStyle = static_cast<Qt::PenStyle> (style);
-    setStyle(sectStyle);
-}
-
-Qt::PenStyle QGISectionLine::getSectionStyle()
-{
-    return PreferencesGui::sectionLineStyle();
-}
-
-//ASME("traditional") vs ISO("reference arrow method") arrows
-int QGISectionLine::getPrefSectionStandard()
-{
-    return Preferences::getPreferenceGroup("Standards")->GetInt("SectionLineStandard", ISOSTANDARD);
-}
-
 
 void QGISectionLine::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {
     QStyleOptionGraphicsItem myOption(*option);

--- a/src/Mod/TechDraw/Gui/QGISectionLine.h
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.h
@@ -62,7 +62,6 @@ public:
     void setDirection(Base::Vector3d dir);
     void setArrowDirections(Base::Vector3d dir1, Base::Vector3d dir2);
     void setFont(QFont f, double fsize);
-    void setSectionStyle(int style);
     void setSectionColor(QColor c);
     void setPathMode(bool mode) { m_pathMode = mode; }
     bool pathMode() { return m_pathMode; }
@@ -86,7 +85,6 @@ protected:
     void makeSymbolsISO();
     void makeChangePointMarks();
     void setTools();
-    int  getPrefSectionStandard();
     void extensionEndsISO();
     void extensionEndsTrad();
     double getArrowRotation(Base::Vector3d arrowDir);

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -637,6 +637,7 @@ void QGIViewPart::drawAllSectionLines()
 
 void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b)
 {
+//    Base::Console().Message("QGIVP::drawSectionLine()\n");
     TechDraw::DrawViewPart* viewPart = static_cast<TechDraw::DrawViewPart*>(getViewObject());
     if (!viewPart)
         return;
@@ -665,7 +666,6 @@ void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b
         QGISectionLine* sectionLine = new QGISectionLine();
         addToGroup(sectionLine);
         sectionLine->setSymbol(const_cast<char*>(viewSection->SectionSymbol.getValue()));
-        sectionLine->setSectionStyle(vp->SectionLineStyle.getValue());
         App::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
         sectionLine->setSectionColor(color.asValue<QColor>());
         sectionLine->setPathMode(false);
@@ -754,7 +754,6 @@ void QGIViewPart::drawComplexSectionLine(TechDraw::DrawViewSection* viewSection,
     QGISectionLine* sectionLine = new QGISectionLine();
     addToGroup(sectionLine);
     sectionLine->setSymbol(const_cast<char*>(viewSection->SectionSymbol.getValue()));
-    sectionLine->setSectionStyle(vp->SectionLineStyle.getValue());
     App::Color color = Preferences::getAccessibleColor(vp->SectionLineColor.getValue());
     sectionLine->setSectionColor(color.asValue<QColor>());
     sectionLine->setPathMode(true);

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -28,6 +28,7 @@
 #endif // #ifndef _PreComp_
 
 #include <Base/Console.h>
+#include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
@@ -180,7 +181,7 @@ void TaskProjGroup::viewToggled(bool toggle)
     // Obtain name of checkbox
     QString viewName = sender()->objectName();
     int index = viewName.mid(7).toInt();
-    const char *viewNameCStr = viewChkIndexToCStr(index);
+    const char *viewNameCStr = viewChkIndexToCStr(index).c_str();
     if ( toggle && !multiView->hasProjection( viewNameCStr ) ) {
         Gui::Command::doCommand(Gui::Command::Doc,
                                 "App.activeDocument().%s.addProjection('%s')",
@@ -234,7 +235,18 @@ void TaskProjGroup::projectionTypeChanged(QString qText)
 
     // Update checkboxes so checked state matches the drawing
     setupViewCheckboxes();
-    multiView->recomputeFeature();
+
+    // set the tooltips of the checkboxes
+    ui->chkView0->setToolTip(getToolTipForBox(0));
+    ui->chkView1->setToolTip(getToolTipForBox(1));
+    ui->chkView2->setToolTip(getToolTipForBox(2));
+    ui->chkView3->setToolTip(getToolTipForBox(3));
+    ui->chkView4->setToolTip(getToolTipForBox(4));
+    ui->chkView5->setToolTip(getToolTipForBox(5));
+    ui->chkView6->setToolTip(getToolTipForBox(6));
+    ui->chkView7->setToolTip(getToolTipForBox(7));
+    ui->chkView8->setToolTip(getToolTipForBox(8));
+    ui->chkView9->setToolTip(getToolTipForBox(9));
 }
 
 void TaskProjGroup::scaleTypeChanged(int index)
@@ -416,7 +428,7 @@ void TaskProjGroup::changeEvent(QEvent *event)
     }
 }
 
-const char * TaskProjGroup::viewChkIndexToCStr(int index)
+std::string TaskProjGroup::viewChkIndexToCStr(int index)
 {
     //   Third Angle:  FTL  T  FTRight
     //                  L   F   Right   Rear
@@ -427,26 +439,44 @@ const char * TaskProjGroup::viewChkIndexToCStr(int index)
     //                 FTRight  T  FTL
     assert (multiView);
 
-    bool thirdAngle = multiView->usedProjectionType().isValue("Third Angle");
+    std::string boxName;
     switch(index) {
-        case 0: return (thirdAngle ? "FrontTopLeft" : "FrontBottomRight");
-        case 1: return (thirdAngle ? "Top" : "Bottom");
-        case 2: return (thirdAngle ? "FrontTopRight" : "FrontBottomLeft");
-        case 3: return (thirdAngle ? "Left" : "Right");
-        case 4: return (thirdAngle ? "Front" : "Front");
-        case 5: return (thirdAngle ? "Right" : "Left");
-        case 6: return (thirdAngle ? "Rear" : "Rear");
-        case 7: return (thirdAngle ? "FrontBottomLeft" : "FrontTopRight");
-        case 8: return (thirdAngle ? "Bottom" : "Top");
-        case 9: return (thirdAngle ? "FrontBottomRight" : "FrontTopLeft");
-        default: return nullptr;
+        case 0: {boxName =  Base::Tools::toStdString(getToolTipForBox(0)); break;}
+        case 1: {boxName =  Base::Tools::toStdString(getToolTipForBox(1)); break;}
+        case 2: {boxName =  Base::Tools::toStdString(getToolTipForBox(2)); break;}
+        case 4: {boxName =  Base::Tools::toStdString(getToolTipForBox(3)); break;}
+        case 5: {boxName =  Base::Tools::toStdString(getToolTipForBox(4)); break;}
+        case 6: {boxName =  Base::Tools::toStdString(getToolTipForBox(5)); break;}
+        case 7: {boxName =  Base::Tools::toStdString(getToolTipForBox(6)); break;}
+        case 8: {boxName =  Base::Tools::toStdString(getToolTipForBox(7)); break;}
+        case 9: {boxName =  Base::Tools::toStdString(getToolTipForBox(8)); break;}
+        default: boxName =  "";
+    }
+    return boxName;
+}
+
+QString TaskProjGroup::getToolTipForBox(int boxNumber)
+{
+    bool thirdAngle = multiView->usedProjectionType().isValue("Third Angle");
+    switch(boxNumber) {
+        case 0: {return (thirdAngle ? tr("FrontTopLeft") : tr("FrontBottomRight")); break;}
+        case 1: {return (thirdAngle ? tr("Top") : tr("Bottom")); break;}
+        case 2: {return (thirdAngle ? tr("FrontTopRight") : tr("FrontBottomLeft")); break;}
+        case 3: {return (thirdAngle ? tr("Left" ): tr("Right")); break;}
+        case 4: {return (thirdAngle ? tr("Front") : tr("Front")); break;}
+        case 5: {return (thirdAngle ? tr("Right") : tr("Left")); break;}
+        case 6: {return (thirdAngle ? tr("Rear") : tr("Rear")); break;}
+        case 7: {return (thirdAngle ? tr("FrontBottomLeft") : tr("FrontTopRight")); break;}
+        case 8: {return (thirdAngle ? tr("Bottom") : tr("Top")); break;}
+        case 9: {return (thirdAngle ? tr("FrontBottomRight") : tr("FrontTopLeft")); break;}
+        default: {return {}; break;}
     }
 }
+
 void TaskProjGroup::setupViewCheckboxes(bool addConnections)
 {
     if (!multiView)
         return;
-
     // There must be a better way to construct this list...
     QCheckBox * viewCheckboxes[] = { ui->chkView0,
                                      ui->chkView1,
@@ -466,7 +496,7 @@ void TaskProjGroup::setupViewCheckboxes(bool addConnections)
             connect(box, &QCheckBox::toggled, this, &TaskProjGroup::viewToggled);
         }
 
-        const char *viewStr = viewChkIndexToCStr(i);
+        const char *viewStr = viewChkIndexToCStr(i).c_str();
         if (viewStr && multiView->hasProjection(viewStr)) {
             box->setCheckState(Qt::Checked);
             if (!multiView->canDelete(viewStr)) {
@@ -475,6 +505,7 @@ void TaskProjGroup::setupViewCheckboxes(bool addConnections)
         } else {
             box->setCheckState(Qt::Unchecked);
         }
+        box->setToolTip(getToolTipForBox(i));
     }
 }
 

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.h
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.h
@@ -104,7 +104,8 @@ private:
 
     bool blockUpdate;
     /// Translate a view checkbox index into represented view string, depending on projection type
-    const char * viewChkIndexToCStr(int index);
+    std::string viewChkIndexToCStr(int index);
+    QString getToolTipForBox(int boxNumber);
 
     QPushButton* m_btnOK;
     QPushButton* m_btnCancel;

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -107,25 +107,15 @@ ViewProviderViewPart::ViewProviderViewPart()
     ADD_PROPERTY_TYPE(ArcCenterMarks ,(defShowCenters), dgroup, App::Prop_None, "Center marks on/off");
     ADD_PROPERTY_TYPE(CenterScale, (defScale), dgroup, App::Prop_None, "Center mark size adjustment, if enabled");
 
-    std::string bodyName = LineGenerator::getLineStandardsBody();
-    if (bodyName == "ISO") {
-        SectionLineStyle.setEnums(ISOLineName::ISOLineNameEnums);
-        HighlightLineStyle.setEnums(ISOLineName::ISOLineNameEnums);
-    } else if (bodyName == "ANSI") {
-        SectionLineStyle.setEnums(ANSILineName::ANSILineNameEnums);
-        HighlightLineStyle.setEnums(ANSILineName::ANSILineNameEnums);
-    } else if (bodyName == "ASME") {
-    SectionLineStyle.setEnums(ASMELineName::ASMELineNameEnums);
-        HighlightLineStyle.setEnums(ASMELineName::ASMELineNameEnums);
-    }
-
     //properties that affect Section Line
     ADD_PROPERTY_TYPE(ShowSectionLine ,(true)    ,sgroup, App::Prop_None, "Show/hide section line if applicable");
-    ADD_PROPERTY_TYPE(SectionLineStyle, (PreferencesGui::sectionLineStyle()), sgroup, App::Prop_None,
+    ADD_PROPERTY_TYPE(SectionLineStyle, (Preferences::SectionLineStyle()), sgroup, App::Prop_None,
                         "Set section line style if applicable");
     ADD_PROPERTY_TYPE(SectionLineColor, (prefSectionColor()), sgroup, App::Prop_None,
                         "Set section line color if applicable");
-    ADD_PROPERTY_TYPE(SectionLineMarks, (PreferencesGui::sectionLineMarks()), sgroup, App::Prop_None,
+
+     bool marksDefault  = Preferences::sectionLineConvention() == 1 ? true : false;
+    ADD_PROPERTY_TYPE(SectionLineMarks, (marksDefault), sgroup, App::Prop_None,
                         "Show marks at direction changes for ComplexSection");
 
     //properties that affect Detail Highlights
@@ -135,7 +125,7 @@ ViewProviderViewPart::ViewProviderViewPart()
                         "Set highlight line color if applicable");
     ADD_PROPERTY_TYPE(HighlightAdjust, (0.0), hgroup, App::Prop_None, "Adjusts the rotation of the Detail highlight");
 
-    ADD_PROPERTY_TYPE(ShowAllEdges ,(false)    ,dgroup, App::Prop_None, "Temporarily show invisible lines");
+    ADD_PROPERTY_TYPE(ShowAllEdges ,(false),dgroup, App::Prop_None, "Temporarily show invisible lines");
 
     // Faces related properties
     ADD_PROPERTY_TYPE(FaceColor, (Preferences::getPreferenceGroup("Colors")->GetUnsigned("FaceColor", 0xFFFFFF)),
@@ -143,6 +133,18 @@ ViewProviderViewPart::ViewProviderViewPart()
     ADD_PROPERTY_TYPE(FaceTransparency, (Preferences::getPreferenceGroup("Colors")->GetBool("ClearFace", false) ? 100 : 0),
                       fgroup, App::Prop_None, "Set transparency of faces");
     FaceTransparency.setConstraints(&intPercent);
+
+    std::string bodyName = LineGenerator::getLineStandardsBody();
+    if (bodyName == "ISO") {
+        SectionLineStyle.setEnums(ISOLineName::ISOLineNameEnums);
+        HighlightLineStyle.setEnums(ISOLineName::ISOLineNameEnums);
+    } else if (bodyName == "ANSI") {
+        SectionLineStyle.setEnums(ANSILineName::ANSILineNameEnums);
+        HighlightLineStyle.setEnums(ANSILineName::ANSILineNameEnums);
+    } else if (bodyName == "ASME") {
+        SectionLineStyle.setEnums(ASMELineName::ASMELineNameEnums);
+        HighlightLineStyle.setEnums(ASMELineName::ASMELineNameEnums);
+    }
 }
 
 ViewProviderViewPart::~ViewProviderViewPart()


### PR DESCRIPTION
This PR implements two small patches to TechDraw.  This first corrects the tooltips in the projection group dialog.   The second makes section lines adhere to ANSI/ASME standards.