### PR TITLE
Toponaming: Enable FC_USE_TNP_FIX code

### DIFF
--- a/cMake/FreeCAD_Helpers/SetGlobalCompilerAndLinkerSettings.cmake
+++ b/cMake/FreeCAD_Helpers/SetGlobalCompilerAndLinkerSettings.cmake
@@ -92,6 +92,6 @@ macro(SetGlobalCompilerAndLinkerSettings)
     endif(MINGW)
 
     # Enable the Topological Naming Problem mitigation code
-    add_compile_options(-DFC_ENABLE_TNP_FIX)
+    add_compile_options(-DFC_USE_TNP_FIX)
 
 endmacro(SetGlobalCompilerAndLinkerSettings)

--- a/cMake/FreeCAD_Helpers/SetGlobalCompilerAndLinkerSettings.cmake
+++ b/cMake/FreeCAD_Helpers/SetGlobalCompilerAndLinkerSettings.cmake
@@ -90,4 +90,8 @@ macro(SetGlobalCompilerAndLinkerSettings)
             link_libraries(-lgdi32)
         endif()
     endif(MINGW)
+
+    # Enable the Topological Naming Problem mitigation code
+    add_compile_options(-DFC_ENABLE_TNP_FIX)
+
 endmacro(SetGlobalCompilerAndLinkerSettings)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,8 @@ if(MSVC)
     endif()
 endif()
 
+add_compile_options("-DFC_USE_TNP_FIX")
+
 if(WIN32)
     add_definitions(-DCOIN_DLL -D_USE_MATH_DEFINES)
 endif(WIN32)

--- a/tests/src/Mod/Material/App/TestMaterials.cpp
+++ b/tests/src/Mod/Material/App/TestMaterials.cpp
@@ -32,6 +32,7 @@
 
 #include <App/Application.h>
 #include <Base/Quantity.h>
+#include <Base/Interpreter.h>
 #include <Gui/MetaTypes.h>
 #include <src/App/InitApplication.h>
 
@@ -55,6 +56,7 @@ class TestMaterial : public ::testing::Test {
   }
 
   void SetUp() override {
+    Base::Interpreter().runString("import Part");
     _modelManager = new Materials::ModelManager();
     _materialManager = new Materials::MaterialManager();
   }

--- a/tests/src/Mod/Part/App/TopoShape.cpp
+++ b/tests/src/Mod/Part/App/TopoShape.cpp
@@ -3,93 +3,124 @@
 #include "gtest/gtest.h"
 #include "PartTestHelpers.h"
 #include <Mod/Part/App/TopoShape.h>
+#include "src/App/InitApplication.h"
+
+
+class TopoShapeTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        Base::Interpreter().runString("import Part");
+        _docName = App::GetApplication().getUniqueDocumentName("test");
+        App::GetApplication().newDocument(_docName.c_str(), "testUser");
+        _hasher = Base::Reference<App::StringHasher>(new App::StringHasher);
+        ASSERT_EQ(_hasher.getRefCount(), 1);
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(_docName.c_str());
+    }
+
+
+private:
+    std::string _docName;
+    Data::ElementIDRefs _sid;
+    App::StringHasherRef _hasher;
+};
 
 // clang-format off
-TEST(TopoShape, TestElementTypeFace1)
+TEST_F(TopoShapeTest, TestElementTypeFace1)
 {
     EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Face1"),
               std::make_pair(std::string("Face"), 1UL));
 }
 
-TEST(TopoShape, TestElementTypeEdge12)
+TEST_F(TopoShapeTest, TestElementTypeEdge12)
 {
     EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Edge12"),
               std::make_pair(std::string("Edge"), 12UL));
 }
 
-TEST(TopoShape, TestElementTypeVertex3)
+TEST_F(TopoShapeTest, TestElementTypeVertex3)
 {
     EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Vertex3"),
               std::make_pair(std::string("Vertex"), 3UL));
 }
 
-TEST(TopoShape, TestElementTypeFacer)
+TEST_F(TopoShapeTest, TestElementTypeFacer)
 {
     EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Facer"),
               std::make_pair(std::string(), 0UL));
 }
 
-TEST(TopoShape, TestElementTypeVertex)
+TEST_F(TopoShapeTest, TestElementTypeVertex)
 {
     EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex("Vertex"),
               std::make_pair(std::string(), 0UL));
 }
 
-TEST(TopoShape, TestElementTypeEmpty)
+TEST_F(TopoShapeTest, TestElementTypeEmpty)
 {
     EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex(""),
               std::make_pair(std::string(), 0UL));
 }
 
-TEST(TopoShape, TestElementTypeNull)
+TEST_F(TopoShapeTest, TestElementTypeNull)
 {
     EXPECT_EQ(Part::TopoShape::getElementTypeAndIndex(nullptr),
               std::make_pair(std::string(), 0UL));
 }
 
-TEST(TopoShape, TestTypeFace1)
+TEST_F(TopoShapeTest, TestTypeFace1)
 {
     EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Face1"),
               std::make_pair(std::string("Face"), 1UL));
 }
 
-TEST(TopoShape, TestTypeEdge12)
+TEST_F(TopoShapeTest, TestTypeEdge12)
 {
     EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Edge12"),
               std::make_pair(std::string("Edge"), 12UL));
 }
 
-TEST(TopoShape, TestTypeVertex3)
+TEST_F(TopoShapeTest, TestTypeVertex3)
 {
     EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Vertex3"),
               std::make_pair(std::string("Vertex"), 3UL));
 }
 
-TEST(TopoShape, TestTypeFacer)
+TEST_F(TopoShapeTest, TestTypeFacer)
 {
     EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Facer"),
               std::make_pair(std::string("Facer"), 0UL));
 }
 
-TEST(TopoShape, TestTypeVertex)
+TEST_F(TopoShapeTest, TestTypeVertex)
 {
     EXPECT_EQ(Part::TopoShape::getTypeAndIndex("Vertex"),
               std::make_pair(std::string("Vertex"), 0UL));
 }
 
-TEST(TopoShape, TestTypeEmpty)
+TEST_F(TopoShapeTest, TestTypeEmpty)
 {
     EXPECT_EQ(Part::TopoShape::getTypeAndIndex(""),
               std::make_pair(std::string(), 0UL));
 }
 
-TEST(TopoShape, TestTypeNull)
+TEST_F(TopoShapeTest, TestTypeNull)
 {
     EXPECT_EQ(Part::TopoShape::getTypeAndIndex(nullptr),
               std::make_pair(std::string(), 0UL));
 }
 
-TEST(TopoShape, TestGetSubshape)
+TEST_F(TopoShapeTest, TestGetSubshape)
 {
     // Arrange
     auto [cube1, cube2] = PartTestHelpers::CreateTwoTopoShapeCubes();

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -45,6 +45,7 @@ protected:
 
     void SetUp() override
     {
+        Base::Interpreter().runString("import Part");
         _docName = App::GetApplication().getUniqueDocumentName("test");
         App::GetApplication().newDocument(_docName.c_str(), "testUser");
         _hasher = Base::Reference<App::StringHasher>(new App::StringHasher);


### PR DESCRIPTION
Enable the Topological Naming Problem mitigation code. This is an interim step: eventually the flag will be removed, along with the old code.

Fixes #8432.