### PR TITLE
Data: Consistent data path

### DIFF
--- a/data/examples/CMakeLists.txt
+++ b/data/examples/CMakeLists.txt
@@ -18,7 +18,7 @@ ADD_CUSTOM_TARGET(Example_data ALL
 
 # 0001097: CMake stops with error "Circular ... <- ... dependency dropped."
 if(NOT "${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
-    fc_copy_sources(Example_data "${CMAKE_BINARY_DIR}/data/examples" ${Examples_Files})
+    fc_copy_sources(Example_data "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/examples" ${Examples_Files})
 endif()
 
 if (WIN32 AND FREECAD_LIBPACK_USE)


### PR DESCRIPTION
During the build process the example files are copied to the hardcoded path 'data/examples' while for the installed files '/examples' is used. On Linux systems the value of the CMake variable is 'share' so that there is an inconsistency between compiled and installed version.