### PR TITLE
Gui: Remove ".desktop" suffix from QGuiApplication::setDesktopFileName()

### DIFF
--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -171,7 +171,7 @@ int main( int argc, char ** argv )
     App::Application::Config()["SplashInfoColor" ] = "#8aadf4"; // light blue 
     App::Application::Config()["SplashInfoPosition" ] = "6,75";
 
-    QGuiApplication::setDesktopFileName(QStringLiteral("org.freecad.FreeCAD.desktop"));
+    QGuiApplication::setDesktopFileName(QStringLiteral("org.freecad.FreeCAD"));
 
     try {
         // Init phase ===========================================================


### PR DESCRIPTION
"QGuiApplication::setDesktopFileName: the specified desktop file name ends with .desktop. For compatibility reasons, the .desktop suffix will be removed. Please specify a desktop file name without .desktop suffix"