### PR TITLE
Path: fix error in Tag dressup when adding a point.

### DIFF
--- a/src/Mod/Path/Path/Base/Gui/GetPoint.py
+++ b/src/Mod/Path/Path/Base/Gui/GetPoint.py
@@ -206,7 +206,7 @@ class TaskPanel:
 
         if cleanup:
             self.removeGlobalCallbacks()
-            FreeCADGui.Snapper.off(True)
+            FreeCADGui.Snapper.off()
             if self.buttonBox:
                 self.buttonBox.setEnabled(True)
             self.removeEscapeShortcut()


### PR DESCRIPTION
Commit c36979f removed the argument from Snapper.off() which is used in GetPoint.py. This causes the Tag dressup user interface to give an error when trying to save or close the widget for adding a new point.

(Should I create an issue for such small pull requests?)