### PR TITLE
Relabel Path to CAM in GitHub template and label action

### DIFF
--- a/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml
@@ -34,6 +34,7 @@ body:
         - Addon Manager
         - Arch
         - Assembly
+        - CAM/Path
         - Core
         - Draft
         - Expressions
@@ -43,7 +44,6 @@ body:
         - OpenSCAD
         - Part
         - PartDesign
-        - Path
         - Project Tools & Websites
         - Sketcher
         - Spreadsheet

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -40,8 +40,8 @@ WB Part:
 WB PartDesign:
 - 'src/Mod/PartDesign/**/*'
 
-WB Path:
-- 'src/Mod/Path/**/*'
+WB CAM:
+- 'src/Mod/CAM/**/*'
 
 WB Points:
 - 'src/Mod/Points/**/*'


### PR DESCRIPTION
- Change label from `WB Path` to `WB CAM` --> already done
- Change label action to apply new label and change folder name to look for
- Change issue template to have CAM in the dropdown. Path is kept as it is still called Path in the stable release. New would be `CAM/Path`