### PR TITLE
Added "streamdeck" Python module

### DIFF
--- a/src/Mod/AddonManager/ALLOWED_PYTHON_PACKAGES.txt
+++ b/src/Mod/AddonManager/ALLOWED_PYTHON_PACKAGES.txt
@@ -29,6 +29,7 @@ pynastran
 requests
 rhino3dm
 scipy
+streamdeck
 xlrd
 xlutils
 xlwt


### PR DESCRIPTION
This module is used by the [Stream Deck Addon](https://github.com/Giraut/freecad_streamdeck_addon). Without the module being listed in the allowed Python packages, FreeCAD forces the user to install it manually when installing the Stream Deck Addon from the addon manager.