### PR TITLE
Gui: PythonWrapper: Do not steal reference  (fixes #12542)

### DIFF
--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -472,7 +472,7 @@ qttype* qt_getCppType(PyObject* pyobj)
     Py::Callable func = mainmod.getDict().getItem("getCppPointer");
 
     Py::Tuple arguments(1);
-    arguments[0] = Py::asObject(pyobj); // PySide pointer
+    arguments[0] = Py::Object(pyobj); // PySide pointer
     Py::Tuple result(func.apply(arguments));
     return reinterpret_cast<qttype*>(PyLong_AsVoidPtr(result[0].ptr()));
 }


### PR DESCRIPTION
Foreign Python objects needs to be passed as Py::Object(). Py::asObject() is stealing reference and object might be garbage collected even before dereferenced. Problem didn't show in the original code because methods Py::asObject() was used in were never called.

Fixes: ac6f991baff6 (Gui: Consolidate Python -> Qt class conversion)