### PR TITLE
[TD]fix fail on undo of cosmetic delete

### DIFF
--- a/src/Mod/TechDraw/App/CosmeticExtension.cpp
+++ b/src/Mod/TechDraw/App/CosmeticExtension.cpp
@@ -349,7 +349,7 @@ TechDraw::CosmeticEdge* CosmeticExtension::getCosmeticEdge(const std::string& ta
 /// used when selecting
 TechDraw::CosmeticEdge* CosmeticExtension::getCosmeticEdgeBySelection(const std::string& name) const
 {
-//    Base::Console().Message("CEx::getCEBySelection(%s)\n", name.c_str());
+    // Base::Console().Message("CEx::getCEBySelection(%s)\n", name.c_str());
     App::DocumentObject* extObj = const_cast<App::DocumentObject*> (getExtendedObject());
     TechDraw::DrawViewPart* dvp = dynamic_cast<TechDraw::DrawViewPart*>(extObj);
     if (!dvp) {
@@ -367,7 +367,7 @@ TechDraw::CosmeticEdge* CosmeticExtension::getCosmeticEdgeBySelection(const std:
 /// find the cosmetic edge corresponding to the input parameter (the 5 in Edge5)
 TechDraw::CosmeticEdge* CosmeticExtension::getCosmeticEdgeBySelection(int i) const
 {
-//    Base::Console().Message("CEx::getCEBySelection(%d)\n", i);
+    // Base::Console().Message("CEx::getCEBySelection(%d)\n", i);
     std::stringstream edgeName;
     edgeName << "Edge" << i;
     return getCosmeticEdgeBySelection(edgeName.str());
@@ -376,7 +376,7 @@ TechDraw::CosmeticEdge* CosmeticExtension::getCosmeticEdgeBySelection(int i) con
 /// remove the cosmetic edge with the given tag from the list property
 void CosmeticExtension::removeCosmeticEdge(const std::string& delTag)
 {
-//    Base::Console().Message("DVP::removeCE(%s)\n", delTag.c_str());
+    // Base::Console().Message("DVP::removeCE(%s)\n", delTag.c_str());
     std::vector<CosmeticEdge*> cEdges = CosmeticEdges.getValues();
     std::vector<CosmeticEdge*> newEdges;
     for (auto& ce: cEdges) {
@@ -420,7 +420,6 @@ int CosmeticExtension::add1CLToGE(const std::string& tag)
         return -1;
     }
     TechDraw::BaseGeomPtr scaledGeom = cl->scaledAndRotatedGeometry(getOwner());
-//    TechDraw::BaseGeomPtr scaledGeom = cl->scaledGeometry(getOwner());
     int iGE = getOwner()->getGeometryObject()->addCenterLine(scaledGeom, tag);
 
     return iGE;
@@ -429,7 +428,7 @@ int CosmeticExtension::add1CLToGE(const std::string& tag)
 //update Edge geometry with current CL's
 void CosmeticExtension::refreshCLGeoms()
 {
-    //    Base::Console().Message("CE::refreshCLGeoms()\n");
+    // Base::Console().Message("CE::refreshCLGeoms()\n");
     std::vector<TechDraw::BaseGeomPtr> gEdges = getOwner()->getEdgeGeometry();
     std::vector<TechDraw::BaseGeomPtr> newGEdges;
     for (auto& ge : gEdges) {
@@ -447,7 +446,6 @@ void CosmeticExtension::addCenterLinesToGeom()
     //   Base::Console().Message("CE::addCenterLinesToGeom()\n");
     const std::vector<TechDraw::CenterLine*> lines = CenterLines.getValues();
     for (auto& cl : lines) {
-//        TechDraw::BaseGeomPtr scaledGeom = cl->scaledGeometry(getOwner());
         TechDraw::BaseGeomPtr scaledGeom = cl->scaledAndRotatedGeometry(getOwner());
         if (!scaledGeom) {
             Base::Console().Error("CE::addCenterLinesToGeom - scaledGeometry is null\n");
@@ -536,7 +534,7 @@ TechDraw::CenterLine* CosmeticExtension::getCenterLineBySelection(int i) const
 
 void CosmeticExtension::removeCenterLine(const std::string& delTag)
 {
-//    Base::Console().Message("DVP::removeCL(%s)\n", delTag.c_str());
+    // Base::Console().Message("DVP::removeCL(%s)\n", delTag.c_str());
     std::vector<CenterLine*> cLines = CenterLines.getValues();
     std::vector<CenterLine*> newLines;
     for (auto& cl: cLines) {

--- a/src/Mod/TechDraw/Gui/QGIEdge.cpp
+++ b/src/Mod/TechDraw/Gui/QGIEdge.cpp
@@ -21,9 +21,8 @@
  ***************************************************************************/
 
 #include "PreCompiled.h"
-#ifndef _PreComp_
-# include <cassert>
 
+#ifndef _PreComp_
 # include <QPainterPath>
 # include <QPainterPathStroker>
 #endif
@@ -34,7 +33,6 @@
 #include <Base/Parameter.h>
 #include <Gui/Control.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
-#include <Mod/TechDraw/App/DrawViewPart.h>
 
 #include "QGIEdge.h"
 #include "PreferencesGui.h"
@@ -50,6 +48,9 @@ QGIEdge::QGIEdge(int index) :
     isHiddenEdge(false),
     isSmoothEdge(false)
 {
+    setFlag(QGraphicsItem::ItemIsFocusable, true);      // to get key press events
+    setFlag(QGraphicsItem::ItemIsSelectable, true);
+
     m_width = 1.0;
     setCosmetic(isCosmetic);
     setFill(Qt::NoBrush);

--- a/src/Mod/TechDraw/Gui/QGIEdge.h
+++ b/src/Mod/TechDraw/Gui/QGIEdge.h
@@ -55,6 +55,9 @@ public:
 
     void setLinePen(QPen isoPen);
 
+    void setSource(int source) { m_source = source; }
+    int getSource() const { return m_source;}
+
 
 protected:
 
@@ -71,6 +74,7 @@ protected:
     Qt::PenStyle getHiddenStyle();
 
 private:
+    int m_source{0};
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -53,6 +53,8 @@ QGIPrimPath::QGIPrimPath():
     setCacheMode(QGraphicsItem::NoCache);
     setFlag(QGraphicsItem::ItemIsSelectable, true);
     setFlag(QGraphicsItem::ItemIsMovable, false);
+    setFlag(QGraphicsItem::ItemIsFocusable, true);      // to get key press events
+
     setFlag(QGraphicsItem::ItemSendsScenePositionChanges, true);
     setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
     setAcceptHoverEvents(true);
@@ -86,6 +88,7 @@ QVariant QGIPrimPath::itemChange(GraphicsItemChange change, const QVariant &valu
     if (change == ItemSelectedHasChanged && scene()) {
         if(isSelected()) {
             setPrettySel();
+            setFocus();
         } else {
             setPrettyNormal();
         }
@@ -98,6 +101,7 @@ void QGIPrimPath::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
     if (!isSelected()) {
         setPrettyPre();
     }
+    setFocus();
     QGraphicsPathItem::hoverEnterEvent(event);
 }
 

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -250,6 +250,7 @@ void QGIView::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
     // TODO don't like this but only solution at the minute (MLP)
     if (isSelected()) {
         m_colCurrent = getSelectColor();
+        setFocus();
     } else {
         m_colCurrent = getPreColor();
     }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -63,6 +63,7 @@ public:
     void paint( QPainter * painter,
                         const QStyleOptionGraphicsItem * option,
                         QWidget * widget = nullptr ) override;
+    bool sceneEventFilter(QGraphicsItem *watched, QEvent *event) override;
 
 
     void toggleCache(bool state) override;
@@ -114,6 +115,8 @@ public:
     void setGroupSelection(bool isSelected, const std::vector<std::string> &subNames) override;
 
     virtual QGraphicsItem *getQGISubItemByName(const std::string &subName) const;
+
+    virtual bool removeSelectedCosmetic() const;
 
 protected:
     QPainterPath drawPainterPath(TechDraw::BaseGeomPtr baseGeom) const;

--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -393,6 +393,8 @@ QGIView* QGSPage::addViewPart(TechDraw::DrawViewPart* partFeat)
     viewPart->setViewPartFeature(partFeat);
 
     addQView(viewPart);
+    // we need to install an event filter for any views derived from DrawViewPart
+    viewPart->installSceneEventFilter(viewPart);
     return viewPart;
 }
 
@@ -403,6 +405,7 @@ QGIView* QGSPage::addViewSection(DrawViewSection* sectionFeat)
     viewSection->setViewPartFeature(sectionFeat);
 
     addQView(viewSection);
+    viewSection->installSceneEventFilter(viewSection);
     return viewSection;
 }
 
@@ -413,6 +416,8 @@ QGIView* QGSPage::addProjectionGroup(TechDraw::DrawProjGroup* projGroupFeat)
 
     qview->setViewFeature(projGroupFeat);
     addQView(qview);
+    qview->installSceneEventFilter(qview);
+
     return qview;
 }
 

--- a/src/Mod/TechDraw/Gui/QGVNavStyle.cpp
+++ b/src/Mod/TechDraw/Gui/QGVNavStyle.cpp
@@ -109,7 +109,7 @@ void QGVNavStyle::handleFocusOutEvent(QFocusEvent* event)
 
 void QGVNavStyle::handleKeyPressEvent(QKeyEvent* event)
 {
-//    Base::Console().Message("QGNS::handleKeyPressEvent(%d)\n", event->key());
+    // Base::Console().Message("QGNS::handleKeyPressEvent(%d)\n", event->key());
     if (event->modifiers().testFlag(Qt::ControlModifier)) {
         switch (event->key()) {
             case Qt::Key_Plus: {
@@ -165,11 +165,11 @@ void QGVNavStyle::handleKeyPressEvent(QKeyEvent* event)
             }
         }
     }
+    event->ignore();
 }
 
 void QGVNavStyle::handleKeyReleaseEvent(QKeyEvent* event)
 {
-    //    Q_UNUSED(event);
     if (event->modifiers().testFlag(Qt::NoModifier)) {
         switch (event->key()) {
             case Qt::Key_Shift: {
@@ -214,7 +214,7 @@ void QGVNavStyle::handleLeaveEvent(QEvent* event)
 
 void QGVNavStyle::handleMousePressEvent(QMouseEvent* event)
 {
-    //    Base::Console().Message("QGVNS::handleMousePressEvent()\n");
+    // Base::Console().Message("QGVNS::handleMousePressEvent()\n");
     if (!panningActive && (event->button() == Qt::MiddleButton)) {
         startPan(event->pos());
         event->accept();

--- a/src/Mod/TechDraw/Gui/QGVNavStyleTouchpad.cpp
+++ b/src/Mod/TechDraw/Gui/QGVNavStyleTouchpad.cpp
@@ -46,7 +46,6 @@ QGVNavStyleTouchpad::~QGVNavStyleTouchpad()
 
 void QGVNavStyleTouchpad::handleKeyPressEvent(QKeyEvent *event)
 {
-//    Q_UNUSED(event)
     if (event->key() == Qt::Key_PageUp) {
         zoomIn();
         event->accept();

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -340,6 +340,7 @@ void ViewProviderPage::createMDIViewPage()
     m_mdiView->setWindowIcon(Gui::BitmapFactory().pixmap("TechDraw_TreePage"));
     Gui::getMainWindow()->addWindow(m_mdiView);
     Gui::getMainWindow()->setActiveWindow(m_mdiView);
+    m_graphicsView->setFocus();
 }
 
 //NOTE: removing MDIViewPage (parent) destroys QGVPage (eventually)


### PR DESCRIPTION
This PR implements a fix for issue #13067.  This fix prevents the creation of the undo transaction that can not be applied since cosmetic elements are not document objects.