### PR TITLE
TechDraw: Enable App::Links to work with view.

### DIFF
--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -29,6 +29,7 @@
 
 #include <App/Application.h>
 #include <App/Document.h>
+#include <App/Link.h>
 #include <Base/Console.h>
 #include <Base/Parameter.h>
 
@@ -114,10 +115,8 @@ void DrawPage::onChanged(const App::Property* prop)
         // WF: not sure this loop is required.  Views figure out their scale as required. but maybe
         //     this is needed just to mark the Views to recompute??
         if (!isRestoring()) {
-            const std::vector<App::DocumentObject*>& vals = Views.getValues();
-            for (std::vector<App::DocumentObject*>::const_iterator it = vals.begin();
-                 it < vals.end(); ++it) {
-                TechDraw::DrawView* view = dynamic_cast<TechDraw::DrawView*>(*it);
+            for (auto* obj : getViews()) {
+                auto* view = dynamic_cast<DrawView*>(obj);
                 if (view && view->ScaleType.isValue("Page")) {
                     if (std::abs(view->Scale.getValue() - Scale.getValue()) > FLT_EPSILON) {
                         view->Scale.setValue(Scale.getValue());
@@ -128,10 +127,8 @@ void DrawPage::onChanged(const App::Property* prop)
     }
     else if (prop == &ProjectionType) {
         // touch all ortho views in the Page as they may be dependent on Projection Type  //(is this true?)
-        const std::vector<App::DocumentObject*>& vals = Views.getValues();
-        for (std::vector<App::DocumentObject*>::const_iterator it = vals.begin(); it < vals.end();
-             ++it) {
-            TechDraw::DrawProjGroup* view = dynamic_cast<TechDraw::DrawProjGroup*>(*it);
+        for (auto* obj : getViews()) {
+            auto* view = dynamic_cast<DrawProjGroup*>(obj);
             if (view && view->ProjectionType.isValue("Default")) {
                 view->ProjectionType.touch();
             }
@@ -228,8 +225,8 @@ int DrawPage::getOrientation() const
 {
     App::DocumentObject* obj = Template.getValue();
 
-    if (obj && obj->isDerivedFrom(TechDraw::DrawTemplate::getClassTypeId())) {
-        TechDraw::DrawTemplate* templ = static_cast<TechDraw::DrawTemplate*>(obj);
+    if (obj && obj->isDerivedFrom(DrawTemplate::getClassTypeId())) {
+        auto* templ = static_cast<DrawTemplate*>(obj);
         return templ->Orientation.getValue();
     }
     throw Base::RuntimeError("Template not set for Page");
@@ -237,24 +234,38 @@ int DrawPage::getOrientation() const
 
 int DrawPage::addView(App::DocumentObject* docObj)
 {
-    if (!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+    if (!docObj->isDerivedFrom<DrawView>()
+        && !docObj->isDerivedFrom<App::Link>()) {
         return -1;
     }
-    DrawView* view = static_cast<DrawView*>(docObj);
+
+    auto* view = dynamic_cast<DrawView*>(docObj);
+
+    if (!view) {
+        auto* link = dynamic_cast<App::Link*>(docObj);
+        if (!link) {
+            return -1;
+        }
+
+        view = dynamic_cast<DrawView*>(link->getLinkedObject());
+        if (!view) {
+            return -1;
+        }
+    }
 
     //position all new views without owners in center of Page (exceptDVDimension)
     if (!view->claimParent()
-        && !docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())
-        && !docObj->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId())) {
+        && !docObj->isDerivedFrom<DrawViewDimension>()
+        && !docObj->isDerivedFrom<DrawViewBalloon>()) {
         view->X.setValue(getPageWidth() / 2.0);
         view->Y.setValue(getPageHeight() / 2.0);
     }
 
     //add view to list
-    const std::vector<App::DocumentObject*> currViews = Views.getValues();
-    std::vector<App::DocumentObject*> newViews(currViews);
+    std::vector<App::DocumentObject*> newViews(Views.getValues());
     newViews.push_back(docObj);
     Views.setValues(newViews);
+
 
     //check if View fits on Page
     if (!view->checkFit(this)) {
@@ -271,7 +282,7 @@ int DrawPage::addView(App::DocumentObject* docObj)
 //Note Views might be removed from document elsewhere so need to check if a View is still in Document here
 int DrawPage::removeView(App::DocumentObject* docObj)
 {
-    if (!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+    if (!docObj->isDerivedFrom<DrawView>() && !docObj->isDerivedFrom<App::Link>()) {
         return -1;
     }
 
@@ -283,18 +294,16 @@ int DrawPage::removeView(App::DocumentObject* docObj)
     if (!docObj->isAttachedToDocument()) {
         return -1;
     }
-    const std::vector<App::DocumentObject*> currViews = Views.getValues();
     std::vector<App::DocumentObject*> newViews;
-    std::vector<App::DocumentObject*>::const_iterator it = currViews.begin();
-    for (; it != currViews.end(); it++) {
-        App::Document* viewDoc = (*it)->getDocument();
+    for (auto* view : Views.getValues()) {
+        App::Document* viewDoc = view->getDocument();
         if (!viewDoc) {
             continue;
         }
 
         std::string viewName = docObj->getNameInDocument();
-        if (viewName.compare((*it)->getNameInDocument()) != 0) {
-            newViews.push_back((*it));
+        if (viewName.compare(view->getNameInDocument()) != 0) {
+            newViews.push_back(view);
         }
     }
     Views.setValues(newViews);
@@ -324,12 +333,12 @@ void DrawPage::redrawCommand()
 void DrawPage::updateAllViews()
 {
     //    Base::Console().Message("DP::updateAllViews()\n");
-    std::vector<App::DocumentObject*> featViews =
-        getAllViews();//unordered list of views within page
+    //unordered list of views within page
+    std::vector<App::DocumentObject*> featViews = getAllViews();
 
     //first, make sure all the Parts have been executed so GeometryObjects exist
     for (auto& v : featViews) {
-        TechDraw::DrawViewPart* part = dynamic_cast<TechDraw::DrawViewPart*>(v);
+        auto* part = dynamic_cast<DrawViewPart*>(v);
         if (part) {
             //view, section, detail, dpgi
             part->recomputeFeature();
@@ -338,12 +347,12 @@ void DrawPage::updateAllViews()
     //second, do the rest of the views that may depend on a part view
     //TODO: check if we have 2 layers of dependency (ex. leader > weld > tile?)
     for (auto& v : featViews) {
-        TechDraw::DrawViewPart* part = dynamic_cast<TechDraw::DrawViewPart*>(v);
+        auto* part = dynamic_cast<DrawViewPart*>(v);
         if (part) {
             continue;
         }
 
-        TechDraw::DrawView* view = dynamic_cast<TechDraw::DrawView*>(v);
+        auto* view = dynamic_cast<DrawView*>(v);
         if (view) {
             view->overrideKeepUpdated(true);
             view->recomputeFeature();
@@ -351,14 +360,40 @@ void DrawPage::updateAllViews()
     }
 }
 
-std::vector<App::DocumentObject*> DrawPage::getAllViews(void)
+std::vector<App::DocumentObject*> DrawPage::getViews() const
 {
-    auto views = Views.getValues();//list of docObjects
+    std::vector<App::DocumentObject*> views = Views.getValues();
     std::vector<App::DocumentObject*> allViews;
     for (auto& v : views) {
+        if (v->isDerivedFrom<App::Link>()) {
+            v = static_cast<App::Link*>(v)->getLinkedObject();
+        }
+        
+        if (!v->isDerivedFrom<DrawView>()) {
+            continue;
+        }
+
         allViews.push_back(v);
-        if (v->isDerivedFrom(TechDraw::DrawProjGroup::getClassTypeId())) {
-            TechDraw::DrawProjGroup* dpg = static_cast<TechDraw::DrawProjGroup*>(v);
+    }
+    return allViews;
+}
+
+std::vector<App::DocumentObject*> DrawPage::getAllViews() const
+{
+    std::vector<App::DocumentObject*> views = Views.getValues();
+    std::vector<App::DocumentObject*> allViews;
+    for (auto& v : views) {
+        if (v->isDerivedFrom<App::Link>()) {
+            v = static_cast<App::Link*>(v)->getLinkedObject();
+        }
+
+        if (!v->isDerivedFrom<DrawView>()) {
+            continue;
+        }
+
+        allViews.push_back(v);
+        if (v->isDerivedFrom<DrawProjGroup>()) {
+            auto* dpg = static_cast<DrawProjGroup*>(v);
             if (dpg) {//can't really happen!
                 std::vector<App::DocumentObject*> pgViews = dpg->Views.getValues();
                 allViews.insert(allViews.end(), pgViews.begin(), pgViews.end());
@@ -378,8 +413,7 @@ void DrawPage::unsetupObject()
     std::string pageName = getNameInDocument();
 
     try {
-        const std::vector<App::DocumentObject*> currViews = Views.getValues();
-        for (auto& v : currViews) {
+        for (auto& v : Views.getValues()) {
             //NOTE: the order of objects in Page.Views does not reflect the object hierarchy
             //      this means that a ProjGroup could be deleted before its child ProjGroupItems.
             //      this causes problems when removing objects from document

--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -366,8 +366,13 @@ std::vector<App::DocumentObject*> DrawPage::getViews() const
     std::vector<App::DocumentObject*> views = Views.getValues();
     std::vector<App::DocumentObject*> allViews;
     for (auto& v : views) {
+        bool addChildren = false;
+
         if (v->isDerivedFrom<App::Link>()) {
+            // In the case of links, child object of the view need to be added since
+            // they are not in the page Views property.
             v = static_cast<App::Link*>(v)->getLinkedObject();
+            addChildren = true;
         }
         
         if (!v->isDerivedFrom<DrawView>()) {
@@ -375,6 +380,14 @@ std::vector<App::DocumentObject*> DrawPage::getViews() const
         }
 
         allViews.push_back(v);
+
+        if (addChildren) {
+            for (auto* dep : v->getInList()) {
+                if (dep && dep->isDerivedFrom<TechDraw::DrawView>()) {
+                    allViews.push_back(dep);
+                }
+            }
+        }
     }
     return allViews;
 }

--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -232,7 +232,7 @@ int DrawPage::getOrientation() const
     throw Base::RuntimeError("Template not set for Page");
 }
 
-int DrawPage::addView(App::DocumentObject* docObj)
+int DrawPage::addView(App::DocumentObject* docObj, bool setPosition)
 {
     if (!docObj->isDerivedFrom<DrawView>()
         && !docObj->isDerivedFrom<App::Link>()) {
@@ -256,7 +256,8 @@ int DrawPage::addView(App::DocumentObject* docObj)
     //position all new views without owners in center of Page (exceptDVDimension)
     if (!view->claimParent()
         && !docObj->isDerivedFrom<DrawViewDimension>()
-        && !docObj->isDerivedFrom<DrawViewBalloon>()) {
+        && !docObj->isDerivedFrom<DrawViewBalloon>()
+        && setPosition) {
         view->X.setValue(getPageWidth() / 2.0);
         view->Y.setValue(getPageHeight() / 2.0);
     }

--- a/src/Mod/TechDraw/App/DrawPage.h
+++ b/src/Mod/TechDraw/App/DrawPage.h
@@ -60,7 +60,7 @@ public:
     void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName,
                                    App::Property* prop) override;
 
-    int addView(App::DocumentObject* docObj);
+    int addView(App::DocumentObject* docObj, bool setPosition = true);
     int removeView(App::DocumentObject* docObj);
     short mustExecute() const override;
     boost::signals2::signal<void(const DrawPage*)> signalGuiPaint;

--- a/src/Mod/TechDraw/App/DrawPage.h
+++ b/src/Mod/TechDraw/App/DrawPage.h
@@ -91,7 +91,8 @@ public:
     int getOrientation() const;
     bool isUnsetting() { return nowUnsetting; }
     void requestPaint();
-    std::vector<App::DocumentObject*> getAllViews();
+    std::vector<App::DocumentObject*> getViews() const;
+    std::vector<App::DocumentObject*> getAllViews() const;
 
     int getNextBalloonIndex();
 

--- a/src/Mod/TechDraw/App/DrawPagePy.xml
+++ b/src/Mod/TechDraw/App/DrawPagePy.xml
@@ -23,6 +23,11 @@
         <UserDocu>removeView(DrawView) - Remove a View to this Page</UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="getViews">
+      <Documentation>
+        <UserDocu>getViews() - returns a list of all the views on page excluding Views inside Collections</UserDocu>
+      </Documentation>
+    </Methode>
     <Methode Name="getAllViews">
       <Documentation>
         <UserDocu>getAllViews() - returns a list of all the views on page including Views inside Collections</UserDocu>

--- a/src/Mod/TechDraw/App/DrawPagePyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawPagePyImp.cpp
@@ -77,6 +77,38 @@ PyObject* DrawPagePy::removeView(PyObject* args)
     return PyLong_FromLong(rc);
 }
 
+PyObject* DrawPagePy::getViews(PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
+    DrawPage* page = getDrawPagePtr();
+    std::vector<App::DocumentObject*> allViews = page->getViews();
+
+    Py::List ret;
+    for (auto v: allViews) {
+        if (v->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())) {
+            TechDraw::DrawProjGroupItem* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(v);
+            ret.append(Py::asObject(new TechDraw::DrawProjGroupItemPy(dpgi)));
+        }
+        else if (v->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+            TechDraw::DrawViewPart* dvp = static_cast<TechDraw::DrawViewPart*>(v);
+            ret.append(Py::asObject(new TechDraw::DrawViewPartPy(dvp)));
+        }
+        else if (v->isDerivedFrom(TechDraw::DrawViewAnnotation::getClassTypeId())) {
+            TechDraw::DrawViewAnnotation* dva = static_cast<TechDraw::DrawViewAnnotation*>(v);
+            ret.append(Py::asObject(new TechDraw::DrawViewAnnotationPy(dva)));
+        }
+        else {
+            TechDraw::DrawView* dv = static_cast<TechDraw::DrawView*>(v);
+            ret.append(Py::asObject(new TechDraw::DrawViewPy(dv)));
+        }
+    }
+
+    return Py::new_reference_to(ret);
+}
+
 PyObject* DrawPagePy::getAllViews(PyObject* args)
 {
     if (!PyArg_ParseTuple(args, "")) {

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -385,16 +385,16 @@ std::vector<DrawPage*> DrawView::findAllParentPages() const
 {
     std::vector<DrawPage*> pages;
 
-   for (auto parent : getInList()) {
-       if (parent->isDerivedFrom<App::Link>()) {
-           for (auto& linkParent : parent->getInList()) {
-               if (linkParent->isDerivedFrom<DrawPage>()
-                   || linkParent->isDerivedFrom<DrawViewCollection>()) {
-                   parent = linkParent;
-                   break;
-               }
-           }
-       }
+    for (auto parent : getInList()) {
+        if (parent->isDerivedFrom<App::Link>()) {
+            for (auto& linkParent : parent->getInList()) {
+                if (linkParent->isDerivedFrom<DrawPage>()
+                    || linkParent->isDerivedFrom<DrawViewCollection>()) {
+                    parent = linkParent;
+                    break;
+                }
+            }
+        }
 
         if (parent->isDerivedFrom<DrawPage>()) {
             pages.emplace_back(static_cast<TechDraw::DrawPage*>(parent));
@@ -415,9 +415,8 @@ std::vector<DrawPage*> DrawView::findAllParentPages() const
 
 bool DrawView::isInClip()
 {
-    std::vector<App::DocumentObject*> parent = getInList();
-    for (std::vector<App::DocumentObject*>::iterator it = parent.begin(); it != parent.end(); ++it) {
-        if ((*it)->isDerivedFrom<DrawViewClip>()) {
+    for (auto* parent : getInList()) {
+        if (parent->isDerivedFrom<DrawViewClip>()) {
             return true;
         }
     }
@@ -440,14 +439,9 @@ DrawView *DrawView::claimParent() const
 
 DrawViewClip* DrawView::getClipGroup()
 {
-    std::vector<App::DocumentObject*> parent = getInList();
-    App::DocumentObject* obj = nullptr;
-    for (std::vector<App::DocumentObject*>::iterator it = parent.begin(); it != parent.end(); ++it) {
-        if ((*it)->isDerivedFrom<DrawViewClip>()) {
-            obj = (*it);
-            DrawViewClip* result = dynamic_cast<DrawViewClip*>(obj);
-            return result;
-
+    for (auto* obj : getInList()) {
+        if (obj->isDerivedFrom<DrawViewClip>()) {
+            return dynamic_cast<DrawViewClip*>(obj);
         }
     }
     return nullptr;
@@ -455,14 +449,11 @@ DrawViewClip* DrawView::getClipGroup()
 
 DrawViewCollection *DrawView::getCollection() const
 {
-    std::vector<App::DocumentObject *> parents = getInList();
-    for (auto it = parents.begin(); it != parents.end(); ++it) {
-        auto parentCollection = dynamic_cast<DrawViewCollection *>(*it);
-        if (parentCollection) {
-            return parentCollection;
+    for (auto* obj : getInList()) {
+        if (obj->isDerivedFrom<DrawViewCollection>()) {
+            return dynamic_cast<DrawViewCollection*>(obj);
         }
     }
-
     return nullptr;
 }
 

--- a/src/Mod/TechDraw/App/DrawViewClip.h
+++ b/src/Mod/TechDraw/App/DrawViewClip.h
@@ -49,9 +49,11 @@ public:
     App::PropertyBool ShowFrame;
     App::PropertyLinkList Views;
 
-    void addView(DrawView *view);
-    void removeView(DrawView *view);
+    void addView(App::DocumentObject* docObj);
+    void removeView(App::DocumentObject* docObj);
     short mustExecute() const override;
+
+    std::vector<App::DocumentObject*> getViews() const;
 
     /** @name methods override Feature */
     //@{

--- a/src/Mod/TechDraw/App/DrawViewCollection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewCollection.cpp
@@ -28,6 +28,7 @@
 
 #include <App/Document.h>
 #include <App/DocumentObject.h>
+#include <App/Link.h>
 #include <Base/Console.h>
 #include <Base/Interpreter.h>
 
@@ -80,26 +81,46 @@ App::DocumentObjectExecReturn *DrawViewCollection::execute()
     return DrawView::execute();
 }
 
-int DrawViewCollection::addView(DrawView *view)
+int DrawViewCollection::addView(App::DocumentObject* docObj)
 {
     // Add the new view to the collection
-    std::vector<App::DocumentObject *> newViews(Views.getValues());
-    newViews.push_back(view);
+
+    if (!docObj->isDerivedFrom<DrawView>()
+        && !docObj->isDerivedFrom<App::Link>()) {
+        return -1;
+    }
+
+    auto* view = dynamic_cast<DrawView*>(docObj);
+
+    if (!view) {
+        auto* link = dynamic_cast<App::Link*>(docObj);
+        if (!link) {
+            return -1;
+        }
+
+        if (link) {
+            view = dynamic_cast<DrawView*>(link->getLinkedObject());
+            if (!view) {
+                return -1;
+            }
+        }
+    }
+
+    std::vector<App::DocumentObject*> newViews(Views.getValues());
+    newViews.push_back(docObj);
     Views.setValues(newViews);
 
     return Views.getSize();
 }
 
-int DrawViewCollection::removeView(DrawView *view)
+int DrawViewCollection::removeView(App::DocumentObject* docObj)
 {
     // Remove the view from the collection
-    const std::vector<App::DocumentObject*> currViews = Views.getValues();
     std::vector<App::DocumentObject*> newViews;
-    std::vector<App::DocumentObject*>::const_iterator it = currViews.begin();
-    for (; it != currViews.end(); it++) {
-        std::string viewName = view->getNameInDocument();
-        if (viewName.compare((*it)->getNameInDocument()) != 0) {
-            newViews.push_back((*it));
+    std::string viewName = docObj->getNameInDocument();
+    for (auto* view : Views.getValues()) {
+        if (viewName.compare(view->getNameInDocument()) != 0) {
+            newViews.push_back(view);
         }
     }
     Views.setValues(newViews);
@@ -107,23 +128,42 @@ int DrawViewCollection::removeView(DrawView *view)
     return Views.getSize();
 }
 
+std::vector<App::DocumentObject*> DrawViewCollection::getViews() const
+{
+    std::vector<App::DocumentObject*> views = Views.getValues();
+    std::vector<App::DocumentObject*> allViews;
+    for (auto& v : views) {
+        if (v->isDerivedFrom(App::Link::getClassTypeId())) {
+            v = static_cast<App::Link*>(v)->getLinkedObject();
+        }
+
+        if (!v->isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
+            continue;
+        }
+
+        allViews.push_back(v);
+    }
+    return allViews;
+}
+
 //make sure everything in View list represents a real DrawView docObj and occurs only once
 void DrawViewCollection::rebuildViewList()
 {
     const std::vector<App::DocumentObject*> currViews = Views.getValues();
     std::vector<App::DocumentObject*> newViews;
-    std::vector<App::DocumentObject*> children = getOutList();
-    for (std::vector<App::DocumentObject*>::iterator it = children.begin(); it != children.end(); ++it) {
-        if ((*it)->isDerivedFrom<DrawView>()) {
+    for (auto* child : getOutList()) {
+        if (child->isDerivedFrom<DrawView>() || 
+            (child->isDerivedFrom<App::Link>() 
+                && static_cast<App::Link*>(child)->getLinkedObject()->isDerivedFrom<DrawView>())) {
             bool found = false;
             for (auto& v:currViews) {
-                if (v == (*it)) {
+                if (v == child) {
                     found = true;
                     break;
                 }
             }
             if (found) {
-                newViews.push_back((*it));
+                newViews.push_back(child);
             }
         }
     } // newViews contains only valid items, but may have duplicates
@@ -137,13 +177,12 @@ int DrawViewCollection::countChildren()
     //Count the children recursively if needed
     int numChildren = 0;
 
-    const std::vector<App::DocumentObject *> &views = Views.getValues();
-    for(std::vector<App::DocumentObject *>::const_iterator it = views.begin(); it != views.end(); ++it) {
-
-        if((*it)->isDerivedFrom<TechDraw::DrawViewCollection>()) {
-            TechDraw::DrawViewCollection *viewCollection = static_cast<TechDraw::DrawViewCollection *>(*it);
+    for(auto* view : Views.getValues()) {
+        if(view->isDerivedFrom<DrawViewCollection>()) {
+            auto *viewCollection = static_cast<DrawViewCollection *>(view);
             numChildren += viewCollection->countChildren() + 1;
-        } else {
+        }
+        else {
             numChildren += 1;
         }
     }
@@ -157,9 +196,8 @@ void DrawViewCollection::onDocumentRestored()
 
 void DrawViewCollection::lockChildren()
 {
-//    Base::Console().Message("DVC::lockChildren()\n");
-    for (auto& v:Views.getValues()) {
-        TechDraw::DrawView *view = dynamic_cast<TechDraw::DrawView *>(v);
+    for (auto& v : getViews()) {
+        auto *view = dynamic_cast<DrawView *>(v);
         if (!view) {
             throw Base::ValueError("DrawViewCollection::lockChildren bad View\n");
         }
@@ -172,25 +210,23 @@ void DrawViewCollection::unsetupObject()
     nowUnsetting = true;
 
     // Remove the collection's views from document
-    App::Document* doc = getDocument();
-    std::string docName = doc->getName();
+    std::string docName = getDocument()->getName();
 
-    const std::vector<App::DocumentObject*> currViews = Views.getValues();
-    std::vector<App::DocumentObject*> emptyViews;
-    std::vector<App::DocumentObject*>::const_iterator it = currViews.begin();
-    for (; it != currViews.end(); it++) {
-        std::string viewName = (*it)->getNameInDocument();
+    for (auto* view : Views.getValues()) {
+        std::string viewName = view->getNameInDocument();
         Base::Interpreter().runStringArg("App.getDocument(\"%s\").removeObject(\"%s\")",
                                           docName.c_str(), viewName.c_str());
     }
+
+    std::vector<App::DocumentObject*> emptyViews;
     Views.setValues(emptyViews);
 }
 
 QRectF DrawViewCollection::getRect() const
 {
     QRectF result;
-    for (auto& v:Views.getValues()) {
-        TechDraw::DrawView *view = dynamic_cast<TechDraw::DrawView *>(v);
+    for (auto& v : getViews()) {
+        auto *view = dynamic_cast<DrawView*>(v);
         if (!view) {
             throw Base::ValueError("DrawViewCollection::getRect bad View\n");
         }

--- a/src/Mod/TechDraw/App/DrawViewCollection.h
+++ b/src/Mod/TechDraw/App/DrawViewCollection.h
@@ -48,8 +48,9 @@ public:
     ~DrawViewCollection() override;
     short mustExecute() const override;
 
-    int addView(DrawView *view);
-    int removeView(DrawView *view);
+    int addView(App::DocumentObject* obj);
+    int removeView(App::DocumentObject* obj);
+    std::vector<App::DocumentObject*> getViews() const;
     void rebuildViewList();
     bool isUnsetting() { return nowUnsetting; }
 

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -1360,7 +1360,7 @@ void CmdTechDrawClipGroupRemove::activated(int iMsg)
     auto view(static_cast<TechDraw::DrawView*>(dObj.front()));
 
     TechDraw::DrawPage* page = view->findParentPage();
-    const std::vector<App::DocumentObject*> pViews = page->Views.getValues();
+    const std::vector<App::DocumentObject*> pViews = page->getViews();
     TechDraw::DrawViewClip* clip(nullptr);
     for (auto& v : pViews) {
         clip = dynamic_cast<TechDraw::DrawViewClip*>(v);
@@ -1721,7 +1721,7 @@ void CmdTechDrawExportPageDXF::activated(int iMsg)
         return;
     }
 
-    std::vector<App::DocumentObject*> views = page->Views.getValues();
+    std::vector<App::DocumentObject*> views = page->getViews();
     for (auto& v : views) {
         if (v->isDerivedFrom(TechDraw::DrawViewArch::getClassTypeId())) {
             QMessageBox::StandardButton rc = QMessageBox::question(

--- a/src/Mod/TechDraw/Gui/TaskLinkDim.cpp
+++ b/src/Mod/TechDraw/Gui/TaskLinkDim.cpp
@@ -89,24 +89,24 @@ void TaskLinkDim::loadAvailDims()
     if (!guiDoc)
         return;
 
-    std::vector<App::DocumentObject*> pageViews = m_page->Views.getValues();
-    std::vector<App::DocumentObject*>::iterator itView = pageViews.begin();
     std::string result;
     int selRefType = TechDraw::DrawViewDimension::getRefTypeSubElements(m_subs);
     //int found = 0;
-    for (; itView != pageViews.end(); itView++) {
-        if ((*itView)->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {
-            TechDraw::DrawViewDimension* dim = static_cast<TechDraw::DrawViewDimension*>((*itView));
+    for (auto* view : m_page->getViews()) {
+        if (view->isDerivedFrom<TechDraw::DrawViewDimension>()) {
+            auto* dim = static_cast<TechDraw::DrawViewDimension*>(view);
             int dimRefType = dim->getRefType();
             if (dimRefType == selRefType) {                                     //potential matches
     //            found++;
                 if (dim->has3DReferences()) {
                     if (dimReferencesSelection(dim))  {
                         loadToTree(dim, true, guiDoc);
-                    } else {
+                    }
+                    else {
                         continue;                                               //already linked to something else
                     }
-                } else {
+                }
+                else {
                     loadToTree(dim, false, guiDoc);
                 }
             }

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -405,27 +405,23 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
     //                                               any FeatuerView in a DrawViewClip
     //                                               DrawHatch
 
-    const std::vector<App::DocumentObject*>& views = getDrawPage()->Views.getValues();
-
     try {
-        for (std::vector<App::DocumentObject*>::const_iterator it = views.begin();
-             it != views.end(); ++it) {
-            TechDraw::DrawView* featView = dynamic_cast<TechDraw::DrawView*>(*it);
+        for (auto* obj : getDrawPage()->Views.getValues()) {
+            auto* featView = dynamic_cast<TechDraw::DrawView*>(obj);
 
             // If the child view appoints a parent, skip it
             if (featView && featView->claimParent()) {
                 continue;
             }
 
-            App::DocumentObject* docObj = *it;
             // Don't collect if dimension, balloon, hatch or member of ClipGroup as these should be grouped elsewhere
-            if (docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())
-                || docObj->isDerivedFrom(TechDraw::DrawHatch::getClassTypeId())
-                || docObj->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId())
+            if (obj->isDerivedFrom<TechDraw::DrawViewDimension>()
+                || obj->isDerivedFrom<TechDraw::DrawHatch>()
+                || obj->isDerivedFrom<TechDraw::DrawViewBalloon>()
                 || (featView && featView->isInClip()))
                 continue;
             else
-                temp.push_back(*it);
+                temp.push_back(obj);
         }
         return temp;
     }
@@ -455,7 +451,7 @@ void ViewProviderPage::setTemplateMarkers(bool state)
     templateFeat = getDrawPage()->Template.getValue();
     Gui::Document* guiDoc = Gui::Application::Instance->getDocument(templateFeat->getDocument());
     Gui::ViewProvider* vp = guiDoc->getViewProvider(templateFeat);
-    ViewProviderTemplate* vpt = dynamic_cast<ViewProviderTemplate*>(vp);
+    auto* vpt = dynamic_cast<ViewProviderTemplate*>(vp);
     if (vpt) {
         vpt->setMarkers(state);
         QGITemplate* t = vpt->getQTemplate();
@@ -570,7 +566,7 @@ void ViewProviderPage::fixSceneDependencies()
         if (!vp) {
             continue;// can't fix this one
         }
-        TechDrawGui::ViewProviderViewPart* vpvp = dynamic_cast<TechDrawGui::ViewProviderViewPart*>(vp);
+        auto* vpvp = dynamic_cast<TechDrawGui::ViewProviderViewPart*>(vp);
         if (!vpvp) {
             continue;// can't fix this one
         }

--- a/src/Mod/TechDraw/Gui/ViewProviderPageExtension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPageExtension.cpp
@@ -154,10 +154,27 @@ void ViewProviderPageExtension::dropObject(App::DocumentObject* obj)
 
     if (obj->isDerivedFrom<TechDraw::DrawView>()) {
         auto dv = static_cast<TechDraw::DrawView*>(obj);
-        if (dv->findParentPage()) {
-            dv->findParentPage()->removeView(dv);
+
+        std::vector<App::DocumentObject*> deps;
+        for (auto* dep : dv->getInList()) {
+            if (dep && dep->isDerivedFrom<TechDraw::DrawView>()) {
+                deps.push_back(dep);
+            }
         }
-        getViewProviderPage()->getDrawPage()->addView(dv);
+
+        auto* parentPage = dv->findParentPage();
+        if (parentPage) {
+            for (auto* dep : deps) {
+                parentPage->removeView(dep);
+            }
+            parentPage->removeView(dv);
+        }
+
+        getViewProviderPage()->getDrawPage()->addView(dv, false);
+        for (auto* dep : deps) {
+            getViewProviderPage()->getDrawPage()->addView(dep, false);
+        }
+
         //don't run ancestor's method as addView does everything we need
         return;
     }

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
@@ -185,10 +185,9 @@ std::vector<App::DocumentObject*> ViewProviderProjGroup::claimChildren() const
 {
     // Collect any child fields
     std::vector<App::DocumentObject*> temp;
-    const std::vector<App::DocumentObject *> &views = getObject()->Views.getValues();
     try {
-      for (std::vector<App::DocumentObject *>::const_iterator it = views.begin(); it != views.end(); ++it) {
-          temp.push_back(*it);
+      for (auto* view : getObject()->Views.getValues()) {
+          temp.push_back(view);
       }
       return temp;
     } catch (...) {

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -301,7 +301,6 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *views << "TechDraw_ArchView";
     *views << "TechDraw_SpreadsheetView";
     *views << "TechDraw_ClipGroup";
-    *views << "TechDraw_ShareView";
     *views << "TechDraw_ProjectShape";
 
     Gui::ToolBarItem* stacking = new Gui::ToolBarItem(root);
@@ -408,7 +407,6 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *views << "TechDraw_DraftView";
     *views << "TechDraw_SpreadsheetView";
     *views << "TechDraw_ClipGroup";
-    *views << "TechDraw_ShareView";
     *views << "TechDraw_ProjectShape";
 
     Gui::ToolBarItem* stacking = new Gui::ToolBarItem(root);


### PR DESCRIPTION
Enable App::Links of views to work. So that it is more consistent with the rest of the application than current 'Share Views' (fixes #12374).

Remove Share View from toolbar.

![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/4122ef5a-d487-490b-bef2-f022fedbcd7f)



