### PR TITLE
Sketcher: Add line mid-point auto-constraint

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -720,6 +720,17 @@ protected:
                             AutoConstraints.push_back(std::move(c));
                         }
                     } break;
+                    case Sketcher::Symmetric: {
+                        auto c = std::make_unique<Sketcher::Constraint>();
+                        c->Type = Sketcher::Symmetric;
+                        c->First = geoId2;
+                        c->FirstPos = Sketcher::PointPos::start;
+                        c->Second = geoId2;
+                        c->SecondPos = Sketcher::PointPos::end;
+                        c->Third = geoId1;
+                        c->ThirdPos = posId1;
+                        AutoConstraints.push_back(std::move(c));
+                    } break;
                     // In special case of Horizontal/Vertical constraint, geoId2 is normally unused
                     // and should be 'Constraint::GeoUndef' However it can be used as a way to
                     // require the function to apply these constraints on another geometry In this


### PR DESCRIPTION
Add a line mid-point (symmetric) auto constraint when creating geometries.
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/ed78c58d-f3ba-4452-abe7-c5fc60cec634)
Refactor a little bit of code at the same time (for loop, auto)

Fixes #10704
Fix one part of #11414
Also mentioned in #6240
@pierreporte