### PR TITLE
TechDraw: remove 'Project Shape' from Techdraw toolbar

### DIFF
--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -298,7 +298,6 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_ClipGroup";
-    *views << "TechDraw_ProjectShape";
 
     Gui::ToolBarItem* stacking = new Gui::ToolBarItem(root);
     stacking->setCommand("TechDraw Stacking");
@@ -400,7 +399,6 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     *views << "TechDraw_DetailView";
     *views << "TechDraw_DraftView";
     *views << "TechDraw_ClipGroup";
-    *views << "TechDraw_ProjectShape";
 
     Gui::ToolBarItem* stacking = new Gui::ToolBarItem(root);
     stacking->setCommand("TechDraw Stacking");


### PR DESCRIPTION
Remove the tool 'Project shape' from techdraw view toolbar.

Following discussion in https://github.com/FreeCAD/FreeCAD/issues/13347.

Before closing the issue I'll let @yorikvanhavre confirm if we need to add this tool in draft in a command group with Draft_Shape2DView. But it seems that TD tool is a duplicate of Draft_Shape2DView so it's probably not necessary.

The tool is still available in the menu.