### PR TITLE
CI: Enable FREECAD_COPY_LIBPACK_BIN_TO_BUILD to address Windows CI failures.

### DIFF
--- a/.github/workflows/sub_buildWindows.yml
+++ b/.github/workflows/sub_buildWindows.yml
@@ -98,10 +98,6 @@ jobs:
           . $env:ccachebindir\ccache -s
           . $env:ccachebindir\ccache -z
           . $env:ccachebindir\ccache -p
-      - name: Append Libpack bin directory to Path
-        if: false # Disabled because not enough to set FREECAD_COPY_LIBPACK_BIN_TO_BUILD=OFF
-        run: |
-          echo "${{ env.libpackdir }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Configuring CMake
         run: >
           cmake -B"${{ env.builddir }}" .
@@ -119,7 +115,7 @@ jobs:
           -DXercesC_LIBRARY_RELEASE="${{ env.libpackdir }}lib/xerces-c_3.lib"
           -DXercesC_LIBRARY_DEBUG="${{ env.libpackdir }}lib/xerces-c_3D.lib"
           -DFREECAD_COPY_DEPEND_DIRS_TO_BUILD=ON
-          -DFREECAD_COPY_LIBPACK_BIN_TO_BUILD=OFF
+          -DFREECAD_COPY_LIBPACK_BIN_TO_BUILD=ON
           -DFREECAD_COPY_PLUGINS_BIN_TO_BUILD=ON
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
@@ -130,9 +126,6 @@ jobs:
       - name: Print Ccache statistics after build
         run: |
           . $env:ccachebindir\ccache -s
-      - name: Move libpack bin folder to build folder # Shorter in time than copying with CMake FREECAD_COPY_LIBPACK_BIN_TO_BUILD
-        run: |
-          Move-Item -Force -Path ${{ env.libpackdir }}bin/* -Destination ${{ env.builddir }}/bin
       - name: C++ unit tests
         if: false # Disabled because seems to not function on Windows build
         timeout-minutes: 1


### PR DESCRIPTION
@adrianinsaval @chennes 

CI on Windows fails occasionally due to PowerShell's `Move-Item` refusing to move `libpack` items into a directory that already exists.  As the destination directory is the `$(env.builddir)/bin`, this issue is frequently encountered.

Attempts to use `Copy-Item` and `New-Item` proved fruitless, so reverting to enabling the CMake option `FREECAD_COPY_LIBPACK_BIN_TO_BUILD` to ensure that copying the necessary `libpack` binaries is performed without error.