### PR TITLE
Sketcher: fix typo in function name -> areCollinear

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -146,7 +146,7 @@ private:
                     }
                 }
                 else {
-                    if (areColinear(firstPoint, secondPoint, onSketchPos)) {
+                    if (areCollinear(firstPoint, secondPoint, onSketchPos)) {
                         // If points are collinear then we can't calculate the center.
                         return;
                     }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCircle.h
@@ -134,7 +134,7 @@ private:
             } break;
             case SelectMode::SeekThird: {
                 try {
-                    if (areColinear(firstPoint, secondPoint, onSketchPos)) {
+                    if (areCollinear(firstPoint, secondPoint, onSketchPos)) {
                         // If points are collinear then we can't calculate the center.
                         return;
                     }
@@ -465,7 +465,7 @@ void DSHCircleControllerBase::doEnforceControlParameters(Base::Vector2d& onSketc
             }
             if (onViewParameters[OnViewParameter::Fifth]->isSet
                 && onViewParameters[OnViewParameter::Sixth]->isSet
-                && areColinear(handler->firstPoint, handler->secondPoint, onSketchPos)) {
+                && areCollinear(handler->firstPoint, handler->secondPoint, onSketchPos)) {
                 unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
                 unsetOnViewParameter(onViewParameters[OnViewParameter::Sixth].get());
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerEllipse.h
@@ -559,7 +559,7 @@ void DSHEllipseControllerBase::doEnforceControlParameters(Base::Vector2d& onSket
 
                 if (onViewParameters[OnViewParameter::Fifth]->isSet
                     && onViewParameters[OnViewParameter::Sixth]->isSet
-                    && areColinear(handler->apoapsis, handler->periapsis, onSketchPos)) {
+                    && areCollinear(handler->apoapsis, handler->periapsis, onSketchPos)) {
                     unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
                     unsetOnViewParameter(onViewParameters[OnViewParameter::Sixth].get());
                 }

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -832,9 +832,9 @@ std::string SketcherGui::angleToDisplayFormat(double value, int digits)
 }
 
 
-bool SketcherGui::areColinear(const Base::Vector2d& p1,
-                              const Base::Vector2d& p2,
-                              const Base::Vector2d& p3)
+bool SketcherGui::areCollinear(const Base::Vector2d& p1,
+                               const Base::Vector2d& p2,
+                               const Base::Vector2d& p3)
 {
     Base::Vector2d u = p2 - p1;
     Base::Vector2d v = p3 - p2;

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -206,7 +206,7 @@ bool useSystemDecimals();
 std::string lengthToDisplayFormat(double value, int digits);
 std::string angleToDisplayFormat(double value, int digits);
 
-bool areColinear(const Base::Vector2d& p1, const Base::Vector2d& p2, const Base::Vector2d& p3);
+bool areCollinear(const Base::Vector2d& p1, const Base::Vector2d& p2, const Base::Vector2d& p3);
 
 int indexOfGeoId(const std::vector<int>& vec, int elem);
 


### PR DESCRIPTION
The same function exists in the Draft module but don't fix it there to avoid to possibly break add-ons

A follow-up PR of #13135