### PR TITLE
[TD]Fix no PAT hatch on first paint

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -385,7 +385,7 @@ TopoDS_Shape DrawViewSection::getShapeForDetail() const
 
 App::DocumentObjectExecReturn* DrawViewSection::execute()
 {
-    //    Base::Console().Message("DVS::execute() - %s\n", getNameInDocument());
+    // Base::Console().Message("DVS::execute() - %s\n", Label.getValue());
     if (!keepUpdated()) {
         return App::DocumentObject::StdReturn;
     }
@@ -445,9 +445,7 @@ bool DrawViewSection::isBaseValid() const
 
 void DrawViewSection::sectionExec(TopoDS_Shape& baseShape)
 {
-    //    Base::Console().Message("DVS::sectionExec() - %s baseShape.IsNull:
-    //    %d\n",
-    //                            getNameInDocument(), baseShape.IsNull());
+    // Base::Console().Message("DVS::sectionExec() - %s baseShape.IsNull: %d\n", Label.getValue(), baseShape.IsNull());
 
     if (waitingForHlr() || waitingForCut()) {
         return;
@@ -486,9 +484,7 @@ void DrawViewSection::sectionExec(TopoDS_Shape& baseShape)
 
 void DrawViewSection::makeSectionCut(const TopoDS_Shape& baseShape)
 {
-    //    Base::Console().Message("DVS::makeSectionCut() - %s - baseShape.IsNull:
-    //    %d\n",
-    //                            getNameInDocument(), baseShape.IsNull());
+    // Base::Console().Message("DVS::makeSectionCut() - %s - baseShape.IsNull:%d\n", Label.getValue(), baseShape.IsNull());
 
     showProgressMessage(getNameInDocument(), "is making section cut");
 
@@ -638,8 +634,7 @@ void DrawViewSection::onSectionCutFinished()
 // activities that depend on updated geometry object
 void DrawViewSection::postHlrTasks(void)
 {
-    //    Base::Console().Message("DVS::postHlrTasks() - %s\n",
-    //    getNameInDocument());
+    // Base::Console().Message("DVS::postHlrTasks() - %s\n", Label.getValue());
 
     DrawViewPart::postHlrTasks();
 
@@ -1172,8 +1167,10 @@ gp_Ax2 DrawViewSection::getProjectionCS(const Base::Vector3d pt) const
 
 std::vector<LineSet> DrawViewSection::getDrawableLines(int i)
 {
-    //    Base::Console().Message("DVS::getDrawableLines(%d) - lineSets: %d\n", i,
-    //    m_lineSets.size());
+    // Base::Console().Message("DVS::getDrawableLines(%d) - lineSets: %d\n", i, m_lineSets.size());
+    if (m_lineSets.empty()) {
+        makeLineSets();
+    }
     std::vector<LineSet> result;
     return DrawGeomHatch::getTrimmedLinesSection(this,
                                                  m_lineSets,
@@ -1236,7 +1233,7 @@ void DrawViewSection::setupObject()
 // create geometric hatch lines
 void DrawViewSection::makeLineSets(void)
 {
-    //    Base::Console().Message("DVS::makeLineSets()\n");
+    // Base::Console().Message("DVS::makeLineSets()\n");
     if (PatIncluded.isEmpty()) {
         return;
     }
@@ -1277,8 +1274,7 @@ void DrawViewSection::replaceSvgIncluded(std::string newSvgFile)
 
 void DrawViewSection::replacePatIncluded(std::string newPatFile)
 {
-    //    Base::Console().Message("DVS::replacePatIncluded(%s)\n",
-    //    newPatFile.c_str());
+    // Base::Console().Message("DVS::replacePatIncluded(%s)\n", newPatFile.c_str());
     if (newPatFile.empty()) {
         return;
     }

--- a/src/Mod/TechDraw/App/LineGenerator.cpp
+++ b/src/Mod/TechDraw/App/LineGenerator.cpp
@@ -362,6 +362,17 @@ std::string  LineGenerator::getLineStandardsBody()
 {
     int activeStandard = Preferences::lineStandard();
     std::vector<std::string> choices = getAvailableLineStandards();
+    if (activeStandard < 0 ||
+        (size_t) activeStandard >= choices.size()) {
+        // there is a condition where the LineStandard parameter exists, but is -1 (the
+        // qt value for no current index in a combobox).  This is likely caused by an old
+        // development version writing an unvalidated value.  In this case, the existing but
+        // invalid value will be returned.  This is a temporary fix and can be removed for
+        // production.
+        // Preferences::lineStandard() will print a message about this every time it is called
+        // (lots of messages!).
+        activeStandard = 0;
+        }
     return getBodyFromString(choices.at(activeStandard));
 }
 

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -23,7 +23,7 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 # include <string>
-
+# include <QApplication>
 # include <QString>
 #endif
 
@@ -422,6 +422,18 @@ bool Preferences::SectionUsePreviousCut()
 //! an index into the list of available line standards/version found in LineGroupDirectory
 int Preferences::lineStandard()
 {
+    // there is a condition where the LineStandard parameter exists, but is -1 (the
+    // qt value for no current index in a combobox).  This is likely caused by an old
+    // development version writing an unvalidated value.  In this case, the
+    // existing but invalid value will be returned.  This is a temporary fix and
+    // can be removed for production.
+    // this message will appear many times if the parameter is invalid.
+    int parameterValue = getPreferenceGroup("Standards")->GetInt("LineStandard", 1);
+    if (parameterValue < 0) {
+        Base::Console().Warning(qPrintable(QApplication::translate(
+        "Preferences", "The LineStandard parameter is invalid. Using zero instead.", nullptr)));
+        return 0;
+    }
     return getPreferenceGroup("Standards")->GetInt("LineStandard", 1);
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSection.cpp
@@ -47,6 +47,7 @@ void QGIViewSection::draw()
 
 void QGIViewSection::drawSectionFace()
 {
+    // Base::Console().Message("QGIVS::drawSectionFace()\n");
     auto section( dynamic_cast<TechDraw::DrawViewSection *>(getViewObject()) );
     if (!section) {
         return;
@@ -85,13 +86,14 @@ void QGIViewSection::drawSectionFace()
             return;
         }
 
-        QColor faceColor = (sectionVp->CutSurfaceColor.getValue()).asValue<QColor>();
-        faceColor.setAlpha((100 - sectionVp->CutSurfaceTransparency.getValue())*255/100);
-        newFace->setFillColor(faceColor);
-
         if (section->CutSurfaceDisplay.isValue("Color")) {
+            newFace->isHatched(true);
+            QColor faceColor = (sectionVp->CutSurfaceColor.getValue()).asValue<QColor>();
+            faceColor.setAlpha((100 - sectionVp->CutSurfaceTransparency.getValue())*255/100);
+            newFace->setFillColor(faceColor);
             newFace->setFillMode(faceColor.alpha() ? QGIFace::PlainFill : QGIFace::NoFill);
         } else if (section->CutSurfaceDisplay.isValue("SvgHatch")) {
+            newFace->isHatched(true);
             newFace->setFillMode(QGIFace::SvgFill);
             newFace->setHatchColor(sectionVp->HatchColor.getValue());
             newFace->setHatchScale(section->HatchScale.getValue());
@@ -104,9 +106,9 @@ void QGIViewSection::drawSectionFace()
             newFace->setFillMode(QGIFace::GeomHatchFill);
             newFace->setHatchColor(sectionVp->GeomHatchColor.getValue());
             newFace->setHatchScale(section->HatchScale.getValue());
-            newFace->setLineWeight(sectionVp->WeightPattern.getValue());
             newFace->setHatchRotation(section->HatchRotation.getValue());
             newFace->setHatchOffset(section->HatchOffset.getValue());
+            newFace->setLineWeight(sectionVp->WeightPattern.getValue());
             std::vector<TechDraw::LineSet> lineSets = section->getDrawableLines(i);
             if (!lineSets.empty()) {
                 newFace->clearLineSets();


### PR DESCRIPTION
This PR implements a fix to a problem with the initial painting of PAT hatches on section views as reported here:  https://forum.freecad.org/viewtopic.php?t=86257&sid=5fc5a6dca5f30062cd1370d1ba182958

I also includes a temporary patch that affect dev users as reported here: https://forum.freecad.org/viewtopic.php?t=86183&sid=5fc5a6dca5f30062cd1370d1ba182958