### PR TITLE
Start: Fix new start page

### DIFF
--- a/src/Mod/Start/App/DisplayedFilesModel.cpp
+++ b/src/Mod/Start/App/DisplayedFilesModel.cpp
@@ -88,9 +88,11 @@ QByteArray loadFCStdThumbnail(const std::string& pathToFCStdFile)
     if (proj.loadDocument()) {
         try {
             std::string thumbnailFile = proj.extractInputFile("thumbnails/Thumbnail.png");
-            auto inputFile = QFile(QString::fromStdString(thumbnailFile));
-            inputFile.open(QIODevice::OpenModeFlag::ReadOnly);
-            return inputFile.readAll();
+            if (!thumbnailFile.empty()) {
+                auto inputFile = QFile(QString::fromStdString(thumbnailFile));
+                inputFile.open(QIODevice::OpenModeFlag::ReadOnly);
+                return inputFile.readAll();
+            }
         }
         catch (...) {
         }

--- a/src/Mod/Start/Gui/CMakeLists.txt
+++ b/src/Mod/Start/Gui/CMakeLists.txt
@@ -53,6 +53,8 @@ SET(StartGui_SRCS
         FileCardDelegate.h
         FileCardView.cpp
         FileCardView.h
+        FlowLayout.cpp
+        FlowLayout.h
         Manipulator.cpp
         Manipulator.h
         PreCompiled.cpp

--- a/src/Mod/Start/Gui/FileCardDelegate.cpp
+++ b/src/Mod/Start/Gui/FileCardDelegate.cpp
@@ -164,6 +164,7 @@ void FileCardDelegate::paint(QPainter* painter,
     widget->render(painter, QPoint(), QRegion(), QWidget::DrawChildren);
     painter->restore();
     delete pixmap;
+    delete widget;
 }
 
 

--- a/src/Mod/Start/Gui/FileCardDelegate.cpp
+++ b/src/Mod/Start/Gui/FileCardDelegate.cpp
@@ -110,27 +110,34 @@ void FileCardDelegate::paint(QPainter* painter,
     thumbnail->setFixedSize(thumbnailSize, thumbnailSize);
     thumbnail->setSizePolicy(QSizePolicy::Policy::Fixed, QSizePolicy::Policy::Fixed);
 
+    widget->setProperty("state", QStringLiteral(""));
     if (option.state & QStyle::State_Selected) {
-        QColor color = getSelectionColor();
-        widget->setStyleSheet(QString::fromLatin1("QWidget#thumbnailWidget {"
-                                                  " border: 2px solid rgb(%1, %2, %3);"
-                                                  " border-radius: 4px;"
-                                                  " padding: 2px;"
-                                                  "}")
-                                  .arg(color.red())
-                                  .arg(color.green())
-                                  .arg(color.blue()));
+        widget->setProperty("state", QStringLiteral("pressed"));
+        if (qApp->styleSheet().isEmpty()) {
+            QColor color = getSelectionColor();
+            widget->setStyleSheet(QString::fromLatin1("QWidget#thumbnailWidget {"
+                                                      " border: 2px solid rgb(%1, %2, %3);"
+                                                      " border-radius: 4px;"
+                                                      " padding: 2px;"
+                                                      "}")
+                                      .arg(color.red())
+                                      .arg(color.green())
+                                      .arg(color.blue()));
+        }
     }
     else if (option.state & QStyle::State_MouseOver) {
-        QColor color = getBorderColor();
-        widget->setStyleSheet(QString::fromLatin1("QWidget#thumbnailWidget {"
-                                                  " border: 2px solid rgb(%1, %2, %3);"
-                                                  " border-radius: 4px;"
-                                                  " padding: 2px;"
-                                                  "}")
-                                  .arg(color.red())
-                                  .arg(color.green())
-                                  .arg(color.blue()));
+        widget->setProperty("state", QStringLiteral("hovered"));
+        if (qApp->styleSheet().isEmpty()) {
+            QColor color = getBorderColor();
+            widget->setStyleSheet(QString::fromLatin1("QWidget#thumbnailWidget {"
+                                                      " border: 2px solid rgb(%1, %2, %3);"
+                                                      " border-radius: 4px;"
+                                                      " padding: 2px;"
+                                                      "}")
+                                      .arg(color.red())
+                                      .arg(color.green())
+                                      .arg(color.blue()));
+        }
     }
     else if (qApp->styleSheet().isEmpty()) {
         QColor color = getBackgroundColor();

--- a/src/Mod/Start/Gui/FileCardDelegate.h
+++ b/src/Mod/Start/Gui/FileCardDelegate.h
@@ -45,6 +45,11 @@ protected:
     QPixmap generateThumbnail(const QString& path) const;
 
 private:
+    QColor getBorderColor() const;
+    QColor getBackgroundColor() const;
+    QColor getSelectionColor() const;
+
+private:
     Base::Reference<ParameterGrp> _parameterGroup;
 };
 

--- a/src/Mod/Start/Gui/FileCardView.cpp
+++ b/src/Mod/Start/Gui/FileCardView.cpp
@@ -44,6 +44,8 @@ FileCardView::FileCardView(QWidget* parent)
     setFlow(QListView::Flow::LeftToRight);
     setResizeMode(QListView::ResizeMode::Adjust);
     setUniformItemSizes(true);
+    setMouseTracking(true);
+    setSpacing(20);
 }
 
 int FileCardView::heightForWidth(int width) const
@@ -82,6 +84,5 @@ QSize FileCardView::sizeHint() const
     return {(cardSize.width() + cardSpacing) * numCards + cardSpacing,
             cardSize.height() + 2 * cardSpacing};
 }
-
 
 }  // namespace StartGui

--- a/src/Mod/Start/Gui/FlowLayout.cpp
+++ b/src/Mod/Start/Gui/FlowLayout.cpp
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2024 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "PreCompiled.h"
+#include <QWidget>
+#include "FlowLayout.h"
+
+using namespace StartGui;
+
+FlowLayout::FlowLayout(QWidget* parent, int margin, int hSpacing, int vSpacing)
+    : QLayout(parent)
+    , hSpace {hSpacing}
+    , vSpace {vSpacing}
+{
+    setContentsMargins(margin, margin, margin, margin);
+}
+
+FlowLayout::~FlowLayout()
+{
+    QLayoutItem* item {};
+    while ((item = takeAt(0))) {
+        delete item;
+    }
+}
+
+void FlowLayout::addItem(QLayoutItem* item)
+{
+    itemList.append(item);
+}
+
+int FlowLayout::horizontalSpacing() const
+{
+    if (hSpace >= 0) {
+        return hSpace;
+    }
+
+    return smartSpacing(QStyle::PM_LayoutHorizontalSpacing);
+}
+
+int FlowLayout::verticalSpacing() const
+{
+    if (vSpace >= 0) {
+        return vSpace;
+    }
+
+    return smartSpacing(QStyle::PM_LayoutVerticalSpacing);
+}
+
+int FlowLayout::count() const
+{
+    return itemList.size();
+}
+
+QLayoutItem* FlowLayout::itemAt(int index) const
+{
+    if (index >= 0 && index < itemList.size()) {
+        return itemList[index];
+    }
+
+    return nullptr;
+}
+
+QLayoutItem* FlowLayout::takeAt(int index)
+{
+    if (index >= 0 && index < itemList.size()) {
+        return itemList.takeAt(index);
+    }
+
+    return nullptr;
+}
+
+Qt::Orientations FlowLayout::expandingDirections() const
+{
+    return {};
+}
+
+bool FlowLayout::hasHeightForWidth() const
+{
+    return true;
+}
+
+int FlowLayout::heightForWidth(int width) const
+{
+    int height = doLayout(QRect(0, 0, width, 0), true);
+    return height;
+}
+
+void FlowLayout::setGeometry(const QRect& rect)
+{
+    QLayout::setGeometry(rect);
+    doLayout(rect, false);
+}
+
+QSize FlowLayout::sizeHint() const
+{
+    return minimumSize();
+}
+
+QSize FlowLayout::minimumSize() const
+{
+    QSize size;
+    for (auto item : qAsConst(itemList)) {
+        size = size.expandedTo(item->minimumSize());
+    }
+
+    QMargins margins = contentsMargins();
+    size += QSize(margins.left() + margins.right(), margins.top() + margins.bottom());
+    return size;
+}
+
+int FlowLayout::smartSpacing(QStyle::PixelMetric pm) const
+{
+    QObject* par = parent();
+    if (!par) {
+        return -1;
+    }
+
+    if (par->isWidgetType()) {
+        auto widget = qobject_cast<QWidget*>(par);
+        return widget->style()->pixelMetric(pm, nullptr, widget);
+    }
+
+    return static_cast<QLayout*>(par)->spacing();
+}
+
+int FlowLayout::doLayout(const QRect& rect, bool testOnly) const
+{
+    int left {};
+    int top {};
+    int right {};
+    int bottom {};
+    getContentsMargins(&left, &top, &right, &bottom);
+    QRect effectiveRect = rect.adjusted(+left, +top, -right, -bottom);
+    int x = effectiveRect.x();
+    int y = effectiveRect.y();
+    int lineHeight = 0;
+
+    for (auto item : qAsConst(itemList)) {
+        QWidget* wid = item->widget();
+        int spaceX = horizontalSpacing();
+        if (spaceX == -1) {
+            spaceX = wid->style()->layoutSpacing(QSizePolicy::PushButton,
+                                                 QSizePolicy::PushButton,
+                                                 Qt::Horizontal);
+        }
+
+        int spaceY = verticalSpacing();
+        if (spaceY == -1) {
+            spaceY = wid->style()->layoutSpacing(QSizePolicy::PushButton,
+                                                 QSizePolicy::PushButton,
+                                                 Qt::Vertical);
+        }
+
+        int nextX = x + item->sizeHint().width() + spaceX;
+        if (nextX - spaceX > effectiveRect.right() && lineHeight > 0) {
+            x = effectiveRect.x();
+            y = y + lineHeight + spaceY;
+            nextX = x + item->sizeHint().width() + spaceX;
+            lineHeight = 0;
+        }
+
+        if (!testOnly) {
+            item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
+        }
+
+        x = nextX;
+        lineHeight = std::max(lineHeight, item->sizeHint().height());
+    }
+
+    return y + lineHeight - rect.y() + bottom;
+}
+
+#include "moc_FlowLayout.cpp"

--- a/src/Mod/Start/Gui/FlowLayout.h
+++ b/src/Mod/Start/Gui/FlowLayout.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2024 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#ifndef FREECAD_FLOWLAYOUT_H
+#define FREECAD_FLOWLAYOUT_H
+
+#include <QLayout>
+#include <QList>
+#include <QStyle>
+
+namespace StartGui
+{
+
+/*!
+ * \brief The FlowLayout class
+ * Based on https://forum.qt.io/topic/109408/is-there-a-qt-layout-grid-that-can-dynamically-
+ * change-row-and-column-counts-to-best-fit-the-space
+ */
+class FlowLayout: public QLayout
+{
+    Q_OBJECT
+
+public:
+    explicit FlowLayout(QWidget* parent = nullptr,
+                        int margin = -1,
+                        int hSpacing = -1,
+                        int vSpacing = -1);
+    ~FlowLayout() override;
+
+    void addItem(QLayoutItem* item) override;
+    int count() const override;
+    QLayoutItem* itemAt(int index) const override;
+    QLayoutItem* takeAt(int index) override;
+    Qt::Orientations expandingDirections() const override;
+    bool hasHeightForWidth() const override;
+    int heightForWidth(int width) const override;
+    void setGeometry(const QRect& rect) override;
+    QSize sizeHint() const override;
+    QSize minimumSize() const override;
+
+private:
+    int horizontalSpacing() const;
+    int verticalSpacing() const;
+    int smartSpacing(QStyle::PixelMetric pm) const;
+    int doLayout(const QRect& rect, bool testOnly) const;
+
+private:
+    QList<QLayoutItem*> itemList;
+    int hSpace = -1;
+    int vSpace = -1;
+};
+
+}  // namespace StartGui
+
+#endif  // FREECAD_FLOWLAYOUT_H

--- a/src/Mod/Start/Gui/Manipulator.cpp
+++ b/src/Mod/Start/Gui/Manipulator.cpp
@@ -69,8 +69,11 @@ void CmdStart::activated(int iMsg)
 void StartGui::Manipulator::modifyMenuBar(Gui::MenuItem* menuBar)
 {
     Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
-    auto newCommand = gsl::owner<CmdStart*>(new CmdStart);
-    rcCmdMgr.addCommand(newCommand);  // Transfer ownership
+    if (!rcCmdMgr.getCommandByName("Start_Start")) {
+        auto newCommand = gsl::owner<CmdStart*>(new CmdStart);
+        rcCmdMgr.addCommand(newCommand);  // Transfer ownership
+    }
+
     Gui::MenuItem* helpMenu = menuBar->findItem("&Help");
     Gui::MenuItem* loadStart = new Gui::MenuItem();
     loadStart->setCommand("Start_Start");

--- a/src/Mod/Start/Gui/PreCompiled.h
+++ b/src/Mod/Start/Gui/PreCompiled.h
@@ -43,8 +43,8 @@
 #include <unordered_map>
 
 // Qt
+#include <QApplication>
 #include <QCheckBox>
-#include <QCoreApplication>
 #include <QFile>
 #include <QFileIconProvider>
 #include <QGridLayout>

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -37,6 +37,7 @@
 #include "StartView.h"
 #include "FileCardDelegate.h"
 #include "FileCardView.h"
+#include "FlowLayout.h"
 #include "Gui/Workbench.h"
 #include <Gui/Document.h>
 #include <App/DocumentObject.h>
@@ -64,8 +65,9 @@ gsl::owner<QPushButton*> createNewButton(const NewButton& newButton)
 {
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Start");
-    const auto cardSpacing = static_cast<int>(hGrp->GetInt("FileCardSpacing", 20));      // NOLINT
-    const auto newFileIconSize = static_cast<int>(hGrp->GetInt("NewFileIconSize", 48));  // NOLINT
+    const auto cardSpacing = static_cast<int>(hGrp->GetInt("FileCardSpacing", 20));       // NOLINT
+    const auto newFileIconSize = static_cast<int>(hGrp->GetInt("NewFileIconSize", 48));   // NOLINT
+    const auto cardLabelWith = static_cast<int>(hGrp->GetInt("FileCardLabelWith", 180));  // NOLINT
 
     auto button = gsl::owner<QPushButton*>(new QPushButton());
     auto mainLayout = gsl::owner<QHBoxLayout*>(new QHBoxLayout(button));
@@ -88,6 +90,7 @@ gsl::owner<QPushButton*> createNewButton(const NewButton& newButton)
     mainLayout->addStretch();
 
     button->setMinimumHeight(newFileIconSize + cardSpacing);
+    button->setMinimumWidth(newFileIconSize + cardLabelWith);
     return button;
 }
 
@@ -137,9 +140,9 @@ StartView::StartView(Gui::Document* pcDocument, QWidget* parent)
 
     auto newFileLabel = gsl::owner<QLabel*>(new QLabel(h1Start + tr("New File") + h1End));
     layout->addWidget(newFileLabel);
-    auto gridLayout = gsl::owner<QGridLayout*>(new QGridLayout);
-    layout->addLayout(gridLayout);
-    configureNewFileButtons(gridLayout);
+    auto flowLayout = gsl::owner<FlowLayout*>(new FlowLayout);
+    layout->addLayout(flowLayout);
+    configureNewFileButtons(flowLayout);
 
     auto recentFilesLabel = gsl::owner<QLabel*>(new QLabel(h1Start + tr("Recent Files") + h1End));
     layout->addWidget(recentFilesLabel);
@@ -165,7 +168,7 @@ StartView::StartView(Gui::Document* pcDocument, QWidget* parent)
     configureRecentFilesListWidget(recentFilesListWidget, recentFilesLabel);
 }
 
-void StartView::configureNewFileButtons(QGridLayout* layout) const
+void StartView::configureNewFileButtons(QLayout* layout) const
 {
     auto newEmptyFile = createNewButton({tr("Empty file"),
                                          tr("Create a new empty FreeCAD file"),
@@ -200,22 +203,12 @@ void StartView::configureNewFileButtons(QGridLayout* layout) const
 
     // TODO: Ensure all of the required WBs are actually available
     // TODO: Make this layout more flexible (e.g. use a single line if possible)
-    if (!hGrp->GetBool("FileCardSingleLine", true)) {
-        layout->addWidget(partDesign, 0, 0);
-        layout->addWidget(assembly, 0, 1);
-        layout->addWidget(draft, 0, 2);
-        layout->addWidget(arch, 1, 0);
-        layout->addWidget(newEmptyFile, 1, 1);
-        layout->addWidget(openFile, 1, 2);
-    }
-    else {
-        layout->addWidget(partDesign, 0, 0);
-        layout->addWidget(assembly, 0, 1);
-        layout->addWidget(draft, 0, 2);
-        layout->addWidget(arch, 0, 3);
-        layout->addWidget(newEmptyFile, 0, 4);
-        layout->addWidget(openFile, 0, 5);
-    }
+    layout->addWidget(partDesign);
+    layout->addWidget(assembly);
+    layout->addWidget(draft);
+    layout->addWidget(arch);
+    layout->addWidget(newEmptyFile);
+    layout->addWidget(openFile);
 
     connect(newEmptyFile, &QPushButton::clicked, this, &StartView::newEmptyFile);
     connect(openFile, &QPushButton::clicked, this, &StartView::openExistingFile);

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -266,7 +266,7 @@ QString StartView::fileCardStyle() const
 
 void StartView::configureFileCardWidget(QListView* fileCardWidget)
 {
-    auto delegate = gsl::owner<FileCardDelegate*>(new FileCardDelegate);
+    auto delegate = gsl::owner<FileCardDelegate*>(new FileCardDelegate(fileCardWidget));
     fileCardWidget->setItemDelegate(delegate);
     fileCardWidget->setMinimumWidth(fileCardWidget->parentWidget()->width());
     //    fileCardWidget->setGridSize(

--- a/src/Mod/Start/Gui/StartView.h
+++ b/src/Mod/Start/Gui/StartView.h
@@ -75,7 +75,7 @@ public:
     };
 
 protected:
-    void configureNewFileButtons(QGridLayout* layout) const;
+    void configureNewFileButtons(QLayout* layout) const;
     static void configureFileCardWidget(QListView* fileCardWidget);
     void configureRecentFilesListWidget(QListView* recentFilesListWidget, QLabel* recentFilesLabel);
     void configureExamplesListWidget(QListView* examplesListWidget);

--- a/src/Mod/Start/Gui/StartView.h
+++ b/src/Mod/Start/Gui/StartView.h
@@ -85,6 +85,7 @@ protected:
     void fileCardSelected(const QModelIndex& index);
 
     void showOnStartupChanged(bool checked);
+    QString fileCardStyle() const;
 
 private:
     QScrollArea* _contents = nullptr;


### PR DESCRIPTION
* Do not try to open empty file name
* Add command Start_Start only once. This fixes an error message that the command is duplicated. And it fixes a memory leak
* Make the new StartPage look more like the old one
* Use style sheets to give visual feedback about hovered or clicked buttons & labels