### PR TITLE
Sketcher: Translate rendering order menu

### DIFF
--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -1078,6 +1078,7 @@ bool CmdSketcherViewSection::isActive()
 /* Grid tool */
 class GridSpaceAction: public QWidgetAction
 {
+    Q_DECLARE_TR_FUNCTIONS(GridSpaceAction)
 public:
     GridSpaceAction(QObject* parent)
         : QWidgetAction(parent)
@@ -1315,6 +1316,7 @@ bool CmdSketcherGrid::isActive()
 /* Snap tool */
 class SnapSpaceAction: public QWidgetAction
 {
+    Q_DECLARE_TR_FUNCTIONS(SnapSpaceAction)
 public:
     SnapSpaceAction(QObject* parent)
         : QWidgetAction(parent)
@@ -1583,6 +1585,7 @@ bool CmdSketcherSnap::isActive()
 /* Rendering Order */
 class RenderingOrderAction: public QWidgetAction
 {
+    Q_DECLARE_TR_FUNCTIONS(RenderingOrderAction)
 public:
     RenderingOrderAction(QObject* parent)
         : QWidgetAction(parent)


### PR DESCRIPTION
`QWidgetAction` is not supplying the correct context to `tr()`, so explicitly set it for these three classes.

Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/287
Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/286
Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/285