### PR TITLE
CI: Use --no-prune when installing the devenv on Windows to prevent errors.

### DIFF
--- a/.github/workflows/sub_buildWindowsConda.yml
+++ b/.github/workflows/sub_buildWindowsConda.yml
@@ -79,7 +79,7 @@ jobs:
           CONDA_VERBOSITY: 2
         run: |
           conda config --add envs_dirs $PWD/.conda
-          mamba-devenv -f conda/environment.devenv.yml
+          mamba-devenv --no-prune -f conda/environment.devenv.yml
       - name: Make needed directories, files and initializations
         id: Init
         run: |


### PR DESCRIPTION
@adrianinsaval  @chennes 

This addresses an omission in the Windows Conda workflow that is present in the scripts: 

* [conda/setup-environment.cmd#L10](https://github.com/FreeCAD/FreeCAD/blob/main/conda/setup-environment.cmd#L10)
* [conda/setup-environment.sh#L12](https://github.com/FreeCAD/FreeCAD/blob/main/conda/setup-environment.sh#L12)

This should resolve the Windows Conda setup-related failures which are due to pruning library files that are being used by the active Python interpreter resulting in segfaults.