### PR TITLE
Addon Manager: Refactor primary view and enable composite

### DIFF
--- a/src/Mod/AddonManager/CMakeLists.txt
+++ b/src/Mod/AddonManager/CMakeLists.txt
@@ -31,6 +31,7 @@ SET(AddonManager_SRCS
     addonmanager_macro_parser.py
     addonmanager_metadata.py
     addonmanager_package_details_controller.py
+    addonmanager_preferences_defaults.json
     addonmanager_pyside_interface.py
     addonmanager_readme_controller.py
     addonmanager_update_all_gui.py
@@ -47,6 +48,7 @@ SET(AddonManager_SRCS
     change_branch.py
     change_branch.ui
     compact_view.py
+    composite_view.py
     dependency_resolution_dialog.ui
     developer_mode.ui
     developer_mode_add_content.ui
@@ -69,7 +71,6 @@ SET(AddonManager_SRCS
     loading.html
     manage_python_dependencies.py
     NetworkManager.py
-        addonmanager_package_details_controller.py
     package_list.py
     PythonDependencyUpdateDialog.ui
     select_toolbar_dialog.ui

--- a/src/Mod/AddonManager/TODO.md
+++ b/src/Mod/AddonManager/TODO.md
@@ -1,14 +1,8 @@
 # Addon Manager Future Work
 
-* Restructure widgets into logical groups to better enable showing and hiding those groups all at once.
 * Reduce coupling between data and UI, switching logical groupings of widgets into a MVC or similar framework.
   * Particularly in the addons list
-* Download Addon statistics from central location.
-  * Allow sorting on those statistics.
-* Download a "rank" from user-specified locations.
-  * Allow sorting on that rank.
 * Implement a server-side cache of Addon metadata.
 * Implement an "offline mode" that does not attempt to use remote data for anything.
 * When installing a Preference Pack, offer to apply it once installed, and to undo after that.
 * Better support "headless" mode, with no GUI.
-* Add "Composite" display mode, showing compact list and details at the same time

--- a/src/Mod/AddonManager/Widgets/addonmanager_widget_addon_buttons.py
+++ b/src/Mod/AddonManager/Widgets/addonmanager_widget_addon_buttons.py
@@ -75,6 +75,8 @@ class WidgetAddonButtons(QtWidgets.QWidget):
         self.retranslateUi(None)
 
     def _setup_ui(self):
+        if self.layout():
+            self.setLayout(None)  # TODO: Check this
         self.horizontal_layout = QtWidgets.QHBoxLayout()
         self.horizontal_layout.setContentsMargins(0, 0, 0, 0)
         self.back = QtWidgets.QToolButton(self)
@@ -97,6 +99,9 @@ class WidgetAddonButtons(QtWidgets.QWidget):
         self.horizontal_layout.addWidget(self.run_macro)
         self.horizontal_layout.addWidget(self.change_branch)
         self.setLayout(self.horizontal_layout)
+
+    def set_show_back_button(self, show: bool) -> None:
+        self.back.setVisible(show)
 
     def _set_icons(self):
         self.back.setIcon(QtGui.QIcon.fromTheme("back", QtGui.QIcon(":/icons/button_left.svg")))

--- a/src/Mod/AddonManager/Widgets/addonmanager_widget_package_details_view.py
+++ b/src/Mod/AddonManager/Widgets/addonmanager_widget_package_details_view.py
@@ -65,6 +65,7 @@ class MessageType(Enum):
 
 @dataclass
 class UpdateInformation:
+    unchecked: bool = True
     check_in_progress: bool = False
     update_available: bool = False
     detached_head: bool = False
@@ -275,6 +276,8 @@ class PackageDetailsView(QtWidgets.QWidget):
     def _get_update_status_string(self) -> str:
         if self.update_info.check_in_progress:
             return translate("AddonsInstaller", "Update check in progress") + "."
+        elif self.update_info.unchecked:
+            return ""
         if self.update_info.detached_head:
             return (
                 translate(

--- a/src/Mod/AddonManager/Widgets/addonmanager_widget_package_details_view.py
+++ b/src/Mod/AddonManager/Widgets/addonmanager_widget_package_details_view.py
@@ -112,6 +112,7 @@ class PackageDetailsView(QtWidgets.QWidget):
         self.vertical_layout.addWidget(self.message_label)
         self.vertical_layout.addWidget(self.location_label)
         self.vertical_layout.addWidget(self.readme_browser)
+        self.button_bar.hide()  # Start with no bar
 
     def set_location(self, location: Optional[str]):
         if location is not None:

--- a/src/Mod/AddonManager/Widgets/addonmanager_widget_readme_browser.py
+++ b/src/Mod/AddonManager/Widgets/addonmanager_widget_readme_browser.py
@@ -63,6 +63,7 @@ class WidgetReadmeBrowser(QtWidgets.QTextBrowser):
     def setMarkdown(self, md: str):
         """Provides an optional fallback to the markdown library for older versions of Qt (prior to 5.15) that did not
         have native markdown support. Lacking that, plaintext is displayed."""
+        geometry = self.geometry()
         if hasattr(super(), "setMarkdown"):
             super().setMarkdown(md)
         else:
@@ -76,6 +77,7 @@ class WidgetReadmeBrowser(QtWidgets.QTextBrowser):
                 FreeCAD.Console.Warning(
                     "Qt < 5.15 and no `import markdown` -- falling back to plain text display\n"
                 )
+        self.setGeometry(geometry)
 
     def set_resource(self, resource_url: str, image: Optional[QtGui.QImage]):
         """Once a resource has been fetched (or the fetch has failed), this method should be used to inform the widget

--- a/src/Mod/AddonManager/Widgets/addonmanager_widget_view_selector.py
+++ b/src/Mod/AddonManager/Widgets/addonmanager_widget_view_selector.py
@@ -119,7 +119,6 @@ class WidgetViewSelector(QtWidgets.QWidget):
         self.composite_button.setIcon(
             QtGui.QIcon.fromTheme("composite_button", QtGui.QIcon(":/icons/composite_view.svg"))
         )
-        self.composite_button.hide()  # TODO: Implement this view
 
         self.horizontal_layout.addWidget(self.compact_button)
         self.horizontal_layout.addWidget(self.expanded_button)

--- a/src/Mod/AddonManager/addonmanager_git.py
+++ b/src/Mod/AddonManager/addonmanager_git.py
@@ -442,10 +442,8 @@ class GitManager:
         on the Mac actually requires us to check for that installation."""
         try:
             subprocess.check_output(["xcode-select", "-p"])
-            fci.Console.PrintMessage("XCode command line tools are installed: git is available\n")
             return True
         except subprocess.CalledProcessError:
-            fci.Console.PrintMessage("XCode command line tools are not installed: not using git\n")
             return False
 
     def _synchronous_call_git(self, args: List[str]) -> str:

--- a/src/Mod/AddonManager/addonmanager_package_details_controller.py
+++ b/src/Mod/AddonManager/addonmanager_package_details_controller.py
@@ -142,6 +142,7 @@ class PackageDetailsController(QtCore.QObject):
         flags.obsolete = repo.obsolete
         flags.python2 = repo.python2
         self.ui.set_warning_flags(flags)
+        self.set_change_branch_button_state()
 
     def requires_newer_freecad(self) -> Optional[Version]:
         """If the current package is not installed, returns the first supported version of
@@ -165,7 +166,7 @@ class PackageDetailsController(QtCore.QObject):
         """The change branch button is only available for installed Addons that have a .git directory
         and in runs where the git is available."""
 
-        self.ui.button_bar.change_branch_button.hide()
+        self.ui.button_bar.change_branch.hide()
 
         pref = fci.ParamGet("User parameter:BaseApp/Preferences/Addons")
         show_switcher = pref.GetBool("ShowBranchSwitcher", False)
@@ -192,7 +193,7 @@ class PackageDetailsController(QtCore.QObject):
 
         # If all four above checks passed, then it's possible for us to switch
         # branches, if there are any besides the one we are on: show the button
-        self.ui.button_bar.change_branch_button.show()
+        self.ui.button_bar.change_branch.show()
 
     def update_macro_info(self, repo: Addon) -> None:
         if not repo.macro.url:

--- a/src/Mod/AddonManager/addonmanager_package_details_controller.py
+++ b/src/Mod/AddonManager/addonmanager_package_details_controller.py
@@ -89,6 +89,10 @@ class PackageDetailsController(QtCore.QObject):
         self.addon = repo
         self.readme_controller.set_addon(repo)
         self.original_disabled_state = self.addon.is_disabled()
+        if repo is not None:
+            self.ui.button_bar.show()
+        else:
+            self.ui.button_bar.hide()
 
         if self.worker is not None:
             if not self.worker.isFinished():
@@ -256,3 +260,7 @@ class PackageDetailsController(QtCore.QObject):
         self.addon.set_status(Addon.Status.PENDING_RESTART)
         self.ui.set_new_branch(name)
         self.update_status.emit(self.addon)
+
+    def display_repo_status(self, addon):
+        pass
+        # TODO: what should happen here?

--- a/src/Mod/AddonManager/addonmanager_preferences_defaults.json
+++ b/src/Mod/AddonManager/addonmanager_preferences_defaults.json
@@ -5,6 +5,7 @@
     "AddonsStatsURL": "https://freecad.org/addon_stats.json",
     "AutoCheck": false,
     "BlockedMacros": "BOLTS,WorkFeatures,how to install,documentation,PartsLibrary,FCGear",
+    "CompositeSplitterState": "",
     "CustomRepoHash": "",
     "CustomRepositories": "",
     "CustomToolbarName": "Auto-Created Macro Toolbar",

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -104,6 +104,20 @@ class PackageList(QtWidgets.QWidget):
         )
         self.item_filter.setHideUnlicensed(pref.GetBool("HideUnlicensed", False))
 
+    def select_addon(self, addon_name: str):
+        for index, addon in enumerate(self.item_model.repos):
+            if addon.name == addon_name:
+                row_index = self.item_model.createIndex(index, 0)
+                if self.item_filter.filterAcceptsRow(index):
+                    self.ui.listPackages.setCurrentIndex(row_index)
+                else:
+                    FreeCAD.Console.PrintLog(
+                        f"Addon {addon_name} is not visible given current "
+                        "filter: not selecting it."
+                    )
+                return
+        FreeCAD.Console.PrintLog(f"Could not find addon '{addon_name}' to select it")
+
     def on_listPackages_clicked(self, index: QtCore.QModelIndex):
         """Determine what addon was selected and emit the itemSelected signal with it as
         an argument."""

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -65,7 +65,6 @@ class PackageList(QtWidgets.QWidget):
         self.ui.listPackages.setItemDelegate(self.item_delegate)
 
         self.ui.listPackages.clicked.connect(self.on_listPackages_clicked)
-        self.ui.view_bar.view_changed.connect(self.set_view_style)
         self.ui.view_bar.filter_changed.connect(self.update_status_filter)
         self.ui.view_bar.search_changed.connect(self.item_filter.setFilterRegularExpression)
         self.ui.view_bar.sort_changed.connect(self.item_filter.setSortRole)
@@ -124,10 +123,10 @@ class PackageList(QtWidgets.QWidget):
 
     def set_view_style(self, style: AddonManagerDisplayStyle) -> None:
         """Set the style (compact or expanded) of the list"""
-        self.item_model.layoutAboutToBeChanged.emit()
+        if self.item_model:
+            self.item_model.layoutAboutToBeChanged.emit()
         self.item_delegate.set_view(style)
-        # TODO: Update to support composite
-        if style == AddonManagerDisplayStyle.COMPACT:
+        if style == AddonManagerDisplayStyle.COMPACT or style == AddonManagerDisplayStyle.COMPOSITE:
             self.ui.listPackages.setSpacing(2)
             self.ui.listPackages.setVerticalScrollMode(QtWidgets.QAbstractItemView.ScrollPerItem)
             self.ui.listPackages.verticalScrollBar().setSingleStep(-1)
@@ -135,7 +134,8 @@ class PackageList(QtWidgets.QWidget):
             self.ui.listPackages.setSpacing(5)
             self.ui.listPackages.setVerticalScrollMode(QtWidgets.QAbstractItemView.ScrollPerPixel)
             self.ui.listPackages.verticalScrollBar().setSingleStep(24)
-        self.item_model.layoutChanged.emit()
+        if self.item_model:
+            self.item_model.layoutChanged.emit()
 
         pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
         pref.SetInt("ViewStyle", style)
@@ -288,6 +288,9 @@ class PackageListItemDelegate(QtWidgets.QStyledItemDelegate):
         elif self.displayStyle == AddonManagerDisplayStyle.COMPACT:
             self.widget = self.compact
             self._setup_compact_view(repo)
+        elif self.displayStyle == AddonManagerDisplayStyle.COMPOSITE:
+            self.widget = self.compact  # For now re-use the compact list
+            self._setup_composite_view(repo)
         self.widget.adjustSize()
 
     def _setup_expanded_view(self, addon: Addon) -> None:
@@ -333,6 +336,22 @@ class PackageListItemDelegate(QtWidgets.QStyledItemDelegate):
             self.widget.ui.labelDescription.setText(description)
         else:
             self.widget.ui.labelDescription.setText(self._get_sort_label_text(addon))
+
+    def _setup_composite_view(self, addon: Addon) -> None:
+        self.widget.ui.labelPackageName.setText(f"<b>{addon.display_name}</b>")
+        self.widget.ui.labelIcon.setPixmap(addon.icon.pixmap(QtCore.QSize(16, 16)))
+        self.widget.ui.labelStatus.setText(self.get_compact_update_string(addon))
+        self.widget.ui.labelIcon.setText("")
+        if addon.metadata:
+            self.widget.ui.labelVersion.setText(f"<i>v{addon.metadata.version}</i>")
+        elif addon.macro:
+            self._set_macro_version_label(addon)
+        else:
+            self.widget.ui.labelVersion.setText("")
+        if self.sort_order != SortOptions.Alphabetical:
+            self.widget.ui.labelDescription.setText(self._get_sort_label_text(addon))
+        else:
+            self.widget.ui.labelDescription.setText("")
 
     def _set_package_maintainer_label(self, addon: Addon):
         maintainers = addon.metadata.maintainer
@@ -395,14 +414,13 @@ class PackageListItemDelegate(QtWidgets.QStyledItemDelegate):
         return ""
 
     def _get_compact_description(self, addon: Addon) -> str:
+        description = ""
         if addon.metadata:
-            trimmed_text = addon.metadata.description
-            # TODO: Un-hardcode the 25 character limiter
-            return trimmed_text.replace("\r\n", " ")[:25] + "..."
-        if addon.macro and addon.macro.comment:
-            trimmed_text = addon.macro.comment
-            return trimmed_text.replace("\r\n", " ")[:25] + "..."
-        return ""
+            description = addon.metadata.description
+        elif addon.macro and addon.macro.comment:
+            description = addon.macro.comment
+        trimmed_text, _, _ = description.partition(".")
+        return trimmed_text.replace("\n", " ")
 
     @staticmethod
     def get_compact_update_string(repo: Addon) -> str:


### PR DESCRIPTION
This brings back something akin to the original Addon Manager display, with the side-by-side display of the list and details views.