### PR TITLE
Toponaming/Part: Bug fix for #13169 while we sort out required sketcher changes.

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -9524,6 +9524,11 @@ void SketchObject::setExpression(const App::ObjectIdentifier& path,
 std::pair<std::string,std::string> SketchObject::getElementName(
         const char *name, ElementNameType type) const
 {
+    //  Todo: Toponaming Project March 2024:  This method override breaks the sketcher - selection and deletion
+    //          of constraints ceases to work.  See #13169.  We need to prove that this works before
+    //          enabling it.  For now, bypass it.
+    return Part2DObject::getElementName(name,type);
+
     std::pair<std::string, std::string> ret;
     if(!name) return ret;
 


### PR DESCRIPTION
It isn't clear if this method override from the linkstage3 branch is correct.  This disables it while we dig into it.