### PR TITLE
Gui: Fix black tooltip

### DIFF
--- a/src/Gui/DlgPreferencesImp.cpp
+++ b/src/Gui/DlgPreferencesImp.cpp
@@ -78,6 +78,29 @@ QModelIndex findRootIndex(const QModelIndex& index)
     return root;
 }
 
+// ----------------------------------------------------------------------------
+
+PreferencesDelegate::PreferencesDelegate(QObject* parent)
+    : QStyledItemDelegate(parent)
+{}
+
+bool PreferencesDelegate::helpEvent(QHelpEvent *event,
+                                    QAbstractItemView *view,
+                                    const QStyleOptionViewItem &option,
+                                    const QModelIndex &index)
+{
+    if (event->type() == QEvent::ToolTip) {
+        QHelpEvent* he = static_cast<QHelpEvent*>(event);
+        QString tooltip = index.isValid() ? index.data(Qt::ToolTipRole).toString() : QString();
+        QToolTip::showText(he->globalPos(), tooltip);
+        event->setAccepted(!tooltip.isEmpty());
+        return true;
+    }
+    return QStyledItemDelegate::helpEvent(event, view, option, index);
+}
+
+// ----------------------------------------------------------------------------
+
 QWidget* PreferencesPageItem::getWidget() const
 {
     return _widget;
@@ -136,6 +159,7 @@ DlgPreferencesImp::DlgPreferencesImp(QWidget* parent, Qt::WindowFlags fl)
     setupConnections();
 
     ui->groupsTreeView->setModel(&_model);
+    ui->groupsTreeView->setItemDelegate(new PreferencesDelegate(this));
 
     setupPages();
 

--- a/src/Gui/DlgPreferencesImp.h
+++ b/src/Gui/DlgPreferencesImp.h
@@ -27,6 +27,7 @@
 #define GUI_DIALOG_DLGPREFERENCESIMP_H
 
 #include <QDialog>
+#include <QStyledItemDelegate>
 #include <QStandardItemModel>
 #include <QStackedWidget>
 #include <memory>
@@ -54,6 +55,19 @@ public:
 private:
     QWidget* _widget = nullptr;
     bool _expanded = false;
+};
+
+class PreferencesDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+public:
+    explicit PreferencesDelegate(QObject *parent = nullptr);
+
+    bool helpEvent(QHelpEvent *event,
+                   QAbstractItemView *view,
+                   const QStyleOptionViewItem &option,
+                   const QModelIndex &index) override;
 };
 
 /**


### PR DESCRIPTION
The QTreeView of the preferences dialog has a transparent background and this somehow causes the tooltips to have black background with black text so that it's not readable.

Overriding the helpEvent() of the delegate class and handling the tooltip slightly different fixes the problem. All what's needed is to not pass the view as 3rd argument