### PR TITLE
Gui: Fix using context-menu of ExpressionLineEdit

### DIFF
--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -90,8 +90,6 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
 #endif
         setAttribute(Qt::WA_NoSystemBackground, true);
         setAttribute(Qt::WA_TranslucentBackground, true);
-
-        qApp->installEventFilter(this);
     }
     else {
         ui->expression->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -109,7 +107,6 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
 
 DlgExpressionInput::~DlgExpressionInput()
 {
-    qApp->removeEventFilter(this);
     delete ui;
 }
 
@@ -280,35 +277,6 @@ void DlgExpressionInput::show()
     QDialog::show();
     this->activateWindow();
     ui->expression->selectAll();
-}
-
-void DlgExpressionInput::showEvent(QShowEvent* ev)
-{
-    QDialog::showEvent(ev);
-}
-
-bool DlgExpressionInput::eventFilter(QObject *obj, QEvent *ev)
-{
-    // if the user clicks on a widget different to this
-    if (ev->type() == QEvent::MouseButtonPress && obj != this) {
-        // Since the widget has a transparent background we cannot rely
-        // on the size of the widget. Instead, it must be checked if the
-        // cursor is on this or an underlying widget or outside.
-        if (!underMouse()) {
-            // if the expression fields context-menu is open do not close the dialog
-            auto menu = qobject_cast<QMenu*>(obj);
-            if (menu && menu->parentWidget() == ui->expression) {
-                return false;
-            }
-            bool on = ui->expression->completerActive();
-            // Do this only if the completer is not shown
-            if (!on) {
-                qApp->removeEventFilter(this);
-                reject();
-            }
-        }
-    }
-    return false;
 }
 
 

--- a/src/Gui/DlgExpressionInput.h
+++ b/src/Gui/DlgExpressionInput.h
@@ -76,13 +76,10 @@ public:
     QPoint expressionPosition() const;
     void   setExpressionInputSize(int width, int height);
 
-    bool eventFilter(QObject *obj, QEvent *event) override;
-
 public Q_SLOTS:
     void show();
 
 protected:
-    void showEvent(QShowEvent*) override;
     void mouseReleaseEvent(QMouseEvent*) override;
     void mousePressEvent(QMouseEvent*) override;
 


### PR DESCRIPTION
If for the DlgExpressionInput the user config parameter 'NoSystemBsckground' is set to True it's not used as a normal dialog but as a pop-up window. In this mode the context-menu of the ExpressionLineEdit isn't working. A previous commit (a3036d16f1de) fixed a crash but not this issue.

For Qt4 DlgExpressionInput has overridden the eventFilter() to handle using the context-menu but this is not working any more for Qt5 or Qt6. Luckily, it has appeared that with Qt5 and Qt6 it works out-of-the box now and the event filter is not needed any more.