### PR TITLE
Material: Removes localization from the material card dictionary

### DIFF
--- a/src/Mod/Material/App/MaterialPyImpl.cpp
+++ b/src/Mod/Material/App/MaterialPyImpl.cpp
@@ -303,7 +303,7 @@ Py::Dict MaterialPy::getProperties() const
         auto materialProperty = it->second;
 
         if (!materialProperty->isNull()) {
-            auto value = materialProperty->getString();
+            auto value = materialProperty->getDictionaryString();
             dict.setItem(Py::String(key.toStdString()), Py::String(value.toStdString()));
         }
     }
@@ -314,7 +314,7 @@ Py::Dict MaterialPy::getProperties() const
         auto materialProperty = it->second;
 
         if (!materialProperty->isNull()) {
-            auto value = materialProperty->getString();
+            auto value = materialProperty->getDictionaryString();
             dict.setItem(Py::String(key.toStdString()), Py::String(value.toStdString()));
         }
     }
@@ -332,7 +332,7 @@ Py::Dict MaterialPy::getPhysicalProperties() const
         auto materialProperty = it->second;
 
         if (!materialProperty->isNull()) {
-            auto value = materialProperty->getString();
+            auto value = materialProperty->getDictionaryString();
             dict.setItem(Py::String(key.toStdString()), Py::String(value.toStdString()));
         }
     }
@@ -350,7 +350,7 @@ Py::Dict MaterialPy::getAppearanceProperties() const
         auto materialProperty = it->second;
 
         if (!materialProperty->isNull()) {
-            auto value = materialProperty->getString();
+            auto value = materialProperty->getDictionaryString();
             dict.setItem(Py::String(key.toStdString()), Py::String(value.toStdString()));
         }
     }

--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -118,6 +118,8 @@ std::shared_ptr<MaterialValue> MaterialProperty::getMaterialValue() const
 
 QString MaterialProperty::getString() const
 {
+    // This method produces a localized string. For a non-localized string use
+    // getDictionaryString()
     if (isNull()) {
         return {};
     }
@@ -130,7 +132,7 @@ QString MaterialProperty::getString() const
         if (value.isNull()) {
             return {};
         }
-        return QString(QString::fromStdString("%1")).arg(value.toFloat(), 0, 'g', PRECISION);
+        return QString(QLatin1String("%L1")).arg(value.toFloat(), 0, 'g', PRECISION);
     }
     return getValue().toString();
 }
@@ -138,6 +140,30 @@ QString MaterialProperty::getString() const
 QString MaterialProperty::getYAMLString() const
 {
     return _valuePtr->getYAMLString();
+}
+
+QString MaterialProperty::getDictionaryString() const
+{
+    // This method produces a non-localized string. For a localized string use
+    // getString()
+    if (isNull()) {
+        return {};
+    }
+    if (getType() == MaterialValue::Quantity) {
+        auto quantity = getValue().value<Base::Quantity>();
+        auto string = QString(QLatin1String("%1 %2"))
+                          .arg(quantity.getValue(), 0, 'g', PRECISION)
+                          .arg(quantity.getUnit().getString());
+        return string;
+    }
+    if (getType() == MaterialValue::Float) {
+        auto value = getValue();
+        if (value.isNull()) {
+            return {};
+        }
+        return QString(QLatin1String("%1")).arg(value.toFloat(), 0, 'g', PRECISION);
+    }
+    return getValue().toString();
 }
 
 void MaterialProperty::setPropertyType(const QString& type)
@@ -449,7 +475,7 @@ QString Material::getAuthorAndLicense() const
     if (!_author.isNull()) {
         authorAndLicense = _author;
         if (!_license.isNull()) {
-            authorAndLicense += QString::fromStdString(" ") + _license;
+            authorAndLicense += QLatin1String(" ") + _license;
         }
     }
     else if (!_license.isNull()) {
@@ -925,7 +951,7 @@ Material::getValueString(const std::map<QString, std::shared_ptr<MaterialPropert
             if (value.isNull()) {
                 return {};
             }
-            return QString(QString::fromStdString("%1"))
+            return QString(QLatin1String("%L1"))
                 .arg(value.toFloat(), 0, 'g', MaterialProperty::PRECISION);
         }
         return property->getValue().toString();

--- a/src/Mod/Material/App/Materials.h
+++ b/src/Mod/Material/App/Materials.h
@@ -78,6 +78,7 @@ public:
     std::shared_ptr<MaterialValue> getMaterialValue() const;
     QString getString() const;
     QString getYAMLString() const;
+    QString getDictionaryString() const;  // Non-localized string
     bool getBoolean() const;
     int getInt() const;
     double getFloat() const;

--- a/src/Mod/Material/materialtests/TestMaterials.py
+++ b/src/Mod/Material/materialtests/TestMaterials.py
@@ -170,19 +170,19 @@ class MaterialTestCases(unittest.TestCase):
         self.assertTrue(len(properties["SpecularColor"]) > 0)
         self.assertTrue(len(properties["Transparency"]) > 0)
 
-        self.assertEqual(properties["Density"],
+        self.assertEqual(parseQuantity(properties["Density"]).UserString,
                          parseQuantity("7900.00 kg/m^3").UserString)
         # self.assertEqual(properties["BulkModulus"], "")
         self.assertAlmostEqual(parseQuantity(properties["PoissonRatio"]).Value,
                                parseQuantity("0.3").Value)
-        self.assertEqual(properties["YoungsModulus"],
+        self.assertEqual(parseQuantity(properties["YoungsModulus"]).UserString,
                          parseQuantity("210.00 GPa").UserString)
         # self.assertEqual(properties["ShearModulus"], "")
-        self.assertEqual(properties["SpecificHeat"],
+        self.assertEqual(parseQuantity(properties["SpecificHeat"]).UserString,
                          parseQuantity("590.00 J/kg/K").UserString)
-        self.assertEqual(properties["ThermalConductivity"],
+        self.assertEqual(parseQuantity(properties["ThermalConductivity"]).UserString,
                          parseQuantity("43.00 W/m/K").UserString)
-        self.assertEqual(properties["ThermalExpansionCoefficient"],
+        self.assertEqual(parseQuantity(properties["ThermalExpansionCoefficient"]).UserString,
                          parseQuantity("12.00 µm/m/K").UserString)
         self.assertEqual(properties["AmbientColor"], "(0.0020, 0.0020, 0.0020, 1.0)")
         self.assertEqual(properties["DiffuseColor"], "(0.0000, 0.0000, 0.0000, 1.0)")


### PR DESCRIPTION
Fixes #12935

The previous card implementation transferred strings directly to the card dictionary without interpretation. The new material system parses the file data, producing a dictionary for compatibility. The new dictionaries localized the strings which is incorrect. This PR removes that localization.