### PR TITLE
add horizontal scrollbar to start page

### DIFF
--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -114,7 +114,7 @@ StartView::StartView(Gui::Document* pcDocument, QWidget* parent)
 
     auto scrolledWidget = gsl::owner<QWidget*>(new QWidget(this));
     _contents->setWidget(scrolledWidget);
-    _contents->setHorizontalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAlwaysOff);
+    _contents->setHorizontalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAsNeeded);
     _contents->setVerticalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAsNeeded);
     _contents->setWidgetResizable(true);
     auto layout = gsl::owner<QVBoxLayout*>(new QVBoxLayout(scrolledWidget));


### PR DESCRIPTION
On systems with legacy monitors the display might be not as large as needed to display completely the start page. In that case the user is forced to use the keyboard to scroll horizontally the start page.