### PR TITLE
Start: Correct card size calculation

### DIFF
--- a/src/Mod/Start/Gui/FileCardDelegate.h
+++ b/src/Mod/Start/Gui/FileCardDelegate.h
@@ -51,6 +51,7 @@ private:
 
 private:
     Base::Reference<ParameterGrp> _parameterGroup;
+    std::unique_ptr<QWidget> _widget;
 };
 
 


### PR DESCRIPTION
Use the layout to figure out the spacing inside the card, not the inter-card spacing. Fixes #13671.