### PR TITLE
Clean trailing spaces for translation

### DIFF
--- a/src/Gui/DlgKeyboard.ui
+++ b/src/Gui/DlgKeyboard.ui
@@ -134,7 +134,7 @@
             <string/>
            </property>
            <property name="text">
-            <string>Multi-key sequence delay: </string>
+            <string>Multi-key sequence delay:</string>
            </property>
           </widget>
          </item>
@@ -153,9 +153,9 @@
             </size>
            </property>
            <property name="toolTip">
-            <string>Time in milliseconds to wait for the next key stroke of the current key sequence.
+            <string>Time in milliseconds to wait for the next keystroke of the current key sequence.
 For example, pressing 'F' twice in less than the time delay setting here will be
-be treated as shorctcut key sequence 'F, F'.</string>
+treated as shortcut key sequence 'F, F'.</string>
            </property>
            <property name="maximum">
             <number>10000</number>

--- a/src/Gui/DlgLocationPos.ui
+++ b/src/Gui/DlgLocationPos.ui
@@ -159,7 +159,7 @@
      </item>
      <item>
       <property name="text">
-       <string>5 m </string>
+       <string>5 m</string>
       </property>
      </item>
     </widget>

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -1084,7 +1084,7 @@ bool NotificationArea::confirmationRequired(Base::LogStyle level)
 
 void NotificationArea::showConfirmationDialog(const QString& notifiername, const QString& message)
 {
-    auto confirmMsg = QObject::tr("Notifier: ") + notifiername + QStringLiteral("\n\n") + message
+    auto confirmMsg = QObject::tr("Notifier:") + QStringLiteral(" ") + notifiername + QStringLiteral("\n\n") + message
         + QStringLiteral("\n\n")
         + QObject::tr("Do you want to skip confirmation of further critical message notifications "
                       "while loading the file?");

--- a/src/Gui/PreferencePages/DlgSettings3DView.ui
+++ b/src/Gui/PreferencePages/DlgSettings3DView.ui
@@ -60,7 +60,7 @@ lower right corner within opened files</string>
         <item row="0" column="2">
          <widget class="QLabel" name="labelCoordSize">
           <property name="text">
-           <string>Relative size :   </string>
+           <string>Relative size:</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Gui/PreferencePages/DlgSettingsPythonConsole.ui
+++ b/src/Gui/PreferencePages/DlgSettingsPythonConsole.ui
@@ -81,7 +81,7 @@ horizontal space in Python console</string>
       <item row="3" column="0">
        <widget class="QLabel" name="labelProfilerInterval">
         <property name="text">
-         <string>Python profiler interval (milliseconds): </string>
+         <string>Python profiler interval (milliseconds):</string>
         </property>
        </widget>
       </item>

--- a/src/Gui/QuantitySpinBox_p.h
+++ b/src/Gui/QuantitySpinBox_p.h
@@ -51,7 +51,7 @@ Q_SIGNALS:
 private:
 
     const QString genericExpressionEditorTooltip = tr("Enter an expression... (=)");
-    const QString expressionEditorTooltipPrefix = tr("Expression: ");
+    const QString expressionEditorTooltipPrefix = tr("Expression:") + QLatin1String(" ");
 };
 
 #endif // QUANTITYSPINBOX_P_H

--- a/src/Mod/AddonManager/addonmanager_installer_gui.py
+++ b/src/Mod/AddonManager/addonmanager_installer_gui.py
@@ -364,9 +364,10 @@ class AddonInstallerGUI(QtCore.QObject):
             translate("AddonsInstaller", "Cannot execute pip"),
             translate(
                 "AddonsInstaller",
-                "Failed to execute pip, which may be missing from your Python installation. Please ensure your system has pip installed and try again. The failed command was: ",
+                "Failed to execute pip, which may be missing from your Python installation. Please ensure your system "
+                "has pip installed and try again. The failed command was:",
             )
-            + f"\n\n{command}\n\n"
+            + f" \n\n{command}\n\n"
             + translate(
                 "AddonsInstaller",
                 "Continue with installation of {} anyway?",

--- a/src/Mod/AddonManager/addonmanager_uninstaller.py
+++ b/src/Mod/AddonManager/addonmanager_uninstaller.py
@@ -244,8 +244,9 @@ class MacroUninstaller(QObject):
                 errors.append(
                     translate(
                         "AddonsInstaller",
-                        "Error while trying to remove macro file {}: ",
+                        "Error while trying to remove macro file {}:",
                     ).format(full_path)
+                    + " "
                     + str(e)
                 )
                 success = False

--- a/src/Mod/CAM/Gui/Resources/panels/DogboneEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DogboneEdit.ui
@@ -104,7 +104,7 @@
        <item row="2" column="0">
         <widget class="QLabel" name="incisionLabel">
          <property name="text">
-          <string>Incision          </string>
+          <string>Incision</string>
          </property>
         </widget>
        </item>

--- a/src/Mod/CAM/Gui/Resources/panels/HoldingTagsEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/HoldingTagsEdit.ui
@@ -37,7 +37,7 @@
       <item row="2" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Angle            </string>
+         <string>Angle</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpSlotEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpSlotEdit.ui
@@ -87,7 +87,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string> Choose what point to use on the first selected feature </string>
+         <string>Choose what point to use on the first selected feature</string>
         </property>
         <property name="editable">
          <bool>false</bool>
@@ -159,7 +159,7 @@
          </font>
         </property>
         <property name="toolTip">
-         <string> Choose what point to use on the second selected feature </string>
+         <string>Choose what point to use on the second selected feature</string>
         </property>
         <property name="editable">
          <bool>false</bool>
@@ -219,7 +219,7 @@
          </font>
         </property>
         <property name="toolTip">
-         <string> No Base Geometry selected </string>
+         <string>No Base Geometry selected</string>
         </property>
         <property name="styleSheet">
          <string notr="true">color:blue</string>
@@ -238,7 +238,7 @@
       <item>
        <widget class="QLabel" name="usingCustomPoints">
         <property name="toolTip">
-         <string> Currently using custom point inputs in the Property View of the Data tab </string>
+         <string>Currently using custom point inputs in the Property View of the Data tab</string>
         </property>
         <property name="text">
          <string>Currently using custom point inputs available in the Property View of the Data tab.</string>
@@ -288,7 +288,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string> Positive extends the beginning of the path, negative shortens </string>
+         <string>Positive extends the beginning of the path, negative shortens</string>
         </property>
         <property name="unit" stdset="0">
          <string notr="true"/>
@@ -314,7 +314,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string> Positive extends the end of the path, negative shortens </string>
+         <string>Positive extends the end of the path, negative shortens</string>
         </property>
         <property name="unit" stdset="0">
          <string notr="true"/>
@@ -354,7 +354,7 @@
          </font>
         </property>
         <property name="toolTip">
-         <string> Complete the operation in a single pass at depth, or multiple passes to final depth </string>
+         <string>Complete the operation in a single pass at depth, or multiple passes to final depth</string>
         </property>
         <item>
          <property name="text">
@@ -378,7 +378,7 @@
       <item row="1" column="1">
        <widget class="QComboBox" name="pathOrientation">
         <property name="toolTip">
-         <string> Choose the path orientation with regard to the feature(s) selected </string>
+         <string>Choose the path orientation with regard to the feature(s) selected</string>
         </property>
         <item>
          <property name="text">
@@ -395,7 +395,7 @@
       <item row="2" column="1">
        <widget class="QCheckBox" name="reverseDirection">
         <property name="toolTip">
-         <string> Enable to reverse the cut direction of the slot path </string>
+         <string>Enable to reverse the cut direction of the slot path</string>
         </property>
         <property name="text">
          <string>Reverse cut direction</string>

--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -1404,7 +1404,7 @@ Default: "5mm"</string>
        <item row="0" column="0">
         <widget class="QLabel" name="label_18">
          <property name="text">
-          <string>Active Tool </string>
+          <string>Active Tool</string>
          </property>
         </widget>
        </item>

--- a/src/Mod/CAM/Gui/Resources/panels/ToolEditor.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/ToolEditor.ui
@@ -193,7 +193,7 @@
          <item row="1" column="0">
           <widget class="QLabel" name="label_D">
            <property name="text">
-            <string>D = </string>
+            <string notr="true">D =</string>
            </property>
           </widget>
          </item>
@@ -210,7 +210,7 @@
          <item row="2" column="0">
           <widget class="QLabel" name="label_d">
            <property name="text">
-            <string>d =</string>
+            <string notr="true">d =</string>
            </property>
           </widget>
          </item>
@@ -227,7 +227,7 @@
          <item row="3" column="0">
           <widget class="QLabel" name="label_H">
            <property name="text">
-            <string>H =</string>
+            <string notr="true">H =</string>
            </property>
           </widget>
          </item>
@@ -264,7 +264,7 @@
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>S = </string>
+            <string notr="true">S = </string>
            </property>
           </widget>
          </item>

--- a/src/Mod/CAM/Gui/Resources/preferences/PathDressupHoldingTags.ui
+++ b/src/Mod/CAM/Gui/Resources/preferences/PathDressupHoldingTags.ui
@@ -106,7 +106,7 @@ If the radius is bigger than that which the tag shape itself supports, the resul
       <item row="0" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>Initial # Tags </string>
+         <string>Initial # Tags</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/CAM/Gui/Resources/preferences/PathJob.ui
+++ b/src/Mod/CAM/Gui/Resources/preferences/PathJob.ui
@@ -285,7 +285,7 @@ See the file save policy below on how to deal with name conflicts.</string>
           <item row="0" column="0">
            <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>Post Processors Selection </string>
+             <string>Post Processors Selection</string>
             </property>
            </widget>
           </item>
@@ -652,7 +652,7 @@ See the file save policy below on how to deal with name conflicts.</string>
          <property name="toolTip">
           <string>References to Tool Bits and their shapes can either be stored with an absolute path or with a relative path to the search path.
 Generally it is recommended to use relative paths due to their flexibility and robustness to layout changes.
-Should multiple tools or tool shapes with the same name exist in different directories it can be required to use absolute paths. </string>
+Should multiple tools or tool shapes with the same name exist in different directories it can be required to use absolute paths.</string>
          </property>
          <property name="text">
           <string>Store Absolute Paths</string>

--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -378,7 +378,7 @@ Note that this can take a while!</string>
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_5">
           <property name="toolTip">
            <string>Objects from the same layers will be joined into Draft Blocks,
-turning the display faster, but making them less easily editable </string>
+turning the display faster, but making them less easily editable.</string>
           </property>
           <property name="text">
            <string>Group layers into blocks</string>

--- a/src/Mod/Draft/Resources/ui/preferences-svg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-svg.ui
@@ -80,7 +80,7 @@
          <widget class="Gui::PrefCheckBox" name="checkBox">
           <property name="toolTip">
            <string>If checked, no units conversion will occur.
-One unit in the SVG file will translate as one millimeter. </string>
+One unit in the SVG file will translate as one millimeter.</string>
           </property>
           <property name="text">
            <string>Disable units scaling</string>
@@ -201,9 +201,9 @@ One unit in the SVG file will translate as one millimeter. </string>
         <item>
          <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox">
           <property name="toolTip">
-           <string>Versions of Open CASCADE older than version 6.8 don't support arc projection.
+           <string>Versions of OpenCASCADE older than version 6.8 don't support arc projection.
 In this case arcs will be discretized into small line segments.
-This value is the maximum segment length. </string>
+This value is the maximum segment length.</string>
           </property>
           <property name="suffix">
            <string>mm</string>

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -261,7 +261,7 @@ def make_label(target_point=App.Vector(0, 0, 0),
 
     types = label.get_label_types()
     if label_type not in types:
-        _err(translate("draft", "Wrong input: label_type must be one of the following: ") + str(types).strip("[]"))
+        _err(translate("draft", "Wrong input: label_type must be one of the following:") + " " + str(types).strip("[]"))
         return None
 
     if not custom_text:

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -705,8 +705,8 @@ def compare_objects(obj1, obj2):
                 elif p == "Placement":
                     delta = obj1.Placement.Base.sub(obj2.Placement.Base)
                     text = translate("draft", "Objects have different placements. "
-                                              "Distance between the two base points: ")
-                    _msg(text + str(delta.Length))
+                                              "Distance between the two base points:")
+                    _msg(text + " " + str(delta.Length))
                 else:
                     if getattr(obj1, p) != getattr(obj2, p):
                         _msg("'{}' ".format(p) + translate("draft", "has a different value"))
@@ -1106,11 +1106,8 @@ def use_instead(function, version=""):
         then we should not give a version.
     """
     if version:
-        _wrn(translate("draft", "This function will be deprecated in ")
-             + "{}. ".format(version)
-             + translate("draft", "Please use ") + "'{}'.".format(function))
+        _wrn(translate("draft", "This function will be deprecated in {}. Please use '{}'.") .format(version, function))
     else:
-        _wrn(translate("draft", "This function will be deprecated. ")
-             + translate("draft", "Please use ") + "'{}'.".format(function))
+        _wrn(translate("draft", "This function will be deprecated. Please use '{}'.") .format(function))
 
 ## @}

--- a/src/Mod/Fem/Gui/DlgSettingsFemCcx.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemCcx.ui
@@ -513,7 +513,7 @@
         <item row="7" column="0">
          <widget class="QLabel" name="l_BeamShellOutput">
           <property name="text">
-           <string>Beam, shell element 3D output format </string>
+           <string>Beam, shell element 3D output format</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/Fem/Gui/Resources/ui/ElectrostaticPotential.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ElectrostaticPotential.ui
@@ -563,7 +563,7 @@ Note: has no effect if a solid was selected</string>
      <item row="0" column="0">
       <widget class="QLabel" name="capacityBody_label">
        <property name="text">
-        <string extracomment="Enabled by 'Calculate Capacity Matrix' in Electrostatic equation">Capacity Body: </string>
+        <string extracomment="Enabled by 'Calculate Capacity Matrix' in Electrostatic equation">Capacity Body:</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/Fem/Gui/Resources/ui/ElementFluid1D.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ElementFluid1D.ui
@@ -61,7 +61,7 @@
              <item>
               <widget class="QLabel" name="label_4">
                <property name="text">
-                <string>Pipe Area </string>
+                <string>Pipe Area</string>
                </property>
               </widget>
              </item>

--- a/src/Mod/Fem/Gui/Resources/ui/ElementGeometry1D.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ElementGeometry1D.ui
@@ -68,7 +68,7 @@
             <item row="1" column="0">
              <widget class="QLabel" name="l_rec_width">
               <property name="text">
-               <string>Width:   </string>
+               <string>Width:</string>
               </property>
              </widget>
             </item>
@@ -112,7 +112,7 @@
             <item row="2" column="0">
              <widget class="QLabel" name="l_rec_height">
               <property name="text">
-               <string>Height:     </string>
+               <string>Height:</string>
               </property>
              </widget>
             </item>
@@ -222,7 +222,7 @@
             <item row="1" column="0">
              <widget class="QLabel" name="l_circ_diameter">
               <property name="text">
-               <string>Diameter:   </string>
+               <string>Diameter:</string>
               </property>
              </widget>
             </item>
@@ -240,7 +240,7 @@
             <item row="1" column="0">
              <widget class="QLabel" name="l_pipe_diameter">
               <property name="text">
-               <string>Outer diameter:   </string>
+               <string>Outer diameter:</string>
               </property>
              </widget>
             </item>

--- a/src/Mod/Fem/Gui/Resources/ui/ElementGeometry2D.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ElementGeometry2D.ui
@@ -74,7 +74,7 @@
         <item row="1" column="0">
          <widget class="QLabel" name="l_thickness">
           <property name="text">
-           <string>Thickness:     </string>
+           <string>Thickness:</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/Fem/Gui/Resources/ui/ElementRotation1D.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/ElementRotation1D.ui
@@ -86,7 +86,7 @@
         <item row="1" column="0">
          <widget class="QLabel" name="l_rotation">
           <property name="text">
-           <string>Rotation:     </string>
+           <string>Rotation:</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/Fem/Gui/Resources/ui/Material.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/Material.ui
@@ -152,7 +152,7 @@
         <item row="4" column="0">
          <widget class="QLabel" name="label_8">
           <property name="text">
-           <string>Density                     </string>
+           <string>Density</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.ui
@@ -25,7 +25,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Boundary </string>
+        <string>Boundary</string>
        </property>
       </widget>
      </item>
@@ -239,7 +239,7 @@
             <string>Select a planar edge or face, then press this button</string>
            </property>
            <property name="text">
-            <string>Direction </string>
+            <string>Direction</string>
            </property>
           </widget>
          </item>
@@ -331,7 +331,7 @@ normal vector of the face is used as direction</string>
          <item row="0" column="0">
           <widget class="QLabel" name="labelTurbulentIntensityValue">
            <property name="text">
-            <string>Intensity    </string>
+            <string>Intensity</string>
            </property>
           </widget>
          </item>
@@ -391,7 +391,7 @@ normal vector of the face is used as direction</string>
          <item row="0" column="0">
           <widget class="QLabel" name="labelThermalBoundaryType">
            <property name="text">
-            <string> Type </string>
+            <string>Type</string>
            </property>
           </widget>
          </item>

--- a/src/Mod/Fem/Gui/TaskPanelConstraintTemperature.ui
+++ b/src/Mod/Fem/Gui/TaskPanelConstraintTemperature.ui
@@ -23,7 +23,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>Select the vertices, lines and surfaces: </string>
+    <string>Select the vertices, lines and surfaces:</string>
    </property>
   </widget>
   <widget class="QLabel" name="label_2">

--- a/src/Mod/Fem/Gui/TaskTetParameter.ui
+++ b/src/Mod/Fem/Gui/TaskTetParameter.ui
@@ -163,7 +163,7 @@
      <item row="0" column="0">
       <widget class="QLabel" name="label_6">
        <property name="text">
-        <string>Node count: </string>
+        <string>Node count:</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -1416,9 +1416,9 @@ PartGui::SteppedSelection::SteppedSelection(const uint& buttonCountIn, QWidget* 
   for (uint index = 0; index < buttonCountIn; ++index)
   {
     ButtonIconPairType tempPair;
-    QString text = QObject::tr("Selection ");
+    QString text = QObject::tr("Selection");
     std::ostringstream stream;
-    stream << text.toStdString() << ((index < 10) ? "0" : "") <<  index + 1;
+    stream << text.toStdString() << " " << ((index < 10) ? "0" : "") <<  index + 1;
     QString buttonText = QString::fromStdString(stream.str());
     QPushButton *button = new QPushButton(buttonText, this);
     button->setCheckable(true);

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1538,7 +1538,7 @@ void TaskSketcherConstraints::change3DViewVisibilityToTrackFilter()
                 Gui::Command::abortCommand();
 
                 Gui::TranslatedUserError(
-                    sketch, tr("Error"), tr("Impossible to update visibility tracking: "));
+                    sketch, tr("Error"), tr("Impossible to update visibility tracking:") + QLatin1String(" "));
 
                 return false;
             }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3140,13 +3140,13 @@ void ViewProviderSketch::UpdateSolverInformation()
     else if (dofs < 0 || hasConflicts) {// over-constrained sketch
         signalSetUp(
             QString::fromUtf8("conflicting_constraints"),
-            tr("Over-constrained: "),
+            tr("Over-constrained:") + QLatin1String(" "),
             QString::fromUtf8("#conflicting"),
             QString::fromUtf8("(%1)").arg(intListHelper(getSketchObject()->getLastConflicting())));
     }
     else if (hasMalformed) {// malformed constraints
         signalSetUp(QString::fromUtf8("malformed_constraints"),
-                    tr("Malformed constraints: "),
+                    tr("Malformed constraints:") + QLatin1String(" "),
                     QString::fromUtf8("#malformed"),
                     QString::fromUtf8("(%1)").arg(
                         intListHelper(getSketchObject()->getLastMalformedConstraints())));
@@ -3154,13 +3154,13 @@ void ViewProviderSketch::UpdateSolverInformation()
     else if (hasRedundancies) {
         signalSetUp(
             QString::fromUtf8("redundant_constraints"),
-            tr("Redundant constraints:"),
+            tr("Redundant constraints:") + QLatin1String(" "),
             QString::fromUtf8("#redundant"),
             QString::fromUtf8("(%1)").arg(intListHelper(getSketchObject()->getLastRedundant())));
     }
     else if (hasPartiallyRedundant) {
         signalSetUp(QString::fromUtf8("partially_redundant_constraints"),
-                    tr("Partially redundant:"),
+                    tr("Partially redundant:") + QLatin1String(" "),
                     QString::fromUtf8("#partiallyredundant"),
                     QString::fromUtf8("(%1)").arg(
                         intListHelper(getSketchObject()->getLastPartiallyRedundant())));
@@ -3173,7 +3173,7 @@ void ViewProviderSketch::UpdateSolverInformation()
     }
     else if (dofs > 0) {
         signalSetUp(QString::fromUtf8("under_constrained"),
-                    tr("Under constrained:"),
+                    tr("Under constrained:") + QLatin1String(" "),
                     QString::fromUtf8("#dofs"),
                     tr("%n DoF(s)", "", dofs));
     }

--- a/src/Mod/Spreadsheet/Gui/DlgSettings.ui
+++ b/src/Mod/Spreadsheet/Gui/DlgSettings.ui
@@ -93,7 +93,7 @@ Defaults to: %V = %A
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Delimiter Character: </string>
+         <string>Delimiter Character:</string>
         </property>
        </widget>
       </item>
@@ -153,7 +153,7 @@ Defaults to: %V = %A
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Quote Character: </string>
+         <string>Quote Character:</string>
         </property>
        </widget>
       </item>
@@ -185,7 +185,7 @@ Defaults to: %V = %A
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Escape Character: </string>
+         <string>Escape Character:</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/TechDraw/Gui/PagePrinter.cpp
+++ b/src/Mod/TechDraw/Gui/PagePrinter.cpp
@@ -322,7 +322,7 @@ void PagePrinter::printBannerPage(QPrinter* printer, QPainter& painter, QPageLay
     painter.setFont(painterFont);
 
     //print a header
-    QString docLine = QObject::tr("Document Name: ") + QString::fromUtf8(doc->getName());
+    QString docLine = QObject::tr("Document Name:") + QLatin1String(" ") + QString::fromUtf8(doc->getName());
     int leftMargin = pageLayout.margins().left() * dpmm + 5 * dpmm; //layout margin + 5mm
     int verticalPos = pageLayout.margins().top() * dpmm + 20 * dpmm;//layout margin + 20mm
     int verticalSpacing = 2;                                        //double space

--- a/src/Mod/TechDraw/Gui/TaskCosmeticCircle.ui
+++ b/src/Mod/TechDraw/Gui/TaskCosmeticCircle.ui
@@ -204,7 +204,7 @@
      <item row="1" column="1">
       <widget class="Gui::QuantitySpinBox" name="qsbStartAngle">
        <property name="toolTip">
-        <string>Start angle (conventional) of arc in degrees. </string>
+        <string>Start angle (conventional) of arc in degrees.</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/TechDraw/Gui/TaskLinkDim.ui
+++ b/src/Mod/TechDraw/Gui/TaskLinkDim.ui
@@ -124,7 +124,7 @@
             <item row="3" column="0">
              <widget class="QLabel" name="label_2">
               <property name="text">
-               <string>Geometry2: </string>
+               <string>Geometry2:</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Removes leading and trailing spaces from translated strings (in most cases moving them to a `QLatin1String(" ")` or `str(" ")`, but in UI files they are simply dropped). Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/292