### PR TITLE
App/Toponaming: GeoFeature - fixes #13009 - fixes #13248

### DIFF
--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -87,6 +87,12 @@ GeoFeature::getElementName(const char *name, ElementNameType type) const
     std::pair<std::string,std::string> ret;
     if(!name)
         return ret;
+
+#ifndef FC_USE_TNP_FIX
+    ret.second = name;
+
+    return ret;
+#else
     auto prop = getPropertyOfGeometry();
     if (!prop) {
         return std::make_pair("", name);
@@ -98,6 +104,7 @@ GeoFeature::getElementName(const char *name, ElementNameType type) const
     }
 
     return _getElementName(name, geo->getElementName(name));
+#endif
 }
 
 std::pair<std::string, std::string>

--- a/tests/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObject.cpp
@@ -276,10 +276,19 @@ TEST_F(SketchObjectTest, testGetElementName)
     EXPECT_STREQ(map[0].name.toString().c_str(), "g39;SKT");
     EXPECT_EQ(map[0].index.toString(), "Edge1");
     // Assert
+#ifndef FC_USE_TNP_FIX
+    EXPECT_STREQ(forward_normal_name.first.c_str(), "");
+    EXPECT_STREQ(forward_normal_name.second.c_str(), "g39;SKT");
+    EXPECT_STREQ(reverse_normal_name.first.c_str(), "");
+    EXPECT_STREQ(reverse_normal_name.second.c_str(), "Vertex2");
+    EXPECT_STREQ(reverse_export_name.first.c_str(), "");
+    EXPECT_STREQ(reverse_export_name.second.c_str(), "Vertex1");
+#else
     EXPECT_STREQ(forward_normal_name.first.c_str(), ";g39;SKT.Edge1");
     EXPECT_STREQ(forward_normal_name.second.c_str(), "Edge1");
     EXPECT_STREQ(reverse_normal_name.first.c_str(), ";g39v2;SKT.Vertex2");
     EXPECT_STREQ(reverse_normal_name.second.c_str(), "Vertex2");
     EXPECT_STREQ(reverse_export_name.first.c_str(), ";g39v1;SKT.Vertex1");
     EXPECT_STREQ(reverse_export_name.second.c_str(), "Vertex1");
+#endif
 }


### PR DESCRIPTION
 * Restored previous logic of GeoFeature::getElementName()
 * Added precompiler directive to use the old logic if FC_USE_TNP_FIX isn't defined, otherwise use the new logic
 * Reworked SketchObjectTest::getElementName() as a consequence of the previous points

fixes #13009
fixes #13248