### PR TITLE
Gui: Fix navigation with overlays

### DIFF
--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -1788,7 +1788,7 @@ bool OverlayManager::eventFilter(QObject *o, QEvent *ev)
                 d->interceptEvent(d->_trackingWidget, ev);
             if(isTreeViewDragging()
                     || ev->type() == QEvent::MouseButtonRelease
-                    || QApplication::mouseButtons() == Qt::NoButton)
+                    && QApplication::mouseButtons() == Qt::NoButton)
             {
                 d->_trackingWidget = nullptr;
                 if (d->_trackingOverlay == grabber


### PR DESCRIPTION
Fixes #13212.

Sets `_trackingWidget` to nullptr when **all** mouse buttons are released. @maxwxyz can you confirm this works?