### PR TITLE
Allow adding subfeatures to MultiTransform if there is no active Body

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -257,10 +257,9 @@ void TaskMultiTransformParameters::onTransformActivated(const QModelIndex& index
 void TaskMultiTransformParameters::onTransformAddMirrored()
 {
     closeSubTask();
-    std::string newFeatName =
-        TransformedView->getObject()->getDocument()->getUniqueObjectName("Mirrored");
-    auto pcActiveBody = PartDesignGui::getBody(false);
-    if (!pcActiveBody) {
+    std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("Mirrored");
+    auto pcBody = static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(getTopTransformedObject()));
+    if (!pcBody) {
         return;
     }
 
@@ -268,8 +267,8 @@ void TaskMultiTransformParameters::onTransformAddMirrored()
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Mirrored"));
     }
 
-    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::Mirrored','" << newFeatName << "')");
-    auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
+    FCMD_OBJ_CMD(pcBody, "newObject('PartDesign::Mirrored','"<<newFeatName<<"')");
+    auto Feat = pcBody->getDocument()->getObject(newFeatName.c_str());
     if (!Feat) {
         return;
     }
@@ -280,9 +279,8 @@ void TaskMultiTransformParameters::onTransformAddMirrored()
                      "MirrorPlane = (" << Gui::Command::getObjectCmd(sketch) << ",['V_Axis'])");
     }
     else {
-        App::Origin* orig = pcActiveBody->getOrigin();
-        FCMD_OBJ_CMD(Feat,
-                     "MirrorPlane = (" << Gui::Command::getObjectCmd(orig->getXY()) << ",[''])");
+        App::Origin* orig = pcBody->getOrigin();
+        FCMD_OBJ_CMD(Feat, "MirrorPlane = ("<<Gui::Command::getObjectCmd(orig->getXY())<<",[''])");
     }
     finishAdd(newFeatName);
     // show the new view when no error
@@ -296,10 +294,9 @@ void TaskMultiTransformParameters::onTransformAddLinearPattern()
     // See CmdPartDesignLinearPattern
     //
     closeSubTask();
-    std::string newFeatName =
-        TransformedView->getObject()->getDocument()->getUniqueObjectName("LinearPattern");
-    auto pcActiveBody = PartDesignGui::getBody(false);
-    if (!pcActiveBody) {
+    std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("LinearPattern");
+    auto pcBody = static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(getTopTransformedObject()));
+    if (!pcBody) {
         return;
     }
 
@@ -307,8 +304,8 @@ void TaskMultiTransformParameters::onTransformAddLinearPattern()
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Make LinearPattern"));
     }
 
-    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::LinearPattern','" << newFeatName << "')");
-    auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
+    FCMD_OBJ_CMD(pcBody, "newObject('PartDesign::LinearPattern','"<<newFeatName<<"')");
+    auto Feat = pcBody->getDocument()->getObject(newFeatName.c_str());
     if (!Feat) {
         return;
     }
@@ -341,10 +338,9 @@ void TaskMultiTransformParameters::onTransformAddLinearPattern()
 void TaskMultiTransformParameters::onTransformAddPolarPattern()
 {
     closeSubTask();
-    std::string newFeatName =
-        TransformedView->getObject()->getDocument()->getUniqueObjectName("PolarPattern");
-    auto pcActiveBody = PartDesignGui::getBody(false);
-    if (!pcActiveBody) {
+    std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("PolarPattern");
+    auto pcBody = static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(getTopTransformedObject()));
+    if (!pcBody) {
         return;
     }
 
@@ -352,8 +348,8 @@ void TaskMultiTransformParameters::onTransformAddPolarPattern()
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "PolarPattern"));
     }
 
-    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::PolarPattern','" << newFeatName << "')");
-    auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
+    FCMD_OBJ_CMD(pcBody, "newObject('PartDesign::PolarPattern','"<<newFeatName<<"')");
+    auto Feat = pcBody->getDocument()->getObject(newFeatName.c_str());
     if (!Feat) {
         return;
     }
@@ -363,8 +359,8 @@ void TaskMultiTransformParameters::onTransformAddPolarPattern()
         FCMD_OBJ_CMD(Feat, "Axis = (" << Gui::Command::getObjectCmd(sketch) << ",['N_Axis'])");
     }
     else {
-        App::Origin* orig = pcActiveBody->getOrigin();
-        FCMD_OBJ_CMD(Feat, "Axis = (" << Gui::Command::getObjectCmd(orig->getX()) << ",[''])");
+        App::Origin* orig = pcBody->getOrigin();
+        FCMD_OBJ_CMD(Feat, "Axis = ("<<Gui::Command::getObjectCmd(orig->getX())<<",[''])");
     }
     FCMD_OBJ_CMD(Feat, "Angle = 360");
     FCMD_OBJ_CMD(Feat, "Occurrences = 2");
@@ -379,10 +375,9 @@ void TaskMultiTransformParameters::onTransformAddPolarPattern()
 void TaskMultiTransformParameters::onTransformAddScaled()
 {
     closeSubTask();
-    std::string newFeatName =
-        TransformedView->getObject()->getDocument()->getUniqueObjectName("Scaled");
-    auto pcActiveBody = PartDesignGui::getBody(false);
-    if (!pcActiveBody) {
+    std::string newFeatName = TransformedView->getObject()->getDocument()->getUniqueObjectName("Scaled");
+    auto pcBody = static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(getTopTransformedObject()));
+    if (!pcBody) {
         return;
     }
 
@@ -390,8 +385,8 @@ void TaskMultiTransformParameters::onTransformAddScaled()
         Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Scaled"));
     }
 
-    FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::Scaled','" << newFeatName << "')");
-    auto Feat = pcActiveBody->getDocument()->getObject(newFeatName.c_str());
+    FCMD_OBJ_CMD(pcBody, "newObject('PartDesign::Scaled','"<<newFeatName<<"')");
+    auto Feat = pcBody->getDocument()->getObject(newFeatName.c_str());
     if (!Feat) {
         return;
     }

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -171,7 +171,7 @@ protected:
 
     /**
      * Returns the base transformation
-     * For stand alone features it will be object associated with the view provider
+     * For standalone features it will be object associated with the view provider
      * For features inside MultiTransform it will be the parent MultiTransform's sub feature object
      */
     PartDesign::Transformed* getObject() const;

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -211,6 +211,13 @@ protected:
     /// Fill combobox with the planes from the sketch and the own bodys origin planes
     void fillPlanesCombo(ComboLinks& combolinks, Part::Part2DObject* sketch);
 
+    /**
+     * Returns the base transformed object
+     * For stand alone features it will be objects associated with this object
+     * For features inside multitransform it will be the base multitransform object
+     */
+    PartDesign::Transformed* getTopTransformedObject() const;
+
     bool isEnabledTransaction() const;
     void setupTransaction();
 
@@ -247,13 +254,6 @@ private:
      * For features inside multitransform it will be the view provider of the multitransform object
      */
     PartDesignGui::ViewProviderTransformed* getTopTransformedView() const;
-
-    /**
-     * Returns the base transformed object
-     * For stand alone features it will be objects associated with this object
-     * For features inside multitransform it will be the base multitransform object
-     */
-    PartDesign::Transformed* getTopTransformedObject() const;
 
     void changeEvent(QEvent* event) override;
 


### PR DESCRIPTION
Previously the active Body would be checked and used to add new subfeatures.
This would either do nothing, when no Body was active, causing confusion for users becaues than can edit other features without an active Body.
Or it would add the subfeature to the wrong Body if another Body than the one of the MultiTransform was active.

Now the Body of the MultiTransform is checked and used. This fixes #12491.