### PR TITLE
Fem: Rescaling and transparency fix for heat constraint symbols

### DIFF
--- a/src/Mod/Fem/Gui/Resources/symbols/ConstraintHeatFlux.iv
+++ b/src/Mod/Fem/Gui/Resources/symbols/ConstraintHeatFlux.iv
@@ -6,42 +6,42 @@ Separator {
   Separator {
 
     Translation {
-      translation 0 0.225 0
+      translation 0 0.5 0
 
     }
     Sphere {
-      radius 0.225
+      radius 0.5
 
     }
     Translation {
-      translation 0 0.5625 0
+      translation 0 1.25 0
 
     }
     Cylinder {
-      radius 0.1125
+      radius 0.25
+      height 1.75
+
+    }
+    Translation {
+      translation 0 1.25 0
+
+    }
+    BaseColor {
+      rgb 1 1 1
+
+    }
+    Cylinder {
+      radius 0.25
       height 0.75
 
     }
     Translation {
-      translation 0 0.5625 0
-
-    }
-    Material {
-      diffuseColor 1 1 1
+      translation 0 -1.25 0
 
     }
     Cylinder {
-      radius 0.1125
-      height 0.375
-
-    }
-    Translation {
-      translation 0 -0.5625 0
-
-    }
-    Cylinder {
-      radius 0.3
-      height 0.075
+      radius 0.7
+      height 0.175
 
     }
   }

--- a/src/Mod/Fem/Gui/Resources/symbols/ConstraintTemperature.iv
+++ b/src/Mod/Fem/Gui/Resources/symbols/ConstraintTemperature.iv
@@ -6,33 +6,33 @@ Separator {
   Separator {
 
     Translation {
-      translation 0 0.225 0
+      translation 0 0.5 0
 
     }
     Sphere {
-      radius 0.225
+      radius 0.5
 
     }
     Translation {
-      translation 0 0.5625 0
+      translation 0 1.25 0
 
     }
     Cylinder {
-      radius 0.1125
+      radius 0.25
+      height 1.75
+
+    }
+    Translation {
+      translation 0 1.25 0
+
+    }
+    BaseColor {
+      rgb 1 1 1
+
+    }
+    Cylinder {
+      radius 0.25
       height 0.75
-
-    }
-    Translation {
-      translation 0 0.5625 0
-
-    }
-    Material {
-      diffuseColor 1 1 1
-
-    }
-    Cylinder {
-      radius 0.1125
-      height 0.375
 
     }
   }


### PR DESCRIPTION
Increase the base size of the temperature and heat flux symbols. They are currently too small.
Change `SoMaterial` to `SoBaseColor` in .iv files so that the white cylinders of both symbols are affected by transparency.