### PR TITLE
Help: Added basic unit tests and minor fixes

### DIFF
--- a/src/Mod/Help/CMakeLists.txt
+++ b/src/Mod/Help/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(Help_SRCS
     default.css
     Help.py
     dlgPreferencesHelp.ui
+    TestHelp.py
 )
 
 SOURCE_GROUP("" FILES ${Help_SRCS})

--- a/src/Mod/Help/Help.py
+++ b/src/Mod/Help/Help.py
@@ -90,6 +90,7 @@ INTERNETTXT = translate(
 )
 PREFS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Help")
 ICON = ":/icons/help-browser.svg"
+WEBWB = False # this allows to work around a crash in certain versions of Qt5
 
 
 def show(page, view=None, conv=None, mode=0):
@@ -254,6 +255,8 @@ def show_dialog(html, baseurl, title, view=None):
             view.setHtml(html, baseUrl=QtCore.QUrl(baseurl))
             view.parent().parent().setWindowTitle(title)
         else:
+            if WEBWB:
+                show_web_tab(html, baseurl, title)
             openBrowserHTML(html, baseurl, title, ICON, dialog=True)
 
 
@@ -267,7 +270,7 @@ def show_tab(html, baseurl, title, view=None):
             view.setHtml(html, baseUrl=QtCore.QUrl(baseurl))
             view.parent().parent().setWindowTitle(title)
         else:
-            if PREFS.GetBool("UseWebModule", False):
+            if PREFS.GetBool("UseWebModule", False) or WEBWB:
                 show_web_tab(html, baseurl, title)
             else:
                 openBrowserHTML(html,baseurl,title,ICON)

--- a/src/Mod/Help/Help.py
+++ b/src/Mod/Help/Help.py
@@ -86,11 +86,11 @@ CONVERTTXT = translate(
 )
 INTERNETTXT = translate(
     "Help",
-    "Internet access has not been granted, the Help module cannot fetch online documentation. <a href=\"allowInternet\">Click here</a> to allow FreeCAD to access the internet, or install the documentation for offline use through the Addon Manager.",
+    'Internet access has not been granted, the Help module cannot fetch online documentation. <a href="allowInternet">Click here</a> to allow FreeCAD to access the internet, or install the documentation for offline use through the Addon Manager.',
 )
 PREFS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Help")
 ICON = ":/icons/help-browser.svg"
-WEBWB = False # this allows to work around a crash in certain versions of Qt5
+WEBWB = False  # this allows to work around a crash in certain versions of Qt5
 
 
 def show(page, view=None, conv=None, mode=0):
@@ -273,7 +273,7 @@ def show_tab(html, baseurl, title, view=None):
             if PREFS.GetBool("UseWebModule", False) or WEBWB:
                 show_web_tab(html, baseurl, title)
             else:
-                openBrowserHTML(html,baseurl,title,ICON)
+                openBrowserHTML(html, baseurl, title, ICON)
 
 
 def get_qtwebwidgets(html, baseurl, title):
@@ -297,6 +297,7 @@ def show_web_tab(html, baseurl, title):
     # crashes with certain versions of Qt5
 
     import WebGui
+
     try:
         WebGui.openBrowserHTML(html, baseurl, title, ICON)
     except TypeError:
@@ -438,6 +439,7 @@ def convert_html(content):
     if "<html" in content:
         try:
             import pypandoc
+
             content = pypandoc.convert_text(content, "plain", format="html")
         except:
             pass

--- a/src/Mod/Help/InitGui.py
+++ b/src/Mod/Help/InitGui.py
@@ -21,7 +21,9 @@
 # *                                                                         *
 # ***************************************************************************
 
+import FreeCAD
 import Help
 
 Help.add_preferences_page()
 Help.add_language_path()
+FreeCAD.__unit_test__ += ["TestHelp"]

--- a/src/Mod/Help/TestHelp.py
+++ b/src/Mod/Help/TestHelp.py
@@ -1,39 +1,40 @@
-#***************************************************************************
-#*   Copyright (c) 2024 Yorik van Havre <yorik@uncreated.net>              *
-#*                                                                         *
-#*   This file is part of the FreeCAD CAx development system.              *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   FreeCAD is distributed in the hope that it will be useful,            *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with FreeCAD; if not, write to the Free Software        *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************/
+# ***************************************************************************
+# *   Copyright (c) 2024 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************/
 
 # Unit test for the Help module
 
 import unittest
 import Help
 
-class HelpTest(unittest.TestCase):
 
+class HelpTest(unittest.TestCase):
     def setUp(self):
         self.BUGGY_QT = False
 
     def test_awebwidgets(self):
         import PySide
         from PySide import QtGui, QtWebEngineWidgets
+
         # workaround Qt5.12 bug
         if PySide.__version_info__[0] == 5:
             if PySide.__version_info__[1] <= 15:
@@ -43,7 +44,10 @@ class HelpTest(unittest.TestCase):
     def test_browser1(self):
         if not self.BUGGY_QT:
             print("Help: Opening an external browser")
-            Help.show("https://raw.githubusercontent.com/FreeCAD/FreeCAD-documentation/main/wiki/Draft_Line.md", mode=1)
+            Help.show(
+                "https://raw.githubusercontent.com/FreeCAD/FreeCAD-documentation/main/wiki/Draft_Line.md",
+                mode=1,
+            )
 
     def test_browser2(self):
         if not self.BUGGY_QT:
@@ -54,6 +58,7 @@ class HelpTest(unittest.TestCase):
         if not self.BUGGY_QT:
             print("Help: Opening a standaline dialog")
             Help.show("Draft_Line", mode=2)
+
     def test_tab(self):
         if not self.BUGGY_QT:
             print("Help: Opening an MDI tab")

--- a/src/Mod/Help/TestHelp.py
+++ b/src/Mod/Help/TestHelp.py
@@ -31,8 +31,13 @@ class HelpTest(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_webwidgets(self):
+    def test_awebwidgets(self):
+        import PySide
         from PySide import QtGui, QtWebEngineWidgets
+        # workaround Qt5.12 bug
+        if PySide.__version_info__[0] == 5:
+            if PySide.__version_info__[1] <= 15:
+                Help.WEBWB = True
 
     def test_browser1(self):
         print("Help: Opening an external browser")

--- a/src/Mod/Help/TestHelp.py
+++ b/src/Mod/Help/TestHelp.py
@@ -1,0 +1,53 @@
+#***************************************************************************
+#*   Copyright (c) 2024 Yorik van Havre <yorik@uncreated.net>              *
+#*                                                                         *
+#*   This file is part of the FreeCAD CAx development system.              *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
+#*   as published by the Free Software Foundation; either version 2 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   FreeCAD is distributed in the hope that it will be useful,            *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with FreeCAD; if not, write to the Free Software        *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************/
+
+# Unit test for the Help module
+
+import unittest
+import Help
+
+class HelpTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_webwidgets(self):
+        from PySide import QtGui, QtWebEngineWidgets
+
+    def test_browser1(self):
+        print("Help: Opening an external browser")
+        Help.show("https://raw.githubusercontent.com/FreeCAD/FreeCAD-documentation/main/wiki/Draft_Line.md", mode=1)
+
+    def test_browser2(self):
+        print("Help: Opening an external browser")
+        Help.show("https://wiki.freecadweb.org/Draft_Line", mode=1)
+
+    def test_dialog(self):
+        print("Help: Opening a standaline dialog")
+        Help.show("Draft_Line", mode=2)
+    def test_tab(self):
+        print("Help: Opening an MDI tab")
+        Help.show("Draft_Line", mode=3)
+
+    def tearDown(self):
+        pass

--- a/src/Mod/Help/TestHelp.py
+++ b/src/Mod/Help/TestHelp.py
@@ -29,7 +29,7 @@ import Help
 class HelpTest(unittest.TestCase):
 
     def setUp(self):
-        pass
+        self.BUGGY_QT = False
 
     def test_awebwidgets(self):
         import PySide
@@ -38,21 +38,26 @@ class HelpTest(unittest.TestCase):
         if PySide.__version_info__[0] == 5:
             if PySide.__version_info__[1] <= 15:
                 Help.WEBWB = True
+                self.BUGGY_QT = True
 
     def test_browser1(self):
-        print("Help: Opening an external browser")
-        Help.show("https://raw.githubusercontent.com/FreeCAD/FreeCAD-documentation/main/wiki/Draft_Line.md", mode=1)
+        if not self.BUGGY_QT:
+            print("Help: Opening an external browser")
+            Help.show("https://raw.githubusercontent.com/FreeCAD/FreeCAD-documentation/main/wiki/Draft_Line.md", mode=1)
 
     def test_browser2(self):
-        print("Help: Opening an external browser")
-        Help.show("https://wiki.freecadweb.org/Draft_Line", mode=1)
+        if not self.BUGGY_QT:
+            print("Help: Opening an external browser")
+            Help.show("https://wiki.freecadweb.org/Draft_Line", mode=1)
 
     def test_dialog(self):
-        print("Help: Opening a standaline dialog")
-        Help.show("Draft_Line", mode=2)
+        if not self.BUGGY_QT:
+            print("Help: Opening a standaline dialog")
+            Help.show("Draft_Line", mode=2)
     def test_tab(self):
-        print("Help: Opening an MDI tab")
-        Help.show("Draft_Line", mode=3)
+        if not self.BUGGY_QT:
+            print("Help: Opening an MDI tab")
+            Help.show("Draft_Line", mode=3)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
This PR brings a series of small fixes to the Help module:

- Adds unit tests to test for the different modes of the Help module
- Allow to launch Help from Python forcing the mode (dialog, tab or ext browser)
- Removed the use of the Web module (still available by setting a pref parameter)
- Better text output when used in non-GUI mode

Fixes FreeCAD/FreeCAD-Help#22