### PR TITLE
Gui: Fix MSVC compilation of SuppressibleExtension

### DIFF
--- a/src/Gui/ViewProviderSuppressibleExtension.cpp
+++ b/src/Gui/ViewProviderSuppressibleExtension.cpp
@@ -20,10 +20,11 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "PreCompiled.h"
+
 #include "ActionFunction.h"
 #include "Control.h"
 #include "Document.h"
-#include "PreCompiled.h"
 
 #include <App/SuppressibleExtension.h>
 

--- a/src/Gui/ViewProviderSuppressibleExtension.h
+++ b/src/Gui/ViewProviderSuppressibleExtension.h
@@ -29,7 +29,7 @@
 namespace Gui
 {
 
-class ViewProviderSuppressibleExtension : public Gui::ViewProviderExtension
+class GuiExport ViewProviderSuppressibleExtension : public Gui::ViewProviderExtension
 {
     EXTENSION_PROPERTY_HEADER_WITH_OVERRIDE(Gui::ViewProviderSuppressibleExtension);
 


### PR DESCRIPTION
Missing an export, and PreCompiled.h in the wrong include order.