### PR TITLE
fix for yaml version

### DIFF
--- a/src/Mod/Material/App/CMakeLists.txt
+++ b/src/Mod/Material/App/CMakeLists.txt
@@ -32,7 +32,7 @@ list(APPEND Material_LIBS
     ${QtConcurrent_LIBRARIES}
 )
 
-if(yaml-cpp_VERSION VERSION_LESS 0.7.0)
+if(yaml-cpp_VERSION VERSION_LESS 0.8.0)
     list(APPEND Material_LIBS
         ${YAML_CPP_LIBRARIES}
     )


### PR DESCRIPTION
My gentoo build failed, it is yaml-cpp 0.7.0.
change if branch version in #12423.
tested on 0.7.0 on linux and 0.8.0 on windows.