### PR TITLE
Draft: update Draft Point viewprovider to account for ShapeAppearance

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_point.py
+++ b/src/Mod/Draft/draftviewproviders/view_point.py
@@ -45,8 +45,7 @@ class ViewProviderPoint(ViewProviderDraft):
         vobj.setEditorMode('DisplayMode', mode)
         vobj.setEditorMode('Lighting', mode)
         vobj.setEditorMode('LineMaterial', mode)
-        vobj.setEditorMode('ShapeColor', mode)
-        vobj.setEditorMode('ShapeMaterial', mode)
+        vobj.setEditorMode('ShapeAppearance', mode)
         vobj.setEditorMode('Transparency', mode)
 
     def getIcon(self):


### PR DESCRIPTION
Without this mod there is an error when opening a V0.21 file with a Draft Point. As well as when creating a Draft Point in V0.22.
