### PR TITLE
FEM: prevent python added properties to be removed

### DIFF
--- a/src/Mod/Fem/femobjects/base_fempythonobject.py
+++ b/src/Mod/Fem/femobjects/base_fempythonobject.py
@@ -62,4 +62,5 @@ class _PropHelper:
 
     def add_to_object(self, obj):
         obj.addProperty(**self.info)
+        obj.setPropertyStatus(self.name, "LockDynamic")
         setattr(obj, self.name, self.value)

--- a/src/Mod/Fem/femobjects/constant_vacuumpermittivity.py
+++ b/src/Mod/Fem/femobjects/constant_vacuumpermittivity.py
@@ -47,6 +47,7 @@ class ConstantVacuumPermittivity(base_fempythonobject.BaseFemPythonObject):
             "Constants",
             "Overwrites default permittivity of vacuum"
         )
+        obj.setPropertyStatus("VacuumPermittivity", "LockDynamic")
         # we must set an expression so that the small value can actually be entered
         permittivity = Units.Quantity(constants.vacuum_permittivity()).getValueAs("F/m")
         obj.setExpression("VacuumPermittivity", str(permittivity))

--- a/src/Mod/Fem/femobjects/constraint_bodyheatsource.py
+++ b/src/Mod/Fem/femobjects/constraint_bodyheatsource.py
@@ -52,4 +52,5 @@ class ConstraintBodyHeatSource(base_fempythonobject.BaseFemPythonObject):
                 "Base",
                 "Body heat source"
             )
+            obj.setPropertyStatus("HeatSource", "LockDynamic")
             obj.HeatSource = 0.0

--- a/src/Mod/Fem/femobjects/constraint_centrif.py
+++ b/src/Mod/Fem/femobjects/constraint_centrif.py
@@ -48,6 +48,7 @@ class ConstraintCentrif(base_fempythonobject.BaseFemPythonObject):
             "Constraint CENTRIF",
             "set rotation frequency f<sub>rot"
         )
+        obj.setPropertyStatus("RotationFrequency", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLinkSubList",
@@ -55,3 +56,4 @@ class ConstraintCentrif(base_fempythonobject.BaseFemPythonObject):
             "Constraint CENTRIF",
             "set line as axis of rotation"
         )
+        obj.setPropertyStatus("RotationAxis", "LockDynamic")

--- a/src/Mod/Fem/femobjects/constraint_currentdensity.py
+++ b/src/Mod/Fem/femobjects/constraint_currentdensity.py
@@ -51,6 +51,7 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Real part of current density x-component"
             )
+            obj.setPropertyStatus("CurrentDensity_re_1", "LockDynamic")
             obj.CurrentDensity_re_1 = "0 A/m^2"
         if not hasattr(obj, "CurrentDensity_re_2"):
             obj.addProperty(
@@ -59,6 +60,7 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Real part of current density y-component"
             )
+            obj.setPropertyStatus("CurrentDensity_re_2", "LockDynamic")
             obj.CurrentDensity_re_2 = "0 A/m^2"
         if not hasattr(obj, "CurrentDensity_re_3"):
             obj.addProperty(
@@ -67,6 +69,7 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Real part of current density z-component"
             )
+            obj.setPropertyStatus("CurrentDensity_re_3", "LockDynamic")
             obj.CurrentDensity_re_3 = "0 A/m^2"
         if not hasattr(obj, "CurrentDensity_im_1"):
             obj.addProperty(
@@ -75,6 +78,7 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Imaginary part of current density x-component"
             )
+            obj.setPropertyStatus("CurrentDensity_im_1", "LockDynamic")
             obj.CurrentDensity_im_1 = "0 A/m^2"
         if not hasattr(obj, "CurrentDensity_im_2"):
             obj.addProperty(
@@ -83,6 +87,7 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Imaginary part of current density y-component"
             )
+            obj.setPropertyStatus("CurrentDensity_im_2", "LockDynamic")
             obj.CurrentDensity_im_2 = "0 A/m^2"
         if not hasattr(obj, "CurrentDensity_im_3"):
             obj.addProperty(
@@ -91,6 +96,7 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Imaginary part of current density z-component"
             )
+            obj.setPropertyStatus("CurrentDensity_im_3", "LockDynamic")
             obj.CurrentDensity_im_3 = "0 A/m^2"
 
         # now the enable bools
@@ -101,6 +107,7 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("CurrentDensity_re_1_Disabled", "LockDynamic")
             obj.CurrentDensity_re_1_Disabled = True
         if not hasattr(obj, "CurrentDensity_re_2_Disabled"):
             obj.addProperty(
@@ -109,6 +116,7 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("CurrentDensity_re_2_Disabled", "LockDynamic")
             obj.CurrentDensity_re_2_Disabled = True
         if not hasattr(obj, "CurrentDensity_re_3_Disabled"):
             obj.addProperty(
@@ -117,6 +125,7 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("CurrentDensity_re_3_Disabled", "LockDynamic")
             obj.CurrentDensity_re_3_Disabled = True
         if not hasattr(obj, "CurrentDensity_im_1_Disabled"):
             obj.addProperty(
@@ -125,6 +134,7 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("CurrentDensity_im_1_Disabled", "LockDynamic")
             obj.CurrentDensity_im_1_Disabled = True
         if not hasattr(obj, "CurrentDensity_im_2_Disabled"):
             obj.addProperty(
@@ -133,6 +143,7 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("CurrentDensity_im_2_Disabled", "LockDynamic")
             obj.CurrentDensity_im_2_Disabled = True
         if not hasattr(obj, "CurrentDensity_im_3_Disabled"):
             obj.addProperty(
@@ -141,4 +152,5 @@ class ConstraintCurrentDensity(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("CurrentDensity_im_3_Disabled", "LockDynamic")
             obj.CurrentDensity_im_3_Disabled = True

--- a/src/Mod/Fem/femobjects/constraint_electrostaticpotential.py
+++ b/src/Mod/Fem/femobjects/constraint_electrostaticpotential.py
@@ -53,6 +53,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Parameter",
                 "Electric Potential"
             )
+            obj.setPropertyStatus("Potential", "LockDynamic")
             # setting  1 V assures that the unit does not switch to mV
             # and the constraint holds usually Volts
             obj.Potential = "1 V"
@@ -64,6 +65,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 "Real part of potential x-component"
             )
+            obj.setPropertyStatus("AV_re_1", "LockDynamic")
             obj.AV_re_1 = "0 V"
         if not hasattr(obj, "AV_re_2"):
             obj.addProperty(
@@ -72,6 +74,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 "Real part of potential y-component"
             )
+            obj.setPropertyStatus("AV_re_2", "LockDynamic")
             obj.AV_re_2 = "0 V"
         if not hasattr(obj, "AV_re_3"):
             obj.addProperty(
@@ -80,6 +83,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 "Real part of potential z-component"
             )
+            obj.setPropertyStatus("AV_re_3", "LockDynamic")
             obj.AV_re_3 = "0 V"
         if not hasattr(obj, "AV_im"):
             obj.addProperty(
@@ -88,6 +92,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 "Imaginary part of scalar potential"
             )
+            obj.setPropertyStatus("AV_im", "LockDynamic")
             obj.AV_im = "0 V"
         if not hasattr(obj, "AV_im_1"):
             obj.addProperty(
@@ -96,6 +101,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 "Imaginary part of potential x-component"
             )
+            obj.setPropertyStatus("AV_im_1", "LockDynamic")
             obj.AV_im_1 = "0 V"
         if not hasattr(obj, "AV_im_2"):
             obj.addProperty(
@@ -104,6 +110,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 "Imaginary part of potential y-component"
             )
+            obj.setPropertyStatus("AV_im_2", "LockDynamic")
             obj.AV_im_2 = "0 V"
         if not hasattr(obj, "AV_im_3"):
             obj.addProperty(
@@ -112,6 +119,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 "Imaginary part of potential z-component"
             )
+            obj.setPropertyStatus("AV_im_3", "LockDynamic")
             obj.AV_im_3 = "0 V"
 
         # now the enable bools
@@ -122,6 +130,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Parameter",
                 "Potential Enabled"
             )
+            obj.setPropertyStatus("PotentialEnabled", "LockDynamic")
             obj.PotentialEnabled = True
         if not hasattr(obj, "AV_re_1_Disabled"):
             obj.addProperty(
@@ -130,6 +139,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("AV_re_1_Disabled", "LockDynamic")
             obj.AV_re_1_Disabled = True
         if not hasattr(obj, "AV_re_2_Disabled"):
             obj.addProperty(
@@ -138,6 +148,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("AV_re_2_Disabled", "LockDynamic")
             obj.AV_re_2_Disabled = True
         if not hasattr(obj, "AV_re_3_Disabled"):
             obj.addProperty(
@@ -146,6 +157,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("AV_re_3_Disabled", "LockDynamic")
             obj.AV_re_3_Disabled = True
         if not hasattr(obj, "AV_im_Disabled"):
             obj.addProperty(
@@ -154,6 +166,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("AV_im_Disabled", "LockDynamic")
             obj.AV_im_Disabled = True
         if not hasattr(obj, "AV_im_1_Disabled"):
             obj.addProperty(
@@ -162,6 +175,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("AV_im_1_Disabled", "LockDynamic")
             obj.AV_im_1_Disabled = True
         if not hasattr(obj, "AV_im_2_Disabled"):
             obj.addProperty(
@@ -170,6 +184,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("AV_im_2_Disabled", "LockDynamic")
             obj.AV_im_2_Disabled = True
         if not hasattr(obj, "AV_im_3_Disabled"):
             obj.addProperty(
@@ -178,6 +193,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("AV_im_3_Disabled", "LockDynamic")
             obj.AV_im_3_Disabled = True
 
         if not hasattr(obj, "PotentialConstant"):
@@ -187,6 +203,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Parameter",
                 "Potential Constant"
             )
+            obj.setPropertyStatus("PotentialConstant", "LockDynamic")
             obj.PotentialConstant = False
 
         if not hasattr(obj, "ElectricInfinity"):
@@ -196,6 +213,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Parameter",
                 "Electric Infinity"
             )
+            obj.setPropertyStatus("ElectricInfinity", "LockDynamic")
             obj.ElectricInfinity = False
 
         if not hasattr(obj, "ElectricForcecalculation"):
@@ -205,6 +223,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Parameter",
                 "Electric Force Calculation"
             )
+            obj.setPropertyStatus("ElectricForcecalculation", "LockDynamic")
             obj.ElectricForcecalculation = False
 
         if not hasattr(obj, "CapacitanceBody"):
@@ -214,6 +233,7 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Parameter",
                 "Capacitance Body"
             )
+            obj.setPropertyStatus("CapacitanceBody", "LockDynamic")
             obj.CapacitanceBody = 0
 
         if not hasattr(obj, "CapacitanceBodyEnabled"):
@@ -223,4 +243,5 @@ class ConstraintElectrostaticPotential(base_fempythonobject.BaseFemPythonObject)
                 "Parameter",
                 "Capacitance Body Enabled"
             )
+            obj.setPropertyStatus("CapacitanceBodyEnabled", "LockDynamic")
             obj.CapacitanceBodyEnabled = False

--- a/src/Mod/Fem/femobjects/constraint_flowvelocity.py
+++ b/src/Mod/Fem/femobjects/constraint_flowvelocity.py
@@ -46,18 +46,21 @@ class ConstraintFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Velocity in x-direction"
         )
+        obj.setPropertyStatus("VelocityX", "LockDynamic")
         obj.addProperty(
             "App::PropertyString",
             "VelocityXFormula",
             "Parameter",
             "Velocity formula in x-direction"
         )
+        obj.setPropertyStatus("VelocityXFormula", "LockDynamic")
         obj.addProperty(
             "App::PropertyBool",
             "VelocityXUnspecified",
             "Parameter",
             "Use velocity in x-direction"
         )
+        obj.setPropertyStatus("VelocityXUnspecified", "LockDynamic")
         obj.VelocityXUnspecified = True
         obj.addProperty(
             "App::PropertyBool",
@@ -65,6 +68,7 @@ class ConstraintFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Use formula for velocity in x-direction"
         )
+        obj.setPropertyStatus("VelocityXHasFormula", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyVelocity",
@@ -72,18 +76,21 @@ class ConstraintFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Velocity in y-direction"
         )
+        obj.setPropertyStatus("VelocityY", "LockDynamic")
         obj.addProperty(
             "App::PropertyString",
             "VelocityYFormula",
             "Parameter",
             "Velocity formula in y-direction"
         )
+        obj.setPropertyStatus("VelocityYFormula", "LockDynamic")
         obj.addProperty(
             "App::PropertyBool",
             "VelocityYUnspecified",
             "Parameter",
             "Use velocity in y-direction"
         )
+        obj.setPropertyStatus("VelocityYUnspecified", "LockDynamic")
         obj.VelocityYUnspecified = True
         obj.addProperty(
             "App::PropertyBool",
@@ -91,6 +98,7 @@ class ConstraintFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Use formula for velocity in y-direction"
         )
+        obj.setPropertyStatus("VelocityYHasFormula", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyVelocity",
@@ -98,18 +106,21 @@ class ConstraintFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Velocity in z-direction"
         )
+        obj.setPropertyStatus("VelocityZ", "LockDynamic")
         obj.addProperty(
             "App::PropertyString",
             "VelocityZFormula",
             "Parameter",
             "Velocity formula in z-direction"
         )
+        obj.setPropertyStatus("VelocityZFormula", "LockDynamic")
         obj.addProperty(
             "App::PropertyBool",
             "VelocityZUnspecified",
             "Parameter",
             "Use velocity in z-direction"
         )
+        obj.setPropertyStatus("VelocityZUnspecified", "LockDynamic")
         obj.VelocityZUnspecified = True
         obj.addProperty(
             "App::PropertyBool",
@@ -117,6 +128,7 @@ class ConstraintFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Use formula for velocity in z-direction"
         )
+        obj.setPropertyStatus("VelocityZHasFormula", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyBool",
@@ -124,3 +136,4 @@ class ConstraintFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Flow is in normal direction"
         )
+        obj.setPropertyStatus("NormalToBoundary", "LockDynamic")

--- a/src/Mod/Fem/femobjects/constraint_initialflowvelocity.py
+++ b/src/Mod/Fem/femobjects/constraint_initialflowvelocity.py
@@ -45,18 +45,21 @@ class ConstraintInitialFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Velocity in x-direction"
         )
+        obj.setPropertyStatus("VelocityX", "LockDynamic")
         obj.addProperty(
             "App::PropertyString",
             "VelocityXFormula",
             "Parameter",
             "Velocity formula in x-direction"
         )
+        obj.setPropertyStatus("VelocityXFormula", "LockDynamic")
         obj.addProperty(
             "App::PropertyBool",
             "VelocityXUnspecified",
             "Parameter",
             "Use velocity in x-direction"
         )
+        obj.setPropertyStatus("VelocityXUnspecified", "LockDynamic")
         obj.VelocityXUnspecified = True
         obj.addProperty(
             "App::PropertyBool",
@@ -64,6 +67,7 @@ class ConstraintInitialFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Use formula for velocity in x-direction"
         )
+        obj.setPropertyStatus("VelocityXHasFormula", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyVelocity",
@@ -71,18 +75,21 @@ class ConstraintInitialFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Velocity in y-direction"
         )
+        obj.setPropertyStatus("VelocityY", "LockDynamic")
         obj.addProperty(
             "App::PropertyString",
             "VelocityYFormula",
             "Parameter",
             "Velocity formula in y-direction"
         )
+        obj.setPropertyStatus("VelocityYFormula", "LockDynamic")
         obj.addProperty(
             "App::PropertyBool",
             "VelocityYUnspecified",
             "Parameter",
             "Use velocity in y-direction"
         )
+        obj.setPropertyStatus("VelocityYUnspecified", "LockDynamic")
         obj.VelocityYUnspecified = True
         obj.addProperty(
             "App::PropertyBool",
@@ -90,6 +97,7 @@ class ConstraintInitialFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Use formula for velocity in y-direction"
         )
+        obj.setPropertyStatus("VelocityYHasFormula", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyVelocity",
@@ -97,18 +105,21 @@ class ConstraintInitialFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Velocity in z-direction"
         )
+        obj.setPropertyStatus("VelocityZ", "LockDynamic")
         obj.addProperty(
             "App::PropertyString",
             "VelocityZFormula",
             "Parameter",
             "Velocity formula in z-direction"
         )
+        obj.setPropertyStatus("VelocityZFormula", "LockDynamic")
         obj.addProperty(
             "App::PropertyBool",
             "VelocityZUnspecified",
             "Parameter",
             "Use velocity in z-direction"
         )
+        obj.setPropertyStatus("VelocityZUnspecified", "LockDynamic")
         obj.VelocityZUnspecified = True
         obj.addProperty(
             "App::PropertyBool",
@@ -116,3 +127,4 @@ class ConstraintInitialFlowVelocity(base_fempythonobject.BaseFemPythonObject):
             "Parameter",
             "Use formula for velocity in z-direction"
         )
+        obj.setPropertyStatus("VelocityZHasFormula", "LockDynamic")

--- a/src/Mod/Fem/femobjects/constraint_initialpressure.py
+++ b/src/Mod/Fem/femobjects/constraint_initialpressure.py
@@ -51,5 +51,6 @@ class ConstraintInitialPressure(base_fempythonobject.BaseFemPythonObject):
                 "Parameter",
                 "Initial Pressure"
             )
+            obj.setPropertyStatus("Pressure", "LockDynamic")
             # we initialize 1 bar
             obj.Pressure = "100 kPa"

--- a/src/Mod/Fem/femobjects/constraint_magnetization.py
+++ b/src/Mod/Fem/femobjects/constraint_magnetization.py
@@ -51,6 +51,7 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Real part of magnetization x-component"
             )
+            obj.setPropertyStatus("Magnetization_re_1", "LockDynamic")
             obj.Magnetization_re_1 = "0 A/m"
         if not hasattr(obj, "Magnetization_re_2"):
             obj.addProperty(
@@ -59,6 +60,7 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Real part of magnetization y-component"
             )
+            obj.setPropertyStatus("Magnetization_re_2", "LockDynamic")
             obj.Magnetization_re_2 = "0 A/m"
         if not hasattr(obj, "Magnetization_re_3"):
             obj.addProperty(
@@ -67,6 +69,7 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Real part of magnetization z-component"
             )
+            obj.setPropertyStatus("Magnetization_re_3", "LockDynamic")
             obj.Magnetization_re_3 = "0 A/m"
         if not hasattr(obj, "Magnetization_im_1"):
             obj.addProperty(
@@ -75,6 +78,7 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Imaginary part of magnetization x-component"
             )
+            obj.setPropertyStatus("Magnetization_im_1", "LockDynamic")
             obj.Magnetization_im_1 = "0 A/m"
         if not hasattr(obj, "Magnetization_im_2"):
             obj.addProperty(
@@ -83,6 +87,7 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Imaginary part of magnetization y-component"
             )
+            obj.setPropertyStatus("Magnetization_im_2", "LockDynamic")
             obj.Magnetization_im_2 = "0 A/m"
         if not hasattr(obj, "Magnetization_im_3"):
             obj.addProperty(
@@ -91,6 +96,7 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 "Imaginary part of magnetization z-component"
             )
+            obj.setPropertyStatus("Magnetization_im_3", "LockDynamic")
             obj.Magnetization_im_3 = "0 A/m"
 
         # now the enable bools
@@ -101,6 +107,7 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("Magnetization_re_1_Disabled", "LockDynamic")
             obj.Magnetization_re_1_Disabled = True
         if not hasattr(obj, "Magnetization_re_2_Disabled"):
             obj.addProperty(
@@ -109,6 +116,7 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("Magnetization_re_2_Disabled", "LockDynamic")
             obj.Magnetization_re_2_Disabled = True
         if not hasattr(obj, "Magnetization_re_3_Disabled"):
             obj.addProperty(
@@ -117,6 +125,7 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("Magnetization_re_3_Disabled", "LockDynamic")
             obj.Magnetization_re_3_Disabled = True
         if not hasattr(obj, "Magnetization_im_1_Disabled"):
             obj.addProperty(
@@ -125,6 +134,7 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("Magnetization_im_1_Disabled", "LockDynamic")
             obj.Magnetization_im_1_Disabled = True
         if not hasattr(obj, "Magnetization_im_2_Disabled"):
             obj.addProperty(
@@ -133,6 +143,7 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("Magnetization_im_2_Disabled", "LockDynamic")
             obj.Magnetization_im_2_Disabled = True
         if not hasattr(obj, "Magnetization_im_3_Disabled"):
             obj.addProperty(
@@ -141,4 +152,5 @@ class ConstraintMagnetization(base_fempythonobject.BaseFemPythonObject):
                 "Vector Potential",
                 ""
             )
+            obj.setPropertyStatus("Magnetization_im_3_Disabled", "LockDynamic")
             obj.Magnetization_im_3_Disabled = True

--- a/src/Mod/Fem/femobjects/constraint_selfweight.py
+++ b/src/Mod/Fem/femobjects/constraint_selfweight.py
@@ -57,12 +57,14 @@ class ConstraintSelfWeight(base_fempythonobject.BaseFemPythonObject):
                         "GravityAcceleration",
                         "Gravity",
                         "Gravity acceleration")
+        obj.setPropertyStatus("GravityAcceleration", "LockDynamic")
         obj.GravityAcceleration = constants.gravity()
 
         obj.addProperty("App::PropertyVector",
                         "GravityDirection",
                         "Gravity",
                         "Normalized gravity direction")
+        obj.setPropertyStatus("GravityDirection", "LockDynamic")
         obj.GravityDirection = FreeCAD.Vector(0, 0, -1)
 
         obj.setPropertyStatus("NormalDirection", "Hidden")

--- a/src/Mod/Fem/femobjects/element_fluid1D.py
+++ b/src/Mod/Fem/femobjects/element_fluid1D.py
@@ -69,6 +69,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "FluidSection",
             "List of fluid section shapes"
         )
+        obj.setPropertyStatus("References", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -76,6 +77,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "FluidSection",
             "select fluid section type"
         )
+        obj.setPropertyStatus("SectionType", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -83,6 +85,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidSection",
             "select liquid section type"
         )
+        obj.setPropertyStatus("LiquidSectionType", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyArea",
@@ -90,6 +93,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidManning",
             "set area of the manning fluid section"
         )
+        obj.setPropertyStatus("ManningArea", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLength",
@@ -97,6 +101,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidManning",
             "set hydraulic radius of manning fluid section"
         )
+        obj.setPropertyStatus("ManningRadius", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloat",
@@ -104,6 +109,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidManning",
             "set coefficient of manning fluid section"
         )
+        obj.setPropertyStatus("ManningCoefficient", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyArea",
@@ -111,12 +117,14 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidEnlargement",
             "set initial area of the enlargement fluid section"
         )
+        obj.setPropertyStatus("EnlargeArea1", "LockDynamic")
         obj.addProperty(
             "App::PropertyArea",
             "EnlargeArea2",
             "LiquidEnlargement",
             "set enlarged area of enlargement fluid section"
         )
+        obj.setPropertyStatus("EnlargeArea2", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyArea",
@@ -124,6 +132,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidContraction",
             "set initial area of the contraction fluid section"
         )
+        obj.setPropertyStatus("ContractArea1", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyArea",
@@ -131,6 +140,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidContraction",
             "set contracted area of contraction fluid section"
         )
+        obj.setPropertyStatus("ContractArea2", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloat",
@@ -138,6 +148,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidInlet",
             "set inlet pressure for fluid section"
         )
+        obj.setPropertyStatus("InletPressure", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloat",
@@ -145,6 +156,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidOutlet",
             "set outlet pressure for fluid section"
         )
+        obj.setPropertyStatus("OutletPressure", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloat",
@@ -152,6 +164,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidInlet",
             "set inlet mass flow rate for fluid section"
         )
+        obj.setPropertyStatus("InletFlowRate", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloat",
@@ -159,6 +172,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidOutlet",
             "set outlet mass flow rate for fluid section"
         )
+        obj.setPropertyStatus("OutletFlowRate", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyBool",
@@ -166,6 +180,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidInlet",
             "activates or deactivates inlet pressure for fluid section"
         )
+        obj.setPropertyStatus("InletPressureActive", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyBool",
@@ -173,6 +188,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidOutlet",
             "activates or deactivates outlet pressure for fluid section"
         )
+        obj.setPropertyStatus("OutletPressureActive", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyBool",
@@ -180,6 +196,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidInlet",
             "activates or deactivates inlet flow rate for fluid section"
         )
+        obj.setPropertyStatus("InletFlowRateActive", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyBool",
@@ -187,6 +204,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidOutlet",
             "activates or deactivates outlet flow rate for fluid section"
         )
+        obj.setPropertyStatus("OutletFlowRateActive", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyArea",
@@ -194,6 +212,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidEntrance",
             "set the pipe area of the entrance fluid section"
         )
+        obj.setPropertyStatus("EntrancePipeArea", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyArea",
@@ -201,6 +220,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidEntrance",
             "set the entrance area of the entrance fluid section"
         )
+        obj.setPropertyStatus("EntranceArea", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyArea",
@@ -208,6 +228,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidDiaphragm",
             "set the pipe area of the diaphragm fluid section"
         )
+        obj.setPropertyStatus("DiaphragmPipeArea", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyArea",
@@ -215,6 +236,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidDiaphragm",
             "set the diaphragm area of the diaphragm fluid section"
         )
+        obj.setPropertyStatus("DiaphragmArea", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyArea",
@@ -222,6 +244,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidBend",
             "set pipe area of the bend fluid section"
         )
+        obj.setPropertyStatus("BendPipeArea", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloat",
@@ -229,6 +252,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidBend",
             "set ratio of bend radius over pipe diameter of the bend fluid section"
         )
+        obj.setPropertyStatus("BendRadiusDiameter", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloat",
@@ -236,6 +260,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidBend",
             "set bend angle of the bend fluid section"
         )
+        obj.setPropertyStatus("BendAngle", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloat",
@@ -243,6 +268,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidBend",
             "set loss coefficient of the bend fluid section"
         )
+        obj.setPropertyStatus("BendLossCoefficient", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyArea",
@@ -250,6 +276,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidGateValve",
             "set pipe area of the gate valve fluid section"
         )
+        obj.setPropertyStatus("GateValvePipeArea", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloat",
@@ -257,6 +284,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidGateValve",
             "set closing coefficient of the gate valve fluid section"
         )
+        obj.setPropertyStatus("GateValveClosingCoeff", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloatList",
@@ -264,6 +292,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidPump",
             "set the pump characteristic flow rate of the pump fluid section"
         )
+        obj.setPropertyStatus("PumpFlowRate", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloatList",
@@ -271,6 +300,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidPump",
             "set the pump characteristic head loss of the pump fluid section"
         )
+        obj.setPropertyStatus("PumpHeadLoss", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyArea",
@@ -278,6 +308,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidColebrooke",
             "set pipe area of the colebrooke fluid section"
         )
+        obj.setPropertyStatus("ColebrookeArea", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLength",
@@ -285,6 +316,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidColebrooke",
             "set hydraulic radius of the colebrooke fluid section"
         )
+        obj.setPropertyStatus("ColebrookeRadius", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLength",
@@ -292,6 +324,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidColebrooke",
             "set grain diameter of the colebrooke fluid section"
         )
+        obj.setPropertyStatus("ColebrookeGrainDiameter", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyFloat",
@@ -299,6 +332,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "LiquidColebrooke",
             "set coefficient of the colebrooke fluid section"
         )
+        obj.setPropertyStatus("ColebrookeFormFactor", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -306,6 +340,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "GasSection",
             "select gas section type"
         )
+        obj.setPropertyStatus("GasSectionType", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -313,6 +348,7 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
             "ChannelSection",
             "select channel section type"
         )
+        obj.setPropertyStatus("ChannelSectionType", "LockDynamic")
 
         # set property default values
         obj.SectionType = ElementFluid1D.known_fluid_types

--- a/src/Mod/Fem/femobjects/element_geometry1D.py
+++ b/src/Mod/Fem/femobjects/element_geometry1D.py
@@ -49,6 +49,7 @@ class ElementGeometry1D(base_fempythonobject.BaseFemPythonObject):
             "RectBeamSection",
             "set width of the rectangular beam elements"
         )
+        obj.setPropertyStatus("RectWidth", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLength",
@@ -56,6 +57,7 @@ class ElementGeometry1D(base_fempythonobject.BaseFemPythonObject):
             "RectBeamSection",
             "set height of therectangular beam elements"
         )
+        obj.setPropertyStatus("RectHeight", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLength",
@@ -63,6 +65,7 @@ class ElementGeometry1D(base_fempythonobject.BaseFemPythonObject):
             "CircBeamSection",
             "set diameter of the circular beam elements"
         )
+        obj.setPropertyStatus("CircDiameter", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLength",
@@ -70,6 +73,7 @@ class ElementGeometry1D(base_fempythonobject.BaseFemPythonObject):
             "PipeBeamSection",
             "set outer diameter of the pipe beam elements"
         )
+        obj.setPropertyStatus("PipeDiameter", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLength",
@@ -77,6 +81,7 @@ class ElementGeometry1D(base_fempythonobject.BaseFemPythonObject):
             "PipeBeamSection",
             "set thickness of the pipe beam elements"
         )
+        obj.setPropertyStatus("PipeThickness", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -84,6 +89,7 @@ class ElementGeometry1D(base_fempythonobject.BaseFemPythonObject):
             "BeamSection",
             "select beam section type"
         )
+        obj.setPropertyStatus("SectionType", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLinkSubList",
@@ -91,6 +97,6 @@ class ElementGeometry1D(base_fempythonobject.BaseFemPythonObject):
             "BeamSection",
             "List of beam section shapes"
         )
-
+        obj.setPropertyStatus("References", "LockDynamic")
         obj.SectionType = ElementGeometry1D.known_beam_types
         obj.SectionType = "Rectangular"

--- a/src/Mod/Fem/femobjects/element_geometry2D.py
+++ b/src/Mod/Fem/femobjects/element_geometry2D.py
@@ -48,6 +48,7 @@ class ElementGeometry2D(base_fempythonobject.BaseFemPythonObject):
             "ShellThickness",
             "set thickness of the shell elements"
         )
+        obj.setPropertyStatus("Thickness", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLinkSubList",
@@ -55,3 +56,4 @@ class ElementGeometry2D(base_fempythonobject.BaseFemPythonObject):
             "ShellThickness",
             "List of shell thickness shapes"
         )
+        obj.setPropertyStatus("References", "LockDynamic")

--- a/src/Mod/Fem/femobjects/element_rotation1D.py
+++ b/src/Mod/Fem/femobjects/element_rotation1D.py
@@ -48,6 +48,7 @@ class ElementRotation1D(base_fempythonobject.BaseFemPythonObject):
             "BeamRotation",
             "Set the rotation of beam elements"
         )
+        obj.setPropertyStatus("Rotation", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLinkSubList",
@@ -55,3 +56,4 @@ class ElementRotation1D(base_fempythonobject.BaseFemPythonObject):
             "BeamRotation",
             "List of beam rotation shapes"
         )
+        obj.setPropertyStatus("References", "LockDynamic")

--- a/src/Mod/Fem/femobjects/material_common.py
+++ b/src/Mod/Fem/femobjects/material_common.py
@@ -56,6 +56,7 @@ class MaterialCommon(base_fempythonobject.BaseFemPythonObject):
                 "Material",
                 "List of material shapes"
             )
+            obj.setPropertyStatus("References", "LockDynamic")
         # Category
         # attribute Category was added in commit 61fb3d429a
         if not hasattr(obj, "Category"):
@@ -65,6 +66,7 @@ class MaterialCommon(base_fempythonobject.BaseFemPythonObject):
                 "Material",
                 "Material type: fluid or solid"
             )
+            obj.setPropertyStatus("Category", "LockDynamic")
             obj.Category = ["Solid", "Fluid"]  # used in TaskPanel
             obj.Category = "Solid"
         """

--- a/src/Mod/Fem/femobjects/material_mechanicalnonlinear.py
+++ b/src/Mod/Fem/femobjects/material_mechanicalnonlinear.py
@@ -79,6 +79,7 @@ class MaterialMechanicalNonlinear(base_fempythonobject.BaseFemPythonObject):
                 "Base",
                 "Set the linear material the nonlinear builds upon."
             )
+            obj.setPropertyStatus("LinearBaseMaterial", "LockDynamic")
 
         if not hasattr(obj, "MaterialModelNonlinearity"):
             choices_nonlinear_material_models = ["isotropic hardening","kinematic hardening"]
@@ -88,6 +89,7 @@ class MaterialMechanicalNonlinear(base_fempythonobject.BaseFemPythonObject):
                 "Fem",
                 "Set the type on nonlinear material model"
             )
+            obj.setPropertyStatus("MaterialModelNonlinearity", "LockDynamic")
             obj.MaterialModelNonlinearity = choices_nonlinear_material_models
             obj.MaterialModelNonlinearity = choices_nonlinear_material_models[0]
 
@@ -104,4 +106,5 @@ class MaterialMechanicalNonlinear(base_fempythonobject.BaseFemPythonObject):
                 "Set stress and strain for yield points as a list of strings, "
                 "each point \"stress, plastic strain\""
             )
+            obj.setPropertyStatus("YieldPoints", "LockDynamic")
             obj.YieldPoints = []

--- a/src/Mod/Fem/femobjects/material_reinforced.py
+++ b/src/Mod/Fem/femobjects/material_reinforced.py
@@ -48,6 +48,7 @@ class MaterialReinforced(base_fempythonobject.BaseFemPythonObject):
             "Material",
             "List of material shapes"
         )
+        obj.setPropertyStatus("References", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyMap",
@@ -55,6 +56,7 @@ class MaterialReinforced(base_fempythonobject.BaseFemPythonObject):
             "Composites",
             "Reinforcement material properties"
         )
+        obj.setPropertyStatus("Reinforcement", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -62,6 +64,7 @@ class MaterialReinforced(base_fempythonobject.BaseFemPythonObject):
             "Material",
             "Matrix material properties"
         )
+        obj.setPropertyStatus("Category", "LockDynamic")
 
         obj.Category = ["Solid"]
         obj.Category = "Solid"

--- a/src/Mod/Fem/femobjects/mesh_boundarylayer.py
+++ b/src/Mod/Fem/femobjects/mesh_boundarylayer.py
@@ -48,6 +48,7 @@ class MeshBoundaryLayer(base_fempythonobject.BaseFemPythonObject):
             "MeshBoundaryLayerProperties",
             "set number of inflation layers for this boundary"
         )
+        obj.setPropertyStatus("NumberOfLayers", "LockDynamic")
         obj.NumberOfLayers = 3
 
         obj.addProperty(
@@ -56,6 +57,7 @@ class MeshBoundaryLayer(base_fempythonobject.BaseFemPythonObject):
             "MeshBoundaryLayerProperties",
             "set minimum thickness,usually the first inflation layer"
         )
+        obj.setPropertyStatus("MinimumThickness", "LockDynamic")
         # default to zero, user must specify a proper value for this property
 
         obj.addProperty(
@@ -64,6 +66,7 @@ class MeshBoundaryLayer(base_fempythonobject.BaseFemPythonObject):
             "MeshBoundaryLayerProperties",
             "set growth rate of inflation layers for smooth transition"
         )
+        obj.setPropertyStatus("GrowthRate", "LockDynamic")
         obj.GrowthRate = 1.5
 
         obj.addProperty(
@@ -72,3 +75,4 @@ class MeshBoundaryLayer(base_fempythonobject.BaseFemPythonObject):
             "MeshBoundaryLayerShapes",
             "List of FEM mesh region shapes"
         )
+        obj.setPropertyStatus("References", "LockDynamic")

--- a/src/Mod/Fem/femobjects/mesh_gmsh.py
+++ b/src/Mod/Fem/femobjects/mesh_gmsh.py
@@ -118,6 +118,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "Base",
                 "Mesh boundaries need inflation layers"
             )
+            obj.setPropertyStatus("MeshBoundaryLayerList", "LockDynamic")
             obj.MeshBoundaryLayerList = []
 
         if not hasattr(obj, "MeshRegionList"):
@@ -127,6 +128,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "Base",
                 "Mesh refinments of the mesh"
             )
+            obj.setPropertyStatus("MeshRegionList", "LockDynamic")
             obj.MeshRegionList = []
 
         if not hasattr(obj, "MeshGroupList"):
@@ -136,6 +138,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "Base",
                 "Mesh groups of the mesh"
             )
+            obj.setPropertyStatus("MeshGroupList", "LockDynamic")
             obj.MeshGroupList = []
 
         if not hasattr(obj, "Part"):
@@ -145,6 +148,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Mesh",
                 "Geometry object, the mesh is made from. The geometry object has to have a Shape."
             )
+            obj.setPropertyStatus("Part", "LockDynamic")
             obj.Part = None
 
         if not hasattr(obj, "CharacteristicLengthMax"):
@@ -154,6 +158,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Max mesh element size (0.0 = infinity)"
             )
+            obj.setPropertyStatus("CharacteristicLengthMax", "LockDynamic")
             obj.CharacteristicLengthMax = 0.0  # will be 1e+22
 
         if not hasattr(obj, "CharacteristicLengthMin"):
@@ -163,6 +168,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Min mesh element size"
             )
+            obj.setPropertyStatus("CharacteristicLengthMin", "LockDynamic")
             obj.CharacteristicLengthMin = 0.0
 
         if not hasattr(obj, "ElementDimension"):
@@ -172,6 +178,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Dimension of mesh elements (Auto = according ShapeType of part to mesh)"
             )
+            obj.setPropertyStatus("ElementDimension", "LockDynamic")
             obj.ElementDimension = MeshGmsh.known_element_dimensions
             obj.ElementDimension = "From Shape"  # according ShapeType of Part to mesh
 
@@ -182,6 +189,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Order of mesh elements"
             )
+            obj.setPropertyStatus("ElementOrder", "LockDynamic")
             obj.ElementOrder = MeshGmsh.known_element_orders
             obj.ElementOrder = "2nd"
 
@@ -192,6 +200,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Optimize tetrahedral elements"
             )
+            obj.setPropertyStatus("OptimizeStd", "LockDynamic")
             obj.OptimizeStd = True
 
         if not hasattr(obj, "OptimizeNetgen"):
@@ -201,6 +210,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Optimize tetra elements by use of Netgen"
             )
+            obj.setPropertyStatus("OptimizeNetgen", "LockDynamic")
             obj.OptimizeNetgen = False
 
         if not hasattr(obj, "HighOrderOptimize"):
@@ -210,6 +220,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Optimization of high order meshes"
             )
+            obj.setPropertyStatus("HighOrderOptimize", "LockDynamic")
             obj.HighOrderOptimize = MeshGmsh.known_mesh_HighOrderOptimizers
             obj.HighOrderOptimize = "None"
 
@@ -220,6 +231,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Apply recombination algorithm to all surfaces"
             )
+            obj.setPropertyStatus("RecombineAll", "LockDynamic")
             obj.RecombineAll = False
 
         if not hasattr(obj, "Recombine3DAll"):
@@ -229,6 +241,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Apply recombination algorithm to all volumes"
             )
+            obj.setPropertyStatus("Recombine3DAll", "LockDynamic")
             obj.Recombine3DAll = False
 
         if not hasattr(obj, "RecombinationAlgorithm"):
@@ -238,6 +251,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Recombination algorithm"
             )
+            obj.setPropertyStatus("RecombinationAlgorithm", "LockDynamic")
             obj.RecombinationAlgorithm = MeshGmsh.known_mesh_RecombinationAlgorithms
             obj.RecombinationAlgorithm = "Simple"
 
@@ -248,6 +262,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Removes all duplicate mesh vertices"
             )
+            obj.setPropertyStatus("CoherenceMesh", "LockDynamic")
             obj.CoherenceMesh = True
 
         if not hasattr(obj, "GeometryTolerance"):
@@ -257,6 +272,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Geometrical Tolerance (0.0 = GMSH std = 1e-08)"
             )
+            obj.setPropertyStatus("GeometryTolerance", "LockDynamic")
             obj.GeometryTolerance = 1e-06
 
         if not hasattr(obj, "SecondOrderLinear"):
@@ -266,6 +282,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Second order nodes are created by linear interpolation"
             )
+            obj.setPropertyStatus("SecondOrderLinear", "LockDynamic")
             obj.SecondOrderLinear = False
             # gives much better meshes in the regard of nonpositive jacobians
             # but
@@ -281,6 +298,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "number of elements per 2*pi radians, 0 to deactivate"
             )
+            obj.setPropertyStatus("MeshSizeFromCurvature", "LockDynamic")
             obj.MeshSizeFromCurvature = (12, 0, 10000, 1)
 
         if not hasattr(obj, "Algorithm2D"):
@@ -290,6 +308,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "mesh algorithm 2D"
             )
+            obj.setPropertyStatus("Algorithm2D", "LockDynamic")
             obj.Algorithm2D = MeshGmsh.known_mesh_algorithm_2D
             obj.Algorithm2D = "Automatic"
 
@@ -300,6 +319,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "mesh algorithm 3D"
             )
+            obj.setPropertyStatus("Algorithm3D", "LockDynamic")
             obj.Algorithm3D = MeshGmsh.known_mesh_algorithm_3D
             obj.Algorithm3D = "Automatic"
 
@@ -310,6 +330,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "For each group create not only the elements but the nodes too."
             )
+            obj.setPropertyStatus("GroupsOfNodes", "LockDynamic")
             obj.GroupsOfNodes = False
 
         if not hasattr(obj, "SubdivisionAlgorithm"):
@@ -319,5 +340,6 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 "FEM Gmsh Mesh Params",
                 "Mesh subdivision algorithm"
             )
+            obj.setPropertyStatus("SubdivisionAlgorithm", "LockDynamic")
             obj.SubdivisionAlgorithm = MeshGmsh.known_mesh_SubdivisionAlgorithms
             obj.SubdivisionAlgorithm = "None"

--- a/src/Mod/Fem/femobjects/mesh_group.py
+++ b/src/Mod/Fem/femobjects/mesh_group.py
@@ -48,6 +48,7 @@ class MeshGroup(base_fempythonobject.BaseFemPythonObject):
             "MeshGroupProperties",
             "The identifier used for export (True: Label, False: Name)"
         )
+        obj.setPropertyStatus("UseLabel", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLinkSubList",
@@ -55,3 +56,4 @@ class MeshGroup(base_fempythonobject.BaseFemPythonObject):
             "MeshGroupShapes",
             "List of FEM mesh group shapes"
         )
+        obj.setPropertyStatus("References", "LockDynamic")

--- a/src/Mod/Fem/femobjects/mesh_region.py
+++ b/src/Mod/Fem/femobjects/mesh_region.py
@@ -48,6 +48,7 @@ class MeshRegion(base_fempythonobject.BaseFemPythonObject):
             "MeshRegionProperties",
             "set characteristic length of FEM elements for this refinement"
         )
+        obj.setPropertyStatus("CharacteristicLength", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyLinkSubList",
@@ -55,3 +56,4 @@ class MeshRegion(base_fempythonobject.BaseFemPythonObject):
             "MeshRegionShapes",
             "List of FEM mesh refinement shapes"
         )
+        obj.setPropertyStatus("References", "LockDynamic")

--- a/src/Mod/Fem/femobjects/result_mechanical.py
+++ b/src/Mod/Fem/femobjects/result_mechanical.py
@@ -50,6 +50,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "Type of the result",
             1  # the 1 set the property to ReadOnly
         )
+        obj.setPropertyStatus("ResultType", "LockDynamic")
         obj.ResultType = str(self.Type)
 
         # for frequency analysis
@@ -60,6 +61,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("Eigenmode", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloat",
             "EigenmodeFrequency",
@@ -67,6 +69,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "User Defined Results",
             True
         )
+        obj.setPropertyStatus("EigenmodeFrequency", "LockDynamic")
 
         # node results
         # set read only or hide a property:
@@ -79,6 +82,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "List of displacement vectors",
             True
         )
+        obj.setPropertyStatus("DisplacementVectors", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "Peeq",
@@ -86,6 +90,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "List of equivalent plastic strain values",
             True
         )
+        obj.setPropertyStatus("Peeq", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "MohrCoulomb",
@@ -93,6 +98,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "List of Mohr Coulomb stress values",
             True
         )
+        obj.setPropertyStatus("MohrCoulomb", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "ReinforcementRatio_x",
@@ -100,6 +106,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "Reinforcement ratio x-direction",
             True
         )
+        obj.setPropertyStatus("ReinforcementRatio_x", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "ReinforcementRatio_y",
@@ -107,6 +114,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "Reinforcement ratio y-direction",
             True
         )
+        obj.setPropertyStatus("ReinforcementRatio_y", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "ReinforcementRatio_z",
@@ -114,6 +122,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "Reinforcement ratio z-direction",
             True
         )
+        obj.setPropertyStatus("ReinforcementRatio_z", "LockDynamic")
         # these three principal vectors are used only if there is a reinforced mat obj
         # https://forum.freecad.org/viewtopic.php?f=18&t=33106&p=416006#p416006
         obj.addProperty(
@@ -123,6 +132,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "List of 1st Principal Stress Vectors",
             True
         )
+        obj.setPropertyStatus("PS1Vector", "LockDynamic")
         obj.addProperty(
             "App::PropertyVectorList",
             "PS2Vector",
@@ -130,6 +140,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "List of 2nd Principal Stress Vectors",
             True
         )
+        obj.setPropertyStatus("PS2Vector", "LockDynamic")
         obj.addProperty(
             "App::PropertyVectorList",
             "PS3Vector",
@@ -137,6 +148,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "List of 3rd Principal Stress Vectors",
             True
         )
+        obj.setPropertyStatus("PS3Vector", "LockDynamic")
 
         # readonly in propertyEditor of comboView
         obj.addProperty(
@@ -146,6 +158,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "List of displacement lengths",
             True
         )
+        obj.setPropertyStatus("DisplacementLengths", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "vonMises",
@@ -153,6 +166,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "List of von Mises equivalent stresses",
             True
         )
+        obj.setPropertyStatus("vonMises", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "PrincipalMax",
@@ -160,6 +174,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("PrincipalMax", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "PrincipalMed",
@@ -167,6 +182,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("PrincipalMed", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "PrincipalMin",
@@ -174,6 +190,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("PrincipalMin", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "MaxShear",
@@ -181,6 +198,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "List of Maximum Shear stress values",
             True
         )
+        obj.setPropertyStatus("MaxShear", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "MassFlowRate",
@@ -188,6 +206,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "List of mass flow rate values",
             True
         )
+        obj.setPropertyStatus("MassFlowRate", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NetworkPressure",
@@ -195,6 +214,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "List of network pressure values",
             True
         )
+        obj.setPropertyStatus("NetworkPressure", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "UserDefined",
@@ -202,6 +222,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "User Defined Results",
             True
         )
+        obj.setPropertyStatus("UserDefined", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "Temperature",
@@ -209,6 +230,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "Temperature field",
             True
         )
+        obj.setPropertyStatus("Temperature", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStressXX",
@@ -216,6 +238,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("NodeStressXX", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStressYY",
@@ -223,6 +246,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("NodeStressYY", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStressZZ",
@@ -230,6 +254,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("NodeStressZZ", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStressXY",
@@ -237,6 +262,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("NodeStressXY", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStressXZ",
@@ -244,6 +270,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("NodeStressXZ", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStressYZ",
@@ -251,6 +278,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("NodeStressYZ", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStrainXX",
@@ -258,6 +286,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("NodeStrainXX", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStrainYY",
@@ -265,6 +294,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("NodeStrainYY", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStrainZZ",
@@ -272,12 +302,14 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("NodeStrainZZ", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStrainXY", "NodeData",
             "",
             True
         )
+        obj.setPropertyStatus("NodeStrainXY", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStrainXZ",
@@ -285,6 +317,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("NodeStrainXZ", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "NodeStrainYZ",
@@ -292,6 +325,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("NodeStrainYZ", "LockDynamic")
         obj.addProperty(
             "App::PropertyFloatList",
             "CriticalStrainRatio",
@@ -299,6 +333,7 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
             "",
             True
         )
+        obj.setPropertyStatus("CriticalStrainRatio", "LockDynamic")
 
         # initialize the Stats with the appropriate count of items
         # see fill_femresult_stats in femresult/resulttools.py
@@ -316,7 +351,9 @@ class ResultMechanical(base_fempythonobject.BaseFemPythonObject):
                 "List of von Mises equivalent stresses",
                 True
             )
+            obj.setPropertyStatus("vonMises", "LockDynamic")
             obj.vonMises = obj.StressValues
+            obj.setPropertyStatus("StressValues", "-LockDynamic")
             obj.removeProperty("StressValues")
 
         # migrate old result objects, because property "Stats"

--- a/src/Mod/Fem/femobjects/solver_ccxtools.py
+++ b/src/Mod/Fem/femobjects/solver_ccxtools.py
@@ -57,6 +57,7 @@ class SolverCcxTools(base_fempythonobject.BaseFemPythonObject):
             "Fem",
             "Working directory for calculations, will only be used it is left blank in preferences"
         )
+        obj.setPropertyStatus("WorkingDir", "LockDynamic")
         # the working directory is not set, the solver working directory is
         # only used if the preferences working directory is left blank
 


### PR DESCRIPTION
Properties added in python with `obj.addProperty()` are removable by user throw the property editor. The status `LockDynamic` has to be set to prevent this.