### PR TITLE
TechDraw: Fix drag&drop of views. Add auto-switch to techdraw on double click.

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -38,6 +38,7 @@
 #include <App/DocumentObject.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
+#include <Gui/CommandT.h>
 #include <Gui/Document.h>
 #include <Gui/MainWindow.h>
 #include <Gui/ViewProviderDocumentObject.h>
@@ -262,6 +263,16 @@ void ViewProviderPage::unsetEdit(int ModNum)
 
 bool ViewProviderPage::doubleClicked(void)
 {
+    // assure the TechDraw workbench
+    if (App::GetApplication()
+        .GetUserParameter()
+        .GetGroup("BaseApp")
+        ->GetGroup("Preferences")
+        ->GetGroup("Mod/TechDraw")
+        ->GetBool("SwitchToWB", true)) {
+        Gui::Command::assureWorkbench("TechDrawWorkbench");
+    }
+
     show();
     if (m_mdiView) {
         Gui::getMainWindow()->setActiveWindow(m_mdiView);

--- a/src/Mod/TechDraw/Gui/ViewProviderPageExtension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPageExtension.cpp
@@ -71,6 +71,22 @@ bool ViewProviderPageExtension::extensionCanDropObject(App::DocumentObject* obj)
     return false;
 }
 
+bool ViewProviderPageExtension::extensionCanDropObjectEx(App::DocumentObject* obj, App::DocumentObject* owner,
+    const char* subname,
+    const std::vector<std::string>& elements) const
+{
+    //only DrawView objects can live on pages (except special case Template)
+    if (obj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+        return true;
+    }
+    if (obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
+        //don't let another extension try to drop templates
+        return true;
+    }
+
+    return false;
+}
+
 void ViewProviderPageExtension::extensionDropObject(App::DocumentObject* obj)
 {
     if (obj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {

--- a/src/Mod/TechDraw/Gui/ViewProviderPageExtension.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderPageExtension.h
@@ -46,6 +46,9 @@ public:
     void extensionDragObject(App::DocumentObject*) override;
     bool extensionCanDropObjects() const override;
     bool extensionCanDropObject(App::DocumentObject*) const override;
+    bool extensionCanDropObjectEx(App::DocumentObject* obj, App::DocumentObject* owner,
+        const char* subname,
+        const std::vector<std::string>& elements) const override;
     void extensionDropObject(App::DocumentObject*) override;
 
     void dropObject(App::DocumentObject* docObj);

--- a/src/Mod/TechDraw/Gui/ViewProviderViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewClip.cpp
@@ -31,6 +31,9 @@
 #endif
 
 #include <App/DocumentObject.h>
+#include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/DrawProjGroupItem.h>
+
 #include "ViewProviderViewClip.h"
 
 using namespace TechDrawGui;
@@ -103,4 +106,41 @@ TechDraw::DrawViewClip* ViewProviderViewClip::getViewObject() const
 TechDraw::DrawViewClip* ViewProviderViewClip::getObject() const
 {
     return getViewObject();
+}
+
+
+void ViewProviderViewClip::dragObject(App::DocumentObject* docObj)
+{
+    if (!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+        return;
+    }
+
+    auto dv = static_cast<TechDraw::DrawView*>(docObj);
+
+    getObject()->removeView(dv);
+}
+
+void ViewProviderViewClip::dropObject(App::DocumentObject* docObj)
+{
+    if (docObj->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())) {
+        //DPGI can not be dropped onto the Page as it belongs to DPG, not Page
+        return;
+    }
+    if (!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+        return;
+    }
+
+    auto dv = static_cast<TechDraw::DrawView*>(docObj);
+    TechDraw::DrawPage* pageClip = getObject()->findParentPage();
+    TechDraw::DrawPage* pageView = dv->findParentPage();
+    if (!pageClip || !pageView) {
+        return;
+    }
+
+    if (pageClip != pageView) {
+        pageView->removeView(dv);
+        pageClip->addView(dv);
+    }
+
+    getObject()->addView(dv);
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderViewClip.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewClip.h
@@ -56,6 +56,8 @@ public:
 
     bool canDelete(App::DocumentObject* obj) const override;
 
+    void dragObject(App::DocumentObject* docObj) override;
+    void dropObject(App::DocumentObject* docObj) override;
 };
 } // namespace TechDrawGui
 

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -49,7 +49,6 @@ using namespace TechDrawGui;
     qApp->translate("Workbench", "TechDraw Annotation");
     qApp->translate("Workbench", "TechDraw Attributes");
     qApp->translate("Workbench", "TechDraw Centerlines");
-    qApp->translate("Workbench", "TechDraw Clips");
     qApp->translate("Workbench", "TechDraw Decoration");
     qApp->translate("Workbench", "TechDraw Dimensions");
     qApp->translate("Workbench", "TechDraw Extend Dimensions");
@@ -217,6 +216,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *views << "TechDraw_ComplexSection";
     *views << "TechDraw_DetailView";
     *views << "TechDraw_ProjectionGroup";
+    *views << "TechDraw_ClipGroup";
     *views << "Separator";
     *views << "TechDraw_Symbol";
     *views << "TechDraw_Image";
@@ -234,13 +234,6 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *other << "TechDraw_DraftView";
     *other << "TechDraw_ArchView";
     *other << "TechDraw_SpreadsheetView";
-
-    // clip groups
-    Gui::MenuItem* clips = new Gui::MenuItem;
-    clips->setCommand("Clipped Views");
-    *clips << "TechDraw_ClipGroup";
-    *clips << "TechDraw_ClipGroupAdd";
-    *clips << "TechDraw_ClipGroupRemove";
 
     // hatching
     Gui::MenuItem* hatch = new Gui::MenuItem;
@@ -262,8 +255,6 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *draw << views;
     *draw << "Separator";
     *draw << other;
-    *draw << "Separator";
-    *draw << clips;
     *draw << "Separator";
     *draw << dimensions;
     *draw << "Separator";
@@ -307,14 +298,9 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *views << "TechDraw_DraftView";
     *views << "TechDraw_ArchView";
     *views << "TechDraw_SpreadsheetView";
+    *views << "TechDraw_ClipGroup";
     *views << "TechDraw_ShareView";
     *views << "TechDraw_ProjectShape";
-
-    Gui::ToolBarItem* clips = new Gui::ToolBarItem(root);
-    clips->setCommand("TechDraw Clips");
-    *clips << "TechDraw_ClipGroup";
-    *clips << "TechDraw_ClipGroupAdd";
-    *clips << "TechDraw_ClipGroupRemove";
 
     Gui::ToolBarItem* stacking = new Gui::ToolBarItem(root);
     stacking->setCommand("TechDraw Stacking");
@@ -420,14 +406,9 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_SpreadsheetView";
+    *views << "TechDraw_ClipGroup";
     *views << "TechDraw_ShareView";
     *views << "TechDraw_ProjectShape";
-
-    Gui::ToolBarItem* clips = new Gui::ToolBarItem(root);
-    clips->setCommand("TechDraw Clips");
-    *clips << "TechDraw_ClipGroup";
-    *clips << "TechDraw_ClipGroupAdd";
-    *clips << "TechDraw_ClipGroupRemove";
 
     Gui::ToolBarItem* stacking = new Gui::ToolBarItem(root);
     stacking->setCommand("TechDraw Stacking");

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -221,7 +221,6 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *views << "TechDraw_Symbol";
     *views << "TechDraw_Image";
     *views << "Separator";
-    *views << "TechDraw_MoveView";
     *views << "TechDraw_ShareView";
     *views << "Separator";
     *views << "TechDraw_ToggleFrame";
@@ -308,7 +307,6 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *views << "TechDraw_DraftView";
     *views << "TechDraw_ArchView";
     *views << "TechDraw_SpreadsheetView";
-    *views << "TechDraw_MoveView";
     *views << "TechDraw_ShareView";
     *views << "TechDraw_ProjectShape";
 
@@ -422,7 +420,6 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_SpreadsheetView";
-    *views << "TechDraw_MoveView";
     *views << "TechDraw_ShareView";
     *views << "TechDraw_ProjectShape";
 


### PR DESCRIPTION
This PR address 3 low hanging fruits in techdraw : 
- Fixes #13061
In sketcher double clicking on a sketch changes the active workbench to sketcher.
Similarly double clicking on an assembly switch to assembly.
For consistency, I offer to implement the same behavior when double clicking on a page, switch to techdraw.

- Fixes #12375 :
Techdraw has a 'move view' tool that is pointless. Moving views should be done by drag and drop. It actually was supported before but got broken with the introduction of `canDropObjectEx

- Fixes #12379:
Remove add/remove from clip. It is now possible to drag and drop between page and clip groups. It is even possible to drag and drop between different pages pages/clip groups.
Remove the Clip toolbar as it now has a single entry, and put the clip button to the view toolbar.
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/5d0b6d0c-611e-40ac-a1f1-82f43364e51a)

@WandererFan 