### PR TITLE
Draft: Do not show temporary line object in tree

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -77,6 +77,7 @@ class Line(gui_base_original.Creator):
 
         self.obj = self.doc.addObject("Part::Feature", self.featureName)
         gui_utils.format_object(self.obj)
+        self.obj.ViewObject.ShowInTree = False
 
         self.call = self.view.addEventCallback("SoEvent", self.action)
         _toolmsg(translate("draft", "Pick first point"))


### PR DESCRIPTION
The Draft line/polyline tool creates a temp object while drawing, for self-snapping, that should not appear in the tree.

Fixes #13700