### PR TITLE
Gui: Allow to unset modified state

### DIFF
--- a/src/Gui/DocumentPy.xml
+++ b/src/Gui/DocumentPy.xml
@@ -237,7 +237,7 @@ obj : Gui.ViewProvider</UserDocu>
       </Documentation>
       <Parameter Name="Transacting" Type="Boolean" />
     </Attribute>
-    <Attribute Name="Modified" ReadOnly="true">
+    <Attribute Name="Modified">
       <Documentation>
         <UserDocu>Returns True if the document is marked as modified, and False otherwise.</UserDocu>
       </Documentation>

--- a/src/Gui/DocumentPyImp.cpp
+++ b/src/Gui/DocumentPyImp.cpp
@@ -504,6 +504,11 @@ Py::Boolean DocumentPy::getModified() const
     return {getDocumentPtr()->isModified()};
 }
 
+void DocumentPy::setModified(Py::Boolean arg)
+{
+    getDocumentPtr()->setModified(arg);
+}
+
 PyObject *DocumentPy::getCustomAttributes(const char* attr) const
 {
     // Note: Here we want to return only a document object if its


### PR DESCRIPTION
GuiDocuments have a "Modified" attribute that says if the doc has been modified or not (and prints an * in the titlebar). This attribute is read-only in the python interface (only getter is defined).

With [NativeIFC](https://github.com/yorikvanhavre/FreeCAD-NativeIFC), we are handling IFC files natively in FreeCAD, so all file loading/saving is done inside the module already, there is no more saving to .FCStd files. Last bit missing, not be annoyed by FreeCAD that the document has not been saved.

So this implements a resetModified() python method to unset the Modified flag.

I considered making the Modified attribute writable (implement a setter), but I'm not sure... People could play wrongly with that and they would loose the warning to save the file when closing FreeCAD. I thought maybe more interesting to implement a specific method, so people would be more aware of what they are doing and would be less prone to reset the modified state accidentally.

Not sure if that makes sense... What do you think @wwmayer ? @adrianinsaval ?

**EDIT** Following Werner's suggestion, this now sets the Modified attribute as read/write (previously read-only)