### PR TITLE
Toponaming/Part move in PyImps

### DIFF
--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -952,8 +952,8 @@ private:
 
         return shape2pyshape(Part::TopoShape().makeElementCompound(getPyShapes(pcObj), op, policy));
 #else
-Py::Object makeCompound(const Py::Tuple& args)
-{
+    Py::Object makeCompound(const Py::Tuple& args)
+    {
         PyObject *pcObj;
         if (!PyArg_ParseTuple(args.ptr(), "O", &pcObj))
             throw Py::Exception();
@@ -989,8 +989,8 @@ Py::Object makeCompound(const Py::Tuple& args)
         return shape2pyshape(
             Part::TopoShape().makeElementBoolean(Part::OpCodes::Shell, getPyShapes(obj), op));
 #else
-Py::Object makeShell(const Py::Tuple& args)
-{
+    Py::Object makeShell(const Py::Tuple& args)
+    {
         PyObject *obj;
         if (!PyArg_ParseTuple(args.ptr(), "O", &obj))
             throw Py::Exception();
@@ -1044,8 +1044,8 @@ Py::Object makeShell(const Py::Tuple& args)
         }
         return shape2pyshape(TopoShape().makeElementFace(getPyShapes(obj), op, className));
 #else
-Py::Object makeFace(const Py::Tuple& args)
-{
+    Py::Object makeFace(const Py::Tuple& args)
+    {
         try {
             char* className = nullptr;
             PyObject* pcPyShapeOrList = nullptr;
@@ -1194,8 +1194,8 @@ Py::Object makeFace(const Py::Tuple& args)
         return shape2pyshape(
             TopoShape(0, shapes.front().Hasher).makeElementFilledFace(shapes, params, op));
 #else
-Py::Object makeFilledSurface(const Py::Tuple &args)
-{
+    Py::Object makeFilledSurface(const Py::Tuple &args)
+    {
         PyObject *obj;
         double tolerance;
         if (!PyArg_ParseTuple(args.ptr(), "Od", &obj, &tolerance))
@@ -1304,8 +1304,8 @@ Py::Object makeFilledSurface(const Py::Tuple &args)
         return shape2pyshape(
             TopoShape(0, shapes.front().Hasher).makeElementFilledFace(shapes, params, op));
 #else
-Py::Object makeFilledFace(const Py::Tuple& args)
-{
+    Py::Object makeFilledFace(const Py::Tuple& args)
+    {
         // TODO: BRepFeat_SplitShape
         PyObject *obj;
         PyObject *surf=nullptr;
@@ -1382,8 +1382,8 @@ Py::Object makeFilledFace(const Py::Tuple& args)
         return shape2pyshape(
             TopoShape().makeElementSolid(*static_cast<TopoShapePy*>(obj)->getTopoShapePtr(), op));
 #else
-Py::Object makeSolid(const Py::Tuple& args)
-{
+    Py::Object makeSolid(const Py::Tuple& args)
+    {
         PyObject *obj;
         if (!PyArg_ParseTuple(args.ptr(), "O!", &(TopoShapePy::Type), &obj))
             throw Py::Exception();
@@ -2017,8 +2017,8 @@ Py::Object makeSolid(const Py::Tuple& args)
         shapes.push_back(*static_cast<TopoShapePy*>(sh2)->getTopoShapePtr());
         return shape2pyshape(TopoShape().makeElementRuledSurface(shapes, orientation, op));
 #else
-Py::Object makeRuledSurface(const Py::Tuple& args)
-{
+    Py::Object makeRuledSurface(const Py::Tuple& args)
+    {
         // http://opencascade.blogspot.com/2009/10/surface-modeling-part1.html
         PyObject *sh1, *sh2;
         if (!PyArg_ParseTuple(args.ptr(), "O!O!", &(TopoShapePy::Type), &sh1,
@@ -2068,9 +2068,9 @@ Py::Object makeRuledSurface(const Py::Tuple& args)
             throw Py::Exception(PartExceptionOCCError, "creation of shell failed");
         }
 #else
-Py::Object makeShellFromWires(const Py::Tuple& args)
-{
-    PyObject *pylist;
+    Py::Object makeShellFromWires(const Py::Tuple& args)
+    {
+        PyObject *pylist;
         if (!PyArg_ParseTuple(args.ptr(), "O", &pylist))
             throw Py::Exception();
 
@@ -2182,6 +2182,7 @@ Py::Object makeShellFromWires(const Py::Tuple& args)
         PyObject *pruled=Py_False;
         PyObject *pclosed=Py_False;
         int degMax = 5;
+
         const char* op = nullptr;
         const std::array<const char*, 7> kwd_list =
             {"shapes", "solid", "ruled", "closed", "max_degree", "op", nullptr};
@@ -2212,13 +2213,14 @@ Py::Object makeShellFromWires(const Py::Tuple& args)
             degMax,
             op));
 #else
-Py::Object makeLoft(const Py::Tuple& args)
-{
-    PyObject *pcObj;
-    PyObject *psolid=Py_False;
-    PyObject *pruled=Py_False;
-    PyObject *pclosed=Py_False;
-    int degMax = 5;
+    Py::Object makeLoft(const Py::Tuple& args)
+    {
+        PyObject *pcObj;
+        PyObject *psolid=Py_False;
+        PyObject *pruled=Py_False;
+        PyObject *pclosed=Py_False;
+        int degMax = 5;
+
         if (!PyArg_ParseTuple(args.ptr(), "O|O!O!O!i", &pcObj,
                                               &(PyBool_Type), &psolid,
                                               &(PyBool_Type), &pruled,

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -122,26 +122,35 @@ extern const char* BRepBuilderAPI_FaceErrorText(BRepBuilderAPI_FaceError fe);
 
 namespace Part {
 
-PartExport void getPyShapes(PyObject *obj, std::vector<TopoShape> &shapes) {
-    if(!obj)
+PartExport void getPyShapes(PyObject* obj, std::vector<TopoShape>& shapes)
+{
+    if (!obj) {
         return;
-    if(PyObject_TypeCheck(obj,&Part::TopoShapePy::Type))
+    }
+    if (PyObject_TypeCheck(obj, &Part::TopoShapePy::Type)) {
         shapes.push_back(*static_cast<TopoShapePy*>(obj)->getTopoShapePtr());
-    else if (PyObject_TypeCheck(obj, &GeometryPy::Type))
+    }
+    else if (PyObject_TypeCheck(obj, &GeometryPy::Type)) {
         shapes.emplace_back(static_cast<GeometryPy*>(obj)->getGeometryPtr()->toShape());
-    else if(PySequence_Check(obj)) {
+    }
+    else if (PySequence_Check(obj)) {
         Py::Sequence list(obj);
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
-            if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type)))
+            if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
                 shapes.push_back(*static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr());
-            else if (PyObject_TypeCheck((*it).ptr(), &GeometryPy::Type))
-                shapes.emplace_back(static_cast<GeometryPy*>(
-                                (*it).ptr())->getGeometryPtr()->toShape());
-            else
+            }
+            else if (PyObject_TypeCheck((*it).ptr(), &GeometryPy::Type)) {
+                shapes.emplace_back(
+                    static_cast<GeometryPy*>((*it).ptr())->getGeometryPtr()->toShape());
+            }
+            else {
                 throw Py::TypeError("expect shape in sequence");
+            }
         }
-    }else
+    }
+    else {
         throw Py::TypeError("expect shape or sequence of shapes");
+    }
 }
 
 PartExport std::vector<TopoShape> getPyShapes(PyObject *obj) {

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -2162,6 +2162,8 @@ private:
                         nullptr,
                         tolerance));
 #else
+            if (tolerance == 0.0)
+                tolerance=0.001;
             const TopoDS_Shape& path_shape = static_cast<TopoShapePy*>(path)->getTopoShapePtr()->getShape();
             const TopoDS_Shape& prof_shape = static_cast<TopoShapePy*>(profile)->getTopoShapePtr()->getShape();
 

--- a/src/Mod/Part/App/TopoShapeCompSolidPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeCompSolidPyImp.cpp
@@ -29,11 +29,13 @@
 #endif
 
 #include "OCCError.h"
+#include "PartPyCXX.h"
 
 // inclusion of the generated files (generated out of TopoShapeCompSolidPy.xml)
 #include "TopoShapeCompSolidPy.h"
 #include "TopoShapeCompSolidPy.cpp"
 #include "TopoShapeSolidPy.h"
+#include "TopoShapeOpCode.h"
 
 
 using namespace Part;
@@ -61,10 +63,16 @@ int TopoShapeCompSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     }
 
     PyErr_Clear();
-    PyObject *pcObj;
-    if (!PyArg_ParseTuple(args, "O", &pcObj))
+    PyObject* pcObj;
+    if (!PyArg_ParseTuple(args, "O", &pcObj)) {
         return -1;
-
+    }
+#ifdef FC_USE_TNP_FIX
+    try {
+        getTopoShapePtr()->makeElementBoolean(Part::OpCodes::Compsolid, getPyShapes(pcObj));
+    }
+    _PY_CATCH_OCC(return (-1))
+#else
     BRep_Builder builder;
     TopoDS_CompSolid Comp;
     builder.MakeCompSolid(Comp);
@@ -73,10 +81,11 @@ int TopoShapeCompSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         Py::Sequence list(pcObj);
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapeSolidPy::Type))) {
-                const TopoDS_Shape& sh = static_cast<TopoShapePy*>((*it).ptr())->
-                    getTopoShapePtr()->getShape();
-                if (!sh.IsNull())
+                const TopoDS_Shape& sh =
+                    static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->getShape();
+                if (!sh.IsNull()) {
                     builder.Add(Comp, sh);
+                }
             }
         }
     }
@@ -87,35 +96,46 @@ int TopoShapeCompSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     }
 
     getTopoShapePtr()->setShape(Comp);
+#endif
     return 0;
 }
 
-PyObject*  TopoShapeCompSolidPy::add(PyObject *args)
+PyObject* TopoShapeCompSolidPy::add(PyObject* args)
 {
-    PyObject *obj;
-    if (!PyArg_ParseTuple(args, "O!", &(Part::TopoShapeSolidPy::Type), &obj))
+    PyObject* obj;
+    if (!PyArg_ParseTuple(args, "O!", &(Part::TopoShapeSolidPy::Type), &obj)) {
         return nullptr;
+    }
 
     BRep_Builder builder;
     TopoDS_Shape comp = getTopoShapePtr()->getShape();
+    auto shapes = getPyShapes(obj);
 
     try {
-        const TopoDS_Shape& sh = static_cast<TopoShapePy*>(obj)->
-            getTopoShapePtr()->getShape();
-        if (!sh.IsNull())
-            builder.Add(comp, sh);
-        else
-            Standard_Failure::Raise("Cannot empty shape to compound solid");
+        for (auto& ts : shapes) {
+            if (!ts.isNull()) {
+                builder.Add(comp, ts.getShape());
+            }
+            else {
+                Standard_Failure::Raise("Cannot empty shape to compound solid");
+            }
+        }
+#ifdef FC_USE_TNP_FIX
+        auto& self = *getTopoShapePtr();
+        shapes.push_back(self);
+        TopoShape tmp(self.Tag, self.Hasher, comp);
+        tmp.mapSubElement(shapes);
+        self = tmp;
+#else
+        getTopoShapePtr()->setShape(comp);
+#endif
+        Py_Return;
     }
     catch (Standard_Failure& e) {
 
         PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
         return nullptr;
     }
-
-    getTopoShapePtr()->setShape(comp);
-
-    Py_Return;
 }
 
 PyObject *TopoShapeCompSolidPy::getCustomAttributes(const char* /*attr*/) const

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -511,6 +511,11 @@ Returns: result of offsetting (wire or face or compound of those). Compounding
 structure follows that of source shape.</UserDocu>
       </Documentation>
     </Methode>
+      <Methode Name="makeEvolved" Const="true" Keyword="true">
+          <Documentation>
+              <UserDocu>Profile along the spine</UserDocu>
+          </Documentation>
+      </Methode>
     <Methode Name="makeWires" Const="true">
       <Documentation>
         <UserDocu>make wire(s) using the edges of this shape
@@ -820,6 +825,45 @@ countElement(type) -> int
         </UserDocu>
       </Documentation>
     </Methode>
+      <Methode Name="mapSubElement">
+          <Documentation>
+              <UserDocu>
+                  mapSubElement(shape|[shape...], op='') - maps the sub element of other shape
+
+                  shape:  other shape or sequence of shapes to map the sub-elements
+                  op:     optional string prefix to append before the mapped sub element names
+              </UserDocu>
+          </Documentation>
+      </Methode>
+      <Methode Name="mapShapes">
+          <Documentation>
+              <UserDocu>
+                  mapShapes(generated, modified, op='')
+
+                  generate element names with user defined mapping
+
+                  generated: a list of tuple(src, dst) that indicating src shape or shapes
+                  generates dst shape or shapes. Note that the dst shape or shapes
+                  must be sub-shapes of this shape.
+                  modified: a list of tuple(src, dst) that indicating src shape or shapes
+                  modifies into dst shape or shapes. Note that the dst shape or
+                  shapes must be sub-shapes of this shape.
+                  op: optional string prefix to append before the mapped sub element names
+              </UserDocu>
+          </Documentation>
+      </Methode>
+      <Methode Name="getElementHistory" Const="true">
+          <Documentation>
+              <UserDocu>
+                  getElementHistory(name) - returns the element mapped name history
+
+                  name: mapped element name belonging to this shape
+
+                  Returns tuple(sourceShapeTag, sourceName, [intermediateNames...]),
+                  or None if no history.
+              </UserDocu>
+          </Documentation>
+      </Methode>
     <Methode Name="getTolerance" Const="true">
       <Documentation>
         <UserDocu>Determines a tolerance from the ones stored in a shape
@@ -906,6 +950,55 @@ optimalBoundingBox([useTriangulation = True, useShapeTolerance = False]) -> boun
         </UserDocu>
       </Documentation>
     </Methode>
+      <Methode Name="clearCache" Const="true">
+          <Documentation>
+              <UserDocu>Clear internal sub-shape cache</UserDocu>
+          </Documentation>
+      </Methode>
+      <Methode Name="findSubShape" Const="true">
+          <Documentation>
+              <UserDocu>
+                  findSubShape(shape) -> (type_name, index)
+
+                  Find sub shape and return the shape type name and index. If not found,
+                  then return (None, 0)
+              </UserDocu>
+          </Documentation>
+      </Methode>
+      <Methode Name="searchSubShape" Const="true" Keyword="true">
+          <Documentation>
+              <UserDocu>
+                  searchSubShape(shape, needName=False, checkGeometry=True, tol=1e-7, atol=1e-12) -> Shape
+
+                  shape: input elementary shape, currently only support Face, Edge, or Vertex
+
+                  needName: if True, return a list of tuple(name, shape), or else return a list
+                  of shapes.
+
+                  checkGeometry: whether to compare geometry
+
+                  tol: distance tolerance
+
+                  atol: angular tolerance
+
+                  Search sub shape by checking vertex coordinates and comparing the underlying
+                  geometries, This can find shapes that are copied. It currently only works with
+                  elementary shapes, Face, Edge, Vertex.
+              </UserDocu>
+          </Documentation>
+      </Methode>
+      <Methode Name="getChildShapes" Const="true">
+          <Documentation>
+              <UserDocu>
+                  getChildShapes(shapetype, avoidtype='') -> list(Shape)
+
+                  Return a list of child sub-shapes of given type.
+
+                  shapetype: the type of requesting sub shapes
+                  avoidtype: optional shape type to skip when exploring
+              </UserDocu>
+          </Documentation>
+      </Methode>
     <!--
     <Attribute Name="Location" ReadOnly="false">
       <Documentation>

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -965,10 +965,10 @@ optimalBoundingBox([useTriangulation = True, useShapeTolerance = False]) -> boun
               </UserDocu>
           </Documentation>
       </Methode>
-      <Methode Name="searchSubShape" Const="true" Keyword="true">
+      <Methode Name="findSubShapesWithSharedVertex" Const="true" Keyword="true">
           <Documentation>
               <UserDocu>
-                  searchSubShape(shape, needName=False, checkGeometry=True, tol=1e-7, atol=1e-12) -> Shape
+                  findSubShapesWithSharedVertex(shape, needName=False, checkGeometry=True, tol=1e-7, atol=1e-12) -> Shape
 
                   shape: input elementary shape, currently only support Face, Edge, or Vertex
 

--- a/src/Mod/Part/App/TopoShapeShellPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeShellPyImp.cpp
@@ -88,8 +88,9 @@ int TopoShapeShellPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
 #ifdef FC_USE_TNP_FIX
     try {
-        getTopoShapePtr()->makeElementBoolean(Part::OpCodes::Shell,getPyShapes(obj));
-    } _PY_CATCH_OCC(return(-1))
+        getTopoShapePtr()->makeElementBoolean(Part::OpCodes::Shell, getPyShapes(obj));
+    }
+    _PY_CATCH_OCC(return (-1))
 #else
     BRep_Builder builder;
     TopoDS_Shape shape;

--- a/src/Mod/Part/App/TopoShapeShellPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeShellPyImp.cpp
@@ -38,6 +38,7 @@
 #include <Base/VectorPy.h>
 
 #include "OCCError.h"
+#include "PartPyCXX.h"
 #include "Tools.h"
 #include "TopoShapeCompoundPy.h"
 #include "TopoShapeCompoundPy.h"
@@ -45,7 +46,7 @@
 #include "TopoShapeShellPy.h"
 #include "TopoShapeShellPy.cpp"
 #include "TopoShapeSolidPy.h"
-
+#include "TopoShapeOpCode.h"
 
 using namespace Part;
 
@@ -85,6 +86,11 @@ int TopoShapeShellPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     if (!PyArg_ParseTuple(args, "O", &obj))
         return -1;
 
+#ifdef FC_USE_TNP_FIX
+    try {
+        getTopoShapePtr()->makeElementBoolean(Part::OpCodes::Shell,getPyShapes(obj));
+    } _PY_CATCH_OCC(return(-1))
+#else
     BRep_Builder builder;
     TopoDS_Shape shape;
     TopoDS_Shell shell;
@@ -121,6 +127,7 @@ int TopoShapeShellPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     }
 
     getTopoShapePtr()->setShape(shape);
+#endif
     return 0;
 }
 
@@ -134,11 +141,14 @@ PyObject*  TopoShapeShellPy::add(PyObject *args)
     TopoDS_Shape shell = getTopoShapePtr()->getShape();
 
     try {
-        const TopoDS_Shape& sh = static_cast<TopoShapeFacePy*>(obj)->
-            getTopoShapePtr()->getShape();
+        const TopoShape& shape = *static_cast<TopoShapeFacePy*>(obj)->getTopoShapePtr();
+        const auto &sh = shape.getShape();
         if (!sh.IsNull()) {
             builder.Add(shell, sh);
             BRepCheck_Analyzer check(shell);
+#ifdef FC_USE_TNP_FIX
+            getTopoShapePtr()->mapSubElement(shape);
+#endif
             if (!check.IsValid()) {
                 ShapeUpgrade_ShellSewing sewShell;
                 getTopoShapePtr()->setShape(sewShell.ApplySewing(shell));
@@ -167,7 +177,14 @@ PyObject*  TopoShapeShellPy::getFreeEdges(PyObject *args)
     as.CheckOrientedShells(getTopoShapePtr()->getShape(), Standard_True, Standard_True);
 
     TopoDS_Compound comp = as.FreeEdges();
+#ifdef FC_USE_TNP_FIX
+    TopoShape res;
+    res.setShape(comp);
+    res.mapSubElement(*getTopoShapePtr());
+    return Py::new_reference_to(shape2pyshape(res));
+#else
     return new TopoShapeCompoundPy(new TopoShape(comp));
+#endif
 }
 
 PyObject*  TopoShapeShellPy::getBadEdges(PyObject *args)
@@ -179,7 +196,14 @@ PyObject*  TopoShapeShellPy::getBadEdges(PyObject *args)
     as.CheckOrientedShells(getTopoShapePtr()->getShape(), Standard_True, Standard_True);
 
     TopoDS_Compound comp = as.BadEdges();
+#ifdef FC_USE_TNP_FIX
+    TopoShape res;
+    res.setShape(comp);
+    res.mapSubElement(*getTopoShapePtr());
+    return Py::new_reference_to(shape2pyshape(res));
+#else
     return new TopoShapeCompoundPy(new TopoShape(comp));
+#endif
 }
 
 PyObject* TopoShapeShellPy::makeHalfSpace(PyObject *args)

--- a/src/Mod/Part/App/TopoShapeSolidPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeSolidPyImp.cpp
@@ -47,6 +47,7 @@
 #include <Base/VectorPy.h>
 
 #include "OCCError.h"
+#include "PartPyCXX.h"
 #include "Tools.h"
 
 // inclusion of the generated files (generated out of TopoShapeSolidPy.xml)
@@ -87,6 +88,9 @@ int TopoShapeSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         return -1;
 
     try {
+#ifdef FC_USE_TNP_FIX
+        getTopoShapePtr()->makeElementSolid(*static_cast<TopoShapePy*>(obj)->getTopoShapePtr());
+#else
         const TopoDS_Shape& shape = static_cast<TopoShapePy*>(obj)
             ->getTopoShapePtr()->getShape();
         //first, if we were given a compsolid, try making a solid out of it
@@ -122,7 +126,7 @@ int TopoShapeSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         } else /*if (count > 1)*/ {
             Standard_Failure::Raise("Only one compsolid can be accepted. Provided shape has more than one compsolid.");
         }
-
+#endif
     }
     catch (Standard_Failure& err) {
         std::stringstream errmsg;
@@ -216,7 +220,14 @@ Py::Object TopoShapeSolidPy::getOuterShell() const
     const TopoDS_Shape& shape = getTopoShapePtr()->getShape();
     if (!shape.IsNull() && shape.ShapeType() == TopAbs_SOLID)
         shell = BRepClass3d::OuterShell(TopoDS::Solid(shape));
+#ifdef FC_USE_TNP_FIX
+    TopoShape res;
+    res.setShape(shell);
+    res.mapSubElement(*getTopoShapePtr());
+    return shape2pyshape(res);
+#else
     return Py::Object(new TopoShapeShellPy(new TopoShape(shell)),true);
+#endif
 }
 
 PyObject* TopoShapeSolidPy::getMomentOfInertia(PyObject *args)
@@ -316,7 +327,13 @@ PyObject* TopoShapeSolidPy::offsetFaces(PyObject *args)
     try {
         builder.MakeOffsetShape();
         const TopoDS_Shape& offsetshape = builder.Shape();
+#ifndef FC_USE_TNP_FIX
+        TopoShape res;
+        res.setShape(offsetshape);
+        return Py::new_reference_to(shape2pyshape(res));
+#else
         return new TopoShapeSolidPy(new TopoShape(offsetshape));
+#endif
     }
     catch (Standard_Failure& e) {
 

--- a/src/Mod/Part/App/TopoShapeSolidPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeSolidPyImp.cpp
@@ -327,7 +327,7 @@ PyObject* TopoShapeSolidPy::offsetFaces(PyObject *args)
     try {
         builder.MakeOffsetShape();
         const TopoDS_Shape& offsetshape = builder.Shape();
-#ifndef FC_USE_TNP_FIX
+#ifdef FC_USE_TNP_FIX
         TopoShape res;
         res.setShape(offsetshape);
         return Py::new_reference_to(shape2pyshape(res));

--- a/src/Mod/Part/parttests/TopoShapeTest.py
+++ b/src/Mod/Part/parttests/TopoShapeTest.py
@@ -3,6 +3,7 @@ import Part
 
 import unittest
 
+
 class TopoShapeAssertions:
 
     def assertAttrEqual(self, toposhape, attr_value_list, msg=None):
@@ -43,16 +44,17 @@ class TopoShapeAssertions:
                     msg = f"Key {key} not found in map:  {map}"
                 raise AssertionError(msg)
 
-    def assertBounds(self, shape, bounds, msg=None, precision=App.Base.Precision.confusion()*100):
+    def assertBounds(self, shape, bounds, msg=None, precision=App.Base.Precision.confusion() * 100):
         shape_bounds = shape.BoundBox
         shape_bounds_max = App.BoundBox(shape_bounds)
         shape_bounds_max.enlarge(precision)
         bounds_max = App.BoundBox(bounds)
-        bounds_max.enlarge(precision);
+        bounds_max.enlarge(precision)
         if not (shape_bounds_max.isInside(bounds) and bounds_max.isInside(shape_bounds)):
             if msg == None:
                 msg = f"Bounds {shape_bounds} doesn't match {bounds}"
             raise AssertionError(msg)
+
 
 class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
     def setUp(self):
@@ -174,18 +176,20 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         self.doc.recompute()
         compound2 = self.doc.Compound.Shape
         # Assert elementMap
-        # This is a flag value to indicate that ElementMaps are supported under the current C++ build:
+        # This flag indicates that ElementMaps are supported under the current C++ build:
         if compound1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             # 52 is 2 cubes of 26 each: 6 Faces, 12 Edges, 8 Vertexes
-            # Todo: This should contain something as soon as the Python interface for Part.Compound TNP exists
-            # self.assertEqual(len(compound1.ElementMap), 52, "ElementMap is Incorrect:  {0}".format(compound1.ElementMap))
+            # Todo: This should contain something as soon as the Python interface
+            #  for Part.Compound TNP exists
+            # self.assertEqual(len(compound1.ElementMap), 52,
+            #                  "ElementMap is Incorrect:  {0}".format(compound1.ElementMap))
             self.assertEqual(
                 compound2.ElementMapSize,
                 52,
                 "ElementMap is Incorrect:  {0}".format(compound2.ElementMap),
             )
         # Assert Shape
-        self.assertBounds(compound2,App.BoundBox(0, 0, 0, 2, 2, 2) )
+        self.assertBounds(compound2, App.BoundBox(0, 0, 0, 2, 2, 2))
 
     def testPartCommon(self):
         # Arrange
@@ -197,37 +201,37 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         # Assert elementMap
         if common1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertKeysInMap(common1.ElementReverseMap,
-            [
-                "Edge1",
-                "Edge2",
-                "Edge3",
-                "Edge4",
-                "Edge5",
-                "Edge6",
-                "Edge7",
-                "Edge8",
-                "Edge9",
-                "Edge10",
-                "Edge11",
-                "Edge12",
-                "Face1",
-                "Face2",
-                "Face3",
-                "Face4",
-                "Face5",
-                "Face6",
-                "Vertex1",
-                "Vertex2",
-                "Vertex3",
-                "Vertex4",
-                "Vertex5",
-                "Vertex6",
-                "Vertex7",
-                "Vertex8",
-            ],
-        )
+                                 [
+                                     "Edge1",
+                                     "Edge2",
+                                     "Edge3",
+                                     "Edge4",
+                                     "Edge5",
+                                     "Edge6",
+                                     "Edge7",
+                                     "Edge8",
+                                     "Edge9",
+                                     "Edge10",
+                                     "Edge11",
+                                     "Edge12",
+                                     "Face1",
+                                     "Face2",
+                                     "Face3",
+                                     "Face4",
+                                     "Face5",
+                                     "Face6",
+                                     "Vertex1",
+                                     "Vertex2",
+                                     "Vertex3",
+                                     "Vertex4",
+                                     "Vertex5",
+                                     "Vertex6",
+                                     "Vertex7",
+                                     "Vertex8",
+                                 ],
+                                 )
         # Assert Shape
-        self.assertBounds(common1,App.BoundBox(0, 0, 0, 1, 1, 2) )
+        self.assertBounds(common1, App.BoundBox(0, 0, 0, 1, 1, 2))
 
     def testPartCut(self):
         # Arrange
@@ -240,37 +244,37 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         # Assert elementMap
         if cut1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertKeysInMap(cut1.ElementReverseMap,
-            [
-                "Edge1",
-                "Edge2",
-                "Edge3",
-                "Edge4",
-                "Edge5",
-                "Edge6",
-                "Edge7",
-                "Edge8",
-                "Edge9",
-                "Edge10",
-                "Edge11",
-                "Edge12",
-                "Face1",
-                "Face2",
-                "Face3",
-                "Face4",
-                "Face5",
-                "Face6",
-                "Vertex1",
-                "Vertex2",
-                "Vertex3",
-                "Vertex4",
-                "Vertex5",
-                "Vertex6",
-                "Vertex7",
-                "Vertex8",
-            ],
-        )
+                                 [
+                                     "Edge1",
+                                     "Edge2",
+                                     "Edge3",
+                                     "Edge4",
+                                     "Edge5",
+                                     "Edge6",
+                                     "Edge7",
+                                     "Edge8",
+                                     "Edge9",
+                                     "Edge10",
+                                     "Edge11",
+                                     "Edge12",
+                                     "Face1",
+                                     "Face2",
+                                     "Face3",
+                                     "Face4",
+                                     "Face5",
+                                     "Face6",
+                                     "Vertex1",
+                                     "Vertex2",
+                                     "Vertex3",
+                                     "Vertex4",
+                                     "Vertex5",
+                                     "Vertex6",
+                                     "Vertex7",
+                                     "Vertex8",
+                                 ],
+                                 )
         # Assert Shape
-        self.assertBounds(cut1,App.BoundBox(0, 1, 0, 1, 2, 2) )
+        self.assertBounds(cut1, App.BoundBox(0, 1, 0, 1, 2, 2))
 
     def testPartFuse(self):
         # Arrange
@@ -288,7 +292,7 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
             self.assertEqual(fuse1.ElementMapSize, 58)
         # Shape is an extruded L, with 8 Faces, 12 Vertexes, 18 Edges
         # Assert Shape
-        self.assertBounds(fuse1,App.BoundBox(0, 0, 0, 2, 2, 2) )
+        self.assertBounds(fuse1, App.BoundBox(0, 0, 0, 2, 2, 2))
 
     def testAppPartMakeCompound(self):
         # This doesn't do element maps.
@@ -299,7 +303,7 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         if compound1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(compound1.ElementMapSize, 52)
         # Assert Shape
-        self.assertBounds(compound1,App.BoundBox(0, 0, 0, 2, 2, 2) )
+        self.assertBounds(compound1, App.BoundBox(0, 0, 0, 2, 2, 2))
 
     def testAppPartMakeShell(self):
         # Act
@@ -308,16 +312,16 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         if shell1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(shell1.ElementMapSize, 26)
         # Assert Shape
-        self.assertBounds(shell1,App.BoundBox(0, 0, 0, 1, 2, 2) )
+        self.assertBounds(shell1, App.BoundBox(0, 0, 0, 1, 2, 2))
 
     def testAppPartMakeFace(self):
         # Act
-        face1 = Part.makeFace(self.doc.Box1.Shape.Faces[0],"Part::FaceMakerCheese")
+        face1 = Part.makeFace(self.doc.Box1.Shape.Faces[0], "Part::FaceMakerCheese")
         # Assert elementMap
         if face1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(face1.ElementMapSize, 10)
         # Assert Shape
-        self.assertBounds(face1,App.BoundBox(0, 0, 0, 0, 2, 2) )
+        self.assertBounds(face1, App.BoundBox(0, 0, 0, 0, 2, 2))
 
     def testAppPartmakeFilledFace(self):
         face1 = Part.makeFilledFace(self.doc.Box1.Shape.Faces[3].Edges)
@@ -325,7 +329,7 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         if face1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(face1.ElementMapSize, 9)
         # Assert Shape
-        self.assertBounds(face1,App.BoundBox(-0.05, 2, -0.1, 1.05, 2, 2.1)  )
+        self.assertBounds(face1, App.BoundBox(-0.05, 2, -0.1, 1.05, 2, 2.1))
 
     def testAppPartMakeSolid(self):
         # Act
@@ -334,7 +338,7 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         if solid1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(solid1.ElementMapSize, 26)
         # Assert Shape
-        self.assertBounds(solid1,App.BoundBox(0, 0, 0, 1, 2, 2) )
+        self.assertBounds(solid1, App.BoundBox(0, 0, 0, 1, 2, 2))
 
     def testAppPartMakeRuled(self):
         # Act
@@ -343,44 +347,46 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         if surface1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(surface1.ElementMapSize, 9)
         # Assert Shape
-        self.assertBounds(surface1,App.BoundBox(0, 0, 0, 1, 2, 2) )
+        self.assertBounds(surface1, App.BoundBox(0, 0, 0, 1, 2, 2))
 
     def testAppPartMakeShellFromWires(self):
         # Arrange
-        wire1 = self.doc.Box1.Shape.Wires[0] #.copy()   Todo: prints double generated/modified warning because
-        wire2 = self.doc.Box1.Shape.Wires[1] #.copy()   Todo: copy() isn't TNP ready yet.  Fix when it is.
+        wire1 = self.doc.Box1.Shape.Wires[0]  # .copy() Todo: prints 2 gen/mod warn because
+        wire2 = self.doc.Box1.Shape.Wires[1]  # Todo: copy() isn't TNP yet.  Fix when it is.
         # Act
-        shell1 = Part.makeShellFromWires([wire1,wire2])
+        shell1 = Part.makeShellFromWires([wire1, wire2])
         # Assert elementMap
         if shell1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(shell1.ElementMapSize, 24)
         # Assert Shape
-        self.assertBounds(shell1,App.BoundBox(0, 0, 0, 1, 2, 2) )
+        self.assertBounds(shell1, App.BoundBox(0, 0, 0, 1, 2, 2))
 
     def testAppPartMakeSweepSurface(self):
         # Arrange
-        circle = Part.makeCircle(5,App.Vector(0,0,0))
-        path = Part.makeLine(App.Vector(),App.Vector(0,0,10))
-        Part.show(circle,"Circle")  # Trigger the elementMapping
-        Part.show(path,"Path")      # Trigger the elementMapping
+        circle = Part.makeCircle(5, App.Vector(0, 0, 0))
+        path = Part.makeLine(App.Vector(), App.Vector(0, 0, 10))
+        Part.show(circle, "Circle")  # Trigger the elementMapping
+        Part.show(path, "Path")  # Trigger the elementMapping
         # Act
-        surface1 = Part.makeSweepSurface(self.doc.Path.Shape,self.doc.Circle.Shape,0.001,0)
-        Part.show(surface1,"Sweep")
+        surface1 = Part.makeSweepSurface(self.doc.Path.Shape, self.doc.Circle.Shape, 0.001, 0)
+        Part.show(surface1, "Sweep")
         self.doc.recompute()
         # Assert elementMap
         if surface1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(surface1.ElementMapSize, 6)
-            self.assertBounds(surface1,App.BoundBox(-5, -5, 0, 5, 5, 10) )
+            self.assertBounds(surface1, App.BoundBox(-5, -5, 0, 5, 5, 10))
         else:
-            # Todo: WHY is the actual sweep different?  That's BAD.  However, the "New" approach above, which uses
-            #       BRepOffsetAPI_MakePipe appears to be correct over the older code which uses Geom_Curve.
-            #       This is done ostensibly because Geom_Curve is so old that it doesn't even support history, which
-            #       toponaming needs, but also, the result is just wrong:  If you look at the resulting shape after
-            #       Sweeping a circle along a line, you do not get a circular pipe:  you get a circular pipe with
-            #       About a third of it removed.  More specifically, an angle of math.radians(math.degrees(360)%180) * 2
-            #       appears to have been applied, which looks suspiciously like a substantial bug in OCCT.
+            # Todo: WHY is the actual sweep different?  That's BAD.  However, the "New" approach
+            #       above, which uses BRepOffsetAPI_MakePipe appears to be correct over the older
+            #       code which uses Geom_Curve.  This is done ostensibly because Geom_Curve is so
+            #       old that it doesn't even support history, which toponaming needs, but also,
+            #       the result is just wrong:  If you look at the resulting shape after Sweeping
+            #       a circle along a line, you do not get a circular pipe:  you get a circular
+            #       pipe with About a third of it removed.  More specifically, an angle of
+            #       math.radians(math.degrees(360)%180) * 2 appears to have been applied, which
+            #       looks suspiciously like a substantial bug in OCCT.
             # Assert Shape
-            self.assertBounds(surface1,App.BoundBox(-5, -2.72011, 0, 5, 5, 6.28319) )
+            self.assertBounds(surface1, App.BoundBox(-5, -2.72011, 0, 5, 5, 6.28319), precision=3)
 
     def testAppPartMakeLoft(self):
         # Act
@@ -389,15 +395,15 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         if solid1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(solid1.ElementMapSize, 24)
         # Assert Shape
-        self.assertBounds(solid1,App.BoundBox(0, 0, 0, 1, 2, 2) )
+        self.assertBounds(solid1, App.BoundBox(0, 0, 0, 1, 2, 2))
 
     def testAppPartMakeSplitShape(self):
         # Todo: Refine this test after all TNP code in place to eliminate warnings.
         # Arrange
-        edge1 = self.doc.Box1.Shape.Faces[0].Edges[0].translated(App.Vector(0,0.5,0))
+        edge1 = self.doc.Box1.Shape.Faces[0].Edges[0].translated(App.Vector(0, 0.5, 0))
         face1 = self.doc.Box1.Shape.Faces[0]
         # Act
-        solids1 = Part.makeSplitShape(face1,[(edge1,face1)])
+        solids1 = Part.makeSplitShape(face1, [(edge1, face1)])
         # Assert elementMap
         self.assertEqual(len(solids1), 2)
         self.assertEqual(len(solids1[0]), 1)
@@ -405,10 +411,11 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
             self.assertEqual(solids1[0][0].ElementMapSize, 9)
             self.assertEqual(solids1[1][0].ElementMapSize, 9)
         # Assert Shape
-        self.assertBounds(solids1[0][0],App.BoundBox(0, 0.5, 0, 0, 2, 2)  )
-        self.assertBounds(solids1[1][0],App.BoundBox(0, 0.5, 0, 0, 2, 2)  )
+        self.assertBounds(solids1[0][0], App.BoundBox(0, 0.5, 0, 0, 2, 2))
+        self.assertBounds(solids1[1][0], App.BoundBox(0, 0.5, 0, 0, 2, 2))
 
     def testTopoShapePyInit(self):
+        # Arrange
         self.doc.addObject("Part::Compound", "Compound")
         self.doc.Compound.Links = [
             App.activeDocument().Box1,
@@ -416,12 +423,16 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         ]
         self.doc.recompute()
         compound = self.doc.Compound.Shape
+        # Act
         new_toposhape = Part.Shape(compound)
+        new_empty_toposhape = Part.Shape()
+        # Assert elementMap
         if compound.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(compound.ElementMapSize, 52)
             self.assertEqual(new_toposhape.ElementMapSize, 52)
 
     def testTopoShapeCopy(self):
+        # Arrange
         self.doc.addObject("Part::Compound", "Compound")
         self.doc.Compound.Links = [
             App.activeDocument().Box1,
@@ -429,12 +440,15 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         ]
         self.doc.recompute()
         compound = self.doc.Compound.Shape
+        # Act
         compound_copy = compound.copy()
+        # Assert elementMap
         if compound.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(compound.ElementMapSize, 52)
             self.assertEqual(compound_copy.ElementMapSize, 52)
 
     def testTopoShapeCleaned(self):
+        # Arrange
         self.doc.addObject("Part::Compound", "Compound")
         self.doc.Compound.Links = [
             App.activeDocument().Box1,
@@ -442,12 +456,15 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         ]
         self.doc.recompute()
         compound = self.doc.Compound.Shape
+        # Act
         compound_cleaned = compound.cleaned()
+        # Assert elementMap
         if compound.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(compound.ElementMapSize, 52)
             self.assertEqual(compound_cleaned.ElementMapSize, 52)
 
     def testTopoShapeReplaceShape(self):
+        # Arrange
         self.doc.addObject("Part::Compound", "Compound")
         self.doc.Compound.Links = [
             App.activeDocument().Box1,
@@ -455,12 +472,16 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         ]
         self.doc.recompute()
         compound = self.doc.Compound.Shape
-        compound_replaced = compound.replaceShape([(App.activeDocument().Box2.Shape,App.activeDocument().Box1.Shape)])
+        # Act
+        compound_replaced = compound.replaceShape([(App.activeDocument().Box2.Shape,
+                                                    App.activeDocument().Box1.Shape)])
+        # Assert elementMap
         if compound.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(compound.ElementMapSize, 52)
             self.assertEqual(compound_replaced.ElementMapSize, 52)
 
     def testTopoShapeRemoveShape(self):
+        # Arrange
         self.doc.addObject("Part::Compound", "Compound")
         self.doc.Compound.Links = [
             App.activeDocument().Box1,
@@ -468,145 +489,269 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         ]
         self.doc.recompute()
         compound = self.doc.Compound.Shape
+        # Act
         compound_removed = compound.removeShape([App.ActiveDocument.Box2.Shape])
+        # Assert elementMap
         if compound.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(compound.ElementMapSize, 52)
             self.assertEqual(compound_removed.ElementMapSize, 52)
 
     def testTopoShapeExtrude(self):
-        extrude = self.doc.Box1.Shape.Faces[0].extrude(App.Vector(2,0,0))
+        # Arrange
+        face = self.doc.Box1.Shape.Faces[0]
+        # Act
+        extrude = face.extrude(App.Vector(2, 0, 0))
         self.doc.recompute()
-
+        # Assert elementMap
         if extrude.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(extrude.ElementMapSize, 26)
 
     def testTopoShapeRevolve(self):
-        face2 = self.doc.Box1.Shape.Faces[0]
-        face2.revolve(App.Vector(),App.Vector(1,0,0),45)
+        # Arrange
+        face = self.doc.Box1.Shape.Faces[0]
+        # Act
+        face.revolve(App.Vector(), App.Vector(1, 0, 0), 45)
         self.doc.recompute()
-
-        if face2.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
-            self.assertEqual(face2.ElementMapSize, 9)
+        # Assert elementMap
+        if face.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+            self.assertEqual(face.ElementMapSize, 9)
 
     def testTopoShapeFuse(self):
+        # Act
         fused = self.doc.Box1.Shape.fuse(self.doc.Box2.Shape)
         self.doc.recompute()
-
+        # Assert elementMap
         if fused.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(fused.ElementMapSize, 58)
 
     def testTopoShapeMultiFuse(self):
+        # Act
         fused = self.doc.Box1.Shape.multiFuse([self.doc.Box2.Shape])
         self.doc.recompute()
-
+        # Assert elementMap
         if fused.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(fused.ElementMapSize, 58)
 
     def testTopoShapeCommon(self):
+        # Act
         common = self.doc.Box1.Shape.common(self.doc.Box2.Shape)
         self.doc.recompute()
-
+        # Assert elementMap
         if common.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(common.ElementMapSize, 26)
 
     def testTopoShapeSection(self):
+        # Act
         section = self.doc.Box1.Shape.Faces[0].section(self.doc.Box2.Shape.Faces[3])
         self.doc.recompute()
-
+        # Assert elementMap
         if section.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(section.ElementMapSize, 3)
 
     def testTopoShapeSlice(self):
-        slice = self.doc.Box1.Shape.slice(App.Vector(10,10,0),1)
+        # Act
+        slice = self.doc.Box1.Shape.slice(App.Vector(10, 10, 0), 1)
         self.doc.recompute()
-
+        # Assert elementMap
         self.assertEqual(len(slice), 1)
         if slice[0].ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(slice[0].ElementMapSize, 8)
 
     def testTopoShapeSlices(self):
-        slices = self.doc.Box1.Shape.Faces[0].slices(App.Vector(10,10,0),[1,2])
+        # Act
+        slices = self.doc.Box1.Shape.Faces[0].slices(App.Vector(10, 10, 0), [1, 2])
         self.doc.recompute()
-
+        # Assert elementMap
         if slices.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(slices.ElementMapSize, 6)
 
     def testTopoShapeCut(self):
+        # Act
         cut = self.doc.Box1.Shape.cut(self.doc.Box2.Shape)
         self.doc.recompute()
-
+        # Assert elementMap
         if cut.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(cut.ElementMapSize, 26)
 
     def testTopoShapeGeneralFuse(self):
+        # Act
         fuse = self.doc.Box1.Shape.generalFuse([self.doc.Box2.Shape])
         self.doc.recompute()
-
+        # Assert elementMap
         self.assertEqual(len(fuse), 2)
         if fuse[0].ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(fuse[0].ElementMapSize, 60)
 
     def testTopoShapeChildShapes(self):
+        # Act
         childShapes = self.doc.Box1.Shape.childShapes()
         self.doc.recompute()
-
+        # Assert elementMap
         self.assertEqual(len(childShapes), 1)
         if childShapes[0].ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(childShapes[0].ElementMapSize, 26)
 
     def testTopoShapeMirror(self):
-        mirror = self.doc.Box1.Shape.mirror(App.Vector(),App.Vector(1,0,0))
+        # Act
+        mirror = self.doc.Box1.Shape.mirror(App.Vector(), App.Vector(1, 0, 0))
         self.doc.recompute()
-
+        # Assert elementMap
         if mirror.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(mirror.ElementMapSize, 26)
 
     def testTopoShapeScale(self):
+        # Act
         scale = self.doc.Box1.Shape.scaled(2)
         self.doc.recompute()
-
+        # Assert elementMap
         if scale.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(scale.ElementMapSize, 26)
 
     def testTopoShapeMakeFillet(self):
+        # Act
         fillet = self.doc.Box1.Shape.makeFillet(0.1, self.doc.Box1.Shape.Faces[0].Edges)
         self.doc.recompute()
-
+        # Assert elementMap
         if fillet.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(fillet.ElementMapSize, 42)
 
     def testTopoShapeMakeChamfer(self):
+        # Act
         chamfer = self.doc.Box1.Shape.makeChamfer(0.1, self.doc.Box1.Shape.Faces[0].Edges)
         self.doc.recompute()
-
+        # Assert elementMap
         if chamfer.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(chamfer.ElementMapSize, 42)
 
     def testTopoShapeMakeThickness(self):
-        thickness = self.doc.Box1.Shape.makeThickness(self.doc.Box1.Shape.Faces[0:2],0.1,0.0001)
+        # Act
+        thickness = self.doc.Box1.Shape.makeThickness(self.doc.Box1.Shape.Faces[0:2], 0.1, 0.0001)
         self.doc.recompute()
-
+        # Assert elementMap
         if thickness.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(thickness.ElementMapSize, 74)
 
-    def testTopoShapemakeOffsetShape(self):
+    def testTopoShapeMakeOffsetShape(self):
+        # Act
         offset = self.doc.Box1.Shape.Faces[0].makeOffset(1)
         self.doc.recompute()
-
+        # Assert elementMap
         if offset.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
-            self.assertEqual(offset.ElementMapSize, 0)  # Todo: Wrong, or deprecated?
+            self.assertEqual(offset.ElementMapSize, 17)
 
     def testTopoShapeOffset2D(self):
+        # Act
         offset = self.doc.Box1.Shape.Faces[0].makeOffset2D(1)
         self.doc.recompute()
-
+        # Assert elementMap
         if offset.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(offset.ElementMapSize, 17)
 
     def testTopoShapeRemoveSplitter(self):
+        # Act
         fused = self.doc.Box1.Shape.fuse(self.doc.Box2.Shape)
         removed = fused.removeSplitter()
         self.doc.recompute()
-
+        # Assert elementMap
         if removed.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(removed.ElementMapSize, 38)
+
+    def testTopoShapeCompSolid(self):
+        # Act
+        compSolid = Part.CompSolid([self.doc.Box1.Shape, self.doc.Box2.Shape])  # list of subobjects
+        box1ts = self.doc.Box1.Shape
+        compSolid.add(box1ts.Solids[0])
+        # Assert elementMap
+        if compSolid.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+            self.assertEqual(compSolid.ElementMapSize, 78)
+
+    def testTopoShapeFaceOffset(self):
+        # Arrange
+        box_toposhape = self.doc.Box1.Shape
+        # Act
+        offset = box_toposhape.Faces[0].makeOffset(2.0)
+        # Assert elementMap
+        if box_toposhape.Faces[0].ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+            self.assertEqual(box_toposhape.Faces[0].ElementMapSize, 9)  # 1 Face, 4 Edges, 4 Vertexes
+            self.assertEqual(offset.ElementMapSize, 17)  # 1 Face, 8 Edges, 8 Vertexes
+
+    # Todo:  makeEvolved doesn't work right, probably due to missing c++ code.
+    # def testTopoShapeFaceEvolve(self):
+    #     # Arrange
+    #     box_toposhape = self.doc.Box1.Shape
+    #     # Act
+    #     evolved = box_toposhape.Faces[0].makeEvolved(self.doc.Box1.Shape.Wires[1])  # 2,3,4,5 bad
+    #     # Assert elementMap
+    #     if box_toposhape.Faces[0].ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+    #         self.assertEqual(box_toposhape.Faces[0].ElementMapSize, 9)  # 1 Face, 4 Edges, 4 Vertexes
+    #         self.assertEqual(evolved.ElementMapSize, 0)  # Todo: This can't be correct.
+
+    def testTopoShapePart(self):
+        # Arrange
+        box1ts = self.doc.Box1.Shape
+        face1 = box1ts.Faces[0]
+        box1ts2 = box1ts.copy()
+        # Act
+        face2 = box1ts.getElement("Face2")
+        indexed_name = box1ts.findSubShape(face1)
+        faces1 = box1ts.findSubShapesWithSharedVertex(face2)
+        subshapes1 = box1ts.getChildShapes("Solid1")
+        # box1ts.clearCache()   # Todo: no apparent way to see a result at this level
+        # Assert
+        self.assertTrue(face2.isSame(box1ts.Faces[1]))
+        self.assertEqual(indexed_name[0], "Face")
+        self.assertEqual(indexed_name[1], 1)
+        self.assertEqual(len(faces1), 1)
+        self.assertTrue(faces1[0].isSame(box1ts.Faces[1]))
+        self.assertEqual(len(subshapes1), 1)
+        self.assertTrue(subshapes1[0].isSame(box1ts.Solids[0]))
+
+    def testTopoShapeMapSubElement(self):
+        # Arrange
+        box = Part.makeBox(1,2,3)
+        # face = box.Faces[0]   # Do not do this.  Need the subelement call each usage.
+        # Assert everything empty
+        self.assertEqual(box.ElementMapSize,0)
+        self.assertEqual(box.Faces[0].ElementMapSize,0)
+        # Act
+        box.mapSubElement(box.Faces[0])
+        # Assert elementMaps created
+        if box.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+            self.assertEqual(box.ElementMapSize,9)  # 1 Face, 4 Edges, 4 Vertexes
+            self.assertEqual(box.Faces[0].ElementMapSize,9)
+
+    def testTopoShapeGetElementHistory(self):
+        self.doc.addObject("Part::Fuse", "Fuse")
+        self.doc.Fuse.Base = self.doc.Box1
+        self.doc.Fuse.Tool = self.doc.Box2
+        # Act
+        self.doc.recompute()
+        fuse1 = self.doc.Fuse.Shape
+        if fuse1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+            history1 = fuse1.getElementHistory(fuse1.ElementReverseMap["Vertex1"])
+            # Assert
+            self.assertEqual(len(history1),3)   # Just the Fuse operation
+
+    # Todo:  Still broken, still can't find parms that consistently work to test this.
+    #           However, the results with an empty elementMap are consistent with making the
+    #           same calls on LS3.  So what this method is supposed to do remains a mystery;
+    #           So far, it just wipes out the elementMap and returns the Toposhape.
+    # def testTopoShapeMapShapes(self):
+    #     self.doc.addObject("Part::Fuse", "Fuse")
+    #     self.doc.Fuse.Base = self.doc.Box1
+    #     self.doc.Fuse.Tool = self.doc.Box2
+    #     # Act
+    #     self.doc.recompute()
+    #     fuse1 = self.doc.Fuse.Shape
+    #     res = fuse1.copy()  # Make it mutable
+    #     self.assertEqual(res.ElementMapSize,58)
+    #     result = res.mapShapes([(fuse1, fuse1.Faces[0])], []) #[(res, res.Vertexes[0])])
+    #     self.assertEqual(res.ElementMapSize,9)
+    #     # result2 = fuse1.copy().mapShapes([],[(fuse1, fuse1.Edges[0]),(fuse1, fuse1.Edges[1])])
+    #     self.assertEqual(fuse1.ElementMapSize,58) #
+    #     self.assertEqual(fuse1.Faces[0].ElementMapSize,9)
+    #     self.assertEqual(result.ElementMapSize,9)
+    #     self.assertEqual(result.Faces[0].ElementMapSize,0)
+    #     self.assertEqual(result2.ElementMapSize,9)
+    #     self.assertEqual(result2.Faces[0].ElementMapSize,0)
+


### PR DESCRIPTION
Python implementations for CompSolid, Face, Shell, Solid as well as missing entries in TopoShape and cleanups from prior PR.