### PR TITLE
Mat: Material editor can't be opened from FEM_MaterialSolid and FEM_MaterialFluid

### DIFF
--- a/src/Ext/freecad/CMakeLists.txt
+++ b/src/Ext/freecad/CMakeLists.txt
@@ -25,9 +25,19 @@ else()
 endif()
 
 configure_file(__init__.py.template ${NAMESPACE_INIT})
-configure_file(project_utility.py ${NAMESPACE_DIR}/project_utility.py)
-configure_file(UiTools.py ${NAMESPACE_DIR}/UiTools.py)
-configure_file(utils.py ${NAMESPACE_DIR}/utils.py)
+
+set(EXT_FILES
+    part.py
+    partdesign.py
+    project_utility.py
+    sketcher.py
+    UiTools.py
+    utils.py
+)
+
+foreach (it ${EXT_FILES})
+    configure_file(${it} ${NAMESPACE_DIR}/${it})
+endforeach()
 
 if (INSTALL_TO_SITEPACKAGES)
     SET(SITE_PACKAGE_DIR ${PYTHON_MAIN_DIR}/freecad)
@@ -38,12 +48,7 @@ endif()
 INSTALL(
     FILES
         ${NAMESPACE_INIT}
-        part.py
-        partdesign.py
-        sketcher.py
-        project_utility.py
-        UiTools.py
-        utils.py
+        ${EXT_FILES}
     DESTINATION
         ${SITE_PACKAGE_DIR}
 )

--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -419,7 +419,6 @@ SET(FemTestsZ88Main_SRCS
 )
 
 SET(FemTestsZ88CcxcantiEleHex20_SRCS
-    femtest/data/z88/__init__.py
     femtest/data/z88/ccx_cantilever_ele_hexa20/51.txt
     femtest/data/z88/ccx_cantilever_ele_hexa20/z88.dyn
     femtest/data/z88/ccx_cantilever_ele_hexa20/z88elp.txt
@@ -432,7 +431,6 @@ SET(FemTestsZ88CcxcantiEleHex20_SRCS
 )
 
 SET(FemTestsZ88CcxcantiEleTria6_SRCS
-    femtest/data/z88/__init__.py
     femtest/data/z88/ccx_cantilever_ele_tria6/51.txt
     femtest/data/z88/ccx_cantilever_ele_tria6/z88.dyn
     femtest/data/z88/ccx_cantilever_ele_tria6/z88elp.txt
@@ -445,7 +443,6 @@ SET(FemTestsZ88CcxcantiEleTria6_SRCS
 )
 
 SET(FemTestsZ88Ccxcantifl_SRCS
-    femtest/data/z88/__init__.py
     femtest/data/z88/ccx_cantilever_faceload/51.txt
     femtest/data/z88/ccx_cantilever_faceload/z88.dyn
     femtest/data/z88/ccx_cantilever_faceload/z88elp.txt
@@ -458,7 +455,6 @@ SET(FemTestsZ88Ccxcantifl_SRCS
 )
 
 SET(FemTestsZ88Ccxcantinl_SRCS
-    femtest/data/z88/__init__.py
     femtest/data/z88/ccx_cantilever_nodeload/51.txt
     femtest/data/z88/ccx_cantilever_nodeload/z88.dyn
     femtest/data/z88/ccx_cantilever_nodeload/z88elp.txt

--- a/src/Mod/Material/CMakeLists.txt
+++ b/src/Mod/Material/CMakeLists.txt
@@ -14,8 +14,11 @@ SET(MaterialScripts_Files
     importFCMat.py
     MaterialEditor.py
     TestMaterialsApp.py
-    Resources/ui/materials-editor.ui
     Templatematerial.yml
+)
+
+SET(Material_Ui_Files
+    Resources/ui/materials-editor.ui
 )
 
 # SOURCE_GROUP("MaterialScripts" FILES ${MaterialScripts_Files})
@@ -292,15 +295,17 @@ fc_target_copy_resource(MateriaTestLib
     ${MaterialTest_Files})
 
 ADD_CUSTOM_TARGET(MaterialScripts ALL
-    SOURCES ${MaterialScripts_Files} ${Material_QRC_SRCS}
+    SOURCES ${MaterialScripts_Files} ${Material_Ui_Files} ${Material_QRC_SRCS}
 )
 
 fc_target_copy_resource(MaterialScripts
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_BINARY_DIR}/Mod/Material
-    ${MaterialScripts_Files})
+    ${MaterialScripts_Files}
+    ${Material_Ui_Files})
 
 INSTALL(FILES ${MaterialScripts_Files} DESTINATION Mod/Material)
+INSTALL(FILES ${Material_Ui_Files} DESTINATION Mod/Material/Resources/ui)
 
 ADD_CUSTOM_TARGET(MaterialToolsLib ALL
     SOURCES ${MaterialTools_Files}
@@ -368,11 +373,6 @@ fc_target_copy_resource(MaterialModelLib
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Material/
     ${MaterialModel_Files})
-
-INSTALL(
-    FILES ${Material_SRCS} ${Material_QRC_SRCS}
-    DESTINATION Mod/Material
-)
 
 INSTALL(
     FILES ${MaterialTest_Files}

--- a/src/Mod/Material/Gui/CMakeLists.txt
+++ b/src/Mod/Material/Gui/CMakeLists.txt
@@ -121,7 +121,7 @@ SET(MatGuiImages
     Resources/images/default_image.png
 )
 
-add_library(MatGui SHARED ${MatGui_SRCS} ${MatGuiIcon_SVG})
+add_library(MatGui SHARED ${MatGui_SRCS} ${MatGuiIcon_SVG} ${MatGuiImages})
 target_link_libraries(MatGui ${MatGui_LIBS})
 
 SET_BIN_DIR(MatGui MatGui /Mod/Material)

--- a/src/Mod/Robot/CMakeLists.txt
+++ b/src/Mod/Robot/CMakeLists.txt
@@ -63,4 +63,5 @@ INSTALL(
         ${CMAKE_INSTALL_DATADIR}/Mod/Robot
     PATTERN "Makefile*" EXCLUDE
     PATTERN "*.pdf" EXCLUDE
+    PATTERN "testprog.*" EXCLUDE
 )


### PR DESCRIPTION
Fixes #12949 

There are several inconsistencies between a built and an installed version. This PR fixes most of them:
* Copy some missing Python modules to Ext of the build directory
* Do not intall `__init__.py` to the sub-directories of the z88 directory
* Do not install the testprog.* files
* Files listed in MatGuiImages are not copied during the build
* Don't install Material_rc.py
* Install materials-editor.ui to the correct sub-directory 