### PR TITLE
Start: Allow system Microsoft GSL to be used

### DIFF
--- a/src/Mod/Start/App/AppStart.cpp
+++ b/src/Mod/Start/App/AppStart.cpp
@@ -29,7 +29,7 @@
 
 #include <Base/PyObjectBase.h>
 
-#include <3rdParty/GSL/include/gsl/pointers>
+#include <gsl/pointers>
 
 namespace Start
 {

--- a/src/Mod/Start/CMakeLists.txt
+++ b/src/Mod/Start/CMakeLists.txt
@@ -21,8 +21,15 @@
 #  *                                                                          *
 #  ***************************************************************************/
 
-if( NOT EXISTS "${CMAKE_SOURCE_DIR}/src/3rdParty/GSL" )
+if ( EXISTS "${CMAKE_SOURCE_DIR}/src/3rdParty/GSL/include" )
+    include_directories( ${CMAKE_SOURCE_DIR}/src/3rdParty/GSL/include )
+else()
+    find_package(Microsoft.GSL)
+    if( Microsoft.GSL_FOUND )
+        message( STATUS "Found Microsoft.GSL: version ${Microsoft.GSL_VERSION}" )
+    else()
         message( SEND_ERROR "The C++ Guidelines Support Library (GSL) submodule is not available. Please run git submodule update --init" )
+    endif()
 endif()
 
 add_subdirectory(App)

--- a/src/Mod/Start/Gui/AppStartGui.cpp
+++ b/src/Mod/Start/Gui/AppStartGui.cpp
@@ -35,7 +35,7 @@
 #include <Gui/MainWindow.h>
 
 
-#include <3rdParty/GSL/include/gsl/pointers>
+#include <gsl/pointers>
 
 #include "Manipulator.h"
 #include "StartView.h"

--- a/src/Mod/Start/Gui/FileCardDelegate.cpp
+++ b/src/Mod/Start/Gui/FileCardDelegate.cpp
@@ -39,7 +39,7 @@
 #include "../App/DisplayedFilesModel.h"
 #include "App/Application.h"
 #include <App/Color.h>
-#include <3rdParty/GSL/include/gsl/pointers>
+#include <gsl/pointers>
 
 using namespace Start;
 

--- a/src/Mod/Start/Gui/Manipulator.cpp
+++ b/src/Mod/Start/Gui/Manipulator.cpp
@@ -36,7 +36,7 @@
 #include <Gui/MainWindow.h>
 #include <Gui/MenuManager.h>
 
-#include <3rdParty/GSL/include/gsl/pointers>
+#include <gsl/pointers>
 
 DEF_STD_CMD(CmdStart)
 

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -45,7 +45,7 @@
 #include <Base/Interpreter.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
-#include <3rdParty/GSL/include/gsl/pointers>
+#include <gsl/pointers>
 
 using namespace StartGui;
 


### PR DESCRIPTION
Microsoft GSL is already packaged on Gentoo Linux, which I have compiled FreeCAD main with using this change. It is also available in Arch and Debian. I think this would make packaging FreeCAD easier in due course.
