### PR TITLE
Add HeightPropagate tooltip info

### DIFF
--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -332,7 +332,7 @@ class BuildingPart(ArchIFC.IfcProduct):
         if not "Height" in pl:
             obj.addProperty("App::PropertyLength","Height","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The height of this object"))
         if not "HeightPropagate" in pl:
-            obj.addProperty("App::PropertyBool","HeightPropagate","Children",QT_TRANSLATE_NOOP("App::Property","If true, the height value propagates to contained objects"))
+            obj.addProperty("App::PropertyBool","HeightPropagate","Children",QT_TRANSLATE_NOOP("App::Property","If true, the height value propagates to contained objects if the height of those objects is set to 0"))
             obj.HeightPropagate = True
         if not "LevelOffset" in pl:
             obj.addProperty("App::PropertyLength","LevelOffset","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The level of the (0,0,0) point of this level"))


### PR DESCRIPTION
The only documentation I could find about how exactly Arch_BuildingPart's `Propagate Height` property works was at https://github.com/FreeCAD/FreeCAD/issues/12921. That is, the children's height needs to be set to 0 for `Propagate Height`.

This PR adds that additional bit of information to the property's tooltip. If merged, the wiki will need to be updated as well.