### PR TITLE
Gui:Making Technical Drawing icons compatible with Part Design and Assembly icon

### DIFF
--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_PageDefault.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_PageDefault.svg
@@ -29,9 +29,9 @@
      inkscape:window-height="837"
      id="namedview3057"
      showgrid="true"
-     inkscape:zoom="5.4250344"
-     inkscape:cx="13.363971"
-     inkscape:cy="5.2534229"
+     inkscape:zoom="43.400275"
+     inkscape:cx="36.60115"
+     inkscape:cy="24.27404"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
@@ -1112,7 +1112,7 @@
     <path
        id="path3900-2"
        d="M 30,23 H 44"
-       style="display:inline;fill:#2e3436;fill-opacity:1;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-dashoffset:2;stroke-opacity:1" />
+       style="display:inline;fill:#2e3436;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4,2;stroke-dashoffset:2;stroke-opacity:1" />
     <rect
        style="display:inline;fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
        id="rect1"

--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_PageDefault.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_PageDefault.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="64"
    height="64"
    id="svg249"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="techdraw-new-default.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="TechDraw_PageDefault.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -25,18 +25,21 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1137"
+     inkscape:window-width="1600"
+     inkscape:window-height="837"
      id="namedview3057"
      showgrid="true"
      inkscape:zoom="5.4250344"
-     inkscape:cx="10.819565"
-     inkscape:cy="26.969954"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:cx="13.363971"
+     inkscape:cy="5.2534229"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer4"
-     inkscape:snap-bbox="true">
+     inkscape:current-layer="svg249"
+     inkscape:snap-bbox="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
        id="grid3284"
@@ -46,7 +49,9 @@
        enabled="true"
        snapvisiblegridlinesonly="true"
        spacingx="1px"
-       spacingy="1px" />
+       spacingy="1px"
+       originx="0"
+       originy="0" />
   </sodipodi:namedview>
   <defs
      id="defs3">
@@ -1028,39 +1033,117 @@
        d="M 19,1 37,1"
        id="path3902"
        inkscape:connector-curvature="0" />
-    <path
-       sodipodi:type="arc"
-       style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6"
+    <circle
+       style="display:none;fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.6;stroke-opacity:1"
        id="path3101"
-       sodipodi:cx="19"
-       sodipodi:cy="25"
-       sodipodi:rx="6"
-       sodipodi:ry="6"
-       d="m 25,25 a 6,6 0 1 1 -12,0 6,6 0 1 1 12,0 z"
-       transform="translate(0,-18)" />
-    <path
-       sodipodi:type="arc"
-       style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6"
+       transform="translate(0,-18)"
+       cx="19"
+       cy="25"
+       r="6" />
+    <circle
+       style="display:none;fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.6;stroke-opacity:1"
        id="path3101-3"
-       sodipodi:cx="19"
-       sodipodi:cy="25"
-       sodipodi:rx="6"
-       sodipodi:ry="6"
-       d="m 25,25 a 6,6 0 1 1 -12,0 6,6 0 1 1 12,0 z"
-       transform="translate(18,-18)" />
-    <path
-       sodipodi:type="arc"
-       style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6"
+       transform="translate(18,-18)"
+       cx="19"
+       cy="25"
+       r="6" />
+    <circle
+       style="display:none;fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.6;stroke-opacity:1"
        id="path3101-6"
-       sodipodi:cx="19"
-       sodipodi:cy="25"
-       sodipodi:rx="6"
-       sodipodi:ry="6"
-       d="m 25,25 a 6,6 0 1 1 -12,0 6,6 0 1 1 12,0 z" />
-    <path
-       d="m 64,-0.99612702 a 15,15 0 0 1 -30,0 15,15 0 1 1 30,0 z"
-       id="path12511"
-       style="color:#000000;fill:url(#radialGradient278);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.25000024;marker:none;visibility:visible;display:block"
-       inkscape:connector-curvature="0" />
+       cx="19"
+       cy="25"
+       r="6" />
   </g>
+  <g
+     id="g2"
+     inkscape:label="front"
+     transform="matrix(0.77777778,0,0,1,6.2482236,-10.882995)"
+     style="display:inline">
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2"
+       width="9"
+       height="2"
+       x="7.3951416"
+       y="26.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2-2"
+       width="9"
+       height="2"
+       x="15.109427"
+       y="32.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.88642;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2-8"
+       width="18"
+       height="2"
+       x="7.3951411"
+       y="38.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect3"
+       width="2.5714285"
+       height="14"
+       x="7.3951416"
+       y="26.882996"
+       rx="0.25714287" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect4"
+       width="2.5714285"
+       height="7"
+       x="15.109427"
+       y="26.882996"
+       rx="0" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect4-3"
+       width="2.5714285"
+       height="7"
+       x="22.823713"
+       y="32.882996"
+       rx="0" />
+  </g>
+  <g
+     id="g3"
+     inkscape:label="side"
+     style="display:inline">
+    <path
+       id="path3900-2"
+       d="M 30,23 H 44"
+       style="display:inline;fill:#2e3436;fill-opacity:1;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-dashoffset:2;stroke-opacity:1" />
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1"
+       width="12"
+       height="12"
+       x="30.982452"
+       y="16.98246" />
+  </g>
+  <g
+     id="g5"
+     inkscape:label="plan"
+     style="display:inline">
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.8;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect3-3"
+       width="2"
+       height="14"
+       x="18"
+       y="34" />
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1-6"
+       width="12"
+       height="12.035084"
+       x="12.98246"
+       y="34.98246" />
+  </g>
+  <path
+     d="m 64,-0.99612702 a 15,15 0 0 1 -30,0 15,15 0 1 1 30,0 z"
+     id="path12511"
+     style="display:inline;color:#000000;visibility:visible;fill:url(#radialGradient278);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.25;marker:none"
+     inkscape:connector-curvature="0"
+     transform="translate(0,16)" />
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_ProjectionGroup.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_ProjectionGroup.svg
@@ -2,25 +2,25 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64"
    height="64"
    id="svg249"
    sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    sodipodi:docname="TechDraw_ProjectionGroup.svg"
    inkscape:export-filename="/home/jimmac/gfx/novell/pdes/trunk/docs/BIGmime-text.png"
    inkscape:export-xdpi="240.00000"
    inkscape:export-ydpi="240.00000"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   version="1.1"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3">
     <linearGradient
@@ -567,26 +567,33 @@
      borderopacity="0.32941176"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="9.7389305"
-     inkscape:cx="2.9672047"
-     inkscape:cy="28.760026"
-     inkscape:current-layer="layer2"
+     inkscape:zoom="13.772928"
+     inkscape:cx="24.359382"
+     inkscape:cy="30.821334"
+     inkscape:current-layer="svg249"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="1137"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-width="1600"
+     inkscape:window-height="837"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
      inkscape:showpageshadow="false"
-     inkscape:window-maximized="1">
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
        id="grid3817"
        empspacing="2"
        visible="true"
        enabled="true"
-       snapvisiblegridlinesonly="true" />
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <metadata
      id="metadata4">
@@ -724,35 +731,142 @@
        d="m 19,-1 18,0"
        id="path3902-5"
        inkscape:connector-curvature="0" />
-    <path
-       sodipodi:type="arc"
-       style="fill:#edd400;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.59999999999999998"
+    <circle
+       style="display:none;fill:#edd400;fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.6;stroke-opacity:1"
        id="path3101-35"
-       sodipodi:cx="19"
-       sodipodi:cy="25"
-       sodipodi:rx="6"
-       sodipodi:ry="6"
-       d="m 25,25 a 6,6 0 1 1 -12,0 6,6 0 1 1 12,0 z"
-       transform="translate(0,-20)" />
-    <path
-       sodipodi:type="arc"
-       style="fill:#edd400;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.59999999999999998"
+       transform="translate(0,-20)"
+       cx="19"
+       cy="25"
+       r="6" />
+    <circle
+       style="display:none;fill:#edd400;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.6;stroke-opacity:1"
        id="path3101-3-6"
-       sodipodi:cx="19"
-       sodipodi:cy="25"
-       sodipodi:rx="6"
-       sodipodi:ry="6"
-       d="m 25,25 a 6,6 0 1 1 -12,0 6,6 0 1 1 12,0 z"
-       transform="translate(18,-20)" />
-    <path
+       transform="translate(18,-20)"
+       cx="19"
+       cy="25"
+       r="6" />
+    <circle
        transform="translate(0,-2)"
-       sodipodi:type="arc"
-       style="fill:#edd400;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.59999999999999998"
+       style="display:none;fill:#edd400;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.6;stroke-opacity:1"
        id="path3101-6-2"
-       sodipodi:cx="19"
-       sodipodi:cy="25"
-       sodipodi:rx="6"
-       sodipodi:ry="6"
-       d="m 25,25 a 6,6 0 1 1 -12,0 6,6 0 1 1 12,0 z" />
+       cx="19"
+       cy="25"
+       r="6" />
+  </g>
+  <g
+     id="g2"
+     inkscape:label="front"
+     transform="matrix(0.77777778,0,0,1,6.2482236,-12.882995)">
+    <rect
+       style="fill:#edd400;fill-opacity:1;stroke:none;stroke-width:2;stroke-dashoffset:2"
+       id="rect5"
+       width="6"
+       height="14"
+       x="12"
+       y="-2"
+       rx="0"
+       transform="matrix(1.2857143,0,0,1,-8.0334303,28.882995)" />
+    <rect
+       style="fill:#edd400;fill-opacity:1;stroke:none;stroke-width:2;stroke-dashoffset:2"
+       id="rect6"
+       width="8"
+       height="6"
+       x="18"
+       y="4"
+       rx="0"
+       transform="matrix(1.2857143,0,0,1,-8.0334303,28.882995)" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2"
+       width="9"
+       height="2"
+       x="7.3951416"
+       y="26.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2-2"
+       width="9"
+       height="2"
+       x="15.109427"
+       y="32.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.88642;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2-8"
+       width="18"
+       height="2"
+       x="7.3951411"
+       y="38.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect3"
+       width="2.5714285"
+       height="14"
+       x="7.3951416"
+       y="26.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect4"
+       width="2.5714285"
+       height="7"
+       x="15.109427"
+       y="26.882996"
+       rx="0" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect4-3"
+       width="2.5714285"
+       height="7"
+       x="22.823713"
+       y="32.882996"
+       rx="0" />
+  </g>
+  <g
+     id="g3"
+     inkscape:label="side"
+     transform="translate(2.5322442e-7,-2)">
+    <rect
+       style="fill:#edd400;fill-opacity:1;stroke:none;stroke-width:2;stroke-dashoffset:2"
+       id="rect7"
+       width="14"
+       height="14"
+       x="30"
+       y="16" />
+    <path
+       id="path3900-2"
+       d="M 30,23 H 44"
+       style="display:inline;fill:#2e3436;fill-opacity:1;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-dashoffset:2;stroke-opacity:1" />
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1"
+       width="12"
+       height="12"
+       x="30.982452"
+       y="16.98246" />
+  </g>
+  <g
+     id="g5"
+     inkscape:label="plan"
+     transform="translate(2.5322442e-7,-2)">
+    <rect
+       style="fill:#edd400;fill-opacity:1;stroke:none;stroke-width:2;stroke-dashoffset:2"
+       id="rect7-1"
+       width="14"
+       height="14"
+       x="12"
+       y="34" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.8;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect3-3"
+       width="2"
+       height="14"
+       x="18"
+       y="34" />
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1-6"
+       width="12"
+       height="12"
+       x="12.98246"
+       y="34.98246" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_ProjectionGroup.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_ProjectionGroup.svg
@@ -570,7 +570,7 @@
      inkscape:zoom="13.772928"
      inkscape:cx="24.431987"
      inkscape:cy="30.893939"
-     inkscape:current-layer="layer2"
+     inkscape:current-layer="svg249"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
@@ -748,35 +748,35 @@
        d="m 12,-2 v 14 h 6 v -2 h 8 V 4 h -8 v -6 z"
        transform="matrix(1.2857143,0,0,1,-8.0334303,28.882995)" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect2"
        width="9"
        height="2"
        x="7.3951416"
        y="26.882996" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect2-2"
        width="9"
        height="2"
        x="15.109427"
        y="32.882996" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.88642;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.88642;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect2-8"
        width="18"
        height="2"
        x="7.3951411"
        y="38.882996" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect3"
        width="2.5714285"
        height="14"
        x="7.3951416"
        y="26.882996" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect4"
        width="2.5714285"
        height="7"
@@ -784,7 +784,7 @@
        y="26.882996"
        rx="0" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect4-3"
        width="2.5714285"
        height="7"
@@ -807,9 +807,9 @@
     <path
        id="path3900-2"
        d="M 30,23 H 44"
-       style="display:inline;fill:#2e3436;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4, 2;stroke-dashoffset:2;stroke-opacity:1" />
+       style="display:inline;fill:#302b00;fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4, 2;stroke-dashoffset:2;stroke-opacity:1" />
     <rect
-       style="display:inline;fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
+       style="display:inline;fill:none;fill-opacity:1;stroke:#302b00;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
        id="rect1"
        width="12"
        height="12"
@@ -829,14 +829,14 @@
        x="12"
        y="34" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.8;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.8;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect3-3"
        width="2"
        height="14"
        x="18"
        y="34" />
     <rect
-       style="display:inline;fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
+       style="display:inline;fill:none;fill-opacity:1;stroke:#302b00;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
        id="rect1-6"
        width="12"
        height="12"

--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_ProjectionGroup.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_ProjectionGroup.svg
@@ -568,9 +568,9 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="13.772928"
-     inkscape:cx="24.359382"
-     inkscape:cy="30.821334"
-     inkscape:current-layer="svg249"
+     inkscape:cx="24.431987"
+     inkscape:cy="30.893939"
+     inkscape:current-layer="layer2"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
@@ -650,85 +650,69 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Shadow"
-     id="layer6"
-     inkscape:groupmode="layer"
-     transform="translate(0,16)" />
-  <g
-     id="layer1"
-     inkscape:label="Base"
-     inkscape:groupmode="layer"
-     style="display:inline"
-     transform="translate(0,16)" />
-  <g
-     inkscape:groupmode="layer"
-     id="layer4"
-     inkscape:label="new"
-     style="display:inline"
-     transform="translate(0,16)" />
-  <g
      inkscape:groupmode="layer"
      id="layer2"
      inkscape:label="Template"
-     transform="translate(0,16)">
+     transform="translate(0,16)"
+     style="display:inline">
     <rect
-       style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect2987"
        width="45.999996"
        height="58.000004"
        x="-36.999996"
        y="3"
-       transform="matrix(0,-1,1,0,0,0)" />
+       transform="rotate(-90)" />
     <rect
-       style="fill:url(#linearGradient3781);fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       style="fill:url(#linearGradient3781);fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect2987-1"
        width="41.999996"
        height="54.000004"
        x="-34.999996"
        y="5"
-       transform="matrix(0,-1,1,0,0,0)" />
+       transform="rotate(-90)" />
     <rect
-       style="color:#000000;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect3894"
        width="50"
        height="38"
        x="7"
        y="-5" />
     <rect
-       style="color:#000000;fill:none;stroke:#555753;stroke-width:1.99999976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect4664"
        width="23.999994"
        height="12.000004"
        x="33"
        y="21" />
     <path
-       style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 37,25 15.398794,0 0,0"
+       style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 37,25 h 15.398794 v 0"
        id="path4666"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 37,29 15.642526,0 0,0"
+       style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 37,29 h 15.642526 v 0"
        id="path4666-7"
        inkscape:connector-curvature="0" />
     <path
        style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 13,5 0,18"
+       d="M 13,5 V 23"
        id="path3896-3"
        inkscape:connector-curvature="0" />
     <path
        style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 25,5 0,18"
+       d="M 25,5 V 23"
        id="path3898-6"
        inkscape:connector-curvature="0" />
     <path
        style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 19,11 18,0"
+       d="M 19,11 H 37"
        id="path3900-7"
        inkscape:connector-curvature="0" />
     <path
        style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 19,-1 18,0"
+       d="M 19,-1 H 37"
        id="path3902-5"
        inkscape:connector-curvature="0" />
     <circle
@@ -756,24 +740,12 @@
   <g
      id="g2"
      inkscape:label="front"
-     transform="matrix(0.77777778,0,0,1,6.2482236,-12.882995)">
-    <rect
-       style="fill:#edd400;fill-opacity:1;stroke:none;stroke-width:2;stroke-dashoffset:2"
+     transform="matrix(0.77777778,0,0,1,6.2482236,-12.882995)"
+     style="display:inline">
+    <path
        id="rect5"
-       width="6"
-       height="14"
-       x="12"
-       y="-2"
-       rx="0"
-       transform="matrix(1.2857143,0,0,1,-8.0334303,28.882995)" />
-    <rect
        style="fill:#edd400;fill-opacity:1;stroke:none;stroke-width:2;stroke-dashoffset:2"
-       id="rect6"
-       width="8"
-       height="6"
-       x="18"
-       y="4"
-       rx="0"
+       d="m 12,-2 v 14 h 6 v -2 h 8 V 4 h -8 v -6 z"
        transform="matrix(1.2857143,0,0,1,-8.0334303,28.882995)" />
     <rect
        style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
@@ -823,7 +795,8 @@
   <g
      id="g3"
      inkscape:label="side"
-     transform="translate(2.5322442e-7,-2)">
+     transform="translate(2.5322442e-7,-2)"
+     style="display:inline">
     <rect
        style="fill:#edd400;fill-opacity:1;stroke:none;stroke-width:2;stroke-dashoffset:2"
        id="rect7"
@@ -834,7 +807,7 @@
     <path
        id="path3900-2"
        d="M 30,23 H 44"
-       style="display:inline;fill:#2e3436;fill-opacity:1;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-dashoffset:2;stroke-opacity:1" />
+       style="display:inline;fill:#2e3436;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4, 2;stroke-dashoffset:2;stroke-opacity:1" />
     <rect
        style="display:inline;fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
        id="rect1"
@@ -846,7 +819,8 @@
   <g
      id="g5"
      inkscape:label="plan"
-     transform="translate(2.5322442e-7,-2)">
+     transform="translate(2.5322442e-7,-2)"
+     style="display:inline">
     <rect
        style="fill:#edd400;fill-opacity:1;stroke:none;stroke-width:2;stroke-dashoffset:2"
        id="rect7-1"

--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_Symbol.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_Symbol.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.0"
    width="64"
    height="64"
    id="svg2160"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="TechDraw_Symbol.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="TechDraw_Symbol.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
      id="metadata8">
     <rdf:RDF>
@@ -62,26 +62,34 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1137"
+     inkscape:window-width="1600"
+     inkscape:window-height="837"
      id="namedview6"
      showgrid="true"
      inkscape:zoom="14.827146"
-     inkscape:cx="49.351463"
-     inkscape:cy="15.369443"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:cx="36.352242"
+     inkscape:cy="34.56498"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2160"
      inkscape:snap-bbox="true"
-     inkscape:snap-nodes="true">
+     inkscape:snap-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
        id="grid2985"
        empspacing="2"
        visible="true"
        enabled="true"
-       snapvisiblegridlinesonly="true" />
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <defs
      id="defs2162">
@@ -351,13 +359,13 @@
      y="3"
      transform="matrix(0,-1,1,0,0,0)" />
   <rect
-     style="fill:url(#linearGradient3781-3);fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     style="display:inline;fill:url(#linearGradient3781-3);fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect2987-1"
      width="41.999996"
      height="54.000004"
      x="-52.999996"
      y="5"
-     transform="matrix(0,-1,1,0,0,0)" />
+     transform="rotate(-90)" />
   <rect
      style="color:#000000;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="rect3894"
@@ -378,41 +386,143 @@
      id="path4666"
      inkscape:connector-curvature="0" />
   <path
-     style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-     d="m 37,47 15.642526,0 0,0"
+     style="display:inline;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 37,47 h 15.642526 v 0"
      id="path4666-7"
      inkscape:connector-curvature="0" />
-  <path
-     sodipodi:type="arc"
-     style="fill:url(#linearGradient3906);fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.59999999999999998"
+  <circle
+     style="display:none;fill:url(#linearGradient3906);fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.6;stroke-opacity:1"
      id="path3112"
-     sodipodi:cx="20"
-     sodipodi:cy="26"
-     sodipodi:rx="10"
-     sodipodi:ry="10"
-     d="m 30,26 a 10,10 0 1 1 -20,0 10,10 0 1 1 20,0 z" />
-  <path
+     cx="20"
+     cy="26"
+     r="10" />
+  <circle
      transform="matrix(0.8,0,0,0.8,4,5.2)"
-     sodipodi:type="arc"
-     style="fill:none;fill-opacity:1;stroke:#fce94f;stroke-width:2.50000000000000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.59999999999999998"
+     style="display:none;fill:none;fill-opacity:1;stroke:#fce94f;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.6;stroke-opacity:1"
      id="path3112-3"
-     sodipodi:cx="20"
-     sodipodi:cy="26"
-     sodipodi:rx="10"
-     sodipodi:ry="10"
-     d="m 30,26 a 10,10 0 1 1 -20,0 10,10 0 1 1 20,0 z" />
+     cx="20"
+     cy="26"
+     r="10" />
   <g
      inkscape:label="Layer 1"
      id="layer1"
-     transform="matrix(0,-0.42543722,0.42543722,0,5.2149434,62.276312)">
+     transform="matrix(0,-0.42543722,0.42543722,0,5.2149434,62.276312)" />
+  <g
+     id="g2"
+     inkscape:label="front"
+     transform="matrix(1.2222222,0,0,1.5714285,1.8614946,-26.244705)"
+     style="display:inline">
+    <path
+       id="rect5"
+       style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:url(#linearGradient3906);fill-opacity:1;stroke:none;stroke-width:1.44314;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.432941;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+       d="m 6.6587773,26.882995 v 12.727274 h 6.5454547 v 0.636363 h 9.818182 v -5.727273 h -6.545455 v -7.636364 z" />
+    <g
+       id="g3"
+       inkscape:label="highlight"
+       style="display:inline">
+      <rect
+         style="display:inline;fill:#fce94f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+         id="rect11"
+         width="9"
+         height="1.2727274"
+         x="7.4769592"
+         y="28.155724" />
+      <rect
+         style="display:inline;fill:#fce94f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70056;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+         id="rect10"
+         width="9.818182"
+         height="1.2727274"
+         x="13.204232"
+         y="34.51936" />
+      <rect
+         style="display:inline;fill:#fce94f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.30257;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+         id="rect9"
+         width="18"
+         height="1.2727274"
+         x="6.6587772"
+         y="38.33754" />
+      <rect
+         style="display:inline;fill:#fce94f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+         id="rect8"
+         width="1.6363636"
+         height="14"
+         x="8.2951412"
+         y="26.882996" />
+      <rect
+         style="display:inline;fill:#fce94f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70056;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+         id="rect7"
+         width="1.6363636"
+         height="7.636364"
+         x="13.204232"
+         y="26.882996"
+         rx="0" />
+      <rect
+         style="fill:#fce94f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+         id="rect1"
+         width="1.6363636"
+         height="7"
+         x="21.386051"
+         y="33.246632"
+         rx="0" />
+    </g>
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2"
+       width="9"
+       height="1.2727274"
+       x="7.4769592"
+       y="26.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2-2"
+       width="9"
+       height="1.2727274"
+       x="14.840596"
+       y="33.246632" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.30257;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2-8"
+       width="18"
+       height="1.2727274"
+       x="6.6587772"
+       y="39.610268" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect3"
+       width="1.6363636"
+       height="14"
+       x="6.6587772"
+       y="26.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect4"
+       width="1.6363636"
+       height="7.0000005"
+       x="14.840596"
+       y="26.882996"
+       rx="0" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect4-3"
+       width="1.6363636"
+       height="7"
+       x="23.022413"
+       y="33.246632"
+       rx="0" />
+  </g>
+  <g
+     id="g1"
+     inkscape:label="arrow"
+     transform="matrix(0,-0.42543722,0.42543722,0,5.2149434,62.276312)"
+     style="display:inline">
     <path
        inkscape:export-ydpi="4.1683898"
        inkscape:export-xdpi="4.1683898"
        inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
        sodipodi:nodetypes="cccccccc"
        id="path3343"
-       d="m 35.907323,8.8968626 0,14.1031384 -32.907323,0 10e-8,23.505231 32.9073229,0 0,14.103138 L 64.1136,34.752616 z"
-       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#172a04;stroke-width:4.70104599;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="M 35.907323,8.8968626 V 23.000001 H 3 l 10e-8,23.505231 H 35.907323 V 60.60837 L 64.1136,34.752616 Z"
+       style="display:inline;fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#172a04;stroke-width:4.70105;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:connector-curvature="0" />
     <path
        inkscape:export-ydpi="4.1683898"
@@ -420,8 +530,8 @@
        inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
        sodipodi:nodetypes="cccccccc"
        id="path3343-2"
-       d="m 40.608369,19.248595 0,8.452452 -32.9073228,0 0,14.103138 32.9073228,0 0,8.06651 16.453662,-15.118079 z"
-       style="fill:none;stroke:#8ae234;stroke-width:4.70104599;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 40.608369,19.248595 v 8.452452 H 7.7010462 V 41.804185 H 40.608369 v 8.06651 L 57.062031,34.752616 Z"
+       style="display:inline;fill:none;stroke:#8ae234;stroke-width:4.70105;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_Symbol.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_Symbol.svg
@@ -67,8 +67,8 @@
      id="namedview6"
      showgrid="true"
      inkscape:zoom="14.827146"
-     inkscape:cx="36.352242"
-     inkscape:cy="34.56498"
+     inkscape:cx="36.385964"
+     inkscape:cy="34.632424"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
@@ -406,7 +406,8 @@
   <g
      inkscape:label="Layer 1"
      id="layer1"
-     transform="matrix(0,-0.42543722,0.42543722,0,5.2149434,62.276312)" />
+     transform="matrix(0,-0.42543722,0.42543722,0,5.2149434,62.276312)"
+     style="display:inline" />
   <g
      id="g2"
      inkscape:label="front"
@@ -466,35 +467,35 @@
          rx="0" />
     </g>
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect2"
        width="9"
        height="1.2727274"
        x="7.4769592"
        y="26.882996" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect2-2"
        width="9"
        height="1.2727274"
        x="14.840596"
        y="33.246632" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.30257;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.30257;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect2-8"
        width="18"
        height="1.2727274"
        x="6.6587772"
        y="39.610268" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect3"
        width="1.6363636"
        height="14"
        x="6.6587772"
        y="26.882996" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect4"
        width="1.6363636"
        height="7.0000005"
@@ -502,7 +503,7 @@
        y="26.882996"
        rx="0" />
     <rect
-       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       style="fill:#302b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.62816;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
        id="rect4-3"
        width="1.6363636"
        height="7"

--- a/src/Mod/TechDraw/Gui/Resources/icons/preferences-techdraw.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/preferences-techdraw.svg
@@ -1,15 +1,57 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    id="svg249"
    height="64"
-   width="64">
+   width="64"
+   sodipodi:docname="preferences-techdraw.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title5">preferences-techdraw</title>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="40.062501"
+     inkscape:cx="19.831513"
+     inkscape:cy="23.700467"
+     inkscape:window-width="1600"
+     inkscape:window-height="837"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg249"
+     showgrid="true">
+    <inkscape:grid
+       id="grid5"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="2"
+       spacingy="2"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="true" />
+  </sodipodi:namedview>
   <defs
      id="defs3">
     <linearGradient
@@ -532,7 +574,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[agryson] Alexander Gryson</dc:title>
@@ -589,85 +630,157 @@
   </metadata>
   <g
      transform="translate(0,16)"
-     id="layer6" />
-  <g
-     transform="translate(0,16)"
-     style="display:inline"
-     id="layer1" />
-  <g
-     transform="translate(0,16)"
-     style="display:inline"
-     id="layer4" />
-  <g
-     transform="translate(0,16)"
-     id="layer2">
+     id="layer2"
+     style="display:inline">
     <rect
-       transform="matrix(0,-1,1,0,0,0)"
+       transform="rotate(-90)"
        y="3"
        x="-38.999996"
        height="58.000004"
        width="45.999996"
        id="rect2987"
-       style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+       style="display:inline;fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <rect
-       transform="matrix(0,-1,1,0,0,0)"
+       transform="rotate(-90)"
        y="5"
        x="-36.999996"
        height="54.000004"
        width="41.999996"
        id="rect2987-1"
-       style="fill:url(#linearGradient3781);fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+       style="display:inline;fill:url(#linearGradient3781);fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <rect
        y="-3"
        x="7"
        height="38"
        width="50"
        id="rect3894"
-       style="color:#000000;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <rect
        y="23"
        x="33"
        height="12.000004"
        width="23.999994"
        id="rect4664"
-       style="color:#000000;fill:none;stroke:#555753;stroke-width:1.99999976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
        id="path4666"
-       d="m 37,27 15.398794,0 0,0"
-       style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       d="m 37,27 h 15.398794 v 0"
+       style="display:inline;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        id="path4666-7"
-       d="m 37,31 15.642526,0 0,0"
-       style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       d="m 37,31 h 15.642526 v 0"
+       style="display:inline;fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
        id="path3896"
-       d="m 13,7 0,18"
-       style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       d="M 13,7 V 25"
+       style="display:inline;fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        id="path3898"
-       d="m 25,7 0,18"
+       d="M 25,7 V 25"
        style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        id="path3900"
-       d="m 19,13 18,0"
+       d="M 19,13 H 37"
        style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        id="path3902"
-       d="M 19,1 37,1"
-       style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       d="M 19,1 H 37"
+       style="display:inline;fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
        transform="translate(0,-18)"
        d="m 25,25 c 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 3.313708,0 6,2.686292 6,6 z"
        id="path3101"
-       style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+       style="display:none;fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.6;stroke-opacity:1" />
     <path
        transform="translate(18,-18)"
        d="m 25,25 c 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 3.313708,0 6,2.686292 6,6 z"
        id="path3101-3"
-       style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+       style="display:none;fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.6;stroke-opacity:1" />
     <path
        d="m 25,25 c 0,3.313708 -2.686292,6 -6,6 -3.313708,0 -6,-2.686292 -6,-6 0,-3.313708 2.686292,-6 6,-6 3.313708,0 6,2.686292 6,6 z"
        id="path3101-6"
-       style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+       style="display:none;fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0.6;stroke-opacity:1" />
+  </g>
+  <g
+     id="g1"
+     inkscape:label="front"
+     transform="matrix(0.77777778,0,0,1,6.2482233,-10.882995)">
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2"
+       width="9"
+       height="2"
+       x="7.3951416"
+       y="26.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2-2"
+       width="9"
+       height="2"
+       x="15.109427"
+       y="32.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.88642;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect2-8"
+       width="18"
+       height="2"
+       x="7.3951411"
+       y="38.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect3"
+       width="2.5714285"
+       height="14"
+       x="7.3951416"
+       y="26.882996" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect4"
+       width="2.5714285"
+       height="7"
+       x="15.109427"
+       y="26.882996"
+       rx="0" />
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.04101;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect4-3"
+       width="2.5714285"
+       height="7"
+       x="22.823713"
+       y="32.882996"
+       rx="0" />
+  </g>
+  <g
+     id="g2"
+     inkscape:label="side">
+    <path
+       id="path3900-2"
+       d="M 30,23 H 44"
+       style="display:inline;fill:#2e3436;fill-opacity:1;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-dashoffset:2;stroke-opacity:1" />
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1"
+       width="12"
+       height="12"
+       x="30.982452"
+       y="16.98246" />
+  </g>
+  <g
+     id="g5"
+     inkscape:label="plan">
+    <rect
+       style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.8;stroke-dasharray:none;stroke-dashoffset:1;stroke-opacity:1"
+       id="rect3-3"
+       width="2"
+       height="14"
+       x="18"
+       y="34" />
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1-6"
+       width="12"
+       height="12"
+       x="12.98246"
+       y="34.98246" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/preferences-techdraw.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/preferences-techdraw.svg
@@ -25,9 +25,9 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="40.062501"
-     inkscape:cx="19.831513"
-     inkscape:cy="23.700467"
+     inkscape:zoom="14.164233"
+     inkscape:cx="9.7075499"
+     inkscape:cy="21.074208"
      inkscape:window-width="1600"
      inkscape:window-height="837"
      inkscape:window-x="-8"
@@ -756,7 +756,7 @@
     <path
        id="path3900-2"
        d="M 30,23 H 44"
-       style="display:inline;fill:#2e3436;fill-opacity:1;stroke:#555753;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-dashoffset:2;stroke-opacity:1" />
+       style="display:inline;fill:#2e3436;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:4,2;stroke-dashoffset:2;stroke-opacity:1" />
     <rect
        style="display:inline;fill:none;fill-opacity:1;stroke:#2e3436;stroke-width:1.96492;stroke-dasharray:none;stroke-opacity:1"
        id="rect1"


### PR DESCRIPTION
It is aimed to provide integrity by including the shape used in other workbenches in technical drawing icons. Accordingly, all icons containing technical drawings have been changed. If I missed anything, please let me know. Thank you from now.

This is not exactly an issue. It is a new detail to make it feel more compact. For this reason, no issue was created, a pull request was made directly.