### PR TITLE
Core: Document getRootObjects : Fix bug of objects linked not returned.

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -4005,6 +4005,32 @@ std::vector<App::DocumentObject*> Document::getRootObjects() const
     return ret;
 }
 
+std::vector<App::DocumentObject*> Document::getRootObjectsIgnoreLinks() const
+{
+    std::vector<App::DocumentObject*> ret;
+
+    for (auto objectIt : d->objectArray) {
+        auto list = objectIt->getInList();
+        bool noParents = list.empty();
+
+        if (!noParents) {
+            // App::Document getRootObjects returns the root objects of the dependency graph.
+            // So if an object is referenced by a App::Link, it will not be returned by that function.
+            // So here, as we want the tree-root level objects,
+            // we check if all the parents are links. In which case its still a root object.
+            noParents = std::all_of(list.cbegin(), list.cend(), [](App::DocumentObject* obj) {
+                return obj->isDerivedFrom<App::Link>();
+            });
+        }
+
+        if (noParents) {
+            ret.push_back(objectIt);
+        }
+    }
+
+    return ret;
+}
+
 void DocumentP::findAllPathsAt(const std::vector <Node> &all_nodes, size_t id,
                                 std::vector <Path> &all_paths, Path tmp)
 {

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -470,6 +470,8 @@ public:
     std::vector<App::DocumentObject*> topologicalSort() const;
     /// get all root objects (objects no other one reference too)
     std::vector<App::DocumentObject*> getRootObjects() const;
+    /// get all tree root objects (objects that are at the root of the object tree)
+    std::vector<App::DocumentObject*> getRootObjectsIgnoreLinks() const;
     /// get all possible paths from one object to another following the OutList
     std::vector<std::list<App::DocumentObject*> > getPathsByOutList
     (const App::DocumentObject* from, const App::DocumentObject* to) const;

--- a/src/App/DocumentPy.xml
+++ b/src/App/DocumentPy.xml
@@ -291,6 +291,12 @@ sort: whether to topologically sort the return list
       </Documentation>
       <Parameter Name="RootObjects" Type="List" />
     </Attribute>
+    <Attribute Name="RootObjectsIgnoreLinks" ReadOnly="true">
+      <Documentation>
+        <UserDocu>The list of root objects in this document ignoring references from links.</UserDocu>
+      </Documentation>
+      <Parameter Name="RootObjectsIgnoreLinks" Type="List" />
+    </Attribute>
     <Attribute Name="UndoMode" ReadOnly="false">
       <Documentation>
         <UserDocu>The Undo mode of the Document (0 = no Undo, 1 = Undo/Redo)</UserDocu>

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -752,6 +752,18 @@ Py::List DocumentPy::getRootObjects() const
     return res;
 }
 
+Py::List DocumentPy::getRootObjectsIgnoreLinks() const
+{
+    std::vector<App::DocumentObject*> objs = getDocumentPtr()->getRootObjectsIgnoreLinks();
+    Py::List res;
+
+    for (auto obj : objs)
+        //Note: Here we must force the Py::Object to own this Python object as getPyObject() increments the counter
+        res.append(Py::Object(obj->getPyObject(), true));
+
+    return res;
+}
+
 Py::Int DocumentPy::getUndoMode() const
 {
     return Py::Int(getDocumentPtr()->getUndoMode());

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -2654,7 +2654,7 @@ void TreeWidget::sortDroppedObjects(TargetItemInfo& targetInfo, std::vector<App:
         propGroup->setValue(sortedObjList);
     }
     else if (targetInfo.targetItem->type() == TreeWidget::DocumentType) {
-        objList = targetInfo.targetDoc->getRootObjects();
+        objList = targetInfo.targetDoc->getRootObjectsIgnoreLinks();
         // First we need to sort objList by treeRank.
         std::sort(objList.begin(), objList.end(),
             [](App::DocumentObject* a, App::DocumentObject* b) {

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -2004,7 +2004,7 @@ Base::Placement AssemblyObject::getGlobalPlacement(App::DocumentObject* targetOb
                                                    App::DocumentObject* container)
 {
     bool inContainerBranch = (container == nullptr);
-    auto rootObjects = App::GetApplication().getActiveDocument()->getRootObjects();
+    auto rootObjects = App::GetApplication().getActiveDocument()->getRootObjectsIgnoreLinks();
     for (auto& part : rootObjects) {
         Base::Placement foundPlc;
         bool found =

--- a/src/Mod/Assembly/CommandInsertLink.py
+++ b/src/Mod/Assembly/CommandInsertLink.py
@@ -203,7 +203,7 @@ class TaskAssemblyInsertLink(QtCore.QObject):
                         ):
                             process_objects(obj.OutList, objItem)
 
-            process_objects(doc.RootObjects, docItem)
+            process_objects(doc.RootObjectsIgnoreLinks, docItem)
             self.form.partList.expandAll()
 
     def onFilterChange(self):

--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -297,7 +297,7 @@ def getGlobalPlacement(targetObj, container=None):
         return App.Placement()
 
     inContainerBranch = container is None
-    for rootObj in App.activeDocument().RootObjects:
+    for rootObj in App.activeDocument().RootObjectsIgnoreLinks:
         foundPlacement = getTargetPlacementRelativeTo(
             targetObj, rootObj, container, inContainerBranch
         )
@@ -308,7 +308,7 @@ def getGlobalPlacement(targetObj, container=None):
 
 
 def isThereOneRootAssembly():
-    for part in App.activeDocument().RootObjects:
+    for part in App.activeDocument().RootObjectsIgnoreLinks:
         if part.TypeId == "Assembly::AssemblyObject":
             return True
     return False


### PR DESCRIPTION
If a root object has a link pointing to it, then it is not returned by RootObjects.
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/a644df67-2693-4cf7-a651-e3d0c8782dd6)
Having a look at the function in cpp it seems to be because its checking if the inList is empty to determine if its a root object.

https://forum.freecad.org/viewtopic.php?p=756837#p756837