### PR TITLE
TD: Fix compiler warning

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -676,7 +676,7 @@ void TaskProjGroup::setupViewCheckboxes(bool addConnections)
         const char *viewStr = viewChkIndexToCStr(i);
 
         if (!multiView) {
-            box->setCheckState(viewStr == "Front" ? Qt::Checked : Qt::Unchecked);
+            box->setCheckState(strcmp(viewStr, "Front") == 0 ? Qt::Checked : Qt::Unchecked);
         }
 
         if (addConnections) {


### PR DESCRIPTION
Warning: result of comparison against a string literal is unspecified (use an explicit string comparison function instead) [-Wstring-compare]