### PR TITLE
Gui: Fix Std_LinkActions

### DIFF
--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -882,6 +882,8 @@ public:
         eType         = AlterDoc;
         bCanLog       = false;
 
+        setCheckable(false);
+
         addCommand(new StdCmdLinkMake());
         addCommand(new StdCmdLinkMakeRelative());
         addCommand(new StdCmdLinkReplace());


### PR DESCRIPTION
Currently the active button of the Std_LinkActions command is toggable that is confusing behaviour. This PR makes the action group non-checkable