### PR TITLE
Fixups with Qt6 enums

### DIFF
--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -583,6 +583,36 @@ QObject* PythonWrapper::toQObject(const Py::Object& pyobject)
     return qt_getCppType<QObject>(pyobject.ptr());
 }
 
+qsizetype PythonWrapper::toEnum(PyObject* pyPtr)
+{
+#if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
+    return Shiboken::Enum::getValue(pyPtr);
+#else
+    return toEnum(Py::Object(pyPtr);
+#endif
+}
+
+qsizetype PythonWrapper::toEnum(const Py::Object& pyobject)
+{
+#if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
+    return toEnum(pyobject.ptr());
+#else
+    try {
+        Py::Int ret;
+        if (pyobject.hasAttr(std::string("value"))) {
+            ret = pyobject.getAttr(std::string("value"));
+        } else {
+            ret = Py::Int(pyobject);
+        }
+        return (qsizetype)ret;
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+#endif
+}
+
 QGraphicsItem* PythonWrapper::toQGraphicsItem(PyObject* pyPtr)
 {
     return qt_getCppType<QGraphicsItem>(pyPtr);

--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -600,7 +600,7 @@ qsizetype PythonWrapper::toEnum(const Py::Object& pyobject)
     try {
         Py::Int ret;
         if (pyobject.hasAttr(std::string("value"))) {
-            ret = pyobject.getAttr(std::string("value"));
+            ret = Py::Int(pyobject.getAttr(std::string("value")));
         } else {
             ret = Py::Int(pyobject);
         }

--- a/src/Gui/PythonWrapper.h
+++ b/src/Gui/PythonWrapper.h
@@ -54,6 +54,8 @@ public:
 
     bool toCString(const Py::Object&, std::string&);
     QObject* toQObject(const Py::Object&);
+    qsizetype toEnum(PyObject* pyPtr);
+    qsizetype toEnum(const Py::Object& pyobject);
     QGraphicsItem* toQGraphicsItem(PyObject* ptr);
     QGraphicsItem* toQGraphicsItem(const Py::Object& pyObject);
     QGraphicsObject* toQGraphicsObject(PyObject* pyPtr);

--- a/src/Gui/TaskView/TaskDialogPython.cpp
+++ b/src/Gui/TaskView/TaskDialogPython.cpp
@@ -734,8 +734,9 @@ QDialogButtonBox::StandardButtons TaskDialogPython::getStandardButtons() const
         if (dlg.hasAttr(std::string("getStandardButtons"))) {
             Py::Callable method(dlg.getAttr(std::string("getStandardButtons")));
             Py::Tuple args;
-            Py::Int ret(method.apply(args));
-            int value = (int)ret;
+            Gui::PythonWrapper wrap;
+            wrap.loadWidgetsModule();
+            int value = wrap.toEnum(method.apply(args));
             return {value};
         }
     }

--- a/src/Mod/Arch/ArchAxis.py
+++ b/src/Mod/Arch/ArchAxis.py
@@ -725,7 +725,7 @@ class _AxisTaskPanel:
 
     def getStandardButtons(self):
 
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def update(self):
 

--- a/src/Mod/Arch/ArchAxisSystem.py
+++ b/src/Mod/Arch/ArchAxisSystem.py
@@ -313,7 +313,7 @@ class AxisSystemTaskPanel:
 
     def getStandardButtons(self):
 
-        return int(QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Ok
 
     def getIcon(self,obj):
 

--- a/src/Mod/Arch/ArchCommands.py
+++ b/src/Mod/Arch/ArchCommands.py
@@ -1018,7 +1018,7 @@ class SurveyTaskPanel:
         return True
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def reject(self):
         if hasattr(FreeCAD,"SurveyObserver"):

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -1660,7 +1660,7 @@ class SelectionTaskPanel:
 
     def getStandardButtons(self):
         """Adds the cancel button."""
-        return int(QtGui.QDialogButtonBox.Cancel)
+        return QtGui.QDialogButtonBox.Cancel
 
     def reject(self):
         """The method run when the user selects the cancel button."""
@@ -1766,7 +1766,7 @@ class ComponentTaskPanel:
     def getStandardButtons(self):
         """Add the standard ok button."""
 
-        return int(QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Ok
 
     def check(self,wid,col):
         """This method is run as the callback when the user selects an item in the tree.

--- a/src/Mod/Arch/ArchCutPlane.py
+++ b/src/Mod/Arch/ArchCutPlane.py
@@ -227,7 +227,7 @@ class _CutPlaneTaskPanel:
         return True
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok|QtGui.QDialogButtonBox.Cancel)
+        return QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel
 
     def previewCutVolume(self, i):
         cutVolume = ArchCommands.getCutVolume(self.cutter, self.base)

--- a/src/Mod/Arch/ArchRoof.py
+++ b/src/Mod/Arch/ArchRoof.py
@@ -985,7 +985,7 @@ class _RoofTaskPanel:
         return True
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def update(self):
         '''fills the treewidget'''

--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -1279,7 +1279,7 @@ class SectionPlaneTaskPanel:
         return True
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Ok
 
     def getIcon(self,obj):
         if hasattr(obj.ViewObject,"Proxy"):

--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -1503,7 +1503,7 @@ class _ArchWindowTaskPanel:
 
     def getStandardButtons(self):
 
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def check(self,wid,col):
 

--- a/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
@@ -59,11 +59,7 @@ class TaskPanel(object):
         self.stockEdit = None
 
     def getStandardButtons(self):
-        return int(
-            QtGui.QDialogButtonBox.Ok
-            | QtGui.QDialogButtonBox.Apply
-            | QtGui.QDialogButtonBox.Cancel
-        )
+        return QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Apply | QtGui.QDialogButtonBox.Cancel
 
     def modifyStandardButtons(self, buttonBox):
         self.buttonBox = buttonBox

--- a/src/Mod/CAM/Path/Dressup/Gui/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Tags.py
@@ -75,11 +75,7 @@ class PathDressupTagTaskPanel:
         self.editItem = None
 
     def getStandardButtons(self):
-        return int(
-            QtGui.QDialogButtonBox.Ok
-            | QtGui.QDialogButtonBox.Apply
-            | QtGui.QDialogButtonBox.Cancel
-        )
+        return QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Apply | QtGui.QDialogButtonBox.Cancel
 
     def clicked(self, button):
         if button == QtGui.QDialogButtonBox.Apply:

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -1274,11 +1274,7 @@ class TaskPanel(object):
 
     def getStandardButtons(self):
         """getStandardButtons() ... returns the Buttons for the task panel."""
-        return int(
-            QtGui.QDialogButtonBox.Ok
-            | QtGui.QDialogButtonBox.Apply
-            | QtGui.QDialogButtonBox.Cancel
-        )
+        return QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Apply | QtGui.QDialogButtonBox.Cancel
 
     def setupUi(self):
         """setupUi() ... internal function to initialise all pages."""

--- a/src/Mod/CAM/PathPythonGui/simple_edit_panel.py
+++ b/src/Mod/CAM/PathPythonGui/simple_edit_panel.py
@@ -88,11 +88,7 @@ class SimpleEditPanel:
         )
 
     def getStandardButtons(self):
-        return int(
-            QtGui.QDialogButtonBox.Ok
-            | QtGui.QDialogButtonBox.Apply
-            | QtGui.QDialogButtonBox.Cancel
-        )
+        return QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Apply | QtGui.QDialogButtonBox.Cancel
 
     def clicked(self, button):
         # callback for standard buttons

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -131,7 +131,7 @@ class DraftTaskPanel:
         else:
             self.form = widget
     def getStandardButtons(self):
-        return int(QtWidgets.QDialogButtonBox.Close)
+        return QtWidgets.QDialogButtonBox.Close
     def accept(self):
         if hasattr(FreeCADGui,"draftToolBar"):
             return FreeCADGui.draftToolBar.validatePoint()
@@ -919,7 +919,7 @@ class DraftToolBar:
                     self.form = [extra]
                 self.callback = callback
             def getStandardButtons(self):
-                return int(QtWidgets.QDialogButtonBox.Close)
+                return QtWidgets.QDialogButtonBox.Close
             def reject(self):
                 if self.callback:
                     self.callback()
@@ -1687,7 +1687,7 @@ class FacebinderTaskPanel:
         return True
 
     def getStandardButtons(self):
-        return int(QtWidgets.QDialogButtonBox.Ok)
+        return QtWidgets.QDialogButtonBox.Ok
 
     def update(self):
         """fills the treewidget"""

--- a/src/Mod/Draft/drafttaskpanels/task_selectplane.py
+++ b/src/Mod/Draft/drafttaskpanels/task_selectplane.py
@@ -40,6 +40,7 @@ to be more similar to OrthoArray and the new tools.
 ## \addtogroup drafttaskpanels
 # @{
 import FreeCADGui as Gui
+from PySide import QtWidgets
 
 
 class SelectPlaneTaskPanel:
@@ -50,6 +51,6 @@ class SelectPlaneTaskPanel:
 
     def getStandardButtons(self):
         """Execute to set the standard buttons."""
-        return 2097152  # int(QtWidgets.QDialogButtonBox.Close)
+        return QtWidgets.QDialogButtonBox.Close
 
 ## @}

--- a/src/Mod/Fem/femsolver/solver_taskpanel.py
+++ b/src/Mod/Fem/femsolver/solver_taskpanel.py
@@ -156,7 +156,7 @@ class ControlTaskPanel(QtCore.QObject):
         femsolver.report.display(machine.report, _REPORT_TITLE, text)
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def reject(self):
         Gui.ActiveDocument.resetEdit()

--- a/src/Mod/Fem/femtaskpanels/task_mesh_gmsh.py
+++ b/src/Mod/Fem/femtaskpanels/task_mesh_gmsh.py
@@ -107,9 +107,7 @@ class _TaskPanel:
         self.update()
 
     def getStandardButtons(self):
-        button_value = int(
-            QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Apply | QtGui.QDialogButtonBox.Cancel
-        )
+        button_value = QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Apply | QtGui.QDialogButtonBox.Cancel
         return button_value
         # show a OK, a apply and a Cancel button
         # def reject() is called on Cancel button

--- a/src/Mod/Fem/femtaskpanels/task_result_mechanical.py
+++ b/src/Mod/Fem/femtaskpanels/task_result_mechanical.py
@@ -265,7 +265,7 @@ class _TaskPanel:
         self.result_widget.sb_displacement_factor_max.setValue(100.)    # init non standard values
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def get_result_stats(self, type_name):
         return resulttools.get_stats(self.result_obj, type_name)

--- a/src/Mod/Fem/femtaskpanels/task_solver_ccxtools.py
+++ b/src/Mod/Fem/femtaskpanels/task_solver_ccxtools.py
@@ -167,7 +167,7 @@ class _TaskPanel:
     def getStandardButtons(self):
         # only show a close button
         # def accept() in no longer needed, since there is no OK button
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def reject(self):
         FreeCADGui.ActiveDocument.resetEdit()

--- a/src/Mod/OpenSCAD/OpenSCADCommands.py
+++ b/src/Mod/OpenSCAD/OpenSCADCommands.py
@@ -379,7 +379,7 @@ class AddSCADTask:
         self.form.buttonrefresh.clicked.connect(self.refreshelement)
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def isAllowedAlterSelection(self):
         return True
@@ -492,7 +492,7 @@ class OpenSCADMeshBooleanTask:
         self.form.buttonadd.clicked.connect(self.doboolean)
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def isAllowedAlterSelection(self):
         return False

--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
@@ -306,7 +306,7 @@ class AttachmentEditorTaskPanel(FrozenClass):
 
     # task dialog handling
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok) | int(QtGui.QDialogButtonBox.Cancel)| int(QtGui.QDialogButtonBox.Apply)
+        return QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Apply
 
     def clicked(self,button):
         if button == QtGui.QDialogButtonBox.Apply:

--- a/src/Mod/PartDesign/InvoluteGearFeature.py
+++ b/src/Mod/PartDesign/InvoluteGearFeature.py
@@ -258,7 +258,7 @@ class _InvoluteGearTaskPanel:
         self.form.doubleSpinBox_ProfileShift.setValue(self.obj.ProfileShiftCoefficient)
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok) | int(QtGui.QDialogButtonBox.Cancel)| int(QtGui.QDialogButtonBox.Apply)
+        return QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Apply
 
     def clicked(self,button):
         if button == QtGui.QDialogButtonBox.Apply:

--- a/src/Mod/PartDesign/SprocketFeature.py
+++ b/src/Mod/PartDesign/SprocketFeature.py
@@ -312,11 +312,7 @@ class SprocketTaskPanel:
         self.obj.Proxy.execute(self.obj)
 
     def getStandardButtons(self):
-        return (
-            int(QtGui.QDialogButtonBox.Ok)
-            | int(QtGui.QDialogButtonBox.Cancel)
-            | int(QtGui.QDialogButtonBox.Apply)
-        )
+        return QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel | QtGui.QDialogButtonBox.Apply
 
     def clicked(self, button):
         if button == QtGui.QDialogButtonBox.Apply:

--- a/src/Mod/PartDesign/WizardShaft/WizardShaft.py
+++ b/src/Mod/PartDesign/WizardShaft/WizardShaft.py
@@ -155,7 +155,7 @@ class TaskWizardShaft:
             self.updateButton(row,  col,  flag)
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Ok
 
     def accept(self):
         if self.table:

--- a/src/Mod/TemplatePyMod/TaskPanel.py
+++ b/src/Mod/TemplatePyMod/TaskPanel.py
@@ -61,7 +61,7 @@ class TaskPanel:
         return True
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok)
+        return QtGui.QDialogButtonBox.Ok
 
     def helpRequested(self):
         pass


### PR DESCRIPTION
Because PySide6 treats `enum`s and `QFlags` as `IntEnum`s and `IntFlag`s respectively I've added converters for Python PySide enums to C++, and due to this I've modified the requirements of task panel's `getStandardButtons` to return standard buttons without casting them to `int`. Fixes #13605 and part of #13303. Related to #6992.
