### PR TITLE
FEM: add radiation heat transfer for CalculiX

### DIFF
--- a/src/Mod/Fem/App/FemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.cpp
@@ -31,19 +31,20 @@ using namespace Fem;
 
 PROPERTY_SOURCE(Fem::ConstraintHeatflux, Fem::Constraint)
 
-static const char* ConstraintTypes[] = {"DFlux", "Convection", nullptr};
+static const char* ConstraintTypes[] = {"DFlux", "Convection", "Radiation", nullptr};
 
 ConstraintHeatflux::ConstraintHeatflux()
 {
     ADD_PROPERTY(AmbientTemp, (0.0));
     /*ADD_PROPERTY(FaceTemp,(0.0));*/
     ADD_PROPERTY(FilmCoef, (0.0));
+    ADD_PROPERTY(Emissivity, (0.0));
     ADD_PROPERTY(DFlux, (0.0));
     ADD_PROPERTY_TYPE(ConstraintType,
                       (1),
                       "ConstraintHeatflux",
                       (App::PropertyType)(App::Prop_None),
-                      "Type of constraint, surface convection or surface heat flux");
+                      "Type of constraint, surface convection, radiation or surface heat flux");
     ConstraintType.setEnums(ConstraintTypes);
 }
 

--- a/src/Mod/Fem/App/FemConstraintHeatflux.h
+++ b/src/Mod/Fem/App/FemConstraintHeatflux.h
@@ -42,6 +42,7 @@ public:
     App::PropertyFloat AmbientTemp;
     /*App::PropertyFloat FaceTemp;*/
     App::PropertyFloat FilmCoef;
+    App::PropertyFloat Emissivity;
     App::PropertyFloat DFlux;
     App::PropertyEnumeration ConstraintType;
 

--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -579,6 +579,9 @@ void CmdFemConstraintHeatflux::activated(int)
               "App.activeDocument().%s.FilmCoef = 10.0",
               FeatName.c_str());  // OvG: set default not equal to 0
     doCommand(Doc,
+              "App.activeDocument().%s.Emissivity = 1.0",
+              FeatName.c_str());  // OvG: set default not equal to 0
+    doCommand(Doc,
               "App.activeDocument().%s.Scale = 1",
               FeatName.c_str());  // OvG: set initial scale to 1
     doCommand(Doc,

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -420,7 +420,7 @@ double TaskFemConstraintHeatflux::getAmbientTemp() const
     if (ui->rb_convection->isChecked()) {
         temperature = ui->if_ambienttemp->getQuantity();
     }
-    else if (ui->rb_radiation->isChecked()){
+    else if (ui->rb_radiation->isChecked()) {
         temperature = ui->if_ambienttemp2->getQuantity();
     }
     double temperature_in_kelvin = temperature.getValueAs(Base::Quantity::Kelvin);

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -81,6 +81,10 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(
             qOverload<double>(&InputField::valueChanged),
             this,
             &TaskFemConstraintHeatflux::onEmissivityChanged);
+    connect(ui->if_ambienttemp2,
+            qOverload<double>(&InputField::valueChanged),
+            this,
+            &TaskFemConstraintHeatflux::onAmbientTempChanged);
     connect(ui->lw_references,
             &QListWidget::itemClicked,
             this,
@@ -93,6 +97,7 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(
     // ui->if_facetemp->blockSignals(true);
     ui->if_filmcoef->blockSignals(true);
     ui->if_emissivity->blockSignals(true);
+    ui->if_ambienttemp2->blockSignals(true);
     ui->lw_references->blockSignals(true);
     ui->btnAdd->blockSignals(true);
     ui->btnRemove->blockSignals(true);
@@ -113,6 +118,9 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(
     ui->if_emissivity->setMinimum(0);
     ui->if_emissivity->setMaximum(FLOAT_MAX);
 
+    ui->if_ambienttemp2->setMinimum(0);
+    ui->if_ambienttemp2->setMaximum(FLOAT_MAX);
+
     std::string constraint_type = pcConstraint->ConstraintType.getValueAsString();
     if (constraint_type == "Convection") {
         ui->rb_convection->setChecked(true);
@@ -129,7 +137,7 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(
         ui->sw_heatflux->setCurrentIndex(1);
         Base::Quantity t =
             Base::Quantity(pcConstraint->AmbientTemp.getValue(), Base::Unit::Temperature);
-        ui->if_ambienttemp->setValue(t);
+        ui->if_ambienttemp2->setValue(t);
         Base::Quantity e = Base::Quantity(pcConstraint->Emissivity.getValue(), Base::Unit());
         ui->if_emissivity->setValue(e);
     }
@@ -156,6 +164,7 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(
     // ui->if_facetemp->blockSignals(false);
     ui->if_filmcoef->blockSignals(false);
     ui->if_emissivity->blockSignals(false);
+    ui->if_ambienttemp2->blockSignals(false);
     ui->lw_references->blockSignals(false);
     ui->btnAdd->blockSignals(false);
     ui->btnRemove->blockSignals(false);
@@ -230,7 +239,7 @@ void TaskFemConstraintHeatflux::Rad()
                             name.c_str(),
                             get_constraint_type().c_str());
     Base::Quantity t = Base::Quantity(300, Base::Unit::Temperature);
-    ui->if_ambienttemp->setValue(t);
+    ui->if_ambienttemp2->setValue(t);
     pcConstraint->AmbientTemp.setValue(300);
     Base::Quantity e = Base::Quantity(1, Base::Unit());
     ui->if_emissivity->setValue(e);
@@ -407,7 +416,13 @@ const std::string TaskFemConstraintHeatflux::getReferences() const
 
 double TaskFemConstraintHeatflux::getAmbientTemp() const
 {
-    Base::Quantity temperature = ui->if_ambienttemp->getQuantity();
+    Base::Quantity temperature;
+    if (ui->rb_convection->isChecked()) {
+        temperature = ui->if_ambienttemp->getQuantity();
+    }
+    else if (ui->rb_radiation->isChecked()){
+        temperature = ui->if_ambienttemp2->getQuantity();
+    }
     double temperature_in_kelvin = temperature.getValueAs(Base::Quantity::Kelvin);
     return temperature_in_kelvin;
 }
@@ -454,10 +469,12 @@ void TaskFemConstraintHeatflux::changeEvent(QEvent* e)
         ui->if_ambienttemp->blockSignals(true);
         ui->if_filmcoef->blockSignals(true);
         ui->if_emissivity->blockSignals(true);
+        ui->if_ambienttemp2->blockSignals(true);
         ui->retranslateUi(proxy);
         ui->if_ambienttemp->blockSignals(false);
         ui->if_filmcoef->blockSignals(false);
         ui->if_emissivity->blockSignals(true);
+        ui->if_ambienttemp2->blockSignals(false);
     }
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -131,7 +131,7 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(
             Base::Quantity(pcConstraint->AmbientTemp.getValue(), Base::Unit::Temperature);
         ui->if_ambienttemp->setValue(t);
         Base::Quantity e = Base::Quantity(pcConstraint->Emissivity.getValue(),
-                                          Base::Unit::ThermalTransferCoefficient);
+                                          Base::Unit());
         ui->if_emissivity->setValue(e);
     }
     else if (constraint_type == "DFlux") {
@@ -233,7 +233,7 @@ void TaskFemConstraintHeatflux::Rad()
     Base::Quantity t = Base::Quantity(300, Base::Unit::Temperature);
     ui->if_ambienttemp->setValue(t);
     pcConstraint->AmbientTemp.setValue(300);
-    Base::Quantity e = Base::Quantity(1, Base::Unit::ThermalTransferCoefficient);
+    Base::Quantity e = Base::Quantity(1, Base::Unit());
     ui->if_emissivity->setValue(e);
     pcConstraint->Emissivity.setValue(1);
     ui->sw_heatflux->setCurrentIndex(1);
@@ -425,7 +425,7 @@ double TaskFemConstraintHeatflux::getEmissivity() const
 {
     Base::Quantity emissivity = ui->if_emissivity->getQuantity();
     double emissivity_in_units =
-        emissivity.getValueAs(Base::Quantity(1.0, Base::Unit::ThermalTransferCoefficient));
+        emissivity.getValueAs(Base::Quantity(1.0, Base::Unit()));
     return emissivity_in_units;
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -130,8 +130,7 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(
         Base::Quantity t =
             Base::Quantity(pcConstraint->AmbientTemp.getValue(), Base::Unit::Temperature);
         ui->if_ambienttemp->setValue(t);
-        Base::Quantity e = Base::Quantity(pcConstraint->Emissivity.getValue(),
-                                          Base::Unit());
+        Base::Quantity e = Base::Quantity(pcConstraint->Emissivity.getValue(), Base::Unit());
         ui->if_emissivity->setValue(e);
     }
     else if (constraint_type == "DFlux") {
@@ -424,8 +423,7 @@ double TaskFemConstraintHeatflux::getFilmCoef() const
 double TaskFemConstraintHeatflux::getEmissivity() const
 {
     Base::Quantity emissivity = ui->if_emissivity->getQuantity();
-    double emissivity_in_units =
-        emissivity.getValueAs(Base::Quantity(1.0, Base::Unit()));
+    double emissivity_in_units = emissivity.getValueAs(Base::Quantity(1.0, Base::Unit()));
     return emissivity_in_units;
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.h
@@ -48,6 +48,7 @@ public:
     double getAmbientTemp() const;
     /*double getFaceTemp(void) const;*/
     double getFilmCoef() const;
+    double getEmissivity() const;
     std::string get_constraint_type() const;
     const std::string getReferences() const override;
 
@@ -56,8 +57,10 @@ private Q_SLOTS:
     void onAmbientTempChanged(double val);
     /*void onFaceTempChanged(double val);*/
     void onFilmCoefChanged(double val);
+    void onEmissivityChanged(double val);
     void onHeatFluxChanged(double val);
     void Conv();
+    void Rad();
     void Flux();
     void addToSelection() override;
     void removeFromSelection() override;

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
@@ -175,16 +175,16 @@
           </layout>
          </item>
          <item>
-          <layout class="QHBoxLayout" name="layoutAmbientTemp">
+          <layout class="QHBoxLayout" name="layoutAmbientTemp2">
            <item>
-            <widget class="QLabel" name="lbl_ambienttemp">
+            <widget class="QLabel" name="lbl_ambienttemp2">
              <property name="text">
               <string>Ambient Temperature</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="Gui::InputField" name="if_ambienttemp">
+            <widget class="Gui::InputField" name="if_ambienttemp2">
              <property name="text">
               <string>300 K</string>
              </property>

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
@@ -70,6 +70,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QRadioButton" name="rb_radiation">
+       <property name="text">
+        <string>Surface Radiation</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QRadioButton" name="rb_dflux">
        <property name="text">
         <string>Surface heat flux</string>
@@ -81,7 +88,7 @@
    <item>
     <widget class="QStackedWidget" name="sw_heatflux">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="page">
       <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -139,6 +146,65 @@
        </item>
       </layout>
      </widget>
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <widget class="QWidget" name="page_1">
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <layout class="QHBoxLayout" name="layoutEmissivity">
+           <item>
+            <widget class="QLabel" name="lbl_emissivity">
+             <property name="text">
+              <string>Emissivity</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Gui::InputField" name="if_emissivity">
+             <property name="text">
+              <string>1 </string>
+             </property>
+             <property name="quantity" stdset="0">
+              <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="layoutAmbientTemp">
+           <item>
+            <widget class="QLabel" name="lbl_ambienttemp">
+             <property name="text">
+              <string>Ambient Temperature</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Gui::InputField" name="if_ambienttemp">
+             <property name="text">
+              <string>300 K</string>
+             </property>
+             <property name="unit" stdset="0">
+              <string notr="true">K</string>
+             </property>
+             <property name="quantity" stdset="0">
+              <double>300.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <property name="currentIndex">
+      <number>2</number>
+     </property>
      <widget class="QWidget" name="page_2">
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>

--- a/src/Mod/Fem/femsolver/calculix/write_constraint_heatflux.py
+++ b/src/Mod/Fem/femsolver/calculix/write_constraint_heatflux.py
@@ -54,6 +54,15 @@ def write_meshdata_constraint(f, femobj, heatflux_obj, ccxwriter):
             heatflux_obj.AmbientTemp,
             heatflux_obj.FilmCoef * 0.001
         )
+
+    elif heatflux_obj.ConstraintType == "Radiation":
+        heatflux_key_word = "RADIATE"
+        heatflux_facetype = "R"
+        heatflux_values = "{:.13G},{:.13G}".format(
+            heatflux_obj.AmbientTemp,
+            heatflux_obj.Emissivity
+        )
+
     elif heatflux_obj.ConstraintType == "DFlux":
         heatflux_key_word = "DFLUX"
         heatflux_facetype = "S"

--- a/src/Mod/Fem/femsolver/calculix/write_femelement_material.py
+++ b/src/Mod/Fem/femsolver/calculix/write_femelement_material.py
@@ -48,6 +48,9 @@ def write_femelement_material(f, ccxwriter):
             return True
         return False
 
+    f.write("** Physical constants for SI(mm) unit system with Kelvins\n")
+    f.write("*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11\n")
+
     f.write("\n{}\n".format(59 * "*"))
     f.write("** Materials\n")
     f.write("** see information about units at file end\n")

--- a/src/Mod/Fem/femtest/data/calculix/box_frequency.inp
+++ b/src/Mod/Fem/femtest/data/calculix/box_frequency.inp
@@ -427,6 +427,8 @@ Evolumes
 ** Element sets for materials and FEM element type (solid, shell, beam, fluid)
 *ELSET,ELSET=MechanicalMaterialSolid
 Evolumes
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
 
 ***********************************************************
 ** Materials

--- a/src/Mod/Fem/femtest/data/calculix/box_static.inp
+++ b/src/Mod/Fem/femtest/data/calculix/box_static.inp
@@ -474,6 +474,9 @@ Evolumes
 68,
 69,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_buckling_flexuralbuckling.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_buckling_flexuralbuckling.inp
@@ -730,6 +730,9 @@ Evolumes
 393,
 410,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_circle.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_circle.inp
@@ -45,6 +45,9 @@ Eedges
 *NSET,NSET=ConstraintFixed
 1,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_pipe.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_pipe.inp
@@ -45,6 +45,9 @@ Eedges
 *NSET,NSET=ConstraintFixed
 1,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_rect.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_beam_rect.inp
@@ -45,6 +45,9 @@ Eedges
 *NSET,NSET=ConstraintFixed
 1,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_hexa20.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_hexa20.inp
@@ -370,6 +370,9 @@ Evolumes
 96,
 97,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_quad4.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_quad4.inp
@@ -70,6 +70,9 @@ Efaces
 2,
 5,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_quad8.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_quad8.inp
@@ -58,6 +58,9 @@ Efaces
 6,
 7,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_seg2.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_seg2.inp
@@ -187,6 +187,9 @@ Eedges
 *NSET,NSET=ConstraintFixed
 1,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_seg3.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_seg3.inp
@@ -45,6 +45,9 @@ Eedges
 *NSET,NSET=ConstraintFixed
 1,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_tria3.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_tria3.inp
@@ -1546,6 +1546,9 @@ Efaces
 9,
 10,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_tria6.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_ele_tria6.inp
@@ -276,6 +276,9 @@ Efaces
 6,
 7,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_faceload.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_faceload.inp
@@ -344,6 +344,9 @@ Evolumes
 194,
 195,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_nodeload.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_nodeload.inp
@@ -344,6 +344,9 @@ Evolumes
 194,
 195,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_prescribeddisplacement.inp
+++ b/src/Mod/Fem/femtest/data/calculix/ccx_cantilever_prescribeddisplacement.inp
@@ -362,6 +362,9 @@ Evolumes
 190,
 191,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/constraint_centrif.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_centrif.inp
@@ -18721,6 +18721,9 @@ Evolumes
 2745,
 2746,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/constraint_contact_shell_shell.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_contact_shell_shell.inp
@@ -38348,6 +38348,9 @@ Efaces
 15603,S2
 15604,S2
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/constraint_contact_solid_solid.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_contact_solid_solid.inp
@@ -5556,6 +5556,9 @@ Evolumes
 1726,S1
 2345,S4
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/constraint_sectionprint.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_sectionprint.inp
@@ -3386,6 +3386,9 @@ Evolumes
 1819,S4
 1823,S4
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/constraint_selfweight_cantilever.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_selfweight_cantilever.inp
@@ -2136,6 +2136,9 @@ Evolumes
 12,
 13,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/constraint_tie.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_tie.inp
@@ -18591,6 +18591,9 @@ Evolumes
 9684,S1
 10647,S2
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/constraint_transform_beam_hinged.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_transform_beam_hinged.inp
@@ -3615,6 +3615,9 @@ Evolumes
 241,
 2088,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/constraint_transform_torque.inp
+++ b/src/Mod/Fem/femtest/data/calculix/constraint_transform_torque.inp
@@ -10959,6 +10959,9 @@ Evolumes
 3933,
 3934,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/frequency_beamsimple.inp
+++ b/src/Mod/Fem/femtest/data/calculix/frequency_beamsimple.inp
@@ -17021,6 +17021,9 @@ Evolumes
 17,
 18,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/material_multiple_bendingbeam_fiveboxes.inp
+++ b/src/Mod/Fem/femtest/data/calculix/material_multiple_bendingbeam_fiveboxes.inp
@@ -27607,6 +27607,9 @@ Evolumes
 4152,
 4153,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/material_multiple_bendingbeam_fivefaces.inp
+++ b/src/Mod/Fem/femtest/data/calculix/material_multiple_bendingbeam_fivefaces.inp
@@ -2518,6 +2518,9 @@ Efaces
 460,
 461,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/material_multiple_tensionrod_twoboxes.inp
+++ b/src/Mod/Fem/femtest/data/calculix/material_multiple_tensionrod_twoboxes.inp
@@ -1210,6 +1210,9 @@ Evolumes
 296,
 297,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/material_nonlinear.inp
+++ b/src/Mod/Fem/femtest/data/calculix/material_nonlinear.inp
@@ -19985,6 +19985,9 @@ Evolumes
 1328,
 1329,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/square_pipe_end_twisted_edgeforces.inp
+++ b/src/Mod/Fem/femtest/data/calculix/square_pipe_end_twisted_edgeforces.inp
@@ -2544,6 +2544,9 @@ Efaces
 1402,
 1407,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/square_pipe_end_twisted_nodeforces.inp
+++ b/src/Mod/Fem/femtest/data/calculix/square_pipe_end_twisted_nodeforces.inp
@@ -2544,6 +2544,9 @@ Efaces
 1402,
 1407,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end

--- a/src/Mod/Fem/femtest/data/calculix/thermomech_bimetall.inp
+++ b/src/Mod/Fem/femtest/data/calculix/thermomech_bimetall.inp
@@ -7040,6 +7040,9 @@ Evolumes
 1520,
 1521,
 
+** Physical constants for SI(mm) unit system with Kelvins
+*PHYSICAL CONSTANTS, ABSOLUTE ZERO=0, STEFAN BOLTZMANN=5.670374419e-11
+
 ***********************************************************
 ** Materials
 ** see information about units at file end


### PR DESCRIPTION
fixes #11651

adds a 3rd mode for heat flux constraint - surface radiation

@lyphrowny and @marioalexis84 I would appreciate your help again. It's working but there are 2 small issues:
- I don't know how to account for the fact that emissivity is unitless so it has the same units as film coefficient for now
- for some reason, if I change the ambient temperature under `Surface Radiation`, it's not saved - only the one under `Surface Convection` is saved this way. Maybe it's not a good idea that both types share the same property but the only other way that I see would be to name one `Ambient Temperature` and the other one `Sink Temperature`. This would be technically correct but confusing since they represent the same thing and would be named differently only to avoid property duplication. Ideally, it should be one property `Ambient Temperature` since the constraint can use only a single mode at once anyway. So maybe there is an easy way to make it save when changed under `Surface Radiation`?