### PR TITLE
Remove useless warning in Tree.cpp introduced by 12293

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -4055,7 +4055,6 @@ int DocumentItem::findRootIndex(App::DocumentObject* childObj) {
     auto getTreeRank = [](Gui::ViewProviderDocumentObject* vp) -> int {
         if (vp->TreeRank.getValue() == -1) {
             vp->TreeRank.setValue(vp->getObject()->getID());
-            Base::Console().Warning("init treerank to %d\n", vp->getObject()->getID());
         }
         return vp->TreeRank.getValue();
     };


### PR DESCRIPTION
Remove warning in https://github.com/FreeCAD/FreeCAD/pull/12293#discussion_r1503038369 
#12293 