### PR TITLE
Base: add missing axis and angle update for Rotation::setEulerAngles

### DIFF
--- a/src/Base/Rotation.cpp
+++ b/src/Base/Rotation.cpp
@@ -1022,6 +1022,7 @@ void Rotation::setEulerAngles(EulerSequence theOrder,
     quat[1] = values[2];
     quat[2] = values[3];
     quat[3] = values[0];
+    this->evaluateVector();
 }
 
 void Rotation::getEulerAngles(EulerSequence theOrder,


### PR DESCRIPTION
When setting a Rotation object via `setEulerAngles`, no matter if in C++ or Python, only the quaternion will be updated but not the rotation axis vector and also not the rotation angle.

```python3
rr = App.Rotation()
rr.setEulerAngles('XYZ', 10, 20, 30)
print(rr.Q)  # --> (0.03813457647485015, 0.189307857412, 0.2392983377447303, 0.9515485246437886)
print(rr.Angle)  # --> 0.0
print(rr.Axis)  # --> Vector (0.0, 0.0, 1.0)
# --> Axis and Angle are obviously wrong
```

This PR will add the missing `evaluateVector` command.

