### PR TITLE
Fixes #11861: Gui::PrefUnitSpinBox requires restart after unit system…

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsGeneral.h
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.h
@@ -75,6 +75,7 @@ public Q_SLOTS:
     void onUnitSystemIndexChanged(int index);
 
 private:
+    void saveUnitSystemSettings();
     void saveDockWindowVisibility();
     void loadDockWindowVisibility();
     void setRecentFileSize();


### PR DESCRIPTION
… change

This fixes a regression of PR #11266 that dropped the case where neither the option 'Ignore project unit system and use the default' is set nor an active document exists. In this case nothing happens even if the user changed the unit system.