### PR TITLE
[TD]2 small fixes 

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPy.xml
+++ b/src/Mod/TechDraw/App/DrawViewPy.xml
@@ -20,6 +20,13 @@
         </UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="getScale">
+      <Documentation>
+        <UserDocu>float scale = getScale().  Returns the correct scale for this view.  Handles whether to
+        use this view's scale property or a parent's view (as in a projection group).
+        </UserDocu>
+      </Documentation>
+    </Methode>
    <CustomAttributes />
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/TechDraw/App/DrawViewPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPyImp.cpp
@@ -78,6 +78,19 @@ PyObject* DrawViewPy::translateLabel(PyObject *args)
     Py_Return;
 }
 
+//! return the correct scale for this view
+PyObject* DrawViewPy::getScale(PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+            throw Py::TypeError("Do not understand passed parameter.");
+    }
+
+    DrawView* dv = getDrawViewPtr();
+
+    return PyFloat_FromDouble(dv->getScale());
+}
+
+
 
 PyObject *DrawViewPy::getCustomAttributes(const char* /*attr*/) const
 {

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -829,6 +829,8 @@ void execAngle3Pt(Gui::Command* cmd)
     positionDimText(dim);
 }
 
+
+// TechDraw_LinkDimension is DEPRECATED.  Use TechDraw_DimensionRepair instead.
 //! link 3D geometry to Dimension(s) on a Page
 //TODO: should we present all potential Dimensions from all Pages?
 //===========================================================================

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -92,6 +92,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *dimensions << "TechDraw_3PtAngleDimension";
     *dimensions << "TechDraw_HorizontalExtentDimension";
     *dimensions << "TechDraw_VerticalExtentDimension";
+    // TechDraw_LinkDimension is DEPRECATED.  Use TechDraw_DimensionRepair instead.
     *dimensions << "TechDraw_LinkDimension";
     *dimensions << "TechDraw_LandmarkDimension";
     *dimensions << "TechDraw_DimensionRepair";
@@ -331,7 +332,8 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *dims << "TechDraw_AngleDimension";
     *dims << "TechDraw_3PtAngleDimension";
     *dims << "TechDraw_ExtentGroup";
-    *dims << "TechDraw_LinkDimension";
+    // TechDraw_LinkDimension is DEPRECATED.  Use TechDraw_DimensionRepair instead.
+    // *dims << "TechDraw_LinkDimension";
     *dims << "TechDraw_Balloon";
     *dims << "TechDraw_AxoLengthDimension";
     *dims << "TechDraw_LandmarkDimension";
@@ -444,6 +446,7 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *dims << "TechDraw_AngleDimension";
     *dims << "TechDraw_3PtAngleDimension";
     *dims << "TechDraw_ExtentGroup";
+    // TechDraw_LinkDimension is DEPRECATED.  Use TechDraw_DimensionRepair instead.
     *dims << "TechDraw_LinkDimension";
     *dims << "TechDraw_Balloon";
     *dims << "TechDraw_AxoLengthDimension";


### PR DESCRIPTION
This PR removes the obsolete Link Dimension command from the toolbar (but not the menu) and exposes DrawView::getScale to Python.