### PR TITLE
Conda: Unpin packages post miniforge upgrade.

### DIFF
--- a/conda/conda-env.yaml
+++ b/conda/conda-env.yaml
@@ -3,6 +3,5 @@ channels:
 - conda-forge
 dependencies:
 - conda-devenv
-- mamba==1.4.9    # NOTE: Pin to highest version supported by the devenv
-- python==3.11.*  # dependencies. If a higher version is installed, a crash
-                  # occurs during the downgrade process.
+- mamba
+- python==3.11.*

--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -73,7 +73,7 @@ dependencies:
 - graphviz
 - hdf5
 - libcxx
-- mamba==1.4.9
+- mamba
 - matplotlib
 - ninja
 - numpy


### PR DESCRIPTION
Miniforge has upgraded from 23.x.y to 24.x.y, permitting the unpinning of dependencies. Furthermore, these pinned packages cause build issues with the latest version of Miniforge.