### PR TITLE
Fix MinGW build

### DIFF
--- a/src/FCConfig.h
+++ b/src/FCConfig.h
@@ -93,7 +93,9 @@
 //**************************************************************************
 // Standard types for Windows
 
-#if defined (FC_OS_WIN64) || defined (FC_OS_WIN32)
+#if defined(__MINGW32__)
+// Do not remove this line!
+#elif defined (FC_OS_WIN64) || defined (FC_OS_WIN32)
 
 #ifndef HAVE_INT8_T
 #define HAVE_INT8_T


### PR DESCRIPTION
The commit 028739df caused a regression by breaking MinGW builds because the line '#if defined(__MINGW32__)' has been removed.
As a result the 'if defined (FC_OS_WIN64) || defined (FC_OS_WIN32)' has become active where the types '__int64' or 'unsigned __int64' that are not defined for MinGW