### PR TITLE
Fix Material resource location

### DIFF
--- a/src/Tools/updatecrowdin.py
+++ b/src/Tools/updatecrowdin.py
@@ -141,8 +141,8 @@ locations = [
     ],
     [
         "Material",
-        "../Mod/Material/Gui/Resources/translations",
-        "../Mod/Material/Gui/Resources/Material.qrc",
+        "../Mod/Material/Resources/translations",
+        "../Mod/Material/Resources/Material.qrc",
     ],
     [
         "Mesh",


### PR DESCRIPTION
Material's translation resources are not in the Gui subdirectory.