### PR TITLE
UI/UX: Create a toolbar command group for default views

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1634,6 +1634,40 @@ bool StdCmdViewFitSelection::isActive()
 }
 
 //===========================================================================
+// Std_ViewCommandGroup
+//===========================================================================
+class StdCmdViewGroup: public Gui::GroupCommand
+{
+public:
+    StdCmdViewGroup()
+        : GroupCommand("Std_ViewGroup")
+    {
+        sGroup = "Standard-View";
+        sMenuText = QT_TR_NOOP("Standard views");
+        sToolTipText = QT_TR_NOOP("Change to a standard view");
+        sStatusTip = QT_TR_NOOP("Change to a standard view");
+        sWhatsThis = "Std_ViewGroup";
+        sPixmap = "view-isometric";
+        eType = Alter3DView;
+
+        setCheckable(false);
+        setRememberLast(true);
+
+        addCommand("Std_ViewIsometric");
+        addCommand("Std_ViewFront");
+        addCommand("Std_ViewRight");
+        addCommand("Std_ViewRear");
+        addCommand("Std_ViewBottom");
+        addCommand("Std_ViewLeft");
+    }
+
+    const char* className() const override
+    {
+        return "StdCmdViewGroup";
+    }
+};
+
+//===========================================================================
 // Std_ViewDock
 //===========================================================================
 DEF_STD_CMD_A(StdViewDock)
@@ -4180,6 +4214,7 @@ void CreateViewStdCommands()
     rcCmdMgr.addCommand(new StdCmdViewRotateRight());
     rcCmdMgr.addCommand(new StdStoreWorkingView());
     rcCmdMgr.addCommand(new StdRecallWorkingView());
+    rcCmdMgr.addCommand(new StdCmdViewGroup());
 
     rcCmdMgr.addCommand(new StdCmdViewExample1());
     rcCmdMgr.addCommand(new StdCmdViewExample2());

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -538,6 +538,7 @@ std::list<std::string> Workbench::listCommandbars() const
     qApp->translate("Workbench", "Workbench");
     qApp->translate("Workbench", "Structure");
     qApp->translate("Workbench", "Standard views");
+    qApp->translate("Workbench", "Individual views");
     qApp->translate("Workbench", "Axonometric");
     qApp->translate("Workbench", "&Stereo");
     qApp->translate("Workbench", "&Zoom");
@@ -661,7 +662,7 @@ MenuItem* StdWorkbench::setupMenuBar() const
     stdviews->setCommand("Standard views");
     *stdviews << "Std_ViewFitAll" << "Std_ViewFitSelection" << axoviews
               << "Separator" << "Std_ViewHome" << "Std_ViewFront" << "Std_ViewTop"
-              << "Std_ViewRight" << "Separator" << "Std_ViewRear"
+              << "Std_ViewRight" << "Std_ViewRear"
               << "Std_ViewBottom" << "Std_ViewLeft"
               << "Separator" << "Std_ViewRotateLeft" << "Std_ViewRotateRight"
               << "Separator" << "Std_StoreWorkingView" << "Std_RecallWorkingView";
@@ -812,11 +813,20 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // View
     auto view = new ToolBarItem( root );
     view->setCommand("View");
-    *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewIsometric"
-          << "Std_ViewFront"<< "Std_ViewTop" << "Std_ViewRight"
-          << "Std_ViewRear" << "Std_ViewBottom"<< "Std_ViewLeft"
+    *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewGroup"
           << "Separator" << "Std_DrawStyle" << "Std_TreeViewActions"
           << "Separator" << "Std_MeasureDistance";
+
+    // Individual views
+    auto individualViews = new ToolBarItem(root, ToolBarItem::DefaultVisibility::Hidden);
+    individualViews->setCommand("Individual views");
+    *individualViews << "Std_ViewIsometric"
+                     << "Std_ViewFront"
+                     << "Std_ViewRight"
+                     << "Std_ViewTop"
+                     << "Std_ViewRear"
+                     << "Std_ViewLeft"
+                     << "Std_ViewBottom";
 
     // Structure
     auto structure = new ToolBarItem( root );
@@ -827,7 +837,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     auto help = new ToolBarItem( root );
     help->setCommand("Help");
     *help << "Std_WhatsThis";
-    
+
     return root;
 }
 
@@ -839,7 +849,7 @@ ToolBarItem* StdWorkbench::setupCommandBars() const
     auto view = new ToolBarItem( root );
     view->setCommand("Standard views");
     *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewIsometric" << "Separator"
-          << "Std_ViewFront" << "Std_ViewRight" << "Std_ViewTop" << "Separator"
+          << "Std_ViewFront" << "Std_ViewRight" << "Std_ViewTop"
           << "Std_ViewRear" << "Std_ViewLeft" << "Std_ViewBottom";
 
     // Special Ops


### PR DESCRIPTION
fixes #12864 
This PR creates a grouped command button in the toolbar for all the default views (more in the issue). It is enabled by default.
All previously visible individual view buttons are available as a separate toolbar and can be easily enabled.

Previously (too much space):
![311622404-09b9f26f-b6cc-4388-b09c-5da9a0308b13](https://github.com/FreeCAD/FreeCAD/assets/6246609/1a4e08ad-ee88-432f-a83d-14302144be66)

With this PR:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/004eaa59-2cf0-440a-a743-91a500771399)
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/91ff89b1-7e51-4972-b4c8-5d81c4344df9)

Optionally all current individual toolbar buttons for the 7 views are still available:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/bf9ec93d-f563-440c-bc52-d7a8113ebc30)
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/51551fd6-73e0-4b1a-a46e-3fd2ed5b7512)
