### PR TITLE
PD: Rename {Sub}ShapeBinder::Support properties - fixes #7052

### DIFF
--- a/src/Mod/PartDesign/App/ShapeBinder.h
+++ b/src/Mod/PartDesign/App/ShapeBinder.h
@@ -49,7 +49,7 @@ public:
     ShapeBinder();
     ~ShapeBinder() override;
 
-    App::PropertyLinkSubListGlobal    Support;
+    App::PropertyLinkSubListGlobal    ObjectSupport; // intentionally not named "Support" to avoid conflict with AttachExtension::Support
     App::PropertyBool TraceSupport;
 
     static void getFilteredReferences(const App::PropertyLinkSubList* prop, App::GeoFeature*& object, std::vector< std::string >& subobjects);
@@ -62,7 +62,7 @@ public:
 protected:
     Part::TopoShape updatedShape() const;
     bool hasPlacementChanged() const;
-    void handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop) override;
+    void handleChangedPropertyName(Base::XMLReader &reader, const char * TypeName, const char * PropName) override;
     short int mustExecute() const override;
     App::DocumentObjectExecReturn* execute() override;
     void onChanged(const App::Property* prop) override;
@@ -89,7 +89,7 @@ public:
 
     void setLinks(std::map<App::DocumentObject *, std::vector<std::string> > &&values, bool reset=false);
 
-    App::PropertyXLinkSubList Support;
+    App::PropertyXLinkSubList ObjectSupport; // intentionally not named "Support" to avoid conflict with AttachExtension::Support
     App::PropertyBool ClaimChildren;
     App::PropertyBool Relative;
     App::PropertyBool Fuse;
@@ -126,8 +126,8 @@ protected:
     App::DocumentObjectExecReturn* execute() override;
     void onChanged(const App::Property *prop) override;
 
-    void handleChangedPropertyType(
-            Base::XMLReader &reader, const char * TypeName, App::Property * prop) override;
+    void handleChangedPropertyName(
+            Base::XMLReader &reader, const char * TypeName, const char * PropName) override;
 
     void onDocumentRestored() override;
     void setupObject() override;

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -319,7 +319,7 @@ void CmdPartDesignShapeBinder::activated(int iMsg)
 
         //test if current selection fits a mode.
         if (support.getSize() > 0) {
-            FCMD_OBJ_CMD(Feat,"Support = " << support.getPyReprString());
+            FCMD_OBJ_CMD(Feat,"ObjectSupport = " << support.getPyReprString());
         }
         updateActive();
         PartDesignGui::setEdit(Feat,pcActiveBody);

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -407,7 +407,7 @@ App::DocumentObject* TaskFeaturePick::makeCopy(App::DocumentObject* obj, std::st
             copy = App::GetApplication().getActiveDocument()->addObject("PartDesign::ShapeBinder", name.c_str());
 
             if(!independent)
-                static_cast<PartDesign::ShapeBinder*>(copy)->Support.setValue(obj, entity.c_str());
+                static_cast<PartDesign::ShapeBinder*>(copy)->ObjectSupport.setValue(obj, entity.c_str());
             else
                 shapeProp = &static_cast<PartDesign::ShapeBinder*>(copy)->Shape;
         }
@@ -417,7 +417,7 @@ App::DocumentObject* TaskFeaturePick::makeCopy(App::DocumentObject* obj, std::st
             copy = App::GetApplication().getActiveDocument()->addObject("PartDesign::ShapeBinder", name.c_str());
 
             if (!independent) {
-                static_cast<PartDesign::ShapeBinder*>(copy)->Support.setValue(obj, entity.c_str());
+                static_cast<PartDesign::ShapeBinder*>(copy)->ObjectSupport.setValue(obj, entity.c_str());
             }
             else {
                 App::GeoFeature* geo = static_cast<App::GeoFeature*>(obj);

--- a/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
@@ -86,13 +86,13 @@ void TaskShapeBinder::updateUI()
     App::GeoFeature* obj = nullptr;
     std::vector<std::string> subs;
 
-    PartDesign::ShapeBinder::getFilteredReferences(&static_cast<PartDesign::ShapeBinder*>(vp->getObject())->Support, obj, subs);
+    PartDesign::ShapeBinder::getFilteredReferences(&static_cast<PartDesign::ShapeBinder*>(vp->getObject())->ObjectSupport, obj, subs);
 
     if (obj) {
         ui->baseEdit->setText(QString::fromStdString(obj->Label.getStrValue()));
     }
 
-    // Allow to clear the Support
+    // Allow to clear the ObjectSupport
     ui->baseEdit->setClearButtonEnabled(true);
     connect(ui->baseEdit, &QLineEdit::textChanged,
             this, &TaskShapeBinder::supportChanged);
@@ -143,7 +143,7 @@ void TaskShapeBinder::supportChanged(const QString& text)
 {
     if (!vp.expired() && text.isEmpty()) {
         PartDesign::ShapeBinder* binder = static_cast<PartDesign::ShapeBinder*>(vp->getObject());
-        binder->Support.setValue(nullptr, nullptr);
+        binder->ObjectSupport.setValue(nullptr, nullptr);
         vp->highlightReferences(false);
         vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
         ui->listWidgetReferences->clear();
@@ -198,7 +198,7 @@ void TaskShapeBinder::deleteItem()
         std::vector<std::string> subs;
 
         PartDesign::ShapeBinder* binder = static_cast<PartDesign::ShapeBinder*>(vp->getObject());
-        PartDesign::ShapeBinder::getFilteredReferences(&binder->Support, obj, subs);
+        PartDesign::ShapeBinder::getFilteredReferences(&binder->ObjectSupport, obj, subs);
 
         std::string subname = data.constData();
         std::vector<std::string>::iterator it = std::find(subs.begin(), subs.end(), subname);
@@ -206,7 +206,7 @@ void TaskShapeBinder::deleteItem()
         // if something was found, delete it and update the support
         if (it != subs.end()) {
             subs.erase(it);
-            binder->Support.setValue(obj, subs);
+            binder->ObjectSupport.setValue(obj, subs);
 
             vp->highlightReferences(false);
             vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
@@ -294,7 +294,7 @@ bool TaskShapeBinder::referenceSelected(const SelectionChanges& msg) const
         App::GeoFeature* obj = nullptr;
         std::vector<std::string> refs;
 
-        PartDesign::ShapeBinder::getFilteredReferences(&static_cast<PartDesign::ShapeBinder*>(vp->getObject())->Support, obj, refs);
+        PartDesign::ShapeBinder::getFilteredReferences(&static_cast<PartDesign::ShapeBinder*>(vp->getObject())->ObjectSupport, obj, refs);
 
         // get selected object
         auto docObj = vp->getObject()->getDocument()->getObject(msg.pObjectName);
@@ -307,7 +307,7 @@ bool TaskShapeBinder::referenceSelected(const SelectionChanges& msg) const
             return false;
         }
         if (!obj) {
-            // Support has not been set before
+            // ObjectSupport has not been set before
             obj = selectedObj;
         }
 
@@ -337,7 +337,7 @@ bool TaskShapeBinder::referenceSelected(const SelectionChanges& msg) const
             obj = selectedObj;
         }
 
-        static_cast<PartDesign::ShapeBinder*>(vp->getObject())->Support.setValue(obj, refs);
+        static_cast<PartDesign::ShapeBinder*>(vp->getObject())->ObjectSupport.setValue(obj, refs);
 
         return true;
     }
@@ -365,7 +365,7 @@ void TaskShapeBinder::accept()
 
     std::string label = ui->baseEdit->text().toStdString();
     PartDesign::ShapeBinder* binder = static_cast<PartDesign::ShapeBinder*>(vp->getObject());
-    if (!binder->Support.getValue() && !label.empty()) {
+    if (!binder->ObjectSupport.getValue() && !label.empty()) {
         auto mode = selectionMode;
         selectionMode = refObjAdd;
         SelectionChanges msg(SelectionChanges::AddSelection, binder->getDocument()->getName(), label.c_str());

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -131,7 +131,7 @@ void ViewProviderShapeBinder::highlightReferences(bool on)
     std::vector<std::string> subs;
 
     if (getObject()->isDerivedFrom(PartDesign::ShapeBinder::getClassTypeId()))
-        PartDesign::ShapeBinder::getFilteredReferences(&static_cast<PartDesign::ShapeBinder*>(getObject())->Support, obj, subs);
+        PartDesign::ShapeBinder::getFilteredReferences(&static_cast<PartDesign::ShapeBinder*>(getObject())->ObjectSupport, obj, subs);
     else
         return;
 
@@ -317,12 +317,12 @@ bool ViewProviderSubShapeBinder::setEdit(int ModNum) {
         break;
     case SelectObject: {
         auto self = dynamic_cast<PartDesign::SubShapeBinder*>(getObject());
-        if (!self || !self->Support.getValue())
+        if (!self || !self->ObjectSupport.getValue())
             break;
 
         Gui::Selection().selStackPush();
         Gui::Selection().clearSelection();
-        for (auto& link : self->Support.getSubListValues()) {
+        for (auto& link : self->ObjectSupport.getSubListValues()) {
             auto obj = link.getValue();
             if (!obj || !obj->isAttachedToDocument())
                 continue;
@@ -345,7 +345,7 @@ bool ViewProviderSubShapeBinder::setEdit(int ModNum) {
 
 void ViewProviderSubShapeBinder::updatePlacement(bool transaction) {
     auto self = dynamic_cast<PartDesign::SubShapeBinder*>(getObject());
-    if (!self || !self->Support.getValue())
+    if (!self || !self->ObjectSupport.getValue())
         return;
 
     std::vector<Base::Matrix4D> mats;
@@ -402,9 +402,9 @@ void ViewProviderSubShapeBinder::updatePlacement(bool transaction) {
 std::vector<App::DocumentObject*> ViewProviderSubShapeBinder::claimChildren() const {
     std::vector<App::DocumentObject*> ret;
     auto self = Base::freecad_dynamic_cast<PartDesign::SubShapeBinder>(getObject());
-    if (self && self->ClaimChildren.getValue() && self->Support.getValue()) {
+    if (self && self->ClaimChildren.getValue() && self->ObjectSupport.getValue()) {
         std::set<App::DocumentObject*> objSet;
-        for (auto& l : self->Support.getSubListValues()) {
+        for (auto& l : self->ObjectSupport.getSubListValues()) {
             auto obj = l.getValue();
             if (!obj)
                 continue;

--- a/src/Mod/PartDesign/PartDesignTests/TestShapeBinder.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestShapeBinder.py
@@ -40,7 +40,7 @@ class TestShapeBinder(unittest.TestCase):
         self.Doc.recompute()
         self.Body001 = self.Doc.addObject('PartDesign::Body','Body001')
         self.ShapeBinder = self.Doc.addObject('PartDesign::ShapeBinder','ShapeBinder')
-        self.ShapeBinder.Support = [(self.Box, 'Face1')]
+        self.ShapeBinder.ObjectSupport = [(self.Box, 'Face1')]
         self.Body001.addObject(self.ShapeBinder)
         self.Doc.recompute()
         self.assertIn('Box', self.ShapeBinder.OutList[0].Label)
@@ -70,7 +70,7 @@ class TestSubShapeBinder(unittest.TestCase):
         box.Height=10.00000
 
         binder = body.newObject('PartDesign::SubShapeBinder','Binder')
-        binder.Support=[(box, ("Edge2", "Edge12", "Edge6", "Edge10"))]
+        binder.ObjectSupport=[(box, ("Edge2", "Edge12", "Edge6", "Edge10"))]
         self.Doc.recompute()
 
         self.assertAlmostEqual(binder.Shape.Length, 40)
@@ -111,7 +111,7 @@ class TestSubShapeBinder(unittest.TestCase):
         self.Doc.recompute()
 
         binder1 = body.newObject('PartDesign::SubShapeBinder','Binder')
-        binder1.Support = sketch
+        binder1.ObjectSupport = sketch
         self.Doc.recompute()
         pad = body.newObject('PartDesign::Pad','Pad')
         pad.Profile = sketch
@@ -122,7 +122,7 @@ class TestSubShapeBinder(unittest.TestCase):
         self.Doc.recompute()
 
         binder2 = body.newObject('PartDesign::SubShapeBinder','Binder001')
-        binder2.Support = [pad, "Sketch."]
+        binder2.ObjectSupport = [pad, "Sketch."]
         self.Doc.recompute()
 
         self.assertAlmostEqual(binder1.Shape.BoundBox.XLength, binder2.Shape.BoundBox.XLength, 2)


### PR DESCRIPTION
⚠️ Superseded by https://github.com/FreeCAD/FreeCAD/pull/12714 ⚠️  If that PR is merged, this can be closed.

**PartDesign:** Rename `ShapeBinder::Support` and `SubShapeBinder::Support` properties to `ObjectSupport`, to avoid name conflict with `Part::AttachExtension::Support`.

Fixes [#7052](https://github.com/FreeCAD/FreeCAD/issues/7052)

This bug is triggered when using the attach extension on a binder.

Hopefully the comments on `handleChangedPropertyName()` are self-explanatory, re: how legacy files are handled.