### PR TITLE
Part/Toponaming: Transfer Part::Feature::create()

### DIFF
--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -536,6 +536,23 @@ TopLoc_Location Feature::getLocation() const
     return TopLoc_Location(trf);
 }
 
+Feature* Feature::create(const TopoShape& shape, const char* name, App::Document* document)
+{
+    if (!name || !name[0]) {
+        name = "Shape";
+    }
+    if (!document) {
+        document = App::GetApplication().getActiveDocument();
+        if (!document) {
+            document = App::GetApplication().newDocument();
+        }
+    }
+    auto res = static_cast<Part::Feature*>(document->addObject("Part::Feature", name));
+    res->Shape.setValue(shape);
+    res->purgeTouched();
+    return res;
+}
+
 ShapeHistory Feature::buildHistory(BRepBuilderAPI_MakeShape& mkShape, TopAbs_ShapeEnum type,
                                    const TopoDS_Shape& newS, const TopoDS_Shape& oldS)
 {

--- a/src/Mod/Part/App/PartFeature.h
+++ b/src/Mod/Part/App/PartFeature.h
@@ -110,6 +110,9 @@ public:
         return owner && owner->isDerivedFrom(getClassTypeId());
     }
 
+    static Feature*
+    create(const TopoShape& shape, const char* name = nullptr, App::Document* document = nullptr);
+
 protected:
     /// recompute only this object
     App::DocumentObjectExecReturn *recompute() override;


### PR DESCRIPTION
Importing method `create()` of `Part::Feature`

Dependency needed for #12535