### PR TITLE
Sketcher: Spelling colinear -> collinear

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -6427,8 +6427,8 @@ CmdSketcherConstrainTangent::CmdSketcherConstrainTangent()
 {
     sAppModule = "Sketcher";
     sGroup = "Sketcher";
-    sMenuText = QT_TR_NOOP("Constrain tangent or colinear");
-    sToolTipText = QT_TR_NOOP("Create a tangent or colinear constraint between two entities");
+    sMenuText = QT_TR_NOOP("Constrain tangent or collinear");
+    sToolTipText = QT_TR_NOOP("Create a tangent or collinear constraint between two entities");
     sWhatsThis = "Sketcher_ConstrainTangent";
     sStatusTip = sToolTipText;
     sPixmap = "Constraint_Tangent";

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -147,7 +147,7 @@ private:
                 }
                 else {
                     if (areColinear(firstPoint, secondPoint, onSketchPos)) {
-                        // If points are colinear then we can't calculate the center.
+                        // If points are collinear then we can't calculate the center.
                         return;
                     }
                     centerPoint =

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -135,7 +135,7 @@ private:
             case SelectMode::SeekThird: {
                 try {
                     if (areColinear(firstPoint, secondPoint, onSketchPos)) {
-                        // If points are colinear then we can't calculate the center.
+                        // If points are collinear then we can't calculate the center.
                         return;
                     }
 

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2375,7 +2375,7 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
 
         switch (constraint->Type) {
 
-            case Tangent: {  // second icon is available only for colinear line segments
+            case Tangent: {  // second icon is available only for collinear line segments
                 const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(constraint->First);
                 const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(constraint->Second);
                 if (geo1 && geo1->is<Part::GeomLineSegment>() && geo2

--- a/src/Mod/Sketcher/SketcherTests/TestSketchFillet.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketchFillet.py
@@ -248,7 +248,7 @@ class TestSketchFillet(unittest.TestCase):
             App.Vector(2, 2, 0).distanceToPoint(SketchFeature.getPoint(4, 3)), 1.0
         )
 
-    # Make sure colinearity doesn't get dropped
+    # Make sure collinearity doesn't get dropped
     def testTangent(self):
         SketchFeature = self.Doc.addObject("Sketcher::SketchObject", "Tangent")
 
@@ -284,7 +284,7 @@ class TestSketchFillet(unittest.TestCase):
         )
 
         # We expect the other end of the tangent line to be at 5,5, but I think 3,3 also satisfies
-        # the colinearity constraint
+        # the collinearity constraint
         try:
             self.assertAlmostEqual(
                 App.Vector(3, 3, 0).distanceToPoint(SketchFeature.getPoint(tangent_line, 2)),


### PR DESCRIPTION
I have not changed the name of the `areColinear` function.
