### PR TITLE
[Part] Add optional tolerance and enable multithreading to distToShape 

### DIFF
--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -784,7 +784,7 @@ proximity(shape,[tolerance]) -> (selfFaces, shapeFaces)
     <Methode Name="distToShape" Const="true">
       <Documentation>
         <UserDocu>Find the minimum distance to another shape.
-distToShape(shape) -> (dist, vectors, infos)
+distToShape(shape, tol=1e-7) -> (dist, vectors, infos)
 --
 dist is the minimum distance, in mm (float value).
 

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -2605,8 +2605,9 @@ PyObject* TopoShapePy::distToShape(PyObject *args)
     BRepExtrema_SupportType supportType1, supportType2;
     TopoDS_Shape suppS1, suppS2;
     Standard_Real minDist = -1, t1, t2, u1, v1, u2, v2;
+    Standard_Real tol = Precision::Confusion();
 
-    if (!PyArg_ParseTuple(args, "O!",&(TopoShapePy::Type), &ps2))
+    if (!PyArg_ParseTuple(args, "O!|d",&(TopoShapePy::Type), &ps2, &tol))
         return nullptr;
 
     const TopoDS_Shape& s1 = getTopoShapePtr()->getShape();
@@ -2619,6 +2620,7 @@ PyObject* TopoShapePy::distToShape(PyObject *args)
         return nullptr;
     }
     BRepExtrema_DistShapeShape extss;
+    extss.SetDeflection(tol);
     extss.LoadS1(s1);
     extss.LoadS2(s2);
     try {

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -2621,6 +2621,9 @@ PyObject* TopoShapePy::distToShape(PyObject *args)
     }
     BRepExtrema_DistShapeShape extss;
     extss.SetDeflection(tol);
+#if OCC_VERSION_HEX >= 0x070600
+    extss.SetMultiThread(true);
+#endif
     extss.LoadS1(s1);
     extss.LoadS2(s2);
     try {


### PR DESCRIPTION
Two changes to python distToShape() function.

- Add optional tolerance to distToShape in order to catch more results if desired.

- Enable multithreading to distToShape. This was added in OCCT in commit [0f05f21194a6711251182a118643efc9eb6c322b](https://git.dev.opencascade.org/gitweb/?p=occt.git;a=commit;h=0f05f21194a6711251182a118643efc9eb6c322b). Published in version [7.6.0](https://git.dev.opencascade.org/gitweb/?p=occt.git;a=shortlog;h=refs/tags/V7_6_0). I get x3 to x6 performance boost on a rather complex 20 Mo STEP file.