### PR TITLE
Sketcher: Improve menu text of Sketcher_MapSketch

### DIFF
--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -549,7 +549,7 @@ CmdSketcherMapSketch::CmdSketcherMapSketch()
 {
     sAppModule = "Sketcher";
     sGroup = "Sketcher";
-    sMenuText = QT_TR_NOOP("Map sketch to face...");
+    sMenuText = QT_TR_NOOP("Attach sketch...");
     sToolTipText = QT_TR_NOOP(
         "Set the 'AttachmentSupport' of a sketch.\n"
         "First select the supporting geometry, for example, a face or an edge of a solid object,\n"


### PR DESCRIPTION
The old menu text of Sketcher_MapSketch did not describe the tool very well. Not just a face can be selected.

"Map sketch to face..." -> "Attach sketch..."

Forum topic:
https://forum.freecad.org/viewtopic.php?t=86112
