### PR TITLE
Gui: fix crash in PythonCommand::isChecked()

### DIFF
--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1462,6 +1462,7 @@ bool PythonCommand::isCheckable() const
 
 bool PythonCommand::isChecked() const
 {
+    Base::PyGILStateLocker lock;
     PyObject* item = PyDict_GetItemString(_pcPyResourceDict,"Checkable");
     if (!item) {
         throw Base::ValueError("PythonCommand::isChecked(): Method GetResources() of the Python "


### PR DESCRIPTION
This very likely fixes the crash reported at https://forum.freecad.org/viewtopic.php?t=86874