### PR TITLE
Gui: PythonWrapper::fromQAction

### DIFF
--- a/src/Gui/CommandActionPy.cpp
+++ b/src/Gui/CommandActionPy.cpp
@@ -59,7 +59,7 @@ Py::Object CommandActionPy::getAction()
         PythonWrapper wrap;
         wrap.loadWidgetsModule();
 
-        return wrap.fromQObject(action->action());
+        return wrap.fromQAction(action->action());
     }
     else {
         return Py::None();

--- a/src/Gui/CommandPyImp.cpp
+++ b/src/Gui/CommandPyImp.cpp
@@ -274,10 +274,10 @@ PyObject* CommandPy::getAction(PyObject *args)
         if (group) {
             const auto actions = group->actions();
             for (auto a : actions)
-                list.append(wrap.fromQObject(a));
+                list.append(wrap.fromQAction(a));
         }
         else if (action) {
-            list.append(wrap.fromQObject(action->action()));
+            list.append(wrap.fromQAction(action->action()));
         }
 
         return Py::new_reference_to(list);

--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -642,7 +642,11 @@ Py::Object PythonWrapper::fromQDir(const QDir& dir)
         return Py::asObject(pyobj);
     }
 #else
-    Q_UNUSED(dir)
+    // Access shiboken/PySide via Python
+    Py::Object obj = qt_wrapInstance<const QIcon*>(icon, "QDir", "QtCore");
+    if (!obj.isNull()) {
+        return obj;
+    }
 #endif
     throw Py::RuntimeError("Failed to wrap directory");
 }
@@ -711,32 +715,23 @@ Py::Object PythonWrapper::fromQObject(QObject* object, const char* className)
     if (!object) {
         return Py::None();
     }
-#if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
-    // Access shiboken/PySide via C++
-    auto type = getPyTypeObjectForTypeName<QObject>();
-    if (type) {
-        std::string typeName;
-        if (className) {
-            typeName = className;
-        }
-        else {
-            typeName = object->metaObject()->className();
-        }
-
-        PyObject* pyobj = Shiboken::Object::newObject(type, object, false, false, typeName.c_str());
-        WrapperManager::instance().addQObject(object, pyobj);
-        return Py::asObject(pyobj);
-    }
-#else
-    // Access shiboken/PySide via Python
-    std::string typeName;
+    const char* typeName {};
     if (className) {
         typeName = className;
     }
     else {
         typeName = object->metaObject()->className();
     }
-
+#if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
+    // Access shiboken/PySide via C++
+    auto type = getPyTypeObjectForTypeName<QObject>();
+    if (type) {
+        PyObject* pyobj = Shiboken::Object::newObject(type, object, false, false, typeName);
+        WrapperManager::instance().addQObject(object, pyobj);
+        return Py::asObject(pyobj);
+    }
+#else
+    // Access shiboken/PySide via Python
     Py::Object obj = qt_wrapInstance<QObject*>(object, typeName, "QtCore");
     if (!obj.isNull()) {
         return obj;
@@ -747,32 +742,23 @@ Py::Object PythonWrapper::fromQObject(QObject* object, const char* className)
 
 Py::Object PythonWrapper::fromQWidget(QWidget* widget, const char* className)
 {
-#if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
-    // Access shiboken/PySide via C++
-    auto type = getPyTypeObjectForTypeName<QWidget>();
-    if (type) {
-        std::string typeName;
-        if (className) {
-            typeName = className;
-        }
-        else {
-            typeName = widget->metaObject()->className();
-        }
-
-        PyObject* pyobj = Shiboken::Object::newObject(type, widget, false, false, typeName.c_str());
-        WrapperManager::instance().addQObject(widget, pyobj);
-        return Py::asObject(pyobj);
-    }
-#else
-    // Access shiboken/PySide via Python
-    std::string typeName;
+    const char* typeName {};
     if (className) {
         typeName = className;
     }
     else {
         typeName = widget->metaObject()->className();
     }
-
+#if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
+    // Access shiboken/PySide via C++
+    auto type = getPyTypeObjectForTypeName<QWidget>();
+    if (type) {
+        PyObject* pyobj = Shiboken::Object::newObject(type, widget, false, false, typeName);
+        WrapperManager::instance().addQObject(widget, pyobj);
+        return Py::asObject(pyobj);
+    }
+#else
+    // Access shiboken/PySide via Python
     Py::Object obj = qt_wrapInstance<QWidget*>(widget, typeName, "QtWidgets");
     if (!obj.isNull()) {
         return obj;

--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -635,6 +635,23 @@ QDir* PythonWrapper::toQDir(PyObject* pyobj)
     return qt_getCppType<QDir>(pyobj);
 }
 
+Py::Object PythonWrapper::fromQAction(QAction* action)
+{
+#if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
+    // Access shiboken/PySide via C++
+    auto type = getPyTypeObjectForTypeName<QAction>();
+    if (type) {
+        PyObject* pyobj = Shiboken::Object::newObject(type, action, false, false, "QAction");
+        WrapperManager::instance().addQObject(action, pyobj);
+        return Py::asObject(pyobj);
+    }
+    throw Py::RuntimeError("Failed to wrap action");
+#else
+    // Access shiboken/PySide via Python
+    return qt_wrapInstance<QAction*>(action, "QAction", "QtGui");
+#endif
+}
+
 Py::Object PythonWrapper::fromQPrinter(QPrinter* printer)
 {
     if (!printer) {

--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -580,12 +580,14 @@ Py::Object PythonWrapper::fromQImage(const QImage& img)
     if (pyobj) {
         return Py::asObject(pyobj);
     }
-
-    throw Py::RuntimeError("Failed to wrap image");
 #else
     // Access shiboken/PySide via Python
-    return qt_wrapInstance<const QImage*>(&img, "QImage", "QtGui");
+    Py::Object obj = qt_wrapInstance<const QImage*>(&img, "QImage", "QtGui");
+    if (!obj.isNull()) {
+        return obj;
+    }
 #endif
+    throw Py::RuntimeError("Failed to wrap image");
 }
 
 QImage *PythonWrapper::toQImage(PyObject *pyobj)
@@ -602,12 +604,14 @@ Py::Object PythonWrapper::fromQIcon(const QIcon* icon)
     if (pyobj) {
         return Py::asObject(pyobj);
     }
-
-    throw Py::RuntimeError("Failed to wrap icon");
 #else
     // Access shiboken/PySide via Python
-    return qt_wrapInstance<const QIcon*>(icon, "QIcon", "QtGui");
+    Py::Object obj = qt_wrapInstance<const QIcon*>(icon, "QIcon", "QtGui");
+    if (!obj.isNull()) {
+        return obj;
+    }
 #endif
+    throw Py::RuntimeError("Failed to wrap icon");
 }
 
 QIcon *PythonWrapper::toQIcon(PyObject *pyobj)
@@ -645,11 +649,14 @@ Py::Object PythonWrapper::fromQAction(QAction* action)
         WrapperManager::instance().addQObject(action, pyobj);
         return Py::asObject(pyobj);
     }
-    throw Py::RuntimeError("Failed to wrap action");
 #else
     // Access shiboken/PySide via Python
-    return qt_wrapInstance<QAction*>(action, "QAction", "QtGui");
+    Py::Object obj = qt_wrapInstance<QAction*>(action, "QAction", "QtGui");
+    if (!obj.isNull()) {
+        return obj;
+    }
 #endif
+    throw Py::RuntimeError("Failed to wrap action");
 }
 
 Py::Object PythonWrapper::fromQPrinter(QPrinter* printer)
@@ -672,12 +679,14 @@ Py::Object PythonWrapper::fromQPrinter(QPrinter* printer)
         PyObject* pyobj = Shiboken::Object::newObject(type, printer, false, false, "QPrinter");
         return Py::asObject(pyobj);
     }
-
-    throw Py::RuntimeError("Failed to wrap printer");
 #else
     // Access shiboken/PySide via Python
-    return qt_wrapInstance<QPrinter*>(printer, "QPrinter", "QtCore");
+    Py::Object obj = qt_wrapInstance<QPrinter*>(printer, "QPrinter", "QtCore");
+    if (!obj.isNull()) {
+        return obj;
+    }
 #endif
+    throw Py::RuntimeError("Failed to wrap printer");
 }
 
 Py::Object PythonWrapper::fromQObject(QObject* object, const char* className)
@@ -701,7 +710,6 @@ Py::Object PythonWrapper::fromQObject(QObject* object, const char* className)
         WrapperManager::instance().addQObject(object, pyobj);
         return Py::asObject(pyobj);
     }
-    throw Py::RuntimeError("Failed to wrap object");
 #else
     // Access shiboken/PySide via Python
     std::string typeName;
@@ -712,8 +720,12 @@ Py::Object PythonWrapper::fromQObject(QObject* object, const char* className)
         typeName = object->metaObject()->className();
     }
 
-    return qt_wrapInstance<QObject*>(object, typeName, "QtCore");
+    Py::Object obj = qt_wrapInstance<QObject*>(object, typeName, "QtCore");
+    if (!obj.isNull()) {
+        return obj;
+    }
 #endif
+    throw Py::RuntimeError("Failed to wrap object");
 }
 
 Py::Object PythonWrapper::fromQWidget(QWidget* widget, const char* className)
@@ -734,7 +746,6 @@ Py::Object PythonWrapper::fromQWidget(QWidget* widget, const char* className)
         WrapperManager::instance().addQObject(widget, pyobj);
         return Py::asObject(pyobj);
     }
-    throw Py::RuntimeError("Failed to wrap widget");
 #else
     // Access shiboken/PySide via Python
     std::string typeName;
@@ -745,8 +756,12 @@ Py::Object PythonWrapper::fromQWidget(QWidget* widget, const char* className)
         typeName = widget->metaObject()->className();
     }
 
-    return qt_wrapInstance<QWidget*>(widget, typeName, "QtWidgets");
+    Py::Object obj = qt_wrapInstance<QWidget*>(widget, typeName, "QtWidgets");
+    if (!obj.isNull()) {
+        return obj;
+    }
 #endif
+    throw Py::RuntimeError("Failed to wrap widget");
 }
 
 const char* PythonWrapper::getWrapperName(QObject* obj) const

--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -575,9 +575,9 @@ QGraphicsObject* PythonWrapper::toQGraphicsObject(const Py::Object& pyobject)
 Py::Object PythonWrapper::fromQImage(const QImage& img)
 {
 #if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
-    PyObject* pyobj = Shiboken::Conversions::copyToPython(getPyTypeObjectForTypeName<QImage>(),
-                              const_cast<QImage*>(&img));
-    if (pyobj) {
+    auto type = getPyTypeObjectForTypeName<QImage>();
+    if (type) {
+        PyObject* pyobj = Shiboken::Conversions::copyToPython(type, const_cast<QImage*>(&img));
         return Py::asObject(pyobj);
     }
 #else
@@ -599,9 +599,9 @@ Py::Object PythonWrapper::fromQIcon(const QIcon* icon)
 {
 #if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
     const char* typeName = typeid(*const_cast<QIcon*>(icon)).name();
-    PyObject* pyobj = Shiboken::Object::newObject(getPyTypeObjectForTypeName<QIcon>(),
-                              const_cast<QIcon*>(icon), true, false, typeName);
-    if (pyobj) {
+    auto type = getPyTypeObjectForTypeName<QIcon>();
+    if (type) {
+        PyObject* pyobj = Shiboken::Object::newObject(type, const_cast<QIcon*>(icon), true, false, typeName);
         return Py::asObject(pyobj);
     }
 #else
@@ -623,9 +623,9 @@ Py::Object PythonWrapper::fromQDir(const QDir& dir)
 {
 #if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
     const char* typeName = typeid(dir).name();
-    PyObject* pyobj = Shiboken::Object::newObject(getPyTypeObjectForTypeName<QDir>(),
-        const_cast<QDir*>(&dir), false, false, typeName);
-    if (pyobj) {
+    auto type = getPyTypeObjectForTypeName<QDir>();
+    if (type) {
+        PyObject* pyobj = Shiboken::Object::newObject(type, const_cast<QDir*>(&dir), false, false, typeName);
         return Py::asObject(pyobj);
     }
 #else

--- a/src/Gui/PythonWrapper.h
+++ b/src/Gui/PythonWrapper.h
@@ -29,6 +29,7 @@
 #include <FCGlobal.h>
 
 QT_BEGIN_NAMESPACE
+class QAction;
 class QDir;
 class QIcon;
 class QImage;
@@ -58,6 +59,7 @@ public:
     QGraphicsObject* toQGraphicsObject(PyObject* pyPtr);
     QGraphicsObject* toQGraphicsObject(const Py::Object& pyObject);
 
+    Py::Object fromQAction(QAction*);
     Py::Object fromQPrinter(QPrinter*);
     Py::Object fromQObject(QObject*, const char* className=nullptr);
     Py::Object fromQWidget(QWidget*, const char* className=nullptr);


### PR DESCRIPTION
* Gui: Implement PythonWrapper::fromQAction
* Gui: PythonWrapper: Raise exception on qt_wrapInstance failure
* Gui: PythonWrapper: Use getPyTypeObjectForTypeName consistently
* Gui: PythonWrapper: Fix qt_wrapInstance
* Gui: PythonWrapper: Consolidate typeName handling