### PR TITLE
Addon Manager: Fix relative external links

### DIFF
--- a/src/Mod/AddonManager/Widgets/addonmanager_widget_readme_browser.py
+++ b/src/Mod/AddonManager/Widgets/addonmanager_widget_readme_browser.py
@@ -49,6 +49,7 @@ class WidgetReadmeBrowser(QtWidgets.QTextBrowser):
     correctly."""
 
     load_resource = QtCore.Signal(str)  # Str is a URL to a resource
+    follow_link = QtCore.Signal(str)  # Str is a URL to another page
 
     def __init__(self, parent: QtWidgets.QWidget = None):
         super().__init__(parent)
@@ -108,6 +109,12 @@ class WidgetReadmeBrowser(QtWidgets.QTextBrowser):
                 self.load_resource.emit(full_url)
                 self.image_map[full_url] = None
             return self.image_map[full_url]
+        elif resource_type == QtGui.QTextDocument.MarkdownResource:
+            self.follow_link.emit(name.toString())
+            return self.toMarkdown()
+        elif resource_type == QtGui.QTextDocument.HtmlResource:
+            self.follow_link.emit(name.toString())
+            return self.toHtml()
         return super().loadResource(resource_type, name)
 
     def _ensure_appropriate_width(self, image: QtGui.QImage) -> QtGui.QImage:

--- a/src/Mod/AddonManager/addonmanager_readme_controller.py
+++ b/src/Mod/AddonManager/addonmanager_readme_controller.py
@@ -63,6 +63,7 @@ class ReadmeController(QtCore.QObject):
         self.stop = True
         self.widget = widget
         self.widget.load_resource.connect(self.loadResource)
+        self.widget.follow_link.connect(self.follow_link)
 
     def set_addon(self, repo: Addon):
         """Set which Addon's information is displayed"""
@@ -152,6 +153,16 @@ class ReadmeController(QtCore.QObject):
             NetworkManager.AM_NETWORK_MANAGER.abort(request)
         self.resource_requests.clear()
 
+    def follow_link(self, url: str) -> None:
+        final_url = url
+        if not url.startswith("http"):
+            if url.endswith(".md"):
+                final_url = self._create_markdown_url(url)
+            else:
+                final_url = self._create_full_url(url)
+        FreeCAD.Console.PrintLog(f"Loading {final_url} in the system browser")
+        QtGui.QDesktopServices.openUrl(final_url)
+
     def _create_full_url(self, url: str) -> str:
         if url.startswith("http"):
             return url
@@ -159,6 +170,11 @@ class ReadmeController(QtCore.QObject):
             return url
         lhs, slash, _ = self.url.rpartition("/")
         return lhs + slash + url
+
+    def _create_markdown_url(self, file: str) -> str:
+        base_url = utils.get_readme_html_url(self.addon)
+        lhs, slash, _ = base_url.rpartition("/")
+        return lhs + slash + file
 
 
 class WikiCleaner(HTMLParser):


### PR DESCRIPTION
External links to relative files were not being followed because Qt had no way of knowing how to get to the file. Complicating matters, for links to markdown files we don't want the "raw" page (showing the markdown) to be the thing loaded in your browser, we want the rendered version. Fixes #12832.