### PR TITLE
Enforce OpenMP version

### DIFF
--- a/src/Mod/Fem/App/CMakeLists.txt
+++ b/src/Mod/Fem/App/CMakeLists.txt
@@ -198,7 +198,7 @@ endif(FREECAD_USE_PCH)
 add_library(Fem SHARED ${Fem_SRCS})
 target_link_libraries(Fem ${Fem_LIBS} ${VTK_LIBRARIES})
 
-find_package(OpenMP)
+find_package(OpenMP 4.0)
 if(OpenMP_CXX_FOUND)
 	target_link_libraries(Fem OpenMP::OpenMP_CXX)
 endif()


### PR DESCRIPTION
On my system only OpenMP 2.0 was present and the build was [failing](https://github.com/FreeCAD/FreeCAD/issues/12586#issuecomment-2041047115).

In that case enforcing OpenMP version allowed to skip FEM linking and avoids build errors.

