### PR TITLE
Addon Manager: Remove mentions of GitPython

### DIFF
--- a/src/Mod/AddonManager/AddonManagerOptions.ui
+++ b/src/Mod/AddonManager/AddonManagerOptions.ui
@@ -18,8 +18,7 @@
     <widget class="Gui::PrefCheckBox" name="guiprefcheckboxcheckupdates">
      <property name="toolTip">
       <string>If this option is selected, when launching the Addon Manager,
-installed addons will be checked for available updates
-(this requires the GitPython package installed on your system)</string>
+installed addons will be checked for available updates</string>
      </property>
      <property name="text">
       <string>Automatically check for updates at start (requires git)</string>

--- a/src/Mod/AddonManager/manage_python_dependencies.py
+++ b/src/Mod/AddonManager/manage_python_dependencies.py
@@ -291,7 +291,6 @@ class PythonPackageManager:
         # Package    Version
         # ---------- -------
         # gitdb      4.0.9
-        # GitPython  3.1.27
         # setuptools 41.2.0
 
         # Outdated Packages output looks like this:


### PR DESCRIPTION
Not used since:
760aaf4afe ("Addon Manager: Complete migration away from GitPython", 2024-01-27)

---

This can be backported too.
