### PR TITLE
Addon Manager: Change branch rename to rm and clone

### DIFF
--- a/src/Mod/AddonManager/addonmanager_installer.py
+++ b/src/Mod/AddonManager/addonmanager_installer.py
@@ -285,7 +285,8 @@ class AddonInstaller(QtCore.QObject):
                 old_branch = get_branch_from_metadata(self.addon_to_install.installed_metadata)
                 new_branch = get_branch_from_metadata(self.addon_to_install.metadata)
                 if old_branch != new_branch:
-                    self.git_manager.migrate_branch(install_path, old_branch, new_branch)
+                    utils.rmdir(install_path)
+                    self.git_manager.clone(self.addon_to_install.url, install_path)
                 else:
                     self.git_manager.update(install_path)
             else:


### PR DESCRIPTION
The branch renaming code was overly complex: the new strategy is that if the branch name changes, simply completely remove the addon and re-clone.