### PR TITLE
Addon Manager: Fix README fetch for macros

### DIFF
--- a/src/Mod/AddonManager/addonmanager_package_details_controller.py
+++ b/src/Mod/AddonManager/addonmanager_package_details_controller.py
@@ -267,3 +267,6 @@ class PackageDetailsController(QtCore.QObject):
     def display_repo_status(self, addon):
         self.update_status.emit(self.addon)
         self.show_repo(self.addon)
+
+    def macro_readme_updated(self):
+        self.show_repo(self.addon)

--- a/src/Mod/AddonManager/addonmanager_readme_controller.py
+++ b/src/Mod/AddonManager/addonmanager_readme_controller.py
@@ -74,6 +74,14 @@ class ReadmeController(QtCore.QObject):
             self.url = self.addon.macro.wiki
             if not self.url:
                 self.url = self.addon.macro.url
+            if not self.url:
+                self.widget.setText(
+                    translate(
+                        "AddonsInstaller",
+                        "Loading info for {} from the FreeCAD Macro Recipes wiki...",
+                    ).format(self.addon.display_name, self.url)
+                )
+                return
         else:
             self.url = utils.get_readme_url(repo)
         self.widget.setUrl(self.url)


### PR DESCRIPTION
When no macro metadata is downloaded, the macro has no URL yet. Fixes #12724 