### PR TITLE
Gui: Fix selection in Blender, CAD and Revit style

### DIFF
--- a/src/Gui/BlenderNavigationStyle.cpp
+++ b/src/Gui/BlenderNavigationStyle.cpp
@@ -131,6 +131,9 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent * const ev)
                 this->centerTime = ev->getTime();
                 processed = true;
             }
+            else if (!press && (this->currentmode == NavigationStyle::DRAGGING)) {
+                processed = true;
+            }
             else if (viewer->isEditing() && (this->currentmode == NavigationStyle::SPINNING)) {
                 processed = true;
             }
@@ -245,12 +248,15 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent * const ev)
         // The left mouse button has been released right now
         if (this->lockButton1) {
             this->lockButton1 = false;
+            if (curmode != NavigationStyle::SELECTION) {
+                processed = true;
+            }
         }
         break;
     case BUTTON1DOWN:
     case CTRLDOWN|BUTTON1DOWN:
         // make sure not to change the selection when stopping spinning
-        if (!viewer->isEditing() && (curmode == NavigationStyle::SPINNING || this->lockButton1))
+        if (curmode == NavigationStyle::SPINNING || this->lockButton1 && curmode != NavigationStyle::SELECTION)
             newmode = NavigationStyle::IDLE;
         else
             newmode = NavigationStyle::SELECTION;

--- a/src/Gui/CADNavigationStyle.cpp
+++ b/src/Gui/CADNavigationStyle.cpp
@@ -253,11 +253,14 @@ SbBool CADNavigationStyle::processSoEvent(const SoEvent * const ev)
         // The left mouse button has been released right now
         if (this->lockButton1) {
             this->lockButton1 = false;
+            if (curmode != NavigationStyle::SELECTION) {
+                processed = true;
+            }
         }
         break;
     case BUTTON1DOWN:
         // make sure not to change the selection when stopping spinning
-        if (!viewer->isEditing() && (curmode == NavigationStyle::SPINNING || this->lockButton1))
+        if (curmode == NavigationStyle::SPINNING || this->lockButton1 && curmode != NavigationStyle::SELECTION)
             newmode = NavigationStyle::IDLE;
         else
             newmode = NavigationStyle::SELECTION;

--- a/src/Gui/RevitNavigationStyle.cpp
+++ b/src/Gui/RevitNavigationStyle.cpp
@@ -130,6 +130,9 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent * const ev)
                 this->centerTime = ev->getTime();
                 processed = true;
             }
+            else if (!press && (this->currentmode == NavigationStyle::DRAGGING)) {
+                processed = true;
+            }
             else if (viewer->isEditing() && (this->currentmode == NavigationStyle::SPINNING)) {
                 processed = true;
             }
@@ -242,12 +245,15 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent * const ev)
         // The left mouse button has been released right now
         if (this->lockButton1) {
             this->lockButton1 = false;
+            if (curmode != NavigationStyle::SELECTION) {
+                processed = true;
+            }
         }
         break;
     case BUTTON1DOWN:
     case CTRLDOWN|BUTTON1DOWN:
         // make sure not to change the selection when stopping spinning
-        if (!viewer->isEditing() && (curmode == NavigationStyle::SPINNING || this->lockButton1))
+        if (curmode == NavigationStyle::SPINNING || this->lockButton1 && curmode != NavigationStyle::SELECTION)
             newmode = NavigationStyle::IDLE;
         else
             newmode = NavigationStyle::SELECTION;


### PR DESCRIPTION
Fixes a regression in the Blender, CAD and Revit navigation style caused by #12104.

With this PR the selected faces are no longer de-selected after rotating using the left and middle mouse buttons.

https://forum.freecad.org/viewtopic.php?t=85491