### PR TITLE
Draft: Allow to prevent layers to claim children

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_layer.py
+++ b/src/Mod/Draft/draftviewproviders/view_layer.py
@@ -177,6 +177,8 @@ class ViewProviderLayer:
         These are the elements of the `Group` property of the Proxy object.
         """
         if hasattr(self, "Object") and hasattr(self.Object, "Group"):
+            if getattr(self.Object.ViewObject, "HideChildren", False):
+                return []
             return self.Object.Group
 
     def getDisplayModes(self, vobj):


### PR DESCRIPTION
Allows to add a *HideChildren* property to Draft layers to prevent them from claiming their objects. This allows other workbenches to create layers that don't list their contents, while leaves current Draft layers unchanged.