### PR TITLE
Fix segmentation fault in Sketcher

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3358,7 +3358,10 @@ void ViewProviderSketch::camSensCB(void* data, SoSensor*)
     auto vp = proxyVPrdr->vp;
     auto cam = proxyVPrdr->renderMgr->getCamera();
 
-    vp->onCameraChanged(cam);
+    if (cam == nullptr)
+        Base::Console().DeveloperWarning("ViewProviderSketch", "Camera is nullptr!\n");
+    else
+        vp->onCameraChanged(cam);
 }
 
 void ViewProviderSketch::onCameraChanged(SoCamera* cam)


### PR DESCRIPTION
Closes #11954. 

- [This topic](https://forum.freecad.org/viewtopic.php?t=72796) has similar backtrace and reproduction steps, however, the user did not create an issue on Github.
- [This issue comment](https://github.com/FreeCAD/FreeCAD/issues/9198#issuecomment-1763448152) also has the same backtrace, but no separate issue has been created.

`proxyVPrdr->renderMgr->getCamera()` returns `nullptr` and then this `nullptr` is fed to `vp->onCameraChanged(cam)` causing segmentation fault.

This commit checks if camera is `nullptr` and shows a warning instead of crashing.


<details><summary>Screenshot</summary>


![KUbuntu 64-bit-2024-03-11-18-54-26](https://github.com/FreeCAD/FreeCAD/assets/9303235/2df6e934-668a-4ef4-81be-6b331c8b1581)


</details>