### PR TITLE
TechDraw: Remove "cosmetic eraser" from toolbar

### DIFF
--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -392,7 +392,6 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *anno << "TechDraw_CenterLineGroup";
     *anno << "TechDraw_2PointCosmeticLine";
     *anno << "TechDraw_CosmeticCircle";
-    *anno << "TechDraw_CosmeticEraser";
     *anno << "TechDraw_DecorateLine";
     *anno << "TechDraw_ShowAll";
     *anno << "TechDraw_WeldSymbol";
@@ -506,7 +505,6 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *anno << "TechDraw_CenterLineGroup";
     *anno << "TechDraw_2PointCosmeticLine";
     *anno << "TechDraw_CosmeticCircle";
-    *anno << "TechDraw_CosmeticEraser";
     *anno << "TechDraw_DecorateLine";
     *anno << "TechDraw_ShowAll";
     *anno << "TechDraw_WeldSymbol";


### PR DESCRIPTION
Remove "cosmetic eraser" from toolbar as it can be done by selecting and pressing delete, which is the expected workflow.
Fixes https://github.com/FreeCAD/FreeCAD/issues/13072

@WandererFan 