### PR TITLE
[TD] AxoLengthDimension: use getScale() instead of Scale

### DIFF
--- a/src/Mod/TechDraw/TechDrawTools/CommandAxoLengthDimension.py
+++ b/src/Mod/TechDraw/TechDrawTools/CommandAxoLengthDimension.py
@@ -71,7 +71,7 @@ class CommandAxoLengthDimension:
             vertexes.append(edges[0].Vertexes[1])
             
         view = Utils.getSelView()
-        scale = view.Scale
+        scale = view.getScale()
 
         StartPt, EndPt = edges[1].Vertexes[0].Point, edges[1].Vertexes[1].Point
         extLineVec = EndPt.sub(StartPt)


### PR DESCRIPTION
Use new function getScale() instead of Scale property to receive the scale of the selected view.