### PR TITLE
Gui: Set rotation center when entering dragging in TinkerCAD style

### DIFF
--- a/src/Gui/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/TinkerCADNavigationStyle.cpp
@@ -224,6 +224,9 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent * const ev)
         newmode = NavigationStyle::SELECTION;
         break;
     case BUTTON2DOWN:
+        if (newmode != NavigationStyle::DRAGGING) {
+            saveCursorPosition(ev);
+        }
         newmode = NavigationStyle::DRAGGING;
         break;
     case BUTTON3DOWN:


### PR DESCRIPTION
The rotation center moved when using the TinkerCAD navigation style and rotation mode set to window center. This happend when pressing MMB -> move mouse -> pressing RMB -> releasing MMB -> move mouse.

This is fixed by setting the rotation center before entering dragging mode.