### PR TITLE
App: Remove unneeded forward declaration

### DIFF
--- a/src/App/PropertyGeo.h
+++ b/src/App/PropertyGeo.h
@@ -44,7 +44,6 @@ class ComplexGeoData;
 
 namespace App
 {
-class Feature;
 class Placement;
 
 


### PR DESCRIPTION
Addresses clang-tidy complaint: declaration 'Feature' is never referenced, but a declaration with the same name found in another namespace 'Part' [bugprone-forward-declaration-namespace]