### PR TITLE
Draft: legacy DXF importer: downloaded libs should be reloaded

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -197,6 +197,7 @@ def getDXFlibs():
     if not libsok:
         errorDXFLib(gui)
         try:
+            import dxfColorMap, dxfLibrary, dxfReader
             import importlib
             importlib.reload(dxfColorMap)
             importlib.reload(dxfLibrary)

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -197,8 +197,11 @@ def getDXFlibs():
     if not libsok:
         errorDXFLib(gui)
         try:
-            import dxfColorMap, dxfLibrary, dxfReader
-        except ImportError:
+            import importlib
+            importlib.reload(dxfColorMap)
+            importlib.reload(dxfLibrary)
+            importlib.reload(dxfReader)
+        except Exception:
             dxfReader = None
             dxfLibrary = None
             FCC.PrintWarning("DXF libraries not available. Aborting.\n")


### PR DESCRIPTION
Otherwise old versions will still be used in the current FreeCAD session.
