### PR TITLE
[TechDraw] Issue #13661 - Split sheet autofill to separate values

### DIFF
--- a/src/Mod/TechDraw/App/DrawTemplate.cpp
+++ b/src/Mod/TechDraw/App/DrawTemplate.cpp
@@ -100,6 +100,32 @@ DrawPage* DrawTemplate::getParentPage() const
     return page;
 }
 
+// Return the counts related to pages, namely collated page index and total page count
+std::pair<int, int> DrawTemplate::getPageNumbers() const
+{
+    std::vector<DocumentObject *> pages = getDocument()->getObjectsOfType(TechDraw::DrawPage::getClassTypeId());
+    std::vector<QString> pageNames;
+    for (auto page : pages) {
+        if (page->isAttachedToDocument() &&
+            !page->testStatus(App::ObjectStatus::Remove)) {
+            pageNames.push_back(QString::fromUtf8(page->Label.getValue()));
+        }
+    }
+    QCollator collator;
+    std::sort(pageNames.begin(), pageNames.end(), collator);
+
+    int pos = 0;
+    DrawPage *page = getParentPage();
+    if (page) {
+        auto it = std::find(pageNames.begin(), pageNames.end(), QString::fromUtf8(page->Label.getValue()));
+        if (it != pageNames.end()) {
+            pos = it - pageNames.begin() + 1;
+        }
+    }
+
+    return std::pair<int, int>(pos, (int) pageNames.size());
+}
+
 QString DrawTemplate::getAutofillValue(const QString &id) const
 {
     // author
@@ -133,31 +159,22 @@ QString DrawTemplate::getAutofillValue(const QString &id) const
     }
     // sheet
     else if (id.compare(QString::fromUtf8(Autofill::Sheet)) == 0) {
-        std::vector<DocumentObject *> pages = getDocument()->getObjectsOfType(TechDraw::DrawPage::getClassTypeId());
-        std::vector<QString> pageNames;
-        for (auto page : pages) {
-            if (page->isAttachedToDocument() &&
-                !page->testStatus(App::ObjectStatus::Remove)) {
-                pageNames.push_back(QString::fromUtf8(page->Label.getValue()));
-            }
-        }
-        QCollator collator;
-        std::sort(pageNames.begin(), pageNames.end(), collator);
-
-        int pos = 0;
-        DrawPage *page = getParentPage();
-        if (page) {
-            auto it = std::find(pageNames.begin(), pageNames.end(), QString::fromUtf8(page->Label.getValue()));
-            if (it != pageNames.end()) {
-                pos = it - pageNames.begin() + 1;
-            }
-        }
-
-        return QString::asprintf("%d / %d", pos, (int) pageNames.size());
+        std::pair<int, int> pageNumbers = getPageNumbers();
+        return QString::asprintf("%d / %d", pageNumbers.first, pageNumbers.second);
     }
     // title
     else if (id.compare(QString::fromUtf8(Autofill::Title)) == 0) {
         return QString::fromUtf8(getDocument()->Label.getValue());
+    }
+    // page number
+    else if (id.compare(QString::fromUtf8(Autofill::PageNumber)) == 0) {
+        std::pair<int, int> pageNumbers = getPageNumbers();
+        return QString::number(pageNumbers.first);
+    }
+    // page total
+    else if (id.compare(QString::fromUtf8(Autofill::PageCount)) == 0) {
+        std::pair<int, int> pageNumbers = getPageNumbers();
+        return QString::number(pageNumbers.second);
     }
 
     return QString();

--- a/src/Mod/TechDraw/App/DrawTemplate.h
+++ b/src/Mod/TechDraw/App/DrawTemplate.h
@@ -56,6 +56,7 @@ public:
     virtual double getHeight() const;
 
     virtual DrawPage* getParentPage() const;
+    virtual std::pair<int, int> getPageNumbers() const;
 
     virtual QString getAutofillValue(const QString &id) const;
 
@@ -76,6 +77,8 @@ public:
             static constexpr const char *Scale        = "scale";
             static constexpr const char *Sheet        = "sheet";
             static constexpr const char *Title        = "title";
+            static constexpr const char *PageNumber   = "page_number";
+            static constexpr const char *PageCount    = "page_count";
     };
 
 private:


### PR DESCRIPTION
This pull request implements the requested splitting of "sheet" field in the "X / Y" form (X for page ordinal number, Y for total count of pages) into two separate values accessible through:

**page_number** autofill value, which determines the position of the new page in the collated set of all page names (identical to X in sheet field)
and
**page_count** autofill value, which delivers the total page count in given document (corresponds to Y in sheet field)

The change is rather minimal, thus I would not expect any fundamental issues, but some testing is definitely welcome. In case of any problems, please let me know.