### PR TITLE
Draft: Fix QImage object has no attribute 'byteCount'

### DIFF
--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -734,7 +734,7 @@ def load_texture(filename, size=None, gui=App.GuiUp):
             # else:
             #    p = QtGui.QImage(filename)
             size = coin.SbVec2s(p.width(), p.height())
-            buffersize = p.byteCount()
+            buffersize = p.sizeInBytes()
             width = size[0]
             height = size[1]
             numcomponents = int(buffersize / (width * height))


### PR DESCRIPTION
```
'PySide6.QtGui.QImage' object has no attribute 'byteCount'
load_texture: unable to load texture
```

A similar change was made before:
eced6aaed1 ("Qt5: 'int QImage::byteCount() const' is deprecated since Qt 5.10: Use sizeInBytes [-Wdeprecated-declarations]", 2020-06-08)
