### PR TITLE
Material: MaterialTreeWidget usability enhancements

### DIFF
--- a/src/Mod/Material/App/AppMaterial.cpp
+++ b/src/Mod/Material/App/AppMaterial.cpp
@@ -27,9 +27,7 @@
 #include <Base/Interpreter.h>
 #include <Base/PyObjectBase.h>
 
-// #include "Model.h"
-#include "MaterialFilter.h"
-
+#include "MaterialFilterPy.h"
 #include "MaterialManagerPy.h"
 #include "MaterialPy.h"
 #include "ModelManagerPy.h"
@@ -68,6 +66,7 @@ PyMOD_INIT_FUNC(Materials)
     Base::Console().Log("Loading Material module... done\n");
 
     Base::Interpreter().addType(&Materials::MaterialManagerPy::Type, module, "MaterialManager");
+    Base::Interpreter().addType(&Materials::MaterialFilterPy::Type, module, "MaterialFilter");
     Base::Interpreter().addType(&Materials::MaterialPy::Type, module, "Material");
     Base::Interpreter().addType(&Materials::ModelManagerPy::Type, module, "ModelManager");
     Base::Interpreter().addType(&Materials::ModelPropertyPy::Type, module, "ModelProperty");

--- a/src/Mod/Material/App/MaterialFilter.cpp
+++ b/src/Mod/Material/App/MaterialFilter.cpp
@@ -33,12 +33,31 @@
 
 using namespace Materials;
 
+MaterialFilterOptions::MaterialFilterOptions()
+    : _includeFavorites(true)
+    , _includeRecent(true)
+    , _includeFolders(true)
+    , _includeLibraries(true)
+    , _includeLegacy(false)
+{}
+
+MaterialFilterTreeWidgetOptions::MaterialFilterTreeWidgetOptions()
+{
+    auto param = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Material/TreeWidget");
+    _includeFavorites = param->GetBool("ShowFavorites", true);
+    _includeRecent = param->GetBool("ShowRecent", true);
+    _includeFolders = param->GetBool("ShowEmptyFolders", false);
+    _includeLibraries = param->GetBool("ShowEmptyLibraries", true);
+    _includeLegacy = param->GetBool("ShowLegacy", false);
+}
+
+//===
+
 TYPESYSTEM_SOURCE(Materials::MaterialFilter, Base::BaseClass)
 
 MaterialFilter::MaterialFilter()
-    : _includeFolders(true)
-    , _includeLegacy(true)
-    , _required()
+    : _required()
     , _requiredComplete()
 {}
 

--- a/src/Mod/Material/App/MaterialFilter.h
+++ b/src/Mod/Material/App/MaterialFilter.h
@@ -24,6 +24,7 @@
 
 #include <memory>
 
+#include <QMetaType>
 #include <QSet>
 #include <QString>
 
@@ -37,6 +38,102 @@ namespace Materials
 class Material;
 
 /*
+ * This class is used to set options for a material tree search
+ *
+ */
+class MaterialsExport MaterialFilterOptions
+{
+
+public:
+    MaterialFilterOptions();
+    virtual ~MaterialFilterOptions() = default;
+
+    /* Indicates if we should show favourite materials
+     *
+     * Default is to show favourite materials
+     */
+    bool includeFavorites() const
+    {
+        return _includeFavorites;
+    }
+    void setIncludeFavorites(bool value)
+    {
+        _includeFavorites = value;
+    }
+
+    /* Indicates if we should show recent materials
+     *
+     * Default is to show recent materials
+     */
+    bool includeRecent() const
+    {
+        return _includeRecent;
+    }
+    void setIncludeRecent(bool value)
+    {
+        _includeRecent = value;
+    }
+
+    /* Indicates if we should include empty folders
+     *
+     * Default is not to include empty folders
+     */
+    bool includeEmptyFolders() const
+    {
+        return _includeFolders;
+    }
+    void setIncludeEmptyFolders(bool value)
+    {
+        _includeFolders = value;
+    }
+
+    /* Indicates if we should include empty libraries
+     *
+     * Default is to include empty libraries
+     */
+    bool includeEmptyLibraries() const
+    {
+        return _includeLibraries;
+    }
+    void setIncludeEmptyLibraries(bool value)
+    {
+        _includeLibraries = value;
+    }
+
+    /* Indicates if we should include materials in the older format
+     *
+     * Default is not to include legacy format materials
+     */
+    bool includeLegacy() const
+    {
+        return _includeLegacy;
+    }
+    void setIncludeLegacy(bool legacy)
+    {
+        _includeLegacy = legacy;
+    }
+
+protected:
+    bool _includeFavorites;
+    bool _includeRecent;
+    bool _includeFolders;
+    bool _includeLibraries;
+    bool _includeLegacy;
+};
+
+/*
+ * The same class initialized with preferences for the MaterialTreeWidget
+ *
+ */
+class MaterialsExport MaterialFilterTreeWidgetOptions: public MaterialFilterOptions
+{
+
+public:
+    MaterialFilterTreeWidgetOptions();
+    ~MaterialFilterTreeWidgetOptions() override = default;
+};
+
+/*
  * This class is used to filter materials during a material tree search
  *
  */
@@ -48,30 +145,17 @@ public:
     MaterialFilter();
     virtual ~MaterialFilter() = default;
 
-    /* Indicates if we should include empty folders
-     *
-     * Default is to include empty folders
+    /*
+     * Filter name when used in a list of filters. The name should be
+     * unique within the list.
      */
-    bool includeEmptyFolders() const
+    QString name() const
     {
-        return _includeFolders;
+        return _name;
     }
-    void setIncludeEmptyFolders(bool value)
+    void setName(const QString& name)
     {
-        _includeFolders = value;
-    }
-
-    /* Indicates if we should include materials in the older format
-     *
-     * Default is to include legacy format materials
-     */
-    bool includeLegacy() const
-    {
-        return _includeLegacy;
-    }
-    void setIncludeLegacy(bool legacy)
-    {
-        _includeLegacy = legacy;
+        _name = name;
     }
 
     /* Sets of model UUIDs that should be included. Optionally, we can
@@ -101,12 +185,13 @@ public:
     }
 
 private:
-    bool _includeFolders;
-    bool _includeLegacy;
+    QString _name;
     QSet<QString> _required;
     QSet<QString> _requiredComplete;
 };
 
 }  // namespace Materials
+
+Q_DECLARE_METATYPE(Materials::MaterialFilter)
 
 #endif  // MATERIAL_MATERIALFILTER_H

--- a/src/Mod/Material/App/MaterialFilterPy.xml
+++ b/src/Mod/Material/App/MaterialFilterPy.xml
@@ -15,17 +15,11 @@
       <Author Licence="LGPL" Name="DavidCarter" EMail="dcarter@davidcarter.ca" />
       <UserDocu>Material filters.</UserDocu>
     </Documentation>
-    <Attribute Name="IncludeEmptyFolders" ReadOnly="false">
+    <Attribute Name="Name" ReadOnly="false">
       <Documentation>
-        <UserDocu>Include empty folders in the material list.</UserDocu>
+        <UserDocu>Name of the filter used to select a filter in a list</UserDocu>
       </Documentation>
-      <Parameter Name="IncludeEmptyFolders" Type="Boolean"/>
-    </Attribute>
-    <Attribute Name="IncludeLegacy" ReadOnly="false">
-      <Documentation>
-        <UserDocu>Include legacy materials in the material list.</UserDocu>
-      </Documentation>
-      <Parameter Name="IncludeLegacy" Type="Boolean"/>
+      <Parameter Name="Name" Type="String"/>
     </Attribute>
     <Attribute Name="RequiredModels" ReadOnly="false">
       <Documentation>

--- a/src/Mod/Material/App/MaterialFilterPyImpl.cpp
+++ b/src/Mod/Material/App/MaterialFilterPyImpl.cpp
@@ -61,24 +61,15 @@ int MaterialFilterPy::PyInit(PyObject* /*args*/, PyObject* /*kwd*/)
     return 0;
 }
 
-Py::Boolean MaterialFilterPy::getIncludeEmptyFolders() const
+Py::String MaterialFilterPy::getName() const
 {
-    return {getMaterialFilterPtr()->includeEmptyFolders()};
+    auto filterName = getMaterialFilterPtr()->name();
+    return {filterName.toStdString()};
 }
 
-void MaterialFilterPy::setIncludeEmptyFolders(const Py::Boolean value)
+void MaterialFilterPy::setName(const Py::String value)
 {
-    getMaterialFilterPtr()->setIncludeEmptyFolders(value.isTrue());
-}
-
-Py::Boolean MaterialFilterPy::getIncludeLegacy() const
-{
-    return {getMaterialFilterPtr()->includeLegacy()};
-}
-
-void MaterialFilterPy::setIncludeLegacy(const Py::Boolean value)
-{
-    getMaterialFilterPtr()->setIncludeLegacy(value.isTrue());
+    getMaterialFilterPtr()->setName(QString::fromStdString(value));
 }
 
 Py::List MaterialFilterPy::getRequiredModels() const

--- a/src/Mod/Material/App/MaterialLibrary.cpp
+++ b/src/Mod/Material/App/MaterialLibrary.cpp
@@ -266,7 +266,8 @@ QString MaterialLibrary::getUUIDFromPath(const QString& path) const
 }
 
 bool MaterialLibrary::materialInTree(const std::shared_ptr<Material>& material,
-                                     const std::shared_ptr<Materials::MaterialFilter>& filter) const
+                                     const std::shared_ptr<Materials::MaterialFilter>& filter,
+                                     const Materials::MaterialFilterOptions& options) const
 {
     if (!filter) {
         // If there's no filter we always include
@@ -274,7 +275,7 @@ bool MaterialLibrary::materialInTree(const std::shared_ptr<Material>& material,
     }
 
     // filter out old format files
-    if (material->isOldFormat() && !filter->includeLegacy()) {
+    if (material->isOldFormat() && !options.includeLegacy()) {
         return false;
     }
 
@@ -283,7 +284,8 @@ bool MaterialLibrary::materialInTree(const std::shared_ptr<Material>& material,
 }
 
 std::shared_ptr<std::map<QString, std::shared_ptr<MaterialTreeNode>>>
-MaterialLibrary::getMaterialTree(const std::shared_ptr<Materials::MaterialFilter>& filter) const
+MaterialLibrary::getMaterialTree(const std::shared_ptr<Materials::MaterialFilter>& filter,
+                                 const Materials::MaterialFilterOptions& options) const
 {
     std::shared_ptr<std::map<QString, std::shared_ptr<MaterialTreeNode>>> materialTree =
         std::make_shared<std::map<QString, std::shared_ptr<MaterialTreeNode>>>();
@@ -292,7 +294,7 @@ MaterialLibrary::getMaterialTree(const std::shared_ptr<Materials::MaterialFilter
         auto filename = it.first;
         auto material = it.second;
 
-        if (materialInTree(material, filter)) {
+        if (materialInTree(material, filter, options)) {
             QStringList list = filename.split(QString::fromStdString("/"));
 
             // Start at the root
@@ -325,7 +327,7 @@ MaterialLibrary::getMaterialTree(const std::shared_ptr<Materials::MaterialFilter
 
     // Empty folders aren't included in _materialPathMap, so we add them by looking at the file
     // system
-    if (!filter || filter->includeEmptyFolders()) {
+    if (!filter || options.includeEmptyFolders()) {
         auto folderList = MaterialLoader::getMaterialFolders(*this);
         for (auto& folder : *folderList) {
             QStringList list = folder.split(QString::fromStdString("/"));

--- a/src/Mod/Material/App/MaterialLibrary.h
+++ b/src/Mod/Material/App/MaterialLibrary.h
@@ -41,6 +41,7 @@ namespace Materials
 class Material;
 class MaterialManager;
 class MaterialFilter;
+class MaterialFilterOptions;
 
 class MaterialsExport MaterialLibrary: public LibraryBase,
                                        public std::enable_shared_from_this<MaterialLibrary>
@@ -79,7 +80,8 @@ public:
     std::shared_ptr<Material> addMaterial(const std::shared_ptr<Material>& material,
                                           const QString& path);
     std::shared_ptr<std::map<QString, std::shared_ptr<MaterialTreeNode>>>
-    getMaterialTree(const std::shared_ptr<Materials::MaterialFilter>& filter) const;
+    getMaterialTree(const std::shared_ptr<Materials::MaterialFilter>& filter,
+                    const Materials::MaterialFilterOptions& options) const;
 
     bool isReadOnly() const
     {
@@ -99,7 +101,8 @@ protected:
     void updatePaths(const QString& oldPath, const QString& newPath);
     QString getUUIDFromPath(const QString& path) const;
     bool materialInTree(const std::shared_ptr<Material>& material,
-                        const std::shared_ptr<Materials::MaterialFilter>& filter) const;
+                        const std::shared_ptr<Materials::MaterialFilter>& filter,
+                        const Materials::MaterialFilterOptions& options) const;
 
     bool _readOnly;
     std::unique_ptr<std::map<QString, std::shared_ptr<Material>>> _materialPathMap;

--- a/src/Mod/Material/App/MaterialManager.cpp
+++ b/src/Mod/Material/App/MaterialManager.cpp
@@ -23,6 +23,7 @@
 #ifndef _PreComp_
 #endif
 
+#include <QMutex>
 #include <QDirIterator>
 #include <QMutexLocker>
 

--- a/src/Mod/Material/App/MaterialManager.h
+++ b/src/Mod/Material/App/MaterialManager.h
@@ -24,8 +24,6 @@
 
 #include <memory>
 
-#include <QMutex>
-
 #include <boost/filesystem.hpp>
 
 #include <Mod/Material/MaterialGlobal.h>
@@ -34,8 +32,11 @@
 #include "Materials.h"
 
 #include "MaterialLibrary.h"
+#include "MaterialFilter.h"
 
 namespace fs = boost::filesystem;
+
+class QMutex;
 
 namespace App
 {
@@ -44,8 +45,6 @@ class Material;
 
 namespace Materials
 {
-
-class MaterialFilter;
 
 class MaterialsExport MaterialManager: public Base::BaseClass
 {
@@ -77,13 +76,22 @@ public:
     getMaterialTree(const std::shared_ptr<MaterialLibrary>& library,
                     const std::shared_ptr<Materials::MaterialFilter>& filter) const
     {
-        return library->getMaterialTree(filter);
+        MaterialFilterOptions options;
+        return library->getMaterialTree(filter, options);
+    }
+    std::shared_ptr<std::map<QString, std::shared_ptr<MaterialTreeNode>>>
+    getMaterialTree(const std::shared_ptr<MaterialLibrary>& library,
+                    const std::shared_ptr<Materials::MaterialFilter>& filter,
+                    const MaterialFilterOptions& options) const
+    {
+        return library->getMaterialTree(filter, options);
     }
     std::shared_ptr<std::map<QString, std::shared_ptr<MaterialTreeNode>>>
     getMaterialTree(const std::shared_ptr<MaterialLibrary>& library) const
     {
         std::shared_ptr<Materials::MaterialFilter> filter;
-        return library->getMaterialTree(filter);
+        MaterialFilterOptions options;
+        return library->getMaterialTree(filter, options);
     }
     std::shared_ptr<std::list<QString>>
     getMaterialFolders(const std::shared_ptr<MaterialLibrary>& library) const;

--- a/src/Mod/Material/App/MaterialManagerPyImpl.cpp
+++ b/src/Mod/Material/App/MaterialManagerPyImpl.cpp
@@ -71,7 +71,7 @@ PyObject* MaterialManagerPy::getMaterial(PyObject* args)
 
 PyObject* MaterialManagerPy::getMaterialByPath(PyObject* args)
 {
-    char* path;
+    char* path {};
     const char* lib = "";
     if (!PyArg_ParseTuple(args, "et|s", "utf-8", &path, &lib)) {
         return nullptr;

--- a/src/Mod/Material/Gui/AppMatGui.cpp
+++ b/src/Mod/Material/Gui/AppMatGui.cpp
@@ -34,6 +34,8 @@
 #include "DlgSettingsMaterial.h"
 #include "Workbench.h"
 #include "WorkbenchManipulator.h"
+#include "MaterialTreeWidget.h"
+#include "MaterialTreeWidgetPy.h"
 
 // use a different name to CreateCommand()
 void CreateMaterialCommands();
@@ -78,7 +80,7 @@ PyMOD_INIT_FUNC(MatGui)
 
     // load needed modules
     try {
-        Base::Interpreter().runString("import Material");
+        Base::Interpreter().runString("import Materials");
     }
     catch (const Base::Exception& e) {
         PyErr_SetString(PyExc_ImportError, e.what());
@@ -106,6 +108,19 @@ PyMOD_INIT_FUNC(MatGui)
 
     // add resources and reloads the translators
     loadMaterialResource();
+
+    Base::Interpreter().addType(&MatGui::MaterialTreeWidgetPy::Type,
+                                matGuiModule,
+                                "MaterialTreeWidget");
+
+
+    // Initialize types
+
+    MatGui::MaterialTreeWidget::init();
+
+    // Add custom widgets
+    new Gui::WidgetProducer<MatGui::MaterialTreeWidget>;
+
 
     PyMOD_Return(matGuiModule);
 }

--- a/src/Mod/Material/Gui/CMakeLists.txt
+++ b/src/Mod/Material/Gui/CMakeLists.txt
@@ -36,6 +36,14 @@ qt_find_and_add_translation(QM_SRCS "Resources/translations/*_*.ts"
 qt_create_resource_file(${Material_TR_QRC} ${QM_SRCS})
 qt_add_resources(MatGui_QRC_SRCS Resources/Material.qrc ${Material_TR_QRC})
 
+generate_from_xml(MaterialTreeWidgetPy)
+
+SET(Python_SRCS
+    MaterialTreeWidgetPy.xml
+    MaterialTreeWidgetPyImpl.cpp
+)
+SOURCE_GROUP("Python" FILES ${Python_SRCS})
+
 set(MatGui_UIC_SRCS
     Array2D.ui
     Array3D.ui
@@ -51,6 +59,7 @@ set(MatGui_UIC_SRCS
 )
 
 SET(MatGui_SRCS
+    ${Python_SRCS}
     ${MatGui_QRC_SRCS}
     ${MatGui_UIC_HDRS}
     AppearancePreview.h

--- a/src/Mod/Material/Gui/DlgDisplayProperties.ui
+++ b/src/Mod/Material/Gui/DlgDisplayProperties.ui
@@ -402,18 +402,6 @@
         </item>
         <item row="0" column="1">
          <widget class="QPushButton" name="buttonUserDefinedMaterial">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>32767</height>
-           </size>
-          </property>
           <property name="text">
            <string notr="true">...</string>
           </property>

--- a/src/Mod/Material/Gui/DlgDisplayPropertiesImp.h
+++ b/src/Mod/Material/Gui/DlgDisplayPropertiesImp.h
@@ -84,6 +84,7 @@ protected:
 
 private:
     void setupConnections();
+    void setupFilters();
     void slotChangedObject(const Gui::ViewProvider&, const App::Property& Prop);
     void setDisplayModes(const std::vector<Gui::ViewProvider*>&);
     void setMaterial(const std::vector<Gui::ViewProvider*>&);

--- a/src/Mod/Material/Gui/DlgSettingsMaterial.cpp
+++ b/src/Mod/Material/Gui/DlgSettingsMaterial.cpp
@@ -43,6 +43,11 @@ void DlgSettingsMaterial::saveSettings()
     ui->fc_custom_mat_dir->onSave();
     ui->cb_delete_duplicates->onSave();
     ui->cb_sort_by_resources->onSave();
+    ui->cb_show_favorites->onSave();
+    ui->cb_show_recent->onSave();
+    ui->cb_show_empty_libraries->onSave();
+    ui->cb_show_empty_folders->onSave();
+    ui->cb_show_legacy->onSave();
 
     // Temporary for testing
     ui->cb_legacy_editor->onSave();
@@ -57,6 +62,11 @@ void DlgSettingsMaterial::loadSettings()
     ui->fc_custom_mat_dir->onRestore();
     ui->cb_delete_duplicates->onRestore();
     ui->cb_sort_by_resources->onRestore();
+    ui->cb_show_favorites->onRestore();
+    ui->cb_show_recent->onRestore();
+    ui->cb_show_empty_libraries->onRestore();
+    ui->cb_show_empty_folders->onRestore();
+    ui->cb_show_legacy->onRestore();
 
     // Temporary for testing
     ui->cb_legacy_editor->onRestore();

--- a/src/Mod/Material/Gui/DlgSettingsMaterial.ui
+++ b/src/Mod/Material/Gui/DlgSettingsMaterial.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>434</width>
-    <height>341</height>
+    <height>553</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -225,6 +225,89 @@ If unchecked, they will be sorted by their name.</string>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Material/Cards</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbMaterialSelector">
+     <property name="title">
+      <string>Material Selector</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_show_favorites">
+        <property name="text">
+         <string>Show favorites</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowFavorites</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Material/TreeWidget</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_show_recent">
+        <property name="text">
+         <string>Show recent</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowRecent</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Material/TreeWidget</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_show_empty_libraries">
+        <property name="text">
+         <string>Show empty libraries</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowEmptyLibraries</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Material/TreeWidget</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_show_empty_folders">
+        <property name="text">
+         <string>Show empty folders</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowEmptyFolders</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Material/TreeWidget</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_show_legacy">
+        <property name="text">
+         <string>Show legacy files</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowLegacy</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Material/TreeWidget</cstring>
         </property>
        </widget>
       </item>

--- a/src/Mod/Material/Gui/MaterialTreeWidgetPy.xml
+++ b/src/Mod/Material/Gui/MaterialTreeWidgetPy.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
+  <PythonExport
+      Father="BaseClassPy"
+      Name="MaterialTreeWidgetPy"
+      Twin="MaterialTreeWidget"
+      TwinPointer="MaterialTreeWidget"
+      Include="Mod/Material/Gui/MaterialTreeWidget.h"
+      Namespace="MatGui"
+      FatherInclude="Base/BaseClassPy.h"
+      FatherNamespace="Base"
+      Constructor="true"
+      Delete="false">
+    <Documentation>
+      <Author Licence="LGPL" Name="DavidCarter" EMail="dcarter@davidcarter.ca" />
+      <UserDocu>Material tree widget.</UserDocu>
+    </Documentation>
+    <Attribute Name="UUID" ReadOnly="false">
+      <Documentation>
+        <UserDocu>Material UUID.</UserDocu>
+      </Documentation>
+      <Parameter Name="UUID" Type="String"/>
+    </Attribute>
+    <Attribute Name="expanded" ReadOnly="false">
+      <Documentation>
+        <UserDocu>Expand material tree.</UserDocu>
+      </Documentation>
+      <Parameter Name="expanded" Type="Boolean"/>
+    </Attribute>
+    <Attribute Name="IncludeFavorites" ReadOnly="false">
+      <Documentation>
+        <UserDocu>Include favorites in the material list.</UserDocu>
+      </Documentation>
+      <Parameter Name="IncludeFavorites" Type="Boolean"/>
+    </Attribute>
+    <Attribute Name="IncludeRecent" ReadOnly="false">
+      <Documentation>
+        <UserDocu>Include recently used materials in the material list.</UserDocu>
+      </Documentation>
+      <Parameter Name="IncludeRecent" Type="Boolean"/>
+    </Attribute>
+    <Attribute Name="IncludeEmptyFolders" ReadOnly="false">
+      <Documentation>
+        <UserDocu>Include empty folders in the material list.</UserDocu>
+      </Documentation>
+      <Parameter Name="IncludeEmptyFolders" Type="Boolean"/>
+    </Attribute>
+    <Attribute Name="IncludeEmptyLibraries" ReadOnly="false">
+      <Documentation>
+        <UserDocu>Include empty libraries in the material list.</UserDocu>
+      </Documentation>
+      <Parameter Name="IncludeEmptyLibraries" Type="Boolean"/>
+    </Attribute>
+    <Attribute Name="IncludeLegacy" ReadOnly="false">
+      <Documentation>
+        <UserDocu>Include legacy materials in the material list.</UserDocu>
+      </Documentation>
+      <Parameter Name="IncludeLegacy" Type="Boolean"/>
+    </Attribute>
+    <Methode Name="setFilter">
+      <Documentation>
+        <UserDocu>Set the material filter or list of filters.</UserDocu>
+      </Documentation>
+    </Methode>
+    <Methode Name="selectFilter">
+      <Documentation>
+        <UserDocu>Set the current material filter.</UserDocu>
+      </Documentation>
+    </Methode>
+  </PythonExport>
+</GenerateModel>

--- a/src/Mod/Material/Gui/MaterialTreeWidgetPyImpl.cpp
+++ b/src/Mod/Material/Gui/MaterialTreeWidgetPyImpl.cpp
@@ -1,0 +1,238 @@
+/***************************************************************************
+ *   Copyright (c) 2023 David Carter <dcarter@david.carter.ca>             *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "PreCompiled.h"
+
+#include <Gui/PythonWrapper.h>
+
+#include "MaterialTreeWidget.h"
+#include "MaterialTreeWidgetPy.h"
+
+#include "MaterialTreeWidgetPy.cpp"
+
+using namespace MatGui;
+
+// returns a string which represents the object e.g. when printed in python
+std::string MaterialTreeWidgetPy::representation() const
+{
+    std::ostringstream str;
+    str << "<MaterialTreeWidget at " << getMaterialTreeWidgetPtr() << ">";
+    return str.str();
+}
+
+PyObject* MaterialTreeWidgetPy::PyMake(struct _typeobject*, PyObject*, PyObject*)  // Python wrapper
+{
+    // never create such objects with the constructor
+    return new MaterialTreeWidgetPy(new MaterialTreeWidget());
+}
+
+// constructor method
+int MaterialTreeWidgetPy::PyInit(PyObject* args, PyObject* /*kwd*/)
+{
+    PyObject* obj {};
+    if (PyArg_ParseTuple(args, "")) {
+        return 0;
+    }
+
+    PyErr_Clear();
+    if (PyArg_ParseTuple(args, "O!", &(MatGui::MaterialTreeWidgetPy::Type), &obj)) {
+        auto widget = static_cast<MatGui::MaterialTreeWidgetPy*>(obj)->getMaterialTreeWidgetPtr();
+        _pcTwinPointer = widget;
+        return 0;
+    }
+
+    // PyErr_Clear();
+    // if (PyArg_ParseTuple(args, "O!", &(QWidget::Type), &obj)) {
+    //     auto widget = static_cast<MatGui::MaterialTreeWidget*>(obj);
+    //     _pcTwinPointer = widget;
+    //     return 0;
+    // }
+
+    PyErr_Clear();
+    if (PyArg_ParseTuple(args, "O", &obj)) {
+        if (QLatin1String(obj->ob_type->tp_name) == QLatin1String("PySide2.QtWidgets.QWidget")) {
+            Gui::PythonWrapper wrap;
+            wrap.loadWidgetsModule();
+            auto qObject = wrap.toQObject(Py::Object(obj));
+            auto widget = static_cast<MatGui::MaterialTreeWidget*>(qObject);
+            _pcTwinPointer = widget;
+            return 0;
+        }
+        else {
+            PyErr_Format(PyExc_TypeError,
+                         "empty parameter list, or MaterialTreeWidget expected not '%s'",
+                         obj->ob_type->tp_name);
+            return -1;
+        }
+    }
+
+    PyErr_SetString(PyExc_TypeError, "empty parameter list, or MaterialTreeWidget expected");
+    // PyErr_Format(PyExc_TypeError,
+    //              "empty parameter list, or MaterialTreeWidget expected not '%s'",
+    //              obj->ob_type->tp_name);
+    return -1;
+}
+
+Py::String MaterialTreeWidgetPy::getUUID() const
+{
+    return Py::String(getMaterialTreeWidgetPtr()->getMaterialUUID().toStdString());
+}
+
+void MaterialTreeWidgetPy::setUUID(const Py::String value)
+{
+    getMaterialTreeWidgetPtr()->setMaterial(QString::fromStdString(value));
+}
+
+Py::Boolean MaterialTreeWidgetPy::getexpanded() const
+{
+    return {getMaterialTreeWidgetPtr()->getExpanded()};
+}
+
+void MaterialTreeWidgetPy::setexpanded(const Py::Boolean value)
+{
+    getMaterialTreeWidgetPtr()->setExpanded(value.isTrue());
+}
+
+Py::Boolean MaterialTreeWidgetPy::getIncludeFavorites() const
+{
+    return {getMaterialTreeWidgetPtr()->includeFavorites()};
+}
+
+void MaterialTreeWidgetPy::setIncludeFavorites(const Py::Boolean value)
+{
+    getMaterialTreeWidgetPtr()->setIncludeFavorites(value.isTrue());
+}
+
+Py::Boolean MaterialTreeWidgetPy::getIncludeRecent() const
+{
+    return {getMaterialTreeWidgetPtr()->includeRecent()};
+}
+
+void MaterialTreeWidgetPy::setIncludeRecent(const Py::Boolean value)
+{
+    getMaterialTreeWidgetPtr()->setIncludeRecent(value.isTrue());
+}
+
+Py::Boolean MaterialTreeWidgetPy::getIncludeEmptyFolders() const
+{
+    return {getMaterialTreeWidgetPtr()->includeEmptyFolders()};
+}
+
+void MaterialTreeWidgetPy::setIncludeEmptyFolders(const Py::Boolean value)
+{
+    getMaterialTreeWidgetPtr()->setIncludeEmptyFolders(value.isTrue());
+}
+
+Py::Boolean MaterialTreeWidgetPy::getIncludeEmptyLibraries() const
+{
+    return {getMaterialTreeWidgetPtr()->includeEmptyLibraries()};
+}
+
+void MaterialTreeWidgetPy::setIncludeEmptyLibraries(const Py::Boolean value)
+{
+    getMaterialTreeWidgetPtr()->setIncludeEmptyLibraries(value.isTrue());
+}
+
+Py::Boolean MaterialTreeWidgetPy::getIncludeLegacy() const
+{
+    return {getMaterialTreeWidgetPtr()->includeLegacy()};
+}
+
+void MaterialTreeWidgetPy::setIncludeLegacy(const Py::Boolean value)
+{
+    getMaterialTreeWidgetPtr()->setIncludeLegacy(value.isTrue());
+}
+
+PyObject* MaterialTreeWidgetPy::setFilter(PyObject* args)
+{
+    PyObject* obj;
+    if (!PyArg_ParseTuple(args, "O", &obj)) {
+        return nullptr;
+    }
+    if (PyObject_TypeCheck(obj, &(Materials::MaterialFilterPy::Type))) {
+        auto filter = static_cast<Materials::MaterialFilterPy*>(obj)->getMaterialFilterPtr();
+        Base::Console().Log("Filter '%s'\n", filter->name().toStdString().c_str());
+        auto filterPtr = std::make_shared<Materials::MaterialFilter>(*filter);
+        getMaterialTreeWidgetPtr()->setFilter(filterPtr);
+    }
+    else if (PyList_Check(obj)) {
+        // The argument is a list of filters
+        Base::Console().Log("Filter List\n");
+        Py_ssize_t n = PyList_Size(obj);
+        Base::Console().Log("n = %d\n", n);
+        if (n < 0) {
+            Py_Return;
+        }
+        PyObject* item;
+        auto filterList = std::make_shared<std::list<std::shared_ptr<Materials::MaterialFilter>>>();
+        for (int i = 0; i < n; i++) {
+            item = PyList_GetItem(obj, i);
+            if (PyObject_TypeCheck(item, &(Materials::MaterialFilterPy::Type))) {
+                auto filter =
+                    static_cast<Materials::MaterialFilterPy*>(item)->getMaterialFilterPtr();
+                Base::Console().Log("\tFilter '%s'\n",
+                filter->name().toStdString().c_str()); auto filterPtr =
+                std::make_shared<Materials::MaterialFilter>(*filter);
+                filterList->push_back(filterPtr);
+                // getMaterialTreeWidgetPtr()->setFilter(
+                //
+                // *static_cast<Materials::MaterialFilterPy*>(obj)->getMaterialFilterPtr());
+            }
+            else {
+                PyErr_Format(PyExc_TypeError,
+                             "List entry must be of type 'MaterialFilter' not '%s'",
+                             obj->ob_type->tp_name);
+                return nullptr;
+            }
+        }
+        getMaterialTreeWidgetPtr()->setFilter(filterList);
+    }
+    else {
+        PyErr_Format(PyExc_TypeError,
+                     "Type must be 'MaterialFilter' or list of 'MaterialFilter' not '%s'",
+                     obj->ob_type->tp_name);
+        return nullptr;
+    }
+
+    Py_Return;
+}
+
+PyObject* MaterialTreeWidgetPy::selectFilter(PyObject* args)
+{
+    char* name;
+    if (!PyArg_ParseTuple(args, "s", &name)) {
+        return nullptr;
+    }
+
+    Base::Console().Log("selectFilter(%s)\n", name);
+
+    Py_Return;
+}
+
+PyObject* MaterialTreeWidgetPy::getCustomAttributes(const char* /*attr*/) const
+{
+    return nullptr;
+}
+
+int MaterialTreeWidgetPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0;
+}


### PR DESCRIPTION
Improves the MaterialTreeWidget beyond minimum viable product.

- Filters can now be filter lists to allow a variety of filtering options.
- User preferences allow the inclusion/exclusion of favorites and recents.
- Widget state such as expansion, tree expansions, etc are saved and restored.
- show current appearancee material when editing.
- implements a python interface

Fixes #13421: always opens full tree