### PR TITLE
Measure: write init message to log instead

### DIFF
--- a/src/Mod/Measure/Gui/Command.cpp
+++ b/src/Mod/Measure/Gui/Command.cpp
@@ -28,5 +28,5 @@
 using namespace std;
 
 void CreateMeasureCommands() {
-    Base::Console().Message("Init MeasureGui\n");
+    Base::Console().Log("Init MeasureGui\n");
 }


### PR DESCRIPTION
writing this as a normal message is completely unnecessay, I'm not sure writing something is necesary at all. With this at least it won't normally pollute the repor view