### PR TITLE
Test: Support system GTest, and give warning if no submodule

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,15 @@
+if ( EXISTS "${CMAKE_SOURCE_DIR}/tests/lib/googletest" )
+    include_directories( ${CMAKE_SOURCE_DIR}/tests/lib/googletest/include/ )
+    include_directories( ${CMAKE_SOURCE_DIR}/tests/lib/googlemock/include/ )
+else()
+    find_package(GTest)
+    if( GTest_FOUND )
+        message( STATUS "Found Google Test: version ${GTest_VERSION}" )
+    else()
+        message( SEND_ERROR "The Google Test submodule is not available. Please run git submodule update --init" )
+    endif()
+endif()
+
 if(MSVC)
     add_compile_options(/wd4251)
 
@@ -106,7 +118,9 @@ foreach (exe ${TestExecutables})
     add_executable(${exe})
 endforeach()
 
-add_subdirectory(lib)
+if ( EXISTS "${CMAKE_SOURCE_DIR}/tests/lib/googletest" )
+    add_subdirectory(lib)
+endif()
 add_subdirectory(src)
 
 target_include_directories(Tests_run PUBLIC

--- a/tests/src/App/Application.cpp
+++ b/tests/src/App/Application.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #define FC_OS_MACOSX 1
 #include "App/ProgramOptionsUtilities.h"
 

--- a/tests/src/App/Branding.cpp
+++ b/tests/src/App/Branding.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "App/Branding.h"
 

--- a/tests/src/App/Color.cpp
+++ b/tests/src/App/Color.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <cmath>
 #include "App/Color.h"
 

--- a/tests/src/App/ComplexGeoData.cpp
+++ b/tests/src/App/ComplexGeoData.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <array>
 #include <boost/core/ignore_unused.hpp>

--- a/tests/src/App/Document.cpp
+++ b/tests/src/App/Document.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
 #include "App/Application.h"

--- a/tests/src/App/ElementMap.cpp
+++ b/tests/src/App/ElementMap.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <App/Application.h>
 #include <App/ElementMap.h>

--- a/tests/src/App/Expression.cpp
+++ b/tests/src/App/Expression.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "App/ExpressionParser.h"
 #include "App/ExpressionTokenizer.h"

--- a/tests/src/App/ExpressionParser.cpp
+++ b/tests/src/App/ExpressionParser.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Base/Quantity.h"
 

--- a/tests/src/App/IndexedName.cpp
+++ b/tests/src/App/IndexedName.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "App/IndexedName.h"
 

--- a/tests/src/App/License.cpp
+++ b/tests/src/App/License.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "App/License.h"
 

--- a/tests/src/App/MappedElement.cpp
+++ b/tests/src/App/MappedElement.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "App/IndexedName.h"
 #include "App/MappedElement.h"

--- a/tests/src/App/MappedName.cpp
+++ b/tests/src/App/MappedName.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "App/ComplexGeoData.h"
 #include "App/MappedName.h"

--- a/tests/src/App/Metadata.cpp
+++ b/tests/src/App/Metadata.cpp
@@ -21,7 +21,7 @@
  ***************************************************************************/
 
 // NOLINTNEXTLINE
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "App/Metadata.h"
 

--- a/tests/src/App/ProjectFile.cpp
+++ b/tests/src/App/ProjectFile.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "InitApplication.h"
 #include <App/ProjectFile.h>

--- a/tests/src/App/Property.cpp
+++ b/tests/src/App/Property.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "App/PropertyLinks.h"
 

--- a/tests/src/App/PropertyExpressionEngine.cpp
+++ b/tests/src/App/PropertyExpressionEngine.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Base/Quantity.h"
 

--- a/tests/src/App/StringHasher.cpp
+++ b/tests/src/App/StringHasher.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include "App/MappedName.h"
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <App/StringHasher.h>
 #include <App/StringHasherPy.h>

--- a/tests/src/App/VRMLObject.cpp
+++ b/tests/src/App/VRMLObject.cpp
@@ -21,7 +21,7 @@
  *                                                                         *
  **************************************************************************/
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "gmock/gmock.h"
 
 #include <App/Application.h>

--- a/tests/src/App/VarSet.cpp
+++ b/tests/src/App/VarSet.cpp
@@ -20,7 +20,7 @@
  *                                                                          *
  ****************************************************************************/
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "gmock/gmock.h"
 
 #include <App/Application.h>

--- a/tests/src/Base/Axis.cpp
+++ b/tests/src/Base/Axis.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/Axis.h>
 
 TEST(Axis, TestDefault)

--- a/tests/src/Base/Bitmask.cpp
+++ b/tests/src/Base/Bitmask.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <Base/Bitmask.h>
 

--- a/tests/src/Base/BoundBox.cpp
+++ b/tests/src/Base/BoundBox.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #ifndef NOMINMAX

--- a/tests/src/Base/Builder3D.cpp
+++ b/tests/src/Base/Builder3D.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <Base/Builder3D.h>
 

--- a/tests/src/Base/CoordinateSystem.cpp
+++ b/tests/src/Base/CoordinateSystem.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/CoordinateSystem.h>
 #include <Base/Exception.h>
 

--- a/tests/src/Base/DualNumber.cpp
+++ b/tests/src/Base/DualNumber.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/DualNumber.h>
 
 TEST(DualNumber, TestDefault)

--- a/tests/src/Base/DualQuaternion.cpp
+++ b/tests/src/Base/DualQuaternion.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/DualQuaternion.h>
 #include <Base/Tools.h>
 

--- a/tests/src/Base/Handle.cpp
+++ b/tests/src/Base/Handle.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/Handle.h>
 
 class Data: public Base::Handled

--- a/tests/src/Base/Matrix.cpp
+++ b/tests/src/Base/Matrix.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/Matrix.h>
 #include <Base/Rotation.h>
 

--- a/tests/src/Base/Parameter.cpp
+++ b/tests/src/Base/Parameter.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <boost/core/ignore_unused.hpp>
 #include <QLockFile>
 #include <Base/FileInfo.h>

--- a/tests/src/Base/Placement.cpp
+++ b/tests/src/Base/Placement.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/DualQuaternion.h>
 #include <Base/Matrix.h>
 #include <Base/Placement.h>

--- a/tests/src/Base/Quantity.cpp
+++ b/tests/src/Base/Quantity.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/Exception.h>
 #include <Base/Quantity.h>
 #include <Base/UnitsApi.h>

--- a/tests/src/Base/Reader.cpp
+++ b/tests/src/Base/Reader.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4996)

--- a/tests/src/Base/Rotation.cpp
+++ b/tests/src/Base/Rotation.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/Exception.h>
 #include <Base/Matrix.h>
 #include <Base/Rotation.h>

--- a/tests/src/Base/Stream.cpp
+++ b/tests/src/Base/Stream.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4996)

--- a/tests/src/Base/TimeInfo.cpp
+++ b/tests/src/Base/TimeInfo.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/TimeInfo.h>
 
 TEST(TimeInfo, TestDefault)

--- a/tests/src/Base/Tools.cpp
+++ b/tests/src/Base/Tools.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/Tools.h>
 #include <bitset>
 

--- a/tests/src/Base/Tools2D.cpp
+++ b/tests/src/Base/Tools2D.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/Tools2D.h>
 
 class Line2D: public ::testing::Test

--- a/tests/src/Base/Tools3D.cpp
+++ b/tests/src/Base/Tools3D.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/Tools3D.h>
 
 class Line3D: public ::testing::Test

--- a/tests/src/Base/Unit.cpp
+++ b/tests/src/Base/Unit.cpp
@@ -1,5 +1,5 @@
 #include "Base/Unit.h"
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/Exception.h>
 
 // NOLINTBEGIN

--- a/tests/src/Base/Vector3D.cpp
+++ b/tests/src/Base/Vector3D.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/Vector3D.h>
 
 // NOLINTBEGIN

--- a/tests/src/Base/ViewProj.cpp
+++ b/tests/src/Base/ViewProj.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/Placement.h>
 #include <Base/ViewProj.h>
 

--- a/tests/src/Base/Writer.cpp
+++ b/tests/src/Base/Writer.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Base/Exception.h"
 #include "Base/Writer.h"

--- a/tests/src/Gui/Assistant.cpp
+++ b/tests/src/Gui/Assistant.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Gui/Assistant.h"
 

--- a/tests/src/Misc/fmt.cpp
+++ b/tests/src/Misc/fmt.cpp
@@ -1,6 +1,6 @@
 #include "fmt/format.h"
 #include "fmt/printf.h"
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <stdexcept>
 
 // NOLINTBEGIN

--- a/tests/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/tests/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <FCConfig.h>
 

--- a/tests/src/Mod/Material/App/TestMaterialCards.cpp
+++ b/tests/src/Mod/Material/App/TestMaterialCards.cpp
@@ -20,7 +20,7 @@
  *                                                                         *
  **************************************************************************/
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <Mod/Material/App/PreCompiled.h>
 #ifndef _PreComp_

--- a/tests/src/Mod/Material/App/TestMaterialProperties.cpp
+++ b/tests/src/Mod/Material/App/TestMaterialProperties.cpp
@@ -20,7 +20,7 @@
  *                                                                         *
  **************************************************************************/
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <Mod/Material/App/PreCompiled.h>
 #ifndef _PreComp_

--- a/tests/src/Mod/Material/App/TestMaterialValue.cpp
+++ b/tests/src/Mod/Material/App/TestMaterialValue.cpp
@@ -20,7 +20,7 @@
  *                                                                         *
  **************************************************************************/
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <Mod/Material/App/PreCompiled.h>
 #ifndef _PreComp_

--- a/tests/src/Mod/Material/App/TestMaterials.cpp
+++ b/tests/src/Mod/Material/App/TestMaterials.cpp
@@ -20,7 +20,7 @@
  *                                                                         *
  **************************************************************************/
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <Mod/Material/App/PreCompiled.h>
 #ifndef _PreComp_

--- a/tests/src/Mod/Material/App/TestModel.cpp
+++ b/tests/src/Mod/Material/App/TestModel.cpp
@@ -20,7 +20,7 @@
  *                                                                         *
  **************************************************************************/
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <Mod/Material/App/PreCompiled.h>
 #ifndef _PreComp_

--- a/tests/src/Mod/Material/App/TestModelProperties.cpp
+++ b/tests/src/Mod/Material/App/TestModelProperties.cpp
@@ -20,7 +20,7 @@
  *                                                                         *
  **************************************************************************/
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <Mod/Material/App/PreCompiled.h>
 #ifndef _PreComp_

--- a/tests/src/Mod/Mesh/App/Core/KDTree.cpp
+++ b/tests/src/Mod/Mesh/App/Core/KDTree.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Mod/Mesh/App/Core/KDTree.h>
 
 // NOLINTBEGIN(cppcoreguidelines-*,readability-*)

--- a/tests/src/Mod/Mesh/App/Exporter.cpp
+++ b/tests/src/Mod/Mesh/App/Exporter.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/FileInfo.h>
 #include <Base/Interpreter.h>
 #include <App/Document.h>

--- a/tests/src/Mod/Mesh/App/Mesh.cpp
+++ b/tests/src/Mod/Mesh/App/Mesh.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Mod/Mesh/App/Mesh.h>
 #include <Mod/Mesh/App/Core/Grid.h>
 

--- a/tests/src/Mod/Part/App/AttachExtension.cpp
+++ b/tests/src/Mod/Part/App/AttachExtension.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <src/App/InitApplication.h>
 #include <App/Document.h>

--- a/tests/src/Mod/Part/App/Attacher.cpp
+++ b/tests/src/Mod/Part/App/Attacher.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "PartTestHelpers.h"
 
 #include <src/App/InitApplication.h>

--- a/tests/src/Mod/Part/App/BRepMesh.cpp
+++ b/tests/src/Mod/Part/App/BRepMesh.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "Mod/Part/App/BRepMesh.h"
 
 // NOLINTBEGIN

--- a/tests/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/tests/src/Mod/Part/App/FeatureChamfer.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <src/App/InitApplication.h>
 

--- a/tests/src/Mod/Part/App/FeatureCompound.cpp
+++ b/tests/src/Mod/Part/App/FeatureCompound.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Mod/Part/App/FeatureCompound.h"
 #include <src/App/InitApplication.h>

--- a/tests/src/Mod/Part/App/FeatureFillet.cpp
+++ b/tests/src/Mod/Part/App/FeatureFillet.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <src/App/InitApplication.h>
 

--- a/tests/src/Mod/Part/App/FeatureMirroring.cpp
+++ b/tests/src/Mod/Part/App/FeatureMirroring.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <src/App/InitApplication.h>
 #include <Mod/Part/App/FeatureMirroring.h>

--- a/tests/src/Mod/Part/App/FeatureOffset.cpp
+++ b/tests/src/Mod/Part/App/FeatureOffset.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <src/App/InitApplication.h>
 

--- a/tests/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Mod/Part/App/FeaturePartBoolean.h"
 #include <src/App/InitApplication.h>

--- a/tests/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Mod/Part/App/FeaturePartCommon.h"
 #include <src/App/InitApplication.h>

--- a/tests/src/Mod/Part/App/FeaturePartCut.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartCut.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Mod/Part/App/FeaturePartCut.h"
 #include <src/App/InitApplication.h>

--- a/tests/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Mod/Part/App/FeaturePartFuse.h"
 #include <src/App/InitApplication.h>

--- a/tests/src/Mod/Part/App/FeatureRevolution.cpp
+++ b/tests/src/Mod/Part/App/FeatureRevolution.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Mod/Part/App/FeatureRevolution.h"
 #include <src/App/InitApplication.h>

--- a/tests/src/Mod/Part/App/PartFeature.cpp
+++ b/tests/src/Mod/Part/App/PartFeature.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <boost/core/ignore_unused.hpp>
 #include "Mod/Part/App/FeaturePartCommon.h"

--- a/tests/src/Mod/Part/App/PartFeatures.cpp
+++ b/tests/src/Mod/Part/App/PartFeatures.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Mod/Part/App/PartFeatures.h"
 #include <src/App/InitApplication.h>

--- a/tests/src/Mod/Part/App/PartTestHelpers.h
+++ b/tests/src/Mod/Part/App/PartTestHelpers.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <boost/format.hpp>
 #include <App/Application.h>
 #include <App/Document.h>

--- a/tests/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/tests/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <BRepFilletAPI_MakeFillet.hxx>
 #include "Mod/Part/App/FeaturePartCommon.h"

--- a/tests/src/Mod/Part/App/TopoDS_Shape.cpp
+++ b/tests/src/Mod/Part/App/TopoDS_Shape.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <Standard_TypeMismatch.hxx>
 #include <TopoDS.hxx>

--- a/tests/src/Mod/Part/App/TopoShape.cpp
+++ b/tests/src/Mod/Part/App/TopoShape.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "PartTestHelpers.h"
 #include <Mod/Part/App/TopoShape.h>
 

--- a/tests/src/Mod/Part/App/TopoShapeCache.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeCache.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Mod/Part/App/TopoShape.h>
 #include <Mod/Part/App/TopoShapeCache.h>
 

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "src/App/InitApplication.h"
 #include <Mod/Part/App/TopoShape.h>
 #include "Mod/Part/App/TopoShapeMapper.h"

--- a/tests/src/Mod/Part/App/TopoShapeMakeElementRefine.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeMakeElementRefine.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <src/App/InitApplication.h>
 

--- a/tests/src/Mod/Part/App/TopoShapeMakeShape.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeMakeShape.cpp
@@ -3,7 +3,7 @@
 // Tests for the makeShape methods, extracted from the main set of tests for TopoShape
 // due to length and complexity.
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "src/App/InitApplication.h"
 #include "PartTestHelpers.h"
 #include <Mod/Part/App/TopoShape.h>

--- a/tests/src/Mod/Part/App/TopoShapeMakeShapeWithElementMap.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeMakeShapeWithElementMap.cpp
@@ -3,7 +3,7 @@
 // Tests for the makeShapeWithElementMap method, extracted from the main set of tests for TopoShape
 // due to length and complexity.
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "src/App/InitApplication.h"
 #include "PartTestHelpers.h"
 #include <Mod/Part/App/TopoShape.h>

--- a/tests/src/Mod/Part/App/TopoShapeMapper.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeMapper.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "src/App/InitApplication.h"
 #include <Mod/Part/App/TopoShape.h>
 #include "Mod/Part/App/TopoShapeMapper.h"

--- a/tests/src/Mod/Part/App/WireJoiner.cpp
+++ b/tests/src/Mod/Part/App/WireJoiner.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "src/App/InitApplication.h"
 #include "Mod/Part/App/WireJoiner.h"
 #include <Mod/Part/App/TopoShapeOpCode.h>

--- a/tests/src/Mod/PartDesign/App/DatumPlane.cpp
+++ b/tests/src/Mod/PartDesign/App/DatumPlane.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "src/App/InitApplication.h"
 
 #include <App/Application.h>

--- a/tests/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/tests/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "src/App/InitApplication.h"
 
 #include <App/Application.h>

--- a/tests/src/Mod/Points/App/Points.cpp
+++ b/tests/src/Mod/Points/App/Points.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <Base/FileInfo.h>
 #include <Mod/Points/App/Points.h>
 #include <Mod/Points/App/PointsAlgos.h>

--- a/tests/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <FCConfig.h>
 

--- a/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -2,7 +2,7 @@
 
 #include <cmath>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Mod/Sketcher/App/planegcs/GCS.h"
 #include "Mod/Sketcher/App/planegcs/Geo.h"

--- a/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "Mod/Sketcher/App/planegcs/GCS.h"
 

--- a/tests/src/zipios++/collectioncollection.cpp
+++ b/tests/src/zipios++/collectioncollection.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <memory>
 #include <zipios++/collcoll.h>
 

--- a/tests/src/zipios++/zipfile.cpp
+++ b/tests/src/zipios++/zipfile.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include <cstdio>
 #include <memory>
 #include <zipios++/zipfile.h>


### PR DESCRIPTION
This adds code similar to that for GSL, that checks for the existence of the GTest submodule, and if it doesn't find it tries to find a system-installed version before printing an error about needing a submodule update. Still needs testing on Linux with GTest installed on the system.