### PR TITLE
PD: Translate shaft end types

### DIFF
--- a/src/Mod/PartDesign/WizardShaft/Shaft.py
+++ b/src/Mod/PartDesign/WizardShaft/Shaft.py
@@ -481,7 +481,7 @@ class Shaft:
                 try:
                     solution = np.linalg.solve(A, b) # A * solution = b
                 except np.linalg.linalg.LinAlgError as e:
-                    FreeCAD.Console.PrintMessage(e.message)
+                    FreeCAD.Console.PrintMessage(str(e))
                     FreeCAD.Console.PrintMessage(". No solution possible.\n")
                     self.parent.updateButtons(ax,  False)
                     continue

--- a/src/Mod/PartDesign/WizardShaft/WizardShaftTable.py
+++ b/src/Mod/PartDesign/WizardShaft/WizardShaftTable.py
@@ -147,12 +147,12 @@ class WizardShaftTable:
         widget.editingFinished.connect(self.slotEditingFinished)
         # Constraint type
         widget = QtGui.QComboBox(self.widget)
-        widget.insertItem(0, "None")
-        widget.insertItem(1, "Fixed")
-        widget.insertItem(2, "Force")
-        widget.insertItem(3, "Bearing")
-        widget.insertItem(4, "Gear")
-        widget.insertItem(5, "Pulley")
+        widget.insertItem(0, translate("WizardShaftTable", "None"), "None")
+        widget.insertItem(1, translate("WizardShaftTable", "Fixed"), "Fixed")
+        widget.insertItem(2, translate("WizardShaftTable", "Force"), "Force")
+        widget.insertItem(3, translate("WizardShaftTable", "Bearing"), "Bearing")
+        widget.insertItem(4, translate("WizardShaftTable", "Gear"), "Gear")
+        widget.insertItem(5, translate("WizardShaftTable", "Pulley"), "Pulley")
         action = QtGui.QAction("Edit constraint", widget)
         action.triggered.connect(self.slotEditConstraint)
         widget.addAction(action)
@@ -162,10 +162,10 @@ class WizardShaftTable:
         self.widget.connect(widget, QtCore.SIGNAL("currentIndexChanged(const QString&)"), self.slotConstraintType)
         # Start edge type
         widget = QtGui.QComboBox(self.widget)
-        widget.insertItem(0, "None",)
-        widget.insertItem(1, "Chamfer")
-        widget.insertItem(2, "Fillet")
-        self.widget.setCellWidget(self.rowDict["StartEdgeType"],index, widget)
+        widget.insertItem(0, translate("WizardShaftTable", "None"), "None",)
+        widget.insertItem(1, translate("WizardShaftTable", "Chamfer"), "Chamfer")
+        widget.insertItem(2, translate("WizardShaftTable", "Fillet"), "Fillet")
+        self.widget.setCellWidget(self.rowDict["StartEdgeType"], index, widget)
         widget.setCurrentIndex(0)
         widget.setEnabled(False)
         #self.widget.connect(widget, QtCore.SIGNAL("currentIndexChanged(const QString&)"), self.slotLoadType)
@@ -213,7 +213,7 @@ class WizardShaftTable:
             self.shaft.updateSegment(self.editedColumn, diameter = self.getDoubleValue(rowName, self.editedColumn))
         elif rowName == "InnerDiameter":
             self.shaft.updateSegment(self.editedColumn, innerdiameter = self.getDoubleValue(rowName, self.editedColumn))
-        elif rowName == "Constraintype":
+        elif rowName == "ConstraintType":
             self.shaft.updateConstraint(self.editedColumn, self.getListValue(rowName, self.editedColumn))
         elif rowName == "StartEdgeType":
             pass
@@ -316,7 +316,11 @@ class WizardShaftTable:
     def getListValue(self, row, column):
         widget = self.widget.cellWidget(self.rowDict[row], column)
         if widget is not None:
-            return widget.currentText() #[0].upper()
+            if widget.data(QtCore.Qt.UserRole):
+                # If the widget has user data attached, assume that is the "value" we are seeking
+                return widget.data(QtCore.Qt.UserRole)
+            else:
+                return widget.currentText() #[0].upper()
         else:
             return None
 


### PR DESCRIPTION
Adds support for menu items having 'user data' that is the untranslated string. It would be better if these were enumerations, but that's a much larger refactoring process.

Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/301