### PR TITLE
Part Design: add missing commands to tree context menu

### DIFF
--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -237,13 +237,20 @@ void Workbench::setupContextMenu(const char* recipient, Gui::MenuItem* item) con
 
             if (Gui::Selection().countObjectsOfType(App::DocumentObject::getClassTypeId()) > 0) {
                 *item << "Std_Placement"
+                      << "Std_ToggleVisibility"
+                      << "Std_ShowSelection"
+                      << "Std_HideSelection"
+                      << "Std_ToggleSelectability"
+                      << "Std_TreeSelectAllInstances"
+                      << "Separator"
                       << "Std_SetAppearance"
                       << "Std_RandomColor"
+                      << "Std_ToggleTransparency"
                       << "Std_Cut"
                       << "Std_Copy"
                       << "Std_Paste"
-                      << "Separator"
-                      << "Std_Delete";
+                      << "Std_Delete"
+                      << "Separator";
             }
         }
     }


### PR DESCRIPTION
fixes https://github.com/FreeCAD/FreeCAD/issues/6043

Adds missing commands to the tree context menu in the Part Design WB to be consistent across WBs.

Previously in PD:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/efe0e551-484c-4b7e-bad9-2440f09fcccb)

Previously in Part:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/0a12cc9b-f78d-4094-a5be-e7693ccf6b15)

With this PR in PD:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/cb6a4249-9ef1-487b-aeb0-9a1a36c1c3ca)


