### PR TITLE
PD: Fix crash when adding sketch to loft via tree view

### DIFF
--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -357,6 +357,7 @@ protected:
             App::DocumentObject *obj, const char *subname, bool select=false);
 
     DocumentObjectItem *findItem(bool sync, DocumentObjectItem *item, const char *subname, bool select=true);
+    DocumentObjectItem *findItem(App::DocumentObject* obj, const std::string& subname) const;
 
     App::DocumentObject *getTopParent(App::DocumentObject *obj, std::string &subname);
 


### PR DESCRIPTION
The underlying problem is the method DocumentItem::updateItemSelection() where the selection is altered. This may cause the destruction and recreation of the DocumentObjectItems so that the passed pointer can become dangling.

The issue is fixed in two steps:
1. Add the method 'DocumentObjectItem *findItem(App::DocumentObject* obj, const std::string& subname) const' to safely re-access the item.
2. Add a boolean flag 'dirtyFlag' and the methods insertItem() and removeItem() to DocumentObjectData. This is needed to check when the iterator over the container becomes invalid.