### PR TITLE
FEM: migrate calculix tests to ccxtools tests

### DIFF
--- a/src/Mod/Fem/femtest/app/test_ccxtools.py
+++ b/src/Mod/Fem/femtest/app/test_ccxtools.py
@@ -41,9 +41,7 @@ class TestCcxTools(unittest.TestCase):
     fcc_print("import TestCcxTools")
 
     # ********************************************************************************************
-    def setUp(
-        self
-    ):
+    def setUp(self):
         # setUp is executed before every test
 
         # new document
@@ -56,35 +54,30 @@ class TestCcxTools(unittest.TestCase):
         self.mesh_name = "Mesh"
         self.test_file_dir = join(
             testtools.get_fem_test_home_dir(),
-            "calculix"
+            "calculix",  # TODO rename directory to "ccxtools" or rename the solver to calculix
         )
 
     # ********************************************************************************************
-    def tearDown(
-        self
-    ):
+    def tearDown(self):
         # tearDown is executed after every test
         FreeCAD.closeDocument(self.document.Name)
 
     # ********************************************************************************************
-    def test_00print(
-        self
-    ):
+    def test_00print(self):
         # since method name starts with 00 this will be run first
         # this test just prints a line with stars
 
-        fcc_print("\n{0}\n{1} run FEM TestCcxTools tests {2}\n{0}".format(
-            100 * "*",
-            10 * "*",
-            62 * "*"
-        ))
+        fcc_print(
+            "\n{0}\n{1} run FEM TestCcxTools tests {2}\n{0}".format(
+                100 * "*", 10 * "*", 62 * "*"
+            )
+        )
 
     # ********************************************************************************************
-    def test_box_frequency(
-        self
-    ):
+    def test_box_frequency(self):
         # set up
         from femexamples.boxanalysis_frequency import setup
+
         setup(self.document, "ccxtools")
         base_name = get_namefromdef("test_")
         res_obj_name = "CCX_EigenMode_1_Results"
@@ -92,7 +85,6 @@ class TestCcxTools(unittest.TestCase):
 
         # test input file writing
         fea = self.input_file_writing_test(
-            None,
             base_name,
             analysis_dir=analysis_dir,
             test_end=True,
@@ -100,19 +92,16 @@ class TestCcxTools(unittest.TestCase):
 
         # test result reading
         self.result_reading_test(
-            None,
             base_name,
             analysis_dir=analysis_dir,
             fea=fea,
             res_obj_name=res_obj_name,
         )
 
-    # ********************************************************************************************
-    def test_box_static(
-        self
-    ):
+    def test_box_static(self):
         # set up
         from femexamples.boxanalysis_static import setup
+
         setup(self.document, "ccxtools")
         base_name = get_namefromdef("test_")
         res_obj_name = "CCX_Results"
@@ -120,7 +109,6 @@ class TestCcxTools(unittest.TestCase):
 
         # test input file writing
         fea = self.input_file_writing_test(
-            None,
             base_name,
             analysis_dir=analysis_dir,
             test_end=True,
@@ -128,7 +116,6 @@ class TestCcxTools(unittest.TestCase):
 
         # test result reading
         self.result_reading_test(
-            None,
             base_name,
             analysis_dir=analysis_dir,
             fea=fea,
@@ -136,9 +123,224 @@ class TestCcxTools(unittest.TestCase):
         )
 
     # ********************************************************************************************
+    def test_ccx_buckling_flexuralbuckling(self):
+        from femexamples.ccx_buckling_flexuralbuckling import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_beam_circle(self):
+        from femexamples.ccx_cantilever_beam_circle import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_beam_pipe(self):
+        from femexamples.ccx_cantilever_beam_pipe import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_beam_rect(self):
+        from femexamples.ccx_cantilever_beam_rect import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_ele_hexa20(self):
+        from femexamples.ccx_cantilever_ele_hexa20 import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_ele_quad4(self):
+        from femexamples.ccx_cantilever_ele_quad4 import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_ele_quad8(self):
+        from femexamples.ccx_cantilever_ele_quad8 import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_ele_seg2(self):
+        from femexamples.ccx_cantilever_ele_seg2 import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_ele_seg3(self):
+        from femexamples.ccx_cantilever_ele_seg3 import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_ele_tria3(self):
+        from femexamples.ccx_cantilever_ele_tria3 import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_ele_tria6(self):
+        from femexamples.ccx_cantilever_ele_tria6 import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_faceload(self):
+        from femexamples.ccx_cantilever_faceload import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_nodeload(self):
+        from femexamples.ccx_cantilever_nodeload import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_ccx_cantilever_prescribeddisplacement(self):
+        from femexamples.ccx_cantilever_prescribeddisplacement import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_constraint_centrif(self):
+        # TODO does pass on my local machine, but not on ci
+        return
+
+        from femexamples.constraint_centrif import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_constraint_contact_shell_shell(self):
+        from femexamples.constraint_contact_shell_shell import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_constraint_contact_solid_solid(self):
+        # TODO does pass on my local machine, but not on ci
+        return
+
+        from femexamples.constraint_contact_solid_solid import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_constraint_sectionprint(self):
+        from femexamples.constraint_section_print import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_constraint_selfweight_cantilever(self):
+        from femexamples.constraint_selfweight_cantilever import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_constraint_tie(self):
+        from femexamples.constraint_tie import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_constraint_transform_beam_hinged(self):
+        from femexamples.constraint_transform_beam_hinged import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_constraint_transform_torque(self):
+        from femexamples.constraint_transform_torque import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_frequency_beamsimple(self):
+        from femexamples.frequency_beamsimple import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_material_multiple_bendingbeam_fiveboxes(self):
+        from femexamples.material_multiple_bendingbeam_fiveboxes import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_material_multiple_bendingbeam_fivefaces(self):
+        from femexamples.material_multiple_bendingbeam_fivefaces import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_material_multiple_tensionrod_twoboxes(self):
+        from femexamples.material_multiple_tensionrod_twoboxes import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_material_nonlinear(self):
+        from femexamples.material_nl_platewithhole import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_square_pipe_end_twisted_edgeforces(self):
+        from femexamples.square_pipe_end_twisted_edgeforces import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_square_pipe_end_twisted_nodeforces(self):
+        from femexamples.square_pipe_end_twisted_nodeforces import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
+    def test_thermomech_bimetall(self):
+        from femexamples.thermomech_bimetall import setup
+
+        setup(self.document, "ccxtools")
+        self.input_file_writing_test(get_namefromdef("test_"))
+
+    # ********************************************************************************************
     def input_file_writing_test(
         self,
-        test_name,
         base_name,
         analysis_dir=None,
         test_end=False,
@@ -146,8 +348,7 @@ class TestCcxTools(unittest.TestCase):
         fcc_print(
             "\n--------------- "
             "Start of FEM ccxtools {} test"
-            "---------------"
-            .format(base_name)
+            "---------------".format(base_name)
         )
 
         if analysis_dir is None:
@@ -161,14 +362,14 @@ class TestCcxTools(unittest.TestCase):
         fea.setup_working_dir(analysis_dir)
         self.assertTrue(
             True if fea.working_dir == analysis_dir else False,
-            "Setting working directory {} failed".format(analysis_dir)
+            "Setting working directory {} failed".format(analysis_dir),
         )
 
         fcc_print("Checking FEM inp file prerequisites for {} ...".format(base_name))
         error = fea.check_prerequisites()
         self.assertFalse(
             error,
-            "ccxtools check_prerequisites returned error message: {}".format(error)
+            "ccxtools check_prerequisites returned error message: {}".format(error),
         )
 
         inpfile_given = join(self.test_file_dir, (base_name + ".inp"))
@@ -176,40 +377,29 @@ class TestCcxTools(unittest.TestCase):
         fcc_print("Checking FEM inp file write...")
         fcc_print("Writing {} for {}".format(inpfile_totest, base_name))
         error = fea.write_inp_file()
-        self.assertFalse(
-            error,
-            "Writing failed"
-        )
+        self.assertFalse(error, "Writing failed")
 
         fcc_print("Comparing {} to {}".format(inpfile_given, inpfile_totest))
         ret = testtools.compare_inp_files(inpfile_given, inpfile_totest)
-        self.assertFalse(
-            ret,
-            "ccxtools write_inp_file test failed.\n{}".format(ret)
-        )
+        self.assertFalse(ret, "ccxtools write_inp_file test failed.\n{}".format(ret))
 
         if test_end is True:
             # do not save and print End of tests
             return fea
 
         save_fc_file = join(analysis_dir, base_name + ".FCStd")
-        fcc_print(
-            "Save FreeCAD file for {} to {}..."
-            .format(base_name, save_fc_file)
-        )
+        fcc_print("Save FreeCAD file for {} to {}...".format(base_name, save_fc_file))
         self.document.saveAs(save_fc_file)
 
         fcc_print(
-            "\n--------------- "
-            "End of FEM ccxtools {}"
-            "---------------"
-            .format(base_name)
+            "\n--------------- " "End of FEM ccxtools {}" "---------------".format(
+                base_name
+            )
         )
 
     # ********************************************************************************************
     def result_reading_test(
         self,
-        test_name,
         base_name,
         analysis_dir,
         fea,
@@ -218,62 +408,44 @@ class TestCcxTools(unittest.TestCase):
         inpfile_given = join(self.test_file_dir, (base_name + ".inp"))
 
         fcc_print(
-            "Setting up working directory to {} in order to read simulated calculations"
-            .format(self.test_file_dir)
+            "Setting up working directory to {} in order to read simulated calculations".format(
+                self.test_file_dir
+            )
         )
         fea.setup_working_dir(self.test_file_dir)
         self.assertTrue(
             True if fea.working_dir == self.test_file_dir else False,
-            "Setting working directory {} failed".format(self.test_file_dir)
+            "Setting working directory {} failed".format(self.test_file_dir),
         )
 
-        fcc_print(
-            "Setting base name to read test {}.frd file..."
-            .format(base_name)
-        )
+        fcc_print("Setting base name to read test {}.frd file...".format(base_name))
         fea.set_base_name(base_name)
         self.assertTrue(
             True if fea.base_name == base_name else False,
-            "Setting base name to {} failed".format(base_name)
+            "Setting base name to {} failed".format(base_name),
         )
 
-        fcc_print(
-            "Setting inp file name to read test {}.frd file..."
-            .format(base_name)
-        )
+        fcc_print("Setting inp file name to read test {}.frd file...".format(base_name))
         fea.set_inp_file_name()
         self.assertTrue(
             True if fea.inp_file_name == inpfile_given else False,
-            "Setting inp file name to {} failed".format(inpfile_given)
+            "Setting inp file name to {} failed".format(inpfile_given),
         )
 
         fcc_print("Checking FEM frd file read from {}...".format(base_name))
         fea.load_results()
         self.assertTrue(
             fea.results_present,
-            "Cannot read results from {}.frd frd file".format(fea.base_name)
+            "Cannot read results from {}.frd frd file".format(fea.base_name),
         )
 
         fcc_print("Reading stats from result object for {}...".format(base_name))
-        expected_values = join(
-            self.test_file_dir,
-            base_name + "_expected_values"
-        )
-        ret = testtools.compare_stats(
-            fea,
-            expected_values,
-            res_obj_name
-        )
-        self.assertFalse(
-            ret,
-            "Invalid results read from .frd file"
-        )
+        expected_values = join(self.test_file_dir, base_name + "_expected_values")
+        ret = testtools.compare_stats(fea, expected_values, res_obj_name)
+        self.assertFalse(ret, "Invalid results read from .frd file")
 
         save_fc_file = join(analysis_dir, base_name + ".FCStd")
-        fcc_print(
-            "Save FreeCAD file for {} to {}..."
-            .format(base_name, save_fc_file)
-        )
+        fcc_print("Save FreeCAD file for {} to {}...".format(base_name, save_fc_file))
         self.document.saveAs(save_fc_file)
 
         fcc_print("--------------- End of {} -------------------".format(base_name))
@@ -281,7 +453,6 @@ class TestCcxTools(unittest.TestCase):
 
 # ************************************************************************************************
 def create_test_results():
-
     import os
     import shutil
     import unittest
@@ -293,16 +464,26 @@ def create_test_results():
     temp_dir = testtools.get_fem_test_tmp_dir()
     test_class = "femtest.app.test_ccxtools.TestCcxTools"  # unit test class
     stat_types = [
-        "U1", "U2", "U3", "Uabs", "Sabs",
-        "MaxPrin", "MidPrin", "MinPrin", "MaxShear",
-        "Peeq", "Temp", "MFlow", "NPress"
+        "U1",
+        "U2",
+        "U3",
+        "Uabs",
+        "Sabs",
+        "MaxPrin",
+        "MidPrin",
+        "MinPrin",
+        "MaxShear",
+        "Peeq",
+        "Temp",
+        "MFlow",
+        "NPress",
     ]
 
     # ****************************************************************************
     # static cube
     print("create static result files")
-    unittest.TextTestRunner().run(unittest.TestLoader().loadTestsFromName(
-        test_class + ".test_static_analysis")
+    unittest.TextTestRunner().run(
+        unittest.TestLoader().loadTestsFromName(test_class + ".test_static_analysis")
     )
     static_analysis_dir = join(temp_dir, "FEM_ccx_static")
     doc_static_cube = FreeCAD.open(join(static_analysis_dir, "cube_static.FCStd"))
@@ -318,12 +499,10 @@ def create_test_results():
     for s in stat_types:
         statval = resulttools.get_stats(res_obj_static, s)
         stats_static.append(
-            "{0}: ({1:.14g}, {2:.14g}, )\n"
-            .format(s, statval[0], statval[1])
+            "{0}: ({1:.14g}, {2:.14g}, )\n".format(s, statval[0], statval[1])
         )
     static_expected_values_file = join(
-        static_analysis_dir,
-        "cube_static_expected_values"
+        static_analysis_dir, "cube_static_expected_values"
     )
     f = open(static_expected_values_file, "w")
     for s in stats_static:
@@ -340,11 +519,13 @@ def create_test_results():
     # ****************************************************************************
     # frequency cube
     print("create frequency result files")
-    unittest.TextTestRunner().run(unittest.TestLoader().loadTestsFromName(
-        test_class + ".test_freq_analysis")
+    unittest.TextTestRunner().run(
+        unittest.TestLoader().loadTestsFromName(test_class + ".test_freq_analysis")
     )
     frequency_analysis_dir = join(temp_dir, "FEM_ccx_frequency")
-    doc_frequency_cube = FreeCAD.open(join(frequency_analysis_dir, "cube_frequency.FCStd"))
+    doc_frequency_cube = FreeCAD.open(
+        join(frequency_analysis_dir, "cube_frequency.FCStd")
+    )
     FemGui.setActiveAnalysis(doc_frequency_cube.Analysis)
     fea = ccxtools.FemToolsCcx()
     fea.update_objects()
@@ -359,12 +540,10 @@ def create_test_results():
     for s in stat_types:
         statval = resulttools.get_stats(res_obj_freq, s)
         stats_frequency.append(
-            "{0}: ({1:.14g}, {2:.14g})\n"
-            .format(s, statval[0], statval[1])
+            "{0}: ({1:.14g}, {2:.14g})\n".format(s, statval[0], statval[1])
         )
     frequency_expected_values_file = join(
-        frequency_analysis_dir,
-        "cube_frequency_expected_values"
+        frequency_analysis_dir, "cube_frequency_expected_values"
     )
     f = open(frequency_expected_values_file, "w")
     for s in stats_frequency:


### PR DESCRIPTION
Closes #12965 
* Migrated tests from test_solver_calculix to test_ccxtools (consequence of `calculix` removal, #12876)
* Removed `test_name` from functions' parameters: was unused
* Ran code formatter