### PR TITLE
UI: Change default UMF colors for better contrast

### DIFF
--- a/src/Mod/Measure/App/Preferences.cpp
+++ b/src/Mod/Measure/App/Preferences.cpp
@@ -46,7 +46,7 @@ Base::Reference<ParameterGrp> Preferences::getPreferenceGroup(const char* Name)
 App::Color Preferences::defaultLineColor()
 {
     App::Color fcColor;
-    fcColor.setPackedValue(getPreferenceGroup("Appearance")->GetUnsigned("DefaultLineColor", 0xFFFFFFFF));
+    fcColor.setPackedValue(getPreferenceGroup("Appearance")->GetUnsigned("DefaultLineColor", 0x3CF00000));
     return fcColor;
 }
 
@@ -60,7 +60,7 @@ App::Color Preferences::defaultTextColor()
 App::Color Preferences::defaultTextBackgroundColor()
 {
     App::Color fcColor;
-    fcColor.setPackedValue(getPreferenceGroup("Appearance")->GetUnsigned("DefaultTextBackgroundColor", 0xFFFFFFFF));
+    fcColor.setPackedValue(getPreferenceGroup("Appearance")->GetUnsigned("DefaultTextBackgroundColor", 0x3CF00000));
     return fcColor;
 }
 

--- a/src/Mod/Measure/Gui/DlgPrefsMeasureAppearanceImp.ui
+++ b/src/Mod/Measure/Gui/DlgPrefsMeasureAppearanceImp.ui
@@ -113,9 +113,9 @@
           </property>
           <property name="color">
            <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
+            <red>60</red>
+            <green>240</green>
+            <blue>0</blue>
            </color>
           </property>
           <property name="prefEntry" stdset="0">
@@ -180,8 +180,8 @@
          <widget class="Gui::PrefColorButton" name="cbBackground">
           <property name="color">
            <color>
-            <red>0</red>
-            <green>0</green>
+            <red>60</red>
+            <green>240</green>
             <blue>0</blue>
            </color>
           </property>


### PR DESCRIPTION
Default colors of the new unified measurement tool are hard to see on either light or dark themes:
![324229416-0060c681-bb31-4759-a601-02c8879de45f](https://github.com/FreeCAD/FreeCAD/assets/6246609/17c88dff-a593-4517-a072-ddcf6766181f)
![325056262-af178977-32d2-4575-bfc0-153bb0a5275d](https://github.com/FreeCAD/FreeCAD/assets/6246609/4ef47202-50bc-40e3-a700-4bf7876b97f1)

This PR sets line and background color to a green which is visible on most themes. Contrast ratio between annotation text and text background is 13.65:1

After:
![image](https://github.com/FreeCAD/FreeCAD/assets/6246609/ea40c15a-92db-4d79-8c2c-28212e4b9f38)
