### PR TITLE
[TD]use weak_ptr as deletion guard in Dimension dialog

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskDimension.h
+++ b/src/Mod/TechDraw/Gui/TaskDimension.h
@@ -23,6 +23,7 @@
 #ifndef GUI_TASKVIEW_TASKDIMENSION_H
 #define GUI_TASKVIEW_TASKDIMENSION_H
 
+#include <Gui/DocumentObserver.h>
 #include <Gui/TaskView/TaskDialog.h>
 #include <Gui/TaskView/TaskView.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
@@ -72,7 +73,7 @@ private Q_SLOTS:
 private:
     std::unique_ptr<Ui_TaskDimension> ui;
     QGIViewDimension *m_parent;
-    ViewProviderDimension *m_dimensionVP;
+    Gui::WeakPtrT<ViewProviderDimension> m_dimensionVP;
     std::pair<double, bool> getAngleFromSelection();
 };
 


### PR DESCRIPTION
This PR is a follow-on to #12966.  It implements the weak_ptr check suggested here: https://forum.freecad.org/viewtopic.php?p=747232#p747232

- prevent crash if dimension deleted by Python while dialog is open