### PR TITLE
Part: Create CompSolid/Compound/Shell if null before adding a sub-shape

### DIFF
--- a/src/Mod/Part/App/TopoShapeCompSolidPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeCompSolidPyImp.cpp
@@ -25,6 +25,7 @@
 #ifndef _PreComp_
 # include <BRep_Builder.hxx>
 # include <Standard_Failure.hxx>
+# include <TopoDS.hxx>
 # include <TopoDS_CompSolid.hxx>
 #endif
 
@@ -109,6 +110,9 @@ PyObject* TopoShapeCompSolidPy::add(PyObject* args)
 
     BRep_Builder builder;
     TopoDS_Shape comp = getTopoShapePtr()->getShape();
+    if (comp.IsNull()) {
+        builder.MakeCompSolid(TopoDS::CompSolid(comp));
+    }
     auto shapes = getPyShapes(obj);
 
     try {

--- a/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
@@ -30,6 +30,7 @@
 # include <ShapeAnalysis_FreeBounds.hxx>
 # include <Standard_Failure.hxx>
 # include <TopExp_Explorer.hxx>
+# include <TopoDS.hxx>
 # include <TopoDS_Compound.hxx>
 # include <TopTools_HSequenceOfShape.hxx>
 #endif
@@ -103,6 +104,9 @@ PyObject*  TopoShapeCompoundPy::add(PyObject *args)
 
     BRep_Builder builder;
     TopoDS_Shape comp = getTopoShapePtr()->getShape();
+    if (comp.IsNull()) {
+        builder.MakeCompound(TopoDS::Compound(comp));
+    }
 
     try {
         const TopoDS_Shape& sh = static_cast<TopoShapePy*>(obj)->

--- a/src/Mod/Part/App/TopoShapeShellPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeShellPyImp.cpp
@@ -140,6 +140,9 @@ PyObject*  TopoShapeShellPy::add(PyObject *args)
 
     BRep_Builder builder;
     TopoDS_Shape shell = getTopoShapePtr()->getShape();
+    if (shell.IsNull()) {
+        builder.MakeShell(TopoDS::Shell(shell));
+    }
 
     try {
         const TopoShape& shape = *static_cast<TopoShapeFacePy*>(obj)->getTopoShapePtr();


### PR DESCRIPTION
Creating a shape with Part.CompSolid(), Part.Compound() or Part.Shell() is a null shape. In order to allow to append sub-shapes with the add() method a valid shape must be created beforehand.

This fixes #13208