### PR TITLE
PD: Fixes 12673: Transforming of sub-shape binder fails

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
@@ -78,7 +78,7 @@ public:
 private:
     enum {
         Synchronize = 0,
-        SelectObject = 1
+        SelectObject = 4  // must be higher than 3 (EditMode::Color)
     };
     void updatePlacement(bool transaction);
 };


### PR DESCRIPTION
The problem is caused by conflicting values of the anonymous enum of ViewProviderSubShapeBinder. The solution is to set a higher value than the highest value of EditMode