### PR TITLE
Move macos CI to arm

### DIFF
--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -39,18 +39,17 @@ jobs:
     with:
       artifactBasename: Prepare-${{ github.run_id }}
 
-  # GA in Jan-Mar 2024 Timeframe: https://github.com/actions/runner-images/issues/8439#issuecomment-1755601587
-  # MacOS_13_Conda_Apple:
-  #   needs: [Prepare]
-  #   uses: ./.github/workflows/sub_buildMacOSCondaApple.yml
-  #   with:
-  #     artifactBasename: MacOS_13_Conda_Apple-${{ github.run_id }}
-
-  MacOS_13_Conda_Intel:
+  MacOS_13_Conda_Apple:
     needs: [Prepare]
-    uses: ./.github/workflows/sub_buildMacOSCondaIntel.yml
+    uses: ./.github/workflows/sub_buildMacOSCondaApple.yml
     with:
-      artifactBasename: MacOS_13_Conda_Intel-${{ github.run_id }}
+      artifactBasename: MacOS_13_Conda_Apple-${{ github.run_id }}
+
+#  MacOS_13_Conda_Intel:
+#    needs: [Prepare]
+#    uses: ./.github/workflows/sub_buildMacOSCondaIntel.yml
+#    with:
+#      artifactBasename: MacOS_13_Conda_Intel-${{ github.run_id }}
 
   Ubuntu_20-04:
     needs: [Prepare]
@@ -88,8 +87,8 @@ jobs:
   WrapUp:
     needs: [
         Prepare,
-        # MacOS_13_Conda_Apple,
-        MacOS_13_Conda_Intel,
+        MacOS_13_Conda_Apple,
+        # MacOS_13_Conda_Intel,
         Ubuntu_20-04,
         Ubuntu_22-04_Conda,
         Windows,

--- a/.github/workflows/sub_buildMacOSCondaApple.yml
+++ b/.github/workflows/sub_buildMacOSCondaApple.yml
@@ -45,7 +45,7 @@ on:
 
 jobs:
   Build:
-    runs-on: macos-13-xlarge
+    runs-on: macos-14
     continue-on-error: ${{ inputs.allowedToFail }}
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache


### PR DESCRIPTION
Github's Mac M1 runners are now available to the public, I think it's more relevant to test there than on intel for mac (plus I think those runners are more powerful). And who knows, maybe those fake failures on mac will go away

@oursland would you have any idea why one of the tests fails here?