### PR TITLE
UI: Add Std_Measure command to menu

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -728,6 +728,7 @@ MenuItem* StdWorkbench::setupMenuBar() const
           << "Std_ProjectUtil"
           << "Separator"
           << "Std_MeasureDistance"
+          << "Std_Measure"
           << "Separator"
           << "Std_TextDocument"
           << "Separator"


### PR DESCRIPTION
Add `Std_Measure` command to tool menu, currently only present in toolbar.
![image](https://github.com/FreeCAD/FreeCAD/assets/6246609/41d7cd28-4745-4b43-a3ca-e6f6c06b5895)
