### PR TITLE
Core: Add properties to variable sets

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -371,6 +371,7 @@ SET(Gui_UIC_SRCS
     TaskElementColors.ui
     DlgObjectSelection.ui
     DlgAddProperty.ui
+    DlgAddPropertyVarSet.ui
     VectorListEditor.ui
 )
 
@@ -458,6 +459,7 @@ SET(Dialog_CPP_SRCS
     TaskMeasure.cpp
     DlgObjectSelection.cpp
     DlgAddProperty.cpp
+    DlgAddPropertyVarSet.cpp
     VectorListEditor.cpp
 )
 
@@ -498,6 +500,7 @@ SET(Dialog_HPP_SRCS
     TaskMeasure.h
     DlgObjectSelection.h
     DlgAddProperty.h
+    DlgAddPropertyVarSet.h
     VectorListEditor.h
 )
 

--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -34,7 +34,6 @@
 #include "Document.h"
 #include "ViewProviderDocumentObject.h"
 
-
 using namespace Gui;
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -126,6 +125,40 @@ bool StdCmdGroup::isActive()
     return hasActiveDocument();
 }
 
+//===========================================================================
+// Std_VarSet
+//===========================================================================
+DEF_STD_CMD_A(StdCmdVarSet)
+
+StdCmdVarSet::StdCmdVarSet()
+  : Command("Std_VarSet")
+{
+    sGroup        = "Structure";
+    sMenuText     = QT_TR_NOOP("Create a variable set");
+    sToolTipText  = QT_TR_NOOP("A Variable Set is an object that maintains a set of properties to be used as "
+                               "variables.");
+    sWhatsThis    = "Std_VarSet";
+    sStatusTip    = sToolTipText;
+    sPixmap       = "VarSet";
+}
+
+void StdCmdVarSet::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+
+    openCommand(QT_TRANSLATE_NOOP("Command", "Add a variable set"));
+
+    std::string VarSetName;
+    VarSetName = getUniqueObjectName("VarSet");
+    doCommand(Doc,"App.activeDocument().addObject('App::VarSet','%s')",VarSetName.c_str());
+    doCommand(Doc, "App.ActiveDocument.getObject('%s').ViewObject.doubleClicked()", VarSetName.c_str());
+}
+
+bool StdCmdVarSet::isActive()
+{
+    return hasActiveDocument();
+}
+
 namespace Gui {
 
 void CreateStructureCommands()
@@ -134,6 +167,7 @@ void CreateStructureCommands()
 
     rcCmdMgr.addCommand(new StdCmdPart());
     rcCmdMgr.addCommand(new StdCmdGroup());
+    rcCmdMgr.addCommand(new StdCmdVarSet());
 }
 
 } // namespace Gui

--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -26,13 +26,15 @@
 #include <QApplication>
 #endif
 
-#include "App/Document.h"
+#include <App/GroupExtension.h>
+#include <App/Document.h>
 
 #include "Command.h"
 #include "ActiveObjectList.h"
 #include "Application.h"
 #include "Document.h"
 #include "ViewProviderDocumentObject.h"
+#include "Selection.h"
 
 using namespace Gui;
 
@@ -151,6 +153,20 @@ void StdCmdVarSet::activated(int iMsg)
     std::string VarSetName;
     VarSetName = getUniqueObjectName("VarSet");
     doCommand(Doc,"App.activeDocument().addObject('App::VarSet','%s')",VarSetName.c_str());
+
+    // add the varset to a group if it is selected
+    auto sels = Selection().getSelectionEx(nullptr, App::DocumentObject::getClassTypeId(),
+                                           ResolveMode::OldStyleElement, true);
+    if (sels.size() == 1) {
+        App::DocumentObject *obj = sels[0].getObject();
+        auto group = obj->getExtension<App::GroupExtension>();
+        if (group) {
+            Gui::Document* docGui = Application::Instance->activeDocument();
+            App::Document* doc = docGui->getDocument();
+            group->addObject(doc->getObject(VarSetName.c_str()));
+        }
+    }
+
     doCommand(Doc, "App.ActiveDocument.getObject('%s').ViewObject.doubleClicked()", VarSetName.c_str());
 }
 

--- a/src/Gui/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/DlgAddPropertyVarSet.cpp
@@ -1,0 +1,393 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <QMessageBox>
+# include <QString>
+# include <QCompleter>
+#endif
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/PropertyUnits.h>
+#include <Base/Tools.h>
+
+#include "DlgAddPropertyVarSet.h"
+#include "ui_DlgAddPropertyVarSet.h"
+#include "MainWindow.h"
+#include "ViewProviderDocumentObject.h"
+#include "ViewProviderVarSet.h"
+
+FC_LOG_LEVEL_INIT("DlgAddPropertyVarSet", true, true)
+
+using namespace Gui;
+using namespace Gui::Dialog;
+
+const std::string DlgAddPropertyVarSet::GROUP_BASE = "Base";
+
+DlgAddPropertyVarSet::DlgAddPropertyVarSet(QWidget* parent,
+                                           ViewProviderVarSet* viewProvider)
+    : QDialog(parent),
+      varSet(dynamic_cast<App::VarSet*>(viewProvider->getObject())),
+      ui(new Ui_DlgAddPropertyVarSet),
+      comboBoxGroup(this),
+      completerType(this),
+      editor(nullptr)
+{
+    ui->setupUi(this);
+
+    initializeWidgets(viewProvider);
+}
+
+DlgAddPropertyVarSet::~DlgAddPropertyVarSet() = default;
+
+void DlgAddPropertyVarSet::initializeGroup()
+{
+    connect(&comboBoxGroup, &EditFinishedComboBox::editFinished,
+            this, &DlgAddPropertyVarSet::onGroupDetermined);
+    comboBoxGroup.setObjectName(QString::fromUtf8("comboBoxGroup"));
+    comboBoxGroup.setInsertPolicy(QComboBox::InsertAtTop);
+    comboBoxGroup.setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    comboBoxGroup.setEditable(true);
+    auto formLayout = qobject_cast<QFormLayout*>(layout());
+    formLayout->setWidget(1, QFormLayout::FieldRole, &comboBoxGroup);
+
+    std::vector<App::Property*> properties;
+    varSet->getPropertyList(properties);
+    std::unordered_set<std::string> groupNames;
+    for (auto prop : properties) {
+        const char* groupName = varSet->getPropertyGroup(prop);
+        groupNames.insert(groupName ? groupName : GROUP_BASE);
+    }
+    std::vector<std::string> groupNamesSorted(groupNames.begin(), groupNames.end());
+    std::sort(groupNamesSorted.begin(), groupNamesSorted.end(), [](std::string& a, std::string& b) {
+        // prefer anything else other than Base, so move it to the back
+        if (a == GROUP_BASE) {
+            return false;
+        }
+        else if (b == GROUP_BASE) {
+            return true;
+        }
+        else {
+            return a < b;
+        }
+    });
+
+    for (const auto& groupName : groupNamesSorted) {
+        comboBoxGroup.addItem(QString::fromStdString(groupName));
+    }
+
+    comboBoxGroup.setEditText(QString::fromStdString(groupNamesSorted[0]));
+}
+
+void DlgAddPropertyVarSet::initializeTypes()
+{
+    auto paramGroup = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/PropertyView");
+    auto lastType = Base::Type::fromName(
+            paramGroup->GetASCII("NewPropertyType","App::PropertyLength").c_str());
+    if(lastType.isBad()) {
+        lastType = App::PropertyLength::getClassTypeId();
+    }
+
+    std::vector<Base::Type> types;
+    Base::Type::getAllDerivedFrom(Base::Type::fromName("App::Property"),types);
+    std::sort(types.begin(), types.end(), [](Base::Type a, Base::Type b) { return strcmp(a.getName(), b.getName()) < 0; });
+
+    for(const auto& type : types) {
+        ui->comboBoxType->addItem(QString::fromLatin1(type.getName()));
+        if(type == lastType)
+            ui->comboBoxType->setCurrentIndex(ui->comboBoxType->count()-1);
+    }
+
+    completerType.setModel(ui->comboBoxType->model());
+    completerType.setCaseSensitivity(Qt::CaseInsensitive);
+    completerType.setFilterMode(Qt::MatchContains);
+    ui->comboBoxType->setCompleter(&completerType);
+    ui->comboBoxType->setInsertPolicy(QComboBox::NoInsert);
+
+    connect(ui->comboBoxType, qOverload<int>(&QComboBox::currentIndexChanged),
+            this, &DlgAddPropertyVarSet::onTypePropertyDetermined);
+}
+
+/*
+// keep some debugging code for debugging tab order
+static void printFocusChain(QWidget *widget) {
+    FC_ERR("Focus Chain:");
+    QWidget* start = widget;
+    int i = 0;
+    do {
+        FC_ERR(" " << widget->objectName().toUtf8().constData());
+        widget = widget->nextInFocusChain();
+        i++;
+    } while (widget != nullptr && i < 30 && start != widget);
+    QWidget *currentWidget = QApplication::focusWidget();
+    FC_ERR("  Current focus widget:" << (currentWidget ? currentWidget->objectName().toUtf8().constData() : "None") << std::endl << std::endl);
+}
+*/
+
+void DlgAddPropertyVarSet::initializeWidgets(ViewProviderVarSet* viewProvider)
+{
+    initializeGroup();
+    initializeTypes();
+
+    connect(this, &QDialog::finished,
+            this, [viewProvider](int result) { viewProvider->onFinished(result); });
+    connect(ui->lineEditName, &QLineEdit::editingFinished,
+            this, &DlgAddPropertyVarSet::onNamePropertyDetermined);
+
+    std::string title = "Add a property to " + varSet->getFullName();
+    setWindowTitle(QString::fromStdString(title));
+
+    setOkEnabled(false);
+
+    ui->lineEditName->setFocus();
+
+    QWidget::setTabOrder(ui->lineEditName, &comboBoxGroup);
+    QWidget::setTabOrder(&comboBoxGroup, ui->comboBoxType);
+
+    // FC_ERR("Initialize widgets");
+    // printFocusChain(ui->lineEditName);
+}
+
+void DlgAddPropertyVarSet::setOkEnabled(bool enabled)
+{
+    QPushButton *okButton = ui->buttonBox->button(QDialogButtonBox::Ok);
+    okButton->setEnabled(enabled);
+}
+
+void DlgAddPropertyVarSet::clearEditors()
+{
+    ui->lineEditName->clear();
+    removeEditor();
+    setOkEnabled(false);
+    namePropertyToAdd.clear();
+    editor = nullptr;
+}
+
+void DlgAddPropertyVarSet::removeEditor()
+{
+    if (editor) {
+        layout()->removeWidget(editor.get());
+        QWidget::setTabOrder(ui->comboBoxType, ui->checkBoxAdd);
+
+        // FC_ERR("remove editor");
+        // printFocusChain(ui->comboBoxType);
+    }
+}
+
+static PropertyEditor::PropertyItem *createPropertyItem(App::Property *prop)
+{
+    const char *editor = prop->getEditorName();
+    if (!editor || !editor[0]) {
+        return nullptr;
+    }
+    auto item = static_cast<PropertyEditor::PropertyItem*>(
+            PropertyEditor::PropertyItemFactory::instance().createPropertyItem(editor));
+    if (!item) {
+        qWarning("No property item for type %s found\n", editor);
+    }
+    return item;
+}
+
+void DlgAddPropertyVarSet::addEditor(PropertyEditor::PropertyItem* propertyItem, std::string& /*type*/)
+{
+    editor.reset(propertyItem->createEditor(this, this, SLOT(valueChanged())));
+    editor->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    editor->setObjectName(QString::fromUtf8("editor"));
+    auto formLayout = qobject_cast<QFormLayout*>(layout());
+    formLayout->setWidget(3, QFormLayout::FieldRole, editor.get());
+
+    QWidget::setTabOrder(ui->comboBoxType, editor.get());
+    QWidget::setTabOrder(editor.get(), ui->checkBoxAdd);
+
+    // FC_ERR("add editor");
+    // printFocusChain(editor.get());
+}
+
+bool DlgAddPropertyVarSet::isSupportedType(std::string& type)
+{
+    return unsupportedTypes.find(type) == unsupportedTypes.end();
+}
+
+void DlgAddPropertyVarSet::createProperty(std::string& name, std::string& group)
+{
+    std::string type = ui->comboBoxType->currentText().toUtf8().constData();
+
+    App::Property* prop;
+    try {
+        prop = varSet->addDynamicProperty(type.c_str(), name.c_str(),
+                                          group.c_str());
+    }
+    catch (Base::Exception& e) {
+        e.ReportException();
+        QMessageBox::critical(this,
+                              QObject::tr("Add property"),
+                              QObject::tr("Failed to add property to '%1': %2").arg(
+                                      QString::fromLatin1(varSet->getFullName().c_str()),
+                                      QString::fromUtf8(e.what())));
+        clearEditors();
+        return;
+    }
+
+    namePropertyToAdd = name;
+
+    objectIdentifier = std::make_unique<App::ObjectIdentifier>(*prop);
+    // creating a propertyItem here because it has all kinds of logic for
+    // editors that we can reuse
+    removeEditor();
+    propertyItem.reset(createPropertyItem(prop));
+    if (propertyItem && isSupportedType(type)) {
+        propertyItem->setPropertyData({prop});
+        propertyItem->bind(*objectIdentifier);
+             addEditor(propertyItem.get(), type);
+    }
+
+    setOkEnabled(true);
+}
+
+void DlgAddPropertyVarSet::onNamePropertyDetermined()
+{
+    if (!namePropertyToAdd.empty()) {
+        // we were already adding a name, so remove that property
+        varSet->removeDynamicProperty(namePropertyToAdd.c_str());
+    }
+    QString nameProperty = ui->lineEditName->text();
+    std::string name = nameProperty.toUtf8().constData();
+    std::string group = comboBoxGroup.currentText().toUtf8().constData();
+    if(name.empty() || group.empty()
+       || name != Base::Tools::getIdentifier(name)
+       || group != Base::Tools::getIdentifier(group)) {
+        QMessageBox::critical(getMainWindow(),
+                              QObject::tr("Invalid name"),
+                              QObject::tr("The property name or group name must only contain alpha numericals,\n"
+                                          "underscore, and must not start with a digit."));
+        clearEditors();
+        return;
+    }
+
+    auto prop = varSet->getPropertyByName(name.c_str());
+    if(prop && prop->getContainer() == varSet) {
+        QMessageBox::critical(this,
+                              QObject::tr("Invalid name"),
+                              QObject::tr("The property '%1' already exists in '%2'").arg(
+                                      QString::fromLatin1(name.c_str()),
+                                      QString::fromLatin1(varSet->getFullName().c_str())));
+        clearEditors();
+        return;
+    }
+
+    App::Document* doc = varSet->getDocument();
+    doc->openTransaction("Add property VarSet");
+    createProperty(name, group);
+
+    // FC_ERR("chain onNameDetermined");
+    // printFocusChain(ui->lineEditName);
+}
+
+void DlgAddPropertyVarSet::onGroupDetermined()
+{
+    std::string group = comboBoxGroup.currentText().toUtf8().constData();
+
+    if (group.empty() || group != Base::Tools::getIdentifier(group)) {
+        QMessageBox::critical(this,
+            QObject::tr("Invalid name"),
+            QObject::tr("The group name must only contain alpha numericals,\n"
+                        "underscore, and must not start with a digit."));
+        comboBoxGroup.setEditText(QString::fromUtf8("Base"));
+        return;
+    }
+
+    if (!namePropertyToAdd.empty()) {
+        // we were already adding a property
+        App::Property* prop = varSet->getPropertyByName(namePropertyToAdd.c_str());
+        if (prop->getGroup() != group) {
+            varSet->changeDynamicProperty(prop, group.c_str(), nullptr);
+        }
+    }
+
+    // FC_ERR("chain onGroupDetermined");
+    // printFocusChain(&comboBoxGroup);
+    ui->comboBoxType->setFocus();
+}
+
+void DlgAddPropertyVarSet::onTypePropertyDetermined()
+{
+    std::string type = ui->comboBoxType->currentText().toUtf8().constData();
+
+    if (!namePropertyToAdd.empty()) {
+        // we were already adding a name, so check this property
+        App::Property* prop = varSet->getPropertyByName(namePropertyToAdd.c_str());
+
+        if (prop->getTypeId() != Base::Type::fromName(type.c_str())) {
+            // the property should have a different type
+            std::string group = prop->getGroup();
+            varSet->removeDynamicProperty(namePropertyToAdd.c_str());
+            createProperty(namePropertyToAdd, group);
+        }
+    }
+}
+
+void DlgAddPropertyVarSet::valueChanged()
+{
+    QWidget* editor = qobject_cast<QWidget*>(sender());
+    QVariant data;
+    data = propertyItem->editorData(editor);
+
+    propertyItem->setData(data);
+}
+
+void DlgAddPropertyVarSet::accept()
+{
+    App::Document* doc = varSet->getDocument();
+    doc->commitTransaction();
+
+    if (ui->checkBoxAdd->isChecked()) {
+        clearEditors();
+        doc->openTransaction();
+        ui->lineEditName->setFocus();
+        return;
+    }
+
+    std::string group = comboBoxGroup.currentText().toUtf8().constData();
+    std::string type = ui->comboBoxType->currentText().toUtf8().constData();
+    auto paramGroup = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/PropertyView");
+    paramGroup->SetASCII("NewPropertyType", type.c_str());
+    paramGroup->SetASCII("NewPropertyGroup", group.c_str());
+    QDialog::accept();
+}
+
+void DlgAddPropertyVarSet::reject()
+{
+    App::Document* doc = varSet->getDocument();
+    // a transaction is not pending if a name has not been determined.
+    if (doc->hasPendingTransaction()) {
+        doc->abortTransaction();
+    }
+    QDialog::reject();
+}
+
+
+#include "moc_DlgAddPropertyVarSet.cpp"

--- a/src/Gui/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/DlgAddPropertyVarSet.cpp
@@ -213,7 +213,9 @@ static PropertyEditor::PropertyItem *createPropertyItem(App::Property *prop)
 
 void DlgAddPropertyVarSet::addEditor(PropertyEditor::PropertyItem* propertyItem, std::string& /*type*/)
 {
-    editor.reset(propertyItem->createEditor(this, this, SLOT(valueChanged())));
+    editor.reset(propertyItem->createEditor(this, [this]() {
+        this->valueChanged();
+    }));
     editor->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     editor->setObjectName(QString::fromUtf8("editor"));
     auto formLayout = qobject_cast<QFormLayout*>(layout());
@@ -351,10 +353,8 @@ void DlgAddPropertyVarSet::onTypePropertyDetermined()
 
 void DlgAddPropertyVarSet::valueChanged()
 {
-    QWidget* editor = qobject_cast<QWidget*>(sender());
     QVariant data;
-    data = propertyItem->editorData(editor);
-
+    data = propertyItem->editorData(editor.get());
     propertyItem->setData(data);
 }
 

--- a/src/Gui/DlgAddPropertyVarSet.h
+++ b/src/Gui/DlgAddPropertyVarSet.h
@@ -1,0 +1,116 @@
+/****************************************************************************
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#ifndef GUI_DIALOG_DLG_ADD_PROPERTY_VARSET_H
+#define GUI_DIALOG_DLG_ADD_PROPERTY_VARSET_H
+
+#include <qcompleter.h>
+#include <unordered_set>
+#include <QDialog>
+#include <QComboBox>
+#include <FCGlobal.h>
+
+#include <App/VarSet.h>
+
+#include "propertyeditor/PropertyItem.h"
+
+namespace Gui {
+
+class ViewProviderVarSet;
+
+namespace Dialog {
+
+class EditFinishedComboBox : public QComboBox {
+    Q_OBJECT
+public:
+    explicit EditFinishedComboBox(QWidget *parent = nullptr) : QComboBox(parent) {}
+
+Q_SIGNALS:
+    void editFinished();
+
+protected:
+    void focusOutEvent(QFocusEvent *event) override {
+        QComboBox::focusOutEvent(event);
+        Q_EMIT editFinished();
+    }
+};
+
+class Ui_DlgAddPropertyVarSet;
+
+class GuiExport DlgAddPropertyVarSet : public QDialog
+{
+    Q_OBJECT
+
+public:
+    static const std::string GROUP_BASE;
+
+public:
+    DlgAddPropertyVarSet(QWidget *parent, ViewProviderVarSet* viewProvider);
+    ~DlgAddPropertyVarSet() override;
+
+    void accept() override;
+    void reject() override;
+
+public Q_SLOTS:
+    void valueChanged();
+
+private:
+    void initializeGroup();
+    void initializeTypes();
+    void initializeWidgets(ViewProviderVarSet* viewProvider);
+
+    void setOkEnabled(bool enabled);
+    void clearEditors();
+
+    void removeEditor();
+    void addEditor(PropertyEditor::PropertyItem* propertyItem, std::string& type);
+
+    bool isSupportedType(std::string& type);
+    void createProperty(std::string& name, std::string& group);
+
+    void onNamePropertyDetermined();
+    void onGroupDetermined();
+    void onTypePropertyDetermined();
+
+private:
+    std::unordered_set<std::string> unsupportedTypes = {
+        "App::PropertyVector", "App::PropertyVectorDistance", "App::PropertyMatrix",
+        "App::PropertyRotation", "App::PropertyPlacement", "App::PropertyEnumeration"};
+
+    App::VarSet* varSet;
+    std::unique_ptr<Ui_DlgAddPropertyVarSet> ui;
+
+    EditFinishedComboBox comboBoxGroup;
+    QCompleter completerType;
+
+    // state between adding properties
+    std::unique_ptr<QWidget> editor;
+    std::unique_ptr<QWidget> expressionEditor;
+    std::string namePropertyToAdd;
+    std::unique_ptr<PropertyEditor::PropertyItem> propertyItem;
+    std::unique_ptr<App::ObjectIdentifier> objectIdentifier;
+};
+
+} // namespace Dialog
+} // namespace Gui
+
+#endif // GUI_DIALOG_DLG_ADD_PROPERTY_VARSET_H

--- a/src/Gui/DlgAddPropertyVarSet.ui
+++ b/src/Gui/DlgAddPropertyVarSet.ui
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Gui::Dialog::DlgAddPropertyVarSet</class>
+ <widget class="QDialog" name="Gui::Dialog::DlgAddPropertyVarSet">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>418</width>
+    <height>223</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Add property</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="labelName">
+     <property name="text">
+      <string>Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="lineEditName"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="labelGroup">
+     <property name="text">
+      <string>Group</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="labelType">
+     <property name="text">
+      <string>Type</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="comboBoxType">
+     <property name="editable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="labelValue">
+     <property name="text">
+      <string>Value</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QCheckBox" name="checkBoxAdd">
+     <property name="text">
+      <string>Add another</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="labelToolTip">
+     <property name="text">
+      <string>Tooltip</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="lineEditToolTip"/>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>lineEditName</tabstop>
+  <tabstop>comboBoxType</tabstop>
+  <tabstop>checkBoxAdd</tabstop>
+  <tabstop>lineEditToolTip</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Gui::Dialog::DlgAddPropertyVarSet</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>199</x>
+     <y>99</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>199</x>
+     <y>58</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Gui::Dialog::DlgAddPropertyVarSet</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>199</x>
+     <y>99</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>199</x>
+     <y>58</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Gui/ViewProviderVarSet.cpp
+++ b/src/Gui/ViewProviderVarSet.cpp
@@ -21,10 +21,17 @@
  ****************************************************************************/
 
 #include "PreCompiled.h"
+#ifndef _PreComp_
+# include <memory>
+#endif
 
+#include <App/VarSet.h>
+
+#include "MainWindow.h"
 #include "ViewProviderVarSet.h"
 
 using namespace Gui;
+using namespace Gui::Dialog;
 
 PROPERTY_SOURCE(Gui::ViewProviderVarSet, Gui::ViewProviderDocumentObject)
 
@@ -33,4 +40,20 @@ ViewProviderVarSet::ViewProviderVarSet()
     sPixmap = "VarSet";
 }
 
+bool ViewProviderVarSet::doubleClicked()
+{
+    if (!dialog) {
+        dialog = std::make_unique<DlgAddPropertyVarSet>(getMainWindow(), this);
+    }
 
+    dialog->show();
+    dialog->raise();
+    dialog->activateWindow();
+
+    return true;
+}
+
+void ViewProviderVarSet::onFinished(int /*result*/)
+{
+    dialog = nullptr;
+}

--- a/src/Gui/ViewProviderVarSet.h
+++ b/src/Gui/ViewProviderVarSet.h
@@ -24,21 +24,29 @@
 #define GUI_ViewProviderVarSet_H
 
 #include "ViewProviderDocumentObject.h"
+#include "DlgAddPropertyVarSet.h"
 
 namespace Gui {
 
 /** View provider associated with an App::VarSet
  */
-class GuiExport ViewProviderVarSet : public ViewProviderDocumentObject {
+class GuiExport ViewProviderVarSet : public ViewProviderDocumentObject
+{
     PROPERTY_HEADER_WITH_OVERRIDE(Gui::ViewProviderVarSet);
 public:
     ViewProviderVarSet();
     ~ViewProviderVarSet() override = default;
 
     bool isShow() const override { return true; }
+
+    bool doubleClicked() override;
+
+    void onFinished(int);
+
+private:
+    std::unique_ptr<Dialog::DlgAddPropertyVarSet> dialog;
 };
 
-}
+} // namespace Gui
 
 #endif
-

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -822,7 +822,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // Structure
     auto structure = new ToolBarItem( root );
     structure->setCommand("Structure");
-    *structure << "Std_Part" << "Std_Group" << "Std_LinkActions";
+    *structure << "Std_Part" << "Std_Group" << "Std_LinkActions" << "Std_VarSet";
 
     // Help
     auto help = new ToolBarItem( root );

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -24,6 +24,7 @@
 #include "PreCompiled.h"
 
 #include <App/Document.h>
+#include <App/VarSet.h>
 #include <App/Origin.h>
 #include <Base/Placement.h>
 
@@ -227,10 +228,12 @@ bool Body::isAllowed(const App::DocumentObject *obj)
             // TODO Shouldn't we replace it with Sketcher::SketchObject? (2015-08-13, Fat-Zer)
             obj->isDerivedFrom<Part::Part2DObject>() ||
             obj->isDerivedFrom<PartDesign::ShapeBinder>() ||
-            obj->isDerivedFrom<PartDesign::SubShapeBinder>()
+            obj->isDerivedFrom<PartDesign::SubShapeBinder>() ||
             // TODO Why this lines was here? why should we allow anything of those? (2015-08-13, Fat-Zer)
             //obj->isDerivedFrom<Part::FeaturePython>() // trouble with this line on Windows!? Linker fails to find getClassTypeId() of the Part::FeaturePython...
             //obj->isDerivedFrom<Part::Feature>()
+            // allow VarSets for parameterization
+            obj->isDerivedFrom<App::VarSet>()
             );
 }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -33,6 +33,7 @@
 #include <App/Document.h>
 #include <App/Origin.h>
 #include <App/Part.h>
+#include <App/VarSet.h>
 #include <Base/Console.h>
 #include <Gui/ActionFunction.h>
 #include <Gui/Application.h>
@@ -495,6 +496,9 @@ bool ViewProviderBody::canDropObjects() const
 
 bool ViewProviderBody::canDropObject(App::DocumentObject* obj) const
 {
+    if (obj->isDerivedFrom<App::VarSet>()) {
+        return true;
+    }
     if (!obj->isDerivedFrom(Part::Feature::getClassTypeId())) {
         return false;
     }


### PR DESCRIPTION
This PR is an alternative solution to the problem discussed in #13038. I still believe PR #13112 would be very valuable but it is a large PR and I think it would benefit from a broader discussion. This PR is much smaller and only focused on variable sets. It allows you to easily add properties to variable sets.

It provides a GUI command to create variable sets and it presents you with a dialog to add properties. It allows you to also add the value of the property immediately once the type has been established. It makes use of the editors available in core, so for lengths and floats you get the familiar input box with expression support and for links you get the familiar dialog to select an object.

If a Part is active, the variable set will be created inside the part and adding new properties to a variable set supports undo and redo.