### PR TITLE
Sketcher: Change rendering colors of points.

### DIFF
--- a/src/Gui/PreferencePackTemplates/Sketcher_Colors.cfg
+++ b/src/Gui/PreferencePackTemplates/Sketcher_Colors.cfg
@@ -7,7 +7,6 @@
           <FCUInt Name="SketchEdgeColor" Value="4294967295"/>
           <FCUInt Name="SketchVertexColor" Value="4294967295"/>
           <FCUInt Name="EditedEdgeColor" Value="4294967295"/>
-          <FCUInt Name="EditedVertexColor" Value="4280680703"/>
           <FCUInt Name="ConstructionColor" Value="56575"/>
           <FCUInt Name="ExternalColor" Value="3425924095"/>
           <FCUInt Name="InvalidSketchColor" Value="4285333759"/>
@@ -16,7 +15,6 @@
           <FCUInt Name="FullyConstraintElementColor" Value="2161156351"/>
           <FCUInt Name="FullyConstraintConstructionElementColor" Value="2410282495"/>
           <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="3739142399"/>
-          <FCUInt Name="FullyConstraintConstructionPointColor" Value="4287987967"/>
           <FCUInt Name="ConstrainedIcoColor" Value="4280680703"/>
           <FCUInt Name="NonDrivingConstrDimColor" Value="2555903"/>
           <FCUInt Name="ConstrainedDimColor" Value="4280680703"/>

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -86,6 +86,12 @@ private:
                                   editPoint.x,
                                   editPoint.y);
 
+            if (!isConstructionMode()) {
+                Gui::cmdAppObjectArgs(sketchgui->getObject(),
+                                      "toggleConstruction(%d)",
+                                      getHighestCurveIndex());
+            }
+
             Gui::Command::commitCommand();
         }
         catch (const Base::Exception&) {

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -181,10 +181,6 @@ void EditModeCoinManager::ParameterObserver::initParameters()
          [this, drawingParameters = Client.drawingParameters](const std::string& param) {
              updateColor(drawingParameters.CreateCurveColor, param);
          }},
-        {"EditedVertexColor",
-         [this, drawingParameters = Client.drawingParameters](const std::string& param) {
-             updateColor(drawingParameters.VertexColor, param);
-         }},
         {"EditedEdgeColor",
          [this, drawingParameters = Client.drawingParameters](const std::string& param) {
              updateColor(drawingParameters.CurveColor, param);
@@ -208,10 +204,6 @@ void EditModeCoinManager::ParameterObserver::initParameters()
         {"FullyConstraintInternalAlignmentColor",
          [this, drawingParameters = Client.drawingParameters](const std::string& param) {
              updateColor(drawingParameters.FullyConstraintInternalAlignmentColor, param);
-         }},
-        {"FullyConstraintConstructionPointColor",
-         [this, drawingParameters = Client.drawingParameters](const std::string& param) {
-             updateColor(drawingParameters.FullyConstraintConstructionPointColor, param);
          }},
         {"FullyConstraintElementColor",
          [this, drawingParameters = Client.drawingParameters](const std::string& param) {

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
@@ -38,11 +38,6 @@ SbColor
                                                              0.87f,
                                                              0.78f);   // #DEDEC8 -> (222,222,200)
 SbColor DrawingParameters::InternalAlignedGeoColor(0.7f, 0.7f, 0.5f);  // #B2B27F -> (178,178,127)
-SbColor
-    DrawingParameters::FullyConstraintConstructionPointColor(1.0f,
-                                                             0.58f,
-                                                             0.50f);  // #FF9580 -> (255,149,128)
-SbColor DrawingParameters::VertexColor(1.0f, 0.149f, 0.0f);           // #FF2600 -> (255, 38,  0)
 SbColor DrawingParameters::FullyConstraintElementColor(0.50f,
                                                        0.81f,
                                                        0.62f);           // #80D0A0 -> (128,208,160)

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -76,9 +76,10 @@ struct DrawingParameters
     const float zConstr = 0.009f;      // Height for rendering constraints
     const float zRootPoint = 0.010f;   // Height used for rendering the root point
     const float zLowPoints = 0.011f;   // Height used for bottom rendered points
-    const float zHighPoints = 0.012f;  // Height used for in-the-middle rendered points
-    const float zHighlight = 0.013f;   // Height for highlighted points (selected/preselected)
-    const float zText = 0.013f;        // Height for rendered text
+    const float zMidPoints = 0.012f;   // Height used for mid rendered points
+    const float zHighPoints = 0.013f;  // Height used for top rendered points
+    const float zHighlight = 0.014f;   // Height for highlighted points (selected/preselected)
+    const float zText = 0.014f;        // Height for rendered text
     //@}
 
     /// Different categories of geometries that can be selected by the user to be rendered on top,

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -106,11 +106,7 @@ struct DrawingParameters
     static SbColor FullyConstrainedColor;                  // Color for a fully constrained sketch
     static SbColor FullyConstraintInternalAlignmentColor;  // Color for fully constrained internal
                                                            // alignment geometry
-    static SbColor
-        InternalAlignedGeoColor;  // Color for non-fully constrained internal alignment geometry
-    static SbColor
-        FullyConstraintConstructionPointColor;   // Color for fully constrained construction points
-    static SbColor VertexColor;                  // Color for vertices
+    static SbColor InternalAlignedGeoColor;  // Color for non-fully constrained internal geometry
     static SbColor FullyConstraintElementColor;  // Color for a fully constrained element
     static SbColor CurveColor;                   // Color for curves
     static SbColor PreselectColor;               // Color used for pre-selection
@@ -473,6 +469,7 @@ struct CoinMapping
         }
         CurvIdToGeoId.clear();
         PointIdToGeoId.clear();
+        PointIdToPosId.clear();
         GeoElementId2SetId.clear();
         PointIdToVertexId.clear();
     };
@@ -488,6 +485,12 @@ struct CoinMapping
     int getPointGeoId(int pointindex, int layerindex)
     {
         return PointIdToGeoId[layerindex][pointindex];
+    }
+    /// given the MF index of a point and the coin layer in which it is drawn returns the PosId of
+    /// the point
+    Sketcher::PointPos getPointPosId(int pointindex, int layerindex)
+    {
+        return PointIdToPosId[layerindex][pointindex];
     }
     /// given the MF index of a point and the coin layer in which it is drawn returns the VertexId
     /// of the point
@@ -531,6 +534,7 @@ struct CoinMapping
     std::vector<std::vector<std::vector<int>>>
         CurvIdToGeoId;                             // conversion of SoLineSet index to GeoId
     std::vector<std::vector<int>> PointIdToGeoId;  // conversion of SoCoordinate3 index to GeoId
+    std::vector<std::vector<Sketcher::PointPos>> PointIdToPosId;  // SoCoordinate3 index to PosId
 
     //* This maps an MF index (second index) of a point within a coin layer (first index) to a
     // global VertexId */

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinConverter.cpp
@@ -75,6 +75,7 @@ void EditModeGeometryCoinConverter::convert(const Sketcher::GeoListFacade& geoli
             coinMapping.CurvIdToGeoId[l].emplace_back();
         }
         coinMapping.PointIdToGeoId.emplace_back();
+        coinMapping.PointIdToPosId.emplace_back();
         coinMapping.PointIdToVertexId.emplace_back();
     }
 
@@ -86,6 +87,7 @@ void EditModeGeometryCoinConverter::convert(const Sketcher::GeoListFacade& geoli
     // empty layer.
     Points[0].emplace_back(0., 0., 0.);
     coinMapping.PointIdToGeoId[0].push_back(-1);  // root point
+    coinMapping.PointIdToPosId[0].push_back(Sketcher::PointPos::start);
     coinMapping.PointIdToVertexId[0].push_back(-1);
     // VertexId is the reference used for point selection/preselection
 
@@ -150,6 +152,23 @@ void EditModeGeometryCoinConverter::convert(const Sketcher::GeoListFacade& geoli
 
         for (int i = 0; i < numberPoints; i++) {
             coinMapping.PointIdToGeoId[coinLayer].push_back(geoId);
+            Sketcher::PointPos pos;
+            if (i == 0) {
+                if (pointmode == PointsMode::InsertMidOnly) {
+                    pos = Sketcher::PointPos::mid;
+                }
+                else {
+                    pos = Sketcher::PointPos::start;
+                }
+            }
+            else if (i == 1) {
+                pos = Sketcher::PointPos::end;
+            }
+            else {
+                pos = Sketcher::PointPos::mid;
+            }
+
+            coinMapping.PointIdToPosId[coinLayer].push_back(pos);
             coinMapping.PointIdToVertexId[coinLayer].push_back(vertexCounter++);
         }
 

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -134,6 +134,21 @@ void EditModeGeometryCoinManager::updateGeometryColor(const GeoListFacade& geoli
         return false;
     };
 
+    auto isCoincident = [&](int GeoId, Sketcher::PointPos PosId) {
+        const std::vector<Sketcher::Constraint*>& constraints =
+            ViewProviderSketchCoinAttorney::getConstraints(viewProvider);
+        for (auto& constr : constraints) {
+            if (constr->Type == Coincident
+                || (constr->Type == Tangent && constr->FirstPos != Sketcher::PointPos::none)) {
+                if ((constr->First == GeoId && constr->FirstPos == PosId)
+                    || (constr->Second == GeoId && constr->SecondPos == PosId)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+
     auto isInternalAlignedGeom = [&geolistfacade](int GeoId) {
         auto geom = geolistfacade.getGeometryFacadeFromGeoId(GeoId);
         if (geom) {
@@ -174,44 +189,63 @@ void EditModeGeometryCoinManager::updateGeometryColor(const GeoListFacade& geoli
         SbVec3f* pverts = editModeScenegraphNodes.PointsCoordinate[l]->point.startEditing();
 
         // colors of the point set
-        if (issketchinvalid) {
-            for (int i = 0; i < PtNum; i++) {
-                pcolor[i] = drawingParameters.InvalidSketchColor;
-            }
-        }
-        else {
+        for (int i = 0; i < PtNum; i++) {
+            int GeoId = coinMapping.getPointGeoId(i, l);
+            Sketcher::PointPos PosId = coinMapping.getPointPosId(i, l);
+            bool isExternal = GeoId < -1;
 
-            for (int i = 0; i < PtNum; i++) {
-                if (!(i == 0 && l == 0) && sketchFullyConstrained) {  // root point is not coloured
-                    pcolor[i] = drawingParameters.FullyConstrainedColor;
+            if (isExternal) {
+                if (isCoincident(GeoId, PosId) && !issketchinvalid) {
+                    pcolor[i] = drawingParameters.ConstrIcoColor;
                 }
                 else {
-                    int GeoId = coinMapping.getPointGeoId(i, l);
-                    Sketcher::PointPos PosId = coinMapping.getPointPosId(i, l);
+                    pcolor[i] = drawingParameters.CurveExternalColor;
+                }
+            }
+            else if (issketchinvalid) {
+                pcolor[i] = drawingParameters.InvalidSketchColor;
+            }
+            else if (!(i == 0 && l == 0) && sketchFullyConstrained) {
+                // root point is not coloured nor external
+                pcolor[i] = drawingParameters.FullyConstrainedColor;
+            }
+            else {
+                bool constrainedElement = isFullyConstraintElement(GeoId);
 
-                    bool constrainedElement = isFullyConstraintElement(GeoId);
-
-                    if (isInternalAlignedGeom(GeoId)) {
-                        if (constrainedElement) {
-                            pcolor[i] = drawingParameters.FullyConstraintInternalAlignmentColor;
+                if (isInternalAlignedGeom(GeoId)) {
+                    if (constrainedElement) {
+                        pcolor[i] = drawingParameters.FullyConstraintInternalAlignmentColor;
+                    }
+                    else {
+                        if (isCoincident(GeoId, PosId)) {
+                            pcolor[i] = drawingParameters.ConstrIcoColor;
                         }
                         else {
                             pcolor[i] = drawingParameters.InternalAlignedGeoColor;
                         }
                     }
-                    else {
-                        if (!isDefinedGeomPoint(GeoId, PosId)) {
-                            if (constrainedElement) {
-                                pcolor[i] =
-                                    drawingParameters.FullyConstraintConstructionElementColor;
+                }
+                else {
+                    if (!isDefinedGeomPoint(GeoId, PosId)) {
+                        if (constrainedElement) {
+                            pcolor[i] = drawingParameters.FullyConstraintConstructionElementColor;
+                        }
+                        else {
+                            if (isCoincident(GeoId, PosId)) {
+                                pcolor[i] = drawingParameters.ConstrIcoColor;
                             }
                             else {
                                 pcolor[i] = drawingParameters.CurveDraftColor;
                             }
                         }
-                        else {  // this is a defined GeomPoint
-                            if (constrainedElement) {
-                                pcolor[i] = drawingParameters.FullyConstraintElementColor;
+                    }
+                    else {  // this is a defined GeomPoint
+                        if (constrainedElement) {
+                            pcolor[i] = drawingParameters.FullyConstraintElementColor;
+                        }
+                        else {
+                            if (isCoincident(GeoId, PosId)) {
+                                pcolor[i] = drawingParameters.ConstrIcoColor;
                             }
                             else {
                                 pcolor[i] = drawingParameters.CurveColor;
@@ -241,30 +275,40 @@ void EditModeGeometryCoinManager::updateGeometryColor(const GeoListFacade& geoli
 
         float zNormPoint = getRenderHeight(DrawingParameters::GeometryRendering::NormalGeometry,
                                            drawingParameters.zHighPoints,
-                                           drawingParameters.zLowPoints,
-                                           drawingParameters.zLowPoints);
+                                           drawingParameters.zMidPoints,
+                                           drawingParameters.zMidPoints);
 
         float zConstrPoint = getRenderHeight(DrawingParameters::GeometryRendering::Construction,
                                              drawingParameters.zHighPoints,
-                                             drawingParameters.zLowPoints,
-                                             drawingParameters.zLowPoints);
+                                             drawingParameters.zMidPoints,
+                                             drawingParameters.zMidPoints);
 
         for (int i = 0; i < PtNum; i++) {  // 0 is the origin
             if (i == 0 && l == 0) {        // reset root point to lowest
                 pverts[i].setValue(0, 0, viewOrientationFactor * drawingParameters.zRootPoint);
             }
             else {
+                int GeoId = coinMapping.getPointGeoId(i, l);
+                Sketcher::PointPos PosId = coinMapping.getPointPosId(i, l);
                 pverts[i].getValue(x, y, z);
-                auto geom =
-                    geolistfacade.getGeometryFacadeFromGeoId(coinMapping.getPointGeoId(i, l));
+                auto geom = geolistfacade.getGeometryFacadeFromGeoId(GeoId);
+                bool isExternal = GeoId < -1;
 
                 if (geom) {
-                    if (geom->getConstruction()) {
-                        pverts[i].setValue(x, y, viewOrientationFactor * zConstrPoint);
+                    z = viewOrientationFactor * zNormPoint;
+
+                    if (isCoincident(GeoId, PosId)) {
+                        z = viewOrientationFactor * drawingParameters.zLowPoints;
                     }
                     else {
-                        pverts[i].setValue(x, y, viewOrientationFactor * zNormPoint);
+                        if (isExternal) {
+                            z = viewOrientationFactor * drawingParameters.zRootPoint;
+                        }
+                        else if (geom->getConstruction()) {
+                            z = viewOrientationFactor * zConstrPoint;
+                        }
                     }
+                    pverts[i].setValue(x, y, z);
                 }
             }
         }

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -124,10 +124,12 @@ void EditModeGeometryCoinManager::updateGeometryColor(const GeoListFacade& geoli
                                                       bool issketchinvalid)
 {
     // Lambdas for convenience retrieval of geometry information
-    auto isDefinedGeomPoint = [&geolistfacade](int GeoId) {
+    auto isDefinedGeomPoint = [&geolistfacade](int GeoId, Sketcher::PointPos PosId) {
         auto geom = geolistfacade.getGeometryFacadeFromGeoId(GeoId);
         if (geom) {
-            return geom->isGeoType(Part::GeomPoint::getClassTypeId()) && !geom->getConstruction();
+            bool isStartOrEnd =
+                PosId == Sketcher::PointPos::start || PosId == Sketcher::PointPos::end;
+            return isStartOrEnd && !geom->getConstruction();
         }
         return false;
     };
@@ -185,6 +187,7 @@ void EditModeGeometryCoinManager::updateGeometryColor(const GeoListFacade& geoli
                 }
                 else {
                     int GeoId = coinMapping.getPointGeoId(i, l);
+                    Sketcher::PointPos PosId = coinMapping.getPointPosId(i, l);
 
                     bool constrainedElement = isFullyConstraintElement(GeoId);
 
@@ -197,12 +200,13 @@ void EditModeGeometryCoinManager::updateGeometryColor(const GeoListFacade& geoli
                         }
                     }
                     else {
-                        if (!isDefinedGeomPoint(GeoId)) {
+                        if (!isDefinedGeomPoint(GeoId, PosId)) {
                             if (constrainedElement) {
-                                pcolor[i] = drawingParameters.FullyConstraintConstructionPointColor;
+                                pcolor[i] =
+                                    drawingParameters.FullyConstraintConstructionElementColor;
                             }
                             else {
-                                pcolor[i] = drawingParameters.VertexColor;
+                                pcolor[i] = drawingParameters.CurveDraftColor;
                             }
                         }
                         else {  // this is a defined GeomPoint

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -505,7 +505,6 @@ void SketcherSettingsAppearance::saveSettings()
     ui->SketchEdgeColor->onSave();
     ui->SketchVertexColor->onSave();
     ui->EditedEdgeColor->onSave();
-    ui->EditedVertexColor->onSave();
     ui->ConstructionColor->onSave();
     ui->ExternalColor->onSave();
     ui->InvalidSketchColor->onSave();
@@ -514,7 +513,6 @@ void SketcherSettingsAppearance::saveSettings()
     ui->FullyConstraintElementColor->onSave();
     ui->FullyConstraintConstructionElementColor->onSave();
     ui->FullyConstraintInternalAlignmentColor->onSave();
-    ui->FullyConstraintConstructionPointColor->onSave();
 
     ui->ConstrainedColor->onSave();
     ui->NonDrivingConstraintColor->onSave();
@@ -556,7 +554,6 @@ void SketcherSettingsAppearance::loadSettings()
     ui->SketchEdgeColor->onRestore();
     ui->SketchVertexColor->onRestore();
     ui->EditedEdgeColor->onRestore();
-    ui->EditedVertexColor->onRestore();
     ui->ConstructionColor->onRestore();
     ui->ExternalColor->onRestore();
     ui->InvalidSketchColor->onRestore();
@@ -565,7 +562,6 @@ void SketcherSettingsAppearance::loadSettings()
     ui->FullyConstraintElementColor->onRestore();
     ui->FullyConstraintConstructionElementColor->onRestore();
     ui->FullyConstraintInternalAlignmentColor->onRestore();
-    ui->FullyConstraintConstructionPointColor->onRestore();
 
     ui->ConstrainedColor->onRestore();
     ui->NonDrivingConstraintColor->onRestore();

--- a/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
@@ -193,69 +193,10 @@
         </property>
        </spacer>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Vertex</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="Gui::PrefColorButton" name="FullyConstraintConstructionPointColor">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Color of fully constrained vertex color in edit mode</string>
-        </property>
-        <property name="color" stdset="0">
-         <color>
-          <red>255</red>
-          <green>149</green>
-          <blue>128</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>FullyConstraintConstructionPointColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="Gui::PrefColorButton" name="EditedVertexColor">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Color of vertices being edited</string>
-        </property>
-        <property name="color" stdset="0">
-         <color>
-          <red>255</red>
-          <green>38</green>
-          <blue>0</blue>
-         </color>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>EditedVertexColor</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>View</cstring>
-        </property>
-       </widget>
-      </item>
       <item row="5" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Edge</string>
+         <string>Geometry</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This PR changes the color of points in sketcher following DWG discussion.

![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/1f45a02b-22c3-420e-9c41-8c632cee4e22)

1- edges (Line/arcs...) end/start points : Normal geo color (white)
2- Conic centers : construction geo color (blue)
3- Construction point : construction geo color (blue)
4- normal point : normal geo color (white)
5- When a point is coincident to another point : Constraint color (red) (other points colors render on top).
6 - Point tool now creates point that reflect construction mode. ie real point or construction point.
7 - Remove Vertex color from preferences as vertexes now use the geometry colors

Fixes https://github.com/FreeCAD/FreeCAD/issues/12582

@pierreporte let me know if you think it closes https://github.com/FreeCAD/FreeCAD/issues/11919

Partial fix of https://github.com/FreeCAD/FreeCAD/issues/11799, island would still be interesting.