### PR TITLE
SpreadSheet: Double clicking a spreadsheet changes to spreadsheet wb

### DIFF
--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -31,6 +31,7 @@
 
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
+#include <Gui/CommandT.h>
 #include <Gui/Document.h>
 #include <Gui/MainWindow.h>
 #include <Gui/View3DInventor.h>
@@ -99,6 +100,16 @@ bool ViewProviderSheet::setEdit(int ModNum)
 
 bool ViewProviderSheet::doubleClicked()
 {
+    // assure the SpreadSheet workbench
+    if (App::GetApplication()
+            .GetUserParameter()
+            .GetGroup("BaseApp")
+            ->GetGroup("Preferences")
+            ->GetGroup("Mod/Spreadsheet")
+            ->GetBool("SwitchToWB", true)) {
+        Gui::Command::assureWorkbench("SpreadsheetWorkbench");
+    }
+
     if (!this->view) {
         showSpreadsheetView();
         view->viewAll();


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/13136
Double clicking on :

- a sketch changes the active workbench to sketcher.
- a assembly switch active workbench to assembly.
- a body switch active workbench to partDesign.
- an Analysis container switch active workbench to FEM
- a techdraw page switch active workbench to techdraw

For consistency we could have the same behavior when double clicking on a spreadsheet, switch to spreadsheet.