### PR TITLE
Assembly: fix segfault when Part property of Joint Connector is missing

### DIFF
--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -1072,6 +1072,12 @@ std::string AssemblyObject::handleOneSideOfJoint(App::DocumentObject* joint,
     App::DocumentObject* part = getLinkObjFromProp(joint, propPartName);
     App::DocumentObject* obj = getObjFromNameProp(joint, propObjName, propPartName);
 
+    if (!part) {
+        std::string msg = std::string("The property ") + propPartName + " of Joint "
+            + joint->getFullName() + " is empty.\n";
+        THROWM(Base::ValueError, msg);
+    }
+
     std::shared_ptr<ASMTPart> mbdPart = getMbDPart(part);
     Base::Placement plc = getPlacementFromProp(joint, propPlcName);
     // Now we have plc which is the JCS placement, but its relative to the Object, not to the


### PR DESCRIPTION
FreeCAD is crashing during 'Solve Assembly' call if the Part property (Assembly/Joints/Fixed/Joint Connector 1/Part1 or Assembly/Joints/Fixed/Joint Connector 2/Part2) of fixed Joint is unset.

Steps to reproduce:

 - make simple Assembly e.g. of two cubes with Fixed joint
 - Select Fixed joint in the tree and go-to property 'Data' tab
 - Select Part1 or Part2 of 'Joint Connector 1' or 'Joint Connector 2' and remove this reference
 - call 'Solve Assembly' now

The FreeCAD will crash here because the call
App::DocumentObject* part = getLinkObjFromProp(joint, propPartName); will return NULL pointer.

The property Part1 or Part2 can get empty (unset) during usual construction operations - during changing construction history and it can be very hard to find the cause of FreeCAD crash on a big model.

This patch tries to fix the crash in such situation.