### PR TITLE
Rewrite PropertyTopoShape::getShape to fix dangling reference

### DIFF
--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -100,21 +100,20 @@ const TopoDS_Shape& PropertyPartShape::getValue() const
     return _Shape.getShape();
 }
 
-TopoShape PropertyPartShape::getShape() const
+const TopoShape& PropertyPartShape::getShape() const
 {
     _Shape.initCache(-1);
-    auto res = _Shape;
     // March, 2024 Toponaming project:  There was originally an unused feature to disable
     // elementMapping that has not been kept:
     //    if (Feature::isElementMappingDisabled(getContainer()))
     //        res.Tag = -1;
     //    else if (!res.Tag) {
-    if (!res.Tag) {
+    if (!_Shape.Tag) {
         if (auto parent = Base::freecad_dynamic_cast<App::DocumentObject>(getContainer())) {
-            res.Tag = parent->getID();
+            _Shape.Tag = parent->getID();
         }
     }
-    return res;
+    return _Shape;
 }
 
 const Data::ComplexGeoData* PropertyPartShape::getComplexData() const

--- a/src/Mod/Part/App/PropertyTopoShape.h
+++ b/src/Mod/Part/App/PropertyTopoShape.h
@@ -55,7 +55,7 @@ public:
     void setValue(const TopoDS_Shape&, bool resetElementMap=true);
     /// get the part shape
     const TopoDS_Shape& getValue() const;
-    TopoShape getShape() const;
+    const TopoShape& getShape() const;
     const Data::ComplexGeoData* getComplexData() const override;
     //@}
 


### PR DESCRIPTION
Fix #13252.  Yikes.  No reason for that code to be doing this, or for the signature to get changed.  Rewrote method.