### PR TITLE
Core: Property Manager

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -117,6 +117,7 @@
 #include "PropertyExpressionEngine.h"
 #include "PropertyFile.h"
 #include "PropertyLinks.h"
+#include "PropertyVarSet.h"
 #include "PropertyPythonObject.h"
 #include "StringHasherPy.h"
 #include "StringIDPy.h"
@@ -1968,6 +1969,7 @@ void Application::initTypes()
     App::PropertyXLinkSubList       ::init();
     App::PropertyXLinkList          ::init();
     App::PropertyXLinkContainer     ::init();
+    App::PropertyVarSet             ::init();
     App::PropertyMatrix             ::init();
     App::PropertyVector             ::init();
     App::PropertyVectorDistance     ::init();

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -238,6 +238,7 @@ SET(Properties_CPP_SRCS
     PropertyFile.cpp
     PropertyGeo.cpp
     PropertyLinks.cpp
+    PropertyVarSet.cpp
     PropertyPythonObject.cpp
     PropertyStandard.cpp
     PropertyUnits.cpp
@@ -251,6 +252,7 @@ SET(Properties_HPP_SRCS
     PropertyFile.h
     PropertyGeo.h
     PropertyLinks.h
+    PropertyVarSet.h
     PropertyPythonObject.h
     PropertyStandard.h
     PropertyUnits.h

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1106,6 +1106,19 @@ ExpressionPtr Expression::replaceObject(const DocumentObject *parent,
     return ExpressionPtr(expr);
 }
 
+VarSet* Expression::findReferencedVarSet() const {
+    std::map<ObjectIdentifier, bool> objectIdentifiers;
+    getIdentifiers(objectIdentifiers);
+    for (auto oid : objectIdentifiers) {
+        VarSet* varSet = oid.first.findReferencedVarSet();
+        if (varSet) {
+            return varSet;
+        }
+    }
+
+    return nullptr;
+}
+
 App::any Expression::getValueAsAny() const {
     Base::PyGILStateLocker lock;
     return pyObjectToAny(getPyValue());

--- a/src/App/Expression.h
+++ b/src/App/Expression.h
@@ -179,6 +179,8 @@ public:
 
     bool hasComponent() const {return !components.empty();}
 
+    VarSet* findReferencedVarSet() const;
+
     boost::any getValueAsAny() const;
 
     Py::Object getPyValue() const;

--- a/src/App/ExpressionParser.h
+++ b/src/App/ExpressionParser.h
@@ -53,6 +53,7 @@ struct AppExport Expression::Component {
     Component &operator=(const Component &)=delete;
 
     void visit(ExpressionVisitor &v);
+    void rewrite(ExpressionVisitor &v);
     bool isTouched() const;
     void toString(std::ostream &ss, bool persistent) const;
     Component *copy() const;
@@ -197,6 +198,8 @@ protected:
 
     void _visit(ExpressionVisitor & v) override;
 
+    void _rewrite(ExpressionVisitor & v) override;
+
     virtual bool isCommutative() const;
 
     virtual bool isLeftAssociative() const;
@@ -224,6 +227,7 @@ public:
 protected:
     Expression * _copy() const override;
     void _visit(ExpressionVisitor & v) override;
+    void _rewrite(ExpressionVisitor & v) override;
     void _toString(std::ostream &ss, bool persistent, int indent) const override;
     Py::Object _getPyValue() const override;
 
@@ -355,7 +359,11 @@ protected:
     Py::Object _getPyValue() const override;
     Expression * _copy() const override;
     void _visit(ExpressionVisitor & v) override;
+    void _rewrite(ExpressionVisitor & v) override;
     void _toString(std::ostream &ss, bool persistent, int indent) const override;
+    Expression * _rewriteVarSetExpression(const DocumentObject *parent, const char *nameProperty,
+                                          const DocumentObject *varSet, bool add,
+                                          ExpressionVisitor &visitor) override;
 
     Function f;        /**< Function to execute */
     std::string fname;
@@ -391,6 +399,8 @@ public:
 
     void addComponent(Component* component) override;
 
+    Expression* _restoreVarSetExpression(const DocumentObject *parent, const char* nameProperty);
+
 protected:
     Expression * _copy() const override;
     Py::Object _getPyValue() const override;
@@ -404,6 +414,9 @@ protected:
     bool _relabeledDocument(const std::string &, const std::string &, ExpressionVisitor &) override;
     bool _renameObjectIdentifier(const std::map<ObjectIdentifier,ObjectIdentifier> &,
                                          const ObjectIdentifier &, ExpressionVisitor &) override;
+    Expression* _rewriteVarSetExpression(const DocumentObject* parent, const char* nameProperty,
+                                         const DocumentObject* varSet, bool add,
+                                         ExpressionVisitor& visitor) override;
     void _collectReplacement(std::map<ObjectIdentifier,ObjectIdentifier> &,
                     const App::DocumentObject *parent, App::DocumentObject *oldObj,
                     App::DocumentObject *newObj) const override;

--- a/src/App/ExpressionVisitors.h
+++ b/src/App/ExpressionVisitors.h
@@ -121,6 +121,24 @@ private:
     int colOffset;
 };
 
+template<class P> class RewriteVarSetExpressionVisitor : public ExpressionModifier<P> {
+public:
+    explicit RewriteVarSetExpressionVisitor(P &_prop, const DocumentObject* parent,
+                                            const char* nameProperty, const DocumentObject* varSet, bool add)
+        : ExpressionModifier<P>(_prop),parent(parent),nameProperty(nameProperty),varSet(varSet),add(add)
+        {}
+
+    Expression* rewrite(Expression &node) override;
+    void visit(Expression &) override {}
+
+private:
+    const DocumentObject* parent;
+    const char* nameProperty;
+    const DocumentObject* varSet;
+    bool add;
+};
+
+
 }
 
 #endif // RENAMEOBJECTIDENTIFIEREXPRESSIONVISITOR_H

--- a/src/App/ObjectIdentifier.h
+++ b/src/App/ObjectIdentifier.h
@@ -32,6 +32,8 @@
 #include <boost/any.hpp>
 #include <FCConfig.h>
 
+#include "VarSet.h"
+
 namespace Py {
 class Object;
 }
@@ -471,7 +473,8 @@ protected:
 
     void getSubPathStr(std::ostream &ss, const ResolveResults &result, bool toPython=false) const;
 
-    Py::Object access(const ResolveResults &rs,
+    void redirect(VarSet* varSet, ResolveResults &rs) const;
+    Py::Object access(ResolveResults &rs,
             Py::Object *value=nullptr, Dependencies *deps=nullptr) const;
 
     void resolve(ResolveResults & results) const;

--- a/src/App/ObjectIdentifier.h
+++ b/src/App/ObjectIdentifier.h
@@ -419,6 +419,8 @@ public:
 
     // Getter
 
+    VarSet* findReferencedVarSet() const;
+
     App::any getValue(bool pathValue=false, bool *isPseudoProperty=nullptr) const;
 
     Py::Object getPyValue(bool pathValue=false, bool *isPseudoProperty=nullptr) const;
@@ -473,8 +475,7 @@ protected:
 
     void getSubPathStr(std::ostream &ss, const ResolveResults &result, bool toPython=false) const;
 
-    void redirect(VarSet* varSet, ResolveResults &rs) const;
-    Py::Object access(ResolveResults &rs,
+    Py::Object access(const ResolveResults &rs,
             Py::Object *value=nullptr, Dependencies *deps=nullptr) const;
 
     void resolve(ResolveResults & results) const;

--- a/src/App/Part.cpp
+++ b/src/App/Part.cpp
@@ -27,6 +27,7 @@
 
 #include "Part.h"
 #include "PartPy.h"
+#include "VarSet.h"
 
 
 using namespace App;
@@ -135,7 +136,6 @@ std::vector<DocumentObject*> Part::removeObjects(std::vector<DocumentObject*> ob
     return GeoFeatureGroupExtension::removeObjects(objs);
 }
 
-
 void Part::handleChangedPropertyType(Base::XMLReader &reader, const char *TypeName, App::Property *prop)
 {
     // Migrate Material from App::PropertyMap to App::PropertyLink
@@ -148,36 +148,6 @@ void Part::handleChangedPropertyType(Base::XMLReader &reader, const char *TypeNa
         }
     } else {
         App::GeoFeature::handleChangedPropertyType(reader, TypeName, prop);
-    }
-}
-
-VarSet *Part::getOriginalVarSet(const PropertyVarSet* prop) const {
-    const PropertyVarSet* propVarSet = dynamic_cast<const PropertyVarSet*>(
-            getDynamicPropertyByName(
-                    VarSet::getNameOriginalVarSetProperty(
-                            prop->getName()).c_str()));
-    if (propVarSet) {
-        return propVarSet->getValue();
-    }
-    return nullptr;
-}
-
-void Part::onChanged(const Property* prop)
-{
-    DocumentObject::onChanged(prop);
-
-    if (prop->isDerivedFrom<PropertyVarSet>()) {
-        auto propVarSet = dynamic_cast<const PropertyVarSet*>(prop);
-        VarSet *varSet = propVarSet->getValue();
-        VarSet *originalVarSet = getOriginalVarSet(propVarSet);
-        if (varSet && originalVarSet) {
-            if (varSet == originalVarSet) {
-                originalVarSet->removeReplacedVarSet();
-            }
-            else {
-                originalVarSet->addReplacedVarSet(varSet);
-            }
-        }
     }
 }
 

--- a/src/App/Part.h
+++ b/src/App/Part.h
@@ -27,6 +27,8 @@
 #include "GeoFeature.h"
 #include "OriginGroupExtension.h"
 #include "PropertyLinks.h"
+#include "VarSet.h"
+#include "PropertyVarSet.h"
 
 
 namespace App
@@ -84,7 +86,9 @@ public:
         return "Gui::ViewProviderPart";
     }
 
-
+    std::vector<DocumentObject*> addObjects(std::vector<DocumentObject*> objs) override;
+    std::vector<DocumentObject*> removeObjects(std::vector<DocumentObject*> objs) override;
+    
     void handleChangedPropertyType(Base::XMLReader &reader, const char *TypeName, App::Property *prop) override;
 
     /**
@@ -96,6 +100,27 @@ public:
     static App::Part* getPartOfObject (const DocumentObject* obj, bool recursive=true);
 
     PyObject *getPyObject() override;
+
+protected:
+
+    void onChanged(const Property* prop) override;
+
+private:
+    /**
+     * @brief Acquire the original varset given a PropertyVarSet.
+     *
+     * When a VarSet is exposed, the parent Part maintains two PropertyVarSets.
+     * The first points to the VarSet that should parameterize this part, the
+     * second one is hidden and points to the original VarSet inside the part.
+     * This function acquires the original VarSet given the first
+     * PropertyVarSet.  Note that the original VarSet can be the same as the
+     * VarSet the first property is pointing to.
+     *
+     * @param prop The property that points to the VarSet that replaces the
+     * exposed VarSet in the Part.
+     * @return The original VarSet that is replaced by prop.
+     */
+    VarSet* getOriginalVarSet(const PropertyVarSet *prop) const;
 };
 
 //using PartPython = App::FeaturePythonT<Part>;

--- a/src/App/Part.h
+++ b/src/App/Part.h
@@ -27,8 +27,6 @@
 #include "GeoFeature.h"
 #include "OriginGroupExtension.h"
 #include "PropertyLinks.h"
-#include "VarSet.h"
-#include "PropertyVarSet.h"
 
 
 namespace App
@@ -100,27 +98,6 @@ public:
     static App::Part* getPartOfObject (const DocumentObject* obj, bool recursive=true);
 
     PyObject *getPyObject() override;
-
-protected:
-
-    void onChanged(const Property* prop) override;
-
-private:
-    /**
-     * @brief Acquire the original varset given a PropertyVarSet.
-     *
-     * When a VarSet is exposed, the parent Part maintains two PropertyVarSets.
-     * The first points to the VarSet that should parameterize this part, the
-     * second one is hidden and points to the original VarSet inside the part.
-     * This function acquires the original VarSet given the first
-     * PropertyVarSet.  Note that the original VarSet can be the same as the
-     * VarSet the first property is pointing to.
-     *
-     * @param prop The property that points to the VarSet that replaces the
-     * exposed VarSet in the Part.
-     * @return The original VarSet that is replaced by prop.
-     */
-    VarSet* getOriginalVarSet(const PropertyVarSet *prop) const;
 };
 
 //using PartPython = App::FeaturePythonT<Part>;

--- a/src/App/PropertyExpressionEngine.h
+++ b/src/App/PropertyExpressionEngine.h
@@ -150,6 +150,9 @@ public:
 
     void renameObjectIdentifiers(const std::map<App::ObjectIdentifier, App::ObjectIdentifier> & paths);
 
+    void rewriteVarSetExpressions(const DocumentObject * parent, const char * nameProperty,
+                                  const DocumentObject * varSet, bool add);
+
     App::ObjectIdentifier canonicalPath(const App::ObjectIdentifier &p) const override;
 
     size_t numExpressions() const;

--- a/src/App/PropertyExpressionEngine.h
+++ b/src/App/PropertyExpressionEngine.h
@@ -189,6 +189,7 @@ private:
                 DiGraph &g, ExecuteOption option=ExecuteAll) const;
 
     void slotChangedObject(const App::DocumentObject &obj, const App::Property &prop);
+    void varSetChanged(const App::DocumentObject &obj, const App::Property &prop);
     void slotChangedProperty(const App::DocumentObject &obj, const App::Property &prop);
     void updateHiddenReference(const std::string &key);
 

--- a/src/App/PropertyVarSet.cpp
+++ b/src/App/PropertyVarSet.cpp
@@ -37,9 +37,24 @@ PropertyVarSet::PropertyVarSet() = default;
 
 void PropertyVarSet::setValue(DocumentObject* obj)
 {
-    if (obj && obj->isDerivedFrom<VarSet>()) {
-        auto varSet = dynamic_cast<VarSet*>(obj);
-        PropertyXLink::setValue(obj);
+    if (obj) {
+        if (obj->isDerivedFrom<VarSet>()) {
+            auto varSet = dynamic_cast<VarSet*>(obj);
+            auto oldVarSet = getValue();
+            if (oldVarSet) {
+                if (!varSet->isEquivalent(oldVarSet)) {
+                    FC_THROWM(Base::ValueError, "Variable Set "
+                              << varSet->getFullName()
+                              << " is not equivalent to "
+                              << oldVarSet->getFullName());
+                }
+            }
+            PropertyXLink::setValue(obj);
+        }
+        else {
+            FC_THROWM(Base::TypeError, obj->getFullName()
+                      << " is not a Variable Set");
+        }
     }
 }
 

--- a/src/App/PropertyVarSet.cpp
+++ b/src/App/PropertyVarSet.cpp
@@ -1,0 +1,48 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#include "PropertyVarSet.h"
+#include "VarSet.h"
+#include "Base/Console.h"
+
+using namespace App;
+
+
+
+FC_LOG_LEVEL_INIT("VarSet", true, true)
+
+
+TYPESYSTEM_SOURCE(App::PropertyVarSet , App::PropertyXLink)
+
+PropertyVarSet::PropertyVarSet() = default;
+
+void PropertyVarSet::setValue(DocumentObject* obj)
+{
+    if (obj && obj->isDerivedFrom<VarSet>()) {
+        auto varSet = dynamic_cast<VarSet*>(obj);
+        PropertyXLink::setValue(obj);
+    }
+}
+
+VarSet* PropertyVarSet::getValue() const {
+    return dynamic_cast<App::VarSet*>(PropertyXLink::getValue());
+}

--- a/src/App/PropertyVarSet.h
+++ b/src/App/PropertyVarSet.h
@@ -41,14 +41,24 @@ class AppExport PropertyVarSet : public PropertyXLink
 public:
 
     /**
-     * @brief Create a PropertyVarSet
+     * @brief Create a PropertyVarSet.
      */
     PropertyVarSet();
 
+    /**
+     * @brief Set the value of this PropertyVarSet.
+     *
+     * @arg obj Should be either a nullptr (typically used in initialization)
+     * or a VarSet.  Once a VarSet has been set, a subsequent new value has to
+     * be equivalent to the already existing VarSet
+     *
+     * @throws Base::ValueError If the VarSet is not equivalent
+     * @throws Base::TypeError If obj is not a VarSet
+     */
     void setValue(DocumentObject* obj) override;
 
     /**
-     * @brief Get the value of this Property
+     * @brief Get the value of this Property.
      *
      * @return The VarSet that this property links to or nullptr if there is no
      * value.

--- a/src/App/PropertyVarSet.h
+++ b/src/App/PropertyVarSet.h
@@ -1,0 +1,61 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#ifndef APP_PROPERTY_VARSET_H
+#define APP_PROPERTY_VARSET_H
+
+#include "PropertyLinks.h"
+
+namespace App {
+
+class VarSet;
+
+
+/**
+ * @brief A Property class that stores external links to VarSets
+ */
+class AppExport PropertyVarSet : public PropertyXLink
+{
+
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
+    
+public:
+
+    /**
+     * @brief Create a PropertyVarSet
+     */
+    PropertyVarSet();
+
+    void setValue(DocumentObject* obj) override;
+
+    /**
+     * @brief Get the value of this Property
+     *
+     * @return The VarSet that this property links to or nullptr if there is no
+     * value.
+     */
+    VarSet *getValue() const;
+};
+
+}
+
+#endif

--- a/src/App/VarSet.cpp
+++ b/src/App/VarSet.cpp
@@ -26,15 +26,226 @@
 #include <iostream>
 #endif
 
+#include "App/Part.h"
 #include "VarSet.h"
 #include "DocumentObject.h"
+#include "PropertyStandard.h"
+
+#include "Base/Console.h"
 
 using namespace App;
 
 PROPERTY_SOURCE(App::VarSet, App::DocumentObject)
+
+FC_LOG_LEVEL_INIT("VarSet", true, true)
+
+const bool HIDDEN = true;
+const bool COPY_ON_CHANGE = true;
+const bool READ_ONLY = true;
+
+
+VarSet::VarSet() {
+    ADD_PROPERTY_TYPE(Exposed, (false), 0, App::Prop_None, "Whether the variable set is exposed.");
+    ADD_PROPERTY_TYPE(ReplacedBy, (nullptr), 0, App::Prop_None, "The VarSet that replaces this VarSet.");
+    ADD_PROPERTY_TYPE(NamePropertyParent, (""), 0, App::Prop_None, "The name of the property of the parent if the variable set is exposed.");
+    Exposed.setStatus(Property::Status::ReadOnly, true);
+    ReplacedBy.setStatus(Property::Status::Hidden, true);
+}
+
+void VarSet::onBeforeChange(const Property* prop)
+{
+    DocumentObject::onBeforeChange(prop);
+    if (prop == &NamePropertyParent && isExposed()) {
+        previousNameParentProperty = NamePropertyParent.getValue();
+    }
+}
+
+void VarSet::onChanged(const Property* prop)
+{
+    DocumentObject::onChanged(prop);
+    if (prop == &Exposed) {
+        exposedChanged();
+    }
+    if (prop == &NamePropertyParent && isExposed()) {
+        renameVarSetPropertiesParent(previousNameParentProperty);
+        previousNameParentProperty = nullptr;
+    }
+}
 
 const char* VarSet::getViewProviderName() const
 {
     return "Gui::ViewProviderVarSet";
 }
 
+void VarSet::enableExposed()
+{
+    Exposed.setStatus(Property::Status::ReadOnly, false);
+}
+
+void VarSet::disableExposed()
+{
+    Exposed.setValue(false);
+    Exposed.setStatus(Property::Status::ReadOnly, true);
+}
+
+void VarSet::exposedChanged()
+{
+    if (!isRestoring()) {
+        if (Exposed.getValue()) {
+            addVarSetPropertiesParent();
+        }
+        else {
+            removeVarSetPropertiesParent();
+        }
+    }
+}
+
+bool VarSet::isExposed() const
+{
+    return Exposed.getValue();
+}
+
+// TODO
+bool VarSet::isEquivalent(VarSet* varSet) const
+{
+    return true;
+}
+
+void VarSet::onDocumentRestored()
+{
+    DocumentObject::onDocumentRestored();
+    DocumentObject* parent = getFirstParent();
+    if (parent && parent->isDerivedFrom<App::Part>()) {
+        enableExposed();
+    }
+    else {
+        disableExposed();
+    }
+}
+
+const char* VarSet::getNameParentProperty()
+{
+    if (strcmp("", NamePropertyParent.getValue()) == 0) {
+        NamePropertyParent.setValue(Label.getValue());
+    }
+    return NamePropertyParent.getValue();
+}
+
+void VarSet::renameVarSetPropertiesParent(const char *oldName)
+{
+    DocumentObject* parent = getParent();
+    if (parent) {
+        auto prop = dynamic_cast<App::PropertyVarSet*>(parent->getPropertyByName(oldName));
+        if (prop) {
+            VarSet* varSet = prop->getValue();
+            assert(parent->removeDynamicProperty(oldName));
+            assert(parent->removeDynamicProperty(getNameOriginalVarSetProperty(oldName).c_str()));
+
+            createVarSetPropertiesParent(getNameParentProperty(), varSet);
+        }
+    }
+    // there may be no parent, for example when copying
+}
+
+DocumentObject* VarSet::getParent()
+{
+    if (isExposed()) {
+        DocumentObject* parent = getFirstParent();
+        // It could be the case that we're copying an exposed VarSet to a place
+        // where we have no valid parent, for example no App::Part.  In that
+        // case disable the exposed and return nullptr.
+        if (parent) {
+            if (parent->isDerivedFrom<App::Part>()) {
+                return parent;
+            }
+            else {
+                disableExposed();
+            }
+        }
+        else {
+            disableExposed();
+        }
+    }
+    return nullptr;
+}
+
+VarSet* VarSet::getParentVarSet()
+{
+    // get a parent if this VarSet is exposed
+    DocumentObject* parent = getParent();
+    if (parent) {
+        const char* nameProp = getNameParentProperty();
+        auto prop = dynamic_cast<App::PropertyVarSet*>(parent->getPropertyByName(nameProp));
+        if (prop) {
+            VarSet *parentVarSet = prop->getValue();
+            if (parentVarSet != this) {
+                return parentVarSet;
+            }
+        }
+        else {
+            throw Base::RuntimeError(std::string("Property ") + nameProp + " not available in " + getFullName());
+        }
+    }
+    return nullptr;
+}
+
+void VarSet::createVarSetPropertyParent(DocumentObject* parent, const char* name,
+                                        std::string& doc, DocumentObject* value,
+                                        bool hidden, bool copyOnChange)
+{
+    auto prop = dynamic_cast<App::PropertyVarSet*>(
+            parent->addDynamicProperty("App::PropertyVarSet",
+                    name, "Expose", doc.c_str(), 0, !READ_ONLY, hidden));
+    prop->setValue(value);
+    if (copyOnChange) {
+        prop->setStatus(Property::CopyOnChange, true);
+    }
+}
+
+std::string VarSet::getNameOriginalVarSetProperty(const char* name) 
+{
+    return "_" + std::string(name) + "Original";
+}
+
+void VarSet::createVarSetPropertiesParent(const char* name, DocumentObject* value)
+{
+    DocumentObject* parent = getParent();
+    if (parent) {
+        std::string docExposed = "A link to a VarSet equivalent to " + std::string(name);
+        createVarSetPropertyParent(parent, name, docExposed, value, !HIDDEN, COPY_ON_CHANGE);
+
+        std::string docOriginal = "A link to the original VarSet";
+        std::string nameOriginal = getNameOriginalVarSetProperty(name);
+        createVarSetPropertyParent(parent, nameOriginal.c_str(), docOriginal, this, HIDDEN);
+    }
+    else { // a copy can go outside of a part, disable exposed
+        disableExposed();
+    }
+}
+
+void VarSet::addVarSetPropertiesParent()
+{
+    createVarSetPropertiesParent(getNameParentProperty(), this);
+}
+
+void VarSet::removeVarSetPropertiesParent()
+{
+    DocumentObject* parent = getParent();
+    if (parent) {
+        // the property may not be there when constructing the object
+        const char *nameProperty = getNameParentProperty();
+        parent->removeDynamicProperty(nameProperty);
+        parent->removeDynamicProperty(getNameOriginalVarSetProperty(nameProperty).c_str());
+    }
+}
+
+void VarSet::addReplacedVarSet(VarSet* varSet)
+{
+    ReplacedBy.setValue(varSet);
+}
+
+
+void VarSet::removeReplacedVarSet()
+{
+    ReplacedBy.setValue(nullptr);
+}

--- a/src/App/VarSet.h
+++ b/src/App/VarSet.h
@@ -24,23 +24,136 @@
 #define APP_VARSET_H
 
 #include "DocumentObject.h"
+#include "PropertyVarSet.h"
+
 
 namespace App
 {
-
-/** A DocumentObject class with the purpose to store variables
-*/
+    
+/**
+ * @brief A DocumentObject class with the purpose to store variables.
+ *
+ * The VarSet is a DocumentObject in core that behaves in a special manner when
+ * its parent is an App::Part.  It will enable a boolean property Expose that
+ * will create a PropertyVarSet (an external link) that points to this VarSet.
+ */
 class AppExport VarSet : public App::DocumentObject
 {
     PROPERTY_HEADER_WITH_OVERRIDE(App::VarSet);
 	
 public:
 
-    VarSet() = default;
+    /**
+     * @brief Get the name of the property in the parent pointing to the
+     * original VarSet.
+     *
+     * Given a name for the PropertyVarSet of the parent that points to a
+     * VarSet, get the name of the property in the parent that points to the
+     * original VarSet.
+     *
+     * @param name The name of the property that points to a VarSet
+     * @return The name of the property that points to the original VarSet
+     */
+    static std::string getNameOriginalVarSetProperty(const char* name);
+    
+
+    /**
+     * @brief Create a VarSet that is not exposed.
+     */
+    VarSet();
     ~VarSet() override = default;
 
+    void onBeforeChange(const Property* prop) override;
+    void onChanged(const Property* prop) override;
+    void onDocumentRestored() override;
+    
     const char* getViewProviderName() const override;
-};
 
+    /**
+     * @brief Acquire the VarSet of the parent.
+     *
+     * Returns the VarSet the parent is pointing to.  This can be this VarSet
+     * but it can also be an equivalent VarSet that replaces this VarSet.  If
+     * the VarSet is not part of an App::Part or if it is not exposed, it
+     * returns nullptr.
+     *
+     * @return The VarSet the parent is pointing to if exposed or nullptr
+     * otherwise.
+     */
+    VarSet* getParentVarSet();
+
+    /**
+     * @brief Enable the PropertyBool Exposed.
+     *
+     * Exposed should only be enabled if the parent is an App::Part.
+     */
+    void enableExposed();
+
+    /**
+     * @brief Disable the PropertyBool Exposed.
+     *
+     * Exposed should only be enabled if the parent is an App::Part.
+     */
+    void disableExposed();
+
+    /**
+     * @brief Whether this VarSet is exposed.
+     *
+     * @return true if the VarSet is exposed.
+     */
+    bool isExposed() const;
+
+    /**
+     * @brief Whether this VarSet is equivalent to varSet.
+     *
+     * VarSets are equivalent if they have the same set of properties with
+     * similar types.
+     *
+     * @param varSet The VarSet to check equivalence with.
+     * @return true if varSet is equivalent to this VarSet.
+     */
+    bool isEquivalent(VarSet* varSet) const;
+
+    /**
+     * @brief Unregister the VarSet that replaces this VarSet.
+     *
+     * The VarSet remains a PropertyVarSet Replaced that keeps track of which
+     * VarSet this one replaces.  This method removes that VarSet from the
+     * administration.
+     */
+    void removeReplacedVarSet();
+
+    /**
+     * @brief Add varSet as the varSet that replaces this VarSet.
+     *
+     * The VarSet remains a PropertyVarSet Replaced that keeps track of which
+     * VarSet this one replaces.  This method adds that VarSet
+     * to the administration.
+     *
+     * @param varSet The VarSet that replaces this VarSet
+     */
+    void addReplacedVarSet(VarSet* varSet);
+
+private:
+    PropertyBool Exposed;
+    PropertyVarSet ReplacedBy;
+    PropertyString NamePropertyParent;
+    
+    void exposedChanged();
+
+    const char* getNameParentProperty();
+    void createVarSetPropertiesParent(const char* name, DocumentObject* value);
+    void createVarSetPropertyParent(DocumentObject* parent, const char* name,
+                                    std::string& doc, DocumentObject* value,
+                                    bool hidden = false, bool copyOnChange = false);
+    void addVarSetPropertiesParent();
+    void removeVarSetPropertiesParent();
+    void renameVarSetPropertiesParent(const char *oldName);
+
+    const char* previousNameParentProperty;
+
+    DocumentObject* getParent();
+    
+    };
 }
 #endif

--- a/src/App/VarSet.h
+++ b/src/App/VarSet.h
@@ -130,6 +130,10 @@ private:
     void removeVarSetPropertiesParent();
     void renameVarSetPropertiesParent(const char *oldName);
 
+    void rewriteExpressions(DocumentObject* obj, const DocumentObject* parent,
+                            const char* nameProperty, bool add);
+    void rewriteExpressionsParent(DocumentObject* parent, bool add);
+
     const char* previousNameParentProperty;
 
     /** @brief Get the parent of a VarSet that is exposed

--- a/src/App/VarSet.h
+++ b/src/App/VarSet.h
@@ -29,7 +29,7 @@
 
 namespace App
 {
-    
+
 /**
  * @brief A DocumentObject class with the purpose to store variables.
  *
@@ -112,27 +112,7 @@ public:
      * @param varSet The VarSet to check equivalence with.
      * @return true if varSet is equivalent to this VarSet.
      */
-    bool isEquivalent(VarSet* varSet) const;
-
-    /**
-     * @brief Unregister the VarSet that replaces this VarSet.
-     *
-     * The VarSet remains a PropertyVarSet Replaced that keeps track of which
-     * VarSet this one replaces.  This method removes that VarSet from the
-     * administration.
-     */
-    void removeReplacedVarSet();
-
-    /**
-     * @brief Add varSet as the varSet that replaces this VarSet.
-     *
-     * The VarSet remains a PropertyVarSet Replaced that keeps track of which
-     * VarSet this one replaces.  This method adds that VarSet
-     * to the administration.
-     *
-     * @param varSet The VarSet that replaces this VarSet
-     */
-    void addReplacedVarSet(VarSet* varSet);
+    bool isEquivalent(VarSet* other) const;
 
 private:
     PropertyBool Exposed;
@@ -141,8 +121,8 @@ private:
     
     void exposedChanged();
 
-    const char* getNameParentProperty();
-    void createVarSetPropertiesParent(const char* name, DocumentObject* value);
+    const char* getNameVarSetPropertyParent();
+    void createVarSetPropertiesParent(DocumentObject* varSet);
     void createVarSetPropertyParent(DocumentObject* parent, const char* name,
                                     std::string& doc, DocumentObject* value,
                                     bool hidden = false, bool copyOnChange = false);
@@ -152,8 +132,15 @@ private:
 
     const char* previousNameParentProperty;
 
-    DocumentObject* getParent();
+    /** @brief Get the parent of a VarSet that is exposed
+     *
+     * Get the parent of a VarSet that is exposed.  If there is no such parent or
+     * the parent is not a Part, disable the boolean flag Exposed.
+     *
+     * @return the parent document object of the exposed VarSet or nullptr otherwise
+     */
+    DocumentObject* getParentExposed();
     
-    };
+    }; 
 }
 #endif

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}/..
     ${CMAKE_CURRENT_BINARY_DIR}/Language
     ${CMAKE_CURRENT_BINARY_DIR}/propertyeditor
+    ${CMAKE_CURRENT_BINARY_DIR}/propertymanager
     ${CMAKE_CURRENT_BINARY_DIR}/TaskView
     ${CMAKE_CURRENT_BINARY_DIR}/Quarter
     ${CMAKE_CURRENT_BINARY_DIR}/DAGView
@@ -729,6 +730,29 @@ SET(Propertyeditor_SRCS
 )
 SOURCE_GROUP("Propertyeditor" FILES ${Propertyeditor_SRCS})
 
+# The property manager
+SET(Propertymanager_SRCS
+    propertymanager/Filter.cpp
+    propertymanager/Filter.h
+    propertymanager/PropertyManager.cpp
+    propertymanager/PropertyManager.h
+    propertymanager/PropertyManager.ui
+    propertymanager/PropertyEditor2.cpp
+    propertymanager/PropertyEditor2.h
+    propertymanager/PropertyItemDelegate2.cpp
+    propertymanager/PropertyItemDelegate2.h
+    propertymanager/PropertyManagerItem.cpp
+    propertymanager/PropertyManagerItem.h
+    propertymanager/PropertyManagerItemDelegate.cpp
+    propertymanager/PropertyManagerItemDelegate.h
+    propertymanager/PropertyManagerModel.cpp
+    propertymanager/PropertyManagerModel.h
+    propertymanager/PropertyModel2.cpp
+    propertymanager/PropertyModel2.h
+)
+SOURCE_GROUP("Propertymanager" FILES ${Propertymanager_SRCS})
+
+
 # The task view
 SET(Task_View_SRCS
     TaskView/TaskAppearance.cpp
@@ -1252,6 +1276,7 @@ SET(FreeCADGui_SRCS
     ${Inventor_SRCS}
     ${Language_SRCS}
     ${Propertyeditor_SRCS}
+    ${Propertymanager_SRCS}
     ${Task_View_SRCS}
     ${qsintActionPanel_SRCS}
     ${Resource_SRCS}

--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -23,7 +23,8 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#include <QApplication>
+# include <QApplication>
+# include <QPointer>
 #endif
 
 #include "App/Document.h"
@@ -33,7 +34,9 @@
 #include "Application.h"
 #include "Document.h"
 #include "ViewProviderDocumentObject.h"
-
+#include "View3DInventor.h"
+#include "MainWindow.h"
+#include "propertymanager/PropertyManager.h"
 
 using namespace Gui;
 
@@ -126,6 +129,74 @@ bool StdCmdGroup::isActive()
     return hasActiveDocument();
 }
 
+//===========================================================================
+// Std_VarSet
+//===========================================================================
+DEF_STD_CMD_A(StdCmdVarSet)
+
+StdCmdVarSet::StdCmdVarSet()
+  : Command("Std_VarSet")
+{
+    sGroup        = "Structure";
+    sMenuText     = QT_TR_NOOP("Create a variable set");
+    sToolTipText  = QT_TR_NOOP("A Variable Set is an object that maintains a set of properties to be used as "
+                               "variables.  Variable Sets inside a Part can be exposed such that these Parts "
+                               "can act as variants.");
+    sWhatsThis    = "Std_VarSet";
+    sStatusTip    = sToolTipText;
+    sPixmap       = "VarSet";
+}
+
+void StdCmdVarSet::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    
+    openCommand(QT_TRANSLATE_NOOP("Command", "Add a variable set"));
+
+    std::string VarSetName;
+    VarSetName = getUniqueObjectName("VarSet");
+    doCommand(Doc,"App.activeDocument().addObject('App::VarSet','%s')",VarSetName.c_str());
+
+    updateActive();
+}
+
+bool StdCmdVarSet::isActive()
+{
+    return hasActiveDocument();
+}
+
+//===========================================================================
+// Std_PropertyManager
+//===========================================================================
+DEF_3DV_CMD(StdCmdPropertyManager)
+
+StdCmdPropertyManager::StdCmdPropertyManager()
+  : Command("Std_PropertyManager")
+{
+    sGroup        = "Structure";
+    sMenuText     = QT_TR_NOOP("Open the Property Manager");
+    sToolTipText  = QT_TR_NOOP("The Property Manager shows an overview of the properties of Variable Sets.");
+    sWhatsThis    = "Std_PropertyManager";
+    sStatusTip    = sToolTipText;
+    sPixmap       = "VarSet";
+}
+
+void StdCmdPropertyManager::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+
+    Gui::Document* doc = Application::Instance->activeDocument();
+    if (doc) {
+        static QPointer<Gui::Dialog::DlgPropertyManager> dlg = nullptr;
+        if (!dlg)
+            dlg = new Gui::Dialog::DlgPropertyManager();
+        //dlg->setDocument(doc);
+        dlg->setAttribute(Qt::WA_DeleteOnClose);
+        dlg->show();
+    }
+}
+
+
 namespace Gui {
 
 void CreateStructureCommands()
@@ -134,6 +205,8 @@ void CreateStructureCommands()
 
     rcCmdMgr.addCommand(new StdCmdPart());
     rcCmdMgr.addCommand(new StdCmdGroup());
+    rcCmdMgr.addCommand(new StdCmdVarSet());
+    rcCmdMgr.addCommand(new StdCmdPropertyManager());
 }
 
 } // namespace Gui

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -821,7 +821,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // Structure
     auto structure = new ToolBarItem( root );
     structure->setCommand("Structure");
-    *structure << "Std_Part" << "Std_Group" << "Std_LinkActions";
+    *structure << "Std_Part" << "Std_Group" << "Std_LinkActions" << "Std_VarSet" << "Std_PropertyManager";
 
     // Help
     auto help = new ToolBarItem( root );

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -80,6 +80,7 @@ namespace PropertyEditor {
 
 class PropertyItem;
 class PropertyModel;
+class PropertyModel2;
 class PropertyEditorWidget;
 
 /**
@@ -278,6 +279,7 @@ class GuiExport PropertySeparatorItem : public PropertyItem
 
 private:
     friend PropertyModel;
+    friend PropertyModel2;
     int _row = -1;
 };
 

--- a/src/Gui/propertymanager/Filter.cpp
+++ b/src/Gui/propertymanager/Filter.cpp
@@ -1,0 +1,166 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <boost/algorithm/string/predicate.hpp>
+#endif
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <Base/Console.h>
+
+#include "Filter.h"
+
+
+using namespace Gui;
+using namespace Gui::PropertyEditor;
+
+FC_LOG_LEVEL_INIT("Filter", true, true)
+
+const QString Filter::STAR = QString::fromLatin1("\"*\"");
+const QString Filter::ACTIVE_DOC = QString::fromLatin1("\"Active document\"");
+const QString Filter::BASE_GROUP = QString::fromLatin1("Base");
+//const QString Filter::ACTIVE_OBJ = QString::fromLatin1("\"Active object\"");
+
+Filter::Filter() : filterDocument(ACTIVE_DOC),
+                   filterTypeObject(STAR), filterNameObject(STAR),
+                   filterGroup(STAR),
+                   filterTypeProp(STAR), filterNameProp(STAR)
+{
+}
+
+UniqueVector<QString> Filter::getFilterValuesDocument()
+{
+    return {filterDocument, STAR};
+}
+
+QString Filter::getType(Base::Persistence* obj)
+{
+    return QString::fromStdString(obj->getTypeId().getName());
+}
+
+UniqueVector<QString> Filter::getFilterValuesTypeObject()
+{
+    return {filterTypeObject, STAR};
+}
+
+UniqueVector<QString> Filter::getFilterValuesNameObject()
+{
+    return {filterNameObject, STAR};
+}
+
+UniqueVector<QString> Filter::getFilterValuesGroup()
+{
+    return {filterGroup, STAR, BASE_GROUP};
+}
+
+UniqueVector<QString> Filter::getFilterValuesTypeProperty()
+{
+    return {filterTypeProp, STAR};
+}
+
+UniqueVector<QString> Filter::getFilterValuesNameProperty()
+{
+    return {filterNameProp, STAR};
+}
+
+void Filter::filter(QString &selectedDocument,
+                    QString &selectedTypeObject, QString &selectedNameObject,
+                    QString &selectedGroup,
+                    QString &selectedTypeProperty,
+                    QString &selectedNameProperty)
+{
+    filterDocument = selectedDocument;
+    filterTypeObject = selectedTypeObject;
+    filterNameObject = selectedNameObject;
+    filterGroup = selectedGroup;
+    filterTypeProp = selectedTypeProperty;
+    filterNameProp = selectedNameProperty;
+}
+
+std::vector<App::Document*> Filter::getDocumentsFiltered()
+{
+    std::vector<App::Document*> docs = App::GetApplication().getDocuments();
+    std::vector<App::Document*> docsFiltered;
+    for (auto doc : docs) {
+        QString label = QString::fromStdString(doc->Label.getStrValue());
+        if (filterDocument == STAR ||
+            filterDocument == label ||
+            (filterDocument == ACTIVE_DOC && 
+             doc == App::GetApplication().getActiveDocument())) {
+            docsFiltered.push_back(doc);
+        }
+    }
+
+    return docsFiltered;
+}
+
+std::vector<App::DocumentObject*> Filter::getObjectsFiltered(App::Document* doc)
+{
+    std::vector<App::DocumentObject*> objs = doc->getObjects();
+    std::vector<App::DocumentObject*> objsFiltered;
+    for (auto obj : objs) {
+        QString label = QString::fromStdString(obj->Label.getStrValue());
+        QString type = getType(obj);
+        if ((filterTypeObject == STAR || filterTypeObject == type) &&
+            (filterNameObject == STAR || filterNameObject == label)) {
+                /* (filterNameObject == ACTIVE_OBJ &&
+                   obj == doc->getActiveObject())*/
+            objsFiltered.push_back(obj);
+        }
+    }
+
+    return objsFiltered;
+}
+
+std::vector<App::Property*> Filter::getPropertiesFiltered(App::DocumentObject* obj)
+{
+    std::vector<App::Property*> properties;
+    obj->getPropertyList(properties);
+    std::vector<App::Property*> propertiesFiltered;
+
+    for (auto prop : properties) {
+        QString group = QString::fromUtf8(prop->getGroup());
+        QString type = getType(prop);
+        QString name = QString::fromUtf8(prop->getName());
+        if ((filterGroup == STAR    || filterGroup == group) &&
+            (filterTypeProp == STAR || filterTypeProp == type) &&
+            (filterNameProp == STAR || filterNameProp == name)) {
+            propertiesFiltered.push_back(prop);
+        }
+    }
+
+    return propertiesFiltered;
+}
+
+QString Filter::getName()
+{
+    return name;
+}
+
+void Filter::setName(QString& name)
+{
+    this->name = name;
+}

--- a/src/Gui/propertymanager/Filter.h
+++ b/src/Gui/propertymanager/Filter.h
@@ -1,0 +1,157 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#ifndef FILTER_H
+#define FILTER_H
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <boost/algorithm/string/predicate.hpp>
+# include <QAbstractItemModel>
+# include <QString>
+# include <map>
+# include <unordered_map>
+# include <vector>
+# include <unordered_set>
+#endif
+
+#include <Base/Persistence.h>
+#include <App/Document.h>
+
+namespace App {
+class Property;
+}
+
+namespace Gui::PropertyEditor {
+
+class DocumentItem;
+class DocumentObjectItem;
+
+template<typename T>
+class UniqueVector {
+public:
+
+    using iterator = typename std::vector<T>::iterator;
+    using const_iterator = typename std::vector<T>::const_iterator;
+
+    template<typename... Args>
+    UniqueVector(Args... args) {
+        addAll(args...);
+    }
+
+    template<typename... Args>
+    void addAll(T first, Args... rest) {
+        push_back(first);
+        addAll(rest...);
+    }    
+
+    void addAll() {}
+    
+    iterator begin() {
+        return vector.begin();
+    }
+
+    const_iterator begin() const {
+        return vector.begin();
+    }
+
+    iterator end() {
+        return vector.end();
+    }
+
+    const_iterator end() const {
+        return vector.end();
+    }
+
+    void push_back(const T& value) {
+        if (set.insert(value).second) { // Insertion was successful, i.e., value was unique
+            vector.push_back(value);     // Add value to the vector
+        }
+    }
+
+    const T& operator[](size_t index) const {
+        return vector[index];
+    }
+
+    size_t size() const {
+        return vector.size();
+    }
+
+private:
+    std::vector<T> vector;  // Container for maintaining insertion order
+    std::unordered_set<T> set;        // Container for ensuring uniqueness
+};
+
+    
+class Filter
+{
+public:
+    static const QString STAR;
+    
+    static const QString ACTIVE_DOC;// = "\"Active document\"";
+    static const QString BASE_GROUP;// = "Base";
+    //static const QString ACTIVE_OBJ;// = "\"Active object\"";
+
+    Filter();
+    // Filter(const Filter&) = default;
+    // Filter(Filter&&) = delete;
+    // Filter& operator=(const Filter&) = default;
+    // Filter& operator=(Filter&&) = delete;
+    ~Filter() = default;
+
+    static QString getType(Base::Persistence* obj);
+
+    UniqueVector<QString> getFilterValuesDocument();
+    UniqueVector<QString> getFilterValuesTypeObject();
+    UniqueVector<QString> getFilterValuesNameObject();
+    UniqueVector<QString> getFilterValuesGroup();
+    UniqueVector<QString> getFilterValuesTypeProperty();
+    UniqueVector<QString> getFilterValuesNameProperty();
+
+    void filter(QString &selectedDocument,
+                QString &selectedTypeObject, QString &selectedNameObject,
+                QString &selectedGroup,
+                QString &selectedTypeProperty,
+                QString &selecteNameProperty);
+    
+    std::vector<App::Document*> getDocumentsFiltered();
+    std::vector<App::DocumentObject*> getObjectsFiltered(App::Document* doc);
+    std::vector<App::Property*> getPropertiesFiltered(App::DocumentObject* obj);
+
+    QString getName();
+    void setName(QString& name);
+    
+private:
+    QString name;
+    
+    QString filterDocument;
+    QString filterTypeObject;
+    QString filterNameObject;
+    QString filterGroup;
+    QString filterTypeProp;
+    QString filterNameProp;
+};
+
+} // namespace Gui::PropertyEditor
+
+#endif

--- a/src/Gui/propertymanager/PropertyEditor2.cpp
+++ b/src/Gui/propertymanager/PropertyEditor2.cpp
@@ -1,0 +1,916 @@
+/***************************************************************************
+ *   Copyright (c) 2004 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <boost/algorithm/string/predicate.hpp>
+# include <QApplication>
+# include <QInputDialog>
+# include <QHeaderView>
+# include <QMenu>
+# include <QPainter>
+#endif
+
+#include <App/Application.h>
+#include <App/AutoTransaction.h>
+#include <App/Document.h>
+#include <Base/Console.h>
+#include <Base/Tools.h>
+
+#include "PropertyEditor2.h"
+#include "DlgAddProperty.h"
+#include "MainWindow.h"
+#include "PropertyManagerItemDelegate.h"
+#include "PropertyManagerModel.h"
+#include "PropertyView.h"
+#include "ViewProviderDocumentObject.h"
+
+
+FC_LOG_LEVEL_INIT("PropertyView", true, true)
+
+using namespace Gui::PropertyEditor;
+
+PropertyEditor2::PropertyEditor2(QWidget *parent)
+    : QTreeView(parent)
+    , autoexpand(false)
+    , autoupdate(false)
+    , committing(false)
+    , delaybuild(false)
+    , binding(false)
+    , checkDocument(false)
+    , closingEditor(false)
+    , dragInProgress(false)
+{
+    propertyModel = new PropertyManagerModel(this);
+    setModel(propertyModel);
+
+    setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+    setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+
+    delegate = new PropertyManagerItemDelegate(this);
+    delegate->setItemEditorFactory(new PropertyItemEditorFactory);
+    setItemDelegate(delegate);
+
+    setAlternatingRowColors(true);
+    setRootIsDecorated(true);
+    setExpandsOnDoubleClick(true);
+
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    QStyleOptionViewItem opt = PropertyEditor2::viewOptions();
+#else
+    QStyleOptionViewItem opt;
+    initViewItemOption(&opt);
+#endif
+    this->background = opt.palette.dark();
+    this->groupColor = opt.palette.color(QPalette::BrightText);
+
+    this->_itemBackground.setColor(QColor(0,0,0,0));
+
+    this->setSelectionMode(QAbstractItemView::ExtendedSelection);
+
+    connect(this, &QTreeView::activated, this, &PropertyEditor2::onItemActivated);
+    connect(this, &QTreeView::clicked, this, &PropertyEditor2::onItemActivated);
+    connect(this, &QTreeView::expanded, this, &PropertyEditor2::onItemExpanded);
+    connect(this, &QTreeView::collapsed, this, &PropertyEditor2::onItemCollapsed);
+    connect(propertyModel, &QAbstractItemModel::rowsMoved, this, &PropertyEditor2::onRowsMoved);
+    connect(propertyModel, &QAbstractItemModel::rowsRemoved, this, &PropertyEditor2::onRowsRemoved);
+
+    setHeaderHidden(true);
+    viewport()->installEventFilter(this);
+    viewport()->setMouseTracking(true);
+
+    auto hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/DockWindows/PropertyView");
+    int firstColumnSize = hGrp->GetInt("FirstColumnSize", 0);
+    if (firstColumnSize != 0) {
+        header()->resizeSection(0, firstColumnSize);
+    }
+}
+
+PropertyEditor2::~PropertyEditor2()
+{
+    QItemEditorFactory* f = delegate->itemEditorFactory();
+    delegate->setItemEditorFactory(nullptr);
+    delete f;
+}
+
+void PropertyEditor2::setAutomaticExpand(bool v)
+{
+    autoexpand = v;
+}
+
+bool PropertyEditor2::isAutomaticExpand(bool) const
+{
+    return autoexpand;
+}
+
+void PropertyEditor2::onItemExpanded(const QModelIndex &index)
+{
+    auto item = static_cast<PropertyItem*>(index.internalPointer());
+    item->setExpanded(true);
+    for(int i=0, c=item->childCount(); i<c; ++i)
+        setExpanded(propertyModel->index(i, 0, index), item->child(i)->isExpanded());
+}
+
+void PropertyEditor2::onItemCollapsed(const QModelIndex &index)
+{
+    auto item = static_cast<PropertyItem*>(index.internalPointer());
+    item->setExpanded(false);
+}
+
+void PropertyEditor2::setAutomaticDocumentUpdate(bool v)
+{
+    autoupdate = v;
+}
+
+bool PropertyEditor2::isAutomaticDocumentUpdate(bool) const
+{
+    return autoupdate;
+}
+
+QBrush PropertyEditor2::groupBackground() const
+{
+    return this->background;
+}
+
+void PropertyEditor2::setGroupBackground(const QBrush& c)
+{
+    this->background = c;
+}
+
+QColor PropertyEditor2::groupTextColor() const
+{
+    return this->groupColor;
+}
+
+void PropertyEditor2::setGroupTextColor(const QColor& c)
+{
+    this->groupColor = c;
+}
+
+QBrush PropertyEditor2::itemBackground() const
+{
+    return this->_itemBackground;
+}
+
+void PropertyEditor2::setItemBackground(const QBrush& c)
+{
+    this->_itemBackground = c;
+}
+
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+QStyleOptionViewItem PropertyEditor2::viewOptions() const
+{
+    QStyleOptionViewItem option = QTreeView::viewOptions();
+    option.showDecorationSelected = true;
+    return option;
+}
+#else
+void PropertyEditor2::initViewItemOption(QStyleOptionViewItem *option) const
+{
+    QTreeView::initViewItemOption(option);
+    option->showDecorationSelected = true;
+}
+#endif
+
+bool PropertyEditor2::event(QEvent* event)
+{
+    if (event->type() == QEvent::ShortcutOverride) {
+        auto kevent = static_cast<QKeyEvent*>(event);
+        Qt::KeyboardModifiers ShiftKeypadModifier = Qt::ShiftModifier | Qt::KeypadModifier;
+        if (kevent->modifiers() == Qt::NoModifier ||
+            kevent->modifiers() == Qt::ShiftModifier ||
+            kevent->modifiers() == Qt::KeypadModifier ||
+            kevent->modifiers() == ShiftKeypadModifier) {
+            switch (kevent->key()) {
+            case Qt::Key_Delete:
+            case Qt::Key_Home:
+            case Qt::Key_End:
+            case Qt::Key_Backspace:
+            case Qt::Key_Left:
+            case Qt::Key_Right:
+                kevent->accept();
+            default:
+                break;
+            }
+        }
+    }
+    return QTreeView::event(event);
+}
+
+void PropertyEditor2::commitData (QWidget * editor)
+{
+    committing = true;
+    QTreeView::commitData(editor);
+    committing = false;
+    if (delaybuild) {
+        delaybuild = false;
+        FC_ERR("propertyModel->buildUp(PropertyModel2::PropertyList());");
+        //propertyModel->buildUp(PropertyModel2::PropertyList());
+    }
+}
+
+void PropertyEditor2::editorDestroyed (QObject * editor)
+{
+    QTreeView::editorDestroyed(editor);
+
+    // When editing expression through context menu, the editor (ExpLineEditor)
+    // deletes itself when finished, so it won't trigger closeEditor signal. We
+    // must handle it here to perform auto update.
+    closeTransaction();
+}
+
+void PropertyEditor2::currentChanged ( const QModelIndex & current, const QModelIndex & previous )
+{
+    FC_LOG("current changed " << current.row()<<","<<current.column()
+            << "  " << previous.row()<<","<<previous.column());
+
+    QTreeView::currentChanged(current, previous);
+
+    // if (previous.isValid())
+    //     closePersistentEditor(model()->buddy(previous));
+
+    // DO NOT activate editor here, use onItemActivate() which response to
+    // signals of activated and clicked.
+    //
+    // if (current.isValid())
+    //     openPersistentEditor(model()->buddy(current));
+}
+
+void PropertyEditor2::closeEditor()
+{
+    if (editingIndex.isValid()) {
+        Base::StateLocker guard(closingEditor);
+        bool hasFocus = activeEditor && activeEditor->hasFocus();
+        closePersistentEditor(editingIndex);
+        editingIndex = QPersistentModelIndex();
+        activeEditor = nullptr;
+        if(hasFocus)
+            setFocus();
+    }
+}
+
+void PropertyEditor2::openEditor(const QModelIndex &index)
+{
+    if(editingIndex == index && activeEditor)
+        return;
+
+    closeEditor();
+
+    openPersistentEditor(model()->buddy(index));
+
+    if(!editingIndex.isValid() || !autoupdate)
+        return;
+
+    auto &app = App::GetApplication();
+    if(app.getActiveTransaction()) {
+        FC_LOG("editor already transacting " << app.getActiveTransaction());
+        return;
+    }
+    auto item = static_cast<PropertyItem*>(editingIndex.internalPointer());
+    auto items = item->getPropertyData();
+    for(auto propItem=item->parent();items.empty() && propItem;propItem=propItem->parent())
+        items = propItem->getPropertyData();
+    if(items.empty()) {
+        FC_LOG("editor no item");
+        return;
+    }
+    auto prop = items[0];
+    auto parent = prop->getContainer();
+    auto obj  = Base::freecad_dynamic_cast<App::DocumentObject>(parent);
+    if (!obj) {
+        auto view  = Base::freecad_dynamic_cast<ViewProviderDocumentObject>(parent);
+        if (view)
+            obj = view->getObject();
+    }
+    if(!obj || !obj->getDocument()) {
+        FC_LOG("invalid object");
+        return;
+    }
+    if(obj->getDocument()->hasPendingTransaction()) {
+        FC_LOG("pending transaction");
+        return;
+    }
+    std::ostringstream str;
+    str << tr("Edit").toUtf8().constData() << ' ';
+    for(auto prop : items) {
+        if(prop->getContainer()!=obj) {
+            obj = nullptr;
+            break;
+        }
+    }
+    if(obj && obj->isAttachedToDocument())
+        str << obj->getNameInDocument() << '.';
+    else
+        str << tr("property").toUtf8().constData() << ' ';
+    str << prop->getName();
+    if(items.size()>1)
+        str << "...";
+    transactionID = app.setActiveTransaction(str.str().c_str());
+    FC_LOG("editor transaction " << app.getActiveTransaction());
+}
+
+void PropertyEditor2::onItemActivated ( const QModelIndex & index )
+{
+    if(index.column() != 1)
+        return;
+    openEditor(index);
+}
+
+void PropertyEditor2::recomputeDocument(App::Document* doc)
+{
+    try {
+        if (doc && !doc->isTransactionEmpty()) {
+            // Between opening and committing a transaction a recompute
+            // could already have been done
+            if (doc->isTouched())
+                doc->recompute();
+        }
+    }
+    // do not re-throw
+    catch (const Base::Exception& e) {
+        e.ReportException();
+    }
+    catch (const std::exception& e) {
+        Base::Console().Error("Unhandled std::exception caught in PropertyEditor2::recomputeDocument.\n"
+                            "The error message is: %s\n", e.what());
+    }
+    catch (...) {
+        Base::Console().Error("Unhandled unknown exception caught in PropertyEditor2::recomputeDocument.\n");
+    }
+}
+
+void PropertyEditor2::closeTransaction()
+{
+    int tid = 0;
+    if (App::GetApplication().getActiveTransaction(&tid) && tid == transactionID) {
+        if (autoupdate) {
+            App::Document* doc = App::GetApplication().getActiveDocument();
+            recomputeDocument(doc);
+        }
+        App::GetApplication().closeActiveTransaction();
+    }
+}
+
+void PropertyEditor2::closeEditor (QWidget * editor, QAbstractItemDelegate::EndEditHint hint)
+{
+    if (closingEditor)
+        return;
+
+    if (removingRows) {
+        // When removing rows, QTreeView will temporary hide the editor which
+        // will trigger Event::FocusOut and subsequently trigger call of
+        // closeEditor() here. Since we are using persistent editor, QTreeView
+        // will not destroy the editor. But we still needs to call
+        // QTreeView::closeEditor() here, in case the editor belongs to the
+        // removed rows.
+        QTreeView::closeEditor(editor, hint);
+        return;
+    }
+
+    closeTransaction();
+
+    // If we are not removing rows, then QTreeView::closeEditor() does nothing
+    // because we are using persistent editor, so we have to call our own
+    // version of closeEditor()
+    this->closeEditor();
+
+    QModelIndex indexSaved = currentIndex();
+
+    if (indexSaved.column() == 0) {
+        // Calling setCurrentIndex() to make sure we focus on column 1 instead of 0.
+        setCurrentIndex(propertyModel->buddy(indexSaved));
+    }
+
+    QModelIndex lastIndex = indexSaved;
+    bool wrapped = false;
+    do {
+        QModelIndex index;
+        if (hint == QAbstractItemDelegate::EditNextItem) {
+            index = moveCursor(MoveDown,Qt::NoModifier);
+        } else if(hint == QAbstractItemDelegate::EditPreviousItem) {
+            index = moveCursor(MoveUp,Qt::NoModifier);
+        } else
+            break;
+        if (!index.isValid() || index == lastIndex) {
+            if (wrapped) {
+                setCurrentIndex(propertyModel->buddy(indexSaved));
+                break;
+            }
+            wrapped = true;
+            if (hint == QAbstractItemDelegate::EditNextItem)
+                index = moveCursor(MoveHome, Qt::NoModifier);
+            else
+                index = moveCursor(MoveEnd, Qt::NoModifier);
+            if (!index.isValid() || index == indexSaved)
+                break;
+        }
+        lastIndex = index;
+        setCurrentIndex(propertyModel->buddy(index));
+
+        auto item = static_cast<PropertyItem*>(index.internalPointer());
+        // Skip readonly item, because the editor will be disabled and hence
+        // does not accept focus, and in turn break Tab/Backtab navigation.
+        if (item && item->isReadOnly())
+            continue;
+
+        openEditor(index);
+
+    } while (!editingIndex.isValid());
+}
+
+void PropertyEditor2::reset()
+{
+    QTreeView::reset();
+
+    closeTransaction();
+
+    QModelIndex parent;
+    int numRows = propertyModel->rowCount(parent);
+    for (int i=0; i<numRows; ++i) {
+        QModelIndex index = propertyModel->index(i, 0, parent);
+        auto item = static_cast<PropertyItem*>(index.internalPointer());
+        if (item->childCount() == 0) {
+            if(item->isSeparator())
+                setRowHidden(i, parent, true);
+        } else
+            setEditorMode(index, 0, item->childCount()-1);
+        if(item->isExpanded())
+            setExpanded(index, true);
+    }
+}
+
+void PropertyEditor2::onRowsMoved(const QModelIndex &parent, int start, int end, const QModelIndex &dst, int)
+{
+    if(parent != dst) {
+        auto item = static_cast<PropertyItem*>(parent.internalPointer());
+        if(item && item->isSeparator() && item->childCount()==0)
+            setRowHidden(parent.row(), propertyModel->parent(parent), true);
+        item = static_cast<PropertyItem*>(dst.internalPointer());
+        if(item && item->isSeparator() && item->childCount()==end-start+1) {
+            setRowHidden(dst.row(), propertyModel->parent(dst), false);
+            setExpanded(dst, true);
+        }
+    }
+}
+
+void PropertyEditor2::rowsInserted (const QModelIndex & parent, int start, int end)
+{
+    QTreeView::rowsInserted(parent, start, end);
+
+    auto item = static_cast<PropertyItem*>(parent.internalPointer());
+    if (item && item->isSeparator() && item->childCount() == end-start+1) {
+        setRowHidden(parent.row(), propertyModel->parent(parent), false);
+        if(item->isExpanded())
+            setExpanded(parent, true);
+    }
+
+    for (int i=start; i<=end; ++i) {
+        QModelIndex index = propertyModel->index(i, 0, parent);
+        auto child = static_cast<PropertyItem*>(index.internalPointer());
+        if(child->isSeparator()) {
+            // Set group header rows to span all columns
+            setFirstColumnSpanned(i, parent, true);
+        }
+        if(child->isExpanded())
+            setExpanded(index, true);
+    }
+
+    if(parent.isValid())
+        setEditorMode(parent, start, end);
+}
+
+void PropertyEditor2::rowsAboutToBeRemoved (const QModelIndex & parent, int start, int end)
+{
+    QTreeView::rowsAboutToBeRemoved(parent, start, end);
+
+    auto item = static_cast<PropertyItem*>(parent.internalPointer());
+    if (item && item->isSeparator() && item->childCount() == end-start+1)
+        setRowHidden(parent.row(), propertyModel->parent(parent), true);
+
+    if (editingIndex.isValid()) {
+        if (editingIndex.row() >= start && editingIndex.row() <= end)
+            closeTransaction();
+        else {
+            removingRows = 1;
+            for (QWidget *w = qApp->focusWidget(); w; w = w->parentWidget()) {
+                if(w == activeEditor) {
+                    removingRows = -1;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+void PropertyEditor2::onRowsRemoved(const QModelIndex &, int, int)
+{
+    if (removingRows < 0 && activeEditor)
+        activeEditor->setFocus();
+    removingRows = 0;
+}
+
+void PropertyEditor2::drawBranches(QPainter *painter, const QRect &rect, const QModelIndex &index) const
+{
+    QTreeView::drawBranches(painter, rect, index);
+
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    //QStyleOptionViewItem opt = viewOptions();
+#else
+    //QStyleOptionViewItem opt;
+    //initViewItemOption(&opt);
+#endif
+    auto property = static_cast<PropertyItem*>(index.internalPointer());
+    // if (property && property->isSeparator()) {
+    //     painter->fillRect(rect, this->background);
+    //} else if (selectionModel()->isSelected(index)) {
+    //    painter->fillRect(rect, opt.palette.brush(QPalette::Highlight));
+    // }
+
+    //QPen savedPen = painter->pen();
+    //QColor color = static_cast<QRgb>(QApplication::style()->styleHint(QStyle::SH_Table_GridLineColor, &opt));
+    //painter->setPen(QPen(color));
+    //painter->drawLine(rect.x(), rect.bottom(), rect.right(), rect.bottom());
+    //painter->setPen(savedPen);
+}
+
+void PropertyEditor2::init()
+{
+    propertyModel->init();
+}
+
+// void PropertyEditor2::buildUp(PropertyModel2::PropertyList &&props, bool _checkDocument)
+// {
+//     checkDocument = _checkDocument;
+
+//     if (committing) {
+//         Base::Console().Warning("While committing the data to the property the selection has changed.\n");
+//         delaybuild = true;
+//         return;
+//     }
+
+//     // Do not close transaction here, because we are now doing incremental
+//     // update in PropertyModel::buildUp()
+//     //
+//     // closeTransaction();
+
+//     QModelIndex index = this->currentIndex();
+//     QStringList propertyPath = propertyModel->propertyPathFromIndex(index);
+//     if (!propertyPath.isEmpty())
+//         this->selectedProperty = propertyPath;
+//     propertyModel->buildUp(props);
+//     if (!this->selectedProperty.isEmpty()) {
+//         QModelIndex index = propertyModel->propertyIndexFromPath(this->selectedProperty);
+//         this->setCurrentIndex(index);
+//     }
+
+//     propList = std::move(props);
+//     propOwners.clear();
+//     for(auto &v : propList) {
+//         for(auto prop : v.second) {
+//             auto container = prop->getContainer();
+//             if(!container)
+//                 continue;
+//             // Include document to get proper handling in PropertyView::slotDeleteDocument()
+//             if(checkDocument && container->isDerivedFrom(App::DocumentObject::getClassTypeId()))
+//                 propOwners.insert(static_cast<App::DocumentObject*>(container)->getDocument());
+//             propOwners.insert(container);
+//         }
+//     }
+
+//     if (autoexpand)
+//         expandAll();
+// }
+
+/*
+  TODO bring back but then with parent info?
+  
+void PropertyEditor2::updateProperty(const App::Property& prop)
+{
+    // forward this to the model if the property is changed from outside
+    if (!committing)
+        propertyModel->updateProperty(prop);
+}
+*/
+
+void PropertyEditor2::setEditorMode(const QModelIndex & parent, int start, int end)
+{
+    int column = 1;
+    for (int i=start; i<=end; i++) {
+        QModelIndex item = propertyModel->index(i, column, parent);
+        auto propItem = static_cast<PropertyItem*>(item.internalPointer());
+        if (!PropertyView::showAll() && propItem && propItem->testStatus(App::Property::Hidden)) {
+            setRowHidden (i, parent, true);
+        }
+    }
+}
+
+/*
+  TOOD bring back with parent info
+void PropertyEditor2::removeProperty(const App::Property& prop)
+{
+    for (PropertyModel2::PropertyList::iterator it = propList.begin(); it != propList.end(); ++it) {
+        // find the given property in the list and remove it if it's there
+        std::vector<App::Property*>::iterator pos = std::find(it->second.begin(), it->second.end(), &prop);
+        if (pos != it->second.end()) {
+            it->second.erase(pos);
+            // if the last property of this name is removed then also remove the whole group
+            if (it->second.empty()) {
+                propList.erase(it);
+            }
+            propertyModel->removeProperty(prop);
+            break;
+        }
+    }
+}
+*/
+
+enum MenuAction {
+    MA_AutoExpand,
+    MA_ShowAll,
+    MA_Expression,
+    MA_RemoveProp,
+    MA_AddProp,
+    MA_EditPropGroup,
+    MA_Transient,
+    MA_Output,
+    MA_NoRecompute,
+    MA_ReadOnly,
+    MA_Hidden,
+    MA_Touched,
+    MA_EvalOnRestore,
+    MA_CopyOnChange,
+};
+
+void PropertyEditor2::contextMenuEvent(QContextMenuEvent *) {
+    QMenu menu;
+    QAction *autoExpand = menu.addAction(tr("Auto expand"));
+    autoExpand->setCheckable(true);
+    autoExpand->setChecked(autoexpand);
+    autoExpand->setData(QVariant(MA_AutoExpand));
+
+    QAction *showAll = menu.addAction(tr("Show all"));
+    showAll->setCheckable(true);
+    showAll->setChecked(PropertyView::showAll());
+    showAll->setData(QVariant(MA_ShowAll));
+
+    auto contextIndex = currentIndex();
+
+    std::unordered_set<App::Property*> props;
+    const auto indexes = selectedIndexes();
+    for(const auto& index : indexes) {
+        auto item = static_cast<PropertyItem*>(index.internalPointer());
+        if(item->isSeparator())
+            continue;
+        for(auto parent=item;parent;parent=parent->parent()) {
+            const auto &ps = parent->getPropertyData();
+            if(!ps.empty()) {
+                props.insert(ps.begin(),ps.end());
+                break;
+            }
+        }
+    }
+
+    if(props.size() == 1) {
+        auto item = static_cast<PropertyItem*>(contextIndex.internalPointer());
+        auto prop = *props.begin();
+        if(item->isBound() 
+            && !prop->isDerivedFrom(App::PropertyExpressionEngine::getClassTypeId())
+            && !prop->isReadOnly() 
+            && !prop->testStatus(App::Property::Immutable)
+            && !(prop->getType() & App::Prop_ReadOnly))
+        {
+            contextIndex = propertyModel->buddy(contextIndex);
+            setCurrentIndex(contextIndex);
+            menu.addSeparator();
+            menu.addAction(tr("Expression..."))->setData(QVariant(MA_Expression));
+        }
+    }
+
+    if(PropertyView::showAll()) {
+        if(!props.empty()) {
+            menu.addAction(tr("Add property"))->setData(QVariant(MA_AddProp));
+            if (std::all_of(props.begin(), props.end(), [](auto prop) {
+                    return prop->testStatus(App::Property::PropDynamic)
+                        && !boost::starts_with(prop->getName(),prop->getGroup());
+               }))
+            {
+                menu.addAction(tr("Rename property group"))->setData(QVariant(MA_EditPropGroup));
+            }
+        }
+
+        bool canRemove = !props.empty();
+        unsigned long propType = 0;
+        unsigned long propStatus = 0xffffffff;
+        for(auto prop : props) {
+            propType |= prop->getType();
+            propStatus &= prop->getStatus();
+            if(!prop->testStatus(App::Property::PropDynamic)
+                || prop->testStatus(App::Property::LockDynamic))
+            {
+                canRemove = false;
+            }
+        }
+        if(canRemove)
+            menu.addAction(tr("Remove property"))->setData(QVariant(MA_RemoveProp));
+
+        if(!props.empty()) {
+            menu.addSeparator();
+
+            QAction *action;
+            QString text;
+#define _ACTION_SETUP(_name) do {\
+                text = tr(#_name);\
+                action = menu.addAction(text);\
+                action->setData(QVariant(MA_##_name));\
+                action->setCheckable(true);\
+                if(propStatus & (1<<App::Property::_name))\
+                    action->setChecked(true);\
+            }while(0)
+#define ACTION_SETUP(_name) do {\
+                _ACTION_SETUP(_name);\
+                if(propType & App::Prop_##_name) {\
+                    action->setText(text + QString::fromLatin1(" *"));\
+                    action->setChecked(true);\
+                }\
+            }while(0)
+
+            ACTION_SETUP(Hidden);
+            ACTION_SETUP(Output);
+            ACTION_SETUP(NoRecompute);
+            ACTION_SETUP(ReadOnly);
+            ACTION_SETUP(Transient);
+            _ACTION_SETUP(Touched);
+            _ACTION_SETUP(EvalOnRestore);
+            _ACTION_SETUP(CopyOnChange);
+        }
+    }
+
+    auto action = menu.exec(QCursor::pos());
+    if(!action)
+        return;
+
+    switch(action->data().toInt()) {
+    case MA_AutoExpand:
+        autoexpand = autoExpand->isChecked();
+        if (autoexpand)
+            expandAll();
+        return;
+    case MA_ShowAll:
+        PropertyView::setShowAll(action->isChecked());
+        return;
+#define ACTION_CHECK(_name) \
+    case MA_##_name:\
+        for(auto prop : props) \
+            prop->setStatus(App::Property::_name,action->isChecked());\
+        break
+    ACTION_CHECK(Transient);
+    ACTION_CHECK(ReadOnly);
+    ACTION_CHECK(Output);
+    ACTION_CHECK(Hidden);
+    ACTION_CHECK(EvalOnRestore);
+    ACTION_CHECK(CopyOnChange);
+    case MA_Touched:
+        for(auto prop : props) {
+            if(action->isChecked())
+                prop->touch();
+            else
+                prop->purgeTouched();
+        }
+        break;
+    case MA_Expression:
+        if(contextIndex == currentIndex()) {
+            Base::FlagToggler<> flag(binding);
+            closeEditor();
+            openEditor(contextIndex);
+        }
+        break;
+    case MA_AddProp: {
+        App::AutoTransaction committer("Add property");
+        std::unordered_set<App::PropertyContainer*> containers;
+        auto sels = Gui::Selection().getSelection("*");
+        if(sels.size() == 1)
+            containers.insert(sels[0].pObject);
+        else {
+            for(auto prop : props)
+                containers.insert(prop->getContainer());
+        }
+        Gui::Dialog::DlgAddProperty dlg(
+                Gui::getMainWindow(),std::move(containers));
+        dlg.exec();
+        return;
+    }
+    case MA_EditPropGroup: {
+        // This operation is not undoable yet.
+        const char *groupName = (*props.begin())->getGroup();
+        if(!groupName)
+            groupName = "Base";
+        QString res = QInputDialog::getText(Gui::getMainWindow(),
+                tr("Rename property group"), tr("Group name:"),
+                QLineEdit::Normal, QString::fromUtf8(groupName));
+        if(res.size()) {
+            std::string group = res.toUtf8().constData();
+            for(auto prop : props)
+                prop->getContainer()->changeDynamicProperty(prop,group.c_str(),nullptr);
+            //FC_ERR("buildUp(PropertyModel2::PropertyList(propList),checkDocument); not implemented");
+            //buildUp(PropertyModel2::PropertyList(propList),checkDocument);
+        }
+        return;
+    }
+    case MA_RemoveProp: {
+        App::AutoTransaction committer("Remove property");
+        for(auto prop : props) {
+            try {
+                prop->getContainer()->removeDynamicProperty(prop->getName());
+            }catch(Base::Exception &e) {
+                e.ReportException();
+            }
+        }
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+
+bool PropertyEditor2::eventFilter(QObject* object, QEvent* event) {
+    if (object == viewport()) {
+        QMouseEvent* mouse_event = dynamic_cast<QMouseEvent*>(event);
+        if (mouse_event) {
+            if (mouse_event->type() == QEvent::MouseMove) {
+                if (dragInProgress) { // apply dragging
+                    QHeaderView* header_view = header();
+                    int delta = mouse_event->pos().x() - dragPreviousPos;
+                    dragPreviousPos = mouse_event->pos().x();
+                    //using minimal size = dragSensibility * 2 to prevent collapsing
+                    header_view->resizeSection(dragSection,
+                        qMax(dragSensibility * 2, header_view->sectionSize(dragSection) + delta));
+                    return true;
+                }
+                else { // set mouse cursor shape
+                    if (indexResizable(mouse_event->pos()).isValid()) {
+                        viewport()->setCursor(Qt::SplitHCursor);
+                    }
+                    else {
+                        viewport()->setCursor(QCursor());
+                    }
+                }
+            }
+            else if (mouse_event->type() == QEvent::MouseButtonPress && mouse_event->button() == Qt::LeftButton && !dragInProgress) {
+                if (indexResizable(mouse_event->pos()).isValid()) {
+                    dragInProgress = true;
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+                    dragPreviousPos = mouse_event->x();
+#else
+                    dragPreviousPos = mouse_event->position().toPoint().x();
+#endif
+                    dragSection = indexResizable(mouse_event->pos()).column();
+                    return true;
+                }
+            }
+            else if (mouse_event->type() == QEvent::MouseButtonRelease &&
+                mouse_event->button() == Qt::LeftButton && dragInProgress) { 
+                dragInProgress = false;
+
+                auto hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/DockWindows/PropertyView");
+                hGrp->SetInt("FirstColumnSize", header()->sectionSize(0));
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+QModelIndex PropertyEditor2::indexResizable(QPoint mouse_pos) {
+    QModelIndex index = indexAt(mouse_pos - QPoint(dragSensibility + 1, 0));
+    if (index.isValid()) {
+        if (qAbs(visualRect(index).right() - mouse_pos.x()) < dragSensibility &&
+            header()->sectionResizeMode(index.column()) == QHeaderView::Interactive) {
+            return index;
+        }
+    }
+    return QModelIndex();
+}
+
+#include "moc_PropertyEditor2.cpp"

--- a/src/Gui/propertymanager/PropertyEditor2.h
+++ b/src/Gui/propertymanager/PropertyEditor2.h
@@ -1,0 +1,171 @@
+/***************************************************************************
+ *   Copyright (c) 2004 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PROPERTYEDITOR2_H
+#define PROPERTYEDITOR2_H
+
+#include <unordered_set>
+
+#include <QTreeView>
+
+#include "propertyeditor/PropertyItem.h"
+#include "PropertyManagerModel.h"
+#include "PropertyManagerItemDelegate.h"
+
+
+namespace App {
+class Property;
+class Document;
+}
+
+namespace Gui {
+
+class PropertyView;
+
+namespace PropertyEditor {
+
+class PropertyItemDelegate2;
+class PropertyModel2;
+/*!
+ Put this into the .qss file after Gui--PropertyEditor--PropertyEditor
+ 
+ Gui--PropertyEditor--PropertyEditor
+ {
+    qproperty-groupBackground: gray;
+    qproperty-groupTextColor: white;
+ }
+
+ See also: https://man42.net/blog/2011/09/qt-4-7-modify-a-custom-q_property-with-a-qt-style-sheet/
+
+*/
+
+class PropertyEditor2 : public QTreeView
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QBrush groupBackground READ groupBackground WRITE setGroupBackground DESIGNABLE true SCRIPTABLE true) // clazy:exclude=qproperty-without-notify
+    Q_PROPERTY(QColor groupTextColor READ groupTextColor WRITE setGroupTextColor DESIGNABLE true SCRIPTABLE true) // clazy:exclude=qproperty-without-notify
+    Q_PROPERTY(QBrush itemBackground READ itemBackground WRITE setItemBackground DESIGNABLE true SCRIPTABLE true) // clazy:exclude=qproperty-without-notify
+
+public:
+    PropertyEditor2(QWidget *parent = nullptr);
+    ~PropertyEditor2() override;
+
+    /** Builds up the list view with the properties. */
+    //void buildUp(PropertyModel2::PropertyList &&props = PropertyModel2::PropertyList(), bool checkDocument=false);
+    void init();
+    /*
+    void updateProperty(const App::Property&);
+    void removeProperty(const App::Property&);
+    */
+    void setAutomaticExpand(bool);
+    bool isAutomaticExpand(bool) const;
+    void setAutomaticDocumentUpdate(bool);
+    bool isAutomaticDocumentUpdate(bool) const;
+    /*! Reset the internal state of the view. */
+    void reset() override;
+
+    QBrush groupBackground() const;
+    void setGroupBackground(const QBrush& c);
+    QColor groupTextColor() const;
+    void setGroupTextColor(const QColor& c);
+    QBrush itemBackground() const;
+    void setItemBackground(const QBrush& c);
+
+    bool isBinding() const { return binding; }
+    void openEditor(const QModelIndex &index);
+    void closeEditor();
+
+    PropertyManagerModel* getPropertyManagerModel();
+
+protected Q_SLOTS:
+    void onItemActivated(const QModelIndex &index);
+    void onItemExpanded(const QModelIndex &index);
+    void onItemCollapsed(const QModelIndex &index);
+    void onRowsMoved(const QModelIndex &parent, int start, int end, const QModelIndex &dst, int row);
+    void onRowsRemoved(const QModelIndex &parent, int start, int end);
+
+protected:
+    bool eventFilter(QObject* object, QEvent* event) override;
+    void closeEditor (QWidget * editor, QAbstractItemDelegate::EndEditHint hint) override;
+    void commitData (QWidget * editor) override;
+    void editorDestroyed (QObject * editor) override;
+    void currentChanged (const QModelIndex & current, const QModelIndex & previous) override;
+    void rowsInserted (const QModelIndex & parent, int start, int end) override;
+    void rowsAboutToBeRemoved (const QModelIndex & parent, int start, int end) override;
+    void drawBranches(QPainter *painter, const QRect &rect, const QModelIndex &index) const override;
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    QStyleOptionViewItem viewOptions() const override;
+#else
+    void initViewItemOption(QStyleOptionViewItem *option) const override;
+#endif
+    void contextMenuEvent(QContextMenuEvent *event) override;
+    bool event(QEvent*) override;
+
+private:
+    void setEditorMode(const QModelIndex & parent, int start, int end);
+    void closeTransaction();
+    void recomputeDocument(App::Document*);
+
+    // check if mouse_pos is around right or bottom side of a cell 
+    // and return the index of that cell if found
+    QModelIndex indexResizable(QPoint mouse_pos);
+
+private:
+    PropertyManagerItemDelegate *delegate;
+    PropertyManagerModel* propertyModel;
+    QStringList selectedProperty;
+    PropertyModel2::PropertyList propList;
+    std::unordered_set<const App::PropertyContainer*> propOwners;
+    bool autoexpand;
+    bool autoupdate;
+    bool committing;
+    bool delaybuild;
+    bool binding;
+    bool checkDocument;
+    bool closingEditor;
+    bool dragInProgress;
+
+    //max distance between mouse and a cell, small enough to trigger resize
+    int dragSensibility = 5; // NOLINT
+    int dragSection = 0;
+    int dragPreviousPos = 0;
+
+    int transactionID = 0;
+
+    QColor groupColor;
+    QBrush background;
+    QBrush _itemBackground;
+
+    QPointer<QWidget> activeEditor;
+    QPersistentModelIndex editingIndex;
+    int removingRows = 0;
+
+    friend class Gui::PropertyView;
+    friend class PropertyItemDelegate2;
+};
+
+} //namespace PropertyEditor
+} //namespace Gui
+
+#endif // PROPERTYEDITOR_H

--- a/src/Gui/propertymanager/PropertyItemDelegate2.cpp
+++ b/src/Gui/propertymanager/PropertyItemDelegate2.cpp
@@ -1,0 +1,248 @@
+/***************************************************************************
+ *   Copyright (c) 2004 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <QApplication>
+# include <QModelIndex>
+# include <QPainter>
+#endif
+
+#include <Base/Tools.h>
+
+#include "PropertyItemDelegate2.h"
+#include "MDIView.h"
+#include "PropertyEditor2.h"
+#include "propertyeditor/PropertyItem.h"
+#include "Tree.h"
+
+
+FC_LOG_LEVEL_INIT("PropertyView", true, true)
+
+using namespace Gui::PropertyEditor;
+
+
+PropertyItemDelegate2::PropertyItemDelegate2(QObject* parent)
+    : QItemDelegate(parent), expressionEditor(nullptr)
+    , pressed(false), changed(false)
+{
+}
+
+PropertyItemDelegate2::~PropertyItemDelegate2() = default;
+
+QSize PropertyItemDelegate2::sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const
+{
+    QSize size = QItemDelegate::sizeHint(option, index);
+    size += QSize(0, 5);
+    return size;
+}
+
+void PropertyItemDelegate2::paint(QPainter *painter, const QStyleOptionViewItem &opt, const QModelIndex &index) const
+{
+    QStyleOptionViewItem option = opt;
+
+    auto property = static_cast<PropertyItem*>(index.internalPointer());
+
+    if (property && property->isSeparator()) {
+        QColor color = option.palette.color(QPalette::BrightText);
+        QObject* par = parent();
+        if (par) {
+            QVariant value = par->property("groupTextColor");
+            if (value.canConvert<QColor>())
+                color = value.value<QColor>();
+        }
+        option.palette.setColor(QPalette::Text, color);
+        option.font.setBold(true);
+
+        // Since the group item now parents all the property items and can be
+        // collapsed, it makes sense to have some selection visual clue for it.
+        //
+        // option.state &= ~QStyle::State_Selected;
+    }
+    else if (index.column() == 1) {
+        option.state &= ~QStyle::State_Selected;
+    }
+
+    option.state &= ~QStyle::State_HasFocus;
+
+    if (property && property->isSeparator()) {
+        QBrush brush = option.palette.dark();
+        QObject* par = parent();
+        if (par) {
+            QVariant value = par->property("groupBackground");
+            if (value.canConvert<QBrush>())
+                brush = value.value<QBrush>();
+        }
+        painter->fillRect(option.rect, brush);
+    }
+
+    QPen savedPen = painter->pen();
+
+    QItemDelegate::paint(painter, option, index);
+
+    QColor color = static_cast<QRgb>(QApplication::style()->styleHint(QStyle::SH_Table_GridLineColor, &opt, qobject_cast<QWidget*>(parent())));
+    painter->setPen(QPen(color));
+    if (index.column() == 1 || !(property && property->isSeparator())) {
+        int right = (option.direction == Qt::LeftToRight) ? option.rect.right() : option.rect.left();
+        painter->drawLine(right, option.rect.y(), right, option.rect.bottom());
+    }
+    painter->drawLine(option.rect.x(), option.rect.bottom(),
+            option.rect.right(), option.rect.bottom());
+    painter->setPen(savedPen);
+}
+
+bool PropertyItemDelegate2::editorEvent (QEvent * event, QAbstractItemModel* model,
+                                        const QStyleOptionViewItem& option, const QModelIndex& index)
+{
+    if (event && event->type() == QEvent::MouseButtonPress)
+        this->pressed = true;
+    else
+        this->pressed = false;
+    return QItemDelegate::editorEvent(event, model, option, index);
+}
+
+bool PropertyItemDelegate2::eventFilter(QObject *o, QEvent *ev)
+{
+    if (ev->type() == QEvent::FocusOut) {
+        auto parentEditor = qobject_cast<PropertyEditor2*>(this->parent());
+        auto widget = qobject_cast<QWidget*>(o);
+        if (widget && parentEditor && parentEditor->activeEditor
+                   && widget != parentEditor->activeEditor) {
+            // All the attempts to ignore the focus-out event has been approved to not work
+            // reliably because there are still cases that cannot be handled.
+            // So, the best for now is to always ignore this event.
+            // See https://forum.freecad.org/viewtopic.php?p=579530#p579530 why this is not
+            // possible.
+            return false;
+        }
+    }
+    return QItemDelegate::eventFilter(o, ev);
+}
+
+QWidget * PropertyItemDelegate2::createEditor (QWidget * parent, const QStyleOptionViewItem & /*option*/, 
+                                              const QModelIndex & index ) const
+{
+    if (!index.isValid())
+        return nullptr;
+
+    auto childItem = static_cast<PropertyItem*>(index.internalPointer());
+    if (!childItem)
+        return nullptr;
+
+    auto parentEditor = qobject_cast<PropertyEditor2*>(this->parent());
+    if(parentEditor)
+        parentEditor->closeEditor();
+
+    if (childItem->isSeparator())
+        return nullptr;
+
+    FC_LOG("create editor " << index.row() << "," << index.column());
+
+    QWidget* editor;
+    expressionEditor = nullptr;
+    userEditor = nullptr;
+    if (parentEditor && parentEditor->isBinding()) {
+        expressionEditor = editor = childItem->createExpressionEditor(parent, this, SLOT(valueChanged()));
+    }
+    else {
+        const auto &props = childItem->getPropertyData();
+        if (!props.empty() && props[0]->testStatus(App::Property::UserEdit)) {
+            editor = userEditor = childItem->createPropertyEditorWidget(parent);
+        }
+        else {
+            editor = childItem->createEditor(parent, this, SLOT(valueChanged()));
+        }
+    }
+    if (editor) {
+        // Make sure the editor background is painted so the cell content doesn't show through
+        editor->setAutoFillBackground(true);
+    }
+    if (editor && childItem->isReadOnly()) {
+        editor->setDisabled(true);
+    }
+    else if (editor /*&& this->pressed*/) {
+        // We changed the way editor is activated in PropertyEditor (in response
+        // of signal activated and clicked), so now we should grab focus
+        // regardless of "pressed" or not (e.g. when activated by keyboard
+        // enter)
+        editor->setFocus();
+    }
+    this->pressed = false;
+
+    if (editor) {
+        const auto widgets = editor->findChildren<QWidget*>();
+        for (auto w : widgets) {
+            if (qobject_cast<QAbstractButton*>(w)
+                    || qobject_cast<QLabel*>(w))
+            {
+                w->installEventFilter(const_cast<PropertyItemDelegate2*>(this));
+            }
+        }
+        parentEditor->activeEditor = editor;
+        parentEditor->editingIndex = index;
+    }
+
+    return editor;
+}
+
+void PropertyItemDelegate2::valueChanged()
+{
+    QWidget* editor = qobject_cast<QWidget*>(sender());
+    if (editor) {
+        Base::FlagToggler<> flag(changed);
+        Q_EMIT commitData(editor);
+    }
+}
+
+void PropertyItemDelegate2::setEditorData(QWidget *editor, const QModelIndex &index) const
+{
+    if (!index.isValid())
+        return;
+    QVariant data = index.data(Qt::EditRole);
+    auto childItem = static_cast<PropertyItem*>(index.internalPointer());
+    editor->blockSignals(true);
+    if (expressionEditor == editor)
+        childItem->setExpressionEditorData(editor, data);
+    else if (userEditor == editor)
+        userEditor->setValue(PropertyItemAttorney::toString(childItem, data));
+    else
+        childItem->setEditorData(editor, data);
+    editor->blockSignals(false);
+    return;
+}
+
+void PropertyItemDelegate2::setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const
+{
+    if (!index.isValid() || !changed || userEditor)
+        return;
+    auto childItem = static_cast<PropertyItem*>(index.internalPointer());
+    QVariant data;
+    if(expressionEditor == editor)
+        data = childItem->expressionEditorData(editor);
+    else
+        data = childItem->editorData(editor);
+    model->setData(index, data, Qt::EditRole);
+}
+
+#include "moc_PropertyItemDelegate2.cpp"

--- a/src/Gui/propertymanager/PropertyItemDelegate2.h
+++ b/src/Gui/propertymanager/PropertyItemDelegate2.h
@@ -1,0 +1,65 @@
+/***************************************************************************
+ *   Copyright (c) 2004 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PROPERTYITEMDELEGATE2_H
+#define PROPERTYITEMDELEGATE2_H
+
+#include <QItemDelegate>
+
+namespace Gui {
+namespace PropertyEditor {
+
+class PropertyEditorWidget;
+
+class PropertyItemDelegate2 : public QItemDelegate
+{
+    Q_OBJECT
+
+public:
+    explicit PropertyItemDelegate2(QObject* parent);
+    ~PropertyItemDelegate2() override;
+
+    void paint(QPainter *painter, const QStyleOptionViewItem &opt, const QModelIndex &index) const override;
+    QWidget * createEditor (QWidget *, const QStyleOptionViewItem&, const QModelIndex&) const override;
+    void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+    void setModelData (QWidget *editor, QAbstractItemModel *model, const QModelIndex& index ) const override;
+    QSize sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const override;
+    bool editorEvent (QEvent *event, QAbstractItemModel *model,
+                              const QStyleOptionViewItem& option, const QModelIndex& index) override;
+protected:
+    bool eventFilter(QObject *, QEvent *) override;
+
+public Q_SLOTS:
+    void valueChanged();
+
+private:
+    mutable QWidget *expressionEditor;
+    mutable PropertyEditorWidget *userEditor = nullptr;
+    mutable bool pressed;
+    bool changed;
+};
+
+} // namespace PropertyEditor
+} // namespace Gui
+
+#endif // PROPERTYITEMDELEGATE2_H

--- a/src/Gui/propertymanager/PropertyManager.cpp
+++ b/src/Gui/propertymanager/PropertyManager.cpp
@@ -1,0 +1,651 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <Inventor/nodes/SoSeparator.h>
+# include <QHeaderView>
+# include <QTextStream>
+# include <QFileSystemModel>
+# include <QCompleter>
+# include <QMessageBox>
+# include <QValidator>
+#include <memory>
+#endif
+
+#include <Base/Tools.h>
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+
+#include "BitmapFactory.h"
+#include "PropertyManager.h"
+#include "ui_PropertyManager.h"
+#include "BitmapFactory.h"
+
+#include "propertymanager/PropertyEditor2.h"
+
+
+FC_LOG_LEVEL_INIT("PropertyManager", true, true)
+
+using namespace Gui::Dialog;
+using namespace Gui::PropertyEditor;
+
+static ParameterGrp::handle _GetParam() {
+    static ParameterGrp::handle hGrp;
+    if(!hGrp) {
+        hGrp = App::GetApplication().GetParameterGroupByPath(
+                "User parameter:BaseApp/Preferences/PropertyView");
+    }
+    return hGrp;
+}
+
+
+
+std::unique_ptr<QPixmap>  DlgPropertyManager::documentPixmap;
+std::unique_ptr<QPixmap>  DlgPropertyManager::documentPartialPixmap;
+
+DlgPropertyManager::DlgPropertyManager(QWidget* parent, Qt::WindowFlags fl)
+    : QDialog(parent, fl), ui(new Ui_PropertyManager()),
+      comboBoxGroupAdd(this),
+      completerDocument(ui->comboBoxDocument),
+      completerTypeObject(ui->comboBoxTypeObject),
+      completerNameObject(ui->comboBoxNameObject),
+      completerGroup(ui->comboBoxGroup),
+      completerTypeProperty(ui->comboBoxTypeProp),
+      completerNameProperty(ui->comboBoxNameProp),
+      editor(nullptr)
+{
+    ui->setupUi(this);
+    setWindowTitle(tr("Property Manager"));
+
+    setupWidgets();
+
+    setupPropertyEditor();
+
+    initializeFilters();
+
+    if (!documentPixmap) {
+        documentPixmap = std::make_unique<QPixmap>(Gui::BitmapFactory().pixmap("Document"));
+        QIcon icon(*documentPixmap);
+        documentPartialPixmap = std::make_unique<QPixmap>(icon.pixmap(documentPixmap->size(), QIcon::Disabled));
+    }
+    setupScopes();
+
+    initializePropertyAdd();
+    showAddPropertyPanel();
+}
+
+void DlgPropertyManager::setupScopes()
+{
+    auto model = getModel();
+    QComboBox* comboBox = ui->comboBoxNameScope;
+    connect(comboBox, &QComboBox::textActivated,
+            this, &DlgPropertyManager::onChoosingNameScope);
+
+   comboBox->blockSignals(true);
+   comboBox->clear();
+   UniqueVector<QString> names = model->getNamesScope();
+   for (const auto& name : names) {
+        comboBox->addItem(name);
+    }
+   comboBox->blockSignals(false);
+}
+
+void DlgPropertyManager::setupWidgets()
+{
+
+    connect(&comboBoxGroupAdd, &EditFinishedComboBox::editFinished,
+            this, &DlgPropertyManager::onGroupDetermined);
+    comboBoxGroupAdd.setInsertPolicy(QComboBox::InsertAtTop);
+    comboBoxGroupAdd.setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    comboBoxGroupAdd.setEditable(true);
+    auto gridLayout = qobject_cast<QGridLayout*>(ui->groupBoxAddProperty->layout());
+    gridLayout->addWidget(&comboBoxGroupAdd, 1, 1);
+
+    ui->comboBoxTypePropertyAdd->setInsertPolicy(QComboBox::NoInsert);
+
+    // can't get this to work properly
+    // QWidget::setTabOrder(ui->lineEditNamePropertyAdd, &comboBoxGroupAdd);
+    // QWidget::setTabOrder(&comboBoxGroupAdd, ui->comboBoxTypePropertyAdd);
+    
+    connect(ui->refreshButton, &QPushButton::clicked,
+            this, &DlgPropertyManager::onRefreshButtonClicked);
+    connect(ui->lineEditNamePropertyAdd, &QLineEdit::editingFinished,
+            this, &DlgPropertyManager::onNamePropertyDetermined);
+    connect(ui->comboBoxTypePropertyAdd, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &DlgPropertyManager::onTypePropertyDetermined);
+
+
+}
+
+void DlgPropertyManager::initializePropertyAdd()
+{
+    completerGroupAdd.setModel(comboBoxGroupAdd.model());
+    completerGroupAdd.setCaseSensitivity(Qt::CaseInsensitive);
+    completerGroupAdd.setFilterMode(Qt::MatchContains);
+    comboBoxGroupAdd.setCompleter(&completerGroupAdd);
+
+    completerTypePropertyAdd.setModel(ui->comboBoxTypePropertyAdd->model());
+    completerTypePropertyAdd.setCaseSensitivity(Qt::CaseInsensitive);
+    completerTypePropertyAdd.setFilterMode(Qt::MatchContains);
+    ui->comboBoxTypePropertyAdd->setCompleter(&completerTypePropertyAdd);
+    
+    auto hGrp = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/PropertyView");
+    auto defType = Base::Type::fromName(
+            hGrp->GetASCII("NewPropertyType","App::PropertyString").c_str());
+    if(defType.isBad())
+        defType = App::PropertyString::getClassTypeId();
+
+    std::vector<Base::Type> types;
+    Base::Type::getAllDerivedFrom(Base::Type::fromName("App::Property"),types);
+    std::sort(types.begin(), types.end(), [](Base::Type a, Base::Type b) { return strcmp(a.getName(), b.getName()) < 0; });
+
+    for(const auto& type : types) {
+        ui->comboBoxTypePropertyAdd->addItem(QString::fromLatin1(type.getName()));
+        if (type == defType) {
+            ui->comboBoxTypePropertyAdd->setCurrentIndex(ui->comboBoxTypePropertyAdd->count()-1);
+        }
+    }
+
+    ui->buttonAddProperty->setEnabled(false);
+    connect(ui->buttonAddProperty, &QPushButton::clicked, this, &DlgPropertyManager::onAddProperty);
+    
+}
+
+void DlgPropertyManager::initializeFilter(QComboBox* comboBox, QCompleter &completer)
+                                          
+{
+    completer.setModel(comboBox->model());
+    completer.setCaseSensitivity(Qt::CaseInsensitive);
+    completer.setFilterMode(Qt::MatchContains);
+    comboBox->setCompleter(&completer);
+    comboBox->setInsertPolicy(QComboBox::NoInsert);
+    connect(comboBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &DlgPropertyManager::filterSelected);
+}
+
+void DlgPropertyManager::initializeFilters()
+{
+    initializeFilter(ui->comboBoxDocument, completerDocument);
+    initializeFilter(ui->comboBoxTypeObject, completerTypeObject);
+    initializeFilter(ui->comboBoxNameObject, completerNameObject);
+    initializeFilter(ui->comboBoxGroup, completerGroup);
+    initializeFilter(ui->comboBoxTypeProp, completerTypeProperty);
+    initializeFilter(ui->comboBoxNameProp, completerNameProperty);
+
+    // doesn't work
+    // setFirstInTabOrder(ui->comboBoxDocument);
+    // setNextInTabOrder(ui->comboBoxTypeObject);
+    // setNextInTabOrder(ui->comboBoxNameObject);
+    // setNextInTabOrder(ui->comboBoxGroup);
+    // setNextInTabOrder(ui->comboBoxTypeProp);
+    // setNextInTabOrder(ui->comboBoxNameProp);
+    // setFirstInTabOrder(nullptr);
+
+    setupFilters();
+}
+
+void DlgPropertyManager::removeEditor()
+{
+    if (editor) {
+        ui->groupBoxAddProperty->layout()->removeWidget(editor.get());
+    }
+}
+
+void DlgPropertyManager::addEditor(PropertyItem* propertyItem, std::string& type)
+{
+    editor.reset(propertyItem->createEditor(this, this, SLOT(valueChanged())));
+    editor->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    auto gridLayout = qobject_cast<QGridLayout*>(ui->groupBoxAddProperty->layout());
+    gridLayout->addWidget(editor.get(), 1, 3);
+
+    // doesn't work as I want
+    QWidget::setTabOrder(ui->lineEditNamePropertyAdd, &comboBoxGroupAdd);
+    QWidget::setTabOrder(&comboBoxGroupAdd, ui->comboBoxTypePropertyAdd);
+    QWidget::setTabOrder(ui->comboBoxTypePropertyAdd, editor.get());
+    QWidget::setTabOrder(editor.get(), ui->buttonAddProperty);
+}
+
+/*
+ *  Destroys the object and frees any allocated resources
+ */
+DlgPropertyManager::~DlgPropertyManager()
+{
+    // no need to delete child widgets, Qt does it all for us
+    delete ui;
+}
+
+
+void DlgPropertyManager::setupPropertyEditor()
+{
+    propertyEditor = new Gui::PropertyEditor::PropertyEditor2();
+    propertyEditor->setObjectName(QStringLiteral("propertyEditor"));
+    propertyEditor->setAutomaticDocumentUpdate(_GetParam()->GetBool("AutoTransactionView", false));
+    propertyEditor->setAutomaticExpand(_GetParam()->GetBool("AutoExpandView", false));
+    propertyEditor->init();
+
+    connect(getModel(), &QAbstractItemModel::modelReset,
+            this, &DlgPropertyManager::onModelReset);
+    
+    ui->gridLayout->addWidget(propertyEditor);
+}
+
+PropertyManagerModel* DlgPropertyManager::getModel()
+{
+    return static_cast<PropertyManagerModel*>(propertyEditor->model());
+}
+
+
+void DlgPropertyManager::setupFilter(QComboBox* comboBox,
+                                     std::function<UniqueVector<QString>(void)> getFilterValuesFunc)
+{
+    comboBox->blockSignals(true);
+    comboBox->clear();
+    UniqueVector<QString> filterValues = getFilterValuesFunc();
+    for (auto filterValue : filterValues) {
+        comboBox->addItem(filterValue);
+    }
+    comboBox->blockSignals(false);
+}
+
+void DlgPropertyManager::setupFilters()
+{
+    auto *model = getModel();
+    FC_ERR("setupFilters");
+
+    setupFilter(ui->comboBoxDocument,
+                [&model]() {
+                    return model->getFilterValuesDocument();
+                });
+    setupFilter(ui->comboBoxTypeObject,
+                [&model]() {
+                    return model->getFilterValuesTypeObject();
+                });
+    setupFilter(ui->comboBoxNameObject,
+                [&model]() {
+                    return model->getFilterValuesNameObject();
+                });
+    setupFilter(ui->comboBoxGroup,
+                [&model]() {
+                    return model->getFilterValuesGroup();
+                });
+    setupFilter(ui->comboBoxTypeProp,
+                [&model]() {
+                    return model->getFilterValuesTypeProperty();
+                });
+    setupFilter(ui->comboBoxNameProp,
+                [&model]() {
+                    return model->getFilterValuesNameProperty();
+                });
+}
+
+void DlgPropertyManager::filterSelected(int index)
+{
+    FC_ERR("filterSelected: " << index);
+    QString selectedDocument = ui->comboBoxDocument->currentText();
+    QString selectedTypeObject = ui->comboBoxTypeObject->currentText();
+    QString selectedNameObject = ui->comboBoxNameObject->currentText();
+    QString selectedGroup = ui->comboBoxGroup->currentText();
+    QString selectedTypeProperty = ui->comboBoxTypeProp->currentText();
+    QString selectedNameProperty = ui->comboBoxNameProp->currentText();
+    
+    auto *model = getModel();
+    model->filterSelected(selectedDocument,
+                          selectedTypeObject, selectedNameObject,
+                          selectedGroup,
+                          selectedTypeProperty, selectedNameProperty);
+
+    ui->comboBoxNameScope->clearEditText();
+}
+
+// TODO: not yet implemented
+void DlgPropertyManager::changeEvent(QEvent *e)
+{
+    // if (e->type() == QEvent::LanguageChange) {
+    //     ui->retranslateUi(this);
+    //     setWindowTitle(tr("Property Manager"));
+    // }
+    // QDialog::changeEvent(e);
+}
+
+
+// doesn't work as I expected need to debug more
+void DlgPropertyManager::setNextInTabOrder(QWidget *widget)
+{
+    FC_ERR("setnext");
+    FC_ERR("  last: " << widgetLastTabOrder->objectName().toUtf8().constData());
+    FC_ERR("  next: " << widget->objectName().toUtf8().constData());
+    // QWidget::setTabOrder(widgetLastTabOrder, widget);
+    // widgetLastTabOrder = widget;
+}
+
+// idem
+void DlgPropertyManager::setFirstInTabOrder(QWidget *widget)
+{
+    FC_ERR("First: " << widget->objectName().toUtf8().constData());
+    // widgetLastTabOrder = widget;
+}
+
+// debug code
+// static void printFocusChain(QWidget *widget) {
+//     FC_ERR("Focus Chain:");
+//     for (int i = 0; i < 30; i++) {
+//         FC_ERR(" " << widget->objectName().toUtf8().constData());
+//         widget = widget->nextInFocusChain();
+//     }
+//     QWidget *currentWidget = QApplication::focusWidget();
+//     FC_ERR("  Current focus widget:" << (currentWidget ? currentWidget->objectName().toUtf8().constData() : "None"));
+// }
+
+// doesn't work as I expected
+void DlgPropertyManager::setTabOrderAddProperty()
+{
+    QWidget::setTabOrder(ui->lineEditNamePropertyAdd, &comboBoxGroupAdd);
+    QWidget::setTabOrder(&comboBoxGroupAdd, ui->comboBoxTypePropertyAdd);
+    QWidget::setTabOrder(ui->comboBoxTypePropertyAdd, ui->buttonAddProperty);
+}
+
+
+// doesn't work as I expected
+void DlgPropertyManager::setTabOrderFilter()
+{
+    QWidget::setTabOrder(ui->comboBoxDocument, ui->comboBoxTypeObject);
+    QWidget::setTabOrder(ui->comboBoxTypeObject, ui->comboBoxNameObject);
+    QWidget::setTabOrder(ui->comboBoxNameObject, ui->comboBoxGroup);
+    QWidget::setTabOrder(ui->comboBoxGroup, ui->comboBoxTypeProp);
+    QWidget::setTabOrder(ui->comboBoxTypeProp, ui->comboBoxNameProp);
+}
+    
+
+
+void DlgPropertyManager::showAddPropertyPanel()
+{
+    PropertyManagerModel* model = getModel();
+    App::DocumentObject* obj = model->getUniqueObject();
+    FC_ERR("onModelReset");
+    if (obj) {
+        setTabOrderAddProperty();
+        ui->groupBoxAddProperty->setVisible(true);
+        ui->lineEditNamePropertyAdd->setFocus();
+
+        comboBoxGroupAdd.clear();
+        for (const auto& groupName : model->getGroupNames()) {
+            comboBoxGroupAdd.addItem(groupName);
+        }
+        
+        QString group = model->getUniqueGroup();
+        if (!group.isEmpty()) {
+            comboBoxGroupAdd.setEditText(group);
+        }
+
+        QString type = model->getUniqueTypeProperty();
+        if (!type.isEmpty()) {
+            ui->comboBoxTypePropertyAdd->setEditText(type);
+        }
+
+        // FC_ERR("showAddPropertyPanel");
+        // printFocusChain(ui->lineEditNamePropertyAdd);
+    }
+    else {
+        setTabOrderFilter();
+        ui->groupBoxAddProperty->setVisible(false);
+        ui->comboBoxDocument->setFocus();
+    }
+}
+
+void DlgPropertyManager::onModelReset()
+{
+    FC_ERR("onModelReset");
+    showAddPropertyPanel();
+    setupFilters();
+}
+
+void DlgPropertyManager::clearPropertyAdd()
+{
+    ui->lineEditNamePropertyAdd->clear();
+    removeEditor();
+    ui->buttonAddProperty->setEnabled(false);
+    namePropertyToAdd.clear();
+    editor = nullptr;
+    
+}
+
+static PropertyItem *createPropertyItem(App::Property *prop)
+{
+    const char *editor = prop->getEditorName();
+    if (!editor || !editor[0]) {
+        return nullptr;
+    }
+    auto item = static_cast<PropertyItem*>(
+            PropertyItemFactory::instance().createPropertyItem(editor));
+    if (!item) {
+        qWarning("No property item for type %s found\n", editor);
+    }
+    return item;
+}
+
+void DlgPropertyManager::createProperty(App::DocumentObject* obj, std::string& name, std::string& group)
+{
+    std::string type = ui->comboBoxTypePropertyAdd->currentText().toUtf8().constData();
+
+    auto prop = obj->addDynamicProperty(type.c_str(), name.c_str(),
+                                        group.c_str());
+    namePropertyToAdd = name;
+
+    // FC_ERR("type: " << prop->getTypeId().getName());
+    // FC_ERR("type class: " << App::PropertyString::getClassTypeId().getName());
+
+    objectIdentifier = std::make_unique<App::ObjectIdentifier>(*prop);
+    // creating a propertyItem here because it has all kinds of logic for
+    // editors that we can reuse
+    propertyItem.reset(createPropertyItem(prop));
+    propertyItem->setPropertyData({prop});
+    propertyItem->bind(*objectIdentifier);
+
+    ui->buttonAddProperty->setEnabled(true);
+
+    removeEditor();
+    if (unsupportedTypes.find(type) == unsupportedTypes.end()) {
+        addEditor(propertyItem.get(), type);
+    }
+}
+
+
+void DlgPropertyManager::onNamePropertyDetermined()
+{
+    PropertyManagerModel* model = getModel();
+    App::DocumentObject* obj = model->getUniqueObject();
+
+    // FC_ERR("onNamePropertyDetermined");
+    // printFocusChain(ui->lineEditNamePropertyAdd);
+
+    if (!namePropertyToAdd.empty()) {
+        // we were already adding a name, so remove this property
+        obj->removeDynamicProperty(namePropertyToAdd.c_str());
+    }
+    
+    QString nameProperty = ui->lineEditNamePropertyAdd->text();
+    std::string name = nameProperty.toUtf8().constData();
+    std::string group = comboBoxGroupAdd.currentText().toUtf8().constData();
+    if(name.empty() || group.empty()
+            || name != Base::Tools::getIdentifier(name)
+            || group != Base::Tools::getIdentifier(group))
+    {
+        QMessageBox::critical(this,
+            QObject::tr("Invalid name"),
+            QObject::tr("The property name or group name must only contain alpha numericals,\n"
+                        "underscore, and must not start with a digit."));
+        clearPropertyAdd();
+        return;
+    }
+
+    auto prop = obj->getPropertyByName(name.c_str());
+    if(prop && prop->getContainer() == obj) {
+        QMessageBox::critical(this,
+                              QObject::tr("Invalid name"),
+                              QObject::tr("The property '%1' already exists in '%2'").arg(
+                                      QString::fromLatin1(name.c_str()),
+                                      QString::fromLatin1(obj->getFullName().c_str())));
+        clearPropertyAdd();
+        return;
+    }
+
+    createProperty(obj, name, group);
+}
+
+
+void DlgPropertyManager::onGroupDetermined()
+{
+    FC_ERR("onGroupDetermined:");
+
+    std::string group = comboBoxGroupAdd.currentText().toUtf8().constData();
+
+    FC_ERR("group: \"" << group << "\"");
+    
+    if (group.empty() || group != Base::Tools::getIdentifier(group)) {
+        QMessageBox::critical(this,
+            QObject::tr("Invalid name"),
+            QObject::tr("The group name must only contain alpha numericals,\n"
+                        "underscore, and must not start with a digit."));
+        PropertyManagerModel* model = getModel();
+        QString group = model->getUniqueGroup();
+        if (group.isEmpty()) {
+            comboBoxGroupAdd.setEditText(Filter::BASE_GROUP);
+        }
+        else {
+            comboBoxGroupAdd.setEditText(group);
+        }
+    }
+
+    PropertyManagerModel* model = getModel();
+    App::DocumentObject* obj = model->getUniqueObject();
+
+    if (!namePropertyToAdd.empty()) {
+        // we were already adding a property
+        App::Property* prop = obj->getPropertyByName(namePropertyToAdd.c_str());
+        if (prop->getGroup() != group) {
+            obj->changeDynamicProperty(prop, group.c_str(), nullptr);
+        }
+    }
+
+    ui->comboBoxTypePropertyAdd->setFocus();
+}
+
+void DlgPropertyManager::onTypePropertyDetermined()
+{
+    FC_ERR("onTypePropertyDetermined");
+
+    PropertyManagerModel* model = getModel();
+    App::DocumentObject* obj = model->getUniqueObject();
+
+    std::string type = ui->comboBoxTypePropertyAdd->currentText().toUtf8().constData();
+    
+    if (!namePropertyToAdd.empty()) {
+        // we were already adding a name, so check this property
+        App::Property* prop = obj->getPropertyByName(namePropertyToAdd.c_str());
+
+        if (prop->getTypeId() != Base::Type::fromName(type.c_str())) {
+            // the property should have a different type
+            std::string group = prop->getGroup();
+            obj->removeDynamicProperty(namePropertyToAdd.c_str());
+            createProperty(obj, namePropertyToAdd, group);
+        }
+    }
+}
+
+void DlgPropertyManager::recomputeDocument()
+{
+    App::Property* prop = propertyItem->getFirstProperty();
+    App::DocumentObject* obj = objectIdentifier->getDocumentObject();
+    App::Document* doc = obj->getDocument();
+
+    try {
+        if (doc /* && !doc->isTransactionEmpty() */) { // no transaction support yet
+            // Between opening and committing a transaction a recompute
+            // could already have been done
+            if (doc->isTouched()) {
+                doc->recompute();
+            }
+        }
+    }
+    // do not re-throw
+    catch (const Base::Exception& e) {
+        e.ReportException();
+    }
+    catch (const std::exception& e) {
+        Base::Console().Error("Unhandled std::exception caught in PropertyManager::recomputeDocument.\n"
+                            "The error message is: %s\n", e.what());
+    }
+    catch (...) {
+        Base::Console().Error("Unhandled unknown exception caught in PropertyManager::recomputeDocument.\n");
+    }
+}
+
+void DlgPropertyManager::onAddProperty()
+{
+    clearPropertyAdd();
+    recomputeDocument();
+    auto *model = getModel();
+    model->refresh();
+    setupFilters();
+    ui->lineEditNamePropertyAdd->setFocus();
+}
+    
+
+
+void DlgPropertyManager::valueChanged()
+{
+    FC_ERR("valueChanged");
+    QWidget* editor = qobject_cast<QWidget*>(sender());
+    QVariant data;
+    data = propertyItem->editorData(editor);
+
+    propertyItem->setData(data);
+}
+
+void DlgPropertyManager::onRefreshButtonClicked()
+{
+    auto *model = getModel();
+    model->refresh();
+    setupFilters();
+}
+
+void DlgPropertyManager::onChoosingNameScope(QString name)
+{
+    FC_ERR("onChoosingNameScope");
+    auto model = getModel();
+    if (model->scopeExists(name)) {
+        FC_ERR("select scope " << name.toUtf8().constData());
+        model->selectScope(name);
+        model->refresh();
+        setupFilters();
+    }
+    else {
+        FC_ERR("inserting scope " << name.toUtf8().constData());
+        model->insertScope(name);
+        setupScopes();
+    }
+}
+
+#include "moc_PropertyManager.cpp"

--- a/src/Gui/propertymanager/PropertyManager.h
+++ b/src/Gui/propertymanager/PropertyManager.h
@@ -1,0 +1,170 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#ifndef GUI_PROPERTY_MANAGER_H
+#define GUI_PROPERTY_MANAGER_H
+#include <QComboBox>
+#include <QDialog>
+#include <QHash>
+#include <QStandardItemModel>
+#include <QAbstractItemModel>
+#include <functional>
+#include <QCompleter>
+
+#include "PropertyManagerModel.h"
+#include "Filter.h"
+#include "propertyeditor/PropertyItem.h"
+
+class SoNode;
+class PropertyEditor2;
+
+
+namespace Gui {
+class Document;
+
+namespace PropertyEditor {
+    class PropertyEditor2;
+}
+    
+namespace Dialog {
+
+class Ui_PropertyManager;
+
+
+    
+class EditFinishedComboBox : public QComboBox {
+    Q_OBJECT
+public:
+    explicit EditFinishedComboBox(QWidget *parent = nullptr) : QComboBox(parent) {}
+
+Q_SIGNALS:
+    void editFinished();
+
+protected:
+    void focusOutEvent(QFocusEvent *event) override {
+        QComboBox::focusOutEvent(event);
+        Q_EMIT editFinished();
+    }
+};
+
+
+/// Dialog window to display scenegraph model as a tree
+class DlgPropertyManager : public QDialog
+{
+    Q_OBJECT
+
+public:
+    DlgPropertyManager(QWidget* parent = nullptr, Qt::WindowFlags fl = Qt::WindowFlags());
+    ~DlgPropertyManager() override;
+
+    Gui::PropertyEditor::PropertyEditor2* propertyEditor;
+    
+    static std::unique_ptr<QPixmap> documentPixmap;
+    static std::unique_ptr<QPixmap> documentPartialPixmap;
+
+
+
+private:
+    void onRefreshButtonClicked();
+    void onNamePropertyDetermined();
+    void onGroupDetermined();
+    void onTypePropertyDetermined();
+    void onModelReset();
+
+    void onChoosingNameScope(QString name);
+
+    void reset();
+    void setupPropertyEditor();
+    void setupWidgets();
+    void setupScopes();
+
+
+    void initializeFilter(QComboBox* comboBox, QCompleter &completer);
+    void initializeFilters();
+    
+    void setupFilter(QComboBox* comboBox,
+                     std::function<Gui::PropertyEditor::UniqueVector<QString>(void)> getFilterValuesFunc);
+    void setupFilters();
+    PropertyEditor::PropertyManagerModel* getModel();
+    void filterSelected(int index);
+
+    void addEditor(PropertyEditor::PropertyItem* propertyItem, std::string& type);
+    void removeEditor();
+
+
+    void initializePropertyAdd();
+
+    void showAddPropertyPanel();
+
+    void clearPropertyAdd();
+
+    void recomputeDocument();
+    
+    void createProperty(App::DocumentObject* obj, std::string& name, std::string& group);
+
+    void setFirstInTabOrder(QWidget* widget);
+    void setNextInTabOrder(QWidget* widget);
+
+    void setTabOrderAddProperty();
+    void setTabOrderFilter();
+
+public Q_SLOTS:
+    void valueChanged();
+    void onAddProperty();
+
+protected:
+    void changeEvent(QEvent *e) override;
+
+private:
+    Ui_PropertyManager* ui;
+
+    EditFinishedComboBox comboBoxGroupAdd;
+
+    std::unordered_set<std::string> unsupportedTypes = {
+        "App::PropertyVector", "App::PropertyVectorDistance", "App::PropertyMatrix",
+        "App::PropertyRotation", "App::PropertyPlacement", "App::PropertyEnumeration"};
+
+    QCompleter completerDocument;
+    QCompleter completerTypeObject;
+    QCompleter completerNameObject;
+    QCompleter completerGroup;
+    QCompleter completerTypeProperty;
+    QCompleter completerNameProperty;
+
+    QCompleter completerGroupAdd;
+    QCompleter completerTypePropertyAdd;
+
+    QWidget* widgetLastTabOrder;
+
+
+    // state between adding properties
+    std::unique_ptr<QWidget> editor;
+    std::unique_ptr<QWidget> expressionEditor;
+    std::string namePropertyToAdd;
+    std::unique_ptr<PropertyEditor::PropertyItem> propertyItem;
+    std::unique_ptr<App::ObjectIdentifier> objectIdentifier;
+};
+
+} // namespace Dialog
+} // namespace Gui
+
+#endif

--- a/src/Gui/propertymanager/PropertyManager.ui
+++ b/src/Gui/propertymanager/PropertyManager.ui
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Gui::Dialog::PropertyManager</class>
+ <widget class="QDialog" name="Gui::Dialog::PropertyManager">
+  <property name="windowModality">
+   <enum>Qt::NonModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1090</width>
+    <height>571</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBoxScope">
+     <property name="title">
+      <string>Scope</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="5">
+       <widget class="QLabel" name="labelNameObject">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Object name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="labelTypeObject">
+        <property name="text">
+         <string>Object type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="5">
+       <widget class="QComboBox" name="comboBoxNameObject">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="8">
+       <widget class="QLabel" name="labelNameProp">
+        <property name="text">
+         <string>Property name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="comboBoxDocument">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="6">
+       <widget class="QLabel" name="labelGroup">
+        <property name="text">
+         <string>Group</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QComboBox" name="comboBoxTypeObject">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="8">
+       <widget class="QComboBox" name="comboBoxNameProp">
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="labelDocument">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Document</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="6">
+       <widget class="QComboBox" name="comboBoxGroup">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="7">
+       <widget class="QComboBox" name="comboBoxTypeProp">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="7">
+       <widget class="QLabel" name="labelTypeProp">
+        <property name="text">
+         <string>Property type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QComboBox" name="comboBoxNameScope">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelName">
+        <property name="text">
+         <string>Name Scope</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBoxAddProperty">
+     <property name="title">
+      <string>Add Property</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="2" column="3">
+       <widget class="QPushButton" name="buttonAddProperty">
+        <property name="text">
+         <string>Add property</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="labelValuePropertyAdd">
+        <property name="text">
+         <string>Value</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="labelTypePropertyAdd">
+        <property name="text">
+         <string>Type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="labelGroupAdd">
+        <property name="text">
+         <string>Group</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelNamePropertyAdd">
+        <property name="text">
+         <string>Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLineEdit" name="lineEditNamePropertyAdd">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QComboBox" name="comboBoxTypePropertyAdd">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="refreshButton">
+       <property name="text">
+        <string>Refresh</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>58</width>
+         <height>31</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="closeButton">
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>comboBoxNameScope</tabstop>
+  <tabstop>comboBoxDocument</tabstop>
+  <tabstop>comboBoxTypeObject</tabstop>
+  <tabstop>comboBoxNameObject</tabstop>
+  <tabstop>comboBoxGroup</tabstop>
+  <tabstop>comboBoxTypeProp</tabstop>
+  <tabstop>comboBoxNameProp</tabstop>
+  <tabstop>lineEditNamePropertyAdd</tabstop>
+  <tabstop>comboBoxTypePropertyAdd</tabstop>
+  <tabstop>buttonAddProperty</tabstop>
+  <tabstop>refreshButton</tabstop>
+  <tabstop>closeButton</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>closeButton</sender>
+   <signal>clicked()</signal>
+   <receiver>Gui::Dialog::PropertyManager</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>369</x>
+     <y>253</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>179</x>
+     <y>282</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Gui/propertymanager/PropertyManagerItem.cpp
+++ b/src/Gui/propertymanager/PropertyManagerItem.cpp
@@ -1,0 +1,128 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <algorithm>
+# include <QApplication>
+# include <QComboBox>
+# include <QFontDatabase>
+# include <QLocale>
+# include <QMessageBox>
+# include <QPalette>
+# include <QPixmap>
+# include <QTextStream>
+# include <QTimer>
+# include <QtGlobal>
+# include <QMenu>
+#endif
+
+#include <Gui/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+
+#include "PropertyManagerItem.h"
+#include "PropertyManager.h"
+
+
+using namespace Gui::PropertyEditor;
+using namespace Gui::Dialog;
+
+PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyManagerItem)
+
+PropertyManagerItem::PropertyManagerItem() : PropertyItem()
+{
+    setExpanded(true);
+}
+
+PropertyManagerItem::~PropertyManagerItem() = default;
+
+
+DocumentItem::DocumentItem(App::Document* doc) :
+    doc(doc)
+{
+}
+
+QVariant DocumentItem::data (int column, int role) const {
+    if (column == 0) {
+        if (role == Qt::DecorationRole) {
+            if (DlgPropertyManager::documentPixmap.get()) {
+                return QVariant::fromValue(QIcon(doc->testStatus(App::Document::PartialDoc) ?
+                                                 *DlgPropertyManager::documentPartialPixmap :
+                                                 *DlgPropertyManager::documentPixmap));
+            }
+        }
+    }
+    return PropertyItem::data(column, role);
+}
+
+
+
+App::Document* DocumentItem::getDocument()
+{
+    return doc;
+}
+
+
+
+DocumentObjectItem::DocumentObjectItem(App::DocumentObject* obj) :
+    obj(obj)
+{
+}
+
+App::DocumentObject* DocumentObjectItem::getObject()
+{
+    return obj;
+}
+
+std::map<QString, DocumentObjectItem::GroupInfo> &DocumentObjectItem::getGroupItems()
+{
+    return groupItems;
+}
+
+std::unordered_map<App::Property*,QPointer<PropertyItem>> &DocumentObjectItem::getItemMap()
+{
+    return itemMap;
+}
+
+Gui::ViewProviderDocumentObject* DocumentObjectItem::getViewProvider() const
+{
+    return Base::freecad_dynamic_cast<ViewProviderDocumentObject>(
+            Gui::Application::Instance->getViewProvider(obj));
+}
+
+QVariant DocumentObjectItem::data (int column, int role) const
+{
+    if (column == 0) {
+        if (role == Qt::DecorationRole) {
+            ViewProviderDocumentObject* vp = getViewProvider();
+            if (vp) {
+                return QVariant::fromValue(vp->getIcon());
+            }
+        }
+    }
+    return PropertyItem::data(column, role);
+}
+
+#include "moc_PropertyManagerItem.cpp"

--- a/src/Gui/propertymanager/PropertyManagerItem.h
+++ b/src/Gui/propertymanager/PropertyManagerItem.h
@@ -1,0 +1,92 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#ifndef PROPERTY_MANAGER_ITEM_H
+#define PROPERTY_MANAGER_ITEM_H
+
+#include "ViewProviderDocumentObject.h"
+#include "propertyeditor/PropertyItem.h"
+
+namespace Gui::PropertyEditor {
+
+class GuiExport PropertyManagerItem : public PropertyItem
+{
+    Q_OBJECT
+    PROPERTYITEM_HEADER
+
+public:
+    ~PropertyManagerItem() override;
+    virtual bool isSeparator() const override { return true; }
+
+protected:
+    PropertyManagerItem();
+};
+
+
+class GuiExport DocumentItem : public PropertyManagerItem
+{
+    Q_OBJECT
+    PROPERTYITEM_HEADER
+
+public:
+    DocumentItem(App::Document* doc);
+    ~DocumentItem() override = default;
+    App::Document* getDocument();
+    QVariant data (int column, int role = Qt::DisplayRole) const override;
+    
+private:
+    App::Document* doc;
+};
+
+class GuiExport DocumentObjectItem : public PropertyManagerItem
+{
+    Q_OBJECT
+    PROPERTYITEM_HEADER
+
+public:
+    DocumentObjectItem(App::DocumentObject* obj);
+    ~DocumentObjectItem() override = default;
+    App::DocumentObject* getObject();
+    QVariant data (int column, int role = Qt::DisplayRole) const override;
+
+    struct GroupInfo {
+        PropertySeparatorItem *groupItem = nullptr;
+        std::vector<PropertyItem *> children;
+    };
+
+    std::map<QString, GroupInfo> &getGroupItems();
+    std::unordered_map<App::Property*, QPointer<PropertyItem>> &getItemMap();
+
+private:
+    App::DocumentObject* obj;
+
+    std::unordered_map<App::Property*, QPointer<PropertyItem> > itemMap;
+
+    std::map<QString, GroupInfo> groupItems;
+
+    ViewProviderDocumentObject* getViewProvider() const;
+};
+
+    
+} // namespace Gui::PropertyEditor
+
+#endif // PROPERTY_MANAGER_ITEM_H

--- a/src/Gui/propertymanager/PropertyManagerItemDelegate.cpp
+++ b/src/Gui/propertymanager/PropertyManagerItemDelegate.cpp
@@ -1,0 +1,128 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <QApplication>
+# include <QModelIndex>
+# include <QPainter>
+#endif
+
+#include <Base/Tools.h>
+
+#include "PropertyManagerItemDelegate.h"
+#include "PropertyItemDelegate2.h"
+#include "PropertyManagerItem.h"
+#include "propertyeditor/PropertyItem.h"
+
+
+FC_LOG_LEVEL_INIT("PropertyView", true, true)
+
+using namespace Gui::PropertyEditor;
+
+
+PropertyManagerItemDelegate::PropertyManagerItemDelegate(QObject* parent)
+    : PropertyItemDelegate2(parent)
+{
+}
+
+void PropertyManagerItemDelegate::paintPropertyItem(QPainter *painter, QStyleOptionViewItem &option,
+                                                    const QStyleOptionViewItem &opt,
+                                                    const QModelIndex &index) const {
+    auto property = static_cast<PropertyItem*>(index.internalPointer());
+    
+    if (property && property->isSeparator()) {
+        QColor color = option.palette.color(QPalette::BrightText);
+        QObject* par = parent();
+        if (par) {
+            QVariant value = par->property("groupTextColor");
+            if (value.canConvert<QColor>()) {
+                color = value.value<QColor>();
+            }
+        }
+        option.palette.setColor(QPalette::Text, color);
+        option.font.setBold(true);
+
+        // Since the group item now parents all the property items and can be
+        // collapsed, it makes sense to have some selection visual clue for it.
+        //
+        // option.state &= ~QStyle::State_Selected;
+    }
+    else if (index.column() == 1) {
+        option.state &= ~QStyle::State_Selected;
+    }
+
+    option.state &= ~QStyle::State_HasFocus;
+
+    if (property && property->isSeparator()) {
+        QBrush brush = option.palette.dark();
+        QObject* par = parent();
+        if (par) {
+            QVariant value = par->property("groupBackground");
+            if (value.canConvert<QBrush>())
+                brush = value.value<QBrush>();
+        }
+        painter->fillRect(option.rect, brush);
+    }
+
+    QPen savedPen = painter->pen();
+
+    QItemDelegate::paint(painter, option, index);
+
+    QColor color = static_cast<QRgb>(QApplication::style()->styleHint(QStyle::SH_Table_GridLineColor, &opt, qobject_cast<QWidget*>(parent())));
+    painter->setPen(QPen(color));
+    if (index.column() == 1 || !(property && property->isSeparator())) {
+        int right = (option.direction == Qt::LeftToRight) ? option.rect.right() : option.rect.left();
+        painter->drawLine(right, option.rect.y(), right, option.rect.bottom());
+    }
+    painter->drawLine(option.rect.x(), option.rect.bottom(),
+            option.rect.right(), option.rect.bottom());
+    painter->setPen(savedPen);
+}
+
+void PropertyManagerItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opt, const QModelIndex &index) const
+{
+    QStyleOptionViewItem option = opt;
+
+    auto propertyItem = static_cast<PropertyItem*>(index.internalPointer());
+    if (propertyItem) {
+        auto documentItem = dynamic_cast<DocumentItem*>(propertyItem);
+        auto objectItem = dynamic_cast<DocumentObjectItem*>(propertyItem);
+
+        if (documentItem || objectItem) {
+            option.font.setBold(true);
+            option.state &= ~QStyle::State_HasFocus;
+            QPen savedPen = painter->pen();
+
+            QItemDelegate::paint(painter, option, index);
+        }
+        else {
+            paintPropertyItem(painter, option, opt, index);
+        }
+    }
+    else {
+        paintPropertyItem(painter, option, opt, index);
+    }
+}
+
+#include "moc_PropertyManagerItemDelegate.cpp"

--- a/src/Gui/propertymanager/PropertyManagerItemDelegate.h
+++ b/src/Gui/propertymanager/PropertyManagerItemDelegate.h
@@ -1,0 +1,50 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#ifndef PROPERTY_MANAGER_ITEM_DELEGATE_H
+#define PROPERTY_MANAGER_ITEM_DELEGATE_H
+
+#include <QItemDelegate>
+
+#include "PropertyItemDelegate2.h"
+
+namespace Gui::PropertyEditor {
+
+class PropertyEditorWidget;
+
+class PropertyManagerItemDelegate : public PropertyItemDelegate2
+{
+    Q_OBJECT
+
+public:
+    explicit PropertyManagerItemDelegate(QObject* parent);
+    ~PropertyManagerItemDelegate() override = default;
+    void paint(QPainter *painter, const QStyleOptionViewItem &opt, const QModelIndex &index) const override;
+
+private:
+    void paintPropertyItem(QPainter *painter, QStyleOptionViewItem &option, const QStyleOptionViewItem &opt,
+                           const QModelIndex &index) const;
+};
+
+} // namespace Gui::PropertyEditor
+
+#endif // PROPERTY_MANAGER_ITEM_DELEGATE_H

--- a/src/Gui/propertymanager/PropertyManagerModel.cpp
+++ b/src/Gui/propertymanager/PropertyManagerModel.cpp
@@ -1,0 +1,365 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <boost/algorithm/string/predicate.hpp>
+#endif
+
+#include <vector>
+#include <App/Application.h>
+#include <App/Document.h>
+#include <Base/Console.h>
+
+#include "PropertyManagerModel.h"
+#include "PropertyManagerItem.h"
+
+
+using namespace Gui;
+using namespace Gui::PropertyEditor;
+
+const int ROOT = -1;
+const int DOC = 0;
+const int OBJ = 1;
+const int GROUP = 2;
+const int PROPERTY = 3;
+
+FC_LOG_LEVEL_INIT("PropertyManagerModel", true, true)
+
+std::unordered_map<QString, PropertyEditor::Filter> PropertyManagerModel::scopes = {};
+
+PropertyManagerModel::PropertyManagerModel(QObject* parent)
+: PropertyModel2(parent)
+{
+}
+
+PropertyManagerModel::~PropertyManagerModel()
+{
+}
+
+void PropertyManagerModel::addProperties(QModelIndex & parentIndex, int rowInParent)
+{
+    QModelIndex objIndex = index(rowInParent, 0, parentIndex);
+    auto* parentItem = static_cast<DocumentObjectItem*>(objIndex.internalPointer());
+    
+    App::DocumentObject* obj = parentItem->getObject();
+
+    std::vector<App::Property*> properties = filter.getPropertiesFiltered(obj);
+
+    if (properties.size() > 0) {
+
+        PropertyEditor::PropertyModel2::PropertyList props;
+    
+        for (auto prop : properties) {
+            std::vector<App::Property*> items(1,prop);
+            props.emplace_back(prop->getName(), std::move(items));
+                           
+        }
+
+        buildUp(objIndex, std::move(props));
+    }
+}
+
+void PropertyManagerModel::addDocumentObjects(/*DocumentItem* parentItem, */QModelIndex & parentIndex, int rowInParent)
+{
+    QModelIndex docIndex = index(rowInParent, 0, parentIndex);
+    auto* docItem = static_cast<DocumentItem*>(docIndex.internalPointer());
+    
+    App::Document* doc = docItem->getDocument();
+    std::vector<App::DocumentObject*> objs = filter.getObjectsFiltered(doc);
+    int nrObjs = static_cast<int>(objs.size());
+    
+    //beginInsertRows(docIndex, 0, nrObjs - 1);
+    for (int row = 0; row < nrObjs; row++) {
+        App::DocumentObject* obj = objs[row];
+        auto *objItem = new DocumentObjectItem(obj);
+        objItem->setParent(docItem);
+        QString name = QString::fromLatin1(obj->Label.getValue());
+        objItem->setPropertyName(name, name);
+        docItem->appendChild(objItem);
+        addProperties(docIndex, row);
+    }
+    //endInsertRows();
+}
+
+void PropertyManagerModel::init()
+{
+    std::vector<App::Document*> docs = filter.getDocumentsFiltered();
+    int nrDocs = static_cast<int>(docs.size());
+
+    QModelIndex rootIndex = index(ROOT, 0);
+
+    beginResetModel();
+    removeRows(0, rowCount(), index(ROOT, 0));
+
+    //beginInsertRows(rootIndex, 0, nrDocs - 1);
+    for (int row = 0; row < nrDocs; row++) {
+        auto doc = docs[row];
+        auto *di = new DocumentItem(doc);
+        di->setParent(rootItem);
+        QString name = QString::fromLatin1(doc->Label.getValue());
+        di->setPropertyName(name, name);
+        rootItem->appendChild(di);
+        addDocumentObjects(rootIndex, row);
+    }
+    //endInsertRows();
+
+    removeItemsWithNoChildren();
+    endResetModel();
+}
+
+void PropertyManagerModel::removeItemsWithNoChildren() {
+    QModelIndex rootIndex = index(ROOT, 0);
+    removeItemsWithNoChildren(rootIndex, 0, PROPERTY);
+}
+
+void PropertyManagerModel::removeItemsWithNoChildren(QModelIndex& parent, int level, int upToLevel)
+{
+    if (level < upToLevel) {
+        for (int row = 0; row < rowCount(parent); row++) {
+            QModelIndex indexChild = index(row, 0, parent);
+
+            removeItemsWithNoChildren(indexChild, ++level, upToLevel);
+            if (rowCount(indexChild) == 0) {
+                removeRow(row, parent);
+                --row;
+            }
+        }
+    }
+}
+
+
+QList<QModelIndex> PropertyManagerModel::childrenAtLevel(int level){
+    QList<QModelIndex> children;
+    QModelIndex rootIndex = index(ROOT, 0);
+    childrenAtLevel(children, rootIndex, level);
+    
+    return children;
+}
+
+void PropertyManagerModel::childrenAtLevel(QList<QModelIndex>& children, QModelIndex& parent, int level){
+    for (int row = 0; row < rowCount(parent); ++row) {
+        QModelIndex childIndex = index(row, 0, parent);
+
+        if (level == 0) {
+            children.append(childIndex);
+        } else {
+            childrenAtLevel(children, childIndex, level - 1);
+        }
+    }
+}
+
+template <class T>
+void PropertyManagerModel::getFilterValues(
+        UniqueVector<QString>& filterValues,
+        int level,
+        std::function<void(T*)> funcAct,
+        std::function<QString(T*)> funcProduce)
+{
+    for (auto index : childrenAtLevel(level)) {
+        auto item = static_cast<T*>(index.internalPointer());
+        funcAct(item);
+        filterValues.push_back(funcProduce(item));
+    }
+}
+
+template<class T>
+static void doNothing(T* item) {};
+
+
+UniqueVector<QString> PropertyManagerModel::getFilterValuesDocument()
+{
+    UniqueVector<QString> filterValues = filter.getFilterValuesDocument();
+
+    getFilterValues<DocumentItem>(filterValues, DOC, [&filterValues](DocumentItem* docItem) {
+        App::Document* doc = docItem->getDocument();
+        App::Document *activeDoc = App::GetApplication().getActiveDocument();
+        if (doc == activeDoc) {
+            filterValues.push_back(Filter::ACTIVE_DOC);
+        }
+    }, [](DocumentItem* docItem) {
+        App::Document* doc = docItem->getDocument();
+        return QString::fromStdString(doc->Label.getStrValue());
+    });
+        
+    return filterValues;
+}
+
+UniqueVector<QString> PropertyManagerModel::getFilterValuesTypeObject()
+{
+    UniqueVector<QString> filterValues = filter.getFilterValuesTypeObject();
+    getFilterValues<DocumentObjectItem>(filterValues, OBJ,
+                                        &doNothing<DocumentObjectItem>,
+                                        [](DocumentObjectItem* objItem) {
+                                            App::DocumentObject* obj = objItem->getObject();
+                                            return Filter::getType(obj);
+                                        });
+    return filterValues;
+}
+
+UniqueVector<QString> PropertyManagerModel::getFilterValuesNameObject()
+{
+    UniqueVector<QString> filterValues = filter.getFilterValuesNameObject();
+
+    getFilterValues<DocumentObjectItem>(filterValues, OBJ,
+                                        &doNothing<DocumentObjectItem>,
+                                        [](DocumentObjectItem* objItem) {
+                                            App::DocumentObject* obj = objItem->getObject();
+                                            return QString::fromStdString(obj->Label.getStrValue());
+                                        });
+
+    return filterValues;
+}
+
+void PropertyManagerModel::getGroupNames(UniqueVector<QString> &groupNames)
+{
+    getFilterValues<PropertySeparatorItem>(groupNames, GROUP, &doNothing<PropertySeparatorItem>,
+                                           [](PropertySeparatorItem* groupItem) {
+                                               return groupItem->propertyName();
+                                           });
+}
+
+UniqueVector<QString> PropertyManagerModel::getGroupNames() {
+    UniqueVector<QString> groupNames;
+    getGroupNames(groupNames);
+    return groupNames;
+}
+
+UniqueVector<QString> PropertyManagerModel::getFilterValuesGroup()
+{
+    UniqueVector<QString> filterValues = filter.getFilterValuesGroup();
+    getGroupNames(filterValues);
+    return filterValues;
+}
+
+UniqueVector<QString> PropertyManagerModel::getFilterValuesTypeProperty()
+{
+    UniqueVector<QString> filterValues = filter.getFilterValuesTypeProperty();
+    getFilterValues<PropertyItem>(filterValues, PROPERTY, &doNothing<PropertyItem>,
+                                  [](PropertyItem* propItem) {
+                                      return Filter::getType(propItem->getFirstProperty());
+                                  });
+    return filterValues;
+}
+
+UniqueVector<QString> PropertyManagerModel::getFilterValuesNameProperty()
+{
+    UniqueVector<QString> filterValues = filter.getFilterValuesNameProperty();
+    getFilterValues<PropertyItem>(filterValues, PROPERTY, &doNothing<PropertyItem>,
+                                  [](PropertyItem* propItem) {
+                                      return QString::fromStdString(propItem->getFirstProperty()->getName());
+                                  });
+    return filterValues;
+}
+
+void PropertyManagerModel::filterSelected(QString &selectedDocument,
+                                          QString &selectedTypeObject, QString &selectedNameObject,
+                                          QString &selectedGroup,
+                                          QString &selectedTypeProperty, QString &selectedNameProperty)
+{
+    filter.filter(selectedDocument,
+                  selectedTypeObject, selectedNameObject,
+                  selectedGroup,
+                  selectedTypeProperty, selectedNameProperty);
+    init();
+}
+
+
+App::DocumentObject* PropertyManagerModel::getUniqueObject()
+{
+    QList<QModelIndex> objs = childrenAtLevel(OBJ);
+    if (objs.size() == 1) {
+        QModelIndex indexObj = objs[0];
+        auto objItem = static_cast<DocumentObjectItem*>(indexObj.internalPointer());
+        return objItem->getObject();
+    }
+    return nullptr;
+}
+
+QString PropertyManagerModel::getUniqueTypeProperty()
+{
+    UniqueVector<QString> types;
+
+    for (auto index : childrenAtLevel(PROPERTY)) {
+        auto propItem = static_cast<PropertyItem*>(index.internalPointer());
+        types.push_back(Filter::getType(propItem->getFirstProperty()));
+    }
+
+    if (types.size() == 1) {
+        return types[0];
+    }
+    
+    return {};
+}
+
+
+QString PropertyManagerModel::getUniqueGroup()
+{
+    UniqueVector<QString> groups;
+    
+    for (auto index : childrenAtLevel(GROUP)) {
+        auto groupItem = static_cast<PropertySeparatorItem*>(index.internalPointer());
+        groups.push_back(groupItem->propertyName());
+    }
+    
+    if (groups.size() == 1) {
+        return groups[0];
+    }
+    
+    return {};
+}
+
+void PropertyManagerModel::refresh()
+{
+    init();
+}
+
+bool PropertyManagerModel::scopeExists(QString& name) {
+    return scopes.find(name) != scopes.end();
+}
+
+void PropertyManagerModel::selectScope(QString& name) {
+    filter = scopes[name];
+}
+
+void PropertyManagerModel::insertScope(QString& name) {
+    scopes[name] = filter;
+    filter.setName(name);
+}
+
+UniqueVector<QString> PropertyManagerModel::getNamesScope()
+{
+    UniqueVector<QString> names;
+    QString nameFilter = filter.getName();
+    if (!nameFilter.isEmpty()) {
+        names.push_back(nameFilter);
+    }
+
+    for (const auto& pair : scopes) {
+        names.push_back(pair.first);
+    }
+
+    return names;
+}
+
+#include "moc_PropertyManagerModel.cpp"

--- a/src/Gui/propertymanager/PropertyManagerModel.h
+++ b/src/Gui/propertymanager/PropertyManagerModel.h
@@ -1,0 +1,112 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#ifndef PROPERTY_MANAGER_MODEL_H
+#define PROPERTY_MANAGER_MODEL_H
+
+#include <QAbstractItemModel>
+#include <QString>
+#include <map>
+#include <unordered_map>
+#include <vector>
+#include "PropertyModel2.h"
+#include "Filter.h"
+
+
+namespace App {
+class Property;
+}
+
+namespace Gui::PropertyEditor {
+
+class DocumentItem;
+class DocumentObjectItem;
+
+class PropertyManagerModel : public PropertyModel2
+{
+    Q_OBJECT
+
+public:
+    using PropertyList = std::vector< std::pair< std::string, std::vector<App::Property*> > >;
+
+
+    explicit PropertyManagerModel(QObject* parent);
+    ~PropertyManagerModel() override;
+
+    void addProperties(QModelIndex & parentIndex, int parentRow);
+    void addDocumentObjects(QModelIndex & parentInex, int parentRow);
+    void init();
+
+    UniqueVector<QString> getFilterValuesDocument();
+    UniqueVector<QString> getFilterValuesTypeObject();
+    UniqueVector<QString> getFilterValuesNameObject();
+    UniqueVector<QString> getFilterValuesGroup();
+    UniqueVector<QString> getFilterValuesTypeProperty();
+    UniqueVector<QString> getFilterValuesNameProperty();
+
+    UniqueVector<QString> getGroupNames();
+
+    void filterSelected(QString &selectedDocument,
+                        QString &selectedTypeObject, QString &selectedNameObject,
+                        QString &selectedGroup,
+                        QString &selectedTypeProperty, QString &selectedNameProperty);
+
+    void refresh();
+    App::DocumentObject* getUniqueObject();
+    QString getUniqueTypeProperty();
+    QString getUniqueGroup();
+
+    // scopes
+
+    bool scopeExists(QString& name);
+    void selectScope(QString& name);
+    void insertScope(QString& name);
+    UniqueVector<QString> getNamesScope();
+
+private:
+
+    QList<QModelIndex> childrenAtLevel(int level);
+    void childrenAtLevel(QList<QModelIndex>& children, QModelIndex& parent, int level);
+
+    void removeItemsWithNoChildren();
+    void removeItemsWithNoChildren(QModelIndex& parent, int level, int upToLevel);
+        
+    void getGroupNames(UniqueVector<QString> &groupNames);
+
+    
+    template<class T>
+    void getFilterValues(
+            UniqueVector<QString>& filterValues,
+            int level,
+            std::function<void(T*)> funcAct,
+            std::function<QString(T*)> funcProduce);
+
+
+private:
+    static std::unordered_map<QString, PropertyEditor::Filter> scopes;
+    Filter filter;
+};
+
+} // namespace Gui
+
+
+#endif // PROPERTY_MANAGER_MODEL_H

--- a/src/Gui/propertymanager/PropertyModel2.cpp
+++ b/src/Gui/propertymanager/PropertyModel2.cpp
@@ -1,0 +1,590 @@
+/***************************************************************************
+ *   Copyright (c) 2004 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <boost/algorithm/string/predicate.hpp>
+#endif
+
+#include "PropertyModel2.h"
+#include "PropertyView.h"
+
+
+
+using namespace Gui;
+using namespace Gui::PropertyEditor;
+
+
+/* TRANSLATOR Gui::PropertyEditor::PropertyModel */
+
+PropertyModel2::PropertyModel2(QObject* parent)
+    : QAbstractItemModel(parent)
+{
+    rootItem = static_cast<PropertyItem*>(PropertyItem::create());
+}
+
+PropertyModel2::~PropertyModel2()
+{
+    delete rootItem;
+}
+
+QModelIndex PropertyModel2::buddy ( const QModelIndex & index ) const
+{
+    if (index.column() == 1)
+        return index;
+    return index.sibling(index.row(), 1);
+}
+
+int PropertyModel2::columnCount ( const QModelIndex & parent ) const
+{
+    // <property, value>, hence always 2
+    if (parent.isValid())
+        return static_cast<PropertyItem*>(parent.internalPointer())->columnCount();
+    else
+        return rootItem->columnCount();
+}
+
+QVariant PropertyModel2::data ( const QModelIndex & index, int role ) const
+{
+    if (!index.isValid())
+        return {};
+
+    auto item = static_cast<PropertyItem*>(index.internalPointer());
+    return item->data(index.column(), role);
+}
+
+bool PropertyModel2::setData(const QModelIndex& index, const QVariant & value, int role)
+{
+    if (!index.isValid())
+        return false;
+
+    // we check whether the data has really changed, otherwise we ignore it
+    if (role == Qt::EditRole) {
+        auto item = static_cast<PropertyItem*>(index.internalPointer());
+        QVariant data = item->data(index.column(), role);
+        if (data.userType() == QMetaType::Double && value.userType() == QMetaType::Double) {
+            // since we store some properties as floats we get some round-off
+            // errors here. Thus, we use an epsilon here.
+            // NOTE: Since 0.14 PropertyFloat uses double precision, so this is maybe unnecessary now?
+            double d = data.toDouble();
+            double v = value.toDouble();
+            if (fabs(d-v) > DBL_EPSILON)
+                return item->setData(value);
+        }
+        // Special case handling for quantities
+        else if (data.canConvert<Base::Quantity>() && value.canConvert<Base::Quantity>()) {
+            const Base::Quantity& val1 = data.value<Base::Quantity>();
+            const Base::Quantity& val2 = value.value<Base::Quantity>();
+            if (!(val1 == val2))
+                return item->setData(value);
+        }
+        else if (data != value)
+            return item->setData(value);
+    }
+
+    return true;
+}
+
+Qt::ItemFlags PropertyModel2::flags(const QModelIndex &index) const
+{
+    auto item = static_cast<PropertyItem*>(index.internalPointer());
+    return item->flags(index.column());
+}
+
+QModelIndex PropertyModel2::index ( int row, int column, const QModelIndex & parent ) const
+{
+    PropertyItem *parentItem;
+
+    if (!parent.isValid())
+        parentItem = rootItem;
+    else
+        parentItem = static_cast<PropertyItem*>(parent.internalPointer());
+
+    PropertyItem *childItem = parentItem->child(row);
+    if (childItem)
+        return createIndex(row, column, childItem);
+    else
+        return {};
+}
+
+QModelIndex PropertyModel2::parent ( const QModelIndex & index ) const
+{
+    if (!index.isValid())
+        return {};
+
+    auto childItem = static_cast<PropertyItem*>(index.internalPointer());
+    PropertyItem *parentItem = childItem->parent();
+
+    if (parentItem == rootItem)
+        return {};
+
+    return createIndex(parentItem->row(), 0, parentItem);
+}
+
+int PropertyModel2::rowCount ( const QModelIndex & parent ) const
+{
+    PropertyItem *parentItem;
+
+    if (!parent.isValid())
+        parentItem = rootItem;
+    else
+        parentItem = static_cast<PropertyItem*>(parent.internalPointer());
+
+    return parentItem->childCount();
+}
+
+QVariant PropertyModel2::headerData (int section, Qt::Orientation orientation, int role) const
+{
+    if (orientation == Qt::Horizontal) {
+        if (role != Qt::DisplayRole)
+            return {};
+        if (section == 0)
+            return tr("Property");
+        if (section == 1)
+            return tr("Value");
+    }
+
+    return {};
+}
+
+bool PropertyModel2::setHeaderData (int, Qt::Orientation, const QVariant &, int)
+{
+    return false;
+}
+
+// TODO convert this?
+// QStringList PropertyModel2::propertyPathFromIndex(const QModelIndex& index) const
+// {
+//     QStringList path;
+//     if (index.isValid()) {
+//         auto item = static_cast<PropertyItem*>(index.internalPointer());
+//         while (item && item != this->rootItem) {
+//             path.push_front(item->propertyName());
+//             item = item->parent();
+//         }
+//     }
+
+//     return path;
+// }
+
+// TODO convert these for whole path?
+/*
+QModelIndex PropertyModel2::propertyIndexFromPath(const QStringList& path) const
+{
+    if (path.size() < 2)
+        return {};
+
+    auto it = groupItems.find(path.front());
+    if (it == groupItems.end())
+        return {};
+
+    PropertyItem *item = it->second.groupItem;
+    // TODO
+    QModelIndex index = this->index(item->row(), 0, QModelIndex());
+
+    for (int j=1; j<path.size(); ++j) {
+        bool found = false;
+        for (int i=0, c = item->childCount(); i<c; ++i) {
+            auto child = item->child(i);
+            if (child->propertyName() == path[j]) {
+                index = this->index(i, 1, index);
+                item = child;
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            return j==1?QModelIndex():index;
+    }
+    return index;
+}
+*/
+
+static void setPropertyItemName(PropertyItem *item, const char *propName, QString groupName) {
+    QString name = QString::fromLatin1(propName);
+    QString realName = name;
+    if(name.size()>groupName.size()+1 
+            && name.startsWith(groupName + QLatin1Char('_')))
+        name = name.right(name.size()-groupName.size()-1);
+
+    item->setPropertyName(name, realName);
+}
+
+static PropertyItem *createPropertyItem(App::Property *prop)
+{
+    const char *editor = prop->getEditorName();
+    if (!editor || !editor[0]) {
+        if (PropertyView::showAll())
+            editor = "Gui::PropertyEditor::PropertyItem";
+        else
+            return nullptr;
+    }
+    auto item = static_cast<PropertyItem*>(
+            PropertyItemFactory::instance().createPropertyItem(editor));
+    if (!item) {
+        qWarning("No property item for type %s found\n", editor);
+    }
+    return item;
+}
+
+DocumentObjectItem::GroupInfo &PropertyModel2::getGroupInfo(QModelIndex& parentIndex, App::Property *prop)
+{
+    auto objItem = static_cast<DocumentObjectItem*>(parentIndex.internalPointer());
+    auto &groupItems = objItem->getGroupItems();
+    
+    const char* group = prop->getGroup();
+    bool isEmpty = (!group || group[0] == '\0');
+    QString groupName = QString::fromLatin1(
+            isEmpty ? QT_TRANSLATE_NOOP("App::Property", "Base") : group);
+
+    auto* parentItem = static_cast<PropertyItem*>(parentIndex.internalPointer());
+
+    auto res = groupItems.insert(std::make_pair(groupName, DocumentObjectItem::GroupInfo()));
+    if (res.second) {
+        auto &groupInfo = res.first->second;
+        groupInfo.groupItem = static_cast<PropertySeparatorItem*>(PropertySeparatorItem::create());
+        groupInfo.groupItem->setReadOnly(true);
+        groupInfo.groupItem->setExpanded(true);
+        groupInfo.groupItem->setParent(parentItem);
+        groupInfo.groupItem->setPropertyName(groupName);
+
+        auto it = res.first;
+        int row = 0;
+        if (it != groupItems.begin()) {
+            --it;
+            row = it->second.groupItem->_row + 1;
+            ++it;
+        }
+        groupInfo.groupItem->_row = row;
+        beginInsertRows(parentIndex, row, row);
+        parentItem->insertChild(row, groupInfo.groupItem);
+        // update row index for all group items behind
+        for (++it; it!=groupItems.end(); ++it)
+            ++it->second.groupItem->_row;
+        endInsertRows();
+    }
+
+    return res.first->second;
+}
+
+void PropertyModel2::buildUp(QModelIndex & parentIndex, const PropertyModel2::PropertyList& props)
+{
+    // If props empty, then simply reset all property items, but keep the group
+    // items.
+    if (props.empty()) {
+        resetGroups(parentIndex);
+        return;
+    }
+
+    // First step, init group info
+    initGroups(parentIndex);
+
+    // Second step, either find existing items or create new items for the given
+    // properties. There is no signaling of model change at this stage. The
+    // change information is kept pending in GroupInfo::children
+    findOrCreateChildren(parentIndex, props);
+
+    // Third step, signal item insertion and movement.
+    insertOrMoveChildren(parentIndex);
+
+
+    // Final step, signal item removal. This is separated from the above because
+    // of the possibility of moving items between groups.
+    removeChildren(parentIndex);
+}
+
+void PropertyModel2::resetGroups(QModelIndex & parentIndex)
+{
+    auto objItem = static_cast<DocumentObjectItem*>(parentIndex.internalPointer());
+    auto &groupItems = objItem->getGroupItems();
+    beginResetModel();
+    for(auto &v : groupItems) {
+        auto &groupInfo = v.second;
+        groupInfo.groupItem->reset();
+        groupInfo.children.clear();
+    }
+    auto &itemMap = objItem->getItemMap();
+    itemMap.clear();
+    endResetModel();
+}
+
+void PropertyModel2::initGroups(QModelIndex & parentIndex)
+{
+    auto objItem = static_cast<DocumentObjectItem*>(parentIndex.internalPointer());
+    auto &groupItems = objItem->getGroupItems();
+    for (auto &v : groupItems) {
+        auto &groupInfo = v.second;
+        groupInfo.children.clear();
+    }
+}
+
+void PropertyModel2::findOrCreateChildren(QModelIndex & parentIndex, const PropertyModel2::PropertyList& props)
+{
+    auto objItem = static_cast<DocumentObjectItem*>(parentIndex.internalPointer());
+    auto &itemMap = objItem->getItemMap();
+    
+    for (const auto & jt : props) {
+        App::Property* prop = jt.second.front();
+
+        PropertyItem *item = nullptr;
+        for (auto prop : jt.second) {
+            auto it = itemMap.find(prop);
+            if (it == itemMap.end() || !it->second) {
+                continue;
+            }
+            item = it->second;
+            break;
+        }
+
+        if (!item) {
+            item = createPropertyItem(prop);
+            if (!item) {
+                continue;
+            }
+        }
+
+        DocumentObjectItem::GroupInfo &groupInfo = getGroupInfo(parentIndex, prop);
+        groupInfo.children.push_back(item);
+
+        item->setLinked(boost::ends_with(jt.first,"*"));
+        setPropertyItemName(item, prop->getName(), groupInfo.groupItem->propertyName());
+
+        if (jt.second != item->getPropertyData()) {
+            for (auto prop : item->getPropertyData()) {
+                itemMap.erase(prop);
+            }
+            for (auto prop : jt.second) {
+                itemMap[prop] = item;
+            }
+            // TODO: is it necessary to make sure the item has no pending commit?
+            item->setPropertyData(jt.second);
+        }
+        else {
+            item->updateData();
+        }
+    }
+}
+
+void PropertyModel2::insertOrMoveChildren(QModelIndex & parentIndex)
+{
+    auto objItem = static_cast<DocumentObjectItem*>(parentIndex.internalPointer());
+    auto &groupItems = objItem->getGroupItems();
+    
+    for (auto &v : groupItems) {
+        auto &groupInfo = v.second;
+        int beginChange = -1;
+        int endChange = 0;
+        int beginInsert = -1;
+        int endInsert = 0;
+        int row = -1;
+        QModelIndex midx = this->index(groupInfo.groupItem->_row, 0, parentIndex);
+
+        auto flushInserts = [&]() {
+            if (beginInsert < 0)
+                return;
+            beginInsertRows(midx, beginInsert, endInsert);
+            for (int i=beginInsert; i<=endInsert; ++i)
+                groupInfo.groupItem->insertChild(i, groupInfo.children[i]);
+            endInsertRows();
+            beginInsert = -1;
+        };
+
+        auto flushChanges = [&]() {
+            if (beginChange < 0)
+                return;
+            (void)endChange;
+            // There is no need to signal dataChange(), because PropertyEditor
+            // will call PropertyModel2::updateProperty() on any property
+            // changes.
+            //
+            // dataChanged(this->index(beginChange,0,midx), this->index(endChange,1,midx));
+            beginChange = -1;
+        };
+
+        for (auto item : groupInfo.children) {
+            ++row;
+            if (!item->parent()) {
+                flushChanges();
+                item->setParent(groupInfo.groupItem);
+                if (beginInsert < 0) {
+                    beginInsert = row;
+                }
+                endInsert = row;
+            }
+            else {
+                flushInserts();
+                int oldRow = item->row();
+                // Dynamic property can rename group, so must check
+                auto groupItem = item->parent();
+                assert(groupItem);
+                if (oldRow == row && groupItem == groupInfo.groupItem) {
+                    if (beginChange < 0)
+                        beginChange = row;
+                    endChange = row;
+                }
+                else {
+                    flushChanges();
+                    beginMoveRows(createIndex(groupItem->row(), 0, groupItem),
+                                  oldRow, oldRow, midx, row);
+                    if (groupItem == groupInfo.groupItem) {
+                        groupInfo.groupItem->moveChild(oldRow, row);
+                    }
+                    else {
+                        groupItem->takeChild(oldRow);
+                        item->setParent(groupInfo.groupItem);
+                        groupInfo.groupItem->insertChild(row, item);
+                    }
+                    endMoveRows();
+                }
+            }
+        }
+
+        flushChanges();
+        flushInserts();
+    }
+}
+
+void PropertyModel2::removeChildren(QModelIndex & parentIndex)
+{
+    auto objItem = static_cast<DocumentObjectItem*>(parentIndex.internalPointer());
+    auto &groupItems = objItem->getGroupItems();
+    
+    for (auto &v : groupItems) {
+        auto &groupInfo = v.second;
+        int first, last;
+        getRange(groupInfo, first, last);
+        if (last > first) {
+            QModelIndex midx = this->index(groupInfo.groupItem->_row, 0, parentIndex);
+            // This can trigger a recursive call of PropertyView::onTimer()
+            beginRemoveRows(midx, first, last - 1);
+            groupInfo.groupItem->removeChildren(first, last - 1);
+            endRemoveRows();
+        }
+        else {
+            assert(last == first);
+        }
+    }
+}
+
+void PropertyModel2::getRange(const DocumentObjectItem::GroupInfo& groupInfo, int& first, int& last) const
+{
+    first = static_cast<int>(groupInfo.children.size());
+    last = groupInfo.groupItem->childCount();
+}
+
+/*
+void PropertyModel2::updateProperty(const App::Property& prop)
+{
+    auto it = itemMap.find(const_cast<App::Property*>(&prop));
+    if (it == itemMap.end() || !it->second || !it->second->parent())
+        return;
+
+    int column = 1;
+    PropertyItem *item = it->second;
+    item->updateData();
+    // TODO
+    QModelIndex parent = this->index(item->parent()->row(), 0, QModelIndex());
+    item->assignProperty(&prop);
+    QModelIndex data = this->index(item->row(), column, parent);
+    Q_EMIT dataChanged(data, data);
+    updateChildren(item, column, data);
+}
+*/
+
+// void PropertyModel2::appendProperty(const App::Property& _prop)
+// {
+//     auto prop = const_cast<App::Property*>(&_prop);
+//     if (!prop->getName())
+//         return;
+//     auto it = itemMap.find(prop);
+//     if (it == itemMap.end() || !it->second)
+//         return;
+
+//     PropertyItem *item = createPropertyItem(prop);
+//     GroupInfo &groupInfo = getGroupInfo(prop);
+
+//     int row = 0;
+//     for (int c=groupInfo.groupItem->childCount(); row<c; ++row) {
+//         PropertyItem *child = groupInfo.groupItem->child(row);
+//         App::Property *firstProp = item->getFirstProperty();
+//         if (firstProp && firstProp->testStatus(App::Property::PropDynamic)
+//                       && item->propertyName() >= child->propertyName())
+//             break;
+//     }
+
+//     QModelIndex midx = this->index(groupInfo.groupItem->_row,0,QModelIndex());
+//     beginInsertRows(midx, row, row);
+//     groupInfo.groupItem->insertChild(row, item);
+//     setPropertyItemName(item, prop->getName(), groupInfo.groupItem->propertyName());
+//     item->setPropertyData({prop});
+//     endInsertRows();
+// }
+
+/* TODO bring back with parent info
+   
+void PropertyModel2::removeProperty(const App::Property& _prop)
+{
+    auto prop = const_cast<App::Property*>(&_prop);
+    auto it = itemMap.find(prop);
+    if (it == itemMap.end() || !it->second)
+        return;
+
+    PropertyItem *item = it->second;
+    if (item->removeProperty(prop)) {
+        PropertyItem *parent = item->parent();
+        int row = item->row();
+        // TODO
+        beginRemoveRows(this->index(parent->row(), 0, QModelIndex()), row, row);
+        parent->removeChildren(row,row);
+        endRemoveRows();
+    }
+}
+*/
+
+void PropertyModel2::updateChildren(PropertyItem* item, int column, const QModelIndex& parent)
+{
+    int numChild = item->childCount();
+    if (numChild > 0) {
+        QModelIndex topLeft = this->index(0, column, parent);
+        QModelIndex bottomRight = this->index(numChild, column, parent);
+        Q_EMIT dataChanged(topLeft, bottomRight);
+    }
+}
+
+bool PropertyModel2::removeRows(int row, int count, const QModelIndex& parent)
+{
+    PropertyItem* item;
+    if (!parent.isValid())
+        item = rootItem;
+    else
+        item = static_cast<PropertyItem*>(parent.internalPointer());
+
+    int start = row;
+    int end = row+count-1;
+    beginRemoveRows(parent, start, end);
+    item->removeChildren(start, end);
+    endRemoveRows();
+    return true;
+}
+
+#include "moc_PropertyModel2.cpp"

--- a/src/Gui/propertymanager/PropertyModel2.h
+++ b/src/Gui/propertymanager/PropertyModel2.h
@@ -1,0 +1,101 @@
+/***************************************************************************
+ *   Copyright (c) 2004 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PROPERTYMODEL2_H
+#define PROPERTYMODEL2_H
+
+#include <QAbstractItemModel>
+#include <QStringList>
+#include <map>
+#include <unordered_map>
+#include <vector>
+#include "propertyeditor/PropertyItem.h"
+#include "PropertyManagerItem.h"
+
+
+namespace App {
+class Property;
+}
+
+namespace Gui {
+namespace PropertyEditor {
+
+
+class PropertyModel2 : public QAbstractItemModel
+{
+    Q_OBJECT
+
+public:
+    using PropertyList = std::vector< std::pair< std::string, std::vector<App::Property*> > >;
+
+    PropertyModel2(QObject* parent);
+    ~PropertyModel2() override;
+
+    QModelIndex buddy (const QModelIndex & index) const override;
+    int columnCount (const QModelIndex & parent = QModelIndex()) const override;
+    QVariant data (const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    bool setData (const QModelIndex & idx, const QVariant & value, int role) override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    QModelIndex index (int row, int column, const QModelIndex & parent = QModelIndex()) const override;
+    QModelIndex parent (const QModelIndex & index) const override;
+    int rowCount (const QModelIndex & parent = QModelIndex()) const override;
+    QVariant headerData (int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    bool setHeaderData (int section, Qt::Orientation orientation, const QVariant & value, int role = Qt::EditRole) override;
+    void buildUp(QModelIndex& parentIndex, const PropertyList & props);
+
+    bool removeRows(int row, int count, const QModelIndex & parent = QModelIndex()) override;
+
+    //void updateProperty(const App::Property&);
+    //void appendProperty(const App::Property&);
+    //void removeProperty(const App::Property&);
+    
+    // QStringList propertyPathFromIndex(const QModelIndex&) const;
+    // QModelIndex propertyIndexFromPath(const QStringList&) const;
+
+private:
+    void resetGroups(QModelIndex& parentIndex);
+    void initGroups(QModelIndex& parentIndex);
+    void updateChildren(PropertyItem* item, int column, const QModelIndex& parent);
+    void findOrCreateChildren(QModelIndex& parentIndex, const PropertyList& props);
+    void insertOrMoveChildren(QModelIndex& parentIndex);
+    void removeChildren(QModelIndex& parentIndex);
+
+    // struct GroupInfo {
+    //     PropertySeparatorItem *groupItem = nullptr;
+    //     std::vector<PropertyItem *> children;
+    // };
+    DocumentObjectItem::GroupInfo &getGroupInfo(QModelIndex& parentIndex, App::Property *);
+    void getRange(const DocumentObjectItem::GroupInfo&, int& first, int& last) const;
+
+protected:
+    PropertyItem *rootItem;
+
+private:
+
+};
+
+} //namespace PropertyEditor
+} //namespace Gui
+
+
+#endif //PROPERTYMODEL2_H

--- a/src/Mod/PartDesign/CMakeLists.txt
+++ b/src/Mod/PartDesign/CMakeLists.txt
@@ -8,6 +8,7 @@ set(PartDesign_Scripts
     __init__.py
     Init.py
     TestPartDesignApp.py
+    TestVarSetApp.py
 )
 
 if(BUILD_GUI)

--- a/src/Mod/PartDesign/TestVarSetApp.py
+++ b/src/Mod/PartDesign/TestVarSetApp.py
@@ -1,0 +1,234 @@
+import unittest
+import tempfile
+import os
+
+import FreeCAD as App
+
+NAME_DOC_BASE = "TestVarSet"
+NAME_DOC_VARIANT = "TestVarSetVariant"
+
+
+def basicSetUp(obj):
+    obj.Doc = App.newDocument(NAME_DOC_BASE)
+
+    # create a part with a body
+    obj.Part = obj.Doc.addObject("App::Part", "Part")
+    obj.Box = obj.Doc.addObject("Part::Box", "Box")
+    obj.Part.addObject(obj.Box)
+
+    # create a variable set Params within the part
+    obj.Params = obj.Doc.addObject("App::VarSet", "Params")
+    obj.Params.addProperty("App::PropertyFloat", "Length", "Params")
+    obj.Params.addProperty("App::PropertyFloat", "Width", "Params")
+    obj.Params.addProperty("App::PropertyFloat", "Height", "Params")
+    obj.Params.Length = 300
+    obj.Params.Width = 200
+    obj.Params.Height = 100
+    obj.Part.addObject(obj.Params)
+
+    obj.Box.setExpression('Length', '<<Params>>.Length')
+    obj.Box.setExpression('Width', '<<Params>>.Width')
+    obj.Box.setExpression('Height', '<<Params>>.Height')
+
+    obj.Doc.recompute()
+
+
+def createArgVarSet(doc, varSet):
+    """Create a VarSet to be used as an argument in a variant
+
+    @param doc the document in which the VarSet has to be created
+    @param varSet the varSet that acts as equivalent one
+
+    @return a copy of varSet (that is naturally equivalent) to be used as
+    argument to a variant.
+    """
+    argVarSet = doc.copyObject(varSet)
+    argVarSet.Length = 350
+    argVarSet.Width = 250
+    argVarSet.Height = 150
+
+    return argVarSet
+
+
+class TestVarSet(unittest.TestCase):
+    def setUp(self):
+        basicSetUp(self)
+
+    # Tests whether changing parameters of a non-exposed varset affect the geometry
+    def testParamsNotExposed(self):
+        self.Params.Length = 400
+        self.Doc.recompute()
+        self.assertEqual(self.Params.Length, self.Box.Length)
+
+    def getExpressionMap(self, Obj):
+        return {k: v for (k, v) in Obj.ExpressionEngine}
+
+    # Tests whether the expressions have changed on expose
+    def testExpressionChangeExposed(self):
+        self.Params.Exposed = True
+        self.Doc.recompute()
+
+        expressionMap = self.getExpressionMap(self.Box)
+
+        self.assertEqual(expressionMap["Length"], "hiddenref(<<Part>>.Params.Length)")
+        self.assertEqual(expressionMap["Width"], "hiddenref(<<Part>>.Params.Width)")
+        self.assertEqual(expressionMap["Height"], "hiddenref(<<Part>>.Params.Height)")
+
+    # Tests whether the expressions have changed back on not exposing
+    def testExpressionChangeNonExposed(self):
+        self.Params.Exposed = True
+        self.Doc.recompute()
+
+        self.Params.Exposed = False
+        self.Doc.recompute()
+
+        expressionMap = self.getExpressionMap(self.Box)
+
+        self.assertEqual(expressionMap["Length"], "<<Params>>.Length")
+        self.assertEqual(expressionMap["Width"], "<<Params>>.Width")
+        self.assertEqual(expressionMap["Height"], "<<Params>>.Height")
+
+    # Tests whether changing parameters of an exposed varset affect the geometry
+    def testParamsExposed(self):
+        self.Params.Exposed = True
+        self.Doc.recompute()
+
+        self.Params.Length = 400
+        self.Doc.recompute()
+        self.assertEqual(self.Params.Length, self.Box.Length)
+        self.assertEqual(self.Part.Params, self.Params)
+
+    # Tests whether copying a non-exposed variable set succeeds
+    def testVarSetCopyNonExposed(self):
+        raisedException = False
+
+        try:
+            varSet = self.Doc.copyObject(self.Params)
+        except Exception:
+            raisedException = True
+
+        self.assertFalse(raisedException)
+        self.assertNotEqual(varSet.Name, self.Params.Name)
+
+    # Tests whether copying an exposed variable set succeeds
+    def testVarSetCopyExposed(self):
+        raisedException = False
+
+        try:
+            self.Params.Exposed = True
+            varSet = self.Doc.copyObject(self.Params)
+        except Exception:
+            raisedException = True
+
+        self.assertFalse(raisedException)
+        self.assertNotEqual(varSet.Name, self.Params.Name)
+        # the copied VarSet should not be exposed
+        self.assertFalse(varSet.Exposed)
+
+    def testExposedReplaced(self):
+        argVarSet = createArgVarSet(self.Doc, self.Params)
+
+        self.Params.Exposed = True
+
+        self.Doc.recompute()
+
+        self.Part.Params = argVarSet
+
+        self.Doc.recompute()
+
+        self.assertEqual(argVarSet.Length, self.Box.Length)
+        self.assertEqual(argVarSet.Width, self.Box.Width)
+        self.assertEqual(argVarSet.Height, self.Box.Height)
+
+    def testExposedReplacedNoEffectInternal(self):
+        argVarSet = createArgVarSet(self.Doc, self.Params)
+
+        self.Params.Exposed = True
+
+        self.Doc.recompute()
+
+        self.Part.Params = argVarSet
+
+        self.Doc.recompute()
+
+        # this should have no effect on the length of the box
+        self.Params.Length = 400
+
+        self.assertEqual(argVarSet.Length, self.Box.Length)
+
+    def tearDown(self):
+        App.closeDocument(NAME_DOC_BASE)
+
+
+class TestVarSetBinder(unittest.TestCase):
+    def setUp(self):
+        basicSetUp(self)
+        self.Params.Exposed = True
+
+        # save the base document as we will link to it
+        tempDir = tempfile.gettempdir()
+        tempPathDoc = os.path.join(tempDir, f"{NAME_DOC_BASE}.FCStd")
+        self.Doc.saveAs(tempPathDoc)
+
+        # the same is necessary for the binder document
+        self.DocBinder = App.newDocument(NAME_DOC_VARIANT)
+        tempPathDocBinder = os.path.join(tempDir, f"{NAME_DOC_VARIANT}.FCStd")
+        self.DocBinder.saveAs(tempPathDocBinder)
+
+        self.Binder = self.DocBinder.addObject("PartDesign::SubShapeBinder", "Binder")
+        self.Binder.Support = self.Part
+        self.DocBinder.recompute()
+
+    # Tests whether changing parameters of a non-exposed varset affect the geometry
+    def testBinderLinked(self):
+        self.assertFalse(hasattr(self.Binder, "Params"))
+        self.assertEqual(self.Params.Length, self.Binder.Shape.BoundBox.XLength)
+        self.assertEqual(self.Params.Width, self.Binder.Shape.BoundBox.YLength)
+        self.assertEqual(self.Params.Height, self.Binder.Shape.BoundBox.ZLength)
+
+    def testBinderCopyOnChange(self):
+        self.Binder.BindCopyOnChange = "Enabled"
+        self.DocBinder.recompute()
+
+        self.assertTrue(hasattr(self.Binder, "Params"))
+        self.assertEqual(self.Binder.Params, self.Params)
+
+        argVarSet = createArgVarSet(self.DocBinder, self.Params)
+
+        self.DocBinder.recompute()
+
+        self.Binder.Params = argVarSet
+
+        self.DocBinder.recompute()
+
+        self.assertEqual(argVarSet.Length, self.Binder.Shape.BoundBox.XLength)
+        self.assertEqual(argVarSet.Width, self.Binder.Shape.BoundBox.YLength)
+        self.assertEqual(argVarSet.Height, self.Binder.Shape.BoundBox.ZLength)
+
+    def testBinderCopyOnChangeDependencies(self):
+        self.Binder.BindCopyOnChange = "Enabled"
+        self.DocBinder.recompute()
+
+        argVarSet = createArgVarSet(self.DocBinder, self.Params)
+
+        self.DocBinder.recompute()
+
+        self.Binder.Params = argVarSet
+
+        self.DocBinder.recompute()
+
+        self.assertEqual(argVarSet.Length, self.Binder.Shape.BoundBox.XLength)
+        self.assertEqual(argVarSet.Width, self.Binder.Shape.BoundBox.YLength)
+        self.assertEqual(argVarSet.Height, self.Binder.Shape.BoundBox.ZLength)
+
+        argVarSet.Length += 100
+
+        self.DocBinder.recompute()
+
+        # this means that even though we make use of hidden references,
+        # dependencies are still tracked.
+        self.assertEqual(argVarSet.Length, self.Binder.Shape.BoundBox.XLength)
+
+    def tearDown(self):
+        App.closeDocument(NAME_DOC_BASE)
+        App.closeDocument(NAME_DOC_VARIANT)

--- a/tests/src/App/VarSet.cpp
+++ b/tests/src/App/VarSet.cpp
@@ -23,12 +23,24 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
+#include <Base/Exception.h>
 #include <App/Application.h>
-#include "App/Document.h"
+#include <App/Document.h>
 #include <App/VarSet.h>
+#include <App/PropertyVarSet.h>
+#include <App/Part.h>
+#include <App/DocumentObjectGroup.h>
+
 #include <src/App/InitApplication.h>
 
+
 using ::testing::NotNull;
+
+const char* const NAME_VARSET = "VarSet";
+const double SOME_VALUE = 123.0;
+
+const char* const NAME_PROPERTY_PARENT = "NamePropertyParent";
+const char* const NAME_PROPERTY_EXPOSED = "Exposed";
 
 // NOLINTBEGIN(readability-magic-numbers)
 
@@ -61,15 +73,69 @@ private:
     App::Document* _doc {};
 };
 
+
+class VarSetEquivalence: public VarSet
+{
+protected:
+    void SetUp() override
+    {
+        VarSet::SetUp();
+        _varSet1 = dynamic_cast<App::VarSet*>(doc()->addObject("App::VarSet", NAME_VARSET));
+        _varSet2 = dynamic_cast<App::VarSet*>(doc()->addObject("App::VarSet", NAME_VARSET));
+    }
+
+    App::VarSet* varSet1()
+    {
+        return _varSet1;
+    }
+
+    App::VarSet* varSet2()
+    {
+        return _varSet2;
+    }
+
+private:
+    App::VarSet* _varSet1 {};
+    App::VarSet* _varSet2 {};
+};
+
+
+class VarSetInPart: public VarSet
+{
+protected:
+    void SetUp() override
+    {
+        VarSet::SetUp();
+        _varSet = doc()->addObject("App::VarSet", NAME_VARSET);
+        _part = dynamic_cast<App::Part*>(doc()->addObject("App::Part", "Part"));
+        _part->addObject(_varSet);
+    }
+
+    App::DocumentObject* varSet()
+    {
+        return _varSet;
+    }
+
+    App::Part* part()
+    {
+        return _part;
+    }
+
+private:
+    std::string _docName;
+    App::Document* _doc {};
+    App::DocumentObject* _varSet {};
+    App::Part* _part {};
+};
+
+
 // Tests whether we can create a VarSet
 TEST_F(VarSet, createVarSet)
 {
     // Arrange
-    const char* nameVarSet = "VarSet";
 
     // Act
-    doc()->addObject("App::VarSet", nameVarSet);
-    auto varSet = dynamic_cast<App::VarSet*>(doc()->getObject(nameVarSet));
+    auto varSet = doc()->addObject("App::VarSet", NAME_VARSET);
 
     // Assert
     EXPECT_THAT(varSet, NotNull());
@@ -79,19 +145,259 @@ TEST_F(VarSet, createVarSet)
 TEST_F(VarSet, addProperty)
 {
     // Arrange
-    const char* nameVarSet = "VarSet001";
-    const long VALUE = 123;
-
-    doc()->addObject("App::VarSet", nameVarSet);
-    auto varSet = dynamic_cast<App::VarSet*>(doc()->getObject(nameVarSet));
+    auto varSet = doc()->addObject("App::VarSet", NAME_VARSET);
 
     // Act
-    auto prop = dynamic_cast<App::PropertyInteger*>(
-        varSet->addDynamicProperty("App::PropertyInteger", "Variable", "Variables"));
-    prop->setValue(VALUE);
+    auto prop = dynamic_cast<App::PropertyFloat*>(
+        varSet->addDynamicProperty("App::PropertyFloat", "Variable", "Variables"));
+    prop->setValue(SOME_VALUE);
 
     // Assert
-    EXPECT_EQ(prop->getValue(), VALUE);
+    EXPECT_EQ(prop->getValue(), SOME_VALUE);
 }
+
+void expectExposedDisabled(App::PropertyBool* prop)
+{
+    EXPECT_THAT(prop, NotNull());
+    if (prop) {
+        EXPECT_EQ(prop->getValue(), false);
+        EXPECT_TRUE(prop->testStatus(App::Property::Immutable));
+        EXPECT_TRUE(prop->testStatus(App::Property::ReadOnly));
+    }
+}
+
+void expectExposedEnabled(App::PropertyBool* prop, bool exposed)
+{
+    EXPECT_THAT(prop, NotNull());
+    if (prop) {
+        EXPECT_EQ(prop->getValue(), exposed);
+        EXPECT_FALSE(prop->testStatus(App::Property::Immutable));
+        EXPECT_FALSE(prop->testStatus(App::Property::ReadOnly));
+    }
+}
+
+// Tests whether there is a property Exposed and whether it is disabled
+TEST_F(VarSet, exposeDisabled)
+{
+    // Arrange
+    auto varSet = doc()->addObject("App::VarSet", NAME_VARSET);
+
+    // Act
+    auto propExposed =
+        dynamic_cast<App::PropertyBool*>(varSet->getPropertyByName(NAME_PROPERTY_EXPOSED));
+
+    // Assert
+    expectExposedDisabled(propExposed);
+}
+
+// Tests whether the property NAME_PROPERTY_EXPOSED is disabled in objects
+TEST_F(VarSet, exposeDisabledInObject)
+{
+    // Arrange
+    auto varSet = doc()->addObject("App::VarSet", NAME_VARSET);
+    auto group = dynamic_cast<App::DocumentObjectGroup*>(
+        doc()->addObject("App::DocumentObjectGroup", "Group"));
+    group->addObject(varSet);
+
+    // Act
+    auto propExposed =
+        dynamic_cast<App::PropertyBool*>(varSet->getPropertyByName(NAME_PROPERTY_EXPOSED));
+
+    // Assert
+    expectExposedDisabled(propExposed);
+}
+
+// Tests whether two VarSets are equivalent
+TEST_F(VarSetEquivalence, sameProps)
+{
+    // Arrange
+
+    // Act
+    varSet1()->addDynamicProperty("App::PropertyFloat", "A");
+    varSet1()->addDynamicProperty("App::PropertyFloat", "B");
+
+    varSet2()->addDynamicProperty("App::PropertyFloat", "A");
+    varSet2()->addDynamicProperty("App::PropertyFloat", "B");
+
+    // Assert
+    EXPECT_TRUE(varSet1()->isEquivalent(varSet2()));
+}
+
+// Tests whether two VarSets are equivalent
+TEST_F(VarSetEquivalence, samePropsDifferentOrder)
+{
+    // Arrange
+
+    // Act
+    varSet1()->addDynamicProperty("App::PropertyFloat", "B");
+    varSet1()->addDynamicProperty("App::PropertyFloat", "A");
+
+    varSet2()->addDynamicProperty("App::PropertyFloat", "A");
+    varSet2()->addDynamicProperty("App::PropertyFloat", "B");
+
+    // Assert
+    EXPECT_TRUE(varSet1()->isEquivalent(varSet2()));
+}
+
+// Tests whether two VarSets are equivalent
+TEST_F(VarSetEquivalence, differentNamesProps)
+{
+    // Arrange
+
+    // Act
+    varSet1()->addDynamicProperty("App::PropertyFloat", "A");
+    varSet1()->addDynamicProperty("App::PropertyFloat", "B");
+
+    varSet2()->addDynamicProperty("App::PropertyFloat", "A");
+    varSet2()->addDynamicProperty("App::PropertyFloat", "C");
+
+    // Assert
+    EXPECT_FALSE(varSet1()->isEquivalent(varSet2()));
+}
+
+// Tests whether two VarSets are equivalent
+TEST_F(VarSetEquivalence, differenTypesProps)
+{
+    // Arrange
+
+    // Act
+    varSet1()->addDynamicProperty("App::PropertyInteger", "A");
+    varSet1()->addDynamicProperty("App::PropertyFloat", "B");
+
+    varSet2()->addDynamicProperty("App::PropertyFloat", "A");
+    varSet2()->addDynamicProperty("App::PropertyFloat", "B");
+
+    // Assert
+    EXPECT_FALSE(varSet1()->isEquivalent(varSet2()));
+}
+
+
+// Tests whether the property NAME_PROPERTY_EXPOSED is enabled in an App::Part
+TEST_F(VarSetInPart, exposeEnabledInPart)
+{
+    // Arrange
+
+    // Act
+    auto propExposed =
+        dynamic_cast<App::PropertyBool*>(varSet()->getPropertyByName(NAME_PROPERTY_EXPOSED));
+
+    // Assert
+    expectExposedEnabled(propExposed, false);  // Expose is false initially
+}
+
+// Tests whether nothing is exposed when set to false
+TEST_F(VarSetInPart, notExposedInitially)
+{
+    // Arrange
+    auto propExposed =
+        dynamic_cast<App::PropertyBool*>(varSet()->getPropertyByName(NAME_PROPERTY_EXPOSED));
+    auto propNameParent =
+        dynamic_cast<App::PropertyString*>(varSet()->getPropertyByName(NAME_PROPERTY_PARENT));
+    auto nameParent = propNameParent->getValue();
+
+    // Act
+
+    // Assert
+    expectExposedEnabled(propExposed, false);  // Expose is false by default
+    EXPECT_STREQ(nameParent, "");              // empty string if it hasn't been enabled yet
+    EXPECT_EQ(part()->getPropertyByName(nameParent), nullptr);
+}
+
+// Tests whether the VarSet is exposed in a Part
+TEST_F(VarSetInPart, exposedInitially)
+{
+    // Arrange
+    auto propExposed =
+        dynamic_cast<App::PropertyBool*>(varSet()->getPropertyByName(NAME_PROPERTY_EXPOSED));
+    // the property that contains the name of the parent property
+    auto propNameParent =
+        dynamic_cast<App::PropertyString*>(varSet()->getPropertyByName(NAME_PROPERTY_PARENT));
+    // the name of the property in the parent that points to a VarSet
+    auto namePropParent = propNameParent->getValue();
+
+    // Act
+    propExposed->setValue(true);
+
+    // Assert
+    expectExposedEnabled(propExposed, true);  // expose should now be enabled
+    EXPECT_STREQ(namePropParent,
+                 NAME_VARSET);  // take the name of the label of the VarSet initially
+
+    auto* propVarSet =
+        dynamic_cast<App::PropertyVarSet*>(part()->getPropertyByName(namePropParent));
+    App::VarSet* varSetParent = propVarSet->getValue();
+
+    EXPECT_THAT(propVarSet, NotNull());
+    EXPECT_EQ(varSetParent,
+              varSet());  // the property should point to the exposed VarSet initially.
+}
+
+// Tests the behavior if a property is already set
+TEST_F(VarSetInPart, exposedParentPropertyExists)
+{
+    // Arrange
+    auto propExposed =
+        dynamic_cast<App::PropertyBool*>(varSet()->getPropertyByName(NAME_PROPERTY_EXPOSED));
+    // add a property that the expose is going to create
+    part()->addDynamicProperty("App::PropertyString", NAME_VARSET);
+
+    // Act / Assert
+    EXPECT_THROW(propExposed->setValue(true), Base::NameError);
+}
+
+// Tests changing a parent property to an equivalent VarSet
+TEST_F(VarSetInPart, setParentPropertyEquivalent)
+{
+    // Arrange
+    auto propExposed =
+        dynamic_cast<App::PropertyBool*>(varSet()->getPropertyByName(NAME_PROPERTY_EXPOSED));
+    auto propNameParent =
+        dynamic_cast<App::PropertyString*>(varSet()->getPropertyByName(NAME_PROPERTY_PARENT));
+    // the name of the property in the parent that points to a VarSet
+    auto namePropParent = propNameParent->getValue();
+
+    varSet()->addDynamicProperty("App::PropertyFloat", "A");
+    varSet()->addDynamicProperty("App::PropertyFloat", "B");
+
+    App::DocumentObject* varSet2 = doc()->addObject("App::VarSet", "VarSet");
+    varSet2->addDynamicProperty("App::PropertyFloat", "A");
+    varSet2->addDynamicProperty("App::PropertyFloat", "B");
+
+    // Act
+    propExposed->setValue(true);
+    auto* propVarSet =
+        dynamic_cast<App::PropertyVarSet*>(part()->getPropertyByName(namePropParent));
+
+    // Assert
+    EXPECT_NO_THROW(propVarSet->setValue(varSet2));
+}
+
+// Tests changing a parent property to a non-equivalent VarSet
+TEST_F(VarSetInPart, setParentPropertyNonEquivalent)
+{
+    // Arrange
+    auto propExposed =
+        dynamic_cast<App::PropertyBool*>(varSet()->getPropertyByName(NAME_PROPERTY_EXPOSED));
+    auto propNameParent =
+        dynamic_cast<App::PropertyString*>(varSet()->getPropertyByName(NAME_PROPERTY_PARENT));
+    // the name of the property in the parent that points to a VarSet
+    auto namePropParent = propNameParent->getValue();
+
+    varSet()->addDynamicProperty("App::PropertyFloat", "A");
+    varSet()->addDynamicProperty("App::PropertyFloat", "B");
+
+    App::DocumentObject* varSet2 = doc()->addObject("App::VarSet", "VarSet");
+    varSet2->addDynamicProperty("App::PropertyFloat", "c");
+    varSet2->addDynamicProperty("App::PropertyFloat", "d");
+
+    // Act
+    propExposed->setValue(true);
+    auto* propVarSet =
+        dynamic_cast<App::PropertyVarSet*>(part()->getPropertyByName(namePropParent));
+
+    // Assert
+    EXPECT_THROW(propVarSet->setValue(varSet2), Base::ValueError);
+}
+
 
 // NOLINTEND(readability-magic-numbers)


### PR DESCRIPTION
This adds a Property Manager dialog to FreeCAD with "named scopes" that allows the user to filter the properties to enable the user to conveniently add properties. 

The screenshot below shows the named scope "all" that shows all documents, document objects, and properties. At the top you can select various filters to filter the properties you're interested in. 
![screenshot-scope-all](https://github.com/FreeCAD/FreeCAD/assets/5336482/d32f9640-27af-464a-85af-4bc3a1d6942e)

In the screenshot below we filtered the properties such that a single document object is selected. We named the scope "myparams" and it filters on the object name "VarSet" and the group "Params". This opens a panel in which we can add properties and their values conveniently:
![screenshot-scope-myparams](https://github.com/FreeCAD/FreeCAD/assets/5336482/7c495cc6-ccc1-4ed5-954c-fdb4bcec5982)

A video explaining the functionality will follow later.

Closes #13038