### PR TITLE
Mod: Show regressions in shape colouring

### DIFF
--- a/src/Mod/Import/CMakeLists.txt
+++ b/src/Mod/Import/CMakeLists.txt
@@ -47,6 +47,7 @@ set(Import_Scripts
 
 if(BUILD_GUI)
     list (APPEND Import_Scripts InitGui.py)
+    list (APPEND Import_Scripts TestImportGui.py)
 endif(BUILD_GUI)
 
 add_custom_target(ImportScripts ALL

--- a/src/Mod/Import/InitGui.py
+++ b/src/Mod/Import/InitGui.py
@@ -35,6 +35,8 @@ FreeCAD.changeImportModule("STEP with colors (*.step *.STEP *.stp *.STP)", "Impo
 FreeCAD.changeExportModule("STEP with colors (*.step *.stp)", "Import", "ImportGui")
 FreeCAD.changeExportModule("glTF (*.gltf *.glb)", "Import", "ImportGui")
 
+App.__unit_test__ += ["TestImportGui"]
+
 """
 class ImportWorkbench ( Workbench ):
     "Import workbench object"

--- a/src/Mod/Import/TestImportGui.py
+++ b/src/Mod/Import/TestImportGui.py
@@ -1,0 +1,91 @@
+# **************************************************************************
+#   Copyright (c) 2024 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+#                                                                         *
+#   This file is part of FreeCAD.                                         *
+#                                                                         *
+#   FreeCAD is free software: you can redistribute it and/or modify it    *
+#   under the terms of the GNU Lesser General Public License as           *
+#   published by the Free Software Foundation, either version 2.1 of the  *
+#   License, or (at your option) any later version.                       *
+#                                                                         *
+#   FreeCAD is distributed in the hope that it will be useful, but        *
+#   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+#   Lesser General Public License for more details.                       *
+#                                                                         *
+#   You should have received a copy of the GNU Lesser General Public      *
+#   License along with FreeCAD. If not, see                               *
+#   <https://www.gnu.org/licenses/>.                                      *
+#                                                                         *
+# **************************************************************************
+
+import os
+import tempfile
+import unittest
+import FreeCAD as App
+import ImportGui
+from pivy import coin
+
+
+class ExportImportTest(unittest.TestCase):
+    def setUp(self):
+        TempPath = tempfile.gettempdir()
+        self.fileName = TempPath + os.sep + "ColorPerFaceTest.step"
+        self.doc = App.newDocument()
+
+    def tearDown(self):
+        App.closeDocument(self.doc.Name)
+
+    def testSaveLoadStepFile(self):
+        """
+        Create a STEP file with color per face
+        """
+        part = self.doc.addObject("App::Part", "Part")
+        box = part.newObject("Part::Box", "Box")
+        self.doc.recompute()
+
+        box.ViewObject.DiffuseColor = [
+            (1.0, 0.0, 0.0, 0.0),
+            (1.0, 0.0, 0.0, 0.0),
+            (1.0, 0.0, 0.0, 0.0),
+            (1.0, 0.0, 0.0, 0.0),
+            (1.0, 1.0, 0.0, 0.0),
+            (1.0, 1.0, 0.0, 0.0),
+        ]
+
+        ImportGui.export([part], self.fileName)
+
+        self.doc.clearDocument()
+        ImportGui.insert(name=self.fileName, docName=self.doc.Name, useLinkGroup=True)
+
+        part_features = list(filter(lambda x: x.isDerivedFrom("Part::Feature"), self.doc.Objects))
+        self.assertEqual(len(part_features), 1)
+        feature = part_features[0]
+
+        self.assertEqual(len(feature.ViewObject.DiffuseColor), 6)
+        self.assertEqual(feature.ViewObject.DiffuseColor[0], (1.0, 0.0, 0.0, 0.0))
+        self.assertEqual(feature.ViewObject.DiffuseColor[1], (1.0, 0.0, 0.0, 0.0))
+        self.assertEqual(feature.ViewObject.DiffuseColor[2], (1.0, 0.0, 0.0, 0.0))
+        self.assertEqual(feature.ViewObject.DiffuseColor[3], (1.0, 0.0, 0.0, 0.0))
+        self.assertEqual(feature.ViewObject.DiffuseColor[4], (1.0, 1.0, 0.0, 0.0))
+        self.assertEqual(feature.ViewObject.DiffuseColor[5], (1.0, 1.0, 0.0, 0.0))
+
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterialBinding.getClassTypeId())
+        # We need an easier way to access nodes of a display mode
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(feature.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        bind = paths.get(2).getTail()
+        self.assertEqual(bind.value.getValue(), bind.PER_PART)
+
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterial.getClassTypeId())
+        # We need an easier way to access nodes of a display mode
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(feature.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        mat = paths.get(2).getTail()
+        self.assertEqual(mat.diffuseColor.getNum(), 6)

--- a/src/Mod/Part/parttests/ColorPerFaceTest.py
+++ b/src/Mod/Part/parttests/ColorPerFaceTest.py
@@ -8,6 +8,7 @@ import Part
 import os
 import tempfile
 import unittest
+from BOPTools import BOPFeatures
 from pivy import coin
 
 class ColorPerFaceTest(unittest.TestCase):
@@ -84,3 +85,123 @@ class ColorPerFaceTest(unittest.TestCase):
 
         mat = paths.get(2).getTail()
         self.assertEqual(mat.diffuseColor.getNum(), 6)
+
+    def testTransparency(self):
+        """
+        If color per face is set then changing the transparency must not revert it
+        """
+        box = self.doc.addObject("Part::Box","Box")
+        self.doc.recompute()
+
+        box.ViewObject.DiffuseColor = [(1.,0.,0.,0.),
+                                       (1.,0.,0.,0.),
+                                       (1.,0.,0.,0.),
+                                       (1.,0.,0.,0.),
+                                       (1.,1.,0.,0.),
+                                       (1.,1.,0.,0.)]
+
+        box.ViewObject.Transparency = 35
+        self.assertEqual(box.ViewObject.Transparency, 35)
+
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterialBinding.getClassTypeId())
+        # We need an easier way to access nodes of a display mode
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(box.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        bind = paths.get(2).getTail()
+        self.assertEqual(bind.value.getValue(), bind.PER_PART)
+
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterial.getClassTypeId())
+        # We need an easier way to access nodes of a display mode
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(box.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        mat = paths.get(2).getTail()
+        self.assertEqual(mat.diffuseColor.getNum(), 6)
+
+    def testMultiFuse(self):
+        """
+        Both input objects are red. So, it's expected that the output object is red, too.
+        """
+        box = self.doc.addObject("Part::Box","Box")
+        cyl = self.doc.addObject("Part::Cylinder","Cylinder")
+        box.ViewObject.ShapeColor = (1.,0.,0.,0.)
+        cyl.ViewObject.ShapeColor = (1.,0.,0.,0.)
+        self.doc.recompute()
+
+        bp = BOPFeatures.BOPFeatures(self.doc)
+        fuse = bp.make_multi_fuse([box.Name, cyl.Name])
+        self.assertEqual(fuse.TypeId, "Part::MultiFuse")
+        self.doc.recompute()
+
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterialBinding.getClassTypeId())
+        # We need an easier way to access nodes of a display mode
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(fuse.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        bind = paths.get(2).getTail()
+        self.assertEqual(bind.value.getValue(), bind.PER_PART)
+
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterial.getClassTypeId())
+        # We need an easier way to access nodes of a display mode
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(fuse.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        mat = paths.get(2).getTail()
+        self.assertEqual(mat.diffuseColor.getNum(), 11)
+
+        self.assertEqual(len(fuse.Shape.Faces), 11)
+        self.assertEqual(len(fuse.ViewObject.DiffuseColor), 11)
+        self.assertEqual(fuse.ViewObject.DiffuseColor[0], (1.,0.,0.,0.))
+
+    def testMultiFuseSaveRestore(self):
+        box = self.doc.addObject("Part::Box","Box")
+        cyl = self.doc.addObject("Part::Cylinder","Cylinder")
+        box.ViewObject.ShapeColor = (1.,0.,0.,0.)
+        cyl.ViewObject.ShapeColor = (1.,0.,0.,0.)
+        self.doc.recompute()
+
+        bp = BOPFeatures.BOPFeatures(self.doc)
+        fuse = bp.make_multi_fuse([box.Name, cyl.Name])
+        self.assertEqual(fuse.TypeId, "Part::MultiFuse")
+        self.doc.recompute()
+
+        fuse.ViewObject.DiffuseColor = [(1.,0.,0.,0.)] * 11
+
+        self.doc.saveAs(self.fileName)
+        App.closeDocument(self.doc.Name)
+
+        self.doc = App.openDocument(self.fileName)
+
+        fuse = self.doc.ActiveObject
+        self.assertEqual(len(fuse.Shape.Faces), 11)
+        self.assertEqual(len(fuse.ViewObject.DiffuseColor), 11)
+        self.assertEqual(fuse.ViewObject.DiffuseColor[0], (1.,0.,0.,0.))
+
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterialBinding.getClassTypeId())
+        # We need an easier way to access nodes of a display mode
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(fuse.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        bind = paths.get(2).getTail()
+        self.assertEqual(bind.value.getValue(), bind.PER_PART)
+
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoMaterial.getClassTypeId())
+        # We need an easier way to access nodes of a display mode
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.apply(fuse.ViewObject.RootNode)
+        paths = sa.getPaths()
+
+        mat = paths.get(2).getTail()
+        self.assertEqual(mat.diffuseColor.getNum(), 11)

--- a/src/Mod/PartDesign/TestPartDesignGui.py
+++ b/src/Mod/PartDesign/TestPartDesignGui.py
@@ -253,3 +253,87 @@ class PartDesignTransformed(unittest.TestCase):
 #   def tearDown(self):
 #       #closing doc
 #       FreeCAD.closeDocument("SketchGuiTest")
+
+class TestShapeBinder(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PartDesignTestShapeBinder")
+
+    def testDefaultColor(self):
+        """
+        A shape binder uses a different default color than a Part feature.
+        This color must still be set after its creation.
+        """
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+        self.Box = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+        self.Body.addObject(self.Box)
+        self.Doc.recompute()
+        binder = self.Doc.addObject('PartDesign::ShapeBinder','ShapeBinder')
+        binder.Support = [(self.Box, 'Face1')]
+
+        grp = App.ParamGet("User parameter:BaseApp/Preferences/Mod/PartDesign")
+        packed_color = grp.GetUnsigned("DefaultDatumColor", 0xFFD70099)
+        r, g, b, a = binder.ViewObject.ShapeColor
+        color = int(r * 255.0 + 0.5) << 24 | int(g * 255.0 + 0.5) << 16 | int(b * 255.0 + 0.5) << 8 | int(a * 255.0 + 0.5)
+
+        self.assertEqual(packed_color, color)
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+
+
+class TestSubShapeBinder(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PartDesignTestSubShapeBinder")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+
+    def testDefaultColor(self):
+        """
+        A sub-shape binder uses a different default color than a Part feature.
+        This color must still be set after its creation.
+        """
+        body = self.Doc.addObject('PartDesign::Body','Body')
+        box = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+        body.addObject(box)
+
+        self.Doc.recompute()
+        binder = body.newObject('PartDesign::SubShapeBinder','Binder')
+        binder.Support = [(box, ("Face1"))]
+
+        grp = App.ParamGet("User parameter:BaseApp/Preferences/Mod/PartDesign")
+        packed_color = grp.GetUnsigned("DefaultDatumColor", 0xFFD70099)
+        r, g, b, a = binder.ViewObject.ShapeColor
+        color = int(r * 255.0 + 0.5) << 24 | int(g * 255.0 + 0.5) << 16 | int(b * 255.0 + 0.5) << 8 | int(a * 255.0 + 0.5)
+
+        self.assertEqual(packed_color, color)
+
+
+class TestDatumPlane(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PartDesignTestDatumPlane")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+
+    def testDefaultColor(self):
+        """
+        A datum object uses a different default color than a Part feature.
+        This color must still be set after its creation.
+        """
+        body = self.Doc.addObject('PartDesign::Body','Body')
+        box = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+        body.addObject(box)
+
+        self.Doc.recompute()
+        datum = body.newObject('PartDesign::Plane','DatumPlane')
+        datum.AttachmentSupport = [(box, 'Face6')]
+        datum.MapMode = 'FlatFace'
+        self.Doc.recompute()
+
+        grp = App.ParamGet("User parameter:BaseApp/Preferences/Mod/PartDesign")
+        packed_color = grp.GetUnsigned("DefaultDatumColor", 0xFFD70099)
+        r, g, b, a = datum.ViewObject.ShapeColor
+        color = int(r * 255.0 + 0.5) << 24 | int(g * 255.0 + 0.5) << 16 | int(b * 255.0 + 0.5) << 8 | int(a * 255.0 + 0.5)
+
+        self.assertEqual(packed_color, color)


### PR DESCRIPTION
This PR demonstrates the known regressions of the recently merged material branch:
* Changing the transparency after setting color per face will reset them
* The result of boolean operations or compound doesn't inherit the colour of its input objects
* If colour is set per face to a boolean operaton object then saving and restoring the file causes weird rendering behaviour because material binding is set to PER_PART but only a single colour is defined
* If a shape inside a part container has set colour per face then saving and restoring as STEP file causes weird rendering behaviour for the same reason
* Shape binder or datum objects don't show the correct default shape colour