### PR TITLE
TD: add space between shaft fit value acc. to ISO 286

### DIFF
--- a/src/Mod/TechDraw/TechDrawTools/TaskHoleShaftFit.py
+++ b/src/Mod/TechDraw/TechDrawTools/TaskHoleShaftFit.py
@@ -114,7 +114,7 @@ class TaskHoleShaftFit:
         iso.calculate(value,fieldChar,quality)
         rangeValues = iso.getValues()
         mainFormat = dim.FormatSpec
-        dim.FormatSpec = mainFormat+selectedField
+        dim.FormatSpec = mainFormat+" "+selectedField
         dim.EqualTolerance = False
         dim.FormatSpecOverTolerance = '(%+.3f)'
         dim.OverTolerance = rangeValues[0]


### PR DESCRIPTION
fixes #12922 

Adds a space between the dimension and the shaft fit tolerance indicator, acc. to ISO 286.

before:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/3d4b101a-e747-4c01-acfe-b6f8d21c8b62)

after:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/98c0751e-a30b-4a79-adef-33406de7e4df)
