### PR TITLE
Fixed Scaling Parameter Bug in importCSG

### DIFF
--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -825,7 +825,10 @@ def p_linear_extrude_with_transform(p):
     s = [1.0,1.0]
     t = 0.0
     if 'scale' in p[3]:
-        s = [float(p[3]['scale'][0]), float(p[3]['scale'][1])]
+        if isinstance(p[3]['scale'], str):
+            s = [float(p[3]['scale']), float(p[3]['scale'])]
+        else:
+            s = [float(p[3]['scale'][0]), float(p[3]['scale'][1])]
         if printverbose: print ("Scale: " + str(s))
     if 'twist' in p[3]:
         t = float(p[3]['twist'])


### PR DESCRIPTION
The OpenScad function [linear_extrude](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Using_the_2D_Subsystem#linear_extrude) exepts both a single value and a vector as a parameter. The current import function only expected a vector. By checking if scale is a string and applying the scale to both x and y I fixed the bug.