### PR TITLE
Arch: Fixed bug in BuildingPart obj

### DIFF
--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -497,7 +497,7 @@ class BuildingPart(ArchIFC.IfcProduct):
                     FreeCAD.Console.PrintLog("Auto-updating Height of "+child.Name+"\n")
                     self.touchChildren(child)
                     child.Proxy.execute(child)
-            elif Draft.getType(child) in ["Group","BuildingPart"]:
+            elif Draft.getType(child) in ["App::DocumentObjectGroup","Group","BuildingPart"]:
                 self.touchChildren(child)
 
 


### PR DESCRIPTION
Fixes #12921.

just find out the reason.   
if you use the Draft.getType() on a group folder
it will not return "Group"  but "App::DocumentObjectGroup"

so I just add `App::DocumentObjectGroup` in the condition list
problem solved
