### PR TITLE
Part: fix shape projection of complex BSpline curves

### DIFF
--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -2309,7 +2309,7 @@ PyObject* TopoShapePy::project(PyObject *args)
 
         algo.Compute3d(Standard_True);
         algo.SetLimit(Standard_True);
-        algo.SetParams(1.e-6, 1.e-6, GeomAbs_C1, 14, 16);
+        algo.SetParams(1.e-6, 1.e-6, GeomAbs_C1, 14, 10000);
         //algo.SetDefaultParams();
         algo.Build();
         return new TopoShapePy(new TopoShape(algo.Projection()));


### PR DESCRIPTION
Projection of complex BSpline curves (containing more than 16 segments) currently fails.
Example code below projects a BSpline curve with 17 segments on a plane shape.
Output projection is empty.

```
num = 18
alt = [0,1] * num
pts = [FreeCAD.Vector(i, alt[i], 0) for i in range(num)]

bsc = Part.BSplineCurve()
bsc.buildFromPoles(pts, False, 1)
edge = bsc.toShape()

rts = Part.RectangularTrimmedSurface(Part.Plane(), -50, 50, -50, 50)
plane_shape = rts.toShape()

proj = plane_shape.project([edge])
print(proj.Edges)

```
Related bug in Curves workbench : [#116](https://github.com/tomate44/CurvesWB/issues/116)