### PR TITLE
Core: Fix unselectable area in SoDatumLabel

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -565,7 +565,7 @@ void SoDatumLabel::generateDistancePrimitives(SoAction * action, const SbVec3f& 
     // Primitive Shape is only for text as this should only be selectable
     SoPrimitiveVertex pv;
 
-    this->beginShape(action, QUADS);
+    this->beginShape(action, TRIANGLE_STRIP);
 
     pv.setNormal( SbVec3f(0.f, 0.f, 1.f) );
 
@@ -616,7 +616,7 @@ void SoDatumLabel::generateDiameterPrimitives(SoAction * action, const SbVec3f& 
     // Primitive Shape is only for text as this should only be selectable
     SoPrimitiveVertex pv;
 
-    this->beginShape(action, QUADS);
+    this->beginShape(action, TRIANGLE_STRIP);
 
     pv.setNormal( SbVec3f(0.f, 0.f, 1.f) );
 
@@ -653,7 +653,7 @@ void SoDatumLabel::generateAnglePrimitives(SoAction * action, const SbVec3f& p0)
     // Primitive Shape is only for text as this should only be selectable
     SoPrimitiveVertex pv;
 
-    this->beginShape(action, QUADS);
+    this->beginShape(action, TRIANGLE_STRIP);
 
     pv.setNormal( SbVec3f(0.f, 0.f, 1.f) );
 


### PR DESCRIPTION
Fix a selection issue. May depends on OpenGL version?
**Previously:**
not pre-selected
![image](https://github.com/FreeCAD/FreeCAD/assets/10371513/8143416c-c674-44ca-8672-82b614677e37)
pre-selected
![image](https://github.com/FreeCAD/FreeCAD/assets/10371513/c5ebcb91-dda1-466d-ae4d-c99e5b5e6dde)
selectable zone
![Capture d’écran_2024-03-06_21-40-29](https://github.com/FreeCAD/FreeCAD/assets/10371513/0e7c04fc-c150-4391-a922-061f09b2b2ab)

**With this fix**
![image](https://github.com/FreeCAD/FreeCAD/assets/10371513/ae03db90-96f9-44a4-a834-351916299aa8)

EDIT: certainly due to QUAD deprecation: see https://www.khronos.org/opengl/wiki/Primitive#Quads
