### PR TITLE
Sketcher: Change Sketcher_CreatePointFillet button text to match menu text

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -1575,7 +1575,7 @@ void CmdSketcherCompCreateFillets::languageChange()
         QApplication::translate("Sketcher_CreateFillet", "Creates a radius between two lines"));
     QAction* pointFillet = a[1];
     pointFillet->setText(QApplication::translate("CmdSketcherCompCreateFillets",
-                                                 "Constraint-preserving sketch fillet"));
+                                                 "Corner-preserving sketch fillet"));
     pointFillet->setToolTip(
         QApplication::translate("Sketcher_CreatePointFillet",
                                 "Fillet that preserves constraints and intersection point"));


### PR DESCRIPTION
The menu text is "Create corner-preserving fillet" it makes sense to use a similar text for the button and not "Constraint-preserving sketch fillet".
