### PR TITLE
Add uncoupled temp-disp and heat transfer CalculiX FEM analysis types

### DIFF
--- a/src/Mod/Fem/feminout/importToolsFem.py
+++ b/src/Mod/Fem/feminout/importToolsFem.py
@@ -350,6 +350,7 @@ def fill_femresult_mechanical(
         step_time = result_set["time"]
         step_time = round(step_time, 2)
 
+    disp = None
     # if disp exists, fill res_obj.NodeNumbers and
     # res_obj.DisplacementVectors as well as stress and strain
     # furthermore the eigenmode number
@@ -430,26 +431,29 @@ def fill_femresult_mechanical(
         if eigenmode_number > 0:
             res_obj.Eigenmode = eigenmode_number
 
-        # it is assumed Temperature can not exist without disp
-        # TODO really proof this
-        # if temperature can exist without disp:
-        # move them out of disp if conditiona and set NodeNumbers
-        if "temp" in result_set:
-            Temperature = result_set["temp"]
-            if len(Temperature) > 0:
-                if len(Temperature.values()) != len(disp.values()):
-                    Temp = []
-                    Temp_extra_nodes = list(Temperature.values())
-                    nodes = len(disp.values())
-                    for i in range(nodes):
-                        # how is this possible? An example is needed!
-                        Console.PrintError("Temperature seems to have extra nodes.\n")
-                        Temp_value = Temp_extra_nodes[i]
-                        Temp.append(Temp_value)
-                    res_obj.Temperature = list(map((lambda x: x), Temp))
-                else:
-                    res_obj.Temperature = list(map((lambda x: x), Temperature.values()))
-                res_obj.Time = step_time
+    # it is assumed Temperature can not exist without disp
+    # TODO really proof this
+    # if temperature can exist without disp:
+    # move them out of disp if conditiona and set NodeNumbers
+    if "temp" in result_set:
+        Temperature = result_set["temp"]
+        if len(Temperature) > 0:
+            if disp is None:
+                res_obj.Temperature = list(Temperature.values())
+                res_obj.NodeNumbers = list(Temperature.keys())
+            elif len(Temperature.values()) != len(disp.values()):
+                Temp = []
+                Temp_extra_nodes = list(Temperature.values())
+                nodes = len(disp.values())
+                for i in range(nodes):
+                    # how is this possible? An example is needed!
+                    Console.PrintError("Temperature seems to have extra nodes.\n")
+                    Temp_value = Temp_extra_nodes[i]
+                    Temp.append(Temp_value)
+                res_obj.Temperature = list(map((lambda x: x), Temp))
+            else:
+                res_obj.Temperature = list(map((lambda x: x), Temperature.values()))
+            res_obj.Time = step_time
 
     # fill res_obj.MassFlow
     if "mflow" in result_set:

--- a/src/Mod/Fem/femsolver/calculix/solver.py
+++ b/src/Mod/Fem/femsolver/calculix/solver.py
@@ -429,6 +429,20 @@ def add_attributes(obj, ccx_prefs):
         )
         obj.ModelSpace = model_space_types
 
+    if not hasattr(obj, "ThermoMechType"):
+        thermomech_types = [
+            "coupled",
+            "uncoupled",
+            "pure heat transfer"
+        ]
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "ThermoMechType",
+            "Fem",
+            "Type of thermomechanical analysis"
+        )
+        obj.ThermoMechType = thermomech_types
+
 """
 Should there be some equation object for Calculix too?
 

--- a/src/Mod/Fem/femsolver/calculix/write_step_equation.py
+++ b/src/Mod/Fem/femsolver/calculix/write_step_equation.py
@@ -71,7 +71,12 @@ def write_step_equation(f, ccxwriter):
     elif ccxwriter.analysis_type == "frequency":
         analysis_type = "*FREQUENCY"
     elif ccxwriter.analysis_type == "thermomech":
-        analysis_type = "*COUPLED TEMPERATURE-DISPLACEMENT"
+        if ccxwriter.solver_obj.ThermoMechType == "coupled":
+            analysis_type = "*COUPLED TEMPERATURE-DISPLACEMENT"
+        elif ccxwriter.solver_obj.ThermoMechType == "uncoupled":
+            analysis_type = "*UNCOUPLED TEMPERATURE-DISPLACEMENT"
+        elif ccxwriter.solver_obj.ThermoMechType == "pure heat transfer":
+            analysis_type = "*HEAT TRANSFER"
     elif ccxwriter.analysis_type == "check":
         analysis_type = "*NO ANALYSIS"
     elif ccxwriter.analysis_type == "buckling":


### PR DESCRIPTION
fixes #11646 and also adds uncoupled temp-disp analysis type

a new property `Thermo Mech Type` is added; by default, it's set to `coupled` - nothing changes, but it can be also set to `uncoupled` (then the analysis type is uncoupled temperature-displacement) or `pure heat transfer` (then the analysis type is heat transfer)