### PR TITLE
Base: Fix possible race condition when restarting the application

### DIFF
--- a/tests/src/Base/Parameter.cpp
+++ b/tests/src/Base/Parameter.cpp
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include <boost/core/ignore_unused.hpp>
+#include <QLockFile>
 #include <Base/FileInfo.h>
 #include <Base/Parameter.h>
 
@@ -440,6 +441,25 @@ TEST_F(ParameterTest, TestObserverNoRef)
     auto grp2 = cfg->GetGroup("TopLevelGroup/Sub1/Sub2");
     grp2->SetFloat("Float", 2.0);
     EXPECT_EQ(obs.getCountNotifications(), 1);
+}
+
+TEST_F(ParameterTest, TestLockFile)
+{
+    std::string fn = getFileName();
+    fn.append(".lock");
+
+    QLockFile lockFile1(QString::fromStdString(fn));
+    EXPECT_TRUE(lockFile1.tryLock(100));
+    EXPECT_TRUE(lockFile1.isLocked());
+
+    QLockFile lockFile2(QString::fromStdString(fn));
+    EXPECT_FALSE(lockFile2.tryLock(100));
+    EXPECT_FALSE(lockFile2.isLocked());
+
+    lockFile1.unlock();
+    EXPECT_TRUE(lockFile2.lock());
+    EXPECT_FALSE(lockFile1.tryLock(500));
+    lockFile2.unlock();
 }
 
 // NOLINTEND(cppcoreguidelines-*,readability-*)


### PR DESCRIPTION
When restarting the application (e.g. after installing an addon) the application will be closed and a new instance will be launched. Now it can happen that the old instance is still busy writing the config files to disk while the new instance wants to read them in. At this time it's possible that a config file is in an invalid state so that the new instance will ignore it but then starts with a default configuration. Later when closing the new instance the config files will be overwritten and destroy the user's original settings.

By using a lock file this race condition will be avoided. It uses a timeout of 1 second that should be enough for the old instance to write the files to disk.