### PR TITLE
FEM: Add two missing PreCompiled.h includes

### DIFF
--- a/src/Mod/Fem/Gui/PreCompiled.h
+++ b/src/Mod/Fem/Gui/PreCompiled.h
@@ -115,6 +115,7 @@
 #include <Inventor/nodes/SoCoordinate3.h>
 #include <Inventor/nodes/SoCube.h>
 #include <Inventor/nodes/SoCylinder.h>
+#include <Inventor/nodes/SoDepthBuffer.h>
 #include <Inventor/nodes/SoDrawStyle.h>
 #include <Inventor/nodes/SoEventCallback.h>
 #include <Inventor/nodes/SoFont.h>
@@ -144,6 +145,8 @@
 #include <Inventor/nodes/SoText3.h>
 #include <Inventor/nodes/SoTransform.h>
 #include <Inventor/nodes/SoTranslation.h>
+#include <Inventor/nodes/SoTransparencyType.h>
+
 
 // Salomesh
 #include <SMDSAbs_ElementType.hxx>


### PR DESCRIPTION
A couple of missing `Inventor/nodes` includes.