### PR TITLE
Fem: Fix display modes order - fixes #13326

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -369,11 +369,11 @@ std::vector<std::string> ViewProviderFemPostObject::getDisplayModes() const
     std::vector<std::string> StrList;
     StrList.emplace_back("Outline");
     StrList.emplace_back("Nodes");
-    StrList.emplace_back("Nodes (surface only)");
     StrList.emplace_back("Surface");
     StrList.emplace_back("Surface with Edges");
     StrList.emplace_back("Wireframe");
     StrList.emplace_back("Wireframe (surface only)");
+    StrList.emplace_back("Nodes (surface only)");
     return StrList;
 }
 


### PR DESCRIPTION
@FEA-eng this fix the display mode for old files.
Files saved with the development branch after the addition of `Nodes (surface only)` and up to this fix, will be affected similarly, but for other saved modes. (Not very problematic since its only for the development branch).