### PR TITLE
Gui: Fix translation strings for Part, Group, and Link

### DIFF
--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -208,12 +208,9 @@ StdCmdLinkMake::StdCmdLinkMake()
 {
     sGroup        = "Link";
     sMenuText     = QT_TR_NOOP("Make link");
-    static std::string toolTip = std::string("<p>")
-        + QT_TR_NOOP("A Link is an object that references or links to another object in the same "
-        "document, or in another document.Unlike Clones, Links reference the original Shape directly, "
-        " making them more memory efficient which helps with the creation of complex assemblies.")
-        + "</p>";
-    sToolTipText = toolTip.c_str();
+    sToolTipText  = QT_TR_NOOP("A Link is an object that references or links to another object in the same document, "
+                               "or in another document. Unlike Clones, Links reference the original Shape directly, "
+                               "making them more memory-efficient, which helps with the creation of complex assemblies.");
     sWhatsThis    = "Std_LinkMake";
     sStatusTip    = sToolTipText;
     eType         = AlterDoc;

--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -49,13 +49,9 @@ StdCmdPart::StdCmdPart()
 {
     sGroup        = "Structure";
     sMenuText     = QT_TR_NOOP("Create part");
-    static std::string toolTip = std::string("<p>")
-        + QT_TR_NOOP("A Part is is a general purpose container to keep together a "
-            "group of objects so that they act as a unit in the 3D view.\n"
-            "It is meant to arrange objects that have a Part TopoShape, like Part Primitives, PartDesign"
-            " Bodies, and other Parts.") 
-        + "</p>";
-    sToolTipText  = toolTip.c_str();
+    sToolTipText  = QT_TR_NOOP("A Part is a general purpose container to keep together a group of objects so that they "
+                               "act as a unit in the 3D view. It is meant to arrange objects that have a Part "
+                               "TopoShape, like Part Primitives, PartDesign Bodies, and other Parts.");
     sWhatsThis    = "Std_Part";
     sStatusTip    = sToolTipText;
     sPixmap       = "Geofeaturegroup";
@@ -96,13 +92,9 @@ StdCmdGroup::StdCmdGroup()
 {
     sGroup        = "Structure";
     sMenuText     = QT_TR_NOOP("Create group");
-    static std::string toolTip = std::string("<p>")
-        + QT_TR_NOOP("A Group is a general purpose container to group objects in the "
-        "Tree view, regardless of their data type. It is a simple folder to organize "
-        "the objects in a model.")
-        + "</p>";
-    
-    sToolTipText = toolTip.c_str();
+    sToolTipText = QT_TR_NOOP("A Group is a general purpose container to group objects in the "
+                              "Tree view, regardless of their data type. It is a simple folder to organize "
+                              "the objects in a model.");
     sWhatsThis    = "Std_Group";
     sStatusTip    = sToolTipText;
     sPixmap       = "folder";


### PR DESCRIPTION
Extra HTML tags were added outside the translation NOOP. They were unnecessary, and broke translation. Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/283