### PR TITLE
Sketcher: correct position of ConstrainLock and ConstrainRadiam in GUI

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -696,8 +696,6 @@ void ElementView::contextMenuEvent(QContextMenuEvent* event)
     CONTEXT_ITEM(
         "Constraint_Block", "Block Constraint", "Sketcher_ConstrainBlock", doBlockConstraint, true)
 
-    CONTEXT_ITEM(
-        "Constraint_Lock", "Lock Constraint", "Sketcher_ConstrainLock", doLockConstraint, true)
     CONTEXT_ITEM("Constraint_HorizontalDistance",
                  "Horizontal Distance",
                  "Sketcher_ConstrainDistanceX",
@@ -713,6 +711,11 @@ void ElementView::contextMenuEvent(QContextMenuEvent* event)
                  "Sketcher_ConstrainDistance",
                  doLengthConstraint,
                  true)
+    CONTEXT_ITEM("Constraint_Radiam",
+                 "Radiam Constraint",
+                 "Sketcher_ConstrainRadiam",
+                 doRadiamConstraint,
+                 true)
     CONTEXT_ITEM("Constraint_Radius",
                  "Radius Constraint",
                  "Sketcher_ConstrainRadius",
@@ -723,16 +726,13 @@ void ElementView::contextMenuEvent(QContextMenuEvent* event)
                  "Sketcher_ConstrainDiameter",
                  doDiameterConstraint,
                  true)
-    CONTEXT_ITEM("Constraint_Radiam",
-                 "Radiam Constraint",
-                 "Sketcher_ConstrainRadiam",
-                 doRadiamConstraint,
-                 true)
     CONTEXT_ITEM("Constraint_InternalAngle",
                  "Angle Constraint",
                  "Sketcher_ConstrainAngle",
                  doAngleConstraint,
                  true)
+    CONTEXT_ITEM(
+        "Constraint_Lock", "Lock Constraint", "Sketcher_ConstrainLock", doLockConstraint, true)
 
     menu.addSeparator();
 
@@ -801,14 +801,14 @@ CONTEXT_MEMBER_DEF("Sketcher_ConstrainEqual", doEqualConstraint)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainSymmetric", doSymmetricConstraint)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainBlock", doBlockConstraint)
 
-CONTEXT_MEMBER_DEF("Sketcher_ConstrainLock", doLockConstraint)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainDistanceX", doHorizontalDistance)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainDistanceY", doVerticalDistance)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainDistance", doLengthConstraint)
+CONTEXT_MEMBER_DEF("Sketcher_ConstrainRadiam", doRadiamConstraint)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainRadius", doRadiusConstraint)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainDiameter", doDiameterConstraint)
-CONTEXT_MEMBER_DEF("Sketcher_ConstrainRadiam", doRadiamConstraint)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainAngle", doAngleConstraint)
+CONTEXT_MEMBER_DEF("Sketcher_ConstrainLock", doLockConstraint)
 
 CONTEXT_MEMBER_DEF("Sketcher_ToggleConstruction", doToggleConstruction)
 

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -450,14 +450,14 @@ inline void SketcherAddWorkbenchConstraints<Gui::MenuItem>(Gui::MenuItem& cons)
          << "Sketcher_ConstrainBlock"
          << "Separator"
          << "Sketcher_Dimension"
-         << "Sketcher_ConstrainLock"
          << "Sketcher_ConstrainDistanceX"
          << "Sketcher_ConstrainDistanceY"
          << "Sketcher_ConstrainDistance"
+         << "Sketcher_ConstrainRadiam"
          << "Sketcher_ConstrainRadius"
          << "Sketcher_ConstrainDiameter"
-         << "Sketcher_ConstrainRadiam"
          << "Sketcher_ConstrainAngle"
+         << "Sketcher_ConstrainLock"
          << "Sketcher_ConstrainSnellsLaw"
          << "Separator"
          << "Sketcher_ToggleDrivingConstraint"
@@ -504,12 +504,12 @@ inline void SketcherAddWorkbenchConstraints<Gui::ToolBarItem>(Gui::ToolBarItem& 
         }
     }
     if (hGrp->GetBool("SeparatedDimensioningTools", false)) {
-        cons << "Sketcher_ConstrainLock"
-             << "Sketcher_ConstrainDistanceX"
+        cons << "Sketcher_ConstrainDistanceX"
              << "Sketcher_ConstrainDistanceY"
              << "Sketcher_ConstrainDistance"
              << "Sketcher_CompConstrainRadDia"
-             << "Sketcher_ConstrainAngle";
+             << "Sketcher_ConstrainAngle"
+             << "Sketcher_ConstrainLock";
         // << "Sketcher_ConstrainSnellsLaw" // Rarely used, show only in menu
     }
     cons << "Separator"


### PR DESCRIPTION
Sketcher_ConstrainLock after Sketcher_ConstrainAngle.
Sketcher_ConstrainRadiam before Sketcher_ConstrainRadius.

This was not always correct.

See also #12667.
