### PR TITLE
Fem: Make pipeline filters invisible if a new filter is added

### DIFF
--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -1666,6 +1666,14 @@ void setupFilter(Gui::Command* cmd, std::string Name)
     cmd->doCommand(Gui::Command::Doc,
                    "__list__ = App.ActiveDocument.%s.Filter",
                    pipeline->getNameInDocument());
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.ActiveDocument.%s.ViewObject.Visibility = False",
+                   pipeline->getNameInDocument());
+
+    std::ostringstream oss;
+    oss << "for _ in __list__:\n";
+    oss << "    _.ViewObject.Visibility = False";
+    cmd->doCommand(Gui::Command::Doc, oss.str().c_str());
     cmd->doCommand(Gui::Command::Doc, "__list__.append(App.ActiveDocument.%s)", FeatName.c_str());
     cmd->doCommand(Gui::Command::Doc,
                    "App.ActiveDocument.%s.Filter = __list__",


### PR DESCRIPTION
This pull request is aimed at fixing issues #13660 and https://github.com/FreeCAD/FreeCAD/issues/13695 making all elements in the pipeline invisible if a new filter is added.

@FEA-eng these changes satisfy the second point of your proposal. The first is more specific to CalculiX features. Can you divide the issue in two?
@maxwxyz I can't reproduce (but I saw that behavior in the past) your second case when editing the warp filter. Can you give more specific steps to reproduce?