### PR TITLE
About info: remove code block quotes / copy plain text

### DIFF
--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -808,7 +808,6 @@ void AboutDialog::copyToClipboard()
             deskInfo = QLatin1String(" (") + deskEnv + QLatin1String("/") + deskSess + QLatin1String(")");
     }
 
-    str << "```\n";
     str << "OS: " << prettyProductInfoWrapper() << deskInfo << '\n';
     str << "Word size of " << exe << ": " << QSysInfo::WordSize << "-bit\n";
     str << "Version: " << major << "." << minor << "." << point << suffix << "." << build;
@@ -884,12 +883,11 @@ void AboutDialog::copyToClipboard()
             auto disablingFile = mod.path() / "ADDON_DISABLED";
             if (fs::exists(disablingFile))
                 str << " (Disabled)";
-            
+
             str << "\n";
         }
     }
 
-    str << "```\n";
     QClipboard* cb = QApplication::clipboard();
     cb->setText(data);
 }


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/12399

This PR removed the code blocks from the copied `About info` in the splash screen. The 3 quotes mess with the GitHub issue template and have to be manually deleted to be formatted correctly. The forum also does not support the 3 quotes as code block.
The `About info` is copied as plain text to the clipboard, the GitHub issue template will automatically display the pasted plain text as code block. No need to manually adjust it, just copy&paste.

Demo of current issue:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/4d656ade-ab44-4843-bde5-82b106b21a2b)
