### PR TITLE
[App][TD]Allow more decimals for PropertyFloat

### DIFF
--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -461,7 +461,7 @@ void PropertyEnumeration::setPyObject(PyObject *value)
             hasSetValue();
         }
         else {
-            FC_THROWM(Base::ValueError, "'" << str 
+            FC_THROWM(Base::ValueError, "'" << str
                     << "' is not part of the enumeration in "
                     << getFullName());
         }
@@ -585,7 +585,7 @@ bool PropertyEnumeration::getPyPathValue(const ObjectIdentifier &path, Py::Objec
     } else if (p == ".String") {
         auto v = getValueAsString();
         r = Py::String(v?v:"");
-    } else 
+    } else
         r = Py::Int(getValue());
     return true;
 }
@@ -979,6 +979,7 @@ void PropertyFloat::setPyObject(PyObject *value)
 void PropertyFloat::Save (Base::Writer &writer) const
 {
     writer.Stream() << writer.ind() << "<Float value=\"" <<  _dValue <<"\"/>" << std::endl;
+    writer.Stream() << writer.ind() << "<IgnoreDecimals value=\"" <<  m_ignoreDecimals <<"\"/>" << std::endl;
 }
 
 void PropertyFloat::Restore(Base::XMLReader &reader)
@@ -987,12 +988,23 @@ void PropertyFloat::Restore(Base::XMLReader &reader)
     reader.readElement("Float");
     // get the value of my Attribute
     setValue(reader.getAttributeAsFloat("value"));
+    if (reader.readNextElement()) {
+        if(strcmp(reader.localName(),"IgnoreDecimals") == 0) {
+            // this PropertyFloat has an IgnoreDecimals attribute
+            int temp = reader.getAttributeAsInteger("value");
+            setIgnoreDecimals(temp == 1 ? true : false);
+        } else {
+            // IgnoreDecimals not found.
+            setIgnoreDecimals(false);
+        }
+    }
 }
 
 Property *PropertyFloat::Copy() const
 {
     PropertyFloat *p= new PropertyFloat();
     p->_dValue = _dValue;
+    p->setIgnoreDecimals(isIgnoreDecimals());
     return p;
 }
 
@@ -1000,6 +1012,7 @@ void PropertyFloat::Paste(const Property &from)
 {
     aboutToSetValue();
     _dValue = dynamic_cast<const PropertyFloat&>(from)._dValue;
+    m_ignoreDecimals = dynamic_cast<const PropertyFloat&>(from).isIgnoreDecimals();
     hasSetValue();
 }
 

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -467,7 +467,7 @@ public:
     void Paste(const Property &from) override;
 
     unsigned int getMemSize () const override;
-    
+
     bool isSame(const Property &other) const override {
         if (&other == this)
             return true;
@@ -531,8 +531,15 @@ public:
             && getValue() == static_cast<decltype(this)>(&other)->getValue();
     }
 
+    void setIgnoreDecimals(bool ignoreDecimals) { m_ignoreDecimals = ignoreDecimals; }
+    inline bool isIgnoreDecimals() const {
+        return m_ignoreDecimals;
+    }
+
+
 protected:
     double _dValue;
+    bool m_ignoreDecimals{false};
 };
 
 /** Constraint float properties
@@ -954,7 +961,7 @@ public:
     void Paste(const Property &from) override;
 
     unsigned int getMemSize () const override{return sizeof(Color);}
-    
+
     bool isSame(const Property &other) const override {
         if (&other == this)
             return true;
@@ -1047,7 +1054,7 @@ public:
     void Paste(const Property &from) override;
 
     unsigned int getMemSize () const override{return sizeof(_cMat);}
-    
+
     bool isSame(const Property &other) const override {
         if (&other == this)
             return true;

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -551,13 +551,13 @@ void PropertyItem::setPropertyValue(const QString& value)
         else if (parent->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
             auto obj = static_cast<App::DocumentObject*>(parent);
             App::Document* doc = obj->getDocument();
-            ss << "FreeCAD.getDocument('" << doc->getName() << "').getObject('" 
+            ss << "FreeCAD.getDocument('" << doc->getName() << "').getObject('"
                << obj->getNameInDocument() << "').";
         }
         else if (parent->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
             App::DocumentObject* obj = static_cast<ViewProviderDocumentObject*>(parent)->getObject();
             App::Document* doc = obj->getDocument();
-            ss << "FreeCADGui.getDocument('" << doc->getName() << "').getObject('" 
+            ss << "FreeCADGui.getDocument('" << doc->getName() << "').getObject('"
                << obj->getNameInDocument() << "').";
         }
         else {
@@ -601,7 +601,7 @@ QVariant PropertyItem::data(int column, int role) const
                 && !propertyItems.front()->testStatus(App::Property::LockDynamic))
             {
                 return role==Qt::BackgroundRole
-                    ? QVariant::fromValue(QColor(0xFF,0xFF,0x99)) 
+                    ? QVariant::fromValue(QColor(0xFF,0xFF,0x99))
                     : QVariant::fromValue(QColor(0,0,0));
             }
             return {};
@@ -644,7 +644,7 @@ QVariant PropertyItem::data(int column, int role) const
             else if (role == Qt::DisplayRole) {
                 QVariant val = parent->property(qPrintable(objectName()));
                 return toString(val);
-            } 
+            }
             else if (role == Qt::ForegroundRole) {
                 if (hasExpression())
                     return QVariant::fromValue(QApplication::palette().color(QPalette::Link));
@@ -774,7 +774,7 @@ QWidget* PropertyStringItem::createEditor(QWidget* parent, const QObject* receiv
         le->bind(getPath());
         le->setAutoApply(autoApply());
     }
-        
+
     return le;
 }
 
@@ -847,9 +847,9 @@ PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertySeparatorItem)
 
 QWidget* PropertySeparatorItem::createEditor(QWidget* parent, const QObject* receiver, const char* method) const
 {
-    Q_UNUSED(parent); 
-    Q_UNUSED(receiver); 
-    Q_UNUSED(method); 
+    Q_UNUSED(parent);
+    Q_UNUSED(receiver);
+    Q_UNUSED(method);
     return nullptr;
 }
 
@@ -1040,7 +1040,15 @@ QWidget* PropertyFloatItem::createEditor(QWidget* parent, const QObject* receive
 {
     auto sb = new Gui::DoubleSpinBox(parent);
     sb->setFrame(false);
-    sb->setDecimals(decimals());
+    const auto prop = static_cast
+        <const App::PropertyFloatConstraint*>(getFirstProperty());
+    if (prop->isIgnoreDecimals()) {
+        // it is not possible to set a QDoubleSpinBox to have unlimited decimals, so
+        // we will arbitrarily allow 10 digits
+        sb->setDecimals(10);
+    } else {
+        sb->setDecimals(decimals());
+    }
     sb->setReadOnly(isReadOnly());
     QObject::connect(sb, SIGNAL(valueChanged(double)), receiver, method);
 
@@ -1110,14 +1118,14 @@ QWidget* PropertyUnitItem::createEditor(QWidget* parent, const QObject* receiver
     infield->setFrame(false);
     infield->setMinimumHeight(0);
     infield->setReadOnly(isReadOnly());
-    
+
     //if we are bound to an expression we need to bind it to the input field
     if (isBound()) {
         infield->bind(getPath());
         infield->setAutoApply(autoApply());
     }
 
-    
+
     QObject::connect(infield, SIGNAL(valueChanged(double)), receiver, method);
     return infield;
 }
@@ -1208,7 +1216,15 @@ void PropertyFloatConstraintItem::setValue(const QVariant& value)
 QWidget* PropertyFloatConstraintItem::createEditor(QWidget* parent, const QObject* receiver, const char* method) const
 {
     auto sb = new Gui::DoubleSpinBox(parent);
-    sb->setDecimals(decimals());
+    const auto prop = static_cast
+        <const App::PropertyFloatConstraint*>(getFirstProperty());
+    if (prop->isIgnoreDecimals()) {
+        // it is not possible to set a QDoubleSpinBox to have unlimited decimals, so
+        // we will arbitrarily allow 10 digits
+        sb->setDecimals(10);
+    } else {
+        sb->setDecimals(decimals());
+    }
     sb->setFrame(false);
     sb->setReadOnly(isReadOnly());
     QObject::connect(sb, SIGNAL(valueChanged(double)), receiver, method);
@@ -1285,7 +1301,7 @@ PropertyBoolItem::PropertyBoolItem() = default;
 QVariant PropertyBoolItem::value(const App::Property* prop) const
 {
     assert(prop && prop->isDerivedFrom<App::PropertyBool>());
-    
+
     bool value = static_cast<const App::PropertyBool*>(prop)->getValue();
     return {value};
 }
@@ -1673,7 +1689,7 @@ PropertyVectorDistanceItem::PropertyVectorDistanceItem()
 QVariant PropertyVectorDistanceItem::toString(const QVariant& prop) const
 {
     const Base::Vector3d& value = prop.value<Base::Vector3d>();
-    QString data = QString::fromLatin1("[") + 
+    QString data = QString::fromLatin1("[") +
            Base::Quantity(value.x, Base::Unit::Length).getUserString() + QString::fromLatin1("  ") +
            Base::Quantity(value.y, Base::Unit::Length).getUserString() + QString::fromLatin1("  ") +
            Base::Quantity(value.z, Base::Unit::Length).getUserString() + QString::fromLatin1("]");
@@ -2730,10 +2746,10 @@ void PropertyPlacementItem::propertyBound()
     if (isBound()) {
         m_a->bind(App::ObjectIdentifier(getPath())<<App::ObjectIdentifier::String("Rotation")
                                                   <<App::ObjectIdentifier::String("Angle"));
-   
+
         m_d->bind(App::ObjectIdentifier(getPath())<<App::ObjectIdentifier::String("Rotation")
                                                   <<App::ObjectIdentifier::String("Axis"));
-        
+
         m_p->bind(App::ObjectIdentifier(getPath())<<App::ObjectIdentifier::String("Base"));
     }
 }
@@ -2756,7 +2772,7 @@ PropertyEnumItem::PropertyEnumItem()
 
 void PropertyEnumItem::propertyBound()
 {
-    if (m_enum && isBound()) 
+    if (m_enum && isBound())
         m_enum->bind(App::ObjectIdentifier(getPath())<<App::ObjectIdentifier::String("Enum"));
 }
 
@@ -4239,7 +4255,7 @@ void LinkSelection::select()
 
 LinkLabel::LinkLabel (QWidget * parent, const App::Property *prop)
     : QWidget(parent), objProp(prop), dlg(nullptr)
-{   
+{
     auto layout = new QHBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(1);
@@ -4260,9 +4276,9 @@ LinkLabel::LinkLabel (QWidget * parent, const App::Property *prop)
 
     this->setFocusPolicy(Qt::StrongFocus);
     this->setFocusProxy(label);
-    
+
     // setLayout(layout);
-    
+
     connect(label, &QLabel::linkActivated,
             this, &LinkLabel::onLinkActivated);
     connect(editButton, &QPushButton::clicked,

--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -84,6 +84,7 @@ DrawPage::DrawPage(void)
                       "Auto-numbering for Balloons");
 
     Scale.setConstraints(&scaleRange);
+    Scale.setIgnoreDecimals(true);
 }
 
 DrawPage::~DrawPage() {}

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -98,12 +98,14 @@ DrawView::DrawView():
 
     ScaleType.setEnums(ScaleTypeEnums);
     ADD_PROPERTY_TYPE(ScaleType, (prefScaleType()), group, App::Prop_Output, "Scale Type");
-    ADD_PROPERTY_TYPE(Scale, (prefScale()), group, App::Prop_None, "Scale factor of the view. Scale factors like 1:100 can be written as =1/100");
+    ADD_PROPERTY_TYPE(Scale, (prefScale()), group, (App::PropertyType)(App::Prop_None), "Scale factor of the view. Scale factors like 1:100 can be written as =1/100");
     Scale.setConstraints(&scaleRange);
 
     ADD_PROPERTY_TYPE(Caption, (""), group, App::Prop_Output, "Short text about the view");
 
     setScaleAttribute();
+    Scale.setIgnoreDecimals(true);
+
 }
 
 DrawView::~DrawView()
@@ -112,7 +114,7 @@ DrawView::~DrawView()
 
 App::DocumentObjectExecReturn *DrawView::execute()
 {
-//    Base::Console().Message("DV::execute() - %s touched: %d\n", getNameInDocument(), isTouched());
+    // Base::Console().Message("DV::execute() - scale.ignoreDecimals: %d\n", Scale.isIgnoreDecimals());
     if (!findParentPage()) {
         return App::DocumentObject::execute();
     }


### PR DESCRIPTION
This PR implements a fix for long standing issue where certain values for Scale
can not be entered in the PropertyEditor due to the system decimals setting.  A recent report
of this issue can be found here: https://forum.freecad.org/viewtopic.php?t=85270&sid=0c8c6aaf8104b2d4d192af412b3a8d1f

For example, to make a 1:12 scale TechDraw drawing, the user would like to enter 0.083333333, but with system decimals set to 2, the user could only enter 0.08.

Similar issue occurs in Draft, also for Scale properties.

The fix involves adding a flag to PropertyFloat and PropertyFloatConstraint which indicates that the property editor should ignore the decimals() value when building the editor for PropertyFloat or PropertyFloatConstraint.

The default setting of the flag leaves the current behaviour unchanged.  

Note: The two new methods PropertyFloat::setIgnoreDecimals() and ropertyFloat::isIgnoreDecimals are not exposed to Python by this PR.  