### PR TITLE
Draft: Enable Draft Edit for Draft Labels

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -235,6 +235,7 @@ class Edit(gui_base_original.Modifier):
         self.gui_tools_repository.add('Ellipse', edit_draft.DraftEllipseGuiTools())
         self.gui_tools_repository.add('Dimension', edit_draft.DraftDimensionGuiTools()) # Backward compatibility
         self.gui_tools_repository.add('LinearDimension', edit_draft.DraftDimensionGuiTools())
+        self.gui_tools_repository.add('Label', edit_draft.DraftLabelGuiTools())
 
         self.gui_tools_repository.add('Wall', edit_arch.ArchWallGuiTools())
         self.gui_tools_repository.add('Window', edit_arch.ArchWindowGuiTools())

--- a/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
@@ -574,6 +574,40 @@ class DraftDimensionGuiTools(GuiTools):
             obj.ViewObject.TextPosition = v
 
 
+class DraftLabelGuiTools(GuiTools):
+
+    def __init__(self):
+        pass
+
+    def get_edit_points(self, obj):
+        editpoints = []
+        if obj.StraightDirection != "Custom":
+            editpoints.append(obj.Points[0])
+            editpoints.append(obj.Points[1])
+            editpoints.append(obj.Points[2])
+            if editpoints[0].isEqual(editpoints[1], 0.001):
+                # If StraightDistance == 0.0, editpoint 1 is exactly on editpoint 0 => Move slightly editpoint 1 to allow selection of editpoint 0
+                editpoints[1] = 0.9 * editpoints[1] + 0.1 * editpoints[2]
+        else:
+            pass # TODO : support custom direction with any number of points
+        return editpoints
+
+    def update_object_from_edit_points(self, obj, node_idx, v, alt_edit_mode=0):
+        if obj.StraightDirection != "Custom":
+            if node_idx == 0:
+                obj.Placement.Base = v
+            elif node_idx == 1:
+                vector_p1_p2 = obj.Placement.inverse().multVec(v) - obj.Placement.inverse().multVec(obj.Placement.Base)
+                if obj.StraightDirection == "Horizontal":
+                    obj.StraightDistance = vector_p1_p2.x
+                elif obj.StraightDirection == "Vertical":
+                    obj.StraightDistance = vector_p1_p2.y
+            elif node_idx == 2:
+                obj.TargetPoint = v
+        else:
+            pass # TODO : support custom direction with any number of points
+
+
 class DraftBezCurveGuiTools(GuiTools):
 
     def __init__(self):


### PR DESCRIPTION
The Draft PR implements EditTrackers for Draft Labels so that Draft Edit command works. If the Label is in a App::Part whose Placement is not (0,0,0), then the EditMarkers are incorrectly placed. The same issue already happens with Draft Dimensions. I think that this happens because Labels and Dimensions don't have the obj.getGlobalPlacement() function.