### PR TITLE
Update grid size nomenclature

### DIFF
--- a/src/Mod/Draft/Resources/ui/TaskSelectPlane.ui
+++ b/src/Mod/Draft/Resources/ui/TaskSelectPlane.ui
@@ -144,7 +144,7 @@ of the buttons above</string>
      <property name="toolTip">
       <string>Moves the working plane without changing its
 orientation. If no point is selected, the plane
-will be moved to the center of the view</string>
+will be moved to the center of the view.</string>
      </property>
      <property name="text">
       <string>Move working plane</string>
@@ -155,18 +155,25 @@ will be moved to the center of the view</string>
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
       <widget class="QLabel" name="label_9">
+       <property name="toolTip">
+        <string>The color of the grid</string>
+       </property>
        <property name="text">
         <string>Grid color</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="Gui::ColorButton" name="buttonColor"/>
+      <widget class="Gui::ColorButton" name="buttonColor">
+       <property name="toolTip">
+        <string>The color of the grid</string>
+       </property>
+      </widget>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_3">
        <property name="toolTip">
-        <string>The spacing between the smaller grid lines</string>
+        <string>The distance between grid lines</string>
        </property>
        <property name="text">
         <string>Grid spacing</string>
@@ -176,7 +183,7 @@ will be moved to the center of the view</string>
      <item row="1" column="1">
       <widget class="Gui::InputField" name="fieldGridSpacing">
        <property name="toolTip">
-        <string>The spacing between the smaller grid lines</string>
+        <string>The distance between grid lines</string>
        </property>
        <property name="unit" stdset="0">
         <string notr="true">mm</string>
@@ -186,31 +193,40 @@ will be moved to the center of the view</string>
      <item row="2" column="0">
       <widget class="QLabel" name="label_4">
        <property name="toolTip">
-        <string>The number of squares between each main line of the grid</string>
+        <string>The number of squares between major grid lines</string>
        </property>
        <property name="text">
-        <string>Main line every</string>
+        <string>Major lines every</string>
        </property>
       </widget>
      </item>
      <item row="2" column="1">
       <widget class="QSpinBox" name="fieldGridMainLine">
        <property name="toolTip">
-        <string>The number of squares between each main line of the grid</string>
+        <string>The number of squares between major grid lines</string>
+       </property>
+       <property name="suffix">
+        <string> squares</string>
        </property>
       </widget>
      </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_8">
+       <property name="toolTip">
+        <string>The number of squares in the X and Y direction of the grid</string>
+       </property>
        <property name="text">
-        <string>Grid extension</string>
+        <string>Grid size</string>
        </property>
       </widget>
      </item>
      <item row="3" column="1">
       <widget class="QSpinBox" name="fieldGridExtension">
+       <property name="toolTip">
+        <string>The number of squares in the X and Y direction of the grid</string>
+       </property>
        <property name="suffix">
-        <string> lines</string>
+        <string> squares</string>
        </property>
        <property name="minimum">
         <number>1</number>
@@ -223,9 +239,7 @@ will be moved to the center of the view</string>
     <item row="4" column="0">
       <widget class="QLabel" name="label_6">
        <property name="toolTip">
-        <string>The distance at which a point can be snapped to
-when approaching the mouse. You can also change this
-value by using the [ and ] keys while drawing</string>
+        <string>The distance at which a point can be snapped to</string>
        </property>
        <property name="text">
         <string>Snapping radius</string>
@@ -235,9 +249,10 @@ value by using the [ and ] keys while drawing</string>
      <item row="4" column="1">
       <widget class="QSpinBox" name="fieldSnapRadius">
        <property name="toolTip">
-        <string>The distance at which a point can be snapped to
-when approaching the mouse. You can also change this
-value by using the [ and ] keys while drawing</string>
+        <string>The distance at which a point can be snapped to</string>
+       </property>
+       <property name="suffix">
+        <string> px</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -143,8 +143,11 @@ if they match the X, Y or Z axis of the global coordinate system</string>
          </size>
         </property>
         <property name="toolTip">
-         <string>Display major lines after the given count of minor grid lines.
+         <string>Display major lines after the given count of minor lines.
 Major lines are thicker than minor grid lines.</string>
+        </property>
+        <property name="suffix">
+         <string> minor lines</string>
         </property>
         <property name="value">
          <number>10</number>

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -130,7 +130,7 @@ if they match the X, Y or Z axis of the global coordinate system</string>
       <item row="5" column="0">
        <widget class="QLabel" name="label_gridEvery">
         <property name="text">
-         <string>Main lines every</string>
+         <string>Major lines every</string>
         </property>
        </widget>
       </item>
@@ -143,8 +143,8 @@ if they match the X, Y or Z axis of the global coordinate system</string>
          </size>
         </property>
         <property name="toolTip">
-         <string>The number of squares between main grid lines.
-These lines are thicker than normal grid lines.</string>
+         <string>Display major lines after the given count of minor grid lines.
+Major lines are thicker than minor grid lines.</string>
         </property>
         <property name="value">
          <number>10</number>
@@ -173,7 +173,7 @@ These lines are thicker than normal grid lines.</string>
       <item row="6" column="0">
        <widget class="QLabel" name="label_gridSpacing">
         <property name="text">
-         <string>Grid spacing</string>
+         <string>Line spacing</string>
         </property>
        </widget>
       </item>
@@ -212,10 +212,10 @@ These lines are thicker than normal grid lines.</string>
       <item row="7" column="1">
        <widget class="Gui::PrefSpinBox" name="spinBox_gridSize">
         <property name="toolTip">
-         <string>The number of horizontal and vertical lines in the grid</string>
+         <string>The number of horizontal and vertical minor lines in the grid</string>
         </property>
         <property name="suffix">
-         <string> lines</string>
+         <string> minor lines</string>
         </property>
         <property name="maximum">
          <number>9999</number>

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -218,7 +218,7 @@ Major lines are thicker than minor grid lines.</string>
          <string>The number of squares in the grid</string>
         </property>
         <property name="suffix">
-         <string> lines</string>
+         <string> squares</string>
         </property>
         <property name="maximum">
          <number>9999</number>

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -143,8 +143,8 @@ if they match the X, Y or Z axis of the global coordinate system</string>
          </size>
         </property>
         <property name="toolTip">
-         <string>Display major lines after the given count of squares.
-Major lines are thicker than minor grid lines.</string>
+         <string>The number of squares between major grid lines.
+Major grid lines are thicker than minor grid lines.</string>
         </property>
         <property name="suffix">
          <string> squares</string>
@@ -176,7 +176,7 @@ Major lines are thicker than minor grid lines.</string>
       <item row="6" column="0">
        <widget class="QLabel" name="label_gridSpacing">
         <property name="text">
-         <string>Line spacing</string>
+         <string>Grid spacing</string>
         </property>
        </widget>
       </item>
@@ -215,7 +215,7 @@ Major lines are thicker than minor grid lines.</string>
       <item row="7" column="1">
        <widget class="Gui::PrefSpinBox" name="spinBox_gridSize">
         <property name="toolTip">
-         <string>The number of squares in the grid</string>
+         <string>The number of squares in the X and Y direction of the grid</string>
         </property>
         <property name="suffix">
          <string> squares</string>

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -215,7 +215,7 @@ Major lines are thicker than minor grid lines.</string>
       <item row="7" column="1">
        <widget class="Gui::PrefSpinBox" name="spinBox_gridSize">
         <property name="toolTip">
-         <string>The number of horizontal and vertical minor lines in the grid</string>
+         <string>The number of squares in the grid</string>
         </property>
         <property name="suffix">
          <string> lines</string>

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -147,7 +147,7 @@ if they match the X, Y or Z axis of the global coordinate system</string>
 Major lines are thicker than minor grid lines.</string>
         </property>
         <property name="suffix">
-         <string> minor lines</string>
+         <string> lines</string>
         </property>
         <property name="value">
          <number>10</number>
@@ -218,7 +218,7 @@ Major lines are thicker than minor grid lines.</string>
          <string>The number of horizontal and vertical minor lines in the grid</string>
         </property>
         <property name="suffix">
-         <string> minor lines</string>
+         <string> lines</string>
         </property>
         <property name="maximum">
          <number>9999</number>

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -143,11 +143,11 @@ if they match the X, Y or Z axis of the global coordinate system</string>
          </size>
         </property>
         <property name="toolTip">
-         <string>Display major lines after the given count of minor lines.
+         <string>Display major lines after the given count of squares.
 Major lines are thicker than minor grid lines.</string>
         </property>
         <property name="suffix">
-         <string> lines</string>
+         <string> squares</string>
         </property>
         <property name="value">
          <number>10</number>


### PR DESCRIPTION
Fixes #13090

1. _"<kbd>Main lines every</kbd> nn" box_: change to "<kbd>Major lines every</kbd> nn lines". Essentially updating nomenclature from "main, normal" to "major, minor" lines, both in the input boxes and in the tooltips.
1. <kbd>Grid spacing</kbd>: change to <kbd>Line spacing</kbd>
1. <kbd>Grid size</kbd>: add a read-only label that shows the size in units of the resulting grid.

| Before | After |  
|---|---|
|![Before](https://github.com/FreeCAD/FreeCAD/assets/148809153/0e47d223-397f-438e-ade1-a2856b7b9bd7)|![After](https://github.com/FreeCAD/FreeCAD/assets/148809153/41140ac4-054f-476a-95f8-36d726c3bd84)|
