### PR TITLE
[TechDraw] Unify Projection Group parent linking

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
@@ -181,14 +181,7 @@ void DrawProjGroupItem::onDocumentRestored()
 
 DrawProjGroup* DrawProjGroupItem::getPGroup() const
 {
-    std::vector<App::DocumentObject*> parent = getInList();
-    for (std::vector<App::DocumentObject*>::iterator it = parent.begin(); it != parent.end(); ++it) {
-        if ((*it)->isDerivedFrom<DrawProjGroup>()) {
-            DrawProjGroup* result = dynamic_cast<TechDraw::DrawProjGroup *>(*it);
-            return result;
-        }
-    }
-    return nullptr;
+    return dynamic_cast<DrawProjGroup *>(getCollection());
 }
 
 bool DrawProjGroupItem::isAnchor(void) const

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -409,10 +409,14 @@ DrawView *DrawView::claimParent() const
 {
     App::PropertyLink *ownerProp = const_cast<DrawView *>(this)->getOwnerProperty();
     if (ownerProp) {
-        return dynamic_cast<DrawView *>(ownerProp->getValue());
+        auto ownerView = dynamic_cast<DrawView *>(ownerProp->getValue());
+        if (ownerView) {
+            return ownerView;
+        }
     }
 
-    return nullptr;
+    // If there is no parent view we are aware of, return the view collection we may belong to
+    return getCollection();
 }
 
 DrawViewClip* DrawView::getClipGroup()
@@ -427,6 +431,19 @@ DrawViewClip* DrawView::getClipGroup()
 
         }
     }
+    return nullptr;
+}
+
+DrawViewCollection *DrawView::getCollection() const
+{
+    std::vector<App::DocumentObject *> parents = getInList();
+    for (auto it = parents.begin(); it != parents.end(); ++it) {
+        auto parentCollection = dynamic_cast<DrawViewCollection *>(*it);
+        if (parentCollection) {
+            return parentCollection;
+        }
+    }
+
     return nullptr;
 }
 

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -37,6 +37,7 @@ namespace TechDraw
 {
 
 class DrawPage;
+class DrawViewCollection;
 class DrawViewClip;
 class DrawLeaderLine;
 /*class CosmeticVertex;*/
@@ -74,6 +75,7 @@ public:
 
     bool isInClip();
     DrawViewClip* getClipGroup();
+    DrawViewCollection *getCollection() const;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override {

--- a/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
@@ -103,7 +103,6 @@ QVariant QGIProjGroup::itemChange(GraphicsItemChange change, const QVariant &val
                 QString type = QString::fromLatin1(projItemPtr->Type.getValueAsString());
 
                 if (type == QString::fromLatin1("Front")) {
-                    gView->setLocked(true);                  //this locks in GUI only
                     gView->alignTo(m_origin, QString::fromLatin1("None"));
                     installSceneEventFilter(gView);
                 } else if ( type == QString::fromLatin1("Top") ||

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -69,7 +69,6 @@ const float labelCaptionFudge = 0.2f;   // temp fiddle for devel
 QGIView::QGIView()
     :QGraphicsItemGroup(),
      viewObj(nullptr),
-     m_locked(false),
      m_innerView(false),
      m_multiselectActivated(false)
 {
@@ -157,15 +156,8 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
 //    Base::Console().Message("QGIV::itemChange(%d)\n", change);
     if(change == ItemPositionChange && scene()) {
         newPos = value.toPointF();            //position within parent!
-        if(m_locked){
-            // ignore position change for locked items
-            newPos.setX(pos().x());
-            newPos.setY(pos().y());
-            return newPos;
-        }
 
         TechDraw::DrawView *viewObj = getViewObject();
-
         if (viewObj->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())) {
             // restrict movements of secondary views.
             TechDraw::DrawProjGroupItem* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(viewObj);

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -122,9 +122,7 @@ public:
     void isInnerView(bool state) { m_innerView = state; }
     QGIViewClip* getClipGroup();
 
-
     void alignTo(QGraphicsItem*, const QString &alignment);
-    void setLocked(bool isLocked) { m_locked = isLocked; }
 
     QColor prefNormalColor(); //preference
     QColor getNormalColor() { return m_colNormal; }  //current setting
@@ -180,7 +178,6 @@ private:
     std::string viewName;
 
     QHash<QString, QGraphicsItem*> alignHash;
-    bool m_locked;
     bool m_innerView;                                                  //View is inside another View
     bool m_multiselectActivated;
 

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -257,16 +257,6 @@ int QGSPage::addQView(QGIView* view)
         // Find if it belongs to a parent
         QGIView *parent = findParent(view);
         if (parent) {
-            auto parentDocObj = parent->getViewObject();
-            auto parentDPG = dynamic_cast<TechDraw::DrawProjGroup*>(parentDocObj);
-            if (parentDPG) {
-                // move the DPGI to the center of the DPG.  the DPGI must be placed in the
-                // correct position on the page before adding it to the DPG or it will be
-                // placed at scene(0,0).
-                QPointF posRef(0., 0.);
-                QPointF mapPos = view->mapToItem(parent, posRef);
-                view->moveBy(-mapPos.x(), -mapPos.y());
-            }
             parent->addToGroup(view);
         }
         view->setPos(viewPos);
@@ -744,24 +734,6 @@ QGIView* QGSPage::findParent(QGIView* view) const
         }
     }
 
-    // Check if part of view collection
-    for (std::vector<QGIView*>::const_iterator it = qviews.begin(); it != qviews.end(); ++it) {
-        QGIViewCollection* grp = nullptr;
-        grp = dynamic_cast<QGIViewCollection*>(*it);
-        if (grp) {
-            TechDraw::DrawViewCollection* collection = nullptr;
-            collection = dynamic_cast<TechDraw::DrawViewCollection*>(grp->getViewObject());
-            if (collection) {
-                std::vector<App::DocumentObject*> objs = collection->Views.getValues();
-                for (std::vector<App::DocumentObject*>::iterator it = objs.begin();
-                     it != objs.end(); ++it) {
-                    if (strcmp(myFeat->getNameInDocument(), (*it)->getNameInDocument()) == 0)
-
-                        return grp;
-                }
-            }
-        }
-    }
     // Not found a parent
     return nullptr;
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -388,8 +388,7 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
     }
 
     // Collect any child views
-    // for Page, valid children are any View except: DrawProjGroupItem
-    //                                               DrawViewDimension
+    // for Page, valid children are any View except: DrawViewDimension
     //                                               DrawViewBalloon
     //                                               any FeatuerView in a DrawViewClip
     //                                               DrawHatch
@@ -407,9 +406,8 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
             }
 
             App::DocumentObject* docObj = *it;
-            // Don't collect if dimension, projection group item, hatch or member of ClipGroup as these should be grouped elsewhere
-            if (docObj->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())
-                || docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())
+            // Don't collect if dimension, balloon, hatch or member of ClipGroup as these should be grouped elsewhere
+            if (docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())
                 || docObj->isDerivedFrom(TechDraw::DrawHatch::getClassTypeId())
                 || docObj->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId())
                 || (featView && featView->isInClip()))


### PR DESCRIPTION
This pull request follows with converting the parent handling code on common infrastructure (see #12812 for details). This time there is no owner/parent property which could be changed by the user, but still the code can benefit from the transition.

As a part of the refactoring effort, I have removed the explicit position locking on the QGIView level. It was used only for DrawProjectionGroupItem and with the QGIView's setFlag(ItemIsMovable, !isLocked) in updateView() it was just duplicating already existing functionality with rather unfortunate consequences.

I believe this pull request does not introduce any regressions, but in spite of my testing this can still happen. In such a case please let me know, so I can fix them.