### PR TITLE
Fix issues with wrong color for preference page tooltips

### DIFF
--- a/src/Gui/DlgPreferences.ui
+++ b/src/Gui/DlgPreferences.ui
@@ -2,6 +2,11 @@
 <ui version="4.0">
  <class>Gui::Dialog::DlgPreferences</class>
  <widget class="QDialog" name="Gui::Dialog::DlgPreferences">
+  <property name="styleSheet">
+    <string notr="true">#sidebar { background-color: rgba(0, 0, 0, 25); }
+      #groupsTreeView { background-color: transparent; }
+      #groupsTreeView::item { padding: 6px 8px; }</string>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -69,10 +74,6 @@
        <property name="autoFillBackground">
         <bool>false</bool>
        </property>
-       <property name="styleSheet">
-        <string notr="true">QFrame { background-color: rgba(0, 0, 0, 25); }
-QFrame::item { padding: 6px 8px };</string>
-       </property>
        <property name="frameShape">
         <enum>QFrame::NoFrame</enum>
        </property>
@@ -105,9 +106,6 @@ QFrame::item { padding: 6px 8px };</string>
           </property>
           <property name="autoFillBackground">
            <bool>false</bool>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: transparent;</string>
           </property>
           <property name="frameShape">
            <enum>QFrame::NoFrame</enum>


### PR DESCRIPTION
Stylesheets associated with controls were applied too aggressively by the Qt, causing issues with rendering tooltips etc. 

![image](https://github.com/FreeCAD/FreeCAD/assets/747404/8fcacc55-493e-4b88-a2af-35218870cbff)


was:
![image](https://github.com/FreeCAD/FreeCAD/assets/747404/9169e93a-aba9-4e5f-8546-70919b702c02)


This narrows styles to exact controls.