### PR TITLE
UI: Update context menu with a toggle for suppress property

### DIFF
--- a/src/Gui/ViewProviderSuppressibleExtension.cpp
+++ b/src/Gui/ViewProviderSuppressibleExtension.cpp
@@ -89,15 +89,12 @@ void ViewProviderSuppressibleExtension::extensionSetupContextMenu(QMenu* menu, Q
 {
     auto vp = getExtendedViewProvider();
     auto obj = vp->getObject()->getExtensionByType<App::SuppressibleExtension>();
-    //show (Un)Suppress action if the Suppressed property is visible
+    //Show Suppressed toggle action if the Suppressed property is visible
     if (obj && ! obj->Suppressed.testStatus(App::Property::Hidden)) {
         Gui::ActionFunction* func = new Gui::ActionFunction(menu);
-        QAction* act;
-        if (obj->Suppressed.getValue())
-            act = menu->addAction(QObject::tr("UnSuppress"));
-        else
-            act = menu->addAction(QObject::tr("Suppress"));
-
+        QAction* act = menu->addAction(QObject::tr("Suppressed"));
+        act->setCheckable(true);
+        act->setChecked(obj->Suppressed.getValue());
         func->trigger(act, [obj](){
             obj->Suppressed.setValue(! obj->Suppressed.getValue());
         });


### PR DESCRIPTION
Update context menu with a toggle for suppress property with checkmark (checked when suppressed).
This is to be in line with active body or active object in the tree context menu:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/d6a092b9-2fa2-4b99-967b-5771b207e42c)
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/5a223fec-a0fe-4c79-a22c-0359724cca6c)

@FEA-eng FYI
@FlachyJoe  FYI, maybe this could be like this for the frozen state.