### PR TITLE
3Dconnexion Navlib: Fix for removeMarkups() function (fixes #13635)

### DIFF
--- a/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
@@ -113,10 +113,11 @@ void NavlibInterface::removeMarkups(std::string& text) const
         if (markupEnd == text.cend())
             return;
 
-        if (*std::prev(markupEnd) == 'p')
-            text.insert(std::next(markupEnd), 2, '\n');
-
+        const char enclosingChar = *std::prev(markupEnd);
         textBegin = text.erase(markupBegin, ++markupEnd);
+        
+        if(enclosingChar == 'p')
+            textBegin = text.insert(textBegin, 2, '\n');
     }
 }
 


### PR DESCRIPTION
Fixed an issue with invalidated iterators. 