### PR TITLE
PD: Translate wire not closed exception

### DIFF
--- a/src/Mod/Part/App/FaceMakerBullseye.cpp
+++ b/src/Mod/Part/App/FaceMakerBullseye.cpp
@@ -71,7 +71,7 @@ void FaceMakerBullseye::Build_Essence()
     //validity check
     for (TopoDS_Wire& w : myWires) {
         if (!BRep_Tool::IsClosed(w))
-            throw Base::ValueError("Wire is not closed.");
+            throw Base::ValueError(QT_TRANSLATE_NOOP("Exception", "Wire is not closed."));
     }
 
 


### PR DESCRIPTION
This is a user-visible exception, shown in a dialog box. Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/299