### PR TITLE
Fix build failure for MinGW

### DIFF
--- a/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
+++ b/src/Mod/Import/Gui/dxf/ImpExpDxfGui.cpp
@@ -20,6 +20,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <FCConfig.h>
 #ifndef _PreComp_
 #include <Standard_Version.hxx>
 #if OCC_VERSION_HEX < 0x070600


### PR DESCRIPTION
MinGW needs to know about the COIN_DLL export macro