### PR TITLE
FEM: Handle unknown exception when applying a constraint to a B-Spli…

### DIFF
--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -430,7 +430,9 @@ bool Constraint::getPoints(std::vector<Base::Vector3d>& points,
                 if (classifier.State() != TopAbs_OUT) {
                     points.emplace_back(p.X(), p.Y(), p.Z());
                     props.Normal(u, v, center, normal);
-                    normal.Normalize();
+                    if (normal.SquareMagnitude() > 0.0) {
+                        normal.Normalize();
+                    }
                     normals.emplace_back(normal.X(), normal.Y(), normal.Z());
                 }
             };


### PR DESCRIPTION
…ne surface

Fixes #13213

An OCC exception is raised when trying to normalize a null vector. The solution is to check the square length before normalizing it