### PR TITLE
Core: Std_ToggleTransparency: Fixes #11353

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -703,6 +703,7 @@ MenuItem* StdWorkbench::setupMenuBar() const
           << "Std_ToggleNavigation"
           << "Std_SetAppearance"
           << "Std_RandomColor"
+          << "Std_ToggleTransparency"
           << "Separator"
           << "Std_Workbench"
           << "Std_ToolBarMenu"
@@ -711,7 +712,6 @@ MenuItem* StdWorkbench::setupMenuBar() const
         *view << "Std_DockOverlay";
     }
     *view << "Separator"
-          << "Std_ToggleTransparency"
           << "Std_LinkSelectActions"
           << "Std_TreeViewActions"
           << "Std_ViewStatusBar";


### PR DESCRIPTION
Fixes #11353 : 
- Groups now toggling their content correctly.
- The command toggle the PD body instead of the tip
- The command placement in the View menu is fixed.