### PR TITLE
Gui: Move more button to the end WB TabBar

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -632,15 +632,16 @@ void WorkbenchGroup::addTo(QWidget *widget)
     if (widget->inherits("QToolBar")) {
         ParameterGrp::handle hGrp;
         hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Workbenches");
-        QWidget* wbSel;
+
+        QWidget* workbenchSelectorWidget;
         if (hGrp->GetInt("WorkbenchSelectorType", 0) == 0) {
-            wbSel = new WorkbenchComboBox(this, widget);
+            workbenchSelectorWidget = new WorkbenchComboBox(this, widget);
         }
         else {
-            wbSel = new WorkbenchTabWidget(this, widget);
+            workbenchSelectorWidget = new WorkbenchTabWidget(this, widget);
         }
 
-        static_cast<QToolBar*>(widget)->addWidget(wbSel);
+        static_cast<QToolBar*>(widget)->addWidget(workbenchSelectorWidget);
     }
     else if (widget->inherits("QMenu")) {
         auto menu = qobject_cast<QMenu*>(widget);

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -627,6 +627,14 @@ WorkbenchGroup::WorkbenchGroup (  Command* pcCmd, QObject * parent )
         this, &WorkbenchGroup::onWorkbenchActivated);
 }
 
+QAction* WorkbenchGroup::getOrCreateAction(const QString& wbName) {
+    if (!actionByWorkbenchName.contains(wbName)) {
+        actionByWorkbenchName[wbName] = new QAction;
+    }
+
+    return actionByWorkbenchName[wbName];
+}
+
 void WorkbenchGroup::addTo(QWidget *widget)
 {
     if (widget->inherits("QToolBar")) {
@@ -657,13 +665,13 @@ void WorkbenchGroup::addTo(QWidget *widget)
 
 void WorkbenchGroup::refreshWorkbenchList()
 {
-    QStringList enabled_wbs_list = DlgSettingsWorkbenchesImp::getEnabledWorkbenches();
+    QStringList enabledWbNames = DlgSettingsWorkbenchesImp::getEnabledWorkbenches();
 
     // Clear the actions.
     for (QAction* action : actions()) {
         groupAction()->removeAction(action);
-        delete action;
     }
+
     enabledWbsActions.clear();
     disabledWbsActions.clear();
 
@@ -671,12 +679,16 @@ void WorkbenchGroup::refreshWorkbenchList()
 
     // Create action list of enabled wb
     int index = 0;
-    for (const auto& wbName : enabled_wbs_list) {
+    for (const auto& wbName : enabledWbNames) {
         QString name = Application::Instance->workbenchMenuText(wbName);
         QPixmap px = Application::Instance->workbenchIcon(wbName);
         QString tip = Application::Instance->workbenchToolTip(wbName);
 
-        QAction* action = groupAction()->addAction(name);
+        QAction* action = getOrCreateAction(wbName);
+        
+        groupAction()->addAction(action);
+
+        action->setText(name);
         action->setCheckable(true);
         action->setData(QVariant(index)); // set the index
         action->setObjectName(wbName);
@@ -694,13 +706,17 @@ void WorkbenchGroup::refreshWorkbenchList()
     }
 
     // Also create action list of disabled wbs
-    QStringList disabled_wbs_list = DlgSettingsWorkbenchesImp::getDisabledWorkbenches();
-    for (const auto& wbName : disabled_wbs_list) {
+    QStringList disabledWbNames = DlgSettingsWorkbenchesImp::getDisabledWorkbenches();
+    for (const auto& wbName : disabledWbNames) {
         QString name = Application::Instance->workbenchMenuText(wbName);
         QPixmap px = Application::Instance->workbenchIcon(wbName);
         QString tip = Application::Instance->workbenchToolTip(wbName);
 
-        QAction* action = groupAction()->addAction(name);
+        QAction* action = getOrCreateAction(wbName);
+
+        groupAction()->addAction(action);
+
+        action->setText(name);
         action->setCheckable(true);
         action->setData(QVariant(index)); // set the index
         action->setObjectName(wbName);

--- a/src/Gui/Action.h
+++ b/src/Gui/Action.h
@@ -28,6 +28,7 @@
 #include <QAction>
 #include <QComboBox>
 #include <QKeySequence>
+#include <QMap>
 #include <FCGlobal.h>
 
 namespace Gui
@@ -188,13 +189,16 @@ class GuiExport WorkbenchGroup : public ActionGroup
 {
     Q_OBJECT
 
+    QAction* getOrCreateAction(const QString& wbName);
+
 public:
     /**
      * Creates an action for the command \a pcCmd to load the workbench \a name
      * when it gets activated.
      */
-    WorkbenchGroup (Command* pcCmd, QObject * parent);
-    void addTo (QWidget * widget) override;
+    WorkbenchGroup(Command* pcCmd, QObject* parent);
+
+    void addTo(QWidget * widget) override;
     void refreshWorkbenchList();
 
     void slotActivateWorkbench(const char*);
@@ -211,6 +215,8 @@ protected Q_SLOTS:
 private:
     QList<QAction*> enabledWbsActions;
     QList<QAction*> disabledWbsActions;
+
+    QMap<QString, QAction*> actionByWorkbenchName;
 
     Q_DISABLE_COPY(WorkbenchGroup)
 };

--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -167,11 +167,13 @@ QList<ToolBarItem*> ToolBarItem::getItems() const
 
 namespace Gui {
 
-class ToolBarArea : public QWidget
+class ToolBarAreaWidget : public QWidget
 {
     using inherited = QWidget;
+
 public:
-    ToolBarArea(QWidget *parent,
+    ToolBarAreaWidget(QWidget *parent,
+                ToolBarArea area,
                 const ParameterGrp::handle& hParam,
                 boost::signals2::scoped_connection &conn,
                 QTimer *timer = nullptr)
@@ -179,34 +181,45 @@ public:
         , _sizingTimer(timer)
         , _hParam(hParam)
         , _conn(conn)
+        , _area(area)
     {
         _layout = new QHBoxLayout(this);
         _layout->setContentsMargins(QMargins());
     }
 
-    void addWidget(QWidget *w)
+    void addWidget(QWidget *widget)
     {
-        if (_layout->indexOf(w) < 0) {
-            _layout->addWidget(w);
-            adjustParent();
-            QString name = w->objectName();
-            if (!name.isEmpty()) {
-                Base::ConnectionBlocker block(_conn);
-                _hParam->SetInt(w->objectName().toUtf8().constData(), _layout->count()-1);
-            }
+        if (_layout->indexOf(widget) > 0) {
+            return;
+        }
+
+        _layout->addWidget(widget);
+        adjustParent();
+
+        QString name = widget->objectName();
+
+        if (!name.isEmpty()) {
+            Base::ConnectionBlocker block(_conn);
+            _hParam->SetInt(widget->objectName().toUtf8().constData(), _layout->count() - 1);
         }
     }
 
-    void insertWidget(int idx, QWidget *w)
+    void insertWidget(int index, QWidget *widget)
     {
-        int index = _layout->indexOf(w);
-        if (index == idx) {
+        int currentIndex = _layout->indexOf(widget);
+
+        // we are inserting widget at the same place, this is no-op
+        if (currentIndex == index) {
             return;
         }
-        if (index > 0) {
-            _layout->removeWidget(w);
+
+        // widget already exists in the area, we need to first remove it and then recreate
+        if (currentIndex > 0) {
+            _layout->removeWidget(widget);
         }
-        _layout->insertWidget(idx, w);
+
+        _layout->insertWidget(index, widget);
+
         adjustParent();
         saveState();
     }
@@ -218,20 +231,23 @@ public:
         }
     }
 
-    void removeWidget(QWidget *w)
+    void removeWidget(QWidget *widget)
     {
-        _layout->removeWidget(w);
-        QString name = w->objectName();
+        _layout->removeWidget(widget);
+
+        QString name = widget->objectName();
         if (!name.isEmpty()) {
             Base::ConnectionBlocker block(_conn);
             _hParam->RemoveInt(name.toUtf8().constData());
         }
+
         adjustParent();
     }
 
     QWidget *widgetAt(int index) const
     {
         auto item = _layout->itemAt(index);
+
         return item ? item->widget() : nullptr;
     }
 
@@ -240,9 +256,14 @@ public:
         return _layout->count();
     }
 
-    int indexOf(QWidget *w) const
+    int indexOf(QWidget *widget) const
     {
-        return _layout->indexOf(w);
+        return _layout->indexOf(widget);
+    }
+
+    ToolBarArea area() const
+    {
+        return _area;
     }
 
     template<class FuncT>
@@ -250,10 +271,12 @@ public:
     {
         for (int i = 0, c = _layout->count(); i < c; ++i) {
             auto toolbar = qobject_cast<QToolBar*>(widgetAt(i));
+
             if (!toolbar || toolbar->objectName().isEmpty()
                          || toolbar->objectName().startsWith(QStringLiteral("*"))) {
                 continue;
             }
+
             func(toolbar, i, this);
         }
     }
@@ -261,10 +284,12 @@ public:
     void saveState()
     {
         Base::ConnectionBlocker block(_conn);
+
         for (auto &v : _hParam->GetIntMap()) {
             _hParam->RemoveInt(v.first.c_str());
         }
-        foreachToolBar([this](QToolBar *toolbar, int idx, ToolBarArea*) {
+
+        foreachToolBar([this](QToolBar *toolbar, int idx, ToolBarAreaWidget*) {
             _hParam->SetInt(toolbar->objectName().toUtf8().constData(), idx);
         });
     }
@@ -281,17 +306,19 @@ public:
 
         for (const auto &[name, visible] : _hParam->GetBoolMap()) {
             auto widget = findChild<QWidget*>(QString::fromUtf8(name.c_str()));
+
             if (widget) {
                 widget->setVisible(visible);
             }
         }
-    }
+    };
 
 private:
     QHBoxLayout *_layout;
     QPointer<QTimer> _sizingTimer;
     ParameterGrp::handle _hParam;
     boost::signals2::scoped_connection &_conn;
+    ToolBarArea _area;
 };
 
 } // namespace Gui
@@ -343,10 +370,10 @@ void ToolBarManager::setupStatusBar()
 {
     if (auto sb = getMainWindow()->statusBar()) {
         sb->installEventFilter(this);
-        statusBarArea = new ToolBarArea(sb, hStatusBar, connParam);
-        statusBarArea->setObjectName(QStringLiteral("StatusBarArea"));
-        sb->insertPermanentWidget(2, statusBarArea);
-        statusBarArea->show();
+        statusBarAreaWidget = new ToolBarAreaWidget(sb, ToolBarArea::StatusBarToolBarArea, hStatusBar, connParam);
+        statusBarAreaWidget->setObjectName(QStringLiteral("StatusBarArea"));
+        sb->insertPermanentWidget(2, statusBarAreaWidget);
+        statusBarAreaWidget->show();
     }
 }
 
@@ -354,14 +381,14 @@ void ToolBarManager::setupMenuBar()
 {
     if (auto mb = getMainWindow()->menuBar()) {
         mb->installEventFilter(this);
-        menuBarLeftArea = new ToolBarArea(mb, hMenuBarLeft, connParam, &menuBarTimer);
-        menuBarLeftArea->setObjectName(QStringLiteral("MenuBarLeftArea"));
-        mb->setCornerWidget(menuBarLeftArea, Qt::TopLeftCorner);
-        menuBarLeftArea->show();
-        menuBarRightArea = new ToolBarArea(mb, hMenuBarRight, connParam, &menuBarTimer);
-        menuBarRightArea->setObjectName(QStringLiteral("MenuBarRightArea"));
-        mb->setCornerWidget(menuBarRightArea, Qt::TopRightCorner);
-        menuBarRightArea->show();
+        menuBarLeftAreaWidget = new ToolBarAreaWidget(mb, ToolBarArea::LeftMenuToolBarArea, hMenuBarLeft, connParam, &menuBarTimer);
+        menuBarLeftAreaWidget->setObjectName(QStringLiteral("MenuBarLeftArea"));
+        mb->setCornerWidget(menuBarLeftAreaWidget, Qt::TopLeftCorner);
+        menuBarLeftAreaWidget->show();
+        menuBarRightAreaWidget = new ToolBarAreaWidget(mb, ToolBarArea::RightMenuToolBarArea, hMenuBarRight, connParam, &menuBarTimer);
+        menuBarRightAreaWidget->setObjectName(QStringLiteral("MenuBarRightArea"));
+        mb->setCornerWidget(menuBarRightAreaWidget, Qt::TopRightCorner);
+        menuBarRightAreaWidget->show();
     }
 }
 
@@ -440,6 +467,38 @@ void ToolBarManager::setupMenuBarTimer()
     });
 }
 
+ToolBarArea ToolBarManager::toolBarArea(QWidget *widget) const
+{
+    if (auto toolBar = qobject_cast<QToolBar*>(widget)) {
+        if (toolBar->isFloating()) {
+            return ToolBarArea::NoToolBarArea;
+        }
+
+        auto qtToolBarArea = getMainWindow()->toolBarArea(toolBar);
+        switch (qtToolBarArea) {
+            case Qt::LeftToolBarArea:
+                return ToolBarArea::LeftToolBarArea;
+            case Qt::RightToolBarArea:
+                return ToolBarArea::RightToolBarArea;
+            case Qt::TopToolBarArea:
+                return ToolBarArea::TopToolBarArea;
+            case Qt::BottomToolBarArea:
+                return ToolBarArea::BottomToolBarArea;
+            default:
+                // no-op
+                break;
+        }
+    }
+
+    for (auto &areaWidget : { statusBarAreaWidget, menuBarLeftAreaWidget, menuBarRightAreaWidget }) {
+        if (areaWidget->indexOf(widget) >= 0) {
+            return areaWidget->area();
+        }
+    }
+
+    return ToolBarArea::NoToolBarArea;
+}
+
 namespace {
 QPointer<QWidget> createActionWidget()
 {
@@ -470,7 +529,7 @@ int ToolBarManager::toolBarIconSize(QWidget *widget) const
 {
     int s = _toolBarIconSize;
     if (widget) {
-        if (widget->parentWidget() == statusBarArea) {
+        if (widget->parentWidget() == statusBarAreaWidget) {
             if (_statusBarIconSize > 0) {
                 s = _statusBarIconSize;
             }
@@ -478,8 +537,8 @@ int ToolBarManager::toolBarIconSize(QWidget *widget) const
                 s *= 0.6;
             }
         }
-        else if (widget->parentWidget() == menuBarLeftArea
-                || widget->parentWidget() == menuBarRightArea) {
+        else if (widget->parentWidget() == menuBarLeftAreaWidget
+                || widget->parentWidget() == menuBarRightAreaWidget) {
             if (_menuBarIconSize > 0) {
                 s = _menuBarIconSize;
             }
@@ -508,11 +567,11 @@ void ToolBarManager::setToolBarIconSize(QToolBar *toolbar)
 {
     int s = toolBarIconSize(toolbar);
     toolbar->setIconSize(QSize(s, s));
-    if (toolbar->parentWidget() == menuBarLeftArea) {
-        menuBarLeftArea->adjustParent();
+    if (toolbar->parentWidget() == menuBarLeftAreaWidget) {
+        menuBarLeftAreaWidget->adjustParent();
     }
-    else if (toolbar->parentWidget() == menuBarRightArea) {
-        menuBarRightArea->adjustParent();
+    else if (toolbar->parentWidget() == menuBarRightAreaWidget) {
+        menuBarRightAreaWidget->adjustParent();
     }
 }
 
@@ -751,9 +810,9 @@ void ToolBarManager::restoreState() const
 
     setMovable(!areToolBarsLocked());
 
-    statusBarArea->restoreState(sbToolBars);
-    menuBarRightArea->restoreState(mbRightToolBars);
-    menuBarLeftArea->restoreState(mbLeftToolBars);
+    statusBarAreaWidget->restoreState(sbToolBars);
+    menuBarRightAreaWidget->restoreState(mbRightToolBars);
+    menuBarLeftAreaWidget->restoreState(mbLeftToolBars);
 }
 
 bool ToolBarManager::addToolBarToArea(QObject *source, QMouseEvent *ev)
@@ -777,7 +836,7 @@ bool ToolBarManager::addToolBarToArea(QObject *source, QMouseEvent *ev)
     }
 
     static QPointer<OverlayDragFrame> tbPlaceholder;
-    static QPointer<ToolBarArea> lastArea;
+    static QPointer<ToolBarAreaWidget> lastArea;
     static int tbIndex = -1;
     if (ev->type() == QEvent::MouseMove) {
         if (tb->orientation() != Qt::Horizontal
@@ -799,11 +858,11 @@ bool ToolBarManager::addToolBarToArea(QObject *source, QMouseEvent *ev)
     }
 
     QPoint pos = QCursor::pos();
-    ToolBarArea *area = nullptr;
+    ToolBarAreaWidget *area = nullptr;
     if (statusBar) {
         QRect rect(statusBar->mapToGlobal(QPoint(0,0)), statusBar->size());
         if (rect.contains(pos)) {
-            area = statusBarArea;
+            area = statusBarAreaWidget;
         }
     }
     if (!area) {
@@ -813,10 +872,10 @@ bool ToolBarManager::addToolBarToArea(QObject *source, QMouseEvent *ev)
         QRect rect(menuBar->mapToGlobal(QPoint(0,0)), menuBar->size());
         if (rect.contains(pos)) {
             if (pos.x() - rect.left() < menuBar->width()/2) {
-                area = menuBarLeftArea;
+                area = menuBarLeftAreaWidget;
             }
             else {
-                area = menuBarRightArea;
+                area = menuBarRightAreaWidget;
             }
         }
         else {
@@ -834,11 +893,11 @@ bool ToolBarManager::addToolBarToArea(QObject *source, QMouseEvent *ev)
 
     int idx = 0;
     for (int c = area->count(); idx < c ;++idx) {
-        auto w = area->widgetAt(idx);
-        if (!w || w->isHidden()) {
+        auto widget = area->widgetAt(idx);
+        if (!widget || widget->isHidden()) {
             continue;
         }
-        int p = w->mapToGlobal(w->rect().center()).x();
+        int p = widget->mapToGlobal(widget->rect().center()).x();
         if (pos.x() < p) {
             break;
         }
@@ -887,40 +946,60 @@ bool ToolBarManager::addToolBarToArea(QObject *source, QMouseEvent *ev)
     return false;
 }
 
-void ToolBarManager::populateUndockMenu(QMenu *menu, ToolBarArea *area)
+void ToolBarManager::populateUndockMenu(QMenu *menu, ToolBarAreaWidget *area)
 {
     menu->setTitle(tr("Undock toolbars"));
-    auto tooltip = QObject::tr("Undock from status bar");
-    auto addMenuUndockItem = [&](QToolBar *toolbar, int, ToolBarArea *area) {
-        auto *action = toolbar->toggleViewAction();
+    auto tooltip = QObject::tr("Undock from toolbar area");
+
+    auto addMenuUndockItem = [&](QToolBar *toolbar, int, ToolBarAreaWidget *area) {
+        auto toggleViewAction = toolbar->toggleViewAction();
         auto undockAction = new QAction(menu);
-        undockAction->setText(action->text());
+
+        undockAction->setText(toggleViewAction->text());
         undockAction->setToolTip(tooltip);
+
         menu->addAction(undockAction);
         QObject::connect(undockAction, &QAction::triggered, [area, toolbar]() {
             if (toolbar->parentWidget() == getMainWindow()) {
                 return;
             }
+
             auto pos = toolbar->mapToGlobal(QPoint(0, 0));
-            QSignalBlocker blocker(toolbar);
-            area->removeWidget(toolbar);
-            getMainWindow()->addToolBar(toolbar);
-            toolbar->setWindowFlags(Qt::Tool
-                    | Qt::FramelessWindowHint
-                    | Qt::X11BypassWindowManagerHint);
-            toolbar->move(pos.x(), pos.y()-toolbar->height()-10);
-            toolbar->adjustSize();
-            toolbar->setVisible(true);
+            auto yOffset = toolbar->height();
+
+            // if widget is on the bottom move it up instead
+            if (area->area() == Gui::ToolBarArea::StatusBarToolBarArea) {
+                yOffset *= -1;
+            }
+
+            {
+                // Block signals caused by manually floating the widget
+                QSignalBlocker blocker(toolbar);
+
+                area->removeWidget(toolbar);
+                getMainWindow()->addToolBar(toolbar);
+
+                // this will make toolbar floating, there is no better way to do that.
+                toolbar->setWindowFlags(Qt::Tool
+                        | Qt::FramelessWindowHint
+                        | Qt::X11BypassWindowManagerHint);
+                toolbar->move(pos.x(), pos.y() + yOffset);
+                toolbar->adjustSize();
+                toolbar->setVisible(true);
+            }
+
+            // but don't block actual information about widget being floated
             Q_EMIT toolbar->topLevelChanged(true);
         });
     };
-    if (area) {
+
+    if (area) { 
         area->foreachToolBar(addMenuUndockItem);
     }
     else {
-        statusBarArea->foreachToolBar(addMenuUndockItem);
-        menuBarLeftArea->foreachToolBar(addMenuUndockItem);
-        menuBarRightArea->foreachToolBar(addMenuUndockItem);
+        statusBarAreaWidget->foreachToolBar(addMenuUndockItem);
+        menuBarLeftAreaWidget->foreachToolBar(addMenuUndockItem);
+        menuBarRightAreaWidget->foreachToolBar(addMenuUndockItem);
     }
 }
 
@@ -929,13 +1008,13 @@ bool ToolBarManager::showContextMenu(QObject *source)
     QMenu menu;
     QMenu menuUndock;
     QLayout* layout = nullptr;
-    ToolBarArea* area = nullptr;
+    ToolBarAreaWidget* area = nullptr;
     if (getMainWindow()->statusBar() == source) {
-        area = statusBarArea;
+        area = statusBarAreaWidget;
         layout = findLayoutOfObject(source, area);
     }
     else if (getMainWindow()->menuBar() == source) {
-        area = findToolBarArea();
+        area = findToolBarAreaWidget();
         if (!area) {
             return false;
         }
@@ -944,7 +1023,7 @@ bool ToolBarManager::showContextMenu(QObject *source)
         return false;
     }
 
-    auto addMenuVisibleItem = [&](QToolBar *toolbar, int, ToolBarArea *) {
+    auto addMenuVisibleItem = [&](QToolBar *toolbar, int, ToolBarAreaWidget *) {
         auto action = toolbar->toggleViewAction();
         if ((action->isVisible() || toolbar->isVisible()) && action->text().size()) {
             action->setVisible(true);
@@ -980,18 +1059,19 @@ QLayout* ToolBarManager::findLayoutOfObject(QObject* source, QWidget* area) cons
     return layout;
 }
 
-ToolBarArea* ToolBarManager::findToolBarArea() const
+ToolBarAreaWidget* ToolBarManager::findToolBarAreaWidget() const
 {
-    ToolBarArea* area = nullptr;
+    ToolBarAreaWidget* area = nullptr;
+
     QPoint pos = QCursor::pos();
-    QRect rect(menuBarLeftArea->mapToGlobal(QPoint(0,0)), menuBarLeftArea->size());
+    QRect rect(menuBarLeftAreaWidget->mapToGlobal(QPoint(0,0)), menuBarLeftAreaWidget->size());
     if (rect.contains(pos)) {
-        area = menuBarLeftArea;
+        area = menuBarLeftAreaWidget;
     }
     else {
-        rect = QRect(menuBarRightArea->mapToGlobal(QPoint(0,0)), menuBarRightArea->size());
+        rect = QRect(menuBarRightAreaWidget->mapToGlobal(QPoint(0,0)), menuBarRightAreaWidget->size());
         if (rect.contains(pos)) {
-            area = menuBarRightArea;
+            area = menuBarRightAreaWidget;
         }
     }
 
@@ -1043,7 +1123,7 @@ bool ToolBarManager::eventFilter(QObject *source, QEvent *ev)
     case QEvent::Hide:
         if (auto toolbar = qobject_cast<QToolBar*>(source)) {
             auto parent = toolbar->parentWidget();
-            if (parent == menuBarLeftArea || parent == menuBarRightArea) {
+            if (parent == menuBarLeftAreaWidget || parent == menuBarRightAreaWidget) {
                 menuBarTimer.start(10);
             }
         }
@@ -1131,9 +1211,9 @@ QList<QToolBar*> ToolBarManager::toolBars() const
         auto parent = it->parentWidget();
         if (parent == mw
                 || parent == mw->statusBar()
-                || parent == statusBarArea
-                || parent == menuBarLeftArea
-                || parent == menuBarRightArea) {
+                || parent == statusBarAreaWidget
+                || parent == menuBarLeftAreaWidget
+                || parent == menuBarRightAreaWidget) {
             tb.push_back(it);
             it->installEventFilter(const_cast<ToolBarManager*>(this));
         }

--- a/src/Gui/ToolBarManager.h
+++ b/src/Gui/ToolBarManager.h
@@ -41,7 +41,20 @@ class QToolBar;
 
 namespace Gui {
 
-class ToolBarArea;
+// Qt treats area as Flag so in theory toolbar could be in multiple areas at once.
+// We don't do that here so simple enum should suffice.
+enum GuiExport ToolBarArea {
+    NoToolBarArea,
+    LeftToolBarArea,
+    RightToolBarArea,
+    TopToolBarArea,
+    BottomToolBarArea,
+    LeftMenuToolBarArea,
+    RightMenuToolBarArea,
+    StatusBarToolBarArea,
+};
+
+class ToolBarAreaWidget;
 
 class GuiExport ToolBarItem
 {
@@ -123,7 +136,9 @@ public:
     int toolBarIconSize(QWidget *widget=nullptr) const;
     void setupToolBarIconSize();
 
-    void populateUndockMenu(QMenu *menu, ToolBarArea *area = nullptr);
+    void populateUndockMenu(QMenu *menu, ToolBarAreaWidget *area = nullptr);
+
+    ToolBarArea toolBarArea(QWidget* toolBar) const;
 
 protected:
     void setup(ToolBarItem*, QToolBar*) const;
@@ -158,7 +173,7 @@ private:
     void setupMenuBarTimer();
     void addToMenu(QLayout* layout, QWidget* area, QMenu* menu);
     QLayout* findLayoutOfObject(QObject* source, QWidget* area) const;
-    ToolBarArea* findToolBarArea() const;
+    ToolBarAreaWidget* findToolBarAreaWidget() const;
 
 private:
     QStringList toolbarNames;
@@ -169,9 +184,9 @@ private:
     QTimer sizeTimer;
     QTimer resizeTimer;
     boost::signals2::scoped_connection connParam;
-    ToolBarArea *statusBarArea = nullptr;
-    ToolBarArea *menuBarLeftArea = nullptr;
-    ToolBarArea *menuBarRightArea = nullptr;
+    ToolBarAreaWidget *statusBarAreaWidget = nullptr;
+    ToolBarAreaWidget *menuBarLeftAreaWidget = nullptr;
+    ToolBarAreaWidget *menuBarRightAreaWidget = nullptr;
     ParameterGrp::handle hGeneral;
     ParameterGrp::handle hPref;
     ParameterGrp::handle hStatusBar;

--- a/src/Gui/WorkbenchSelector.cpp
+++ b/src/Gui/WorkbenchSelector.cpp
@@ -225,6 +225,8 @@ void WorkbenchTabWidget::addWorkbenchTab(QAction* action)
         tabBar->addTab(icon, action->text());
     }
 
+    tabBar->setTabToolTip(tabBar->count() - 1, action->toolTip());
+
     if (action->isChecked()) {
         tabBar->setCurrentIndex(tabBar->count() - 1);
     }

--- a/src/Gui/WorkbenchSelector.h
+++ b/src/Gui/WorkbenchSelector.h
@@ -37,6 +37,12 @@ namespace Gui
 {
 class WorkbenchGroup;
 
+enum WorkbenchItemStyle {
+    IconAndText = 0,
+    IconOnly = 1,
+    TextOnly = 2
+};
+
 class GuiExport WorkbenchComboBox : public QComboBox
 {
     Q_OBJECT
@@ -56,8 +62,15 @@ private:
 class GuiExport WorkbenchTabWidget : public QWidget
 {
     Q_OBJECT
+    Q_PROPERTY(Qt::LayoutDirection direction READ direction WRITE setDirection NOTIFY directionChanged)
 
-    void addWorkbenchTab(QAction* workbenchActivateAction);
+    int addWorkbenchTab(QAction* workbenchActivateAction, int index = -1);
+
+    void setTemporaryWorkbenchTab(QAction* workbenchActivateAction);
+    int temporaryWorkbenchTabIndex() const;
+
+    QAction* workbenchActivateActionByTabIndex(int tabIndex) const;
+    int tabIndexForWorkbenchActivateAction(QAction* workbenchActivateAction) const;
 
 public:
     explicit WorkbenchTabWidget(WorkbenchGroup* aGroup, QWidget* parent = nullptr);
@@ -65,6 +78,8 @@ public:
     void setToolBarArea(Gui::ToolBarArea area);
     void buildPrefMenu();
 
+    Qt::LayoutDirection direction() const;
+    void setDirection(Qt::LayoutDirection direction);
 
     void adjustSize();
 
@@ -75,6 +90,9 @@ public Q_SLOTS:
     void updateLayout();
     void updateWorkbenchList();
 
+Q_SIGNALS:
+    void directionChanged(const Qt::LayoutDirection&);
+
 private:
     bool isInitializing = false;
 
@@ -82,8 +100,11 @@ private:
     QToolButton* moreButton;
     QTabBar* tabBar;
     QBoxLayout* layout;
+
+    Qt::LayoutDirection _direction = Qt::LeftToRight;
+
     // this action is used for workbenches that are typically disabled
-    QAction* additionalWorkbenchAction = nullptr;
+    QAction* temporaryWorkbenchAction = nullptr;
 
     std::map<QAction*, int> actionToTabIndex;
     std::map<int, QAction*> tabIndexToAction;

--- a/src/Gui/WorkbenchSelector.h
+++ b/src/Gui/WorkbenchSelector.h
@@ -28,7 +28,9 @@
 #include <QTabBar>
 #include <QMenu>
 #include <QToolButton>
+#include <QLayout>
 #include <FCGlobal.h>
+#include <Gui/ToolBarManager.h>
 #include <map>
 
 namespace Gui
@@ -55,20 +57,31 @@ class GuiExport WorkbenchTabWidget : public QWidget
 {
     Q_OBJECT
 
+    void addWorkbenchTab(QAction* workbenchActivateAction);
+
 public:
     explicit WorkbenchTabWidget(WorkbenchGroup* aGroup, QWidget* parent = nullptr);
     
-    void updateLayoutAndTabOrientation(bool);
+    void setToolBarArea(Gui::ToolBarArea area);
     void buildPrefMenu();
 
+
+    void adjustSize();
+
 public Q_SLOTS:
-    void refreshList(QList<QAction*>);
-    void addWorkbenchTab(QAction* workbenchActivateAction);
+    void handleWorkbenchSelection(QAction* selectedWorkbenchAction);
+    void handleTabChange(int selectedTabIndex);
+
+    void updateLayout();
+    void updateWorkbenchList();
 
 private:
+    bool isInitializing = false;
+
     WorkbenchGroup* wbActionGroup;
     QToolButton* moreButton;
     QTabBar* tabBar;
+    QBoxLayout* layout;
     // this action is used for workbenches that are typically disabled
     QAction* additionalWorkbenchAction = nullptr;
 

--- a/src/Gui/WorkbenchSelector.h
+++ b/src/Gui/WorkbenchSelector.h
@@ -27,7 +27,9 @@
 #include <QComboBox>
 #include <QTabBar>
 #include <QMenu>
+#include <QToolButton>
 #include <FCGlobal.h>
+#include <map>
 
 namespace Gui
 {
@@ -49,7 +51,7 @@ private:
 };
 
 
-class GuiExport WorkbenchTabWidget : public QTabBar
+class GuiExport WorkbenchTabWidget : public QWidget
 {
     Q_OBJECT
 
@@ -61,10 +63,17 @@ public:
 
 public Q_SLOTS:
     void refreshList(QList<QAction*>);
+    void addWorkbenchTab(QAction* workbenchActivateAction);
 
 private:
     WorkbenchGroup* wbActionGroup;
-    QMenu* menu;
+    QToolButton* moreButton;
+    QTabBar* tabBar;
+    // this action is used for workbenches that are typically disabled
+    QAction* additionalWorkbenchAction = nullptr;
+
+    std::map<QAction*, int> actionToTabIndex;
+    std::map<int, QAction*> tabIndexToAction;
 };
 
 


### PR DESCRIPTION
Please don't squash - I keep the commit history meaningful :)

This changes back placement of the "more" button of the WB TabBar to be at the end, where it should be naturally placed. In order to ensure that it is always visible the control was reworked to show this button always after the tab bar widget which now is dynamically sized. This is behavior that is well known from browsers.

![image](https://github.com/FreeCAD/FreeCAD/assets/747404/b0e3b592-7789-436a-8121-c338d44a8796)

This commit also ensures that active workbench is always visible in the TabBar by adding additional temporary tab when necessary. This tab will automatically dissapear when not needed.

https://github.com/FreeCAD/FreeCAD/assets/747404/c13018f6-26f7-4f0a-a31e-19ab75a6004d

https://github.com/FreeCAD/FreeCAD/assets/747404/d1171ec4-5533-4d6b-a775-1d2e590370f5

https://github.com/FreeCAD/FreeCAD/assets/747404/e4b52671-c5c4-439e-a6a1-0cbf20d21cff


Fixes: #13720
Fixes: #13630
Fixes: #13729
Fixes: #13286
Fixes: #13634