### PR TITLE
Base/Toponaming: Correct string hasher output

### DIFF
--- a/src/App/StringHasher.cpp
+++ b/src/App/StringHasher.cpp
@@ -507,6 +507,7 @@ void StringHasher::SaveDocFile(Base::Writer& writer) const
 
 void StringHasher::saveStream(std::ostream& stream) const
 {
+    Base::TextOutputStream textStreamWrapper(stream);
     boost::io::ios_flags_saver ifs(stream);
     stream << std::hex;
 
@@ -594,8 +595,9 @@ void StringHasher::saveStream(std::ostream& stream) const
         }
         else {
             // Reaching here means the string may contain space and newlines
+            // We rely on OutputStream (i.e. textStreamWrapper) to save the string.
             stream << ' ';
-            stream << std::dec << d._data.constData() << std::hex;
+            textStreamWrapper << d._data.constData();
         }
     }
 }

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -158,9 +158,6 @@ Data::ElementMapPtr TopoShape::resetElementMap(Data::ElementMapPtr elementMap)
         _cache->subLocation.Identity();
         _subLocation.Identity();
         _parentCache.reset();
-        if ( ! elementMap->hasher && Hasher ) {
-            elementMap->hasher = Hasher;
-        }
     }
     return Data::ComplexGeoData::resetElementMap(elementMap);
 }


### PR DESCRIPTION
The corrects the string hasher output to use the `TextOutputStream` class to handle multi-line data. It also removes unneeded hasher reset code from `resetElementMap` that was breaking the synchronization between references and marks of string IDs.