### PR TITLE
Addon Manager: Fix ZIP-based update

### DIFF
--- a/src/Mod/AddonManager/AddonManagerTest/app/test_installer.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_installer.py
@@ -125,7 +125,7 @@ class TestAddonInstaller(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             test_simple_repo = os.path.join(self.test_data_dir, "test_simple_repo.zip")
             non_gh_mock = MockAddon()
-            non_gh_mock.url = test_simple_repo
+            non_gh_mock.url = test_simple_repo[:-4]
             non_gh_mock.name = "NonGitHubMock"
             installer = AddonInstaller(non_gh_mock, [])
             installer.installation_path = temp_dir
@@ -136,7 +136,7 @@ class TestAddonInstaller(unittest.TestCase):
     def test_finalize_zip_installation_github(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             test_github_style_repo = os.path.join(self.test_data_dir, "test_github_style_repo.zip")
-            self.mock_addon.url = test_github_style_repo
+            self.mock_addon.url = "https://github.com/something/test_github_style_repo"
             self.mock_addon.branch = "master"
             installer = AddonInstaller(self.mock_addon, [])
             installer.installation_path = temp_dir
@@ -146,9 +146,10 @@ class TestAddonInstaller(unittest.TestCase):
 
     def test_code_in_branch_subdirectory_true(self):
         """When there is a subdirectory with the branch name in it, find it"""
+        self.mock_addon.url = "https://something.com/something_else/something"
         installer = AddonInstaller(self.mock_addon, [])
         with tempfile.TemporaryDirectory() as temp_dir:
-            os.mkdir(os.path.join(temp_dir, f"{self.mock_addon.name}-{self.mock_addon.branch}"))
+            os.mkdir(os.path.join(temp_dir, f"something-{self.mock_addon.branch}"))
             result = installer._code_in_branch_subdirectory(temp_dir)
             self.assertTrue(result, "Failed to find ZIP subdirectory")
 
@@ -171,9 +172,10 @@ class TestAddonInstaller(unittest.TestCase):
 
     def test_move_code_out_of_subdirectory(self):
         """All files are moved out and the subdirectory is deleted"""
+        self.mock_addon.url = "https://something.com/something_else/something"
         installer = AddonInstaller(self.mock_addon, [])
         with tempfile.TemporaryDirectory() as temp_dir:
-            subdir = os.path.join(temp_dir, f"{self.mock_addon.name}-{self.mock_addon.branch}")
+            subdir = os.path.join(temp_dir, f"something-{self.mock_addon.branch}")
             os.mkdir(subdir)
             with open(os.path.join(subdir, "README.txt"), "w", encoding="utf-8") as f:
                 f.write("# Test file for unit testing")

--- a/src/Mod/AddonManager/addonmanager_installer.py
+++ b/src/Mod/AddonManager/addonmanager_installer.py
@@ -374,23 +374,36 @@ class AddonInstaller(QtCore.QObject):
         # after the branch. If that is the setup that we just extracted, move all files out of
         # that subdirectory.
         if self._code_in_branch_subdirectory(destination):
+            actual_path = os.path.join(
+                destination, f"{self.addon_to_install.name}-{self.addon_to_install.branch}"
+            )
+            FreeCAD.Console.PrintLog(
+                f"ZIP installation moving code from {actual_path} to {destination}"
+            )
             self._move_code_out_of_subdirectory(destination)
 
         FreeCAD.Console.PrintLog("ZIP installation complete.\n")
         self._finalize_successful_installation()
 
     def _code_in_branch_subdirectory(self, destination: str) -> bool:
-        subdirectories = os.listdir(destination)
-        if len(subdirectories) == 1:
-            subdir_name = subdirectories[0]
-            if subdir_name.endswith(os.path.sep):
-                subdir_name = subdir_name[:-1]  # Strip trailing slash if present
-            if subdir_name.endswith(self.addon_to_install.branch):
-                return True
+        test_path = os.path.join(destination, self._expected_subdirectory_name())
+        FreeCAD.Console.PrintLog(f"Checking for possible zip sub-path {test_path}...")
+        if os.path.isdir(test_path):
+            FreeCAD.Console.PrintLog(f"path exists.\n")
+            return True
+        FreeCAD.Console.PrintLog(f"path does not exist.\n")
         return False
 
+    def _expected_subdirectory_name(self) -> str:
+        url = self.addon_to_install.url
+        if url.endswith(".git"):
+            url = url[:-4]
+        _, _, name = url.rpartition("/")
+        branch = self.addon_to_install.branch
+        return f"{name}-{branch}"
+
     def _move_code_out_of_subdirectory(self, destination):
-        subdirectory = os.listdir(destination)[0]
+        subdirectory = os.path.join(destination, self._expected_subdirectory_name())
         for extracted_filename in os.listdir(os.path.join(destination, subdirectory)):
             shutil.move(
                 os.path.join(destination, subdirectory, extracted_filename),


### PR DESCRIPTION
Updating using the ZIP-based method failed for addons on GitHub - this fixes the issue by correctly searching for the expected subdirectory name instead of assuming there is only one subdirectory.