### PR TITLE
Addon Manager: Strip some HTML tags from Markdown

### DIFF
--- a/src/Mod/AddonManager/Widgets/addonmanager_widget_readme_browser.py
+++ b/src/Mod/AddonManager/Widgets/addonmanager_widget_readme_browser.py
@@ -20,6 +20,7 @@
 # *   <https://www.gnu.org/licenses/>.                                      *
 # *                                                                         *
 # ***************************************************************************
+import re
 
 import FreeCAD
 
@@ -65,7 +66,8 @@ class WidgetReadmeBrowser(QtWidgets.QTextBrowser):
         have native markdown support. Lacking that, plaintext is displayed."""
         geometry = self.geometry()
         if hasattr(super(), "setMarkdown"):
-            super().setMarkdown(md)
+
+            super().setMarkdown(self._clean_markdown(md))
         else:
             try:
                 import markdown
@@ -78,6 +80,16 @@ class WidgetReadmeBrowser(QtWidgets.QTextBrowser):
                     "Qt < 5.15 and no `import markdown` -- falling back to plain text display\n"
                 )
         self.setGeometry(geometry)
+
+    def _clean_markdown(self, md: str):
+        # Remove some HTML tags (for now just img and br, which are the most common offenders that break rendering)
+        br_re = re.compile(r"<br\s*/?>")
+        img_re = re.compile(r"<img\s.*?src=(?:'|\")([^'\">]+)(?:'|\").*?\/?>")
+
+        cleaned = br_re.sub("\n", md)
+        cleaned = img_re.sub("[html tag removed]", cleaned)
+
+        return cleaned
 
     def set_resource(self, resource_url: str, image: Optional[QtGui.QImage]):
         """Once a resource has been fetched (or the fetch has failed), this method should be used to inform the widget


### PR DESCRIPTION
Fixes #12825. Even with "GitHub flavored Markdown" enabled, Qt's Markdown processor chokes on some HTML tags. This small method removes the tags that are known to break rendering. It may be extended in the future to do a more intelligent replacement.