### PR TITLE
Toponaming/Part: Move missed attacher code into place

### DIFF
--- a/src/Mod/Part/App/AttachEnginePyImp.cpp
+++ b/src/Mod/Part/App/AttachEnginePyImp.cpp
@@ -131,8 +131,12 @@ Py::Object AttachEnginePy::getReferences() const
 {
     try {
         AttachEngine &attacher = *(this->getAttachEnginePtr());
-        AttachEngine::verifyReferencesAreSafe(attacher.references);
-        return Py::Object(attacher.references.getPyObject(),true);
+        Py::List ret;
+        int i=0;
+        for(auto obj : attacher.getRefObjects())
+            ret.append(Py::TupleN(Py::asObject(obj->getPyObject()),
+                                  Py::String(attacher.subnames[i++])));
+        return ret;
     } ATTACHERPY_STDCATCH_ATTR;
 }
 
@@ -140,7 +144,9 @@ void AttachEnginePy::setReferences(Py::Object arg)
 {
     try {
         AttachEngine &attacher = *(this->getAttachEnginePtr());
-        attacher.references.setPyObject(arg.ptr());
+        App::PropertyLinkSubList references;
+        references.setPyObject(arg.ptr());
+        attacher.setReferences(references);
     } ATTACHERPY_STDCATCH_ATTR;
 }
 
@@ -542,8 +548,7 @@ PyObject* AttachEnginePy::writeParametersToFeature(PyObject* args)
         }
         Part::AttachExtension* feat = dobj->getExtensionByType<Part::AttachExtension>();
         const AttachEngine &attacher = *(this->getAttachEnginePtr());
-        AttachEngine::verifyReferencesAreSafe(attacher.references);
-        feat->AttachmentSupport.Paste(attacher.references);
+        feat->AttachmentSupport.setValues(attacher.getRefObjects(),attacher.getSubValues());
         feat->MapMode.setValue(attacher.mapMode);
         feat->MapReversed.setValue(attacher.mapReverse);
         feat->MapPathParameter.setValue(attacher.attachParameter);

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -119,7 +119,10 @@ bool AttachExtension::positionBySupport()
     try {
         if (_attacher->mapMode == mmDeactivated)
             return false;
-        getPlacement().setValue(_attacher->calculateAttachedPlacement(getPlacement().getValue()));
+        bool subChanged = false;
+        getPlacement().setValue(_attacher->calculateAttachedPlacement(getPlacement().getValue(), &subChanged));
+        if(subChanged)
+            AttachmentSupport.setValues(AttachmentSupport.getValues(),_attacher->getSubValues());
         _active = 1;
         return true;
     } catch (ExceptionCancel&) {
@@ -193,7 +196,7 @@ void AttachExtension::extensionOnChanged(const App::Property* prop)
 
             // MapPathParameter is only used if there is a reference to one edge and not edge + vertex
             bool hasOneRef = false;
-            if (_attacher && _attacher->references.getSubValues().size() == 1) {
+            if (_attacher && _attacher->subnames.size() == 1) {
                 hasOneRef = true;
             }
 
@@ -257,7 +260,7 @@ void AttachExtension::onExtendedDocumentRestored()
 
         // MapPathParameter is only used if there is a reference to one edge and not edge + vertex
         bool hasOneRef = false;
-        if (_attacher && _attacher->references.getSubValues().size() == 1) {
+        if (_attacher && _attacher->subnames.size() == 1) {
             hasOneRef = true;
         }
 

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -245,13 +245,16 @@ void AttachEngine::setUp(const App::PropertyLinkSubList &references,
 
 void AttachEngine::setUp(const AttachEngine &another)
 {
-    setUp(another.references,
-          another.mapMode,
-          another.mapReverse,
-          another.attachParameter,
-          another.surfU,
-          another.surfV,
-          another.attachmentOffset);
+    this->docName = another.docName;
+    this->objNames = another.objNames;
+    this->subnames = another.subnames;
+    this->shadowSubs = another.shadowSubs;
+    this->mapMode = another.mapMode;
+    this->mapReverse = another.mapReverse;
+    this->attachParameter = another.attachParameter;
+    this->surfU = another.surfU;
+    this->surfV = another.surfV;
+    this->attachmentOffset = another.attachmentOffset;
 }
 
 Base::Placement AttachEngine::placementFactory(const gp_Dir &ZAxis,

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -376,7 +376,6 @@ public: //enums
 
 
 public: //members
-    App::PropertyLinkSubList references;
     std::string docName;
     std::vector<std::string> objNames;
     std::vector<std::string> subnames;

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -129,7 +129,7 @@ void UnifiedDatumCommand(Gui::Command &cmd, Base::Type type, std::string name)
             //test if current selection fits a mode.
             if (support.getSize() > 0) {
                 Part::AttachExtension* pcDatum = Feat->getExtensionByType<Part::AttachExtension>();
-                pcDatum->attacher().references.Paste(support);
+                pcDatum->attacher().setReferences(support);
                 SuggestResult sugr;
                 pcDatum->attacher().suggestMapModes(sugr);
                 if (sugr.message == Attacher::SuggestResult::srOK) {


### PR DESCRIPTION
Fix #13055.   Passes #13078.  Also passes all other c++ and python tests.