### PR TITLE
Draft: Introduce mouse delay

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -160,6 +160,7 @@ class DraftToolBar:
     def __init__(self):
         self.tray = None
         self.sourceCmd = None
+        self.mouse = True
         self.cancel = None
         self.pointcallback = None
 
@@ -1096,6 +1097,8 @@ class DraftToolBar:
 
         if txt == "" or txt[0] in "0123456789.,-":
             self.updateSnapper()
+            if txt[0] in "0123456789.,-":
+                self.setMouseMode(False)
             return
 
         txt = txt[0].upper()
@@ -1206,6 +1209,20 @@ class DraftToolBar:
                     delta = plane.get_global_coords(
                         FreeCAD.Vector(self.x,self.y,self.z))
                     FreeCADGui.Snapper.trackLine.p2(last.add(delta))
+
+    def setMouseMode(self, mode=True):
+        """Sets self.mouse True (default) or False and sets a timer
+        to set it back to True if applicable. self.mouse is then
+        used by gui_tools_utils.get_point() to know if the mouse can
+        update field values and point position or not."""
+        if mode == True:
+            self.mouse = True
+        else:
+            delay = params.get_param("MouseDelay")
+            if delay:
+                if self.mouse is True:
+                    self.mouse = False
+                    QtCore.QTimer.singleShot(delay*1000, self.setMouseMode)
 
     def checkEnterText(self):
         """this function checks if the entered text ends with two blank lines"""

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>518</width>
-    <height>645</height>
+    <height>682</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -162,6 +162,12 @@ These lines are thicker than normal grid lines.</string>
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
        </spacer>
       </item>
       <item row="6" column="0">
@@ -176,23 +182,23 @@ These lines are thicker than normal grid lines.</string>
         <property name="toolTip">
          <string>The distance between grid lines</string>
         </property>
-        <property name="decimals">
-         <number>4</number>
+        <property name="unit" stdset="0">
+         <string notr="true">mm</string>
         </property>
         <property name="maximum">
          <double>9999.989999999999782</double>
         </property>
-        <property name="rawValue">
+        <property name="rawValue" stdset="0">
          <double>1.000000000000000</double>
-        </property>
-        <property name="unit">
-         <string notr="true">mm</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>gridSpacing</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Draft</cstring>
+        </property>
+        <property name="decimals" stdset="0">
+         <number>4</number>
         </property>
        </widget>
       </item>
@@ -263,7 +269,7 @@ These lines are thicker than normal grid lines.</string>
         <property name="toolTip">
          <string>The color of the grid</string>
         </property>
-        <property name="color" stdset="0">
+        <property name="color">
          <color>
           <red>50</red>
           <green>50</green>
@@ -287,71 +293,7 @@ These lines are thicker than normal grid lines.</string>
       <string>Snapping and modifier keys</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_snapStyle">
-        <property name="text">
-         <string>Snap symbol style</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="Gui::PrefComboBox" name="comboBox_snapStyle">
-        <property name="toolTip">
-         <string>The style for snap symbols</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>snapStyle</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-        <item>
-         <property name="text">
-          <string>Draft classic style</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Bitsnpieces style</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </spacer>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_snapcolor">
-        <property name="text">
-         <string>Snap symbol color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="Gui::PrefColorButton" name="colorButton_snapcolor">
-        <property name="toolTip">
-         <string>The color for snap symbols</string>
-        </property>
-        <property name="color">
-         <color>
-          <red>255</red>
-          <green>170</green>
-          <blue>255</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>snapcolor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="3">
+      <item row="3" column="0" colspan="3">
        <widget class="Gui::PrefCheckBox" name="checkBox_alwaysSnap">
         <property name="toolTip">
          <string>If checked, snapping is activated without the need to press the Snap modifier key</string>
@@ -370,99 +312,7 @@ These lines are thicker than normal grid lines.</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_modsnap">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Snap modifier</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="Gui::PrefComboBox" name="comboBox_modsnap">
-        <property name="minimumSize">
-         <size>
-          <width>140</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>The Snap modifier key</string>
-        </property>
-        <property name="currentIndex">
-         <number>1</number>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>modsnap</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-        <item>
-         <property name="text">
-          <string>Shift</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Ctrl</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Alt</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_modconstrain">
-        <property name="text">
-         <string>Constrain modifier</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="Gui::PrefComboBox" name="comboBox_modconstrain">
-        <property name="toolTip">
-         <string>The Constrain modifier key</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>modconstrain</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Draft</cstring>
-        </property>
-        <item>
-         <property name="text">
-          <string>Shift</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Ctrl</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Alt</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_modalt">
-        <property name="text">
-         <string>Alt modifier</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
+      <item row="6" column="1">
        <widget class="Gui::PrefComboBox" name="comboBox_modalt">
         <property name="toolTip">
          <string>The Alt modifier key. The function of this key depends on the command.</string>
@@ -493,6 +343,197 @@ These lines are thicker than normal grid lines.</string>
         </item>
        </widget>
       </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefColorButton" name="colorButton_snapcolor">
+        <property name="toolTip">
+         <string>The color for snap symbols</string>
+        </property>
+        <property name="color">
+         <color>
+          <red>255</red>
+          <green>170</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>snapcolor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_modsnap">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Snap modifier</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_modconstrain">
+        <property name="text">
+         <string>Constrain modifier</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_modalt">
+        <property name="text">
+         <string>Alt modifier</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_snapcolor">
+        <property name="text">
+         <string>Snap symbol color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefComboBox" name="comboBox_snapStyle">
+        <property name="toolTip">
+         <string>The style for snap symbols</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>snapStyle</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+        <item>
+         <property name="text">
+          <string>Draft classic style</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Bitsnpieces style</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_snapStyle">
+        <property name="text">
+         <string>Snap symbol style</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefComboBox" name="comboBox_modsnap">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>140</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>The Snap modifier key</string>
+        </property>
+        <property name="currentIndex">
+         <number>1</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>modsnap</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+        <item>
+         <property name="text">
+          <string>Shift</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Ctrl</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Alt</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="Gui::PrefComboBox" name="comboBox_modconstrain">
+        <property name="toolTip">
+         <string>The Constrain modifier key</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>modconstrain</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+        <item>
+         <property name="text">
+          <string>Shift</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Ctrl</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Alt</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Mouse delay</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefSpinBox" name="spinBox">
+        <property name="toolTip">
+         <string>This is a delay during which the mouse is inactive, after entering
+numbers manually in any of the coordinate fields. Setting this
+to 0 disables the delay. If a delay of 1 is set, after enterting a numeric
+value, the mouse will not update the field anymore during one
+second, to avoid moving the mouse accidentally and modify the
+entered value. If you use a very large value, for ex. 3600, mouse
+movement will be disabled until the command finishes.</string>
+        </property>
+        <property name="suffix">
+         <string> seconds</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>MouseDelay</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Draft</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -501,6 +542,12 @@ These lines are thicker than normal grid lines.</string>
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
     </spacer>
    </item>
   </layout>
@@ -508,6 +555,26 @@ These lines are thicker than normal grid lines.</string>
  <layoutdefault spacing="6" margin="11"/>
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::ColorButton</class>
+   <extends>QPushButton</extends>
+   <header>Gui/Widgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefColorButton</class>
+   <extends>Gui::ColorButton</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
   <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
@@ -519,23 +586,8 @@ These lines are thicker than normal grid lines.</string>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
    <class>Gui::PrefQuantitySpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::ColorButton</class>
-   <extends>QPushButton</extends>
-   <header>Gui/Widgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefColorButton</class>
-   <extends>Gui::ColorButton</extends>
+   <extends>Gui::QuantitySpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>
@@ -546,24 +598,64 @@ These lines are thicker than normal grid lines.</string>
    <signal>toggled(bool)</signal>
    <receiver>checkBox_grid</receiver>
    <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_gridBorder</sender>
    <signal>toggled(bool)</signal>
    <receiver>checkBox_gridShowHuman</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_alwaysSnap</sender>
    <signal>toggled(bool)</signal>
    <receiver>label_modsnap</receiver>
    <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>checkBox_alwaysSnap</sender>
    <signal>toggled(bool)</signal>
    <receiver>comboBox_modsnap</receiver>
    <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
  </connections>
 </ui>

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>518</width>
-    <height>682</height>
+    <height>719</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -525,6 +525,9 @@ movement will be disabled until the command finishes.</string>
         </property>
         <property name="suffix">
          <string> seconds</string>
+        </property>
+        <property name="value">
+         <number>1</number>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>MouseDelay</cstring>

--- a/src/Mod/Draft/draftguitools/gui_base_original.py
+++ b/src/Mod/Draft/draftguitools/gui_base_original.py
@@ -128,6 +128,7 @@ class DraftTool:
         self.pos = []
         self.support = None
         self.ui = Gui.draftToolBar
+        self.ui.mouse = True  # reset mouse movement
         self.ui.sourceCmd = self
         self.view = gui_utils.get_3d_view()
         self.wp = WorkingPlane.get_working_plane()

--- a/src/Mod/Draft/draftguitools/gui_tool_utils.py
+++ b/src/Mod/Draft/draftguitools/gui_tool_utils.py
@@ -190,6 +190,8 @@ def get_point(target, args, noTracker=False):
         returned by the `Snapper` or by the `ActiveView`.
     """
     ui = Gui.draftToolBar
+    if not ui.mouse:
+        return None, None, None
 
     if target.node:
         last = target.node[-1]


### PR DESCRIPTION
This PR introduces a new "Mouse delay" preferences located under Edit -> Preferences -> Draft -> Grid and Snapping

* When mouse delay is set to 0, nothing happens, same as how it works now
* When it's set to a value, ex. 1 second, after you enter a number in one of the coordinate fields in Draft/Arch, the mouse will not change the value anymore during 1 second. After that, it resumes normal working.
* If you set the value to something very high, for ex. 3600 (one hour), mouse movement will be disabled after you start entering numeric values, until the command is finished.

This fixes #11807