### PR TITLE
Sketcher: Sketcher_ConstrainHorizontal before Sketcher_ConstrainVertical in GUI

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -658,15 +658,15 @@ void ElementView::contextMenuEvent(QContextMenuEvent* event)
                  "Sketcher_ConstrainPointOnObject",
                  doPointOnObjectConstraint,
                  true)
-    CONTEXT_ITEM("Constraint_Vertical",
-                 "Vertical Constraint",
-                 "Sketcher_ConstrainVertical",
-                 doVerticalConstraint,
-                 true)
     CONTEXT_ITEM("Constraint_Horizontal",
                  "Horizontal Constraint",
                  "Sketcher_ConstrainHorizontal",
                  doHorizontalConstraint,
+                 true)
+    CONTEXT_ITEM("Constraint_Vertical",
+                 "Vertical Constraint",
+                 "Sketcher_ConstrainVertical",
+                 doVerticalConstraint,
                  true)
     CONTEXT_ITEM("Constraint_Parallel",
                  "Parallel Constraint",
@@ -792,8 +792,8 @@ void ElementView::contextMenuEvent(QContextMenuEvent* event)
 
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainCoincident", doPointCoincidence)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainPointOnObject", doPointOnObjectConstraint)
-CONTEXT_MEMBER_DEF("Sketcher_ConstrainVertical", doVerticalConstraint)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainHorizontal", doHorizontalConstraint)
+CONTEXT_MEMBER_DEF("Sketcher_ConstrainVertical", doVerticalConstraint)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainParallel", doParallelConstraint)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainPerpendicular", doPerpendicularConstraint)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainTangent", doTangentConstraint)

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -4044,8 +4044,8 @@ void ViewProviderSketch::generateContextMenu()
             menu << "Sketcher_Dimension";
             if (selectedConics == 0) {
                 menu << "Sketcher_ConstrainHorVer"
-                     << "Sketcher_ConstrainVertical"
-                     << "Sketcher_ConstrainHorizontal";
+                     << "Sketcher_ConstrainHorizontal"
+                     << "Sketcher_ConstrainVertical";
 
                 if (selectedLines > 1) {
                     menu << "Sketcher_ConstrainParallel";
@@ -4073,8 +4073,8 @@ void ViewProviderSketch::generateContextMenu()
             if (selectedConics == 0 && selectedBsplines == 0) {
                 menu << "Sketcher_ConstrainCoincidentUnified"
                      << "Sketcher_ConstrainHorVer"
-                     << "Sketcher_ConstrainVertical"
-                     << "Sketcher_ConstrainHorizontal";
+                     << "Sketcher_ConstrainHorizontal"
+                     << "Sketcher_ConstrainVertical";
                 if (selectedPoints == 2) {
                     menu << "Sketcher_ConstrainSymmetric";
                 }
@@ -4095,8 +4095,8 @@ void ViewProviderSketch::generateContextMenu()
             if (selectedPoints > 1) {
                 menu << "Sketcher_ConstrainCoincidentUnified"
                      << "Sketcher_ConstrainHorVer"
-                     << "Sketcher_ConstrainVertical"
-                     << "Sketcher_ConstrainHorizontal";
+                     << "Sketcher_ConstrainHorizontal"
+                     << "Sketcher_ConstrainVertical";
             }
             if (selectedPoints == 2) {
                 menu << "Sketcher_ConstrainPerpendicular"
@@ -4109,8 +4109,8 @@ void ViewProviderSketch::generateContextMenu()
         else if (selectedLines >= 1 && selectedPoints >= 1 && !onlyOrigin) {
             menu << "Sketcher_Dimension"
                  << "Sketcher_ConstrainHorVer"
-                 << "Sketcher_ConstrainVertical"
-                 << "Sketcher_ConstrainHorizontal";
+                 << "Sketcher_ConstrainHorizontal"
+                 << "Sketcher_ConstrainVertical";
         }
         // context menu if only constraints are selected
         else if (selectedConstraints >= 1) {

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -438,9 +438,9 @@ inline void SketcherAddWorkbenchConstraints<Gui::MenuItem>(Gui::MenuItem& cons)
         cons << "Sketcher_ConstrainCoincident"
              << "Sketcher_ConstrainPointOnObject";
     }
-    cons << "Sketcher_ConstrainVertical"
+    cons << "Sketcher_ConstrainHorVer"
          << "Sketcher_ConstrainHorizontal"
-         << "Sketcher_ConstrainHorVer"
+         << "Sketcher_ConstrainVertical"
          << "Sketcher_ConstrainParallel"
          << "Sketcher_ConstrainPerpendicular"
          << "Sketcher_ConstrainTangent"
@@ -480,8 +480,8 @@ inline void SketcherAddWorkbenchConstraints<Gui::ToolBarItem>(Gui::ToolBarItem& 
         cons << "Sketcher_CompHorVer";
     }
     else {
-        cons << "Sketcher_ConstrainVertical"
-             << "Sketcher_ConstrainHorizontal";
+        cons << "Sketcher_ConstrainHorizontal"
+             << "Sketcher_ConstrainVertical";
     }
     cons << "Sketcher_ConstrainParallel"
          << "Sketcher_ConstrainPerpendicular"


### PR DESCRIPTION
Changes to TaskSketcherElements.cpp are not required, but were done for consistency. The order in the file follows the GUI.
