### PR TITLE
Part: Add  BRepOffsetAPI_MakeEvolved.hxx to OpenCascadeAll.h

### DIFF
--- a/src/Mod/Part/App/OpenCascadeAll.h
+++ b/src/Mod/Part/App/OpenCascadeAll.h
@@ -174,6 +174,7 @@
 
 #include <BRepOffset_MakeOffset.hxx>
 #include <BRepOffsetAPI_DraftAngle.hxx>
+#include <BRepOffsetAPI_MakeEvolved.hxx>
 #include <BRepOffsetAPI_MakeOffset.hxx>
 #include <BRepOffsetAPI_MakePipe.hxx>
 #include <BRepOffsetAPI_MakePipeShell.hxx>


### PR DESCRIPTION
Missing file, compilation fails with PCH turned on.