### PR TITLE
PATH: Fix adaptive glitch by removing coincident points

### DIFF
--- a/src/Mod/Path/libarea/Adaptive.cpp
+++ b/src/Mod/Path/libarea/Adaptive.cpp
@@ -147,6 +147,27 @@ inline DoublePoint GetPathDirectionV(const Path &pth, size_t pointIndex)
 	return DirectionV(p1, p2);
 }
 
+// Returns true if points 'a' and 'b' are coincident or nearly so.
+bool isClose(const IntPoint &a, const IntPoint &b) {
+	return abs(a.X - b.X) <= 1 && abs(a.Y - b.Y) <= 1;
+}
+
+// Remove coincident and almost-coincident points from Paths.
+void filterCloseValues(Paths &ppg) {
+	for (auto& pth : ppg) {
+		while (true) {
+			auto i = std::adjacent_find(pth.begin(), pth.end(), isClose);
+			if (i == pth.end())
+				break;
+			pth.erase(i);
+		}
+		// adjacent_find doesn't compare first with last element, so
+		// do that manually.
+		while (pth.size() > 1 && isClose(pth.front(), pth.back()))
+			pth.pop_back();
+	}
+}
+
 //*****************************************
 // Utils
 //*****************************************
@@ -1654,9 +1675,11 @@ void Adaptive2d::ApplyStockToLeave(Paths &inputPaths)
 		clipof.Clear();
 		clipof.AddPaths(inputPaths, JoinType::jtRound, EndType::etClosedPolygon);
 		clipof.Execute(inputPaths, -1);
+		filterCloseValues(inputPaths);
 		clipof.Clear();
 		clipof.AddPaths(inputPaths, JoinType::jtRound, EndType::etClosedPolygon);
 		clipof.Execute(inputPaths, 1);
+		filterCloseValues(inputPaths);
 	}
 }
 


### PR DESCRIPTION
Remove adjacent coincident and nearly-coincident points from Path. This is issue #6217 

This is based on PR#5276 by sundtek, but it only collapses adjacent points on the Path. It also addresses (IMO) most of the feedback on the original PR.

see also discussion on the forum: https://forum.freecadweb.org/viewtopic.php?f=15&t=42755&start=10#p555566

test file: [glitch.zip](https://github.com/FreeCAD/FreeCAD/files/14441490/glitch.zip)

before:
![Screenshot from 2024-02-29 11-34-50](https://github.com/FreeCAD/FreeCAD/assets/170281/41af7df7-d019-4283-8bd4-ba6f4b829d2b)

after:
![Screenshot from 2024-02-29 11-35-09](https://github.com/FreeCAD/FreeCAD/assets/170281/30a1ea15-d78f-4530-a7b3-bea1020d04a0)
