### PR TITLE
Part: Fix crash in AttachEngine3D::calculateAttachedPlacement

### DIFF
--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -346,7 +346,7 @@ public://helper functions that may be useful outside of the class
 
     static eRefType getRefTypeByName(const std::string &typeName);
 
-    static GProp_GProps getInertialPropsOfShape(const std::vector<const TopoDS_Shape*> &shapes);
+    static GProp_GProps getInertialPropsOfShape(const std::vector<TopoDS_Shape> &shapes);
 
     /**
      * @brief verifyReferencesAreSafe: checks if pointers in references still
@@ -406,7 +406,7 @@ protected:
         return ret;
     }
     static void readLinks(const App::PropertyLinkSubList &references, std::vector<App::GeoFeature *> &geofs,
-                          std::vector<const TopoDS_Shape*>& shapes, std::vector<TopoDS_Shape> &storage,
+                          std::vector<TopoDS_Shape>& shapes, std::vector<TopoDS_Shape> &storage,
                           std::vector<eRefType> &types);
 
     static void throwWrongMode(eMapMode mmode);


### PR DESCRIPTION
See: https://forum.freecad.org/viewtopic.php?t=85902

The commit cd0d58cfe9 caused a regression by storing the address of a temporary object inside a vector. Accessing them in the calling instance afterwards causes undefined behaviour.