### PR TITLE
Arch: Register interactive arch tools to draft

### DIFF
--- a/src/Mod/Arch/ArchStructure.py
+++ b/src/Mod/Arch/ArchStructure.py
@@ -325,6 +325,7 @@ class _CommandStructure:
             title=translate("Arch","First point of the beam")+":"
         else:
             title=translate("Arch","Base point of column")+":"
+        FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
         FreeCADGui.Snapper.getPoint(callback=self.getPoint,movecallback=self.update,extradlg=[self.taskbox(),self.precast.form,self.dents.form],title=title)
 
     def getPoint(self,point=None,obj=None):
@@ -334,12 +335,16 @@ class _CommandStructure:
         self.bmode = self.modeb.isChecked()
         if point is None:
             self.tracker.finalize()
+            FreeCAD.activeDraftCommand = None
+            FreeCADGui.Snapper.off()
             return
         if self.bmode and (self.bpoint is None):
             self.bpoint = point
             FreeCADGui.Snapper.getPoint(last=point,callback=self.getPoint,movecallback=self.update,extradlg=[self.taskbox(),self.precast.form,self.dents.form],title=translate("Arch","Next point")+":",mode="line")
             return
         self.tracker.finalize()
+        FreeCAD.activeDraftCommand = None
+        FreeCADGui.Snapper.off()
         horiz = True # determines the type of rotation to apply to the final object
         FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Structure"))
         FreeCADGui.addModule("Arch")

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -349,6 +349,7 @@ class _CommandWall:
             import WorkingPlane
             self.wp = WorkingPlane.get_working_plane()
             self.tracker = DraftTrackers.boxTracker()
+            FreeCAD.activeDraftCommand = self  # register as a Draft command for auto grid on/off
             FreeCADGui.Snapper.getPoint(callback=self.getPoint,
                                         extradlg=self.taskbox(),
                                         title=translate("Arch","First point of wall")+":")
@@ -373,6 +374,8 @@ class _CommandWall:
                     self.existing.append(obj)
         if point is None:
             self.tracker.finalize()
+            FreeCAD.activeDraftCommand = None
+            FreeCADGui.Snapper.off()
             return
         self.points.append(point)
         if len(self.points) == 1:
@@ -390,6 +393,8 @@ class _CommandWall:
             l = Part.LineSegment(self.wp.get_local_coords(self.points[0]),
                                  self.wp.get_local_coords(self.points[1]))
             self.tracker.finalize()
+            FreeCAD.activeDraftCommand = None
+            FreeCADGui.Snapper.off()
             FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Wall"))
             FreeCADGui.addModule("Arch")
             FreeCADGui.doCommand('import Part')


### PR DESCRIPTION
Some Arch tools behave like Draft tools (they allow "drawing"). These should be registered to Draft so additional Draft mechanisms such as the grid turning automatically on/off apply.