### PR TITLE
Fem: Remove unused view properties

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
@@ -24,16 +24,15 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-#include <Inventor/nodes/SoBaseColor.h>
 #include <Inventor/nodes/SoCone.h>
 #include <Inventor/nodes/SoCube.h>
 #include <Inventor/nodes/SoCylinder.h>
-#include <Inventor/nodes/SoFontStyle.h>
+#include <Inventor/nodes/SoMaterial.h>
 #include <Inventor/nodes/SoMultipleCopy.h>
+#include <Inventor/nodes/SoPickStyle.h>
 #include <Inventor/nodes/SoRotation.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoShapeHints.h>
-#include <Inventor/nodes/SoText2.h>
 #include <Inventor/nodes/SoTranslation.h>
 #include <QAction>
 #include <QDockWidget>
@@ -67,40 +66,19 @@ ViewProviderFemConstraint::ViewProviderFemConstraint()
     , wizardSubLayout(nullptr)
     , constraintDialog(nullptr)
 {
-    ADD_PROPERTY(TextColor, (0.0f, 0.0f, 0.0f));
-    ADD_PROPERTY(FaceColor, (1.0f, 0.0f, 0.2f));
-    ADD_PROPERTY(FontSize, (18));
-    ADD_PROPERTY(DistFactor, (1.0));
-    ADD_PROPERTY(Mirror, (false));
-
-    pFont = new SoFontStyle();
-    pFont->ref();
-    pLabel = new SoText2();
-    pLabel->ref();
-    pTextColor = new SoBaseColor();
-    pTextColor->ref();
     pShapeSep = new SoSeparator();
     pShapeSep->ref();
     pMultCopy = new SoMultipleCopy();
     pMultCopy->ref();
 
-    pMaterials = new SoBaseColor();
-    pMaterials->ref();
-    pMaterials->rgb.setValue(1.0f, 0.0f, 0.2f);
-
-    TextColor.touch();
-    FontSize.touch();
-    FaceColor.touch();
+    ShapeAppearance.setDiffuseColor(1.0f, 0.0f, 0.2f);
+    ShapeAppearance.setSpecularColor(0.0f, 0.0f, 0.0f);
 
     Gui::ViewProviderSuppressibleExtension::initExtension(this);
 }
 
 ViewProviderFemConstraint::~ViewProviderFemConstraint()
 {
-    pFont->unref();
-    pLabel->unref();
-    pTextColor->unref();
-    pMaterials->unref();
     pMultCopy->unref();
     pShapeSep->unref();
 }
@@ -118,7 +96,7 @@ void ViewProviderFemConstraint::attach(App::DocumentObject* pcObject)
     hints->vertexOrdering.setValue(SoShapeHints::COUNTERCLOCKWISE);
     sep->addChild(ps);
     sep->addChild(hints);
-    sep->addChild(pMaterials);
+    sep->addChild(pcShapeMaterial);
     sep->addChild(pShapeSep);
     addDisplayMaskMode(sep, "Base");
 }
@@ -191,23 +169,7 @@ void ViewProviderFemConstraint::setupContextMenu(QMenu* menu, QObject* receiver,
 
 void ViewProviderFemConstraint::onChanged(const App::Property* prop)
 {
-    if (prop == &Mirror) {
-        updateData(prop);
-    }
-    else if (prop == &TextColor) {
-        const App::Color& c = TextColor.getValue();
-        pTextColor->rgb.setValue(c.r, c.g, c.b);
-    }
-    else if (prop == &FaceColor) {
-        const App::Color& c = FaceColor.getValue();
-        pMaterials->rgb.setValue(c.r, c.g, c.b);
-    }
-    else if (prop == &FontSize) {
-        pFont->size = FontSize.getValue();
-    }
-    else {
-        ViewProviderDocumentObject::onChanged(prop);  // clazy:exclude=skipped-base-method
-    }
+    ViewProviderGeometryObject::onChanged(prop);
 }
 
 void ViewProviderFemConstraint::updateData(const App::Property* prop)
@@ -220,6 +182,25 @@ void ViewProviderFemConstraint::updateData(const App::Property* prop)
     }
     else {
         ViewProviderGeometryObject::updateData(prop);
+    }
+}
+
+void ViewProviderFemConstraint::handleChangedPropertyName(Base::XMLReader& reader,
+                                                          const char* typeName,
+                                                          const char* propName)
+{
+    if (strcmp(propName, "FaceColor") == 0
+        && Base::Type::fromName(typeName) == App::PropertyColor::getClassTypeId()) {
+        App::PropertyColor color;
+        color.Restore(reader);
+        ShapeAppearance.setDiffuseColor(color.getValue());
+    }
+    else if (strcmp(propName, "ShapeMaterial") == 0
+             && Base::Type::fromName(typeName) == App::PropertyMaterial::getClassTypeId()) {
+        // nothing
+    }
+    else {
+        ViewProviderGeometryObject::handleChangedPropertyName(reader, typeName, propName);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
@@ -35,10 +35,6 @@
 
 
 class SbRotation;
-class SoFontStyle;
-class SoText2;
-class SoBaseColor;
-class SoMaterial;
 class SoMultipleCopy;
 
 namespace FemGui
@@ -55,13 +51,6 @@ public:
     /// Constructor
     ViewProviderFemConstraint();
     ~ViewProviderFemConstraint() override;
-
-    // Display properties
-    App::PropertyColor TextColor;
-    App::PropertyColor FaceColor;
-    App::PropertyInteger FontSize;
-    App::PropertyFloat DistFactor;
-    App::PropertyBool Mirror;
 
     void attach(App::DocumentObject*) override;
     void updateData(const App::Property* prop) override;
@@ -98,6 +87,9 @@ protected:
     void onChanged(const App::Property* prop) override;
     bool setEdit(int ModNum) override;
     void unsetEdit(int ModNum) override;
+    void handleChangedPropertyName(Base::XMLReader& reader,
+                                   const char* typeName,
+                                   const char* propName) override;
 
     void updateSymbol();
     virtual void
@@ -165,10 +157,6 @@ protected:
                                const bool gap = false);
 
 private:
-    SoFontStyle* pFont;
-    SoText2* pLabel;
-    SoBaseColor* pTextColor;
-    SoBaseColor* pMaterials;
     bool rotateSymbol;
 
 protected:

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintContact.cpp
@@ -44,7 +44,7 @@ ViewProviderFemConstraintContact::ViewProviderFemConstraintContact()
     loadSymbol((resourceSymbolDir + "ConstraintContact.iv").c_str());
     // Note change "Contact" in line above to new constraint name, make sure it is the same as in
     // taskFem* cpp file
-    ADD_PROPERTY(FaceColor, (0.2f, 0.3f, 0.2f));
+    ShapeAppearance.setDiffuseColor(0.2f, 0.3f, 0.2f);
 }
 
 ViewProviderFemConstraintContact::~ViewProviderFemConstraintContact() = default;

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp
@@ -45,7 +45,7 @@ ViewProviderFemConstraintDisplacement::ViewProviderFemConstraintDisplacement()
 {
     sPixmap = "FEM_ConstraintDisplacement";
     loadSymbol((resourceSymbolDir + "ConstraintDisplacement.iv").c_str());
-    ADD_PROPERTY(FaceColor, (0.2f, 0.3f, 0.2f));
+    ShapeAppearance.setDiffuseColor(0.2f, 0.3f, 0.2f);
 
     // do not rotate symbol according to boundary normal
     setRotateSymbol(false);

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintFixed.cpp
@@ -24,10 +24,6 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-#include <Inventor/SbRotation.h>
-#include <Inventor/SbVec3f.h>
-#include <Inventor/nodes/SoMultipleCopy.h>
-#include <Inventor/nodes/SoSeparator.h>
 #include <QMessageBox>
 #endif
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.cpp
@@ -134,19 +134,19 @@ void ViewProviderFemConstraintFluidBoundary::updateData(const App::Property* pro
     std::string boundaryType = pcConstraint->BoundaryType.getValueAsString();
     if (prop == &pcConstraint->BoundaryType) {
         if (boundaryType == "wall") {
-            FaceColor.setValue(0.0, 1.0, 1.0);
+            ShapeAppearance.setDiffuseColor(0.0, 1.0, 1.0);
         }
         else if (boundaryType == "interface") {
-            FaceColor.setValue(0.0, 1.0, 0.0);
+            ShapeAppearance.setDiffuseColor(0.0, 1.0, 0.0);
         }
         else if (boundaryType == "freestream") {
-            FaceColor.setValue(1.0, 1.0, 0.0);
+            ShapeAppearance.setDiffuseColor(1.0, 1.0, 0.0);
         }
         else if (boundaryType == "inlet") {
-            FaceColor.setValue(1.0, 0.0, 0.0);
+            ShapeAppearance.setDiffuseColor(1.0, 0.0, 0.0);
         }
         else {  //(boundaryType == "outlet")
-            FaceColor.setValue(0.0, 0.0, 1.0);
+            ShapeAppearance.setDiffuseColor(0.0, 0.0, 1.0);
         }
     }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintHeatflux.cpp
@@ -44,8 +44,7 @@ ViewProviderFemConstraintHeatflux::ViewProviderFemConstraintHeatflux()
 {
     sPixmap = "FEM_ConstraintHeatflux";
     loadSymbol((resourceSymbolDir + "ConstraintHeatFlux.iv").c_str());
-
-    FaceColor.setValue(1.0f, 0.0f, 0.0f);
+    ShapeAppearance.setDiffuseColor(1.0f, 0.0f, 0.0f);
 }
 
 ViewProviderFemConstraintHeatflux::~ViewProviderFemConstraintHeatflux() = default;

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintInitialTemperature.cpp
@@ -40,7 +40,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderFemConstraintInitialTemperature,
 ViewProviderFemConstraintInitialTemperature::ViewProviderFemConstraintInitialTemperature()
 {
     sPixmap = "FEM_ConstraintInitialTemperature";
-    ADD_PROPERTY(FaceColor, (0.2f, 0.3f, 0.2f));
+    ShapeAppearance.setDiffuseColor(0.2f, 0.3f, 0.2f);
 }
 
 ViewProviderFemConstraintInitialTemperature::~ViewProviderFemConstraintInitialTemperature() =

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.cpp
@@ -99,10 +99,10 @@ void ViewProviderFemConstraintOnBoundary::highlightReferences(const bool on)
                 std::vector<App::Color> colors = originalFaceColors[base];
 
                 // go through the subelements with constraint and recolor them
-                // TODO: Replace `FaceColor` with anything more appropriate
-                PartGui::ReferenceHighlighter highlighter(base->Shape.getValue(),
-                                                          colors.empty() ? FaceColor.getValue()
-                                                                         : colors[0]);
+                // TODO: Replace shape DiffuseColor with anything more appropriate
+                PartGui::ReferenceHighlighter highlighter(
+                    base->Shape.getValue(),
+                    colors.empty() ? ShapeAppearance.getDiffuseColor() : colors[0]);
                 highlighter.getFaceColors(subSet.second, colors);
                 vp->DiffuseColor.setValues(colors);
             }

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPlaneRotation.cpp
@@ -45,7 +45,7 @@ ViewProviderFemConstraintPlaneRotation::ViewProviderFemConstraintPlaneRotation()
     loadSymbol((resourceSymbolDir + "ConstraintPlaneRotation.iv").c_str());
     // Note change "planerotation" in line above to new constraint name, make sure it is the same as
     // in taskFem* cpp file
-    ADD_PROPERTY(FaceColor, (0.2f, 0.3f, 0.2f));
+    ShapeAppearance.setDiffuseColor(0.2f, 0.3f, 0.2f);
 }
 
 ViewProviderFemConstraintPlaneRotation::~ViewProviderFemConstraintPlaneRotation() = default;

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
@@ -45,8 +45,7 @@ ViewProviderFemConstraintPressure::ViewProviderFemConstraintPressure()
 {
     sPixmap = "FEM_ConstraintPressure";
     loadSymbol((resourceSymbolDir + "ConstraintPressure.iv").c_str());
-
-    ADD_PROPERTY(FaceColor, (0.0f, 0.2f, 0.8f));
+    ShapeAppearance.setDiffuseColor(0.0f, 0.2f, 0.8f);
 }
 
 ViewProviderFemConstraintPressure::~ViewProviderFemConstraintPressure() = default;

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintSpring.cpp
@@ -42,7 +42,7 @@ ViewProviderFemConstraintSpring::ViewProviderFemConstraintSpring()
 {
     sPixmap = "FEM_ConstraintSpring";
     loadSymbol((resourceSymbolDir + "ConstraintSpring.iv").c_str());
-    ADD_PROPERTY(FaceColor, (0.0f, 0.2f, 0.8f));
+    ShapeAppearance.setDiffuseColor(0.0f, 0.2f, 0.8f);
 }
 
 ViewProviderFemConstraintSpring::~ViewProviderFemConstraintSpring() = default;

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintTemperature.cpp
@@ -43,8 +43,7 @@ ViewProviderFemConstraintTemperature::ViewProviderFemConstraintTemperature()
 {
     sPixmap = "FEM_ConstraintTemperature";
     loadSymbol((resourceSymbolDir + "ConstraintTemperature.iv").c_str());
-
-    FaceColor.setValue(1.0f, 0.0f, 0.0f);
+    ShapeAppearance.setDiffuseColor(1.0f, 0.0f, 0.0f);
 }
 
 ViewProviderFemConstraintTemperature::~ViewProviderFemConstraintTemperature() = default;

--- a/src/Mod/Fem/femviewprovider/view_constraint_tie.py
+++ b/src/Mod/Fem/femviewprovider/view_constraint_tie.py
@@ -40,6 +40,9 @@ class VPConstraintTie(view_base_femconstraint.VPBaseFemConstraint):
 
     def __init__(self, vobj):
         super().__init__(vobj)
+        mat = vobj.ShapeAppearance[0]
+        mat.DiffuseColor = (0.3, 0.7, 0.5, 0.0)
+        vobj.ShapeAppearance = mat
 
     def setEdit(self, vobj, mode=0):
         view_base_femconstraint.VPBaseFemConstraint.setEdit(


### PR DESCRIPTION
To be merged after #13274.
Removes unused constraint symbol view properties.
Now the color of the symbol is controlled by the ShapeAppearance property.