### PR TITLE
[Core] Fix for frozen status

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1577,7 +1577,8 @@ void StdCmdPlacement::activated(int iMsg)
 
 bool StdCmdPlacement::isActive()
 {
-    return Gui::Selection().countObjectsOfType(App::GeoFeature::getClassTypeId()) >= 1;
+    std::vector<App::DocumentObject*> sel = Gui::Selection().getObjectsOfType(App::GeoFeature::getClassTypeId());
+    return (sel.size() == 1 && ! sel.front()->isFreezed());
 }
 
 //===========================================================================
@@ -1611,7 +1612,8 @@ void StdCmdTransformManip::activated(int iMsg)
 
 bool StdCmdTransformManip::isActive()
 {
-    return Gui::Selection().countObjectsOfType(App::GeoFeature::getClassTypeId()) == 1;
+    std::vector<App::DocumentObject*> sel = Gui::Selection().getObjectsOfType(App::GeoFeature::getClassTypeId());
+    return (sel.size() == 1 && ! sel.front()->isFreezed());
 }
 
 //===========================================================================

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -172,22 +172,27 @@ StdCmdToggleFreeze::StdCmdToggleFreeze()
 void StdCmdToggleFreeze::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    getActiveGuiDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Toggle freeze"));
 
     std::vector<Gui::SelectionSingleton::SelObj> sels = Gui::Selection().getCompleteSelection();
 
+    Command::openCommand(QT_TRANSLATE_NOOP("Command", "Toggle freeze"));
     for (Gui::SelectionSingleton::SelObj& sel : sels) {
         App::DocumentObject* obj = sel.pObject;
         if (!obj)
             continue;
 
-        if (obj->isFreezed())
+        if (obj->isFreezed()){
             obj->unfreeze();
-        else
+            for (auto child : obj->getInListRecursive())
+                child->unfreeze();
+        } else {
             obj->freeze();
-    }
+            for (auto parent : obj->getOutListRecursive())
+                parent->freeze();
+        }
 
-    getActiveGuiDocument()->commitCommand();
+    }
+    Command::commitCommand();
 }
 
 bool StdCmdToggleFreeze::isActive()

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2987,6 +2987,11 @@ bool ViewProviderSketch::setEdit(int ModNum)
     }
 
     Sketcher::SketchObject* sketch = getSketchObject();
+
+    if(sketch->isFreezed()) {
+        return false; // Disallow edit of a frozen sketch
+    }
+
     if (!sketch->evaluateConstraints()) {
         QMessageBox box(Gui::getMainWindow());
         box.setIcon(QMessageBox::Critical);


### PR DESCRIPTION
Fix #12829 

Ping @maxwxyz 

- [x] Frozen state does not persist on save and opening a file. If I freeze an object, alter it and save it, the alteration is not displayed. When reopening, the modified object is visible and the object is not frozen anymore (recompute at opening). The last modification before closing is now irreversible and lost, although the object was frozen and shouln't be altered.
**a 'freezed' object now prevent the document to be saved.**
- [x] If a PartDesign body is frozen, all nested features can be changed and alter the frozen body.
**linked objects are 'freezed' / 'unfreezed' when the state changes**
- [x] A frozen body can be chamfered in the PartWB. After that it cannot be unfrozen again.
**Part_Chamfer create a new ('unfreezed') object, the nested Body is still 'freezed' and 'unfreezable'**
- [x] A frozen sketch can be activated but is displayed empty in the Sketcher WB
- [x] The visibility eye icon does not change its state when clicked but the visibillity in the 3D view is toggled (reproduced with a nested sketch in a PartDesign Pad feature)
Also reproduceable with nested object which are frozen inside of a group (e.g. walls in an arch group)
- [ ] Frozen command does not register with undo/redo
**It acts on the object state not on a property. The object is not modified. Not sure it's needed**
- [ ] If you use a part of a frozen object to create a new feature it throws an error (tried to pad a face of the frozen feature: Index out of bound)
**Can not reproduce**
- [ ] If you undo and redo and the body is frozen, all redone features are now outside of the body and cannot be moved inside of the body
- [ ] You can edit frozen features (e.g. draft objects). They wont change but the edit is permanent. On unfreezing, the edit will be applied.
- [x] Transform commands move the object, even when frozen. When using Draft WB move, they don't move
- [x] Placement command moves the frozen object.
- [ ] Non-reversable operations could be applied to frozen objects (e.g. smooth a frozen mesh). If this is done by accident it is not noticed, as there is no feedback to the user. If the mesh is later unfrozen, the smoothed, decimated shape is visible.
- [x] The freeze icon is not optimal. It covers the entire icon of the feature, body or object. It is not clear if you want to unfreeze something if this is a body or part container, a spreadsheet or PartDesign features. Maybe it can also be combined with the eye icon as the appearance of the object is frozen
**Fixed** 
![image](https://github.com/FreeCAD/FreeCAD/assets/10371513/256785a8-7ea0-4cca-ab63-0c7f072b4ec3)

- [ ] Could it be placed in the context menu section at the bottom, where "Mark to recompute" and "Recompute" is located, as I understand it's related to that?
- [ ] Could it be renamed? I did not figure out what this is doing and had to look through the PRs.
Proposals: Exclude from recompute, Lock current state,
- [ ] Could it have a checkbox like "Active body" (at the top of the context menu), like: [ x ] Locked to see the current state in the context menu