### PR TITLE
Update sub_wrapup.yml

### DIFF
--- a/.github/workflows/sub_wrapup.yml
+++ b/.github/workflows/sub_wrapup.yml
@@ -111,7 +111,7 @@ jobs:
           cat report.md >> $GITHUB_STEP_SUMMARY
       - name: Delete used artifacts
         continue-on-error: true
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v5
         with:
           name: |
             ${{ env.usedArtifacts }}


### PR DESCRIPTION
update geekyeggo/delete-artifact to v5
v5.0
Switch to actions/artifact, removing the need for a token parameter 
Add default token.
Fix over-arching catch output; errors now correctly result in a failed run  
v4.0
Add support for artifacts uploaded with actions/upload-artifactv4.
Add requirement of token with read and write access to actions.
Update requests to use GitHub REST API.
Deprecate support for actions/upload-artifactv1, actions/upload-artifactv2, and actions/upload-artifact@v3