### PR TITLE
Fem: Add element types to ABAQUS writer

### DIFF
--- a/src/Mod/Fem/App/FemMesh.h
+++ b/src/Mod/Fem/App/FemMesh.h
@@ -47,6 +47,35 @@ class TopoDS_Solid;
 namespace Fem
 {
 
+enum class ABAQUS_VolumeVariant
+{
+    Standard,
+    Reduced,
+    Incompatible,
+    Modified,
+    Fluid
+};
+enum class ABAQUS_FaceVariant
+{
+    Shell,
+    Shell_Reduced,
+    Membrane,
+    Membrane_Reduced,
+    Stress,
+    Stress_Reduced,
+    Strain,
+    Strain_Reduced,
+    Axisymmetric,
+    Axisymmetric_Reduced
+};
+enum class ABAQUS_EdgeVariant
+{
+    Beam,
+    Beam_Reduced,
+    Truss,
+    Network
+};
+
 using SMESH_HypothesisPtr = std::shared_ptr<SMESH_Hypothesis>;
 
 /** The representation of a FemMesh
@@ -172,7 +201,12 @@ public:
     /// import from files
     void read(const char* FileName);
     void write(const char* FileName) const;
-    void writeABAQUS(const std::string& Filename, int elemParam, bool groupParam) const;
+    void writeABAQUS(const std::string& Filename,
+                     int elemParam,
+                     bool groupParam,
+                     ABAQUS_VolumeVariant volVariant = ABAQUS_VolumeVariant::Standard,
+                     ABAQUS_FaceVariant faceVariant = ABAQUS_FaceVariant::Shell,
+                     ABAQUS_EdgeVariant edgeVariant = ABAQUS_EdgeVariant::Beam) const;
     void writeZ88(const std::string& FileName) const;
 
 private:

--- a/src/Mod/Fem/App/FemMeshPy.xml
+++ b/src/Mod/Fem/App/FemMeshPy.xml
@@ -74,13 +74,40 @@
                 </UserDocu>
             </Documentation>
         </Methode>
-        <Methode Name="writeABAQUS" Const="true">
+        <Methode Name="writeABAQUS" Const="true" Keyword="true">
             <Documentation>
                 <UserDocu>Write out as ABAQUS inp
                     writeABAQUS(file, int elemParam, bool groupParam)
                     elemParam: 0 = all elements, 1 = highest elements only, 2 = FEM elements only (only edges not belonging to faces and faces not belonging to volumes)
                     groupParam: true = write group data, false = do not write group data
-                </UserDocu>
+                    volVariant: Volume elements
+                        "standard": Tetra4 -> C3D4, Penta6 -> C3D6, Hexa8 -> C3D8, Tetra10 -> C3D10, Penta15 -> C3D15, Hexa20 -> C3D20
+                        "reduced": Hexa8 -> C3D8R, Hexa20 -> C3D20R
+                        "incompatible": Hexa8 -> C3D8I
+                        "modified": Tetra10 -> C3D10T
+                        "fluid": Tetra4 -> F3D4, Penta6 -> F3D6, Hexa8  -> F3D8
+
+                    faceVariant: Face elements
+                        "shell": Tria3 -> S3, Quad4 -> S4, Tria6 -> S6, Quad8 -> S8
+                        "shell reduced": Tria3 -> S3, Quad4 -> S4R, Tria6 -> S6, Quad8 -> S8R
+                        "membrane": Tria3 -> M3D3, Quad4 -> M3D4, Tria6 -> M3D6, Quad8 -> M3D8
+                        "membrane reduced": Tria3 -> M3D3, Quad4 -> M3D4R, Tria6 -> M3D6, Quad8 -> M3D8R
+                        "stress": Tria3 -> CPS3, Quad4 -> CPS4, Tria6 -> CPS6, Quad8 -> CPS8
+                        "stress reduced": Tria3 -> CPS3, Quad4 -> CPS4R, Tria6 -> CPS6, Quad8 -> CPS8R
+                        "strain": Tria3 -> CPE3, Quad4 -> CPE4, Tria6 -> CPE6, Quad8 -> CPE8
+                        "strain reduced": Tria3 -> CPE3, Quad4 -> CPE4R, Tria6 -> CPE6, Quad8 -> CPE8R
+                        "axisymmetric": Tria3 -> CAX3, Quad4 -> CAX4, Tria6 -> CAX6, Quad8 -> CAX8
+                        "axisymmetric reduced": Tria3 -> CAX3, Quad4 -> CAX4R, Tria6 -> CAX6, Quad8 -> CAX8R
+
+                    edgeVariant: Edge elements
+                        "beam": Seg2 -> B31, Seg3 -> B32
+                        "beam reduced": Seg2 -> B31R, Seg3 -> B32R
+                        "truss": Seg2 -> T3D2, eg3 -> T3D3
+                        "network": Seg3 -> D
+
+                    Elements are selected according to CalculiX availability.
+                    For example if volume variant "modified" is selected, Tetra10 mesh
+                    elements are assigned to C3D10T and remain elements uses "standard"</UserDocu>
             </Documentation>
         </Methode>
         <Methode Name="setTransform">

--- a/src/Mod/Fem/femmesh/meshtools.py
+++ b/src/Mod/Fem/femmesh/meshtools.py
@@ -2344,24 +2344,6 @@ def get_three_non_colinear_nodes(
 
 
 # ************************************************************************************************
-def write_D_network_element_to_inputfile(
-    fileName
-):
-    # replace B32 elements with D elements for fluid section
-    f = open(fileName, "r+")
-    lines = f.readlines()
-    f.seek(0)
-    for line in lines:
-        if line.find("B32") == -1:
-            f.write(line)
-        else:
-            dummy = line.replace("B32", "D")
-            f.write(dummy)
-    f.truncate()
-    f.close()
-
-
-# ************************************************************************************************
 def use_correct_fluidinout_ele_def(
     FluidInletoutlet_ele,
     fileName,
@@ -2504,85 +2486,6 @@ def compact_mesh(
 
     # may be return another value if the mesh was compacted, just check last map entries
     return (new_mesh, node_map, elem_map)
-
-# ************************************************************************************************
-def beam_reduced_integration(
-    fileName
-):
-    # replace B3x elements with B3xR elements
-    f = open(fileName, "r+")
-    lines = f.readlines()
-    f.seek(0)
-    for line in lines:
-        if line.find("B32") != -1:
-            line = line.replace("B32", "B32R")
-        if line.find("B31") != -1:
-            line = line.replace("B31", "B31R")
-        f.write(line)
-    
-    f.truncate()
-    f.close()
-
-def plane_stress(
-    fileName
-):
-    # replace shell elements with plane stress elements
-    f = open(fileName, "r+")
-    lines = f.readlines()
-    f.seek(0)
-    for line in lines:
-        if line.find("S3") != -1:
-            line = line.replace("S3", "CPS3")
-        if line.find("S6") != -1:
-            line = line.replace("S6", "CPS6")
-        if line.find("S4") != -1:
-            line = line.replace("S4", "CPS4")
-        if line.find("S8") != -1:
-            line = line.replace("S8", "CPS8")
-        f.write(line)
-    
-    f.truncate()
-    f.close()
-def plane_strain(
-    fileName
-):
-    # replace shell elements with plane strain elements
-    f = open(fileName, "r+")
-    lines = f.readlines()
-    f.seek(0)
-    for line in lines:
-        if line.find("S3") != -1:
-            line = line.replace("S3", "CPE3")
-        if line.find("S6") != -1:
-            line = line.replace("S6", "CPE6")
-        if line.find("S4") != -1:
-            line = line.replace("S4", "CPE4")
-        if line.find("S8") != -1:
-            line = line.replace("S8", "CPE8")
-        f.write(line)
-    
-    f.truncate()
-    f.close()
-def axisymmetric(
-    fileName
-):
-    # replace shell elements with axisymmetric elements
-    f = open(fileName, "r+")
-    lines = f.readlines()
-    f.seek(0)
-    for line in lines:
-        if line.find("S3") != -1:
-            line = line.replace("S3", "CAX3")
-        if line.find("S6") != -1:
-            line = line.replace("S6", "CAX6")
-        if line.find("S4") != -1:
-            line = line.replace("S4", "CAX4")
-        if line.find("S8") != -1:
-            line = line.replace("S8", "CAX8")
-        f.write(line)
-    
-    f.truncate()
-    f.close()
 
 # ************************************************************************************************
 def sub_shape_at_global_placement(obj, sub_name):

--- a/src/Mod/Fem/femsolver/calculix/write_mesh.py
+++ b/src/Mod/Fem/femsolver/calculix/write_mesh.py
@@ -36,7 +36,27 @@ def write_mesh(ccxwriter):
 
     element_param = 1  # highest element order only
     group_param = False  # do not write mesh group data
-    if ccxwriter.split_inpfile is True:
+
+    # Use reduced integration beam elements if this option is enabled in ccx solver settings
+    vol_variant = "standard"
+    edge_variant = "beam"
+    if ccxwriter.solver_obj.BeamReducedIntegration:
+        edge_variant = "beam reduced"
+    # Check to see if fluid sections are in analysis and use D network element type
+    if ccxwriter.member.geos_fluidsection:
+        edge_variant = "network"
+
+    # Use 2D elements if model space is not set to 3D
+    if ccxwriter.solver_obj.ModelSpace == "3D":
+        face_variant = "shell"
+    elif ccxwriter.solver_obj.ModelSpace == "plane stress":
+        face_variant = "stress"
+    elif ccxwriter.solver_obj.ModelSpace == "plane strain":
+        face_variant = "strain"
+    elif ccxwriter.solver_obj.ModelSpace == "axisymmetric":
+        face_variant = "axisymmetric"
+
+    if ccxwriter.split_inpfile:
         write_name = "femesh"
         file_name_split = ccxwriter.mesh_name + "_" + write_name + ".inp"
         ccxwriter.femmesh_file = join(ccxwriter.dir_name, file_name_split)
@@ -44,24 +64,11 @@ def write_mesh(ccxwriter):
         ccxwriter.femmesh.writeABAQUS(
             ccxwriter.femmesh_file,
             element_param,
-            group_param
+            group_param,
+            volVariant=vol_variant,
+            faceVariant=face_variant,
+            edgeVariant=edge_variant
         )
-
-        # Check to see if fluid sections are in analysis and use D network element type
-        if ccxwriter.member.geos_fluidsection:
-            meshtools.write_D_network_element_to_inputfile(ccxwriter.femmesh_file)
-
-        # Use reduced integration beam elements if this option is enabled in ccx solver settings
-        if ccxwriter.solver_obj.BeamReducedIntegration:
-            meshtools.beam_reduced_integration(ccxwriter.femmesh_file)
-
-        # Use 2D elements if model space is not set to 3D
-        if ccxwriter.solver_obj.ModelSpace == "plane stress":
-            meshtools.plane_stress(ccxwriter.femmesh_file)
-        if ccxwriter.solver_obj.ModelSpace == "plane strain":
-            meshtools.plane_strain(ccxwriter.femmesh_file)
-        if ccxwriter.solver_obj.ModelSpace == "axisymmetric":
-            meshtools.axisymmetric(ccxwriter.femmesh_file)
 
         inpfile = codecs.open(ccxwriter.file_name, "w", encoding="utf-8")
         inpfile.write("{}\n".format(59 * "*"))
@@ -73,25 +80,11 @@ def write_mesh(ccxwriter):
         ccxwriter.femmesh.writeABAQUS(
             ccxwriter.femmesh_file,
             element_param,
-            group_param
+            group_param,
+            volVariant=vol_variant,
+            faceVariant=face_variant,
+            edgeVariant=edge_variant
         )
-
-        # Check to see if fluid sections are in analysis and use D network element type
-        if ccxwriter.member.geos_fluidsection:
-            # inpfile is closed
-            meshtools.write_D_network_element_to_inputfile(ccxwriter.femmesh_file)
-
-        # Use reduced integration beam elements if this option is enabled in ccx solver settings
-        if ccxwriter.solver_obj.BeamReducedIntegration:
-            meshtools.beam_reduced_integration(ccxwriter.femmesh_file)
-
-        # Use 2D elements if model space is not set to 3D
-        if ccxwriter.solver_obj.ModelSpace == "plane stress":
-            meshtools.plane_stress(ccxwriter.femmesh_file)
-        if ccxwriter.solver_obj.ModelSpace == "plane strain":
-            meshtools.plane_strain(ccxwriter.femmesh_file)
-        if ccxwriter.solver_obj.ModelSpace == "axisymmetric":
-            meshtools.axisymmetric(ccxwriter.femmesh_file)
 
         # reopen file with "append" to add all the rest
         inpfile = codecs.open(ccxwriter.femmesh_file, "a", encoding="utf-8")


### PR DESCRIPTION
This pull request extends the ABAQUS writer to select the element types available in CalculiX.
A set of "variants" is added to manage how to map mesh elements to specific solver elements.
See the Python `writeABAQUS` function for more details.
Additionally, the need to overwrite the .inp file to change element types is avoided. The second commit removes the now unused functions.
@FEA-eng your suggestions are welcome.