### PR TITLE
Small stylesheet fix to issue in the preference menu

### DIFF
--- a/src/Gui/Stylesheets/Dark-modern.qss
+++ b/src/Gui/Stylesheets/Dark-modern.qss
@@ -2282,7 +2282,7 @@ QListView::item:selected:!active,
 QTableView::item:selected:!active,
 QColumnView::item:selected:!active {
   color: White;
-  background-color: #353535;
+  background-color: @ThemeAccentColor1;
 }
 
 QTreeView::item:!selected:hover,

--- a/src/Gui/Stylesheets/Dark.qss
+++ b/src/Gui/Stylesheets/Dark.qss
@@ -2269,7 +2269,7 @@ QListView::item:selected:!active,
 QTableView::item:selected:!active,
 QColumnView::item:selected:!active {
   color: White;
-  background-color: #353535;
+  background-color: @ThemeAccentColor1;
 }
 
 QTreeView::item:!selected:hover,

--- a/src/Gui/Stylesheets/Darker.qss
+++ b/src/Gui/Stylesheets/Darker.qss
@@ -2274,7 +2274,7 @@ QListView::item:selected:!active,
 QTableView::item:selected:!active,
 QColumnView::item:selected:!active {
   color: White;
-  background-color: #353535;
+  background-color: @ThemeAccentColor1;
 }
 
 QTreeView::item:!selected:hover,

--- a/src/Gui/Stylesheets/Light-modern.qss
+++ b/src/Gui/Stylesheets/Light-modern.qss
@@ -2290,7 +2290,7 @@ QListView::item:selected:!active,
 QTableView::item:selected:!active,
 QColumnView::item:selected:!active {
   color: black;
-  background-color: #bfc1c0;
+  background-color: @ThemeAccentColor1;
 }
 
 QTreeView::item:!selected:hover,

--- a/src/Gui/Stylesheets/Light.qss
+++ b/src/Gui/Stylesheets/Light.qss
@@ -2281,7 +2281,7 @@ QListView::item:selected:!active,
 QTableView::item:selected:!active,
 QColumnView::item:selected:!active {
   color: black;
-  background-color: #BABABA;
+  background-color: @ThemeAccentColor1;
 }
 
 QTreeView::item:!selected:hover,


### PR DESCRIPTION
Small fix to issue in the menu that happens when a menu is selected but not active.
Now:
![image](https://github.com/FreeCAD/FreeCAD/assets/29804962/f5b053fc-84f6-41e4-a330-b6d928b33825)
Then (ignore the branch lines and such)
![image](https://github.com/FreeCAD/FreeCAD/assets/29804962/7075f7a7-2615-4c85-a994-294493afc22a)
@kadet1090 pointed me to this. 
