### PR TITLE
TechDraw: Add space before tolerance class for hole/shaft fits

### DIFF
--- a/src/Mod/TechDraw/TechDrawTools/TaskHoleShaftFit.py
+++ b/src/Mod/TechDraw/TechDrawTools/TaskHoleShaftFit.py
@@ -114,7 +114,7 @@ class TaskHoleShaftFit:
         iso.calculate(value,fieldChar,quality)
         rangeValues = iso.getValues()
         mainFormat = dim.FormatSpec
-        dim.FormatSpec = mainFormat+selectedField
+        dim.FormatSpec = mainFormat+' '+selectedField
         dim.EqualTolerance = False
         dim.FormatSpecOverTolerance = '(%+.3f)'
         dim.OverTolerance = rangeValues[0]


### PR DESCRIPTION
According to ISO 286 there is supposed to be a space inbetween the nominal size and the tolerance class. This change just adds this space. Fixes #12922 