### PR TITLE
Toponaming/Base: Add ASCII stream output class

### DIFF
--- a/src/Base/Stream.h
+++ b/src/Base/Stream.h
@@ -328,7 +328,7 @@ public:
     }
 
     template<>
-    TextOutputStream& operator<<(const std::string& object)
+    TextOutputStream& operator<<(const std::string object)  // NOLINT - making it a ref breaks
     {
         return (*this) << object.c_str();
     }

--- a/src/Base/Stream.h
+++ b/src/Base/Stream.h
@@ -266,7 +266,7 @@ class BaseExport TextOutputStream: public Stream
 {
 public:
     /** Constructor
-     * @param rin: upstream input
+     * @param rout: upstream output
      */
     explicit TextOutputStream(std::ostream& rout)
         : _out(rout)
@@ -289,7 +289,6 @@ public:
         return *this;
     }
 
-    template<>
     TextOutputStream& operator<<(const char* object)
     {
         std::string_view str(object);
@@ -327,13 +326,11 @@ public:
         return *this;
     }
 
-    template<>
-    TextOutputStream& operator<<(const std::string object)  // NOLINT - making it a ref breaks
+    TextOutputStream& operator<<(const std::string& object)
     {
         return (*this) << object.c_str();
     }
 
-    template<>
     TextOutputStream& operator<<(char object)
     {
         _out.put(object);
@@ -348,7 +345,6 @@ public:
 
 private:
     std::ostream& _out;
-    std::ostringstream _ss;
 };
 
 // ----------------------------------------------------------------------------

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(
             ${CMAKE_CURRENT_SOURCE_DIR}/Quantity.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Reader.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Rotation.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/Stream.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/TimeInfo.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Tools.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/Tools2D.cpp

--- a/tests/src/Base/Stream.cpp
+++ b/tests/src/Base/Stream.cpp
@@ -27,7 +27,7 @@ TEST_F(TextOutputStreamTest, singleLineCharStar)
     Base::TextOutputStream tos(ss);
 
     // Act
-    tos << testString.c_str();
+    tos << testString;
 
     // Assert - the number of newlines in the string, a colon, the string, a newline
     EXPECT_EQ(std::string("0:") + testString + "\n", ss.str());
@@ -55,7 +55,7 @@ TEST_F(TextOutputStreamTest, singleLineCharStarWithCarriageReturns)
     Base::TextOutputStream tos(ss);
 
     // Act
-    tos << testString.c_str();
+    tos << testString;
 
     // Assert - the number of newlines in the string, a colon, the string, a newline. Carriage
     // returns are left alone because they aren't followed by a newline
@@ -71,7 +71,7 @@ TEST_F(TextOutputStreamTest, multiLineCharStarWithCarriageReturnsAndNewlines)
     Base::TextOutputStream tos(ss);
 
     // Act
-    tos << testString.c_str();
+    tos << testString;
 
     // Assert - the number of newlines in the string, a colon, the string, a newline, but the string
     // has been stripped of the carriage returns.

--- a/tests/src/Base/Stream.cpp
+++ b/tests/src/Base/Stream.cpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "gtest/gtest.h"
+
+#ifdef _MSC_VER
+#pragma warning(disable : 4996)
+#endif
+
+#include "Base/Stream.h"
+
+
+class TextOutputStreamTest: public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {}
+
+    void TearDown() override
+    {}
+};
+
+TEST_F(TextOutputStreamTest, singleLineCharStar)
+{
+    // Arrange
+    const std::string testString("Single line const char *");
+    std::ostringstream ss;
+    Base::TextOutputStream tos(ss);
+
+    // Act
+    tos << testString.c_str();
+
+    // Assert - the number of newlines in the string, a colon, the string, a newline
+    EXPECT_EQ(std::string("0:") + testString + "\n", ss.str());
+}
+
+TEST_F(TextOutputStreamTest, multiLineCharStar)
+{
+    // Arrange
+    const std::string testString("Multi-line\nconst char *");
+    std::ostringstream ss;
+    Base::TextOutputStream tos(ss);
+
+    // Act
+    tos << testString;  // Testing it with a string instead of a const char * -- failing right now
+
+    // Assert - the number of newlines in the string, a colon, the string, a newline
+    EXPECT_EQ(std::string("1:") + testString + "\n", ss.str());
+}
+
+TEST_F(TextOutputStreamTest, singleLineCharStarWithCarriageReturns)
+{
+    // Arrange
+    const std::string testString("Single-line\rconst char *");
+    std::ostringstream ss;
+    Base::TextOutputStream tos(ss);
+
+    // Act
+    tos << testString.c_str();
+
+    // Assert - the number of newlines in the string, a colon, the string, a newline. Carriage
+    // returns are left alone because they aren't followed by a newline
+    EXPECT_EQ(std::string("0:") + testString + "\n", ss.str());
+}
+
+TEST_F(TextOutputStreamTest, multiLineCharStarWithCarriageReturnsAndNewlines)
+{
+    // Arrange
+    const std::string testString("Multi-line\r\nconst char *");
+    const std::string testStringWithoutCR("Multi-line\nconst char *");
+    std::ostringstream ss;
+    Base::TextOutputStream tos(ss);
+
+    // Act
+    tos << testString.c_str();
+
+    // Assert - the number of newlines in the string, a colon, the string, a newline, but the string
+    // has been stripped of the carriage returns.
+    EXPECT_EQ(std::string("1:") + testStringWithoutCR + "\n", ss.str());
+}

--- a/tests/src/Base/Stream.cpp
+++ b/tests/src/Base/Stream.cpp
@@ -77,3 +77,51 @@ TEST_F(TextOutputStreamTest, multiLineCharStarWithCarriageReturnsAndNewlines)
     // has been stripped of the carriage returns.
     EXPECT_EQ(std::string("1:") + testStringWithoutCR + "\n", ss.str());
 }
+
+
+class TextStreamIntegrationTest: public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {}
+
+    void TearDown() override
+    {}
+};
+
+TEST_F(TextStreamIntegrationTest, OutputThenInputSimpleMultiLine)
+{
+    // Arrange
+    std::string multiLineString("One\nTwo\nThree");
+
+    // Act
+    std::ostringstream ssO;
+    Base::TextOutputStream tos(ssO);
+    tos << multiLineString;
+    std::istringstream ssI(ssO.str());
+    Base::TextInputStream tis(ssI);
+    std::string result;
+    tis >> result;
+
+    // Assert
+    EXPECT_EQ(multiLineString, result);
+}
+
+TEST_F(TextStreamIntegrationTest, OutputThenInputMultiLineWithCarriageReturns)
+{
+    // Arrange
+    std::string multiLineString("One\r\nTwo\r\nThree");
+    std::string multiLineStringResult("One\nTwo\nThree");
+
+    // Act
+    std::ostringstream ssO;
+    Base::TextOutputStream tos(ssO);
+    tos << multiLineString;
+    std::istringstream ssI(ssO.str());
+    Base::TextInputStream tis(ssI);
+    std::string result;
+    tis >> result;
+
+    // Assert
+    EXPECT_EQ(multiLineStringResult, result);
+}


### PR DESCRIPTION
This adds the matching output class for the StringInputStream class, to handle multi-line strings in the same way that LinkStage3 does (and therefore retain file compatibility with the ElementMap output).

~~In order to make the template specialization work I have to use a `std::string`, rather than a `std::string &`, and I'm not sure why yet. Anyone who knows template specialization better than I do please feel free to explain..~~