### PR TITLE
Tools: Resolve SyntaxWarning in generateTools.py

### DIFF
--- a/src/Tools/generateBase/generateTools.py
+++ b/src/Tools/generateBase/generateTools.py
@@ -142,7 +142,7 @@ def replace(template, dict, file):
     import re
 
     rex = re.compile("@([^@]+)@")
-    rbe = re.compile("\+")
+    rbe = re.compile(r"\+")
     ren = re.compile("-")
     rco = re.compile("= ")
     x = 23  # just a variable to try substitution
@@ -157,7 +157,7 @@ if __name__ == "__main__":
     import re
 
     rex = re.compile("@([^@]+)@")
-    rbe = re.compile("\+")
+    rbe = re.compile(r"\+")
     ren = re.compile("-")
     rco = re.compile("= ")
     x = 23  # just a variable to try substitution


### PR DESCRIPTION
```py
src/Tools/generateBase/generateTools.py:144: SyntaxWarning: invalid escape sequence '\+'
  rbe = re.compile("\+")
```
