### PR TITLE
Remove placeholder title from PROBLEM_REPORT.yml issue report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml
@@ -1,6 +1,5 @@
 name: Report a Problem
 description: Have you found something that does not work well, is too hard to do or is missing altogether? Please create a Problem Report.
-title: "Replace with a concise issue title"
 labels: ["needs triage"]
 body:
   - type: checkboxes


### PR DESCRIPTION
Removes optional title key from the issue template on the FreeCAD GitHub project. The intention is to avoid having to include a placeholder issue title. This has two benefits:

1. Fix the current inconsistency of having a template that refers to the submission as a "Problem" and its description referring to it as an "Issue". E.g. `name: Report a Problem` (used also in the template chooser), `title: "Replace with a concise issue title"`
2. Save the reporters the step of selecting the `title: "Replace with a concise issue title"` placeholder string and deleting it before writing their issue title. If the string were selected by default,  it'd make it easier. But it's not, as far as I can tell.

This also avoids the `title must be of type String and cannot be empty. ` error that popped up after https://github.com/FreeCAD/FreeCAD/pull/12854 and was then fixed on https://github.com/FreeCAD/FreeCAD/pull/12855

I've tested this on my fork  before submitting the PR:

1. https://github.com/furgo16/FreeCAD/blob/title-removed/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml => `title` key removed: it works, [issues can be reported as expected](https://github.com/furgo16/FreeCAD/issues/2) (they've been activated on that fork for testing purposes). This is essentially this PR.
   ![title-removed](https://github.com/FreeCAD/FreeCAD/assets/148809153/5a06c302-e1f5-49e5-a32e-e64c3b250213)
1. https://github.com/furgo16/FreeCAD/blob/title-empty/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml => `title` key present, with empty string. It shows an error, prevents issues from being submitted. This branch can be discarded, it's just there for illustration purposes.
   ![title-empty](https://github.com/FreeCAD/FreeCAD/assets/148809153/737e08ae-ace1-4111-a957-79952ba42f1f)

## References

1. [`title` key cannot be empty](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#key-must-be-a-string): 
   > Empty strings, or strings consisting of only whitespaces, are also not permissible when the field expects a string.
1. [`title` key is optional and expects a string value](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax)