### PR TITLE
App: Fix segmentation fault while dragging object

### DIFF
--- a/src/App/GroupExtension.h
+++ b/src/App/GroupExtension.h
@@ -147,6 +147,7 @@ public:
  
     //override the documentobjectextension functions to make them available in python 
     bool allowObject(DocumentObject* obj)  override {
+        Base::PyGILStateLocker locker;
         Py::Object pyobj = Py::asObject(obj->getPyObject());
         EXTENSION_PROXY_ONEARG(allowObject, pyobj);
                 


### PR DESCRIPTION
For more details see: https://forum.freecad.org/viewtopic.php?t=86001

The reason of the crash is that the GIL is not locked while accessing certain Python functions