### PR TITLE
PD: Translate attachment task title

### DIFF
--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -1059,7 +1059,7 @@ TaskDlgAttacher::TaskDlgAttacher(Gui::ViewProviderDocumentObject *ViewProvider, 
     setDocumentName(ViewProvider->getDocument()->getDocument()->getName());
 
     if(createBox) {
-        parameter  = new TaskAttacher(ViewProvider);
+        parameter  = new TaskAttacher(ViewProvider, nullptr, QString(), tr("Attachment"));
         Content.push_back(parameter);
     }
 }

--- a/src/Mod/Part/Gui/TaskAttacher.h
+++ b/src/Mod/Part/Gui/TaskAttacher.h
@@ -56,9 +56,9 @@ public:
     using VisibilityFunction =  std::function<void (bool, const std::string &, Gui::ViewProviderDocumentObject*,
                                 App::DocumentObject *, const std::string&)>;
 
-    explicit TaskAttacher(Gui::ViewProviderDocumentObject *ViewProvider, QWidget *parent = nullptr,
-                 QString picture = QString(),
-                 QString text = QString::fromLatin1("Attachment"), VisibilityFunction func = 0);
+    explicit TaskAttacher(Gui::ViewProviderDocumentObject *ViewProvider, QWidget *parent,
+                 QString picture,
+                 QString text, VisibilityFunction func = 0);
     ~TaskAttacher() override;
 
     bool   getFlip() const;


### PR DESCRIPTION
Eliminate default title, which is untranslatable. Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/300