### PR TITLE
Fem: Constraint symbol scaling based on shape size - fixes #7030

### DIFF
--- a/src/Mod/Fem/App/FemConstraint.h
+++ b/src/Mod/Fem/App/FemConstraint.h
@@ -123,43 +123,12 @@ public:
     App::DocumentObjectExecReturn* execute() override;
 
     /**
-     * @brief Calculates scale factor based on length of edge.
+     * @brief Calculates scale factor based on characteristic length of shape.
      *
      * @details
      *  Used to calculate the scale factor returned by @ref getPoints when the
-     *  scale factor is calculated for a face.
-     *
-     * @note
-     *  This method does a really crazy calculation that I didn't dare to try
-     *  to understand.
      */
-    unsigned int calcSizeFactor(double lparam) const;
-
-    /**
-     * @brief Calculates scale factor based on size of face.
-     *
-     * @details
-     *  Used to calculate the scale factor returned by @ref getPoints when the
-     *  scale factor is calculated for a edge.
-     *
-     * @note
-     *  This method does a really crazy calculation that I didn't dare to try
-     *  to understand.
-     */
-    unsigned int calcSizeFactor(double lvparam, double luparam) const;
-
-    /**
-     * @brief Returns default scale factor of 1.
-     *
-     * @details
-     *  This is just used to make code more understandable. Other versions
-     *  (overloads) of this function do useful calculations based on faces or
-     *  edges. Used by @ref getPoints if no useful shape information is
-     *  available.
-     *
-     * @return always the integer 1
-     */
-    unsigned int calcSizeFactor() const;
+    double calcSizeFactor(double characLen) const;
 
     const char* getViewProviderName() const override
     {
@@ -227,7 +196,7 @@ protected:
      */
     bool getPoints(std::vector<Base::Vector3d>& points,
                    std::vector<Base::Vector3d>& normals,
-                   int* scale) const;
+                   double* scale) const;
 
     /**
      * @brief Extract properties of cylindrical face.
@@ -263,7 +232,7 @@ private:
     /**
      * @brief Symbol size factor determined from the size of the shape.
      */
-    int sizeFactor;
+    double sizeFactor;
 
     void slotChangedObject(const App::DocumentObject& Obj, const App::Property& Prop);
     boost::signals2::connection connDocChangedObject;

--- a/src/Mod/Fem/App/FemConstraintTransform.cpp
+++ b/src/Mod/Fem/App/FemConstraintTransform.cpp
@@ -110,7 +110,7 @@ void ConstraintTransform::onChanged(const App::Property* prop)
     if (prop == &References) {
         std::vector<Base::Vector3d> points;
         std::vector<Base::Vector3d> normals;
-        int scale = 1;  // OvG: Enforce use of scale
+        double scale = 1;  // OvG: Enforce use of scale
         if (getPoints(points, normals, &scale)) {
             std::string transform_type = TransformType.getValueAsString();
             if (transform_type == "Cylindrical") {


### PR DESCRIPTION
To be merged after https://github.com/FreeCAD/FreeCAD/pull/13274.
@FEA-eng could you test? The last commit fixes #7030 (initial scaling for very small and big objects).
Scaling is based on a characteristic length of the objects, basically the diagonal of the bounding box, so symbols scale linearly with the shapes.