### PR TITLE
Part/Toponaming: WireJoiner - use std::hash

### DIFF
--- a/src/Mod/Part/App/WireJoiner.cpp
+++ b/src/Mod/Part/App/WireJoiner.cpp
@@ -786,7 +786,11 @@ public:
         for (auto vit = vmap.qbegin(bgi::nearest(p1, INT_MAX)); vit != vmap.qend(); ++vit) {
             auto& vinfo = *vit;
             if (canShowShape()) {
+#if OCC_VERSION_HEX < 0x070800
                 FC_MSG("addcheck " << vinfo.edge().HashCode(INT_MAX));
+#else
+                FC_MSG("addcheck " << std::hash<TopoDS_Edge> {}(vinfo.edge()));
+#endif
             }
             double d1 = vinfo.pt().SquareDistance(p1);
             if (d1 >= tol) {
@@ -2712,7 +2716,12 @@ public:
     {
         FC_MSG("init:");
         for (const auto& shape : sourceEdges) {
+#if OCC_VERSION_HEX < 0x070800
             FC_MSG(shape.getShape().TShape().get() << ", " << shape.getShape().HashCode(INT_MAX));
+#else
+            FC_MSG(shape.getShape().TShape().get()
+                   << ", " << std::hash<TopoDS_Shape> {}(shape.getShape()));
+#endif
         }
         printHistory(aHistory, sourceEdges);
         printHistory(newHistory, inputEdges);
@@ -2726,7 +2735,11 @@ public:
         FC_MSG("final:");
         for (int i = 1; i <= wireData->NbEdges(); ++i) {
             auto shape = wireData->Edge(i);
+#if OCC_VERSION_HEX < 0x070800
             FC_MSG(shape.TShape().get() << ", " << shape.HashCode(INT_MAX));
+#else
+            FC_MSG(shape.TShape().get() << ", " << std::hash<TopoDS_Edge> {}(shape));
+#endif
         }
     }
 
@@ -2786,9 +2799,15 @@ public:
     {
         for (TopTools_ListIteratorOfListOfShape it(hist->Modified(shape.getShape())); it.More();
              it.Next()) {
+#if OCC_VERSION_HEX < 0x070800
             FC_MSG(shape.getShape().TShape().get()
                    << ", " << shape.getShape().HashCode(INT_MAX) << " -> "
                    << it.Value().TShape().get() << ", " << it.Value().HashCode(INT_MAX));
+#else
+            FC_MSG(shape.getShape().TShape().get()
+                   << ", " << std::hash<TopoDS_Shape> {}(shape.getShape()) << " -> "
+                   << it.Value().TShape().get() << ", " << std::hash<TopoDS_Shape> {}(it.Value()));
+#endif
         }
     }
 


### PR DESCRIPTION
Added precompiler directive to use `std::hash` instead of `HashCode(INT_MAX)` if `OCC_VERSION_HEX >= 0x070800`

Fixes https://github.com/FreeCAD/FreeCAD/issues/13210