### PR TITLE
Gui: fix several regressions caused by PR #12035

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1260,6 +1260,10 @@ void Application::viewActivated(MDIView* pcView)
 #endif
 
     signalActivateView(pcView);
+    getMainWindow()->setWindowTitle(pcView->buildWindowTitle());
+    if (auto document = pcView->getGuiDocument()) {
+        getMainWindow()->setWindowModified(document->isModified());
+    }
 
     // Set the new active document which is taken of the activated view. If, however,
     // this view is passive we let the currently active document unchanged as we would

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -448,18 +448,11 @@ void MDIView::setCurrentViewMode(ViewMode mode)
     }
 }
 
-QString MDIView::buildWindowTitle()
+QString MDIView::buildWindowTitle() const
 {
     QString windowTitle;
     if (Gui::Document* document = getGuiDocument()) {
-        if (document->isModified()) {
-            getMainWindow()->setWindowModified(TRUE);
-        }
-        else {
-            getMainWindow()->setWindowModified(FALSE);
-        }
-
-        windowTitle.append(QString::fromUtf8(getAppDocument()->getName()));
+        windowTitle.append(QString::fromStdString(getAppDocument()->Label.getStrValue()));
     }
 
     return windowTitle;

--- a/src/Gui/MDIView.h
+++ b/src/Gui/MDIView.h
@@ -75,7 +75,7 @@ public:
     virtual void viewAll();
 
     /// build window title
-    QString buildWindowTitle();
+    QString buildWindowTitle() const;
 
     /// Message handler
     bool onMsg(const char* pMsg,const char** ppReturn) override;


### PR DESCRIPTION
* fix hard crash in MainWindow::_updateActions() if no MDI view exists
* in MDIView::buildWindowTitle() use the label of the document because this changes when saving it while the name is immutable
* fix const correctness in MDIView::buildWindowTitle()
* do not set the modified flag of the main window in MDIView::buildWindowTitle() but in the calling instance
* move setting the main window title to Application::viewActivated to reduce code duplication
* fix missing application name if FreeCADGui is loaded as Python module