### PR TITLE
Fixes #12494: Refactor PD patterns so Scaled works correctly with multiple features

### DIFF
--- a/src/Mod/PartDesign/App/DatumPlane.cpp
+++ b/src/Mod/PartDesign/App/DatumPlane.cpp
@@ -68,7 +68,7 @@ Plane::Plane()
 
 Plane::~Plane() = default;
 
-Base::Vector3d Plane::getNormal()
+Base::Vector3d Plane::getNormal() const
 {
     Base::Rotation rot = Placement.getValue().getRotation();
     Base::Vector3d normal;

--- a/src/Mod/PartDesign/App/DatumPlane.h
+++ b/src/Mod/PartDesign/App/DatumPlane.h
@@ -49,7 +49,7 @@ public:
         return "PartDesignGui::ViewProviderDatumPlane";
     }
 
-    Base::Vector3d getNormal();
+    Base::Vector3d getNormal() const;
 
 protected:
     void Restore(Base::XMLReader& reader) override;

--- a/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
@@ -89,29 +89,30 @@ void LinearPattern::setReadWriteStatusForMode(LinearPatternMode mode)
 
 std::vector<gp_Trsf> LinearPattern::calculateTransformations() const
 {
-    int occurrences = Occurrences.getValue();
+    int const occurrences = Occurrences.getValue();
+
     if (occurrences < 1)
         throw Base::ValueError("At least one occurrence required");
 
     if (occurrences == 1)
         return {};
 
-    double distance = Length.getValue();
+    double const distance = Length.getValue();
     if (distance < Precision::Confusion())
         throw Base::ValueError("Pattern length too small");
-    bool reversed = Reversed.getValue();
+    bool const reversed = Reversed.getValue();
 
-    App::DocumentObject* refObject = Direction.getValue();
+    App::DocumentObject const* refObject = Direction.getValue();
     if (!refObject)
         throw Base::ValueError("No direction reference specified");
 
-    std::vector<std::string> subStrings = Direction.getSubValues();
+    std::vector<std::string> const subStrings = Direction.getSubValues();
     if (subStrings.empty())
         throw Base::ValueError("No direction reference specified");
 
     gp_Dir dir;
     if (refObject->isDerivedFrom<Part::Part2DObject>()) {
-        Part::Part2DObject* refSketch = static_cast<Part::Part2DObject*>(refObject);
+        Part::Part2DObject const* refSketch = static_cast<Part::Part2DObject const*>(refObject);
         Base::Axis axis;
         if (subStrings[0] == "H_Axis") {
             axis = refSketch->getAxis(Part::Part2DObject::H_Axis);
@@ -152,15 +153,15 @@ std::vector<gp_Trsf> LinearPattern::calculateTransformations() const
         }
         dir = gp_Dir(axis.getDirection().x, axis.getDirection().y, axis.getDirection().z);
     } else if (refObject->isDerivedFrom<PartDesign::Plane>()) {
-        PartDesign::Plane* plane = static_cast<PartDesign::Plane*>(refObject);
+        PartDesign::Plane const* plane = static_cast<PartDesign::Plane const*>(refObject);
         Base::Vector3d d = plane->getNormal();
         dir = gp_Dir(d.x, d.y, d.z);
     } else if (refObject->isDerivedFrom<PartDesign::Line>()) {
-        PartDesign::Line* line = static_cast<PartDesign::Line*>(refObject);
+        PartDesign::Line const* line = static_cast<PartDesign::Line const*>(refObject);
         Base::Vector3d d = line->getDirection();
         dir = gp_Dir(d.x, d.y, d.z);
     } else if (refObject->isDerivedFrom<App::Line>()) {
-        App::Line* line = static_cast<App::Line*>(refObject);
+        App::Line const* line = static_cast<App::Line const*>(refObject);
         Base::Rotation rot = line->Placement.getValue().getRotation();
         Base::Vector3d d(1,0,0);
         rot.multVec(d, d);
@@ -168,7 +169,7 @@ std::vector<gp_Trsf> LinearPattern::calculateTransformations() const
     } else if (refObject->isDerivedFrom<Part::Feature>()) {
         if (subStrings[0].empty())
             throw Base::ValueError("No direction reference specified");
-        Part::Feature* refFeature = static_cast<Part::Feature*>(refObject);
+        Part::Feature const* refFeature = static_cast<Part::Feature const*>(refObject);
         Part::TopoShape refShape = refFeature->Shape.getShape();
         TopoDS_Shape ref = refShape.getSubShape(subStrings[0].c_str());
 

--- a/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
@@ -119,7 +119,7 @@ std::vector<gp_Trsf> LinearPattern::calculateTransformations() const
 
     gp_Dir dir;
     if (refObject->isDerivedFrom<Part::Part2DObject>()) {
-        Part::Part2DObject const* refSketch = static_cast<Part::Part2DObject const*>(refObject);
+        auto refSketch = static_cast<Part::Part2DObject const*>(refObject);
         Base::Axis axis;
         if (subStrings[0] == "H_Axis") {
             axis = refSketch->getAxis(Part::Part2DObject::H_Axis);
@@ -163,17 +163,17 @@ std::vector<gp_Trsf> LinearPattern::calculateTransformations() const
         dir = gp_Dir(axis.getDirection().x, axis.getDirection().y, axis.getDirection().z);
     }
     else if (refObject->isDerivedFrom<PartDesign::Plane>()) {
-        PartDesign::Plane const* plane = static_cast<PartDesign::Plane const*>(refObject);
+        auto plane = static_cast<PartDesign::Plane const*>(refObject);
         Base::Vector3d d = plane->getNormal();
         dir = gp_Dir(d.x, d.y, d.z);
     }
     else if (refObject->isDerivedFrom<PartDesign::Line>()) {
-        PartDesign::Line const* line = static_cast<PartDesign::Line const*>(refObject);
+        auto line = static_cast<PartDesign::Line const*>(refObject);
         Base::Vector3d d = line->getDirection();
         dir = gp_Dir(d.x, d.y, d.z);
     }
     else if (refObject->isDerivedFrom<App::Line>()) {
-        App::Line const* line = static_cast<App::Line const*>(refObject);
+        auto line = static_cast<App::Line const*>(refObject);
         Base::Rotation rot = line->Placement.getValue().getRotation();
         Base::Vector3d d(1, 0, 0);
         rot.multVec(d, d);
@@ -183,7 +183,7 @@ std::vector<gp_Trsf> LinearPattern::calculateTransformations() const
         if (subStrings[0].empty()) {
             throw Base::ValueError("No direction reference specified");
         }
-        Part::Feature const* refFeature = static_cast<Part::Feature const*>(refObject);
+        auto refFeature = static_cast<Part::Feature const*>(refObject);
         Part::TopoShape refShape = refFeature->Shape.getShape();
         TopoDS_Shape ref = refShape.getSubShape(subStrings[0].c_str());
 

--- a/src/Mod/PartDesign/App/FeatureLinearPattern.h
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.h
@@ -29,55 +29,60 @@
 
 namespace PartDesign
 {
-enum class LinearPatternMode {
+enum class LinearPatternMode
+{
     length,
     offset
 };
 
-class PartDesignExport LinearPattern : public PartDesign::Transformed
+class PartDesignExport LinearPattern: public PartDesign::Transformed
 {
     PROPERTY_HEADER_WITH_OVERRIDE(PartDesign::LinearPattern);
 
 public:
     LinearPattern();
 
-    App::PropertyLinkSub     Direction;
-    App::PropertyBool        Reversed;
+    App::PropertyLinkSub Direction;
+    App::PropertyBool Reversed;
     App::PropertyEnumeration Mode;
-    App::PropertyLength      Length;
-    App::PropertyLength      Offset;
+    App::PropertyLength Length;
+    App::PropertyLength Offset;
     App::PropertyIntegerConstraint Occurrences;
 
-   /** @name methods override feature */
+    /** @name methods override feature */
     //@{
     short mustExecute() const override;
 
     /// returns the type name of the view provider
-    const char* getViewProviderName() const override {
+    const char* getViewProviderName() const override
+    {
         return "PartDesignGui::ViewProviderLinearPattern";
     }
     //@}
 
     /** Apply linear pattern
-      * Returns a list of (Occurrences * N) shapes. The first N shapes will be the untransformed
-      * original shapes.
-      *
-      * Depending on Mode selection the list will be constructed differently:
-      * 1. For "Overall Length" each transformation will move the shape it is applied to by the distance
-      *    (Length / (Occurrences - 1)) so that the transformations will cover the total Length.
-      * 2. For "Spacing" each transformation will move the shape by the distance explicitly given in
-      *    the Offset parameter.
-      *
-      * If Direction contains a feature and a face name, then the transformation direction will be
-      *   the normal of the given face, which must be planar. If it contains an edge name, then the
-      *   transformation direction will be parallel to the given edge, which must be linear
-      *
-      * If Reversed is true, the direction of transformations will be opposite
-      */
+     * Returns a list of (Occurrences * N) shapes. The first N shapes will be the untransformed
+     * original shapes.
+     *
+     * Depending on Mode selection the list will be constructed differently:
+     * 1. For "Overall Length" each transformation will move the shape it is applied to by the
+     * distance (Length / (Occurrences - 1)) so that the transformations will cover the total
+     * Length.
+     * 2. For "Spacing" each transformation will move the shape by the distance explicitly given in
+     *    the Offset parameter.
+     *
+     * If Direction contains a feature and a face name, then the transformation direction will be
+     *   the normal of the given face, which must be planar. If it contains an edge name, then the
+     *   transformation direction will be parallel to the given edge, which must be linear
+     *
+     * If Reversed is true, the direction of transformations will be opposite
+     */
     std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const override;
 
 protected:
-    void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop) override;
+    void handleChangedPropertyType(Base::XMLReader& reader,
+                                   const char* TypeName,
+                                   App::Property* prop) override;
     void onChanged(const App::Property* prop) override;
 
     static const App::PropertyIntegerConstraint::Constraints intOccurrences;
@@ -89,7 +94,7 @@ private:
     std::vector<gp_Trsf> calculateTransformations() const;
 };
 
-} //namespace PartDesign
+}  // namespace PartDesign
 
 
-#endif // PARTDESIGN_FeatureLinearPattern_H
+#endif  // PARTDESIGN_FeatureLinearPattern_H

--- a/src/Mod/PartDesign/App/FeatureLinearPattern.h
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.h
@@ -58,23 +58,23 @@ public:
     }
     //@}
 
-    /** Create transformations
-      * Returns a list of (Occurrences - 1) transformations since the first, untransformed instance
-      * is not counted. 
-      * 
-      * Depending on Mode selection list will be constructed differently:
+    /** Apply linear pattern
+      * Returns a list of (Occurrences * N) shapes. The first N shapes will be the untransformed
+      * original shapes.
+      *
+      * Depending on Mode selection the list will be constructed differently:
       * 1. For "Overall Length" each transformation will move the shape it is applied to by the distance
       *    (Length / (Occurrences - 1)) so that the transformations will cover the total Length.
-      * 2. For "Spacing" each transformation will move the shape by the distance explicitly given in 
+      * 2. For "Spacing" each transformation will move the shape by the distance explicitly given in
       *    the Offset parameter.
-      * 
+      *
       * If Direction contains a feature and a face name, then the transformation direction will be
       *   the normal of the given face, which must be planar. If it contains an edge name, then the
       *   transformation direction will be parallel to the given edge, which must be linear
-      * 
-      * If Reversed is true, the direction of transformation will be opposite
+      *
+      * If Reversed is true, the direction of transformations will be opposite
       */
-    const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*> ) override;
+    std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const override;
 
 protected:
     void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop) override;
@@ -86,6 +86,7 @@ private:
     static const char* ModeEnums[];
 
     void setReadWriteStatusForMode(LinearPatternMode mode);
+    std::vector<gp_Trsf> calculateTransformations() const;
 };
 
 } //namespace PartDesign

--- a/src/Mod/PartDesign/App/FeatureMirrored.cpp
+++ b/src/Mod/PartDesign/App/FeatureMirrored.cpp
@@ -90,13 +90,13 @@ gp_Trsf Mirrored::calculateTransformation() const
         axbase = gp_Pnt(axis.getBase().x, axis.getBase().y, axis.getBase().z);
         axdir = gp_Dir(axis.getDirection().x, axis.getDirection().y, axis.getDirection().z);
     } else if (refObject->isDerivedFrom<PartDesign::Plane>()) {
-        PartDesign::Plane* plane = static_cast<PartDesign::Plane*>(refObject);
+        PartDesign::Plane const* plane = static_cast<PartDesign::Plane const*>(refObject);
         Base::Vector3d base = plane->getBasePoint();
         axbase = gp_Pnt(base.x, base.y, base.z);
         Base::Vector3d dir = plane->getNormal();
         axdir = gp_Dir(dir.x, dir.y, dir.z);
     } else if (refObject->isDerivedFrom<App::Plane>()) {
-        App::Plane* plane = static_cast<App::Plane*>(refObject);
+        App::Plane const* plane = static_cast<App::Plane const*>(refObject);
         Base::Vector3d base = plane->Placement.getValue().getPosition();
         axbase = gp_Pnt(base.x, base.y, base.z);
         Base::Rotation rot = plane->Placement.getValue().getRotation();
@@ -106,7 +106,7 @@ gp_Trsf Mirrored::calculateTransformation() const
     } else if (refObject->isDerivedFrom<Part::Feature>()) {
         if (subStrings[0].empty())
             throw Base::ValueError("No direction reference specified");
-        Part::TopoShape baseShape = static_cast<Part::Feature*>(refObject)->Shape.getShape();
+        Part::TopoShape baseShape = static_cast<Part::Feature const*>(refObject)->Shape.getShape();
         // TODO: Check for multiple mirror planes?
         TopoDS_Shape shape = baseShape.getSubShape(subStrings[0].c_str());
         TopoDS_Face face = TopoDS::Face(shape);

--- a/src/Mod/PartDesign/App/FeatureMirrored.cpp
+++ b/src/Mod/PartDesign/App/FeatureMirrored.cpp
@@ -78,7 +78,7 @@ gp_Trsf Mirrored::calculateTransformation() const
     gp_Pnt axbase;
     gp_Dir axdir;
     if (refObject->isDerivedFrom<Part::Part2DObject>()) {
-        Part::Part2DObject* refSketch = static_cast<Part::Part2DObject*>(refObject);
+        auto refSketch = static_cast<Part::Part2DObject*>(refObject);
         Base::Axis axis;
         if (subStrings[0] == "H_Axis") {
             axis = refSketch->getAxis(Part::Part2DObject::V_Axis);
@@ -104,14 +104,14 @@ gp_Trsf Mirrored::calculateTransformation() const
         axdir = gp_Dir(axis.getDirection().x, axis.getDirection().y, axis.getDirection().z);
     }
     else if (refObject->isDerivedFrom<PartDesign::Plane>()) {
-        PartDesign::Plane const* plane = static_cast<PartDesign::Plane const*>(refObject);
+        auto plane = static_cast<PartDesign::Plane const*>(refObject);
         Base::Vector3d base = plane->getBasePoint();
         axbase = gp_Pnt(base.x, base.y, base.z);
         Base::Vector3d dir = plane->getNormal();
         axdir = gp_Dir(dir.x, dir.y, dir.z);
     }
     else if (refObject->isDerivedFrom<App::Plane>()) {
-        App::Plane const* plane = static_cast<App::Plane const*>(refObject);
+        auto plane = static_cast<App::Plane const*>(refObject);
         Base::Vector3d base = plane->Placement.getValue().getPosition();
         axbase = gp_Pnt(base.x, base.y, base.z);
         Base::Rotation rot = plane->Placement.getValue().getRotation();

--- a/src/Mod/PartDesign/App/FeatureMirrored.h
+++ b/src/Mod/PartDesign/App/FeatureMirrored.h
@@ -50,7 +50,7 @@ public:
     }
     //@}
 
-    /** Apply mirrir transformation
+    /** Apply mirror transformation
      * Returns a list containing the original shapes and mirrors of each one.
      * The transformation will mirror a shape it is applied to on a plane
      * If MirrorPlane contains a feature and a face name, then the mirror plane will be

--- a/src/Mod/PartDesign/App/FeatureMirrored.h
+++ b/src/Mod/PartDesign/App/FeatureMirrored.h
@@ -30,7 +30,7 @@
 namespace PartDesign
 {
 
-class PartDesignExport Mirrored : public PartDesign::Transformed
+class PartDesignExport Mirrored: public PartDesign::Transformed
 {
     PROPERTY_HEADER_WITH_OVERRIDE(PartDesign::Mirrored);
 
@@ -39,29 +39,30 @@ public:
 
     App::PropertyLinkSub MirrorPlane;
 
-   /** @name methods override feature */
+    /** @name methods override feature */
     //@{
     short mustExecute() const override;
 
     /// returns the type name of the view provider
-    const char* getViewProviderName() const override {
+    const char* getViewProviderName() const override
+    {
         return "PartDesignGui::ViewProviderMirrored";
     }
     //@}
 
     /** Apply mirrir transformation
-      * Returns a list containing the original shapes and mirrors of each one.
-      * The transformation will mirror a shape it is applied to on a plane
-      * If MirrorPlane contains a feature and a face name, then the mirror plane will be
-      * the given face, which must be planar.
-      */
+     * Returns a list containing the original shapes and mirrors of each one.
+     * The transformation will mirror a shape it is applied to on a plane
+     * If MirrorPlane contains a feature and a face name, then the mirror plane will be
+     * the given face, which must be planar.
+     */
     std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const override;
 
 private:
     gp_Trsf calculateTransformation() const;
 };
 
-} //namespace PartDesign
+}  // namespace PartDesign
 
 
-#endif // PARTDESIGN_FeatureMirrored_H
+#endif  // PARTDESIGN_FeatureMirrored_H

--- a/src/Mod/PartDesign/App/FeatureMirrored.h
+++ b/src/Mod/PartDesign/App/FeatureMirrored.h
@@ -49,13 +49,16 @@ public:
     }
     //@}
 
-    /** Create transformations
-      * Returns a list containing one transformation since the first, untransformed instance
-      * is not counted. The transformation will mirror the shape it is applied to on a plane
+    /** Apply mirrir transformation
+      * Returns a list containing the original shapes and mirrors of each one.
+      * The transformation will mirror a shape it is applied to on a plane
       * If MirrorPlane contains a feature and a face name, then the mirror plane will be
-      * the given face, which must be planar
+      * the given face, which must be planar.
       */
-    const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*>) override;
+    std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const override;
+
+private:
+    gp_Trsf calculateTransformation() const;
 };
 
 } //namespace PartDesign

--- a/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
+++ b/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
@@ -71,112 +71,20 @@ short MultiTransform::mustExecute() const
     return Transformed::mustExecute();
 }
 
-const std::list<gp_Trsf> MultiTransform::getTransformations(const std::vector<App::DocumentObject*> originals)
+std::vector<TopoDS_Shape> MultiTransform::applyTransformation(std::vector<TopoDS_Shape> shapes) const
 {
-    std::vector<App::DocumentObject*> transFeatures = Transformations.getValues();
+    std::vector<App::DocumentObject*> const transFeatures = Transformations.getValues();
 
-    // Find centre of gravity of first original
-    // FIXME: This method will NOT give the expected result for more than one original!
-    Part::Feature* originalFeature = static_cast<Part::Feature*>(originals.front());
-    TopoDS_Shape original;
-
-    if (originalFeature->isDerivedFrom<PartDesign::FeatureAddSub>()) {
-        PartDesign::FeatureAddSub* addFeature = static_cast<PartDesign::FeatureAddSub*>(originalFeature);
-        //if (addFeature->getAddSubType() == FeatureAddSub::Additive)
-        //    original = addFeature->AddSubShape.getShape().getShape();
-        //else
-            original = addFeature->AddSubShape.getShape().getShape();
-    }
-
-    GProp_GProps props;
-    BRepGProp::VolumeProperties(original,props);
-    gp_Pnt cog = props.CentreOfMass();
-
-    std::list<gp_Trsf> result;
-    std::list<gp_Pnt> cogs;
-    std::vector<App::DocumentObject*>::const_iterator f;
-
-    for (f = transFeatures.begin(); f != transFeatures.end(); ++f) {
-        if (!((*f)->isDerivedFrom<PartDesign::Transformed>()))
+    for (auto docObj : transFeatures) {
+        if (!docObj->isDerivedFrom<PartDesign::Transformed>()) {
             throw Base::TypeError("Transformation features must be subclasses of Transformed");
-        PartDesign::Transformed* transFeature = static_cast<PartDesign::Transformed*>(*f);
-        std::list<gp_Trsf> newTransformations = transFeature->getTransformations(originals);
-
-        if (result.empty()) {
-            // First transformation Feature
-            result = newTransformations;
-            for (std::list<gp_Trsf>::const_iterator nt = newTransformations.begin(); nt != newTransformations.end(); ++nt) {
-                cogs.push_back(cog.Transformed(*nt));
-            }
-        } else {
-            // Retain a copy of the first set of transformations for iterator ot
-            // We can't iterate through result if we are also adding elements with push_back()!
-            std::list<gp_Trsf> oldTransformations;
-            result.swap(oldTransformations); // empty result to receive new transformations
-            std::list<gp_Pnt> oldCogs;
-            cogs.swap(oldCogs); // empty cogs to receive new cogs
-
-            if ((*f)->is<PartDesign::Scaled>()) {
-                // Diagonal method
-                // Multiply every element in the old transformations' slices with the corresponding
-                // element in the newTransformations. Example:
-                // a11 a12 a13 a14          b1    a11*b1 a12*b1 a13*b1 a14*b1
-                // a21 a22 a23 a24   diag   b2  = a21*b2 a22*b2 a23*b2 a24*b1
-                // a31 a23 a33 a34          b3    a31*b3 a23*b3 a33*b3 a34*b1
-                // In other words, the length of the result vector is equal to the length of the
-                // oldTransformations vector
-
-                if (newTransformations.empty())
-                    throw Base::ValueError("Number of occurrences must be a divisor of previous number of occurrences");
-                if (oldTransformations.size() % newTransformations.size() != 0)
-                    throw Base::ValueError("Number of occurrences must be a divisor of previous number of occurrences");
-
-                unsigned sliceLength = oldTransformations.size() / newTransformations.size();
-                std::list<gp_Trsf>::const_iterator ot = oldTransformations.begin();
-                std::list<gp_Pnt>::const_iterator oc = oldCogs.begin();
-
-                for (std::list<gp_Trsf>::const_iterator nt = newTransformations.begin(); nt != newTransformations.end(); ++nt) {
-                    for (unsigned s = 0; s < sliceLength; s++) {
-                        gp_Trsf trans;
-                        double factor = nt->ScaleFactor(); // extract scale factor
-
-                        if (factor > Precision::Confusion()) {
-                            trans.SetScale(*oc, factor); // recreate the scaled transformation to use the correct COG
-                            trans = trans * (*ot);
-                            cogs.push_back(*oc); // Scaling does not affect the COG
-                        } else {
-                            trans = (*nt) * (*ot);
-                            cogs.push_back(oc->Transformed(*nt));
-                        }
-                        result.push_back(trans);
-                        ++ot;
-                        ++oc;
-                    }
-                }
-            } else {
-                // Multiplication method: Combine the new transformations with the old ones.
-                // All old transformations are multiplied with all new ones, so that the length of the
-                // result vector is the length of the old and new transformations multiplied.
-                // a11 a12         b1    a11*b1 a12*b1 a11*b2 a12*b2 a11*b3 a12*b3
-                // a21 a22   mul   b2  = a21*b1 a22*b1 a21*b2 a22*b2 a21*b3 a22*b3
-                //                 b3
-                for (std::list<gp_Trsf>::const_iterator nt = newTransformations.begin(); nt != newTransformations.end(); ++nt) {
-                    std::list<gp_Pnt>::const_iterator oc = oldCogs.begin();
-
-                    for (std::list<gp_Trsf>::const_iterator ot = oldTransformations.begin(); ot != oldTransformations.end(); ++ot) {
-                        result.push_back((*nt) * (*ot));
-                        cogs.push_back(oc->Transformed(*nt));
-                        ++oc;
-                    }
-                }
-            }
-            // What about the Additive method: Take the last (set of) transformations and use them as
-            // "originals" for the next transformationFeature, so that something similar to a sweep
-            // for transformations could be put together?
         }
+        auto transFeature = static_cast<PartDesign::Transformed const*>(docObj);
+
+        shapes = transFeature->applyTransformation(std::move(shapes));
     }
 
-    return result;
+    return shapes;
 }
 
 }

--- a/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
+++ b/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
@@ -55,7 +55,7 @@ void MultiTransform::positionBySupport()
         if (!(f->isDerivedFrom<PartDesign::Transformed>())) {
             throw Base::TypeError("Transformation features must be subclasses of Transformed");
         }
-        PartDesign::Transformed* transFeature = static_cast<PartDesign::Transformed*>(f);
+        auto transFeature = static_cast<PartDesign::Transformed*>(f);
         transFeature->Placement.setValue(this->Placement.getValue());
 
         // To avoid that a linked transform feature stays touched after a recompute

--- a/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
+++ b/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
@@ -23,9 +23,9 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <BRepGProp.hxx>
-# include <GProp_GProps.hxx>
-# include <Precision.hxx>
+#include <BRepGProp.hxx>
+#include <GProp_GProps.hxx>
+#include <Precision.hxx>
 #endif
 
 #include "FeatureMultiTransform.h"
@@ -35,14 +35,15 @@
 
 using namespace PartDesign;
 
-namespace PartDesign {
+namespace PartDesign
+{
 
 
 PROPERTY_SOURCE(PartDesign::MultiTransform, PartDesign::Transformed)
 
 MultiTransform::MultiTransform()
 {
-    ADD_PROPERTY(Transformations,(nullptr));
+    ADD_PROPERTY(Transformations, (nullptr));
     Transformations.setSize(0);
 }
 
@@ -51,8 +52,9 @@ void MultiTransform::positionBySupport()
     PartDesign::Transformed::positionBySupport();
     std::vector<App::DocumentObject*> transFeatures = Transformations.getValues();
     for (auto f : transFeatures) {
-        if (!(f->isDerivedFrom<PartDesign::Transformed>()))
+        if (!(f->isDerivedFrom<PartDesign::Transformed>())) {
             throw Base::TypeError("Transformation features must be subclasses of Transformed");
+        }
         PartDesign::Transformed* transFeature = static_cast<PartDesign::Transformed*>(f);
         transFeature->Placement.setValue(this->Placement.getValue());
 
@@ -66,12 +68,14 @@ void MultiTransform::positionBySupport()
 
 short MultiTransform::mustExecute() const
 {
-    if (Transformations.isTouched())
+    if (Transformations.isTouched()) {
         return 1;
+    }
     return Transformed::mustExecute();
 }
 
-std::vector<TopoDS_Shape> MultiTransform::applyTransformation(std::vector<TopoDS_Shape> shapes) const
+std::vector<TopoDS_Shape>
+MultiTransform::applyTransformation(std::vector<TopoDS_Shape> shapes) const
 {
     std::vector<App::DocumentObject*> const transFeatures = Transformations.getValues();
 
@@ -87,4 +91,4 @@ std::vector<TopoDS_Shape> MultiTransform::applyTransformation(std::vector<TopoDS
     return shapes;
 }
 
-}
+}  // namespace PartDesign

--- a/src/Mod/PartDesign/App/FeatureMultiTransform.h
+++ b/src/Mod/PartDesign/App/FeatureMultiTransform.h
@@ -51,12 +51,12 @@ public:
 
     std::vector<App::DocumentObject*> getOriginals() const { return Originals.getValues(); }
 
-    /** Create transformations
-      * Returns a list containing the product of all transformations of the subfeatures given
-      * by the Transformations property. Subfeatures can be Mirrored, LinearPattern, PolarPattern and
-      * Scaled.
+    /** Apply all subfeature transformations
+      * Returns a list containing the shapes resulting from applying all transformations of
+      * the subfeatures, given by the Transformations property, after each other.
+      * Subfeatures can be Mirrored, LinearPattern, PolarPattern and Scaled.
       */
-    const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*> originals) override;
+    std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const override;
 
 protected:
     void positionBySupport() override;

--- a/src/Mod/PartDesign/App/FeatureMultiTransform.h
+++ b/src/Mod/PartDesign/App/FeatureMultiTransform.h
@@ -30,7 +30,7 @@
 namespace PartDesign
 {
 
-class PartDesignExport MultiTransform : public PartDesign::Transformed
+class PartDesignExport MultiTransform: public PartDesign::Transformed
 {
     PROPERTY_HEADER_WITH_OVERRIDE(PartDesign::MultiTransform);
 
@@ -39,30 +39,34 @@ public:
 
     App::PropertyLinkList Transformations;
 
-   /** @name methods override feature */
+    /** @name methods override feature */
     //@{
     short mustExecute() const override;
 
     /// returns the type name of the view provider
-    const char* getViewProviderName() const override {
+    const char* getViewProviderName() const override
+    {
         return "PartDesignGui::ViewProviderMultiTransform";
     }
     //@}
 
-    std::vector<App::DocumentObject*> getOriginals() const { return Originals.getValues(); }
+    std::vector<App::DocumentObject*> getOriginals() const
+    {
+        return Originals.getValues();
+    }
 
     /** Apply all subfeature transformations
-      * Returns a list containing the shapes resulting from applying all transformations of
-      * the subfeatures, given by the Transformations property, after each other.
-      * Subfeatures can be Mirrored, LinearPattern, PolarPattern and Scaled.
-      */
+     * Returns a list containing the shapes resulting from applying all transformations of
+     * the subfeatures, given by the Transformations property, after each other.
+     * Subfeatures can be Mirrored, LinearPattern, PolarPattern and Scaled.
+     */
     std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const override;
 
 protected:
     void positionBySupport() override;
 };
 
-} //namespace PartDesign
+}  // namespace PartDesign
 
 
-#endif // PARTDESIGN_FeatureMultiTransform_H
+#endif  // PARTDESIGN_FeatureMultiTransform_H

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -115,7 +115,7 @@ std::vector<gp_Trsf> PolarPattern::calculateTransformations() const
     gp_Pnt axbase;
     gp_Dir axdir;
     if (refObject->isDerivedFrom<Part::Part2DObject>()) {
-        Part::Part2DObject const* refSketch = static_cast<Part::Part2DObject const*>(refObject);
+        auto refSketch = static_cast<Part::Part2DObject const*>(refObject);
         Base::Axis axis;
         if (subStrings[0] == "H_Axis") {
             axis = refSketch->getAxis(Part::Part2DObject::H_Axis);
@@ -137,14 +137,14 @@ std::vector<gp_Trsf> PolarPattern::calculateTransformations() const
         axdir = gp_Dir(axis.getDirection().x, axis.getDirection().y, axis.getDirection().z);
     }
     else if (refObject->isDerivedFrom<PartDesign::Line>()) {
-        PartDesign::Line const* line = static_cast<PartDesign::Line const*>(refObject);
+        auto line = static_cast<PartDesign::Line const*>(refObject);
         Base::Vector3d base = line->getBasePoint();
         axbase = gp_Pnt(base.x, base.y, base.z);
         Base::Vector3d dir = line->getDirection();
         axdir = gp_Dir(dir.x, dir.y, dir.z);
     }
     else if (refObject->isDerivedFrom<App::Line>()) {
-        App::Line const* line = static_cast<App::Line const*>(refObject);
+        auto line = static_cast<App::Line const*>(refObject);
         Base::Rotation rot = line->Placement.getValue().getRotation();
         Base::Vector3d d(1, 0, 0);
         rot.multVec(d, d);
@@ -154,7 +154,7 @@ std::vector<gp_Trsf> PolarPattern::calculateTransformations() const
         if (subStrings[0].empty()) {
             throw Base::ValueError("No axis reference specified");
         }
-        Part::Feature const* refFeature = static_cast<Part::Feature const*>(refObject);
+        auto refFeature = static_cast<Part::Feature const*>(refObject);
         Part::TopoShape refShape = refFeature->Shape.getShape();
         TopoDS_Shape ref = refShape.getSubShape(subStrings[0].c_str());
 

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -86,16 +86,17 @@ short PolarPattern::mustExecute() const
 
 std::vector<gp_Trsf> PolarPattern::calculateTransformations() const
 {
-    int occurrences = Occurrences.getValue();
+    int const occurrences = Occurrences.getValue();
+
     if (occurrences < 1)
         throw Base::ValueError("At least one occurrence required");
 
     if (occurrences == 1)
         return {};
 
-    bool reversed = Reversed.getValue();
+    bool const reversed = Reversed.getValue();
 
-    App::DocumentObject* refObject = Axis.getValue();
+    App::DocumentObject const* refObject = Axis.getValue();
     if (!refObject)
         throw Base::ValueError("No axis reference specified");
     std::vector<std::string> subStrings = Axis.getSubValues();
@@ -105,7 +106,7 @@ std::vector<gp_Trsf> PolarPattern::calculateTransformations() const
     gp_Pnt axbase;
     gp_Dir axdir;
     if (refObject->isDerivedFrom<Part::Part2DObject>()) {
-        Part::Part2DObject* refSketch = static_cast<Part::Part2DObject*>(refObject);
+        Part::Part2DObject const* refSketch = static_cast<Part::Part2DObject const*>(refObject);
         Base::Axis axis;
         if (subStrings[0] == "H_Axis")
             axis = refSketch->getAxis(Part::Part2DObject::H_Axis);
@@ -122,13 +123,13 @@ std::vector<gp_Trsf> PolarPattern::calculateTransformations() const
         axbase = gp_Pnt(axis.getBase().x, axis.getBase().y, axis.getBase().z);
         axdir = gp_Dir(axis.getDirection().x, axis.getDirection().y, axis.getDirection().z);
     } else if (refObject->isDerivedFrom<PartDesign::Line>()) {
-        PartDesign::Line* line = static_cast<PartDesign::Line*>(refObject);
+        PartDesign::Line const* line = static_cast<PartDesign::Line const*>(refObject);
         Base::Vector3d base = line->getBasePoint();
         axbase = gp_Pnt(base.x, base.y, base.z);
         Base::Vector3d dir = line->getDirection();
         axdir = gp_Dir(dir.x, dir.y, dir.z);
     } else if (refObject->isDerivedFrom<App::Line>()) {
-        App::Line* line = static_cast<App::Line*>(refObject);
+        App::Line const* line = static_cast<App::Line const*>(refObject);
         Base::Rotation rot = line->Placement.getValue().getRotation();
         Base::Vector3d d(1,0,0);
         rot.multVec(d, d);
@@ -136,7 +137,7 @@ std::vector<gp_Trsf> PolarPattern::calculateTransformations() const
     } else if (refObject->isDerivedFrom<Part::Feature>()) {
         if (subStrings[0].empty())
             throw Base::ValueError("No axis reference specified");
-        Part::Feature* refFeature = static_cast<Part::Feature*>(refObject);
+        Part::Feature const* refFeature = static_cast<Part::Feature const*>(refObject);
         Part::TopoShape refShape = refFeature->Shape.getShape();
         TopoDS_Shape ref = refShape.getSubShape(subStrings[0].c_str());
 
@@ -190,7 +191,7 @@ std::vector<gp_Trsf> PolarPattern::calculateTransformations() const
             throw Base::ValueError("Invalid mode");
     }
 
-    double offset = Base::toRadians<double>(angle);
+    double const offset = Base::toRadians<double>(angle);
 
     if (offset < Precision::Angular())
         throw Base::ValueError("Pattern angle too small");

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.h
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.h
@@ -60,26 +60,27 @@ public:
     }
     //@}
 
-    /** Create transformations
-     * 
-      * Returns a list of (Occurrences - 1) transformations since the first, untransformed instance
-      * is not counted. Each transformation will rotate the shape it is applied to by the supplied angle.
-      * 
+    /** Apply polar pattern
+      *
+      * Returns a list of (Occurrences * N) shapes. The first N shapes will be the untransformed
+      * original shapes.
+      * Each transformation will rotate the shape it is applied to by the supplied angle.
+      *
       * Depending on Mode selection list will be constructed differently:
-      * 1. For "angle" mode each feature will be rotated by (Angle / (Occurrences - 1)) so 
-      * that the transformations will cover the total Angle. The only exception is Angle = 360 degrees in 
-      * which case the transformation angle will be (Angle / Occurrences) so that the last transformed shape 
-      * is not identical with the original shape. 
-      * 2. For "offset" mode each feature will be rotated using exact angle from Offset parameter. It can 
+      * 1. For "angle" mode each feature will be rotated by (Angle / (Occurrences - 1)) so
+      * that the transformations will cover the total Angle. The only exception is Angle = 360 degrees in
+      * which case the transformation angle will be (Angle / Occurrences) so that the last transformed shape
+      * is not identical with the original shape.
+      * 2. For "offset" mode each feature will be rotated using exact angle from Offset parameter. It can
       * potentially result in transformation that extends beyond full rotation or results in overlapping shapes.
       * This situations are considered as potential user errors and should be solved by user.
-      * 
+      *
       * If Axis contains a feature and an edge name, then the transformation axis will be
       * the given edge, which must be linear.
-      * 
+      *
       * If Reversed is true, the direction of rotation will be opposite.
       */
-    const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*>) override;
+    std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const override;
 
 protected:
     void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop) override;
@@ -92,6 +93,7 @@ private:
     static const char* ModeEnums[];
 
     void setReadWriteStatusForMode(PolarPatternMode mode);
+    std::vector<gp_Trsf> calculateTransformations() const;
 };
 
 } //namespace PartDesign

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.h
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.h
@@ -31,59 +31,64 @@
 
 namespace PartDesign
 {
-enum class PolarPatternMode {
+enum class PolarPatternMode
+{
     angle,
     offset
 };
 
-class PartDesignExport PolarPattern : public PartDesign::Transformed
+class PartDesignExport PolarPattern: public PartDesign::Transformed
 {
     PROPERTY_HEADER_WITH_OVERRIDE(PartDesign::PolarPattern);
 
 public:
     PolarPattern();
 
-    App::PropertyLinkSub     Axis;
-    App::PropertyBool        Reversed;
+    App::PropertyLinkSub Axis;
+    App::PropertyBool Reversed;
     App::PropertyEnumeration Mode;
-    App::PropertyAngle       Angle;
-    App::PropertyAngle       Offset;
+    App::PropertyAngle Angle;
+    App::PropertyAngle Offset;
     App::PropertyIntegerConstraint Occurrences;
 
-   /** @name methods override feature */
+    /** @name methods override feature */
     //@{
     short mustExecute() const override;
 
     /// returns the type name of the view provider
-    const char* getViewProviderName() const override {
+    const char* getViewProviderName() const override
+    {
         return "PartDesignGui::ViewProviderPolarPattern";
     }
     //@}
 
     /** Apply polar pattern
-      *
-      * Returns a list of (Occurrences * N) shapes. The first N shapes will be the untransformed
-      * original shapes.
-      * Each transformation will rotate the shape it is applied to by the supplied angle.
-      *
-      * Depending on Mode selection list will be constructed differently:
-      * 1. For "angle" mode each feature will be rotated by (Angle / (Occurrences - 1)) so
-      * that the transformations will cover the total Angle. The only exception is Angle = 360 degrees in
-      * which case the transformation angle will be (Angle / Occurrences) so that the last transformed shape
-      * is not identical with the original shape.
-      * 2. For "offset" mode each feature will be rotated using exact angle from Offset parameter. It can
-      * potentially result in transformation that extends beyond full rotation or results in overlapping shapes.
-      * This situations are considered as potential user errors and should be solved by user.
-      *
-      * If Axis contains a feature and an edge name, then the transformation axis will be
-      * the given edge, which must be linear.
-      *
-      * If Reversed is true, the direction of rotation will be opposite.
-      */
+     *
+     * Returns a list of (Occurrences * N) shapes. The first N shapes will be the untransformed
+     * original shapes.
+     * Each transformation will rotate the shape it is applied to by the supplied angle.
+     *
+     * Depending on Mode selection list will be constructed differently:
+     * 1. For "angle" mode each feature will be rotated by (Angle / (Occurrences - 1)) so
+     * that the transformations will cover the total Angle. The only exception is Angle = 360
+     * degrees in which case the transformation angle will be (Angle / Occurrences) so that the last
+     * transformed shape is not identical with the original shape.
+     * 2. For "offset" mode each feature will be rotated using exact angle from Offset parameter. It
+     * can potentially result in transformation that extends beyond full rotation or results in
+     * overlapping shapes. This situations are considered as potential user errors and should be
+     * solved by user.
+     *
+     * If Axis contains a feature and an edge name, then the transformation axis will be
+     * the given edge, which must be linear.
+     *
+     * If Reversed is true, the direction of rotation will be opposite.
+     */
     std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const override;
 
 protected:
-    void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop) override;
+    void handleChangedPropertyType(Base::XMLReader& reader,
+                                   const char* TypeName,
+                                   App::Property* prop) override;
     void onChanged(const App::Property* prop) override;
 
     static const App::PropertyIntegerConstraint::Constraints intOccurrences;
@@ -96,7 +101,7 @@ private:
     std::vector<gp_Trsf> calculateTransformations() const;
 };
 
-} //namespace PartDesign
+}  // namespace PartDesign
 
 
-#endif // PARTDESIGN_FeaturePolarPattern_H
+#endif  // PARTDESIGN_FeaturePolarPattern_H

--- a/src/Mod/PartDesign/App/FeatureScaled.cpp
+++ b/src/Mod/PartDesign/App/FeatureScaled.cpp
@@ -23,10 +23,10 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <BRepGProp.hxx>
-# include <BRepBuilderAPI_Transform.hxx>
-# include <GProp_GProps.hxx>
-# include <Precision.hxx>
+#include <BRepGProp.hxx>
+#include <BRepBuilderAPI_Transform.hxx>
+#include <GProp_GProps.hxx>
+#include <Precision.hxx>
 #endif
 
 #include "FeatureScaled.h"
@@ -35,33 +35,36 @@
 
 using namespace PartDesign;
 
-namespace PartDesign {
+namespace PartDesign
+{
 
 
 PROPERTY_SOURCE(PartDesign::Scaled, PartDesign::Transformed)
 
 Scaled::Scaled()
 {
-    ADD_PROPERTY(Factor,(2.0));
-    ADD_PROPERTY(Occurrences,(2));
+    ADD_PROPERTY(Factor, (2.0));
+    ADD_PROPERTY(Occurrences, (2));
 }
 
 short Scaled::mustExecute() const
 {
-    if (Factor.isTouched() ||
-        Occurrences.isTouched())
+    if (Factor.isTouched() || Occurrences.isTouched()) {
         return 1;
+    }
     return Transformed::mustExecute();
 }
 
 std::vector<TopoDS_Shape> Scaled::applyTransformation(std::vector<TopoDS_Shape> shapes) const
 {
     double const factor = Factor.getValue();
-    if (factor < Precision::Confusion())
+    if (factor < Precision::Confusion()) {
         throw Base::ValueError("Scaling factor too small");
+    }
     int const occurrences = Occurrences.getValue();
-    if (occurrences < 2)
+    if (occurrences < 2) {
         throw Base::ValueError("At least two occurrences required");
+    }
 
     double const f = (factor - 1.0) / double(occurrences - 1);
 
@@ -82,10 +85,12 @@ std::vector<TopoDS_Shape> Scaled::applyTransformation(std::vector<TopoDS_Shape> 
         }
         result.push_back(mkScale);
 
-        if (++i == occurrences) i = 0;
+        if (++i == occurrences) {
+            i = 0;
+        }
     }
 
     return result;
 }
 
-}
+}  // namespace PartDesign

--- a/src/Mod/PartDesign/App/FeatureScaled.cpp
+++ b/src/Mod/PartDesign/App/FeatureScaled.cpp
@@ -56,14 +56,14 @@ short Scaled::mustExecute() const
 
 std::vector<TopoDS_Shape> Scaled::applyTransformation(std::vector<TopoDS_Shape> shapes) const
 {
-    double factor = Factor.getValue();
+    double const factor = Factor.getValue();
     if (factor < Precision::Confusion())
         throw Base::ValueError("Scaling factor too small");
-    int occurrences = Occurrences.getValue();
+    int const occurrences = Occurrences.getValue();
     if (occurrences < 2)
         throw Base::ValueError("At least two occurrences required");
 
-    double f = (factor - 1.0) / double(occurrences - 1);
+    double const f = (factor - 1.0) / double(occurrences - 1);
 
     std::vector<TopoDS_Shape> result;
 

--- a/src/Mod/PartDesign/App/FeatureScaled.h
+++ b/src/Mod/PartDesign/App/FeatureScaled.h
@@ -31,37 +31,38 @@
 namespace PartDesign
 {
 
-class PartDesignExport Scaled : public PartDesign::Transformed
+class PartDesignExport Scaled: public PartDesign::Transformed
 {
     PROPERTY_HEADER_WITH_OVERRIDE(PartDesign::Scaled);
 
 public:
     Scaled();
 
-    App::PropertyFloat   Factor;
+    App::PropertyFloat Factor;
     App::PropertyInteger Occurrences;
 
-   /** @name methods override feature */
+    /** @name methods override feature */
     //@{
     short mustExecute() const override;
 
     /// returns the type name of the view provider
-    const char* getViewProviderName() const override {
+    const char* getViewProviderName() const override
+    {
         return "PartDesignGui::ViewProviderScaled";
     }
     //@}
 
     /** Apply scale transformation
-      * Returns a list containing the same number of shapes as given.
-      * Each shape will be scaled by an additional factor of (Factor / (Occurences - 1)).
-      * If there are less shapes than Occurences, not all factors will be present.
-      * If there are more shapes than Occurences, the factors will repeat.
-      * The centre point of the scaling is the centre of mass of each shape.
-      */
+     * Returns a list containing the same number of shapes as given.
+     * Each shape will be scaled by an additional factor of (Factor / (Occurences - 1)).
+     * If there are less shapes than Occurences, not all factors will be present.
+     * If there are more shapes than Occurences, the factors will repeat.
+     * The centre point of the scaling is the centre of mass of each shape.
+     */
     std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const override;
 };
 
-} //namespace PartDesign
+}  // namespace PartDesign
 
 
-#endif // PARTDESIGN_FeatureScaled_H
+#endif  // PARTDESIGN_FeatureScaled_H

--- a/src/Mod/PartDesign/App/FeatureScaled.h
+++ b/src/Mod/PartDesign/App/FeatureScaled.h
@@ -54,9 +54,9 @@ public:
 
     /** Apply scale transformation
      * Returns a list containing the same number of shapes as given.
-     * Each shape will be scaled by an additional factor of (Factor / (Occurences - 1)).
-     * If there are less shapes than Occurences, not all factors will be present.
-     * If there are more shapes than Occurences, the factors will repeat.
+     * Each shape will be scaled by an additional factor of (Factor / (Occurrences - 1)).
+     * If there are less shapes than Occurrences, not all factors will be present.
+     * If there are more shapes than Occurrences, the factors will repeat.
      * The centre point of the scaling is the centre of mass of each shape.
      */
     std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const override;

--- a/src/Mod/PartDesign/App/FeatureScaled.h
+++ b/src/Mod/PartDesign/App/FeatureScaled.h
@@ -51,16 +51,14 @@ public:
     }
     //@}
 
-    /** Create transformations
-      * Returns a list containing (Occurrences-1) transformation since the first, untransformed instance
-      * is not counted. Each transformation will scale the shape it is applied to by the factor
-      * (Factor / (Occurrences - 1))
-      * The centre point of the scaling (currently) is the centre of gravity of the first original shape
-      * for this reason we need to pass the list of originals into the feature
+    /** Apply scale transformation
+      * Returns a list containing the same number of shapes as given.
+      * Each shape will be scaled by an additional factor of (Factor / (Occurences - 1)).
+      * If there are less shapes than Occurences, not all factors will be present.
+      * If there are more shapes than Occurences, the factors will repeat.
+      * The centre point of the scaling is the centre of mass of each shape.
       */
-    // Note: We can't just use the Originals property because this will fail if the Scaled feature
-    // is being used inside a MultiTransform feature
-    const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*> originals) override;
+    std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const override;
 };
 
 } //namespace PartDesign

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -108,7 +108,7 @@ App::DocumentObject* Transformed::getSketchObject() const
 {
     std::vector<DocumentObject*> originals = Originals.getValues();
     if (!originals.empty() && originals.front()->isDerivedFrom<PartDesign::ProfileBased>()) {
-        return (static_cast<PartDesign::ProfileBased*>(originals.front()))->getVerifiedSketch(true);
+        return (static_cast<PartDesign::ProfileBased const*>(originals.front()))->getVerifiedSketch(true);
     }
     else if (!originals.empty() && originals.front()->isDerivedFrom<PartDesign::FeatureAddSub>()) {
         return nullptr;

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -147,11 +147,6 @@ App::DocumentObject* Transformed::getSketchObject() const
     }
 }
 
-void Transformed::Restore(Base::XMLReader& reader)
-{
-    PartDesign::Feature::Restore(reader);
-}
-
 void Transformed::handleChangedPropertyType(Base::XMLReader& reader,
                                             const char* TypeName,
                                             App::Property* prop)

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -129,17 +129,17 @@ App::DocumentObject* Transformed::getSketchObject() const
     }
     else if (this->isDerivedFrom<LinearPattern>()) {
         // if Originals is empty then try the linear pattern's Direction property
-        const LinearPattern* pattern = static_cast<const LinearPattern*>(this);
+        auto pattern = static_cast<const LinearPattern*>(this);
         return pattern->Direction.getValue();
     }
     else if (this->isDerivedFrom<PolarPattern>()) {
         // if Originals is empty then try the polar pattern's Axis property
-        const PolarPattern* pattern = static_cast<const PolarPattern*>(this);
+        auto pattern = static_cast<const PolarPattern*>(this);
         return pattern->Axis.getValue();
     }
     else if (this->isDerivedFrom<Mirrored>()) {
         // if Originals is empty then try the mirror pattern's MirrorPlane property
-        const Mirrored* pattern = static_cast<const Mirrored*>(this);
+        auto pattern = static_cast<const Mirrored*>(this);
         return pattern->MirrorPlane.getValue();
     }
     else {

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -37,7 +37,7 @@ namespace PartDesign
  * Abstract superclass of all features that are created by transformation of another feature
  * Transformations are translation, rotation and mirroring
  */
-class PartDesignExport Transformed : public PartDesign::Feature
+class PartDesignExport Transformed: public PartDesign::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(PartDesign::Transformed);
 
@@ -45,8 +45,8 @@ public:
     Transformed();
 
     /** The shapes to be transformed
-      * if Originals is empty the instance is just a container for storing transformation data
-      */
+     * if Originals is empty the instance is just a container for storing transformation data
+     */
     App::PropertyLinkList Originals;
 
     App::PropertyBool Refine;
@@ -58,7 +58,7 @@ public:
      *               silently return a nullptr, otherwise throw Base::Exception.
      *               Default is false.
      */
-    Part::Feature* getBaseObject(bool silent=false) const override;
+    Part::Feature* getBaseObject(bool silent = false) const override;
 
     /// Return the sketch of the first original
     App::DocumentObject* getSketchObject() const;
@@ -69,37 +69,40 @@ public:
         return shapes;
     }
 
-   /** @name methods override feature */
+    /** @name methods override feature */
     //@{
     /** Recalculate the feature
-      * Gets the transformations from the virtual getTransformations() method of the sub class
-      * and applies them to every member of Originals. The total number of copies including
-      * the untransformed Originals will be sizeof(Originals) times sizeof(getTransformations())
-      * If Originals is empty, execute() returns immediately without doing anything as
-      * the actual processing will happen in the MultiTransform feature
-      */
-    App::DocumentObjectExecReturn *execute() override;
+     * Gets the transformations from the virtual getTransformations() method of the sub class
+     * and applies them to every member of Originals. The total number of copies including
+     * the untransformed Originals will be sizeof(Originals) times sizeof(getTransformations())
+     * If Originals is empty, execute() returns immediately without doing anything as
+     * the actual processing will happen in the MultiTransform feature
+     */
+    App::DocumentObjectExecReturn* execute() override;
     short mustExecute() const override;
     //@}
 
     /** returns the compound of the shapes that were rejected during the last execute
-      * because they did not overlap with the support
-      */
+     * because they did not overlap with the support
+     */
     TopoDS_Shape rejected;
 
 protected:
-    void Restore(Base::XMLReader &reader) override;
-    void handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop) override;
+    void Restore(Base::XMLReader& reader) override;
+    void handleChangedPropertyType(Base::XMLReader& reader,
+                                   const char* TypeName,
+                                   App::Property* prop) override;
     virtual void positionBySupport();
     TopoDS_Shape refineShapeIfActive(const TopoDS_Shape&) const;
-    void divideTools(const std::vector<TopoDS_Shape> &toolsIn, std::vector<TopoDS_Shape> &individualsOut,
-                     TopoDS_Compound &compoundOut) const;
+    void divideTools(const std::vector<TopoDS_Shape>& toolsIn,
+                     std::vector<TopoDS_Shape>& individualsOut,
+                     TopoDS_Compound& compoundOut) const;
     static TopoDS_Shape getRemainingSolids(const TopoDS_Shape&);
 
 private:
 };
 
-} //namespace PartDesign
+}  // namespace PartDesign
 
 
-#endif // PARTDESIGN_FeatureTransformed_H
+#endif  // PARTDESIGN_FeatureTransformed_H

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -63,10 +63,10 @@ public:
     /// Return the sketch of the first original
     App::DocumentObject* getSketchObject() const;
 
-    /// Get the list of transformations describing the members of the pattern
-    // Note: Only the Scaled feature requires the originals
-    virtual const std::list<gp_Trsf> getTransformations(const std::vector<App::DocumentObject*> /*originals*/) {
-        return std::list<gp_Trsf>(); // Default method
+    /// Apply this feature's transformation to the given shapes and return a list of new shapes
+    virtual std::vector<TopoDS_Shape> applyTransformation(std::vector<TopoDS_Shape> shapes) const
+    {
+        return shapes;
     }
 
    /** @name methods override feature */

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -88,7 +88,6 @@ public:
     TopoDS_Shape rejected;
 
 protected:
-    void Restore(Base::XMLReader& reader) override;
     void handleChangedPropertyType(Base::XMLReader& reader,
                                    const char* TypeName,
                                    App::Property* prop) override;


### PR DESCRIPTION
This refactors the way the PD patterns apply their transformations to the feature list. It will also fix #12494.

### Explanation
The old code calculates the required transformations beforehand.
If a MultiTransform is used, the transformations from the subfeatures are pre-multiplied into a final list of transformations.
Then the transformations are applied to the feature shapes.

This requires that the transformations:
    1. Use the same coordinate system (that of the Body)
    2. Are independent of the shapes

Both are broken by the Scaled feature because:
    1. The effective coordinate system is the center of mass
    2. The center of mass is dependent on the shape

For the most often used case of a single feature, this is mitigated by supplying the list of shapes to the ``getTransformations()`` function. But this also requires code duplication in the MultiTransform feature and special handling of scale subfeatures.

In the new code the transformations are applied to the shapes directly, so that the transformations can be arbitrary.
For this, the function ``applyTransformation()`` is called with a list of shapes that should be transformed. The function returns a new list of transformed shapes.
For MultiTransform these calls are just chained in the order of subfeatures. The final list of shapes is then fused/cut with the base feature's shape.

### Behaviour changes
#### Performance
The old code pre-calculated all transformations, but made an explicit copy of the underlying geometry for each shape and transformation. The new code only needs to make copies when necessary but can otherwise use sharing (internal ``TopoDS_TShape``) by only copying the ``TopoDS_Shape`` objects and changing the locations. I would assume that this might be a bit faster, but in any case the difference should be negligible.

There might be some more optimizations for Mirror and Scale that would only require a copy per shared ``TopoDS_TShape`` and then the rest of the transformations could be realized by copying the new ``TopoDS_Shape`` and changing it's location. But I'm not sure if the added complexity is worth the effort (and if I undestand the OCCT documentation correctly).

#### Output
There are changes in the behaviour of the scale feature that might break existing files:
    1. The center of mass of each shape is used instead of only the first
    2. The scale Occurrences don't need to be a multiple of the previous occurrences

I suspect that the order of scaling of the shapes worked a bit different with the old code. 
I thought the old code applied the scale to the occurrence groups of the previous feature, but playing around with it that does not seem constistent.
The new code scales the shapes in the order that the previous transformations created them, repeating the pattern if there are more shapes than occurrences.

If the new behaviour seems unexpected to users, I can try to change it to the expected behaviour.