### PR TITLE
Part: Rename AttachExtension::Support property - fixes #7052

### DIFF
--- a/src/Mod/Arch/ArchCommands.py
+++ b/src/Mod/Arch/ArchCommands.py
@@ -112,8 +112,8 @@ def addComponents(objectsList,host):
                             g.append(host)
                             o.Hosts = g
                 elif DraftGeomUtils.isValidPath(o.Shape) and (hostType in ["Structure","Precast"]):
-                    if o.Support == host:
-                        o.Support = None
+                    if o.AttachmentSupport == host:
+                        o.AttachmentSupport = None
                     host.Tool = o
                 elif Draft.getType(o) == "Axis":
                     if not o in x:

--- a/src/Mod/Arch/ArchRebar.py
+++ b/src/Mod/Arch/ArchRebar.py
@@ -66,13 +66,13 @@ def makeRebar(baseobj=None,sketch=None,diameter=None,amount=1,offset=None,name=N
     if FreeCAD.GuiUp:
         _ViewProviderRebar(obj.ViewObject)
     if baseobj and sketch:
-        if hasattr(sketch,"Support"):
-            if sketch.Support:
-                if isinstance(sketch.Support,tuple):
-                    if sketch.Support[0] == baseobj:
-                        sketch.Support = None
-                elif sketch.Support == baseobj:
-                    sketch.Support = None
+        if hasattr(sketch,"AttachmentSupport"):
+            if sketch.AttachmentSupport:
+                if isinstance(sketch.AttachmentSupport,tuple):
+                    if sketch.AttachmentSupport[0] == baseobj:
+                        sketch.AttachmentSupport = None
+                elif sketch.AttachmentSupport == baseobj:
+                    sketch.AttachmentSupport = None
         obj.Base = sketch
         if FreeCAD.GuiUp:
             sketch.ViewObject.hide()
@@ -145,10 +145,10 @@ class _CommandRebar:
                 if len(obj.Shape.Wires) == 1:
                     # we have only a wire: extract its support object, if available, and make the rebar
                     support = "None"
-                    if hasattr(obj,"Support"):
-                        if obj.Support:
-                            if len(obj.Support) != 0:
-                                support = "FreeCAD.ActiveDocument."+obj.Support[0][0].Name
+                    if hasattr(obj,"AttachmentSupport"):
+                        if obj.AttachmentSupport:
+                            if len(obj.AttachmentSupport) != 0:
+                                support = "FreeCAD.ActiveDocument."+obj.AttachmentSupport[0][0].Name
                     FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Rebar"))
                     FreeCADGui.addModule("Arch")
                     FreeCADGui.doCommand("Arch.makeRebar("+support+",FreeCAD.ActiveDocument."+obj.Name+")")

--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -195,15 +195,15 @@ class _CommandWindow:
                 if obj.Shape.Wires and (not obj.Shape.Solids) and (not obj.Shape.Shells):
                     FreeCADGui.Control.closeDialog()
                     host = None
-                    if hasattr(obj,"Support"):
-                        if obj.Support:
-                            if isinstance(obj.Support,tuple):
-                                host = obj.Support[0]
-                            elif isinstance(obj.Support,list):
-                                host = obj.Support[0][0]
+                    if hasattr(obj,"AttachmentSupport"):
+                        if obj.AttachmentSupport:
+                            if isinstance(obj.AttachmentSupport,tuple):
+                                host = obj.AttachmentSupport[0]
+                            elif isinstance(obj.AttachmentSupport,list):
+                                host = obj.AttachmentSupport[0][0]
                             else:
-                                host = obj.Support
-                            obj.Support = None # remove
+                                host = obj.AttachmentSupport
+                            obj.AttachmentSupport = None # remove
                     elif Draft.isClone(obj,"Window"):
                         if obj.Objects[0].Inlist:
                             host = obj.Objects[0].Inlist[0]

--- a/src/Mod/Arch/TestArch.py
+++ b/src/Mod/Arch/TestArch.py
@@ -444,7 +444,7 @@ class ArchTest(unittest.TestCase):
         App.Console.PrintLog ('Checking Arch Rebar...\n')
         s = Arch.makeStructure(length=2,width=3,height=5)
         sk = App.ActiveDocument.addObject('Sketcher::SketchObject','Sketch')
-        sk.Support = (s,["Face6"])
+        sk.AttachmentSupport = (s,["Face6"])
         sk.addGeometry(Part.LineSegment(App.Vector(-0.85,1.25,0),App.Vector(0.75,1.25,0)))
         sk.addGeometry(Part.LineSegment(App.Vector(0.75,1.25,0),App.Vector(0.75,-1.20,0)))
         sk.addGeometry(Part.LineSegment(App.Vector(0.75,-1.20,0),App.Vector(-0.85,-1.20,0)))

--- a/src/Mod/Draft/draftmake/make_bezcurve.py
+++ b/src/Mod/Draft/draftmake/make_bezcurve.py
@@ -91,7 +91,7 @@ def make_bezcurve(pointslist,
         obj.Degree = min((len(pointslist)-(1 * (not closed))),
                          Part.BezierCurve().MaxDegree)
     obj.Closed = closed
-    obj.Support = support
+    obj.AttachmentSupport = support
     if face is not None:
         obj.MakeFace = face
     obj.Proxy.resetcontinuity(obj)

--- a/src/Mod/Draft/draftmake/make_bspline.py
+++ b/src/Mod/Draft/draftmake/make_bspline.py
@@ -96,7 +96,7 @@ def make_bspline(pointslist, closed=False, placement=None, face=None, support=No
     BSpline(obj)
     obj.Closed = closed
     obj.Points = pointslist
-    obj.Support = support
+    obj.AttachmentSupport = support
     if face is not None:
         obj.MakeFace = face
     if placement: obj.Placement = placement

--- a/src/Mod/Draft/draftmake/make_circle.py
+++ b/src/Mod/Draft/draftmake/make_circle.py
@@ -119,7 +119,7 @@ def make_circle(radius, placement=None, face=None, startangle=None, endangle=Non
             obj.FirstAngle = math.copysign(abs(startangle) % 360, startangle)
             obj.LastAngle = math.copysign(abs(endangle) % 360, endangle)
 
-    obj.Support = support
+    obj.AttachmentSupport = support
 
     if placement:
         obj.Placement = placement

--- a/src/Mod/Draft/draftmake/make_ellipse.py
+++ b/src/Mod/Draft/draftmake/make_ellipse.py
@@ -72,7 +72,7 @@ def make_ellipse(majradius, minradius, placement=None, face=None, support=None):
         majradius, minradius = minradius, majradius
     obj.MajorRadius = majradius
     obj.MinorRadius = minradius
-    obj.Support = support
+    obj.AttachmentSupport = support
 
     if face is not None:
         obj.MakeFace = face

--- a/src/Mod/Draft/draftmake/make_polygon.py
+++ b/src/Mod/Draft/draftmake/make_polygon.py
@@ -74,7 +74,7 @@ def make_polygon(nfaces, radius=1, inscribed=True, placement=None, face=None, su
         obj.DrawMode = "inscribed"
     else:
         obj.DrawMode = "circumscribed"
-    obj.Support = support
+    obj.AttachmentSupport = support
     if placement: obj.Placement = placement
     if App.GuiUp:
         ViewProviderDraft(obj.ViewObject)

--- a/src/Mod/Draft/draftmake/make_rectangle.py
+++ b/src/Mod/Draft/draftmake/make_rectangle.py
@@ -82,7 +82,7 @@ def make_rectangle(length, height=0, placement=None, face=None, support=None):
 
     obj.Length = length
     obj.Height = height
-    obj.Support = support
+    obj.AttachmentSupport = support
 
     if face is not None:
         obj.MakeFace = face

--- a/src/Mod/Draft/draftmake/make_wire.py
+++ b/src/Mod/Draft/draftmake/make_wire.py
@@ -112,7 +112,7 @@ def make_wire(pointslist, closed=False, placement=None, face=None, support=None,
     Wire(obj)
     obj.Points = pointslist
     obj.Closed = closed
-    obj.Support = support
+    obj.AttachmentSupport = support
 
     if face is not None:
         obj.MakeFace = face

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -168,7 +168,7 @@ class ShapeStringTaskPanelCmd(ShapeStringTaskPanel):
                                    'plm.Base = ' + toString(ssBase),
                                    'plm.Rotation.Q = ' + qr,
                                    'ss.Placement = plm',
-                                   'ss.Support = ' + sup,
+                                   'ss.AttachmentSupport = ' + sup,
                                    'Draft.autogroup(ss)',
                                    'FreeCAD.ActiveDocument.recompute()'])
         except Exception:

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -588,7 +588,7 @@ class DraftModification(unittest.TestCase):
 
         obj = Draft.make_clone(box1)
         obj.MapMode = "ObjectXY"
-        obj.Support = [(box2, ("",))]
+        obj.AttachmentSupport = [(box2, ("",))]
         App.ActiveDocument.recompute()
 
         box1.Length = 1

--- a/src/Mod/Fem/femexamples/equation_deformation_spring_elmer.py
+++ b/src/Mod/Fem/femexamples/equation_deformation_spring_elmer.py
@@ -73,7 +73,7 @@ def setup(doc=None, solvertype="elmer"):
     # sketch defining the spring form
     body = doc.addObject("PartDesign::Body", "Body")
     SketchPath = body.newObject("Sketcher::SketchObject", "Spring_Path")
-    SketchPath.Support = (doc.getObject("XY_Plane"), [""])
+    SketchPath.AttachmentSupport = (doc.getObject("XY_Plane"), [""])
     SketchPath.MapMode = "FlatFace"
     SketchPath.addGeometry(Part.LineSegment(Vector(
         -20.0, 30.0, 0.0), Vector(-20.0, 0.0, 0.0)), False)
@@ -91,7 +91,7 @@ def setup(doc=None, solvertype="elmer"):
 
     # sketch defining the spring cross section
     SketchCircle = body.newObject("Sketcher::SketchObject", "Spring_Circle")
-    SketchCircle.Support = (doc.getObject("XZ_Plane"), [""])
+    SketchCircle.AttachmentSupport = (doc.getObject("XZ_Plane"), [""])
     SketchCircle.MapMode = "FlatFace"
     SketchCircle.addGeometry(Part.Circle(Vector(-20.0, 0.0, 0.0), Vector(0, 0, 1), 7.5), False)
     SketchCircle.addConstraint(Sketcher.Constraint('PointOnObject', 0, 3, -1))

--- a/src/Mod/Fem/femexamples/equation_electrostatics_electricforce_elmer_nongui6.py
+++ b/src/Mod/Fem/femexamples/equation_electrostatics_electricforce_elmer_nongui6.py
@@ -80,7 +80,7 @@ def setup(doc=None, solvertype="elmer"):
     # name is important because the other method in this module use obj name
     geom_obj = doc.addObject("PartDesign::Body", "Body")
     base_sketch = geom_obj.newObject("Sketcher::SketchObject", "Base_Sketch")
-    base_sketch.Support = (doc.getObject("XY_Plane"), [""])
+    base_sketch.AttachmentSupport = (doc.getObject("XY_Plane"), [""])
     base_sketch.MapMode = "FlatFace"
     base_geoList = [
         Part.LineSegment(Vector(0.000000, 0.000000, 0), Vector(57.407921, 0.000000, 0)),
@@ -111,7 +111,7 @@ def setup(doc=None, solvertype="elmer"):
     pad.Length2 = 1000.0
 
     upper_sketch = geom_obj.newObject("Sketcher::SketchObject", "Upper_Sketch")
-    upper_sketch.Support = None
+    upper_sketch.AttachmentSupport = None
     upper_sketch.MapMode = "Deactivated"
     upper_sketch.Placement = FreeCAD.Placement(Vector(0, 0, 1000), Rotation(Vector(0, 0, 1), 0))
     upper_geoList = [

--- a/src/Mod/Part/App/AttachEnginePyImp.cpp
+++ b/src/Mod/Part/App/AttachEnginePyImp.cpp
@@ -518,7 +518,7 @@ PyObject* AttachEnginePy::readParametersFromFeature(PyObject* args)
         }
         Part::AttachExtension* feat = dobj->getExtensionByType<Part::AttachExtension>();
         AttachEngine &attacher = *(this->getAttachEnginePtr());
-        attacher.setUp(feat->Support,
+        attacher.setUp(feat->AttachmentSupport,
                        eMapMode(feat->MapMode.getValue()),
                        feat->MapReversed.getValue(),
                        feat->MapPathParameter.getValue(),
@@ -543,7 +543,7 @@ PyObject* AttachEnginePy::writeParametersToFeature(PyObject* args)
         Part::AttachExtension* feat = dobj->getExtensionByType<Part::AttachExtension>();
         const AttachEngine &attacher = *(this->getAttachEnginePtr());
         AttachEngine::verifyReferencesAreSafe(attacher.references);
-        feat->Support.Paste(attacher.references);
+        feat->AttachmentSupport.Paste(attacher.references);
         feat->MapMode.setValue(attacher.mapMode);
         feat->MapReversed.setValue(attacher.mapReverse);
         feat->MapPathParameter.setValue(attacher.attachParameter);

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -38,7 +38,7 @@ AttachExtension::AttachExtension()
     EXTENSION_ADD_PROPERTY_TYPE(AttacherType, ("Attacher::AttachEngine3D"), "Attachment",(App::PropertyType)(App::Prop_None),"Class name of attach engine object driving the attachment.");
     this->AttacherType.setStatus(App::Property::Status::Hidden, true);
 
-    EXTENSION_ADD_PROPERTY_TYPE(Support, (nullptr,nullptr), "Attachment",(App::PropertyType)(App::Prop_None),"Support of the 2D geometry");
+    EXTENSION_ADD_PROPERTY_TYPE(AttachmentSupport, (nullptr,nullptr), "Attachment",(App::PropertyType)(App::Prop_None),"Support of the 2D geometry");
 
     EXTENSION_ADD_PROPERTY_TYPE(MapMode, (mmDeactivated), "Attachment", App::Prop_None, "Mode of attachment to other object");
     MapMode.setEditorName("PartGui::PropertyEnumAttacherItem");
@@ -165,7 +165,7 @@ App::DocumentObjectExecReturn *AttachExtension::extensionExecute()
 void AttachExtension::extensionOnChanged(const App::Property* prop)
 {
     if(! getExtendedObject()->isRestoring()){
-        if ((prop == &Support
+        if ((prop == &AttachmentSupport
              || prop == &MapMode
              || prop == &MapPathParameter
              || prop == &MapReversed
@@ -212,13 +212,32 @@ void AttachExtension::extensionOnChanged(const App::Property* prop)
     App::DocumentObjectExtension::extensionOnChanged(prop);
 }
 
-void AttachExtension::extHandleChangedPropertyName(Base::XMLReader &reader, const char* TypeName, const char* PropName)
+bool AttachExtension::extensionHandleChangedPropertyName(Base::XMLReader &reader, const char* TypeName, const char *PropName)
 {
-    // Was superPlacement
+    // superPlacement -> AttachmentOffset
     Base::Type type = Base::Type::fromName(TypeName);
-    if (AttachmentOffset.getClassTypeId() == type && strcmp(PropName, "superPlacement") == 0) {
+    if (strcmp(PropName, "superPlacement") == 0 && AttachmentOffset.getClassTypeId() == type) {
         AttachmentOffset.Restore(reader);
+        return true;
     }
+    // Support -> AttachmentSupport
+    else if (strcmp(PropName, "Support") == 0) {
+        // At one point, the type of Support changed from PropertyLinkSub to its present type of PropertyLinkSubList.
+        // Later, the property name changed to AttachmentSupport
+        App::PropertyLinkSub tmp;
+        if (0 == strcmp(tmp.getTypeId().getName(),TypeName)) {
+            tmp.setContainer(this->getExtendedContainer());
+            tmp.Restore(reader);
+            AttachmentSupport.setValue(tmp.getValue(), tmp.getSubValues());
+            this->MapMode.setValue(Attacher::mmFlatFace);
+            return true;
+        }
+        else if (AttachmentSupport.getClassTypeId() == type) {
+            AttachmentSupport.Restore(reader);
+            return true;
+        }
+    }
+    return App::DocumentObjectExtension::extensionHandleChangedPropertyName(reader, TypeName, PropName);
 }
 
 void AttachExtension::onExtendedDocumentRestored()
@@ -257,7 +276,7 @@ void AttachExtension::updateAttacherVals()
 {
     if (!_attacher)
         return;
-    _attacher->setUp(this->Support,
+    _attacher->setUp(this->AttachmentSupport,
                      eMapMode(this->MapMode.getValue()),
                      this->MapReversed.getValue(),
                      this->MapPathParameter.getValue(),

--- a/src/Mod/Part/App/AttachExtension.h
+++ b/src/Mod/Part/App/AttachExtension.h
@@ -85,7 +85,7 @@ public:
 
 
     App::PropertyString         AttacherType;
-    App::PropertyLinkSubList    Support;
+    App::PropertyLinkSubList    AttachmentSupport;
     App::PropertyEnumeration    MapMode; //see AttachEngine::eMapMode
     App::PropertyBool           MapReversed; //inverts Z and X internal axes
     App::PropertyPlacement      AttachmentOffset;
@@ -97,7 +97,7 @@ public:
       */
     App::PropertyFloat MapPathParameter;
 
-    /** calculate and update the Placement property based on the Support, and
+    /** calculate and update the Placement property based on the AttachmentSupport, and
       * mode. Can throw FreeCAD and OCC exceptions. Returns true if attached,
       * false if not, throws if attachment failed.
       */
@@ -108,7 +108,7 @@ public:
     bool isAttacherActive() const;
 
     virtual bool isTouched_Mapping()
-    {return true; /*support.isTouched isn't true when linked objects are changed... why?..*/}
+    {return true; /*AttachmentSupport.isTouched isn't true when linked objects are changed... why?..*/}
 
     short int extensionMustExecute() override;
     App::DocumentObjectExecReturn *extensionExecute() override;
@@ -117,7 +117,7 @@ public:
 
 protected:
     void extensionOnChanged(const App::Property* /*prop*/) override;
-    virtual void extHandleChangedPropertyName(Base::XMLReader &reader, const char* TypeName, const char* PropName);
+    virtual bool extensionHandleChangedPropertyName(Base::XMLReader &reader, const char * TypeName, const char *PropName) override;
 
     App::PropertyPlacement& getPlacement() const;
 

--- a/src/Mod/Part/App/AttachExtensionPy.xml
+++ b/src/Mod/Part/App/AttachExtensionPy.xml
@@ -15,7 +15,7 @@
     </Documentation>
     <Methode Name="positionBySupport">
       <Documentation>
-        <UserDocu>positionBySupport(): Reposition object based on Support, MapMode and MapPathParameter properties.
+        <UserDocu>positionBySupport(): Reposition object based on AttachmentSupport, MapMode and MapPathParameter properties.
 Returns True if attachment calculation was successful, false if object is not attached and Placement wasn't updated,
 and raises an exception if attachment calculation fails.</UserDocu>
       </Documentation>

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -144,7 +144,7 @@ enum eRefType {
 };
 
 
-using refTypeString = std::vector<eRefType>; //a sequence of ref types, according to Support contents for example
+using refTypeString = std::vector<eRefType>; //a sequence of ref types, according to AttachmentSupport contents for example
 using refTypeStringList = std::vector<refTypeString>; //a set of type strings, defines which selection sets are supported by a certain mode
 
 

--- a/src/Mod/Part/App/DatumFeature.cpp
+++ b/src/Mod/Part/App/DatumFeature.cpp
@@ -44,7 +44,7 @@ Datum::~Datum() = default;
 void Datum::onDocumentRestored()
 {
     // This seems to be the only way to make the ViewProvider display the datum feature
-    Support.touch();
+    AttachmentSupport.touch();
     Part::Feature::onDocumentRestored();
 }
 
@@ -82,9 +82,4 @@ App::DocumentObject *Datum::getSubObject(const char *subname,
 
 Base::Vector3d Datum::getBasePoint () const {
     return Placement.getValue().getPosition();
-}
-
-void Datum::handleChangedPropertyName(Base::XMLReader &reader, const char* TypeName, const char* PropName)
-{
-    extHandleChangedPropertyName(reader, TypeName, PropName); // AttachExtension
 }

--- a/src/Mod/Part/App/DatumFeature.h
+++ b/src/Mod/Part/App/DatumFeature.h
@@ -55,7 +55,6 @@ public:
             Base::Matrix4D *mat, bool transform, int depth) const override;
 protected:
     void onDocumentRestored() override;
-    void handleChangedPropertyName(Base::XMLReader &reader, const char* TypeName, const char* PropName) override;
 };
 
 } //namespace Part

--- a/src/Mod/Part/App/Part2DObject.cpp
+++ b/src/Mod/Part/App/Part2DObject.cpp
@@ -75,7 +75,7 @@ App::DocumentObjectExecReturn *Part2DObject::execute()
 
 void Part2DObject::transformPlacement(const Base::Placement &transform)
 {
-    if (!Support.getValues().empty()) {
+    if (!AttachmentSupport.getValues().empty()) {
         //part->transformPlacement(transform);
         positionBySupport();
     } else {
@@ -252,33 +252,6 @@ void Part2DObject::acceptGeometry()
 void Part2DObject::Restore(Base::XMLReader &reader)
 {
     Part::Feature::Restore(reader);
-}
-
-void Part2DObject::handleChangedPropertyType(Base::XMLReader &reader,
-                                             const char * TypeName,
-                                             App::Property * prop)
-{
-    //override generic restoration to convert Support property from PropertyLinkSub to PropertyLinkSubList
-    if (prop->isDerivedFrom(App::PropertyLinkSubList::getClassTypeId())) {
-        //reading legacy Support - when the Support could only be a single flat face.
-        App::PropertyLinkSub tmp;
-        if (0 == strcmp(tmp.getTypeId().getName(),TypeName)) {
-            tmp.setContainer(this);
-            tmp.Restore(reader);
-            static_cast<App::PropertyLinkSubList*>(prop)->setValue(tmp.getValue(), tmp.getSubValues());
-        }
-        this->MapMode.setValue(Attacher::mmFlatFace);
-    }
-    else {
-        Part::Feature::handleChangedPropertyType(reader, TypeName, prop);
-    }
-}
-
-void Part2DObject::handleChangedPropertyName(Base::XMLReader &reader,
-                                             const char * TypeName,
-                                             const char *PropName)
-{
-    extHandleChangedPropertyName(reader, TypeName, PropName); // AttachExtension
 }
 
 // Python Drawing feature ---------------------------------------------------------

--- a/src/Mod/Part/App/Part2DObject.h
+++ b/src/Mod/Part/App/Part2DObject.h
@@ -94,10 +94,6 @@ public:
     //@}
 
     void Restore(Base::XMLReader &reader) override;
-
-protected:
-    void handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop) override;
-    void handleChangedPropertyName(Base::XMLReader &reader, const char * TypeName, const char *PropName) override;
 };
 
 using Part2DObjectPython = App::FeaturePythonT<Part2DObject>;

--- a/src/Mod/Part/App/PrimitiveFeature.cpp
+++ b/src/Mod/Part/App/PrimitiveFeature.cpp
@@ -116,11 +116,6 @@ void Primitive::Restore(Base::XMLReader &reader)
     Part::Feature::Restore(reader);
 }
 
-void Primitive::handleChangedPropertyName(Base::XMLReader &reader, const char * TypeName, const char *PropName)
-{
-    extHandleChangedPropertyName(reader, TypeName, PropName); // AttachExtension
-}
-
 void Primitive::handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop)
 {
     // For #0001652 the property types of many primitive features have changed

--- a/src/Mod/Part/App/PrimitiveFeature.h
+++ b/src/Mod/Part/App/PrimitiveFeature.h
@@ -49,7 +49,6 @@ public:
 protected:
     void Restore(Base::XMLReader &reader) override;
     void onChanged (const App::Property* prop) override;
-    void handleChangedPropertyName(Base::XMLReader &reader, const char * TypeName, const char *PropName) override;
     void handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop) override;
 };
 

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -89,8 +89,8 @@ const QString makeRefString(const App::DocumentObject* obj, const std::string& s
 
 void TaskAttacher::makeRefStrings(std::vector<QString>& refstrings, std::vector<std::string>& refnames) {
     Part::AttachExtension* pcAttach = ViewProvider->getObject()->getExtensionByType<Part::AttachExtension>();
-    std::vector<App::DocumentObject*> refs = pcAttach->Support.getValues();
-    refnames = pcAttach->Support.getSubValues();
+    std::vector<App::DocumentObject*> refs = pcAttach->AttachmentSupport.getValues();
+    refnames = pcAttach->AttachmentSupport.getSubValues();
 
     for (size_t r = 0; r < 4; r++) {
         if ((r < refs.size()) && (refs[r])) {
@@ -172,7 +172,7 @@ TaskAttacher::TaskAttacher(Gui::ViewProviderDocumentObject *ViewProvider, QWidge
 
     // Get the feature data
     Part::AttachExtension* pcAttach = ViewProvider->getObject()->getExtensionByType<Part::AttachExtension>();
-    std::vector<std::string> refnames = pcAttach->Support.getSubValues();
+    std::vector<std::string> refnames = pcAttach->AttachmentSupport.getSubValues();
 
     ui->checkBoxFlip->setChecked(pcAttach->MapReversed.getValue());
     std::vector<QString> refstrings;
@@ -203,7 +203,7 @@ TaskAttacher::TaskAttacher(Gui::ViewProviderDocumentObject *ViewProvider, QWidge
         this->iActiveRef = 0;
     else
         this->iActiveRef = -1;
-    if (pcAttach->Support.getSize() == 0){
+    if (pcAttach->AttachmentSupport.getSize() == 0){
         autoNext = true;
     } else {
         autoNext = false;
@@ -279,7 +279,7 @@ void TaskAttacher::updateReferencesUI()
 
     Part::AttachExtension* pcAttach = ViewProvider->getObject()->getExtensionByType<Part::AttachExtension>();
 
-    std::vector<App::DocumentObject*> refs = pcAttach->Support.getValues();
+    std::vector<App::DocumentObject*> refs = pcAttach->AttachmentSupport.getValues();
     completed = false;
 
     // Get hints for further required references...
@@ -363,8 +363,8 @@ void TaskAttacher::onSelectionChanged(const Gui::SelectionChanges& msg)
 
         // Note: The validity checking has already been done in ReferenceSelection.cpp
         Part::AttachExtension* pcAttach = ViewProvider->getObject()->getExtensionByType<Part::AttachExtension>();
-        std::vector<App::DocumentObject*> refs = pcAttach->Support.getValues();
-        std::vector<std::string> refnames = pcAttach->Support.getSubValues();
+        std::vector<App::DocumentObject*> refs = pcAttach->AttachmentSupport.getValues();
+        std::vector<std::string> refnames = pcAttach->AttachmentSupport.getSubValues();
         App::DocumentObject* selObj = ViewProvider->getObject()->getDocument()->getObject(msg.pObjectName);
         if (!selObj || selObj == ViewProvider->getObject())//prevent self-referencing
             return;
@@ -401,7 +401,7 @@ void TaskAttacher::onSelectionChanged(const Gui::SelectionChanges& msg)
 
         //bool error = false;
         try {
-            pcAttach->Support.setValues(refs, refnames);
+            pcAttach->AttachmentSupport.setValues(refs, refnames);
             updateListOfModes();
             eMapMode mmode = getActiveMapMode();//will be mmDeactivated, if selected or if no modes are available
             if(mmode == mmDeactivated){
@@ -572,8 +572,8 @@ void TaskAttacher::onRefName(const QString& text, unsigned idx)
         // Reference was removed
         // Update the reference list
         Part::AttachExtension* pcAttach = ViewProvider->getObject()->getExtensionByType<Part::AttachExtension>();
-        std::vector<App::DocumentObject*> refs = pcAttach->Support.getValues();
-        std::vector<std::string> refnames = pcAttach->Support.getSubValues();
+        std::vector<App::DocumentObject*> refs = pcAttach->AttachmentSupport.getValues();
+        std::vector<std::string> refnames = pcAttach->AttachmentSupport.getSubValues();
         std::vector<App::DocumentObject*> newrefs;
         std::vector<std::string> newrefnames;
         for (size_t r = 0; r < refs.size(); r++) {
@@ -582,7 +582,7 @@ void TaskAttacher::onRefName(const QString& text, unsigned idx)
                 newrefnames.push_back(refnames[r]);
             }
         }
-        pcAttach->Support.setValues(newrefs, newrefnames);
+        pcAttach->AttachmentSupport.setValues(newrefs, newrefnames);
         updateListOfModes();
         pcAttach->MapMode.setValue(getActiveMapMode());
         selectMapMode(getActiveMapMode());
@@ -665,8 +665,8 @@ void TaskAttacher::onRefName(const QString& text, unsigned idx)
     }
 
     Part::AttachExtension* pcAttach = ViewProvider->getObject()->getExtensionByType<Part::AttachExtension>();
-    std::vector<App::DocumentObject*> refs = pcAttach->Support.getValues();
-    std::vector<std::string> refnames = pcAttach->Support.getSubValues();
+    std::vector<App::DocumentObject*> refs = pcAttach->AttachmentSupport.getValues();
+    std::vector<std::string> refnames = pcAttach->AttachmentSupport.getSubValues();
     if (idx < refs.size()) {
         refs[idx] = obj;
         refnames[idx] = subElement;
@@ -674,7 +674,7 @@ void TaskAttacher::onRefName(const QString& text, unsigned idx)
         refs.push_back(obj);
         refnames.emplace_back(subElement);
     }
-    pcAttach->Support.setValues(refs, refnames);
+    pcAttach->AttachmentSupport.setValues(refs, refnames);
     updateListOfModes();
     pcAttach->MapMode.setValue(getActiveMapMode());
     selectMapMode(getActiveMapMode());
@@ -697,7 +697,7 @@ void TaskAttacher::updateRefButton(int idx)
     }
 
     Part::AttachExtension* pcAttach = ViewProvider->getObject()->getExtensionByType<Part::AttachExtension>();
-    std::vector<App::DocumentObject*> refs = pcAttach->Support.getValues();
+    std::vector<App::DocumentObject*> refs = pcAttach->AttachmentSupport.getValues();
 
     int numrefs = refs.size();
     bool enable = true;
@@ -792,7 +792,7 @@ void TaskAttacher::updateListOfModes()
     this->lastSuggestResult.bestFitMode = mmDeactivated;
     size_t lastValidModeItemIndex = mmDummy_NumberOfModes;
 
-    if (pcAttach->Support.getSize() > 0){
+    if (pcAttach->AttachmentSupport.getSize() > 0){
         pcAttach->attacher().suggestMapModes(this->lastSuggestResult);
         modesInList = this->lastSuggestResult.allApplicableModes;
         modesInList.insert(modesInList.begin(), mmDeactivated); // always have the option to choose Deactivated mode
@@ -976,8 +976,8 @@ void TaskAttacher::visibilityAutomation(bool opening_not_closing)
                 "_tv_%4.hide(dep_features)\n"
                 "del(dep_features)\n"
                 "if not tvObj.isDerivedFrom('PartDesign::CoordinateSystem'):\n"
-                "\t\tif len(tvObj.Support) > 0:\n"
-                "\t\t\t_tv_%4.show([lnk[0] for lnk in tvObj.Support])\n"
+                "\t\tif len(tvObj.AttachmentSupport) > 0:\n"
+                "\t\t\t_tv_%4.show([lnk[0] for lnk in tvObj.AttachmentSupport])\n"
                 "del(tvObj)"
                 ).arg(
                     QString::fromLatin1(Gui::Command::getObjectCmd(vp->getObject()).c_str()),
@@ -1103,7 +1103,7 @@ bool TaskDlgAttacher::accept()
 
         Gui::cmdAppObjectArgs(obj, "MapReversed = %s", pcAttach->MapReversed.getValue() ? "True" : "False");
 
-        Gui::cmdAppObjectArgs(obj, "Support = %s", pcAttach->Support.getPyReprString().c_str());
+        Gui::cmdAppObjectArgs(obj, "AttachmentSupport = %s", pcAttach->AttachmentSupport.getPyReprString().c_str());
 
         Gui::cmdAppObjectArgs(obj, "MapPathParameter = %f", pcAttach->MapPathParameter.getValue());
 

--- a/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
@@ -95,7 +95,7 @@ void ViewProviderAttachExtension::extensionUpdateData(const App::Property* prop)
         auto* attach = getExtendedViewProvider()->getObject()->getExtensionByType<Part::AttachExtension>();
 
         if(attach) {
-            if( prop == &(attach->Support) ||
+            if( prop == &(attach->AttachmentSupport) ||
                 prop == &(attach->MapMode) ||
                 prop == &(attach->MapPathParameter) ||
                 prop == &(attach->MapReversed) ||

--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -551,7 +551,7 @@ bool ViewProviderGridExtension::extensionHandleChangedPropertyType(Base::XMLRead
         return true;
     }
 
-    return false;
+    return Gui::ViewProviderExtension::extensionHandleChangedPropertyType(reader, TypeName, prop);
 }
 
 namespace Gui {

--- a/src/Mod/PartDesign/App/DatumLine.cpp
+++ b/src/Mod/PartDesign/App/DatumLine.cpp
@@ -62,7 +62,7 @@ Line::Line()
     myShape.Infinite(Standard_True);
     Shape.setValue(myShape);
 
-    Support.touch();
+    AttachmentSupport.touch();
 }
 
 Line::~Line() = default;

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -147,11 +147,6 @@ void FeaturePrimitive::onChanged(const App::Property* prop)
     FeatureAddSub::onChanged(prop);
 }
 
-void FeaturePrimitive::handleChangedPropertyName(Base::XMLReader &reader, const char* TypeName, const char* PropName)
-{
-    extHandleChangedPropertyName(reader, TypeName, PropName); // AttachExtension
-}
-
 // suppress warning about tp_print for Py3.8
 #if defined(__clang__)
 # pragma clang diagnostic push

--- a/src/Mod/PartDesign/App/FeaturePrimitive.h
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.h
@@ -61,7 +61,6 @@ public:
         return PartDesign::FeatureAddSub::execute();
     }
 protected:
-    void handleChangedPropertyName(Base::XMLReader &reader, const char* TypeName, const char* PropName) override;
     //make the boolean ops with the primitives provided by the derived features
     App::DocumentObjectExecReturn* execute(const TopoDS_Shape& primitiveShape);
     Type primitiveType = Box;

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -99,7 +99,7 @@ void ProfileBased::positionByPrevious()
     else {
         //no base. Use either Sketch support's placement, or sketch's placement itself.
         Part::Part2DObject* sketch = getVerifiedSketch();
-        App::DocumentObject* support = sketch->Support.getValue();
+        App::DocumentObject* support = sketch->AttachmentSupport.getValue();
         if (support && support->isDerivedFrom(App::GeoFeature::getClassTypeId())) {
             this->Placement.setValue(static_cast<App::GeoFeature*>(support)->Placement.getValue());
         }
@@ -307,13 +307,13 @@ const TopoDS_Face ProfileBased::getSupportFace() const
 
 TopoDS_Face ProfileBased::getSupportFace(const Part::Part2DObject* sketch) const
 {
-    if (sketch && sketch->MapMode.getValue() == Attacher::mmFlatFace && sketch->Support.getValue()) {
-        const auto& Support = sketch->Support;
-        App::DocumentObject* ref = Support.getValue();
+    if (sketch && sketch->MapMode.getValue() == Attacher::mmFlatFace && sketch->AttachmentSupport.getValue()) {
+        const auto& AttachmentSupport = sketch->AttachmentSupport;
+        App::DocumentObject* ref = AttachmentSupport.getValue();
 
         Part::Feature* part = dynamic_cast<Part::Feature*>(ref);
         if (part) {
-            const std::vector<std::string>& sub = Support.getSubValues();
+            const std::vector<std::string>& sub = AttachmentSupport.getSubValues();
             assert(sub.size() == 1);
 
             if (sub.at(0).empty()) {
@@ -385,7 +385,7 @@ Part::Feature* ProfileBased::getBaseObject(bool silent) const
     Part::Part2DObject* sketch = getVerifiedSketch(silent);
     const char* err = nullptr;
 
-    App::DocumentObject* spt = sketch->Support.getValue();
+    App::DocumentObject* spt = sketch->AttachmentSupport.getValue();
     if (spt) {
         if (spt->isDerivedFrom(Part::Feature::getClassTypeId())) {
             rv = static_cast<Part::Feature*>(spt);

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -133,8 +133,8 @@ void UnifiedDatumCommand(Gui::Command &cmd, Base::Type type, std::string name)
                 SuggestResult sugr;
                 pcDatum->attacher().suggestMapModes(sugr);
                 if (sugr.message == Attacher::SuggestResult::srOK) {
-                    //fits some mode. Populate support property.
-                    FCMD_OBJ_CMD(Feat,"Support = " << support.getPyReprString());
+                    //fits some mode. Populate AttachmentSupport property.
+                    FCMD_OBJ_CMD(Feat,"AttachmentSupport = " << support.getPyReprString());
                     FCMD_OBJ_CMD(Feat,"MapMode = '" << AttachEngine::getModeName(sugr.bestFitMode) << "'");
                 } else {
                     QMessageBox::information(Gui::getMainWindow(),QObject::tr("Invalid selection"), QObject::tr("There are no attachment modes that fit selected objects. Select something else."));

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -271,7 +271,7 @@ void CmdPartDesignBody::activated(int iMsg)
                         App::Plane* plane = static_cast<App::Plane*>(features.front());
                         std::string supportString = Gui::Command::getObjectCmd(plane,"(",", [''])");
 
-                        FCMD_OBJ_CMD(baseFeature,"Support = " << supportString);
+                        FCMD_OBJ_CMD(baseFeature,"AttachmentSupport = " << supportString);
                         FCMD_OBJ_CMD(baseFeature,"MapMode = '" << Attacher::AttachEngine::getModeName(Attacher::mmFlatFace) << "'");
                         Gui::Command::updateActive();
                     };

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -247,7 +247,7 @@ public:
         guidocument->openCommand(QT_TRANSLATE_NOOP("Command", "Create a Sketch on Face"));
         FCMD_OBJ_CMD(activeBody, "newObject('Sketcher::SketchObject','" << FeatName << "')");
         auto Feat = appdocument->getObject(FeatName.c_str());
-        FCMD_OBJ_CMD(Feat, "Support = " << supportString);
+        FCMD_OBJ_CMD(Feat, "AttachmentSupport = " << supportString);
         FCMD_OBJ_CMD(Feat, "MapMode = '" << Attacher::AttachEngine::getModeName(Attacher::mmFlatFace)<<"'");
         Gui::Command::updateActive();
         PartDesignGui::setEdit(Feat, activeBody);
@@ -619,9 +619,9 @@ private:
 
         FCMD_OBJ_CMD(partDesignBody,"newObject('Sketcher::SketchObject','" << FeatName << "')");
         auto Feat = partDesignBody->getDocument()->getObject(FeatName.c_str());
-        FCMD_OBJ_CMD(Feat,"Support = " << supportString);
+        FCMD_OBJ_CMD(Feat,"AttachmentSupport = " << supportString);
         FCMD_OBJ_CMD(Feat,"MapMode = '" << Attacher::AttachEngine::getModeName(Attacher::mmFlatFace)<<"'");
-        Gui::Command::updateActive(); // Make sure the Support's Placement property is updated
+        Gui::Command::updateActive(); // Make sure the AttachmentSupport's Placement property is updated
         PartDesignGui::setEdit(Feat, partDesignBody);
     }
 

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -116,7 +116,7 @@ bool TaskDlgDatumParameters::accept() {
     //check the prerequisites for the selected objects
     //the user has to decide which option we should take if external references are used
     bool extReference = false;
-    for (App::DocumentObject* obj : pcDatum->Support.getValues()) {
+    for (App::DocumentObject* obj : pcDatum->AttachmentSupport.getValues()) {
         if (pcActiveBody && !pcActiveBody->hasObject(obj) && !pcActiveBody->getOrigin()->hasObject(obj))
             extReference = true;
     }
@@ -133,9 +133,9 @@ bool TaskDlgDatumParameters::accept() {
         else if (!dlg.radioXRef->isChecked()) {
             std::vector<App::DocumentObject*> copyObjects;
             std::vector<std::string> copySubValues;
-            std::vector<std::string> subs = pcDatum->Support.getSubValues();
+            std::vector<std::string> subs = pcDatum->AttachmentSupport.getSubValues();
             int index = 0;
-            for (App::DocumentObject* obj : pcDatum->Support.getValues()) {
+            for (App::DocumentObject* obj : pcDatum->AttachmentSupport.getValues()) {
                 if (pcActiveBody && !pcActiveBody->hasObject(obj) && !pcActiveBody->getOrigin()->hasObject(obj)) {
                     auto* copy = PartDesignGui::TaskFeaturePick::makeCopy(obj, subs[index], dlg.radioIndependent->isChecked());
                     if (copy) {
@@ -152,7 +152,7 @@ bool TaskDlgDatumParameters::accept() {
                 index++;
             }
 
-            pcDatum->Support.setValues(copyObjects, copySubValues);
+            pcDatum->AttachmentSupport.setValues(copyObjects, copySubValues);
         }
     }
 

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -392,7 +392,7 @@ App::DocumentObject* TaskFeaturePick::makeCopy(App::DocumentObject* obj, std::st
 
             // TODO Recheck this. This looks strange in case of independent copy (2015-10-31, Fat-Zer)
             if(!independent) {
-                datumCopy->Support.setValue(obj, entity.c_str());
+                datumCopy->AttachmentSupport.setValue(obj, entity.c_str());
                 datumCopy->MapMode.setValue(mode);
             }
             else if(!entity.empty()) {

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -273,7 +273,7 @@ App::Part* getPartFor(const App::DocumentObject* obj, bool messageIfNot) {
 
 void fixSketchSupport (Sketcher::SketchObject* sketch)
 {
-    App::DocumentObject* support = sketch->Support.getValue();
+    App::DocumentObject* support = sketch->AttachmentSupport.getValue();
 
     if (support)
         return; // Sketch is on a face of a solid, do nothing
@@ -317,7 +317,7 @@ void fixSketchSupport (Sketcher::SketchObject* sketch)
 
     if (fabs(offset) < Precision::Confusion()) {
         // One of the base planes
-        FCMD_OBJ_CMD(sketch,"Support = (" << Gui::Command::getObjectCmd(plane) << ",[''])");
+        FCMD_OBJ_CMD(sketch,"AttachmentSupport = (" << Gui::Command::getObjectCmd(plane) << ",[''])");
         FCMD_OBJ_CMD(sketch,"MapReversed = " << (reverseSketch ? "True" : "False"));
         FCMD_OBJ_CMD(sketch,"MapMode = '" << Attacher::AttachEngine::getModeName(Attacher::mmFlatFace) << "'");
 
@@ -331,12 +331,12 @@ void fixSketchSupport (Sketcher::SketchObject* sketch)
         std::string Datum = doc->getUniqueObjectName("DatumPlane");
         FCMD_DOC_CMD(doc,"addObject('PartDesign::Plane','"<<Datum<<"')");
         auto obj = doc->getObject(Datum.c_str());
-        FCMD_OBJ_CMD(obj,"Support = [(" << Gui::Command::getObjectCmd(plane) << ",'')]");
+        FCMD_OBJ_CMD(obj,"AttachmentSupport = [(" << Gui::Command::getObjectCmd(plane) << ",'')]");
         FCMD_OBJ_CMD(obj,"MapMode = '" << AttachEngine::getModeName(Attacher::mmFlatFace) << "'");
         FCMD_OBJ_CMD(obj,"AttachmentOffset.Base.z = " << offset);
         FCMD_OBJ_CMD(body,"insertObject("<<Gui::Command::getObjectCmd(obj)<<','<<
                 Gui::Command::getObjectCmd(sketch)<<")");
-        FCMD_OBJ_CMD(sketch,"Support = (" << Gui::Command::getObjectCmd(obj) << ",[''])");
+        FCMD_OBJ_CMD(sketch,"AttachmentSupport = (" << Gui::Command::getObjectCmd(obj) << ",[''])");
         FCMD_OBJ_CMD(sketch,"MapReversed = " <<  (reverseSketch ? "True" : "False"));
         FCMD_OBJ_CMD(sketch,"MapMode = '" << Attacher::AttachEngine::getModeName(Attacher::mmFlatFace) << "'");
     }
@@ -500,7 +500,7 @@ bool isFeatureMovable(App::DocumentObject* const feat)
 
     if (feat->hasExtension(Part::AttachExtension::getExtensionClassTypeId())) {
         auto attachable = feat->getExtensionByType<Part::AttachExtension>();
-        App::DocumentObject* support = attachable->Support.getValue();
+        App::DocumentObject* support = attachable->AttachmentSupport.getValue();
         if (support && !support->isDerivedFrom<App::OriginFeature>())
             return false;
     }
@@ -559,12 +559,12 @@ void relinkToOrigin(App::DocumentObject* feat, PartDesign::Body* targetbody)
 {
     if (feat->hasExtension(Part::AttachExtension::getExtensionClassTypeId())) {
         auto attachable = feat->getExtensionByType<Part::AttachExtension>();
-        App::DocumentObject* support = attachable->Support.getValue();
+        App::DocumentObject* support = attachable->AttachmentSupport.getValue();
         if (support && support->isDerivedFrom<App::OriginFeature>()) {
             auto originfeat = static_cast<App::OriginFeature*>(support);
             App::OriginFeature* targetOriginFeature = targetbody->getOrigin()->getOriginFeature(originfeat->Role.getValue());
             if (targetOriginFeature) {
-                attachable->Support.setValue(static_cast<App::DocumentObject*>(targetOriginFeature), "");
+                attachable->AttachmentSupport.setValue(static_cast<App::DocumentObject*>(targetOriginFeature), "");
             }
         }
     }

--- a/src/Mod/PartDesign/PartDesignTests/TestDatum.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestDatum.py
@@ -32,7 +32,7 @@ class TestDatumPoint(unittest.TestCase):
     def testOriginDatumPoint(self):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
         self.DatumPoint = self.Doc.addObject('PartDesign::Point','DatumPoint')
-        self.DatumPoint.Support = [(self.Doc.XY_Plane,'')]
+        self.DatumPoint.AttachmentSupport = [(self.Doc.XY_Plane,'')]
         self.DatumPoint.MapMode = 'ObjectOrigin'
         self.Body.addObject(self.DatumPoint)
         self.Doc.recompute()
@@ -50,7 +50,7 @@ class TestDatumLine(unittest.TestCase):
     def testXAxisDatumLine(self):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
         self.DatumLine = self.Doc.addObject('PartDesign::Line','DatumLine')
-        self.DatumLine.Support = [(self.Doc.XY_Plane,'')]
+        self.DatumLine.AttachmentSupport = [(self.Doc.XY_Plane,'')]
         self.DatumLine.MapMode = 'ObjectX'
         self.Body.addObject(self.DatumLine)
         self.Doc.recompute()
@@ -68,7 +68,7 @@ class TestDatumPlane(unittest.TestCase):
     def testXYDatumPlane(self):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
         self.DatumPlane = self.Doc.addObject('PartDesign::Plane','DatumPlane')
-        self.DatumPlane.Support = [(self.Doc.XY_Plane,'')]
+        self.DatumPlane.AttachmentSupport = [(self.Doc.XY_Plane,'')]
         self.DatumPlane.MapMode = 'FlatFace'
         self.Body.addObject(self.DatumPlane)
         self.Doc.recompute()

--- a/src/Mod/PartDesign/PartDesignTests/TestDraft.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestDraft.py
@@ -41,12 +41,12 @@ class TestDraft(unittest.TestCase):
         self.Box.Height=10.00
         self.Doc.recompute()
         self.DatumPlane = self.Doc.addObject('PartDesign::Plane','DatumPlane')
-        self.DatumPlane.Support = [(self.Doc.YZ_Plane,'')]
+        self.DatumPlane.AttachmentSupport = [(self.Doc.YZ_Plane,'')]
         self.DatumPlane.MapMode = 'FlatFace'
         self.Body.addObject(self.DatumPlane)
         self.Doc.recompute()
         self.DatumLine = self.Doc.addObject('PartDesign::Line','DatumLine')
-        self.DatumLine.Support = [(self.Doc.X_Axis,'')]
+        self.DatumLine.AttachmentSupport = [(self.Doc.X_Axis,'')]
         self.DatumLine.MapMode = 'TwoPointLine'
         self.Body.addObject(self.DatumLine)
         self.Doc.recompute()

--- a/src/Mod/PartDesign/PartDesignTests/TestHelix.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestHelix.py
@@ -38,7 +38,7 @@ class TestHelix(unittest.TestCase):
     def testHelicalTubeCase(self):
         body = self.Doc.addObject('PartDesign::Body','Body')
         sketch = body.newObject('Sketcher::SketchObject','Sketch')
-        sketch.Support = (self.Doc.getObject('XY_Plane'),[''])
+        sketch.AttachmentSupport = (self.Doc.getObject('XY_Plane'),[''])
         sketch.MapMode = 'FlatFace'
 
         geoList = []
@@ -107,7 +107,7 @@ class TestHelix(unittest.TestCase):
         self.Doc.recompute()
 
         # xz_plane = body.Origin.OriginFeatures[4]
-        # coneSketch.Support = xz_plane
+        # coneSketch.AttachmentSupport = xz_plane
         # coneSketch.MapMode = 'FlatFace'
         helix = self.Doc.addObject("PartDesign::AdditiveHelix","AdditiveHelix")
         body.addObject(helix)
@@ -159,7 +159,7 @@ class TestHelix(unittest.TestCase):
         coneSketch.addConstraint(conList)
 
         xz_plane = body.Origin.OriginFeatures[4]
-        coneSketch.Support = xz_plane
+        coneSketch.AttachmentSupport = xz_plane
         coneSketch.MapMode = 'FlatFace'
         helix = self.Doc.addObject("PartDesign::AdditiveHelix","AdditiveHelix")
         body.addObject(helix)

--- a/src/Mod/PartDesign/PartDesignTests/TestHole.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestHole.py
@@ -38,7 +38,7 @@ class TestHole(unittest.TestCase):
         self.Body.addObject(self.Box)
         self.Doc.recompute()
         self.HoleSketch = self.Doc.addObject('Sketcher::SketchObject', 'SketchHole')
-        self.HoleSketch.Support = (self.Doc.XY_Plane, [''])
+        self.HoleSketch.AttachmentSupport = (self.Doc.XY_Plane, [''])
         self.HoleSketch.MapMode = 'FlatFace'
         self.HoleSketch.MapReversed = True
         self.Body.addObject(self.HoleSketch)

--- a/src/Mod/PartDesign/PartDesignTests/TestLoft.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestLoft.py
@@ -41,7 +41,7 @@ class TestLoft(unittest.TestCase):
         self.LoftSketch = self.Doc.addObject('Sketcher::SketchObject', 'LoftSketch')
         self.Body.addObject(self.LoftSketch)
         self.LoftSketch.MapMode = 'FlatFace'
-        self.LoftSketch.Support = (self.Doc.XZ_Plane, [''])
+        self.LoftSketch.AttachmentSupport = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
         TestSketcherApp.CreateRectangleSketch(self.LoftSketch, (0, 1), (1, 1))
         self.Doc.recompute()
@@ -70,7 +70,7 @@ class TestLoft(unittest.TestCase):
         self.LoftSketch = self.Doc.addObject('Sketcher::SketchObject', 'LoftSketch')
         self.Body.addObject(self.LoftSketch)
         self.LoftSketch.MapMode = 'FlatFace'
-        self.LoftSketch.Support = (self.Doc.XZ_Plane, [''])
+        self.LoftSketch.AttachmentSupport = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
         TestSketcherApp.CreateRectangleSketch(self.LoftSketch, (0, 1), (1, 1))
         self.Doc.recompute()
@@ -86,7 +86,7 @@ class TestLoft(unittest.TestCase):
         body = self.Doc.addObject('PartDesign::Body','Body')
 
         sketch1 = body.newObject('Sketcher::SketchObject','Sketch')
-        sketch1.Support = (self.Doc.XZ_Plane,[''])
+        sketch1.AttachmentSupport = (self.Doc.XZ_Plane,[''])
         sketch1.MapMode = 'FlatFace'
         sketch1.addGeometry(Part.Circle(Base.Vector(-40.0,0.0,0.0),Base.Vector(0,0,1),10.0), False)
         sketch1.addConstraint(Sketcher.Constraint('PointOnObject',0,3,-1))
@@ -96,7 +96,7 @@ class TestLoft(unittest.TestCase):
         sketch1.setDatum(2,Units.Quantity('40.000000 mm'))
 
         sketch2 = body.newObject('Sketcher::SketchObject','Sketch001')
-        sketch2.Support = (self.Doc.YZ_Plane,'')
+        sketch2.AttachmentSupport = (self.Doc.YZ_Plane,'')
         sketch2.MapMode = 'FlatFace'
         sketch2.addGeometry(Part.Circle(Base.Vector(-10.0,0.0,0.0),Base.Vector(0,0,1),10.0),False)
         sketch2.addConstraint(Sketcher.Constraint('PointOnObject',0,3,-1))
@@ -106,7 +106,7 @@ class TestLoft(unittest.TestCase):
         sketch2.setDatum(2,Units.Quantity('40.000000 mm'))
 
         sketch3 = body.newObject('Sketcher::SketchObject','Sketch002')
-        sketch3.Support = (self.Doc.getObject('YZ_Plane'),'')
+        sketch3.AttachmentSupport = (self.Doc.getObject('YZ_Plane'),'')
         sketch3.MapMode = 'FlatFace'
         sketch3.addGeometry(Part.Circle(Base.Vector(40.0,0.0,0.0),Base.Vector(0,0,1),10.0),False)
         sketch3.addConstraint(Sketcher.Constraint('PointOnObject',0,3,-1))
@@ -116,7 +116,7 @@ class TestLoft(unittest.TestCase):
         sketch3.setDatum(2,Units.Quantity('20.000000 mm'))
 
         sketch4 = body.newObject('Sketcher::SketchObject','Sketch003')
-        sketch4.Support = (self.Doc.XZ_Plane,'')
+        sketch4.AttachmentSupport = (self.Doc.XZ_Plane,'')
         sketch4.MapMode = 'FlatFace'
         sketch4.addGeometry(Part.Circle(Base.Vector(40.0,0.0,0.0),Base.Vector(0,0,1),10.0),False)
         sketch4.addConstraint(Sketcher.Constraint('PointOnObject',0,3,-1))

--- a/src/Mod/PartDesign/PartDesignTests/TestPad.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPad.py
@@ -40,7 +40,7 @@ class TestPad(unittest.TestCase):
     def testSketchOnPlane(self):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
         self.PadSketch = self.Doc.addObject('Sketcher::SketchObject','SketchPad')
-        self.PadSketch.Support = (self.Doc.XY_Plane, [''])
+        self.PadSketch.AttachmentSupport = (self.Doc.XY_Plane, [''])
         self.PadSketch.MapMode = 'FlatFace'
         self.Body.addObject(self.PadSketch)
         TestSketcherApp.CreateSlotPlateSet(self.PadSketch)
@@ -67,7 +67,7 @@ class TestPad(unittest.TestCase):
         self.PadSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad1')
         self.Body.addObject(self.PadSketch1)
         self.PadSketch1.MapMode = 'FlatFace'
-        self.PadSketch1.Support = (self.Doc.XZ_Plane, [''])
+        self.PadSketch1.AttachmentSupport = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
         TestSketcherApp.CreateRectangleSketch(self.PadSketch1, (0, 0), (1, 1))
         self.Doc.recompute()
@@ -95,7 +95,7 @@ class TestPad(unittest.TestCase):
         self.PadSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad1')
         self.Body.addObject(self.PadSketch1)
         self.PadSketch1.MapMode = 'FlatFace'
-        self.PadSketch1.Support = (self.Doc.XZ_Plane, [''])
+        self.PadSketch1.AttachmentSupport = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
         TestSketcherApp.CreateRectangleSketch(self.PadSketch1, (0, 0), (1, 1))
         self.Doc.recompute()
@@ -123,7 +123,7 @@ class TestPad(unittest.TestCase):
         self.PadSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad1')
         self.Body.addObject(self.PadSketch1)
         self.PadSketch1.MapMode = 'FlatFace'
-        self.PadSketch1.Support = (self.Doc.XZ_Plane, [''])
+        self.PadSketch1.AttachmentSupport = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
         TestSketcherApp.CreateRectangleSketch(self.PadSketch1, (0, 0), (1, 1))
         self.Doc.recompute()
@@ -152,7 +152,7 @@ class TestPad(unittest.TestCase):
         self.PadSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad1')
         self.Body.addObject(self.PadSketch1)
         self.PadSketch1.MapMode = 'FlatFace'
-        self.PadSketch1.Support = (self.Doc.XZ_Plane, [''])
+        self.PadSketch1.AttachmentSupport = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
         TestSketcherApp.CreateRectangleSketch(self.PadSketch1, (0, 0), (1, 1))
         self.Doc.recompute()

--- a/src/Mod/PartDesign/PartDesignTests/TestPipe.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPipe.py
@@ -41,7 +41,7 @@ class TestPipe(unittest.TestCase):
         self.SpineSketch = self.Doc.addObject('Sketcher::SketchObject', 'SpineSketch')
         self.Body.addObject(self.SpineSketch)
         self.SpineSketch.MapMode = 'FlatFace'
-        self.SpineSketch.Support = (self.Doc.XZ_Plane, [''])
+        self.SpineSketch.AttachmentSupport = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
         self.SpineSketch.addGeometry(Part.LineSegment(App.Vector(0.0,0.0,0),App.Vector(0,1,0)),False)
         self.SpineSketch.addConstraint(Sketcher.Constraint('Coincident',0,1,-1,1))
@@ -64,7 +64,7 @@ class TestPipe(unittest.TestCase):
         self.SpineSketch = self.Doc.addObject('Sketcher::SketchObject', 'SpineSketch')
         self.Body.addObject(self.SpineSketch)
         self.SpineSketch.MapMode = 'FlatFace'
-        self.SpineSketch.Support = (self.Doc.XZ_Plane, [''])
+        self.SpineSketch.AttachmentSupport = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
         self.SpineSketch.addGeometry(Part.LineSegment(App.Vector(0.0,0.0,0),App.Vector(0,1,0)),False)
         self.SpineSketch.addConstraint(Sketcher.Constraint('Coincident',0,1,-1,1))

--- a/src/Mod/PartDesign/PartDesignTests/TestPocket.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPocket.py
@@ -75,7 +75,7 @@ class TestPocket(unittest.TestCase):
         self.PocketSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'PocketSketch')
         self.Body.addObject(self.PocketSketch1)
         self.PocketSketch1.MapMode = 'FlatFace'
-        self.PocketSketch1.Support = (self.Doc.XZ_Plane, [''])
+        self.PocketSketch1.AttachmentSupport = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
         TestSketcherApp.CreateRectangleSketch(self.PocketSketch1, (2.5, -0.75), (5, 0.50))
         self.Doc.recompute()
@@ -110,7 +110,7 @@ class TestPocket(unittest.TestCase):
         self.PocketSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'PocketSketch')
         self.Body.addObject(self.PocketSketch1)
         self.PocketSketch1.MapMode = 'FlatFace'
-        self.PocketSketch1.Support = (self.Doc.XZ_Plane, [''])
+        self.PocketSketch1.AttachmentSupport = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
         TestSketcherApp.CreateRectangleSketch(self.PocketSketch1, (2.5, -1), (5, 1))
         self.Doc.recompute()
@@ -145,7 +145,7 @@ class TestPocket(unittest.TestCase):
         self.PocketSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'PocketSketch')
         self.Body.addObject(self.PocketSketch1)
         self.PocketSketch1.MapMode = 'FlatFace'
-        self.PocketSketch1.Support = (self.Doc.XZ_Plane, [''])
+        self.PocketSketch1.AttachmentSupport = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
         TestSketcherApp.CreateRectangleSketch(self.PocketSketch1, (0, -1), (10, 1))
         self.Doc.recompute()

--- a/src/Mod/PartDesign/PartDesignTests/TestShapeBinder.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestShapeBinder.py
@@ -85,7 +85,7 @@ class TestSubShapeBinder(unittest.TestCase):
         """ Test case for PR #8763 """
         body = self.Doc.addObject('PartDesign::Body','Body')
         sketch = body.newObject('Sketcher::SketchObject','Sketch')
-        sketch.Support = (self.Doc.XZ_Plane,[''])
+        sketch.AttachmentSupport = (self.Doc.XZ_Plane,[''])
         sketch.MapMode = 'FlatFace'
         self.Doc.recompute()
 

--- a/src/Mod/PartDesign/TestPartDesignGui.py
+++ b/src/Mod/PartDesign/TestPartDesignGui.py
@@ -100,7 +100,7 @@ class PartDesignGuiTestCases(unittest.TestCase):
         App.ActiveDocument.recompute()
 
         self.Sketch = self.Doc.addObject('Sketcher::SketchObject','Sketch')
-        self.Sketch.Support = (self.BoxObj, ('Face3',))
+        self.Sketch.AttachmentSupport = (self.BoxObj, ('Face3',))
         self.Sketch.MapMode = 'FlatFace'
         self.BodySource.addObject(self.Sketch)
 
@@ -154,7 +154,7 @@ class PartDesignGuiTestCases(unittest.TestCase):
 
         self.Sketch = self.Doc.addObject('Sketcher::SketchObject','Sketch')
         self.BodySource.addObject(self.Sketch)
-        self.Sketch.Support = (self.BodySource.Origin.OriginFeatures[3], [''])
+        self.Sketch.AttachmentSupport = (self.BodySource.Origin.OriginFeatures[3], [''])
         self.Sketch.MapMode = 'FlatFace'
 
 
@@ -198,8 +198,8 @@ class PartDesignGuiTestCases(unittest.TestCase):
         #assert dependencies of the Sketch
         self.Doc.recompute()
 
-        self.assertFalse(self.Sketch.Support[0][0] in self.BodySource.Origin.OriginFeatures)
-        self.assertTrue(self.Sketch.Support[0][0] in self.BodyTarget.Origin.OriginFeatures)
+        self.assertFalse(self.Sketch.AttachmentSupport[0][0] in self.BodySource.Origin.OriginFeatures)
+        self.assertTrue(self.Sketch.AttachmentSupport[0][0] in self.BodyTarget.Origin.OriginFeatures)
         self.assertEqual(len(self.BodySource.Group), 0, "Source body feature count is wrong")
         self.assertEqual(len(self.BodyTarget.Group), 2, "Target body feature count is wrong")
 

--- a/src/Mod/Sandbox/exportDRAWEXE.py
+++ b/src/Mod/Sandbox/exportDRAWEXE.py
@@ -513,7 +513,7 @@ class Drawexporter(object):
                     curname=nxtname
                     i+=1
         elif (isDraftPolygon(ob) and ob.ChamferSize.Value == 0 and\
-                ob.FilletRadius.Value == 0 and ob.Support is None) or\
+                ob.FilletRadius.Value == 0 and ob.AttachmentSupport is None) or\
                 ob.TypeId == "Part::Prism" or \
                 ob.TypeId == "Part::RegularPolygon":
             if checksupported: return True # The object is supported

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -4003,7 +4003,7 @@ bool SketchObject::isExternalAllowed(App::Document* pDoc, App::DocumentObject* p
 
     // Note: Checking for the body of the support doesn't work when the support are the three base
     // planes
-    // App::DocumentObject *support = this->Support.getValue();
+    // App::DocumentObject *support = this->AttachmentSupport.getValue();
     Part::BodyBase* body_this = Part::BodyBase::findBodyOf(this);
     Part::BodyBase* body_obj = Part::BodyBase::findBodyOf(pObj);
     App::Part* part_this = App::Part::getPartOfObject(this);
@@ -4068,7 +4068,7 @@ bool SketchObject::isCarbonCopyAllowed(App::Document* pDoc, App::DocumentObject*
 
     // Note: Checking for the body of the support doesn't work when the support are the three base
     // planes
-    // App::DocumentObject *support = this->Support.getValue();
+    // App::DocumentObject *support = this->AttachmentSupport.getValue();
     Part::BodyBase* body_this = Part::BodyBase::findBodyOf(this);
     Part::BodyBase* body_obj = Part::BodyBase::findBodyOf(pObj);
     App::Part* part_this = App::Part::getPartOfObject(this);
@@ -7375,7 +7375,7 @@ Part::Geometry* projectLine(const BRepAdaptor_Curve& curve, const Handle(Geom_Pl
 bool SketchObject::evaluateSupport()
 {
     // returns false if the shape is broken, null or non-planar
-    App::DocumentObject* link = Support.getValue();
+    App::DocumentObject* link = AttachmentSupport.getValue();
     if (!link || !link->isDerivedFrom<Part::Feature>())
         return false;
     return true;
@@ -8863,7 +8863,7 @@ void SketchObject::onChanged(const App::Property* prop)
 #if 0
     // For now do not delete anything (#0001791). When changing the support
     // face it might be better to check which external geometries can be kept.
-    else if (prop == &Support) {
+    else if (prop == &AttachmentSupport) {
         // make sure not to change anything while restoring this object
         if (!isRestoring()) {
             // if support face has changed then clear the external geometry

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -240,7 +240,7 @@ void CmdSketcherNewSketch::activated(int iMsg)
         else
             assert(0 /* mapmode index out of range */);
         doCommand(
-            Gui, "App.activeDocument().%s.Support = %s", FeatName.c_str(), supportString.c_str());
+            Gui, "App.activeDocument().%s.AttachmentSupport = %s", FeatName.c_str(), supportString.c_str());
         doCommand(Gui, "App.activeDocument().recompute()");// recompute the sketch placement based
                                                            // on its support
         doCommand(Gui, "Gui.activeDocument().setEdit('%s')", FeatName.c_str());
@@ -414,7 +414,7 @@ CmdSketcherReorientSketch::CmdSketcherReorientSketch()
     sGroup = "Sketcher";
     sMenuText = QT_TR_NOOP("Reorient sketch...");
     sToolTipText = QT_TR_NOOP("Place the selected sketch on one of the global coordinate planes.\n"
-                              "This will clear the 'Support' property, if any.");
+                              "This will clear the 'AttachmentSupport' property, if any.");
     sWhatsThis = "Sketcher_ReorientSketch";
     sStatusTip = sToolTipText;
     sPixmap = "Sketcher_ReorientSketch";
@@ -425,7 +425,7 @@ void CmdSketcherReorientSketch::activated(int iMsg)
     Q_UNUSED(iMsg);
     Sketcher::SketchObject* sketch =
         Gui::Selection().getObjectsOfType<Sketcher::SketchObject>().front();
-    if (sketch->Support.getValue()) {
+    if (sketch->AttachmentSupport.getValue()) {
         int ret = QMessageBox::question(
             Gui::getMainWindow(),
             qApp->translate("Sketcher_ReorientSketch", "Sketch has support"),
@@ -435,7 +435,7 @@ void CmdSketcherReorientSketch::activated(int iMsg)
             QMessageBox::Yes | QMessageBox::No);
         if (ret == QMessageBox::No)
             return;
-        sketch->Support.setValue(nullptr);
+        sketch->AttachmentSupport.setValue(nullptr);
     }
 
     // ask user for orientation
@@ -551,7 +551,7 @@ CmdSketcherMapSketch::CmdSketcherMapSketch()
     sGroup = "Sketcher";
     sMenuText = QT_TR_NOOP("Map sketch to face...");
     sToolTipText = QT_TR_NOOP(
-        "Set the 'Support' of a sketch.\n"
+        "Set the 'AttachmentSupport' of a sketch.\n"
         "First select the supporting geometry, for example, a face or an edge of a solid object,\n"
         "then call this command, then choose the desired sketch.");
     sWhatsThis = "Sketcher_MapSketch";
@@ -707,7 +707,7 @@ void CmdSketcherMapSketch::activated(int iMsg)
             openCommand(QT_TRANSLATE_NOOP("Command", "Attach sketch"));
             Gui::cmdAppObjectArgs(
                 sketch, "MapMode = \"%s\"", AttachEngine::getModeName(suggMapMode).c_str());
-            Gui::cmdAppObjectArgs(sketch, "Support = %s", supportString.c_str());
+            Gui::cmdAppObjectArgs(sketch, "AttachmentSupport = %s", supportString.c_str());
             commitCommand();
             doCommand(Gui, "App.activeDocument().recompute()");
         }
@@ -715,7 +715,7 @@ void CmdSketcherMapSketch::activated(int iMsg)
             openCommand(QT_TRANSLATE_NOOP("Command", "Detach sketch"));
             Gui::cmdAppObjectArgs(
                 sketch, "MapMode = \"%s\"", AttachEngine::getModeName(suggMapMode).c_str());
-            Gui::cmdAppObjectArgs(sketch, "Support = None");
+            Gui::cmdAppObjectArgs(sketch, "AttachmentSupport = None");
             commitCommand();
             doCommand(Gui, "App.activeDocument().recompute()");
         }

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -844,7 +844,7 @@ int SketchSelection::setUp()
         if (selection[0].getObject()->isDerivedFrom<Sketcher::SketchObject>()) {
             SketchObj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
             // check if the none sketch object is the support of the sketch
-            if (selection[1].getObject() != SketchObj->Support.getValue()) {
+            if (selection[1].getObject() != SketchObj->AttachmentSupport.getValue()) {
                 ErrorMsg = QObject::tr("Only sketch and its support are allowed to be selected.");
                 return -1;
             }
@@ -856,7 +856,7 @@ int SketchSelection::setUp()
         else if (selection[1].getObject()->isDerivedFrom<Sketcher::SketchObject>()) {
             SketchObj = static_cast<Sketcher::SketchObject*>(selection[1].getObject());
             // check if the none sketch object is the support of the sketch
-            if (selection[0].getObject() != SketchObj->Support.getValue()) {
+            if (selection[0].getObject() != SketchObj->AttachmentSupport.getValue()) {
                 ErrorMsg = QObject::tr("Only sketch and its support are allowed to be selected.");
                 return -1;
             }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2973,7 +2973,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
                     "if ActiveSketch.ViewObject.HideDependent:\n"
                     "  tv.hide(tv.get_all_dependent(%3, '%4'))\n"
                     "if ActiveSketch.ViewObject.ShowSupport:\n"
-                    "  tv.show([ref[0] for ref in ActiveSketch.Support if not "
+                    "  tv.show([ref[0] for ref in ActiveSketch.AttachmentSupport if not "
                     "ref[0].isDerivedFrom(\"PartDesign::Plane\")])\n"
                     "if ActiveSketch.ViewObject.ShowLinks:\n"
                     "  tv.show([ref[0] for ref in ActiveSketch.ExternalGeometry])\n"
@@ -3012,7 +3012,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
     // The false parameter indicates that the geometry of the SketchObject shall not be updateData
     // so as not to trigger an onChanged that would set the document as modified and trigger a
     // recompute if we just close the sketch without touching anything.
-    if (getSketchObject()->Support.getValue()) {
+    if (getSketchObject()->AttachmentSupport.getValue()) {
         if (!getSketchObject()->evaluateSupport())
             getSketchObject()->validateExternalLinks();
     }

--- a/src/Mod/TechDraw/App/CosmeticExtension.h
+++ b/src/Mod/TechDraw/App/CosmeticExtension.h
@@ -99,11 +99,6 @@ public:
 
     PyObject* getExtensionPyObject() override;
 
-protected:
-/*    virtual void extHandleChangedPropertyName(Base::XMLReader &reader, */
-/*                                              const char* TypeName, */
-/*                                              const char* PropName);*/
-
 private:
 
 };


### PR DESCRIPTION
⚠️ Supersedes https://github.com/FreeCAD/FreeCAD/pull/12579

### Summary
**Part:** Rename `AttachExtension::Support` property to `AttachmentSupport`, to avoid name conflict with base features, e.g. `ShapeBinder`.

Fixes https://github.com/FreeCAD/FreeCAD/issues/7052

The above bug is triggered when using the attach extension on a binder.

### Details
When projects are saved, the scoping of object properties is lost, which means a class must be careful not to use the same name for a property as another class if the two classes can be composed via inheritance or extension into a single feature.

`AttachExtension` and `ShapeBinder` currently conflict on `Support`. https://github.com/FreeCAD/FreeCAD/pull/12579 renames `ShapeBinder`'s but in discussion it was noted that since `AttachExtension` is an `App::Extension`, it should be the one to avoid conflicts. This PR is longer due to the ubiquity of attachments, and trickier due to the lack of compile-type checking on the python side, but I think it's worth it.

The approach taken here is to do a full migration instead of keeping a deprecated `Support` property around, which could get very confusing since attachments are so widely used.

While I was there, I moved the migration for an old type change out of `Part2DObject` into `AttachExtension` where it belongs, which cleaned up some cruft.