### PR TITLE
Sketcher: Symmetry fix #13164

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -4486,7 +4486,6 @@ std::vector<Part::Geometry*> SketchObject::getSymmetric(const std::vector<int>& 
     if (refIsLine) {
         const Part::Geometry* georef = getGeometry(refGeoId);
         if (!georef->is<Part::GeomLineSegment>()) {
-            Base::Console().Error("Reference for symmetric is neither a point nor a line.\n");
             return {};
         }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
@@ -91,6 +91,7 @@ private:
                 int VtId = getPreselectPoint();
                 int CrvId = getPreselectCurve();
                 int CrsId = getPreselectCross();
+                Sketcher::SketchObject* obj = sketchgui->getSketchObject();
 
                 if (VtId >= 0) {  // Vertex
                     SketchObject* Obj = sketchgui->getSketchObject();
@@ -108,7 +109,8 @@ private:
                     refGeoId = Sketcher::GeoEnum::VAxis;
                     refPosId = Sketcher::PointPos::none;
                 }
-                else if (CrvId >= 0 || CrvId <= Sketcher::GeoEnum::RefExt) {  // Curves
+                else if ((CrvId >= 0 || CrvId <= Sketcher::GeoEnum::RefExt)
+                         && isLineSegment(*obj->getGeometry(CrvId))) {  // Curves
                     refGeoId = CrvId;
                     refPosId = Sketcher::PointPos::none;
                 }


### PR DESCRIPTION
Sketcher: Symmetry fix an error message when hovering on non-line geos. Also prevent validation of tool when clicking on non-line geos.
Fixes #13164