### PR TITLE
[TechDraw] Reimplement Weld Symbol parent linking

### DIFF
--- a/src/Mod/TechDraw/App/DrawWeldSymbol.cpp
+++ b/src/Mod/TechDraw/App/DrawWeldSymbol.cpp
@@ -98,6 +98,12 @@ void DrawWeldSymbol::onSettingDocument()
 void DrawWeldSymbol::onChanged(const App::Property* prop)
 {
     DrawView::onChanged(prop);
+
+    // If leader was switched, our coordinates were adjusted, but we want to stick to the new leader line
+    if (prop == &Leader && Leader.getValue()) {
+        X.setValue(0.0);
+        Y.setValue(0.0);
+    }
 }
 
 short DrawWeldSymbol::mustExecute() const

--- a/src/Mod/TechDraw/App/DrawWeldSymbol.h
+++ b/src/Mod/TechDraw/App/DrawWeldSymbol.h
@@ -62,6 +62,8 @@ public:
     bool isTailRightSide();
     std::vector<DrawTileWeld*> getTiles() const;
 
+    App::PropertyLink *getOwnerProperty() override { return &Leader; }
+
 protected:
     void onChanged(const App::Property* prop) override;
 

--- a/src/Mod/TechDraw/Gui/QGIWeldSymbol.h
+++ b/src/Mod/TechDraw/Gui/QGIWeldSymbol.h
@@ -63,7 +63,7 @@ class TechDrawGuiExport QGIWeldSymbol : public QGIView
 public:
     enum {Type = QGraphicsItem::UserType + 340};
 
-    explicit QGIWeldSymbol(QGILeaderLine* myParent = nullptr);
+    explicit QGIWeldSymbol();
     ~QGIWeldSymbol() override = default;
 
     int type() const override { return Type;}
@@ -78,7 +78,7 @@ public:
     void updateView(bool update = false) override;
 
     virtual TechDraw::DrawWeldSymbol* getFeature();
-    virtual void setFeature(TechDraw::DrawWeldSymbol* feat);
+    virtual TechDraw::DrawLeaderLine *getLeader();
 
     QPointF getTileOrigin();
     QPointF getKinkPoint();
@@ -110,14 +110,11 @@ protected:
     double prefArrowSize();
     double prefFontSize() const;
 
-    TechDraw::DrawWeldSymbol* m_weldFeat;
-    TechDraw::DrawLeaderLine* m_leadFeat;
     TechDraw::DrawTileWeld*   m_arrowFeat;
     TechDraw::DrawTileWeld*   m_otherFeat;
     std::string               m_arrowName;
     std::string               m_otherName;
 
-    QGILeaderLine* m_qgLead;
     QGCustomText* m_tailText;
     QGIPrimPath* m_fieldFlag;
     QGIVertex* m_allAround;
@@ -126,7 +123,6 @@ protected:
 
     bool m_blockDraw;    //prevent redraws while updating.
 
-    std::string m_weldFeatName;
     virtual QRectF customBoundingRect() const;
 
 };

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -623,28 +623,11 @@ QGIView* QGSPage::addRichAnno(TechDraw::DrawRichAnno* richFeat)
 
 QGIView* QGSPage::addWeldSymbol(TechDraw::DrawWeldSymbol* weldFeat)
 {
-    //    Base::Console().Message("QGSP::addWeldSymbol()\n");
-    QGIWeldSymbol* weldGroup = nullptr;
-    TechDraw::DrawView* parentDV = nullptr;
+    QGIWeldSymbol *weldView = new QGIWeldSymbol;
+    weldView->setViewFeature(weldFeat);
 
-    App::DocumentObject* parentObj = weldFeat->Leader.getValue();
-    if (parentObj) {
-        parentDV = dynamic_cast<TechDraw::DrawView*>(parentObj);
-    }
-    else {
-        //        Base::Console().Message("QGSP::addWeldSymbol - no parent doc obj\n");
-    }
-    if (parentDV) {
-        QGIView* parentQV = findQViewForDocObj(parentObj);
-        QGILeaderLine* leadParent = dynamic_cast<QGILeaderLine*>(parentQV);
-        if (leadParent) {
-            weldGroup = new QGIWeldSymbol(leadParent);
-            weldGroup->setFeature(weldFeat);    //for QGIWS
-            weldGroup->setViewFeature(weldFeat);//for QGIV
-            weldGroup->updateView(true);
-        }
-    }
-    return weldGroup;
+    addQView(weldView);
+    return weldView;
 }
 
 void QGSPage::setDimensionGroups(void)

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
@@ -456,78 +456,32 @@ void TaskWeldingSymbol::getTileFeats()
 TechDraw::DrawWeldSymbol* TaskWeldingSymbol::createWeldingSymbol()
 {
 //    Base::Console().Message("TWS::createWeldingSymbol()\n");
-
-    const std::string objectName{QT_TR_NOOP("SectionView")};
-    std::string symbolName = m_leadFeat->getDocument()->getUniqueObjectName(objectName.c_str());
-    std::string generatedSuffix {symbolName.substr(objectName.length())};
-
-    std::string symbolType = "TechDraw::DrawWeldSymbol";
-
-    TechDraw::DrawPage* page = m_leadFeat->findParentPage();
-    std::string pageName = page->getNameInDocument();
-
-    Command::doCommand(Command::Doc, "App.activeDocument().addObject('%s', '%s')",
-                       symbolType.c_str(), symbolName.c_str());
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.addView(App.activeDocument().%s)",
-                       pageName.c_str(), symbolName.c_str());
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.Leader = App.activeDocument().%s",
-                           symbolName.c_str(), m_leadFeat->getNameInDocument());
-
-    bool allAround = ui->cbAllAround->isChecked();
-    std::string allAroundText = allAround ? "True" : "False";
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.AllAround = %s",
-                           symbolName.c_str(), allAroundText.c_str());
-
-    bool fieldWeld = ui->cbFieldWeld->isChecked();
-    std::string fieldWeldText = fieldWeld ? "True" : "False";
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.FieldWeld = %s",
-                           symbolName.c_str(), fieldWeldText.c_str());
-
-    bool altWeld = ui->cbAltWeld->isChecked();
-    std::string altWeldText = altWeld ? "True" : "False";
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.AlternatingWeld = %s",
-                           symbolName.c_str(), altWeldText.c_str());
-
-    std::string tailText = ui->leTailText->text().toStdString();
-    tailText = Base::Tools::escapeEncodeString(tailText);
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.TailText = '%s'",
-                           symbolName.c_str(), tailText.c_str());
-
-    App::DocumentObject* newObj = m_leadFeat->getDocument()->getObject(symbolName.c_str());
-    TechDraw::DrawWeldSymbol* newSym = dynamic_cast<TechDraw::DrawWeldSymbol*>(newObj);
-    if (!newObj || !newSym)
+    App::Document *doc = Application::Instance->activeDocument()->getDocument();
+    auto weldSymbol = dynamic_cast<TechDraw::DrawWeldSymbol*>(doc->addObject("TechDraw::DrawWeldSymbol", "WeldSymbol"));
+    if (!weldSymbol) {
         throw Base::RuntimeError("TaskWeldingSymbol - new symbol object not found");
+    }
 
-    std::string translatedObjectName{tr(objectName.c_str()).toStdString()};
-    newObj->Label.setValue(translatedObjectName + generatedSuffix);
+    weldSymbol->AllAround.setValue(ui->cbAllAround->isChecked());
+    weldSymbol->FieldWeld.setValue(ui->cbFieldWeld->isChecked());
+    weldSymbol->AlternatingWeld.setValue(ui->cbAltWeld->isChecked());
+    weldSymbol->TailText.setValue(ui->leTailText->text().toStdString());
+    weldSymbol->Leader.setValue(m_leadFeat);
 
-    return newSym;
+    TechDraw::DrawPage *page = m_leadFeat->findParentPage();
+    if (page) {
+        page->addView(weldSymbol);
+    }
+
+    return weldSymbol;
 }
 
 void TaskWeldingSymbol::updateWeldingSymbol()
 {
-//    Base::Console().Message("TWS::updateWeldingSymbol()\n");
-    std::string symbolName = m_weldFeat->getNameInDocument();
-
-    bool allAround = ui->cbAllAround->isChecked();
-    std::string allAroundText = allAround ? "True" : "False";
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.AllAround = %s",
-                           symbolName.c_str(), allAroundText.c_str());
-
-    bool fieldWeld = ui->cbFieldWeld->isChecked();
-    std::string fieldWeldText = fieldWeld ? "True" : "False";
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.FieldWeld = %s",
-                           symbolName.c_str(), fieldWeldText.c_str());
-
-    bool altWeld = ui->cbAltWeld->isChecked();
-    std::string altWeldText = altWeld ? "True" : "False";
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.AlternatingWeld = %s",
-                           symbolName.c_str(), altWeldText.c_str());
-
-    std::string tailText = ui->leTailText->text().toStdString();
-    tailText = Base::Tools::escapeEncodeString(tailText);
-    Command::doCommand(Command::Doc, "App.activeDocument().%s.TailText = '%s'",
-                           symbolName.c_str(), tailText.c_str());
+    m_weldFeat->AllAround.setValue(ui->cbAllAround->isChecked());
+    m_weldFeat->FieldWeld.setValue(ui->cbFieldWeld->isChecked());
+    m_weldFeat->AlternatingWeld.setValue(ui->cbAltWeld->isChecked());
+    m_weldFeat->TailText.setValue(ui->leTailText->text().toStdString());
 }
 
 void TaskWeldingSymbol::updateTiles()

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -393,7 +393,6 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
     //                                               DrawViewBalloon
     //                                               any FeatuerView in a DrawViewClip
     //                                               DrawHatch
-    //                                               DrawWeldSymbol
 
     const std::vector<App::DocumentObject*>& views = getDrawPage()->Views.getValues();
 
@@ -413,7 +412,6 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
                 || docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())
                 || docObj->isDerivedFrom(TechDraw::DrawHatch::getClassTypeId())
                 || docObj->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId())
-                || docObj->isDerivedFrom(TechDraw::DrawWeldSymbol::getClassTypeId())
                 || (featView && featView->isInClip()))
                 continue;
             else


### PR DESCRIPTION
This pull request ports Weld Symbols parent handling to the common infrastructure based on PRs #12342, #12421 and #12749. The benefits are corrected tree view positioning and the possibility to switch weld symbol between different leader lines freely. Also the code maintainability should be improved.

I have made some basic testing and it seems there are no issues, but as always, bugs may creep in. In such a case please let me know.