### PR TITLE
Material: Appearance Updates 2

### DIFF
--- a/src/App/Material.cpp
+++ b/src/App/Material.cpp
@@ -25,9 +25,25 @@
 
 #ifndef _PreComp_
 #include <cstring>
+#include <random>
 #endif
 
+#include "Application.h"
 #include "Material.h"
+
+// Helper functions to consistently convert between float and long
+namespace
+{
+float fromPercent(long value)
+{
+    return std::roundf(value) / 100.0F;
+}
+
+long toPercent(float value)
+{
+    return std::lround(100.0 * value);
+}
+}  // namespace
 
 using namespace App;
 
@@ -316,5 +332,48 @@ void Material::setType(MaterialType MatType)
             transparency = 0.0000F;
             break;
     }
+}
+
+App::Material Material::getDefaultAppearance()
+{
+    ParameterGrp::handle hGrp =
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+
+    auto getColor = [hGrp](const char* parameter, App::Color& color) {
+        uint32_t packed = color.getPackedRGB();
+        packed = hGrp->GetUnsigned(parameter, packed);
+        color.setPackedRGB(packed);
+    };
+    auto intRandom = [](int min, int max) -> int {
+        static std::mt19937 generator;
+        std::uniform_int_distribution<int> distribution(min, max);
+        return distribution(generator);
+    };
+
+    App::Material mat(App::Material::DEFAULT);
+    mat.transparency = fromPercent(hGrp->GetInt("DefaultShapeTransparency", 0));
+    long shininess = toPercent(mat.shininess);
+    mat.shininess = fromPercent(hGrp->GetInt("DefaultShapeShininess", shininess));
+
+    // This is handled in the material code when using the object appearance
+    bool randomColor = hGrp->GetBool("RandomColor", false);
+
+    // diffuse color
+    if (randomColor) {
+        float red = static_cast<float>(intRandom(0, 255)) / 255.0F;
+        float green = static_cast<float>(intRandom(0, 255)) / 255.0F;
+        float blue = static_cast<float>(intRandom(0, 255)) / 255.0F;
+        mat.diffuseColor = App::Color(red, green, blue);
+    }
+    else {
+        // Color = (204, 204, 230) = 3435980543UL
+        getColor("DefaultShapeColor", mat.diffuseColor);
+    }
+
+    getColor("DefaultAmbientColor", mat.ambientColor);
+    getColor("DefaultEmissiveColor", mat.emissiveColor);
+    getColor("DefaultSpecularColor", mat.specularColor);
+
+    return mat;
 }
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)

--- a/src/App/Material.h
+++ b/src/App/Material.h
@@ -131,6 +131,8 @@ public:
     Color emissiveColor; /**< Defines the emissive color. */
     float shininess;
     float transparency;
+    std::string image;
+    std::string imagePath;
     std::string uuid;
     // NOLINTEND
     //@}
@@ -145,6 +147,8 @@ public:
             && diffuseColor == m.diffuseColor
             && specularColor == m.specularColor
             && emissiveColor == m.emissiveColor
+            && image == m.image
+            && image == m.imagePath
             && uuid == m.uuid;
         // clang-format on
     }
@@ -154,6 +158,8 @@ public:
     }
     Material& operator=(const Material& other) = default;
     Material& operator=(Material&& other) = default;
+
+    static Material getDefaultAppearance();
 
 private:
     MaterialType _matType;

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -2579,6 +2579,8 @@ void PropertyMaterial::Save(Base::Writer& writer) const
                     << "\" emissiveColor=\"" << _cMat.emissiveColor.getPackedValue()
                     << "\" shininess=\"" << _cMat.shininess
                     << "\" transparency=\"" << _cMat.transparency
+                    << "\" image=\"" << _cMat.image
+                    << "\" imagePath=\"" << _cMat.imagePath
                     << "\" uuid=\"" << _cMat.uuid
                     << "\"/>" << std::endl;
     // clang-format on
@@ -2596,6 +2598,12 @@ void PropertyMaterial::Restore(Base::XMLReader& reader)
     _cMat.emissiveColor.setPackedValue(reader.getAttributeAsUnsigned("emissiveColor"));
     _cMat.shininess = (float)reader.getAttributeAsFloat("shininess");
     _cMat.transparency = (float)reader.getAttributeAsFloat("transparency");
+    if (reader.hasAttribute("image")) {
+        _cMat.image = reader.getAttribute("image");
+    }
+    if (reader.hasAttribute("imagePath")) {
+        _cMat.imagePath = reader.getAttribute("imagePath");
+    }
     if (reader.hasAttribute("uuid")) {
         _cMat.uuid = reader.getAttribute("uuid");
     }
@@ -2635,7 +2643,7 @@ TYPESYSTEM_SOURCE(App::PropertyMaterialList, App::PropertyLists)
 
 PropertyMaterialList::PropertyMaterialList()
 {
-    setSizeOne();
+    setMinimumSizeOne();
 }
 
 PropertyMaterialList::~PropertyMaterialList() = default;
@@ -2662,7 +2670,7 @@ void PropertyMaterialList::verifyIndex(int index) const
     }
 }
 
-void PropertyMaterialList::setSizeOne()
+void PropertyMaterialList::setMinimumSizeOne()
 {
     int size = getSize();
     if (size < 1) {
@@ -2690,7 +2698,7 @@ void PropertyMaterialList::setValue()
 void PropertyMaterialList::setValue(const Material& mat)
 {
     aboutToSetValue();
-    setSizeOne();
+    setSize(1);
     for (auto& material : _lValueList) {
         material = mat;
     }
@@ -2710,7 +2718,7 @@ void PropertyMaterialList::setValue(int index, const Material& mat)
 void PropertyMaterialList::setAmbientColor(const Color& col)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.ambientColor = col;
     }
@@ -2720,7 +2728,7 @@ void PropertyMaterialList::setAmbientColor(const Color& col)
 void PropertyMaterialList::setAmbientColor(float r, float g, float b, float a)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.ambientColor.set(r, g, b, a);
     }
@@ -2730,7 +2738,7 @@ void PropertyMaterialList::setAmbientColor(float r, float g, float b, float a)
 void PropertyMaterialList::setAmbientColor(uint32_t rgba)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.ambientColor.setPackedValue(rgba);
     }
@@ -2770,7 +2778,7 @@ void PropertyMaterialList::setAmbientColor(int index, uint32_t rgba)
 void PropertyMaterialList::setDiffuseColor(const Color& col)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.diffuseColor = col;
     }
@@ -2780,7 +2788,7 @@ void PropertyMaterialList::setDiffuseColor(const Color& col)
 void PropertyMaterialList::setDiffuseColor(float r, float g, float b, float a)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.diffuseColor.set(r, g, b, a);
     }
@@ -2790,7 +2798,7 @@ void PropertyMaterialList::setDiffuseColor(float r, float g, float b, float a)
 void PropertyMaterialList::setDiffuseColor(uint32_t rgba)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.diffuseColor.setPackedValue(rgba);
     }
@@ -2827,10 +2835,21 @@ void PropertyMaterialList::setDiffuseColor(int index, uint32_t rgba)
     hasSetValue();
 }
 
+void PropertyMaterialList::setDiffuseColors(const std::vector<App::Color>& colors)
+{
+    aboutToSetValue();
+    setSize(colors.size(), _lValueList[0]);
+
+    for (int i = 0; i < colors.size(); i++) {
+        _lValueList[i].diffuseColor = colors[i];
+    }
+    hasSetValue();
+}
+
 void PropertyMaterialList::setSpecularColor(const Color& col)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.specularColor = col;
     }
@@ -2840,7 +2859,7 @@ void PropertyMaterialList::setSpecularColor(const Color& col)
 void PropertyMaterialList::setSpecularColor(float r, float g, float b, float a)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.specularColor.set(r, g, b, a);
     }
@@ -2850,7 +2869,7 @@ void PropertyMaterialList::setSpecularColor(float r, float g, float b, float a)
 void PropertyMaterialList::setSpecularColor(uint32_t rgba)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.specularColor.setPackedValue(rgba);
     }
@@ -2890,7 +2909,7 @@ void PropertyMaterialList::setSpecularColor(int index, uint32_t rgba)
 void PropertyMaterialList::setEmissiveColor(const Color& col)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.emissiveColor = col;
     }
@@ -2900,7 +2919,7 @@ void PropertyMaterialList::setEmissiveColor(const Color& col)
 void PropertyMaterialList::setEmissiveColor(float r, float g, float b, float a)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.emissiveColor.set(r, g, b, a);
     }
@@ -2910,7 +2929,7 @@ void PropertyMaterialList::setEmissiveColor(float r, float g, float b, float a)
 void PropertyMaterialList::setEmissiveColor(uint32_t rgba)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.emissiveColor.setPackedValue(rgba);
     }
@@ -2950,7 +2969,7 @@ void PropertyMaterialList::setEmissiveColor(int index, uint32_t rgba)
 void PropertyMaterialList::setShininess(float val)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.shininess = val;
     }
@@ -2970,7 +2989,7 @@ void PropertyMaterialList::setShininess(int index, float val)
 void PropertyMaterialList::setTransparency(float val)
 {
     aboutToSetValue();
-    setSizeOne();
+    setMinimumSizeOne();
     for (auto& material : _lValueList) {
         material.transparency = val;
     }
@@ -3039,12 +3058,12 @@ const Color& PropertyMaterialList::getEmissiveColor(int index) const
 
 float PropertyMaterialList::getShininess() const
 {
-    return _lValueList[0].transparency;
+    return _lValueList[0].shininess;
 }
 
 float PropertyMaterialList::getShininess(int index) const
 {
-    return _lValueList[index].transparency;
+    return _lValueList[index].shininess;
 }
 
 float PropertyMaterialList::getTransparency() const
@@ -3074,7 +3093,7 @@ void PropertyMaterialList::Save(Base::Writer& writer) const
     if (!writer.isForceXML()) {
         writer.Stream() << writer.ind() << "<MaterialList file=\""
                         << (getSize() ? writer.addFile(getName(), this) : "") << "\""
-                        << " version=\"2\"/>"
+                        << " version=\"3\"/>"
                         << std::endl;
     }
 }
@@ -3107,8 +3126,21 @@ void PropertyMaterialList::SaveDocFile(Base::Writer& writer) const
         str << it.emissiveColor.getPackedValue();
         str << it.shininess;
         str << it.transparency;
-        // str << it.uuid.c_str();
     }
+
+    // Apply the latest changes last for backwards compatibility
+    for (const auto& it : _lValueList) {
+        writeString(str, it.image);
+        writeString(str, it.imagePath);
+        writeString(str, it.uuid);
+    }
+}
+
+void PropertyMaterialList::writeString(Base::OutputStream& str, const std::string &value) const
+{
+    uint32_t uCt = (uint32_t)value.size();
+    str << uCt;
+    str.write(value.c_str(), uCt);
 }
 
 void PropertyMaterialList::RestoreDocFile(Base::Reader& reader)
@@ -3120,11 +3152,20 @@ void PropertyMaterialList::RestoreDocFile(Base::Reader& reader)
         str >> count;
         RestoreDocFileV0(count, reader);
     }
+    else if (formatVersion == Version_3) {
+        // Default to the latest
+        RestoreDocFileV3(reader);
+    }
     else {
         int32_t version;
         str >> version;
         if (version < 0) {
-            RestoreDocFileV1(reader);
+            // This was a failed attempt at versioning, but is included
+            // to support files created during development. In can be removed
+            // in a future release once dev files are migrated.
+            uint32_t count = 0;
+            str >> count;
+            RestoreDocFileV0(count, reader);
         }
         else {
             uint32_t uCt = static_cast<uint32_t>(version);
@@ -3156,14 +3197,14 @@ void PropertyMaterialList::RestoreDocFileV0(uint32_t count, Base::Reader& reader
     setValues(values);
 }
 
-void PropertyMaterialList::RestoreDocFileV1(Base::Reader& reader)
+void PropertyMaterialList::RestoreDocFileV3(Base::Reader& reader)
 {
     Base::InputStream str(reader);
     uint32_t count = 0;
     str >> count;
     std::vector<Material> values(count);
-    uint32_t value {};  // must be 32 bit long
-    float valueF {};
+    uint32_t value;  // must be 32 bit long
+    float valueF;
     for (auto& it : values) {
         str >> value;
         it.ambientColor.setPackedValue(value);
@@ -3177,10 +3218,27 @@ void PropertyMaterialList::RestoreDocFileV1(Base::Reader& reader)
         it.shininess = valueF;
         str >> valueF;
         it.transparency = valueF;
-        // str >> valueS;
-        // it.uuid = valueS;
+    }
+    for (auto& it : values) {
+        readString(str, it.image);
+        readString(str, it.imagePath);
+        readString(str, it.uuid);
     }
     setValues(values);
+}
+
+void PropertyMaterialList::readString(Base::InputStream& str,
+                                                    std::string& value)
+{
+    uint32_t uCt;
+    str >> uCt;
+
+    char *temp = new char[uCt];
+
+    str.read(temp, uCt);
+    value.assign(temp, static_cast<std::size_t>(uCt));
+
+    delete [] temp;
 }
 
 const char* PropertyMaterialList::getEditorName() const

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -38,6 +38,8 @@
 
 
 namespace Base {
+class InputStream;
+class OutputStream;
 class Writer;
 }
 
@@ -1132,6 +1134,7 @@ public:
     void setDiffuseColor(int index, const Color& col);
     void setDiffuseColor(int index, float r, float g, float b, float a = 0.0F);
     void setDiffuseColor(int index, uint32_t rgba);
+    void setDiffuseColors(const std::vector<App::Color>& colors);
 
     void setSpecularColor(const Color& col);
     void setSpecularColor(float r, float g, float b, float a = 0.0F);
@@ -1193,14 +1196,18 @@ private:
     enum Format {
         Version_0,
         Version_1,
-        Version_2
+        Version_2,
+        Version_3
     };
 
     void RestoreDocFileV0(uint32_t count, Base::Reader& reader);
-    void RestoreDocFileV1(Base::Reader& reader);
+    void RestoreDocFileV3(Base::Reader& reader);
+
+    void writeString(Base::OutputStream& str, const std::string &value) const;
+    void readString(Base::InputStream& str, std::string& value);
 
     void verifyIndex(int index) const;
-    void setSizeOne();
+    void setMinimumSizeOne();
     int resizeByOneIfNeeded(int index);
 
     Format formatVersion {Version_0};

--- a/src/Base/Stream.cpp
+++ b/src/Base/Stream.cpp
@@ -150,6 +150,12 @@ OutputStream& OutputStream::operator<<(double d)
     return *this;
 }
 
+OutputStream& OutputStream::write(const char* s, int n)
+{
+    _out.write(s, n);
+    return *this;
+}
+
 InputStream::InputStream(std::istream& rin)
     : _in(rin)
 {}
@@ -243,6 +249,12 @@ InputStream& InputStream::operator>>(double& d)
     if (isSwapped()) {
         SwapEndian<double>(d);
     }
+    return *this;
+}
+
+InputStream& InputStream::read(char* s, int n)
+{
+    _in.read(s, n);
     return *this;
 }
 

--- a/src/Base/Stream.h
+++ b/src/Base/Stream.h
@@ -95,6 +95,8 @@ public:
     OutputStream& operator<<(float f);
     OutputStream& operator<<(double d);
 
+    OutputStream& write(const char* s, int n);
+
     OutputStream(const OutputStream&) = delete;
     OutputStream(OutputStream&&) = delete;
     void operator=(const OutputStream&) = delete;
@@ -125,6 +127,8 @@ public:
     InputStream& operator>>(uint64_t& ul);
     InputStream& operator>>(float& f);
     InputStream& operator>>(double& d);
+
+    InputStream& read(char* s, int n);
 
     explicit operator bool() const
     {

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -271,7 +271,7 @@ protected:
          std::make_pair(QT_TRANSLATE_NOOP("EditMode", "Color"),
                         QT_TRANSLATE_NOOP("EditMode",
                                           "The object will have the color of its individual faces "
-                                          "editable with the Part FaceColors command"))},
+                                          "editable with the Part FaceAppearances command"))},
     };
     int userEditMode = userEditModes.begin()->first;
 

--- a/src/Gui/DlgMaterialProperties.ui
+++ b/src/Gui/DlgMaterialProperties.ui
@@ -41,62 +41,6 @@
       <property name="spacing">
        <number>6</number>
       </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="textLabel2">
-        <property name="text">
-         <string>Ambient color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="Gui::ColorButton" name="ambientColor">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="textLabel1">
-        <property name="text">
-         <string>Diffuse color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="Gui::ColorButton" name="diffuseColor">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Emissive color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="Gui::ColorButton" name="emissiveColor">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="textLabel3">
-        <property name="text">
-         <string>Specular color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="Gui::ColorButton" name="specularColor">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
       <item row="4" column="0" colspan="2">
        <layout class="QHBoxLayout">
         <property name="spacing">
@@ -148,6 +92,76 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="textLabel1">
+        <property name="text">
+         <string>Diffuse color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::ColorButton" name="ambientColor">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::ColorButton" name="emissiveColor">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="textLabel3">
+        <property name="text">
+         <string>Specular color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::ColorButton" name="diffuseColor">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="textLabel2">
+        <property name="text">
+         <string>Ambient color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::ColorButton" name="specularColor">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Emissive color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QPushButton" name="buttonReset">
+        <property name="text">
+         <string>Reset</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QPushButton" name="buttonDefault">
+        <property name="text">
+         <string>Default</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/Gui/DlgMaterialPropertiesImp.cpp
+++ b/src/Gui/DlgMaterialPropertiesImp.cpp
@@ -22,8 +22,11 @@
 
 #include "PreCompiled.h"
 
+#include <App/Color.h>
+#include <App/Material.h>
 #include <App/PropertyStandard.h>
 
+#include "Application.h"
 #include "DlgMaterialPropertiesImp.h"
 #include "ui_DlgMaterialProperties.h"
 #include "ViewProvider.h"
@@ -46,11 +49,12 @@ DlgMaterialPropertiesImp::DlgMaterialPropertiesImp(const std::string& mat, QWidg
   : QDialog(parent, fl)
   , ui(new Ui_DlgMaterialProperties)
   , material(mat)
+  , updateColors(true)
 {
     ui->setupUi(this);
     setupConnections();
 
-    if (material != "ShapeMaterial") {
+    if (material != "ShapeAppearance") {
         ui->textLabel1->hide();
         ui->diffuseColor->hide();
     }
@@ -68,6 +72,8 @@ DlgMaterialPropertiesImp::~DlgMaterialPropertiesImp() = default;
 
 void DlgMaterialPropertiesImp::setupConnections()
 {
+    Base::Console().Log("DlgMaterialPropertiesImp::setupConnections()\n");
+
     connect(ui->ambientColor, &ColorButton::changed,
             this, &DlgMaterialPropertiesImp::onAmbientColorChanged);
     connect(ui->diffuseColor, &ColorButton::changed,
@@ -78,6 +84,10 @@ void DlgMaterialPropertiesImp::setupConnections()
             this, &DlgMaterialPropertiesImp::onSpecularColorChanged);
     connect(ui->shininess, qOverload<int>(&QSpinBox::valueChanged),
             this, &DlgMaterialPropertiesImp::onShininessValueChanged);
+    connect(ui->buttonReset, &QPushButton::clicked,
+            this, &DlgMaterialPropertiesImp::onButtonReset);
+    connect(ui->buttonDefault, &QPushButton::clicked,
+            this, &DlgMaterialPropertiesImp::onButtonDefault);
 }
 
 QColor DlgMaterialPropertiesImp::diffuseColor() const
@@ -85,24 +95,54 @@ QColor DlgMaterialPropertiesImp::diffuseColor() const
     return ui->diffuseColor->color();
 }
 
+App::Material DlgMaterialPropertiesImp::getMaterial()
+{
+    for (std::vector<ViewProvider*>::iterator it = Objects.begin(); it != Objects.end(); ++it) {
+        App::Property* prop = (*it)->getPropertyByName(material.c_str());
+        if (prop && prop->isDerivedFrom<App::PropertyMaterialList>()) {
+            auto ShapeAppearance = static_cast<App::PropertyMaterialList*>(prop);
+            auto& materials = ShapeAppearance->getValues();
+            auto mat = materials[0];
+
+            mat.setType(App::Material::USER_DEFINED);
+
+            // Reset any texture data
+            mat.image = "";
+            mat.imagePath = "";
+            mat.uuid = "";
+
+            return mat;
+        }
+    }
+
+    return App::Material::getDefaultAppearance();
+}
+
+App::Color DlgMaterialPropertiesImp::getColor(const QColor& color) const
+{
+    float r = (float)color.red() / 255.0F;
+    float g = (float)color.green() / 255.0F;
+    float b = (float)color.blue() / 255.0F;
+
+    return App::Color(r, g, b);
+}
+
 /**
  * Sets the ambient color.
  */
 void DlgMaterialPropertiesImp::onAmbientColorChanged()
 {
-    QColor col = ui->ambientColor->color();
-    float r = (float)col.red() / 255.0f;
-    float g = (float)col.green() / 255.0f;
-    float b = (float)col.blue() / 255.0f;
-    App::Color ambient(r, g, b);
+    if (updateColors) {
+        App::Color ambient = getColor(ui->ambientColor->color());
 
-    for (std::vector<ViewProvider*>::iterator it= Objects.begin(); it != Objects.end(); ++it) {
-        App::Property* prop = (*it)->getPropertyByName(material.c_str());
-        if (prop && prop->isDerivedFrom<App::PropertyMaterial>()) {
-            auto ShapeMaterial = static_cast<App::PropertyMaterial*>(prop);
-            App::Material mat = ShapeMaterial->getValue();
-            mat.ambientColor = ambient;
-            ShapeMaterial->setValue(mat);
+        for (std::vector<ViewProvider*>::iterator it= Objects.begin(); it != Objects.end(); ++it) {
+            App::Property* prop = (*it)->getPropertyByName(material.c_str());
+            if (prop && prop->isDerivedFrom<App::PropertyMaterialList>()) {
+                auto ShapeAppearance = static_cast<App::PropertyMaterialList*>(prop);
+                auto mat = getMaterial();
+                mat.ambientColor = ambient;
+                ShapeAppearance->setValue(mat);
+            }
         }
     }
 }
@@ -112,19 +152,17 @@ void DlgMaterialPropertiesImp::onAmbientColorChanged()
  */
 void DlgMaterialPropertiesImp::onDiffuseColorChanged()
 {
-    QColor col = ui->diffuseColor->color();
-    float r = (float)col.red() / 255.0f;
-    float g = (float)col.green() / 255.0f;
-    float b = (float)col.blue() / 255.0f;
-    App::Color diffuse(r, g, b);
+    if (updateColors) {
+        App::Color diffuse = getColor(ui->diffuseColor->color());
 
-    for (std::vector<ViewProvider*>::iterator it = Objects.begin(); it != Objects.end(); ++it) {
-        App::Property* prop = (*it)->getPropertyByName(material.c_str());
-        if (prop && prop->isDerivedFrom<App::PropertyMaterial>()) {
-            auto ShapeMaterial = static_cast<App::PropertyMaterial*>(prop);
-            App::Material mat = ShapeMaterial->getValue();
-            mat.diffuseColor = diffuse;
-            ShapeMaterial->setValue(mat);
+        for (std::vector<ViewProvider*>::iterator it = Objects.begin(); it != Objects.end(); ++it) {
+            App::Property* prop = (*it)->getPropertyByName(material.c_str());
+            if (prop && prop->isDerivedFrom<App::PropertyMaterialList>()) {
+                auto ShapeAppearance = static_cast<App::PropertyMaterialList*>(prop);
+                auto mat = getMaterial();
+                mat.diffuseColor = diffuse;
+                ShapeAppearance->setValue(mat);
+            }
         }
     }
 }
@@ -134,19 +172,17 @@ void DlgMaterialPropertiesImp::onDiffuseColorChanged()
  */
 void DlgMaterialPropertiesImp::onEmissiveColorChanged()
 {
-    QColor col = ui->emissiveColor->color();
-    float r = (float)col.red() / 255.0f;
-    float g = (float)col.green() / 255.0f;
-    float b = (float)col.blue() / 255.0f;
-    App::Color emissive(r, g, b);
+    if (updateColors) {
+        App::Color emissive = getColor(ui->emissiveColor->color());
 
-    for (std::vector<ViewProvider*>::iterator it = Objects.begin(); it != Objects.end(); ++it) {
-        App::Property* prop = (*it)->getPropertyByName(material.c_str());
-        if (prop && prop->isDerivedFrom<App::PropertyMaterial>()) {
-            auto ShapeMaterial = static_cast<App::PropertyMaterial*>(prop);
-            App::Material mat = ShapeMaterial->getValue();
-            mat.emissiveColor = emissive;
-            ShapeMaterial->setValue(mat);
+        for (std::vector<ViewProvider*>::iterator it = Objects.begin(); it != Objects.end(); ++it) {
+            App::Property* prop = (*it)->getPropertyByName(material.c_str());
+            if (prop && prop->isDerivedFrom<App::PropertyMaterialList>()) {
+                auto ShapeAppearance = static_cast<App::PropertyMaterialList*>(prop);
+                auto mat = getMaterial();
+                mat.emissiveColor = emissive;
+                ShapeAppearance->setValue(mat);
+            }
         }
     }
 }
@@ -156,19 +192,17 @@ void DlgMaterialPropertiesImp::onEmissiveColorChanged()
  */
 void DlgMaterialPropertiesImp::onSpecularColorChanged()
 {
-    QColor col = ui->specularColor->color();
-    float r = (float)col.red() / 255.0f;
-    float g = (float)col.green() / 255.0f;
-    float b = (float)col.blue() / 255.0f;
-    App::Color specular(r, g, b);
+    if (updateColors) {
+        App::Color specular = getColor(ui->specularColor->color());
 
-    for (std::vector<ViewProvider*>::iterator it = Objects.begin(); it != Objects.end(); ++it) {
-        App::Property* prop = (*it)->getPropertyByName(material.c_str());
-        if (prop && prop->isDerivedFrom<App::PropertyMaterial>()) {
-            auto ShapeMaterial = static_cast<App::PropertyMaterial*>(prop);
-            App::Material mat = ShapeMaterial->getValue();
-            mat.specularColor = specular;
-            ShapeMaterial->setValue(mat);
+        for (std::vector<ViewProvider*>::iterator it = Objects.begin(); it != Objects.end(); ++it) {
+            App::Property* prop = (*it)->getPropertyByName(material.c_str());
+            if (prop && prop->isDerivedFrom<App::PropertyMaterialList>()) {
+                auto ShapeAppearance = static_cast<App::PropertyMaterialList*>(prop);
+                auto mat = getMaterial();
+                mat.specularColor = specular;
+                ShapeAppearance->setValue(mat);
+            }
         }
     }
 }
@@ -178,14 +212,63 @@ void DlgMaterialPropertiesImp::onSpecularColorChanged()
  */
 void DlgMaterialPropertiesImp::onShininessValueChanged(int sh)
 {
-    float shininess = (float)sh / 100.0f;
+    if (updateColors) {
+        float shininess = (float)sh / 100.0F;
+        for (std::vector<ViewProvider*>::iterator it = Objects.begin(); it != Objects.end(); ++it) {
+            App::Property* prop = (*it)->getPropertyByName(material.c_str());
+            if (prop && prop->isDerivedFrom<App::PropertyMaterialList>()) {
+                auto ShapeAppearance = static_cast<App::PropertyMaterialList*>(prop);
+                auto mat = getMaterial();
+                mat.shininess = shininess;
+                ShapeAppearance->setValue(mat);
+            }
+        }
+    }
+}
+
+/**
+ * Reset the colors to the Coin3D defaults
+ */
+void DlgMaterialPropertiesImp::onButtonReset(bool checked)
+{
     for (std::vector<ViewProvider*>::iterator it = Objects.begin(); it != Objects.end(); ++it) {
         App::Property* prop = (*it)->getPropertyByName(material.c_str());
-        if (prop && prop->isDerivedFrom<App::PropertyMaterial>()) {
-            auto ShapeMaterial = static_cast<App::PropertyMaterial*>(prop);
-            App::Material mat = ShapeMaterial->getValue();
-            mat.shininess = shininess;
-            ShapeMaterial->setValue(mat);
+        if (prop && prop->isDerivedFrom<App::PropertyMaterialList>()) {
+            auto ShapeAppearance = static_cast<App::PropertyMaterialList*>(prop);
+            auto mat = getMaterial();
+
+            App::Color defaultAmbient(0.2, 0.2, 0.2);
+            App::Color defaultDiffuse(0.8, 0.8, 0.8);
+            App::Color black(0, 0, 0);
+
+            mat.ambientColor = defaultAmbient;
+            mat.diffuseColor = defaultDiffuse;
+            mat.emissiveColor = black;
+            mat.specularColor = black;
+            mat.shininess = 0.2;
+            ShapeAppearance->setValue(mat);
+
+            setButtonColors();
+            break;
+        }
+    }
+}
+
+/**
+ * Reset the colors to the current default
+ */
+void DlgMaterialPropertiesImp::onButtonDefault(bool checked)
+{
+    for (std::vector<ViewProvider*>::iterator it = Objects.begin(); it != Objects.end(); ++it) {
+        App::Property* prop = (*it)->getPropertyByName(material.c_str());
+        if (prop && prop->isDerivedFrom<App::PropertyMaterialList>()) {
+            auto ShapeAppearance = static_cast<App::PropertyMaterialList*>(prop);
+            auto mat = App::Material::getDefaultAppearance();
+
+            ShapeAppearance->setValue(mat);
+
+            setButtonColors();
+            break;
         }
     }
 }
@@ -197,33 +280,82 @@ void DlgMaterialPropertiesImp::setViewProviders(const std::vector<Gui::ViewProvi
 {
     Objects = Obj;
 
+    setButtonColors();
+}
+
+/**
+ * Sets the button colors to match the current material settings.
+ */
+void DlgMaterialPropertiesImp::setButtonColors()
+{
     for (std::vector<ViewProvider*>::iterator it = Objects.begin(); it != Objects.end(); ++it) {
         App::Property* prop = (*it)->getPropertyByName(material.c_str());
-        if (prop && prop->isDerivedFrom<App::PropertyMaterial>()) {
-            auto ShapeMaterial = static_cast<App::PropertyMaterial*>(prop);
-            App::Material mat = ShapeMaterial->getValue();
-            int r = int(mat.ambientColor.r * 255.0f);
-            int g = int(mat.ambientColor.g * 255.0f);
-            int b = int(mat.ambientColor.b * 255.0f);
+        if (prop && prop->isDerivedFrom<App::PropertyMaterialList>()) {
+            auto ShapeAppearance = static_cast<App::PropertyMaterialList*>(prop);
+            auto& materials = ShapeAppearance->getValues();
+            auto& mat = materials[0];
+            int r = int(mat.ambientColor.r * 255.0F);
+            int g = int(mat.ambientColor.g * 255.0F);
+            int b = int(mat.ambientColor.b * 255.0F);
             ui->ambientColor->setColor(QColor(r, g, b));
-            r = int(mat.diffuseColor.r * 255.0f);
-            g = int(mat.diffuseColor.g * 255.0f);
-            b = int(mat.diffuseColor.b * 255.0f);
+            r = int(mat.diffuseColor.r * 255.0F);
+            g = int(mat.diffuseColor.g * 255.0F);
+            b = int(mat.diffuseColor.b * 255.0F);
             ui->diffuseColor->setColor(QColor(r, g, b));
-            r = int(mat.emissiveColor.r * 255.0f);
-            g = int(mat.emissiveColor.g * 255.0f);
-            b = int(mat.emissiveColor.b * 255.0f);
+            r = int(mat.emissiveColor.r * 255.0F);
+            g = int(mat.emissiveColor.g * 255.0F);
+            b = int(mat.emissiveColor.b * 255.0F);
             ui->emissiveColor->setColor(QColor(r, g, b));
-            r = int(mat.specularColor.r * 255.0f);
-            g = int(mat.specularColor.g * 255.0f);
-            b = int(mat.specularColor.b * 255.0f);
+            r = int(mat.specularColor.r * 255.0F);
+            g = int(mat.specularColor.g * 255.0F);
+            b = int(mat.specularColor.b * 255.0F);
             ui->specularColor->setColor(QColor(r, g, b));
             ui->shininess->blockSignals(true);
-            ui->shininess->setValue((int)(100.0f * (mat.shininess + 0.001f)));
+            ui->shininess->setValue((int)(100.0f * (mat.shininess + 0.001F)));
             ui->shininess->blockSignals(false);
             break;
         }
     }
+}
+
+/**
+ *  Constructs a Gui::Dialog::DlgFaceMaterialPropertiesImp as a child of 'parent', with the
+ *  name 'name' and widget flags set to 'f'.
+ *
+ *  The dialog will by default be modeless, unless you set 'modal' to
+ *  true to construct a modal dialog.
+ *
+ *  This differs from Gui::Dialog::DlgMaterialPropertiesImp in that it does not update
+ *  the underlying object. This is undesirable when we're updating only a single face.
+ */
+DlgFaceMaterialPropertiesImp::DlgFaceMaterialPropertiesImp(const std::string& mat,
+                                                           QWidget* parent,
+                                                           Qt::WindowFlags fl)
+    : DlgMaterialPropertiesImp(mat, parent, fl)
+{
+    Base::Console().Log("DlgFaceMaterialPropertiesImp::DlgFaceMaterialPropertiesImp()\n");
+
+    // Override the base class on this. Otherwise the whole object changes
+    updateColors = false;
+}
+
+/**
+ *  Destroys the object and frees any allocated resources
+ */
+DlgFaceMaterialPropertiesImp::~DlgFaceMaterialPropertiesImp() = default;
+
+App::Material DlgFaceMaterialPropertiesImp::getCustomAppearance() const
+{
+    App::Material material;
+    material.setType(App::Material::USER_DEFINED);
+
+    material.ambientColor = getColor(ui->ambientColor->color());
+    material.diffuseColor = getColor(ui->diffuseColor->color());
+    material.emissiveColor = getColor(ui->emissiveColor->color());
+    material.specularColor = getColor(ui->specularColor->color());
+    material.shininess = (float)ui->shininess->value() / 100.0F;
+
+    return material;
 }
 
 #include "moc_DlgMaterialPropertiesImp.cpp"

--- a/src/Gui/DlgMaterialPropertiesImp.h
+++ b/src/Gui/DlgMaterialPropertiesImp.h
@@ -28,6 +28,12 @@
 #include <memory>
 #include <vector>
 
+namespace App
+{
+class Color;
+class Material;
+}
+
 namespace Gui
 {
 class ViewProvider;
@@ -48,18 +54,36 @@ public:
     void setViewProviders(const std::vector<Gui::ViewProvider*>&);
     QColor diffuseColor() const;
 
-private:
+protected:
     void setupConnections();
+    App::Material getMaterial();
+    App::Color getColor(const QColor& color) const;
     void onAmbientColorChanged();
     void onDiffuseColorChanged();
     void onEmissiveColorChanged();
     void onSpecularColorChanged();
     void onShininessValueChanged(int);
+    void onButtonReset(bool checked);
+    void onButtonDefault(bool checked);
+    void setButtonColors();
 
-private:
+protected:
     std::unique_ptr<Ui_DlgMaterialProperties> ui;
     std::string material;
     std::vector<Gui::ViewProvider*> Objects;
+    bool updateColors;
+};
+
+class GuiExport DlgFaceMaterialPropertiesImp: public DlgMaterialPropertiesImp
+{
+    Q_OBJECT
+
+public:
+    explicit DlgFaceMaterialPropertiesImp(const std::string& mat,
+                                          QWidget* parent = nullptr,
+                                          Qt::WindowFlags fl = Qt::WindowFlags());
+    ~DlgFaceMaterialPropertiesImp() override;
+    App::Material getCustomAppearance() const;
 };
 
 }  // namespace Dialog

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -23,7 +23,6 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-#include <random>
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/actions/SoSearchAction.h>
@@ -35,12 +34,14 @@
 #include <Inventor/nodes/SoMaterial.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoSwitch.h>
+#include <Inventor/nodes/SoTexture2.h>
 #endif
 
 #include <Inventor/nodes/SoResetTransform.h>
 
 #include <App/GeoFeature.h>
 #include <App/PropertyGeo.h>
+#include <Gui/BitmapFactory.h>
 
 #include "Application.h"
 #include "Document.h"
@@ -56,12 +57,12 @@ using namespace Gui;
 namespace {
 float fromPercent(long value)
 {
-    return static_cast<float>(value) / 100.0F;
+    return std::roundf(value) / 100.0F;
 }
 
 long toPercent(float value)
 {
-    return static_cast<long>(100.0 * value + 0.5);
+    return std::lround(100.0 * value);
 }
 }
 
@@ -71,7 +72,7 @@ const App::PropertyIntegerConstraint::Constraints intPercent = {0, 100, 5};
 
 ViewProviderGeometryObject::ViewProviderGeometryObject()
 {
-    App::Material mat = getUserDefinedMaterial();
+    App::Material mat = App::Material::getDefaultAppearance();
     long initialTransparency = toPercent(mat.transparency);
 
     static const char* dogroup = "Display Options";
@@ -95,9 +96,28 @@ ViewProviderGeometryObject::ViewProviderGeometryObject()
 
     Selectable.setValue(isSelectionEnabled());
 
+    pcSwitchAppearance = new SoSwitch;
+    pcSwitchAppearance->ref();
+    pcSwitchTexture = new SoSwitch;
+    pcSwitchTexture->ref();
+
     pcShapeMaterial = new SoMaterial;
-    setSoMaterial(mat);
+    setCoinAppearance(mat);
     pcShapeMaterial->ref();
+
+    pcShapeTexture2D = new SoTexture2;
+    pcShapeTexture2D->ref();
+
+    pcTextureGroup3D = new SoGroup;
+    pcTextureGroup3D->ref();
+
+    // Materials go first, with textured faces drawing over them
+    pcSwitchAppearance->addChild(pcShapeMaterial);
+    pcSwitchAppearance->addChild(pcSwitchTexture);
+    pcSwitchTexture->addChild(pcShapeTexture2D);
+    pcSwitchTexture->addChild(pcTextureGroup3D);
+    pcSwitchAppearance->whichChild.setValue(0);
+    pcSwitchTexture->whichChild.setValue(SO_SWITCH_NONE);
 
     pcBoundingBox = new Gui::SoFCBoundingBox;
     pcBoundingBox->ref();
@@ -110,52 +130,13 @@ ViewProviderGeometryObject::ViewProviderGeometryObject()
 
 ViewProviderGeometryObject::~ViewProviderGeometryObject()
 {
+    pcSwitchAppearance->unref();
+    pcSwitchTexture->unref();
     pcShapeMaterial->unref();
+    pcShapeTexture2D->unref();
+    pcTextureGroup3D->unref();
     pcBoundingBox->unref();
     pcBoundColor->unref();
-}
-
-App::Material ViewProviderGeometryObject::getUserDefinedMaterial()
-{
-    ParameterGrp::handle hGrp =
-        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-
-    auto getColor = [hGrp](const char* parameter, App::Color& color) {
-        uint32_t packed = color.getPackedRGB();
-        packed = hGrp->GetUnsigned(parameter, packed);
-        color.setPackedRGB(packed);
-    };
-    auto intRandom = [] (int min, int max) -> int {
-        static std::mt19937 generator;
-        std::uniform_int_distribution<int> distribution(min, max);
-        return distribution(generator);
-    };
-
-    App::Material mat(App::Material::DEFAULT);
-    mat.transparency = fromPercent(hGrp->GetInt("DefaultShapeTransparency", 0));
-    long shininess = toPercent(mat.shininess);
-    mat.shininess = fromPercent(hGrp->GetInt("DefaultShapeShininess", shininess));
-
-    // This is handled in the material code when using the object appearance
-    bool randomColor = hGrp->GetBool("RandomColor", false);
-
-    // diffuse color
-    if (randomColor) {
-        float red = static_cast<float>(intRandom(0, 255)) / 255.0F;
-        float green = static_cast<float>(intRandom(0, 255)) / 255.0F;
-        float blue = static_cast<float>(intRandom(0, 255)) / 255.0F;
-        mat.diffuseColor = App::Color(red, green, blue);
-    }
-    else {
-        // Color = (204, 204, 230) = 3435980543UL
-        getColor("DefaultShapeColor", mat.diffuseColor);
-    }
-
-    getColor("DefaultAmbientColor", mat.ambientColor);
-    getColor("DefaultEmissiveColor", mat.emissiveColor);
-    getColor("DefaultSpecularColor", mat.specularColor);
-
-    return mat;
 }
 
 bool ViewProviderGeometryObject::isSelectionEnabled() const
@@ -187,12 +168,14 @@ void ViewProviderGeometryObject::onChanged(const App::Property* prop)
         if (getObject() && getObject()->testStatus(App::ObjectStatus::TouchOnColorChange)) {
             getObject()->touch(true);
         }
-        const App::Material& Mat = ShapeAppearance[0];
         long value = toPercent(ShapeAppearance.getTransparency());
         if (value != Transparency.getValue()) {
             Transparency.setValue(value);
         }
-        setSoMaterial(Mat);
+        if (ShapeAppearance.getSize() == 1) {
+            const App::Material& Mat = ShapeAppearance[0];
+            setCoinAppearance(Mat);
+        }
     }
     else if (prop == &BoundingBox) {
         showBoundingBox(BoundingBox.getValue());
@@ -288,14 +271,33 @@ unsigned long ViewProviderGeometryObject::getBoundColor() const
     return bbcol;
 }
 
-void ViewProviderGeometryObject::setSoMaterial(const App::Material& source)
+void ViewProviderGeometryObject::setCoinAppearance(const App::Material& source)
 {
+#if 0
+    if (!source.image.empty()) {
+        Base::Console().Log("setCoinAppearance(Texture)\n");
+        activateTexture2D();
+
+        QByteArray by = QByteArray::fromBase64(QString::fromStdString(source.image).toUtf8());
+        auto image = QImage::fromData(by, "PNG");  //.scaled(64, 64, Qt::KeepAspectRatio);
+
+        SoSFImage texture;
+        Gui::BitmapFactory().convert(image, texture);
+        pcShapeTexture2D->image = texture;
+    } else {
+        Base::Console().Log("setCoinAppearance(Material)\n");
+        activateMaterial();
+    }
+#endif
+    activateMaterial();
+
+    // Always set the material for items such as lines that don't support textures
     pcShapeMaterial->ambientColor.setValue(source.ambientColor.r,
-                                           source.ambientColor.g,
-                                           source.ambientColor.b);
+                                        source.ambientColor.g,
+                                        source.ambientColor.b);
     pcShapeMaterial->diffuseColor.setValue(source.diffuseColor.r,
-                                           source.diffuseColor.g,
-                                           source.diffuseColor.b);
+                                        source.diffuseColor.g,
+                                        source.diffuseColor.b);
     pcShapeMaterial->specularColor.setValue(source.specularColor.r,
                                             source.specularColor.g,
                                             source.specularColor.b);
@@ -305,6 +307,31 @@ void ViewProviderGeometryObject::setSoMaterial(const App::Material& source)
     pcShapeMaterial->shininess.setValue(source.shininess);
     pcShapeMaterial->transparency.setValue(source.transparency);
 }
+
+void ViewProviderGeometryObject::activateMaterial()
+{
+    pcSwitchAppearance->whichChild.setValue(0);
+    pcSwitchTexture->whichChild.setValue(SO_SWITCH_NONE);
+}
+
+void ViewProviderGeometryObject::activateTexture2D()
+{
+    pcSwitchAppearance->whichChild.setValue(1);
+    pcSwitchTexture->whichChild.setValue(0);
+}
+
+void ViewProviderGeometryObject::activateTexture3D()
+{
+    pcSwitchAppearance->whichChild.setValue(1);
+    pcSwitchTexture->whichChild.setValue(1);
+}
+
+void ViewProviderGeometryObject::activateMixed3D()
+{
+    pcSwitchAppearance->whichChild.setValue(SO_SWITCH_ALL);
+    pcSwitchTexture->whichChild.setValue(1);
+}
+
 
 namespace
 {

--- a/src/Gui/ViewProviderGeometryObject.h
+++ b/src/Gui/ViewProviderGeometryObject.h
@@ -30,6 +30,7 @@
 class SoPickedPointList;
 class SoSwitch;
 class SoSensor;
+class SoTexture2;
 class SbVec2s;
 class SoBaseColor;
 
@@ -58,7 +59,6 @@ public:
 
     // Display properties
     App::PropertyPercent Transparency;
-    // App::PropertyMaterial ShapeMaterial;        // Default appearance and physical properties
     App::PropertyMaterialList ShapeAppearance;  // May be different from material
     App::PropertyBool BoundingBox;
     App::PropertyBool Selectable;
@@ -108,13 +108,30 @@ protected:
     void handleChangedPropertyName(Base::XMLReader& reader,
                                    const char* TypeName,
                                    const char* PropName) override;
+    void setCoinAppearance(const App::Material& source);
+
+    /**
+     * Select which appearance type is active
+     * 
+     */
+    /** Material only */
+    void activateMaterial();
+    /** 2D Texture */
+    void activateTexture2D();
+    /** 3D texture only */
+    void activateTexture3D();
+    /** Mix of material and 3D textures */
+    void activateMixed3D();
 
 private:
-    void setSoMaterial(const App::Material& source);
     bool isSelectionEnabled() const;
 
 protected:
+    SoSwitch* pcSwitchAppearance {nullptr};
+    SoSwitch* pcSwitchTexture {nullptr};
     SoMaterial* pcShapeMaterial {nullptr};
+    SoTexture2* pcShapeTexture2D {nullptr};
+    SoGroup* pcTextureGroup3D {nullptr};
     SoFCBoundingBox* pcBoundingBox {nullptr};
     SoSwitch* pcBoundSwitch {nullptr};
     SoBaseColor* pcBoundColor {nullptr};

--- a/src/Gui/ViewProviderGeometryObjectPyImp.cpp
+++ b/src/Gui/ViewProviderGeometryObjectPyImp.cpp
@@ -71,7 +71,7 @@ PyObject* ViewProviderGeometryObjectPy::getCustomAttributes(const char* attr) co
 
 PyObject* ViewProviderGeometryObjectPy::getUserDefinedMaterial()
 {
-    App::Material mat = ViewProviderGeometryObject::getUserDefinedMaterial();
+    App::Material mat = App::Material::getDefaultAppearance();
     return new App::MaterialPy(new App::Material(mat));
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.cpp
@@ -94,7 +94,7 @@ void ViewProviderFemConstraintOnBoundary::highlightReferences(const bool on)
             else if (subSet.second[0].find("Face") != std::string::npos) {
                 // make sure original colors are remembered
                 if (originalFaceColors[base].empty()) {
-                    originalFaceColors[base] = vp->DiffuseColor.getValues();
+                    originalFaceColors[base] = vp->ShapeAppearance.getDiffuseColors();
                 }
                 std::vector<App::Color> colors = originalFaceColors[base];
 
@@ -104,7 +104,7 @@ void ViewProviderFemConstraintOnBoundary::highlightReferences(const bool on)
                     base->Shape.getValue(),
                     colors.empty() ? ShapeAppearance.getDiffuseColor() : colors[0]);
                 highlighter.getFaceColors(subSet.second, colors);
-                vp->DiffuseColor.setValues(colors);
+                vp->ShapeAppearance.setDiffuseColors(colors);
             }
         }
         else {
@@ -117,7 +117,7 @@ void ViewProviderFemConstraintOnBoundary::highlightReferences(const bool on)
                 originalLineColors[base].clear();
             }
             else if (!originalFaceColors[base].empty()) {
-                vp->DiffuseColor.setValues(originalFaceColors[base]);
+                vp->ShapeAppearance.setDiffuseColors(originalFaceColors[base]);
                 originalFaceColors[base].clear();
             }
         }
@@ -164,7 +164,7 @@ void ViewProviderFemConstraintOnBoundary::highlightReferences(const bool on)
                 continue;
             }
 
-            vp->DiffuseColor.setValues(ogPair.second);
+            vp->ShapeAppearance.setDiffuseColors(ogPair.second);
             ogPair.second.clear();
         }
     }

--- a/src/Mod/Import/Gui/ExportOCAFGui.cpp
+++ b/src/Mod/Import/Gui/ExportOCAFGui.cpp
@@ -39,10 +39,6 @@ void ExportOCAFGui::findColors(Part::Feature* part, std::vector<App::Color>& col
 {
     Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider(part);
     if (vp && vp->isDerivedFrom(PartGui::ViewProviderPartExt::getClassTypeId())) {
-        colors = static_cast<PartGui::ViewProviderPartExt*>(vp)->DiffuseColor.getValues();
-        if (colors.empty()) {
-            colors.push_back(
-                static_cast<PartGui::ViewProviderPart*>(vp)->ShapeAppearance.getDiffuseColor());
-        }
+        colors = static_cast<PartGui::ViewProviderPartExt*>(vp)->ShapeAppearance.getDiffuseColors();
     }
 }

--- a/src/Mod/Import/Gui/ImportOCAFGui.cpp
+++ b/src/Mod/Import/Gui/ImportOCAFGui.cpp
@@ -54,7 +54,7 @@ void ImportOCAFGui::applyFaceColors(Part::Feature* part, const std::vector<App::
         vp->Transparency.setValue(100 * colors.front().a);
     }
     else {
-        vp->DiffuseColor.setValues(colors);
+        vp->ShapeAppearance.setDiffuseColors(colors);
     }
 }
 

--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -333,6 +333,11 @@ void MaterialProperty::setString(const QString& value)
     _valuePtr->setValue(QVariant(value));
 }
 
+void MaterialProperty::setString(const std::string& value)
+{
+    _valuePtr->setValue(QVariant(QString::fromStdString(value)));
+}
+
 void MaterialProperty::setBoolean(bool value)
 {
     _valuePtr->setValue(QVariant(value));
@@ -1545,13 +1550,21 @@ Material& Material::operator=(const App::Material& other)
         addAppearance(ModelUUIDs::ModelUUID_Rendering_Basic);
     }
 
-    getAppearanceProperty(QString::fromLatin1("AmbientColor"))->setColor(other.ambientColor);
-    getAppearanceProperty(QString::fromLatin1("DiffuseColor"))->setColor(other.diffuseColor);
-    getAppearanceProperty(QString::fromLatin1("SpecularColor"))->setColor(other.specularColor);
-    getAppearanceProperty(QString::fromLatin1("EmissiveColor"))->setColor(other.emissiveColor);
-    getAppearanceProperty(QString::fromLatin1("Shininess"))->setFloat(other.shininess);
-    getAppearanceProperty(QString::fromLatin1("Transparency"))->setFloat(other.transparency);
-    // std::string uuid;
+    getAppearanceProperty(QLatin1String("AmbientColor"))->setColor(other.ambientColor);
+    getAppearanceProperty(QLatin1String("DiffuseColor"))->setColor(other.diffuseColor);
+    getAppearanceProperty(QLatin1String("SpecularColor"))->setColor(other.specularColor);
+    getAppearanceProperty(QLatin1String("EmissiveColor"))->setColor(other.emissiveColor);
+    getAppearanceProperty(QLatin1String("Shininess"))->setFloat(other.shininess);
+    getAppearanceProperty(QLatin1String("Transparency"))->setFloat(other.transparency);
+
+    if (!other.image.empty() || !other.imagePath.empty()) {
+        if (!hasAppearanceModel(ModelUUIDs::ModelUUID_Rendering_Texture)) {
+            addAppearance(ModelUUIDs::ModelUUID_Rendering_Texture);
+        }
+
+        getAppearanceProperty(QLatin1String("TextureImage"))->setString(other.image);
+        getAppearanceProperty(QLatin1String("TexturePath"))->setString(other.imagePath);
+    }
 
     return *this;
 }
@@ -1641,33 +1654,46 @@ App::Material Material::getMaterialAppearance() const
     App::Material material(App::Material::DEFAULT);
 
     bool custom = false;
-    if (hasAppearanceProperty(QString::fromLatin1("AmbientColor"))) {
-        material.ambientColor =
-            getAppearanceProperty(QString::fromLatin1("AmbientColor"))->getColor();
+    if (hasAppearanceProperty(QLatin1String("AmbientColor"))) {
+        material.ambientColor = getAppearanceProperty(QLatin1String("AmbientColor"))->getColor();
         custom = true;
     }
-    if (hasAppearanceProperty(QString::fromLatin1("DiffuseColor"))) {
-        material.diffuseColor =
-            getAppearanceProperty(QString::fromLatin1("DiffuseColor"))->getColor();
+    if (hasAppearanceProperty(QLatin1String("DiffuseColor"))) {
+        material.diffuseColor = getAppearanceProperty(QLatin1String("DiffuseColor"))->getColor();
         custom = true;
     }
-    if (hasAppearanceProperty(QString::fromLatin1("SpecularColor"))) {
-        material.specularColor =
-            getAppearanceProperty(QString::fromLatin1("SpecularColor"))->getColor();
+    if (hasAppearanceProperty(QLatin1String("SpecularColor"))) {
+        material.specularColor = getAppearanceProperty(QLatin1String("SpecularColor"))->getColor();
         custom = true;
     }
-    if (hasAppearanceProperty(QString::fromLatin1("EmissiveColor"))) {
-        material.emissiveColor =
-            getAppearanceProperty(QString::fromLatin1("EmissiveColor"))->getColor();
+    if (hasAppearanceProperty(QLatin1String("EmissiveColor"))) {
+        material.emissiveColor = getAppearanceProperty(QLatin1String("EmissiveColor"))->getColor();
         custom = true;
     }
-    if (hasAppearanceProperty(QString::fromLatin1("Shininess"))) {
-        material.shininess = getAppearanceProperty(QString::fromLatin1("Shininess"))->getFloat();
+    if (hasAppearanceProperty(QLatin1String("Shininess"))) {
+        material.shininess = getAppearanceProperty(QLatin1String("Shininess"))->getFloat();
         custom = true;
     }
-    if (hasAppearanceProperty(QString::fromLatin1("Transparency"))) {
-        material.transparency =
-            getAppearanceProperty(QString::fromLatin1("Transparency"))->getFloat();
+    if (hasAppearanceProperty(QLatin1String("Transparency"))) {
+        material.transparency = getAppearanceProperty(QLatin1String("Transparency"))->getFloat();
+        custom = true;
+    }
+    if (hasAppearanceProperty(QLatin1String("TextureImage"))) {
+        auto property = getAppearanceProperty(QLatin1String("TextureImage"));
+        if (!property->isNull()) {
+            Base::Console().Log("Has 'TextureImage'\n");
+            material.image = property->getString().toStdString();
+        }
+
+        custom = true;
+    }
+    else if (hasAppearanceProperty(QLatin1String("TexturePath"))) {
+        auto property = getAppearanceProperty(QLatin1String("TexturePath"));
+        if (!property->isNull()) {
+            Base::Console().Log("Has 'TexturePath'\n");
+            material.imagePath = property->getString().toStdString();
+        }
+
         custom = true;
     }
 

--- a/src/Mod/Material/App/Materials.h
+++ b/src/Mod/Material/App/Materials.h
@@ -116,6 +116,7 @@ public:
     void setValue(const QString& value);
     void setValue(const std::shared_ptr<MaterialValue>& value);
     void setString(const QString& value);
+    void setString(const std::string& value);
     void setBoolean(bool value);
     void setBoolean(int value);
     void setBoolean(const QString& value);

--- a/src/Mod/Material/Gui/AppearancePreview.h
+++ b/src/Mod/Material/Gui/AppearancePreview.h
@@ -26,7 +26,11 @@
 #include <Gui/View3DInventorViewer.h>
 #include <Gui/View3DSettings.h>
 
+class SoGroup;
 class SoMaterial;
+class SoSwitch;
+class SoTexture2;
+class SoTextureCoordinateEnvironment;
 
 namespace MatGui
 {
@@ -57,6 +61,8 @@ public:
     void setEmissiveColor(const QColor& color);
     void setShininess(double value);
     void setTransparency(double value);
+    void setTexture(const QImage& image);
+    void setTextureScaling(double scale);
 
     void resetAmbientColor();
     void resetDiffuseColor();
@@ -64,12 +70,20 @@ public:
     void resetEmissiveColor();
     void resetShininess();
     void resetTransparency();
+    void resetTexture();
+    void resetTextureScaling();
 
 private:
+    SoSeparator* _group;
+    SoSwitch* _switch;
     SoMaterial* _material;
+    SoTexture2* _texture;
+    SoTextureCoordinateEnvironment* _environment;
     std::unique_ptr<AppearanceSettings> viewSettings;
 
     void applySettings();
+    void setCoinTexture();
+    void setCoinMaterial();
 };
 
 }  // namespace MatGui

--- a/src/Mod/Material/Gui/DlgDisplayProperties.ui
+++ b/src/Mod/Material/Gui/DlgDisplayProperties.ui
@@ -369,7 +369,7 @@
         <item row="0" column="0">
          <widget class="QLabel" name="label_6">
           <property name="text">
-           <string>Shape Appearance:</string>
+           <string>Custom Appearance</string>
           </property>
          </widget>
         </item>
@@ -401,7 +401,7 @@
          <widget class="Gui::ColorButton" name="buttonLineColor"/>
         </item>
         <item row="0" column="1">
-         <widget class="QPushButton" name="buttonUserDefinedMaterial">
+         <widget class="QPushButton" name="buttonCustomAppearance">
           <property name="text">
            <string notr="true">...</string>
           </property>

--- a/src/Mod/Material/Gui/DlgDisplayPropertiesImp.h
+++ b/src/Mod/Material/Gui/DlgDisplayPropertiesImp.h
@@ -75,7 +75,7 @@ private Q_SLOTS:
     void onButtonPointColorChanged();
     void onSpinLineWidthValueChanged(int);
     void onSpinLineTransparencyValueChanged(int);
-    void onButtonUserDefinedMaterialClicked();
+    void onbuttonCustomAppearanceClicked();
     void onButtonColorPlotClicked();
     void onMaterialSelected(const std::shared_ptr<Materials::Material>& material);
 
@@ -87,7 +87,6 @@ private:
     void setupFilters();
     void slotChangedObject(const Gui::ViewProvider&, const App::Property& Prop);
     void setDisplayModes(const std::vector<Gui::ViewProvider*>&);
-    void setMaterial(const std::vector<Gui::ViewProvider*>&);
     void setColorPlot(const std::vector<Gui::ViewProvider*>&);
     void setShapeAppearance(const std::vector<Gui::ViewProvider*>&);
     void setLineColor(const std::vector<Gui::ViewProvider*>&);

--- a/src/Mod/Material/Gui/DlgMaterialImp.cpp
+++ b/src/Mod/Material/Gui/DlgMaterialImp.cpp
@@ -31,7 +31,6 @@
 
 #include <Base/Console.h>
 #include <Gui/Application.h>
-#include <Gui/DlgMaterialPropertiesImp.h>
 #include <Gui/DockWindowManager.h>
 #include <Gui/Document.h>
 #include <Gui/Selection.h>

--- a/src/Mod/Material/Gui/MaterialTreeWidget.cpp
+++ b/src/Mod/Material/Gui/MaterialTreeWidget.cpp
@@ -285,9 +285,19 @@ QModelIndex MaterialTreeWidget::findInTree(const QString& uuid)
 
 void MaterialTreeWidget::setMaterial(const QString& uuid)
 {
-    if (uuid.isEmpty() || uuid == m_uuid) {
+    if (uuid == m_uuid) {
         return;
     }
+
+    if (uuid.isEmpty()) {
+        // Nothing is selected
+        QItemSelectionModel* selectionModel = m_materialTree->selectionModel();
+        selectionModel->clear();
+        m_material->clear();
+
+        return;
+    }
+
     updateMaterial(uuid);
 
     // Now select the material in the tree
@@ -633,6 +643,11 @@ void MaterialTreeWidget::onSelectMaterial(const QItemSelection& selected,
                                           const QItemSelection& deselected)
 {
     Q_UNUSED(deselected);
+
+    if (selected.isEmpty()) {
+        m_uuid.clear();
+        return;
+    }
 
     // Get the UUID before changing the underlying data model
     QString uuid;

--- a/src/Mod/Material/Gui/MaterialsEditor.h
+++ b/src/Mod/Material/Gui/MaterialsEditor.h
@@ -152,6 +152,8 @@ private:
     void onInheritNew(bool checked);
 
     void setMaterialDefaults();
+    bool updateTexturePreview() const;
+    bool updateMaterialPreview() const;
     void updatePreview() const;
     static QString getColorHash(const QString& colorString, int colorRange = 255);
 

--- a/src/Mod/Material/Gui/PreCompiled.h
+++ b/src/Mod/Material/Gui/PreCompiled.h
@@ -61,10 +61,10 @@
 #include <Gui/QtAll.h>
 #endif
 
-// // Inventor includes OpenGL
-// #ifndef __InventorAll__
-// # include <Gui/InventorAll.h>
-// #endif
+// Inventor includes OpenGL
+#ifndef __InventorAll__
+# include <Gui/InventorAll.h>
+#endif
 
 #endif  //_PreComp_
 

--- a/src/Mod/Material/Resources/Models/Rendering/TextureRendering.yml
+++ b/src/Mod/Material/Resources/Models/Rendering/TextureRendering.yml
@@ -35,8 +35,9 @@ AppearanceModel:
     Type: 'File'
     Units: ''
     URL: ''
-    Description: "Path to file containing a texture image. Only used if TextureImage is unpopulated"
+    Description: "Path to file containing a texture image. Only used if Texture Image is unpopulated"
   TextureImage:
+    DisplayName: "Texture Image"
     Type: 'Image'
     Units: ''
     URL: ''

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -378,7 +378,7 @@ void Tessellation::setFaceColors(int method, App::Document* doc, App::DocumentOb
             auto svp = Base::freecad_dynamic_cast<PartGui::ViewProviderPartExt>(
                 Gui::Application::Instance->getViewProvider(obj));
             if (vpmesh && svp) {
-                std::vector<App::Color> diff_col = svp->DiffuseColor.getValues();
+                std::vector<App::Color> diff_col = svp->ShapeAppearance.getDiffuseColors();
                 if (ui->groupsFaceColors->isChecked()) {
                     diff_col = getUniqueColors(diff_col);
                 }

--- a/src/Mod/Part/Gui/AppPartGui.cpp
+++ b/src/Mod/Part/Gui/AppPartGui.cpp
@@ -1,25 +1,25 @@
 /***************************************************************************
-*   Copyright (c) 2002 Juergen Riegel <juergen.riegel@web.de>             *
-*                                                                         *
-*   This file is part of the FreeCAD CAx development system.              *
-*                                                                         *
-*   This program is free software; you can redistribute it and/or modify  *
-*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-*   as published by the Free Software Foundation; either version 2 of     *
-*   the License, or (at your option) any later version.                   *
-*   for detail see the LICENCE text file.                                 *
-*                                                                         *
-*   FreeCAD is distributed in the hope that it will be useful,            *
-*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-*   GNU Lesser General Public License for more details.                   *
-*                                                                         *
-*   You should have received a copy of the GNU Library General Public     *
-*   License along with FreeCAD; if not, write to the Free Software        *
-*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-*   USA                                                                   *
-*                                                                         *
-***************************************************************************/
+ *   Copyright (c) 2002 Juergen Riegel <juergen.riegel@web.de>             *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+ *   as published by the Free Software Foundation; either version 2 of     *
+ *   the License, or (at your option) any later version.                   *
+ *   for detail see the LICENCE text file.                                 *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful,            *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Lesser General Public License for more details.                   *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with FreeCAD; if not, write to the Free Software        *
+ *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+ *   USA                                                                   *
+ *                                                                         *
+ ***************************************************************************/
 
 
 #include "PreCompiled.h"
@@ -92,13 +92,15 @@ void loadPartResource()
     Gui::Translator::instance()->refresh();
 }
 
-namespace PartGui {
-class Module : public Py::ExtensionModule<Module>
+namespace PartGui
+{
+class Module: public Py::ExtensionModule<Module>
 {
 public:
-    Module() : Py::ExtensionModule<Module>("PartGui")
+    Module()
+        : Py::ExtensionModule<Module>("PartGui")
     {
-        initialize("This module is the PartGui module."); // register with Python
+        initialize("This module is the PartGui module.");  // register with Python
     }
 
 private:
@@ -106,10 +108,11 @@ private:
 
 PyObject* initModule()
 {
-    return Base::Interpreter().addModule(new Module);;
+    return Base::Interpreter().addModule(new Module);
+    ;
 }
 
-} // namespace PartGui
+}  // namespace PartGui
 
 PyMOD_INIT_FUNC(PartGui)
 {
@@ -123,7 +126,7 @@ PyMOD_INIT_FUNC(PartGui)
         Base::Interpreter().runString("import Part");
         Base::Interpreter().runString("import MatGui");
     }
-    catch(const Base::Exception& e) {
+    catch (const Base::Exception& e) {
         PyErr_SetString(PyExc_ImportError, e.what());
         PyMOD_Return(nullptr);
     }
@@ -137,13 +140,15 @@ PyMOD_INIT_FUNC(PartGui)
     Gui::BitmapFactory().addPath(QString::fromLatin1(":/icons/parametric"));
     Gui::BitmapFactory().addPath(QString::fromLatin1(":/icons/tools"));
 
-    static struct PyModuleDef pAttachEngineTextsModuleDef = {
-        PyModuleDef_HEAD_INIT,
-        "AttachEngineResources",
-        "AttachEngineResources", -1,
-        AttacherGui::AttacherGuiPy::Methods,
-        nullptr, nullptr, nullptr, nullptr
-    };
+    static struct PyModuleDef pAttachEngineTextsModuleDef = {PyModuleDef_HEAD_INIT,
+                                                             "AttachEngineResources",
+                                                             "AttachEngineResources",
+                                                             -1,
+                                                             AttacherGui::AttacherGuiPy::Methods,
+                                                             nullptr,
+                                                             nullptr,
+                                                             nullptr,
+                                                             nullptr};
     PyObject* pAttachEngineTextsModule = PyModule_Create(&pAttachEngineTextsModuleDef);
 
     Py_INCREF(pAttachEngineTextsModule);
@@ -220,23 +225,31 @@ PyMOD_INIT_FUNC(PartGui)
     CreateSimplePartCommands();
     CreateParamPartCommands();
     CreatePartSelectCommands();
-    try{
-        Py::Object ae = Base::Interpreter().runStringObject("__import__('AttachmentEditor.Commands').Commands");
-        Py::Module(partGuiModule).setAttr(std::string("AttachmentEditor"),ae);
-    } catch (Base::PyException &err){
+    try {
+        Py::Object ae =
+            Base::Interpreter().runStringObject("__import__('AttachmentEditor.Commands').Commands");
+        Py::Module(partGuiModule).setAttr(std::string("AttachmentEditor"), ae);
+    }
+    catch (Base::PyException& err) {
         err.ReportException();
     }
 
     // register preferences pages
-    Gui::Dialog::DlgPreferencesImp::setGroupData("Part/Part Design", "Part design", QObject::tr("Part and Part Design workbench"));
-    (void)new Gui::PrefPageProducer<PartGui::DlgSettingsGeneral>(QT_TRANSLATE_NOOP("QObject", "Part/Part Design"));
-    (void)new Gui::PrefPageProducer<PartGui::DlgSettings3DViewPart>(QT_TRANSLATE_NOOP("QObject", "Part/Part Design"));
-    (void)new Gui::PrefPageProducer<PartGui::DlgSettingsObjectColor>(QT_TRANSLATE_NOOP("QObject", "Part/Part Design"));
-    (void)new Gui::PrefPageProducer<PartGui::DlgImportExportIges>(QT_TRANSLATE_NOOP("QObject", "Import-Export"));
-    (void)new Gui::PrefPageProducer<PartGui::DlgImportExportStep>(QT_TRANSLATE_NOOP("QObject", "Import-Export"));
-    Gui::ViewProviderBuilder::add(
-        Part::PropertyPartShape::getClassTypeId(),
-        PartGui::ViewProviderPart::getClassTypeId());
+    Gui::Dialog::DlgPreferencesImp::setGroupData("Part/Part Design",
+                                                 "Part design",
+                                                 QObject::tr("Part and Part Design workbench"));
+    (void)new Gui::PrefPageProducer<PartGui::DlgSettingsGeneral>(
+        QT_TRANSLATE_NOOP("QObject", "Part/Part Design"));
+    (void)new Gui::PrefPageProducer<PartGui::DlgSettings3DViewPart>(
+        QT_TRANSLATE_NOOP("QObject", "Part/Part Design"));
+    (void)new Gui::PrefPageProducer<PartGui::DlgSettingsObjectColor>(
+        QT_TRANSLATE_NOOP("QObject", "Part/Part Design"));
+    (void)new Gui::PrefPageProducer<PartGui::DlgImportExportIges>(
+        QT_TRANSLATE_NOOP("QObject", "Import-Export"));
+    (void)new Gui::PrefPageProducer<PartGui::DlgImportExportStep>(
+        QT_TRANSLATE_NOOP("QObject", "Import-Export"));
+    Gui::ViewProviderBuilder::add(Part::PropertyPartShape::getClassTypeId(),
+                                  PartGui::ViewProviderPart::getClassTypeId());
 
     // add resources and reloads the translators
     loadPartResource();

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -31,6 +31,8 @@ list(APPEND PartGui_LIBS
     ${QtConcurrent_LIBRARIES}
 )
 
+generate_from_xml(ViewProviderExtPy)
+
 set (Part_TR_QRC ${CMAKE_CURRENT_BINARY_DIR}/Resources/Part_translation.qrc)
 qt_find_and_add_translation(QM_SRCS "Resources/translations/*_*.ts"
     ${CMAKE_CURRENT_BINARY_DIR}/Resources/translations)
@@ -61,7 +63,7 @@ set(PartGui_UIC_SRCS
     DlgProjectionOnSurface.ui
     SectionCutting.ui
     ShapeFromMesh.ui
-    TaskFaceColors.ui
+    TaskFaceAppearances.ui
     TaskShapeBuilder.ui
     TaskLoft.ui
     TaskOffset.ui
@@ -69,9 +71,16 @@ set(PartGui_UIC_SRCS
     TaskAttacher.ui
 )
 
+SET(Python_SRCS
+    ViewProviderExtPy.xml
+    ViewProviderExtPyImp.cpp
+)
+SOURCE_GROUP("Python" FILES ${Python_SRCS})
+
 SET(PartGui_SRCS
     ${PartGui_QRC_SRCS}
     ${PartGui_UIC_HDRS}
+    ${Python_SRCS}
     AppPartGui.cpp
     AttacherTexts.h
     AttacherTexts.cpp
@@ -224,9 +233,9 @@ SET(PartGui_SRCS
     SectionCutting.ui
     ShapeFromMesh.cpp
     ShapeFromMesh.h
-    TaskFaceColors.cpp
-    TaskFaceColors.h
-    TaskFaceColors.ui
+    TaskFaceAppearances.cpp
+    TaskFaceAppearances.h
+    TaskFaceAppearances.ui
     TaskShapeBuilder.cpp
     TaskShapeBuilder.h
     TaskShapeBuilder.ui

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -2112,7 +2112,7 @@ void CmdColorPerFace::activated(int iMsg)
         return;
     PartGui::ViewProviderPartExt* vp = dynamic_cast<PartGui::ViewProviderPartExt*>(Gui::Application::Instance->getViewProvider(sel.front()));
     if (vp)
-        vp->changeFaceColors();
+        vp->changeFaceAppearances();
 }
 
 bool CmdColorPerFace::isActive()

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -720,34 +720,38 @@ void PartGui::DlgProjectionOnSurface::higlight_object(Part::Feature* iCurrentObj
     auto vp = dynamic_cast<PartGui::ViewProviderPartExt*>(
         Gui::Application::Instance->getViewProvider(iCurrentObject));
     if (vp) {
-        std::vector<App::Color> colors;
-        App::Color defaultColor;
+        App::Color aColor;
+        aColor.setPackedValue(iColor);
         if (currentShapeType == TopAbs_FACE) {
-            colors = vp->DiffuseColor.getValues();
-            defaultColor = vp->ShapeAppearance.getDiffuseColor();
+            std::vector<App::Material> colors = vp->ShapeAppearance.getValues();
+            App::Color defaultColor = vp->ShapeAppearance.getDiffuseColor();
+
+            if (static_cast<Standard_Integer>(colors.size()) != anIndices.Extent()) {
+                colors.resize(anIndices.Extent(), vp->ShapeAppearance[0]);
+            }
+
+            if (iHighlight) {
+                colors.at(index - 1).diffuseColor = aColor;
+            }
+            else {
+                colors.at(index - 1).diffuseColor = defaultColor;
+            }
+            vp->ShapeAppearance.setValues(colors);
         }
         else if (currentShapeType == TopAbs_EDGE) {
-            colors = vp->LineColorArray.getValues();
-            defaultColor = vp->LineColor.getValue();
-        }
+            std::vector<App::Color> colors = vp->LineColorArray.getValues();
+            App::Color defaultColor = vp->LineColor.getValue();
 
-        if (static_cast<Standard_Integer>(colors.size()) != anIndices.Extent()) {
-            colors.resize(anIndices.Extent(), defaultColor);
-        }
+            if (static_cast<Standard_Integer>(colors.size()) != anIndices.Extent()) {
+                colors.resize(anIndices.Extent(), defaultColor);
+            }
 
-        if (iHighlight) {
-            App::Color aColor;
-            aColor.setPackedValue(iColor);
-            colors.at(index - 1) = aColor;
-        }
-        else {
-            colors.at(index - 1) = defaultColor;
-        }
-        if (currentShapeType == TopAbs_FACE) {
-            vp->DiffuseColor.setValues(colors);
-        }
-        else if (currentShapeType == TopAbs_EDGE) {
-            vp->LineColorArray.setValues(colors);
+            if (iHighlight) {
+                colors.at(index - 1) = aColor;
+            }
+            else {
+                colors.at(index - 1) = defaultColor;
+            }
         }
     }
 }

--- a/src/Mod/Part/Gui/ReferenceHighlighter.cpp
+++ b/src/Mod/Part/Gui/ReferenceHighlighter.cpp
@@ -210,6 +210,17 @@ void ReferenceHighlighter::getFaceColor(const std::string& element, std::vector<
         colors[pos] = elementColor;
 }
 
+void ReferenceHighlighter::getFaceColor(const std::string& element,
+                                        std::vector<App::Material>& materials) const
+{
+    int idx = std::stoi(element.substr(4)) - 1;
+    assert(idx >= 0);
+    std::size_t pos = std::size_t(idx);
+    if (pos < materials.size()) {
+        materials[pos].diffuseColor = elementColor;
+    }
+}
+
 void ReferenceHighlighter::getFaceColors(const std::vector<std::string>& elements,
                                          std::vector<App::Color>& colors) const
 {
@@ -224,5 +235,26 @@ void ReferenceHighlighter::getFaceColors(const std::vector<std::string>& element
     }
     else {
         std::fill(colors.begin(), colors.end(), objectColor);
+    }
+}
+
+void ReferenceHighlighter::getFaceMaterials(const std::vector<std::string>& elements,
+                                         std::vector<App::Material>& materials) const
+{
+    App::Material defaultMaterial;
+    materials.resize(fMap.Extent(), defaultMaterial);
+
+    if (!elements.empty()) {
+        for (const std::string& e : elements) {
+            if (boost::starts_with(e, "Face")) {
+                getFaceColor(e, materials);
+            }
+        }
+    }
+    else {
+        for (auto& material : materials) {
+            material.diffuseColor = objectColor;
+        }
+        // std::fill(materials.begin(), materials.end(), objectColor);
     }
 }

--- a/src/Mod/Part/Gui/ReferenceHighlighter.h
+++ b/src/Mod/Part/Gui/ReferenceHighlighter.h
@@ -79,6 +79,14 @@ public:
      */
     void getFaceColors(const std::vector<std::string>& elements,
                        std::vector<App::Color>& colors) const;
+    /*!
+     * \brief getFaceMaterials
+     * \param elements The sub-element names. If this list is empty \a materials will be filled with
+     * the default color. \param materials The size of the \a materials array is equal to the number
+     * of faces of the shape
+     */
+    void getFaceMaterials(const std::vector<std::string>& elements,
+                          std::vector<App::Material>& materials) const;
 
 private:
     void getVertexColor(const std::string& element, std::vector<App::Color>& colors) const;
@@ -89,6 +97,7 @@ private:
     void getEdgeColorsOfWire(const std::string& element, std::vector<App::Color>& colors) const;
     void getEdgeColorsOfFace(const std::string& element, std::vector<App::Color>& colors) const;
     void getFaceColor(const std::string& element, std::vector<App::Color>& colors) const;
+    void getFaceColor(const std::string& element, std::vector<App::Material>& materials) const;
 
 private:
     App::Color defaultColor;

--- a/src/Mod/Part/Gui/TaskFaceAppearances.h
+++ b/src/Mod/Part/Gui/TaskFaceAppearances.h
@@ -31,17 +31,21 @@ namespace Gui {
     class ViewProvider;
 }
 
+namespace Materials {
+    class Material;
+}
+
 namespace PartGui {
 
 class ViewProviderPartExt;
 
-class FaceColors : public QWidget, public Gui::SelectionObserver
+class FaceAppearances : public QWidget, public Gui::SelectionObserver
 {
     Q_OBJECT
 
 public:
-    explicit FaceColors(ViewProviderPartExt* vp, QWidget* parent = nullptr);
-    ~FaceColors() override;
+    explicit FaceAppearances(ViewProviderPartExt* vp, QWidget* parent = nullptr);
+    ~FaceAppearances() override;
 
     void open();
     bool accept();
@@ -49,9 +53,10 @@ public:
 
 private:
     void setupConnections();
-    void onColorButtonChanged();
+    void onMaterialSelected(const std::shared_ptr<Materials::Material>& material);
     void onDefaultButtonClicked();
     void onBoxSelectionToggled(bool checked);
+    void onButtonCustomAppearanceClicked();
 
 protected:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
@@ -66,13 +71,13 @@ private:
     Private* d;
 };
 
-class TaskFaceColors : public Gui::TaskView::TaskDialog
+class TaskFaceAppearances : public Gui::TaskView::TaskDialog
 {
     Q_OBJECT
 
 public:
-    explicit TaskFaceColors(ViewProviderPartExt* vp);
-    ~TaskFaceColors() override;
+    explicit TaskFaceAppearances(ViewProviderPartExt* vp);
+    ~TaskFaceAppearances() override;
 
 public:
     void open() override;
@@ -84,7 +89,7 @@ public:
     { return QDialogButtonBox::Ok|QDialogButtonBox::Cancel; }
 
 private:
-    FaceColors* widget;
+    FaceAppearances* widget;
 };
 
 } //namespace PartGui

--- a/src/Mod/Part/Gui/TaskFaceAppearances.ui
+++ b/src/Mod/Part/Gui/TaskFaceAppearances.ui
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>PartGui::TaskFaceColors</class>
- <widget class="QWidget" name="PartGui::TaskFaceColors">
+ <class>PartGui::TaskFaceAppearances</class>
+ <widget class="QWidget" name="PartGui::TaskFaceAppearances">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>247</width>
-    <height>143</height>
+    <height>219</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Set color per face</string>
+   <string>Set appearance per face</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -26,57 +26,57 @@
      <property name="title">
       <string notr="true">Group box</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="faceLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Faces:</string>
-        </property>
-       </widget>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="faceLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Faces:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelElement">
+          <property name="text">
+           <string notr="true">[]</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QLabel" name="labelElement">
-        <property name="text">
-         <string notr="true">[]</string>
-        </property>
-       </widget>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="MatGui::MaterialTreeWidget" name="widgetMaterial" native="true"/>
+        </item>
+       </layout>
       </item>
-     <item row="1" column="0" colspan="2">
-       <widget class="Gui::ColorButton" name="colorButton">
-        <property name="minimumSize">
-         <size>
-          <width>146</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>160</width>
-          <height>16777215</height>
-         </size>
-        </property>
-       </widget>
+      <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="1">
+         <widget class="QPushButton" name="buttonCustomAppearance">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelCustomAppearance">
+          <property name="text">
+           <string>Custom Appearance</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="1" column="2">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      </layout>
+     </layout>
     </widget>
    </item>
    <item>
@@ -136,9 +136,10 @@ by dragging a selection rectangle in the 3D view</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::ColorButton</class>
-   <extends>QPushButton</extends>
-   <header>Gui/Widgets.h</header>
+   <class>MatGui::MaterialTreeWidget</class>
+   <extends>QWidget</extends>
+   <header>Mod/Material/Gui/MaterialTreeWidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/Mod/Part/Gui/ViewProvider.cpp
+++ b/src/Mod/Part/Gui/ViewProvider.cpp
@@ -71,6 +71,20 @@ void ViewProviderPart::applyColor(const Part::ShapeHistory& hist,
     }
 }
 
+void ViewProviderPart::applyMaterial(const Part::ShapeHistory& hist,
+                                  const App::PropertyMaterialList& colBase,
+                                  std::vector<App::Material>& colBool)
+{
+    std::map<int, std::vector<int>>::const_iterator jt;
+    // apply color from modified faces
+    for (jt = hist.shapeMap.begin(); jt != hist.shapeMap.end(); ++jt) {
+        std::vector<int>::const_iterator kt;
+        for (kt = jt->second.begin(); kt != jt->second.end(); ++kt) {
+            colBool[*kt] = colBase[jt->first];
+        }
+    }
+}
+
 void ViewProviderPart::applyTransparency(const float& transparency,
                                   std::vector<App::Color>& colors)
 {
@@ -81,6 +95,20 @@ void ViewProviderPart::applyTransparency(const float& transparency,
             // transparency hasn't been set for this face
             if (j->a == 0.0)
                 j->a = transparency/100.0; // transparency comes in percent
+        }
+    }
+}
+
+void ViewProviderPart::applyTransparency(const float& transparency, std::vector<App::Material>& colors)
+{
+    if (transparency != 0.0) {
+        // transparency has been set object-wide
+        std::vector<App::Material>::iterator j;
+        for (j = colors.begin(); j != colors.end(); ++j) {
+            // transparency hasn't been set for this face
+            if (j->transparency == 0.0) {
+                j->transparency = transparency / 100.0;  // transparency comes in percent
+            }
         }
     }
 }

--- a/src/Mod/Part/Gui/ViewProvider.h
+++ b/src/Mod/Part/Gui/ViewProvider.h
@@ -57,8 +57,13 @@ protected:
     void applyColor(const Part::ShapeHistory& hist,
                     const std::vector<App::Color>& colBase,
                     std::vector<App::Color>& colBool);
+    void applyMaterial(const Part::ShapeHistory& hist,
+                       const App::PropertyMaterialList& colBase,
+                       std::vector<App::Material>& colBool);
     void applyTransparency(const float& transparency,
                     std::vector<App::Color>& colors);
+    void applyTransparency(const float& transparency,
+                    std::vector<App::Material>& colors);
 };
 
 } // namespace PartGui

--- a/src/Mod/Part/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/Part/Gui/ViewProviderBoolean.cpp
@@ -100,27 +100,27 @@ void ViewProviderBoolean::updateData(const App::Property* prop)
             auto vpTool = dynamic_cast<PartGui::ViewProviderPart*>(
                     Gui::Application::Instance->getViewProvider(objTool));
             if (vpBase && vpTool) {
-                std::vector<App::Color> colBase = vpBase->DiffuseColor.getValues();
-                std::vector<App::Color> colTool = vpTool->DiffuseColor.getValues();
-                std::vector<App::Color> colBool;
-                colBool.resize(boolMap.Extent(), this->ShapeAppearance.getDiffuseColor());
-                applyTransparency(vpBase->Transparency.getValue(),colBase);
-                applyTransparency(vpTool->Transparency.getValue(),colTool);
+                std::vector<App::Material> colBool;
+                colBool.resize(boolMap.Extent(), this->ShapeAppearance[0]);
+                vpBase->ShapeAppearance.setTransparency(vpBase->Transparency.getValue());
+                vpTool->ShapeAppearance.setTransparency(vpTool->Transparency.getValue());
 
-                if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
-                    applyColor(hist[0], colBase, colBool);
+                if (static_cast<int>(vpBase->ShapeAppearance.getSize()) == baseMap.Extent()) {
+                    applyMaterial(hist[0], vpBase->ShapeAppearance, colBool);
                 }
-                else if (!colBase.empty() && colBase[0] != this->ShapeAppearance.getDiffuseColor()) {
-                    colBase.resize(baseMap.Extent(), colBase[0]);
-                    applyColor(hist[0], colBase, colBool);
+                else if (vpBase->ShapeAppearance.getSize() > 0
+                         && vpBase->ShapeAppearance[0] != this->ShapeAppearance[0]) {
+                    vpBase->ShapeAppearance.setSize(baseMap.Extent(), vpBase->ShapeAppearance[0]);
+                    applyMaterial(hist[0], vpBase->ShapeAppearance, colBool);
                 }
 
-                if (static_cast<int>(colTool.size()) == toolMap.Extent()) {
-                    applyColor(hist[1], colTool, colBool);
+                if (static_cast<int>(vpTool->ShapeAppearance.getSize()) == toolMap.Extent()) {
+                    applyMaterial(hist[1], vpTool->ShapeAppearance, colBool);
                 }
-                else if (!colTool.empty() && colTool[0] != this->ShapeAppearance.getDiffuseColor()) {
-                    colTool.resize(toolMap.Extent(), colTool[0]);
-                    applyColor(hist[1], colTool, colBool);
+                else if (vpTool->ShapeAppearance.getSize() > 0
+                         && vpTool->ShapeAppearance[0] != this->ShapeAppearance[0]) {
+                    vpTool->ShapeAppearance.setSize(toolMap.Extent(), vpTool->ShapeAppearance[0]);
+                    applyMaterial(hist[1], vpTool->ShapeAppearance, colBool);
                 }
 
                 // If the view provider has set a transparency then override the values
@@ -129,7 +129,7 @@ void ViewProviderBoolean::updateData(const App::Property* prop)
                     applyTransparency(Transparency.getValue(), colBool);
                 }
 
-                this->DiffuseColor.setValues(colBool);
+                this->ShapeAppearance.setValues(colBool);
             }
         }
     }
@@ -186,8 +186,8 @@ void ViewProviderMultiFuse::updateData(const App::Property* prop)
         TopTools_IndexedMapOfShape boolMap;
         TopExp::MapShapes(boolShape, TopAbs_FACE, boolMap);
 
-        std::vector<App::Color> colBool;
-        colBool.resize(boolMap.Extent(), this->ShapeAppearance.getDiffuseColor());
+        std::vector<App::Material> colBool;
+        colBool.resize(boolMap.Extent(), this->ShapeAppearance[0]);
 
         int index=0;
         for (std::vector<App::DocumentObject*>::iterator it = sources.begin(); it != sources.end(); ++it, ++index) {
@@ -201,14 +201,14 @@ void ViewProviderMultiFuse::updateData(const App::Property* prop)
 
             auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                std::vector<App::Color> colBase = vpBase->DiffuseColor.getValues();
-                applyTransparency(vpBase->Transparency.getValue(),colBase);
-                if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
-                    applyColor(hist[index], colBase, colBool);
+                vpBase->ShapeAppearance.setTransparency(vpBase->Transparency.getValue());
+                if (static_cast<int>(vpBase->ShapeAppearance.getSize()) == baseMap.Extent()) {
+                    applyMaterial(hist[index], vpBase->ShapeAppearance, colBool);
                 }
-                else if (!colBase.empty() && colBase[0] != this->ShapeAppearance.getDiffuseColor()) {
-                    colBase.resize(baseMap.Extent(), colBase[0]);
-                    applyColor(hist[index], colBase, colBool);
+                else if (vpBase->ShapeAppearance.getSize() > 0
+                         && vpBase->ShapeAppearance[0] != this->ShapeAppearance[0]) {
+                    vpBase->ShapeAppearance.setSize(baseMap.Extent(), vpBase->ShapeAppearance[0]);
+                    applyMaterial(hist[index], vpBase->ShapeAppearance, colBool);
                 }
             }
         }
@@ -219,7 +219,7 @@ void ViewProviderMultiFuse::updateData(const App::Property* prop)
             applyTransparency(Transparency.getValue(), colBool);
         }
 
-        this->DiffuseColor.setValues(colBool);
+        this->ShapeAppearance.setValues(colBool);
     }
     else if (prop->isDerivedFrom<App::PropertyLinkList>()) {
         std::vector<App::DocumentObject*> pShapes = static_cast<const App::PropertyLinkList*>(prop)->getValues();
@@ -321,8 +321,8 @@ void ViewProviderMultiCommon::updateData(const App::Property* prop)
         TopTools_IndexedMapOfShape boolMap;
         TopExp::MapShapes(boolShape, TopAbs_FACE, boolMap);
 
-        std::vector<App::Color> colBool;
-        colBool.resize(boolMap.Extent(), this->ShapeAppearance.getDiffuseColor());
+        std::vector<App::Material> colBool;
+        colBool.resize(boolMap.Extent(), this->ShapeAppearance[0]);
 
         int index=0;
         for (std::vector<App::DocumentObject*>::iterator it = sources.begin(); it != sources.end(); ++it, ++index) {
@@ -336,14 +336,14 @@ void ViewProviderMultiCommon::updateData(const App::Property* prop)
 
             auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                std::vector<App::Color> colBase = vpBase->DiffuseColor.getValues();
-                applyTransparency(vpBase->Transparency.getValue(),colBase);
-                if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
-                    applyColor(hist[index], colBase, colBool);
+                vpBase->ShapeAppearance.setTransparency(vpBase->Transparency.getValue());
+                if (static_cast<int>(vpBase->ShapeAppearance.getSize()) == baseMap.Extent()) {
+                    applyMaterial(hist[index], vpBase->ShapeAppearance, colBool);
                 }
-                else if (!colBase.empty() && colBase[0] != this->ShapeAppearance.getDiffuseColor()) {
-                    colBase.resize(baseMap.Extent(), colBase[0]);
-                    applyColor(hist[index], colBase, colBool);
+                else if (vpBase->ShapeAppearance.getSize() > 0
+                         && vpBase->ShapeAppearance[0] != this->ShapeAppearance[0]) {
+                    vpBase->ShapeAppearance.setSize(baseMap.Extent(), vpBase->ShapeAppearance[0]);
+                    applyMaterial(hist[index], vpBase->ShapeAppearance, colBool);
                 }
             }
         }
@@ -354,7 +354,7 @@ void ViewProviderMultiCommon::updateData(const App::Property* prop)
             applyTransparency(Transparency.getValue(), colBool);
         }
 
-        this->DiffuseColor.setValues(colBool);
+        this->ShapeAppearance.setValues(colBool);
     }
     else if (prop->isDerivedFrom<App::PropertyLinkList>()) {
         std::vector<App::DocumentObject*> pShapes = static_cast<const App::PropertyLinkList*>(prop)->getValues();

--- a/src/Mod/Part/Gui/ViewProviderCompound.cpp
+++ b/src/Mod/Part/Gui/ViewProviderCompound.cpp
@@ -95,8 +95,8 @@ void ViewProviderCompound::updateData(const App::Property* prop)
         TopTools_IndexedMapOfShape compMap;
         TopExp::MapShapes(compShape, TopAbs_FACE, compMap);
 
-        std::vector<App::Color> compCol;
-        compCol.resize(compMap.Extent(), this->ShapeAppearance.getDiffuseColor());
+        std::vector<App::Material> compCol;
+        compCol.resize(compMap.Extent(), this->ShapeAppearance[0]);
 
         int index=0;
         for (std::vector<App::DocumentObject*>::iterator it = sources.begin(); it != sources.end(); ++it, ++index) {
@@ -111,14 +111,14 @@ void ViewProviderCompound::updateData(const App::Property* prop)
 
             auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                std::vector<App::Color> baseCol = vpBase->DiffuseColor.getValues();
-                applyTransparency(vpBase->Transparency.getValue(),baseCol);
-                if (static_cast<int>(baseCol.size()) == baseMap.Extent()) {
-                    applyColor(hist[index], baseCol, compCol);
+                vpBase->ShapeAppearance.setTransparency(vpBase->Transparency.getValue());
+                if (static_cast<int>(vpBase->ShapeAppearance.getSize()) == baseMap.Extent()) {
+                    applyMaterial(hist[index], vpBase->ShapeAppearance, compCol);
                 }
-                else if (!baseCol.empty() && baseCol[0] != this->ShapeAppearance.getDiffuseColor()) {
-                    baseCol.resize(baseMap.Extent(), baseCol[0]);
-                    applyColor(hist[index], baseCol, compCol);
+                else if (vpBase->ShapeAppearance.getSize() > 0
+                         && vpBase->ShapeAppearance[0] != this->ShapeAppearance[0]) {
+                    vpBase->ShapeAppearance.setSize(baseMap.Extent(), vpBase->ShapeAppearance[0]);
+                    applyMaterial(hist[index], vpBase->ShapeAppearance, compCol);
                 }
             }
         }
@@ -129,7 +129,7 @@ void ViewProviderCompound::updateData(const App::Property* prop)
             applyTransparency(Transparency.getValue(), compCol);
         }
 
-        this->DiffuseColor.setValues(compCol);
+        this->ShapeAppearance.setValues(compCol);
     }
     else if (prop->isDerivedFrom<App::PropertyLinkList>()) {
         const std::vector<App::DocumentObject *>& pBases = static_cast<const App::PropertyLinkList*>(prop)->getValues();

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -52,6 +52,7 @@ class SoNormal;
 class SoNormalBinding;
 class SoMaterialBinding;
 class SoIndexedLineSet;
+class SoTexture3;
 
 namespace PartGui {
 
@@ -85,8 +86,8 @@ public:
     App::PropertyColor LineColor;
     App::PropertyMaterial LineMaterial;
     App::PropertyColorList LineColorArray;
-    // Faces (Gui::ViewProviderGeometryObject::ShapeColor and Gui::ViewProviderGeometryObject::ShapeMaterial apply)
-    App::PropertyColorList DiffuseColor;
+    // Faces (Gui::ViewProviderGeometryObject::ShapeAppearance and Gui::ViewProviderGeometryObject::ShapeMaterial apply)
+    // App::PropertyColorList DiffuseColor;
 
     void attach(App::DocumentObject *) override;
     void setDisplayMode(const char* ModeName) override;
@@ -95,7 +96,7 @@ public:
     /// Update the view representation
     void reload();
     /// If no other task is pending it opens a dialog to allow to change face colors
-    bool changeFaceColors();
+    bool changeFaceAppearances();
 
     void updateData(const App::Property*) override;
 
@@ -125,8 +126,8 @@ public:
     * This group of methods do the highlighting of elements.
     */
     //@{
-    void setHighlightedFaces(const std::vector<App::Color>& colors);
-    void setHighlightedFaces(const std::vector<App::Material>& colors);
+    void setHighlightedFaces(const std::vector<App::Material>& materials);
+    void setHighlightedFaces(const App::PropertyMaterialList& appearance);
     void unsetHighlightedFaces();
     void setHighlightedEdges(const std::vector<App::Color>& colors);
     void unsetHighlightedEdges();
@@ -151,6 +152,9 @@ public:
     //@{
     void setupContextMenu(QMenu*, QObject*, const char*) override;
 
+    /// Get the python wrapper for that ViewProvider
+    PyObject* getPyObject() override;
+
 protected:
     bool setEdit(int ModNum) override;
     void unsetEdit(int ModNum) override;
@@ -161,6 +165,9 @@ protected:
     void onChanged(const App::Property* prop) override;
     bool loadParameter();
     void updateVisual();
+    void handleChangedPropertyName(Base::XMLReader& reader,
+                                   const char* TypeName,
+                                   const char* PropName) override;
 
     // nodes for the data representation
     SoMaterialBinding * pcFaceBind;
@@ -179,6 +186,11 @@ protected:
     SoBrepEdgeSet     * lineset;
     SoBrepPointSet    * nodeset;
 
+    // Used to support per face textures
+    SoTexture3        * pcShapeTexture3D;
+    SoCoordinate3     * pcShapeCoordinates;
+    SoIndexedFaceSet  * pcShapeFaceset;
+
     bool VisualTouched;
     bool NormalsFromUV;
 
@@ -190,6 +202,10 @@ private:
     static App::PropertyQuantityConstraint::Constraints angDeflectionRange;
     static const char* LightingEnums[];
     static const char* DrawStyleEnums[];
+
+    // This is needed to restore old DiffuseColor values since the restore
+    // function is asynchronous
+    App::PropertyColorList _diffuseColor;
 };
 
 }

--- a/src/Mod/Part/Gui/ViewProviderExtPy.xml
+++ b/src/Mod/Part/Gui/ViewProviderExtPy.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
+    <PythonExport
+        Father="ViewProviderGeometryObjectPy"
+        Name="ViewProviderPartExtPy"
+        Twin="ViewProviderPartExt"
+        TwinPointer="ViewProviderPartExt"
+        Include="Mod/Part/Gui/ViewProviderExt.h"
+        Namespace="PartGui"
+        FatherInclude="Gui/ViewProviderGeometryObjectPy.h"
+        FatherNamespace="Gui">
+        <Documentation>
+            <Author Licence="LGPL" Name="David Carter" EMail="dcarter@davidcarter.ca" />
+            <UserDocu>This is the ViewProvider geometry class</UserDocu>
+        </Documentation>
+    </PythonExport>
+</GenerateModel>

--- a/src/Mod/Part/Gui/ViewProviderExtPyImp.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExtPyImp.cpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2024 David Carter <dcarter@david.carter.ca>             *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#include <sstream>
+#endif
+
+#include <App/GeoFeature.h>
+#include <App/PropertyStandard.h>
+
+#include "ViewProviderExt.h"
+#include "ViewProviderPartExtPy.h"
+
+#include "ViewProviderPartExtPy.cpp"
+
+
+using namespace PartGui;
+
+// returns a string which represents the object e.g. when printed in python
+std::string ViewProviderPartExtPy::representation() const
+{
+    std::stringstream str;
+    str << "<View provider geometry object at " << getViewProviderPartExtPtr() << ">";
+
+    return str.str();
+}
+
+PyObject* ViewProviderPartExtPy::getCustomAttributes(const char* attr) const
+{
+    ViewProviderPartExt* vp = getViewProviderPartExtPtr();
+    if (strcmp(attr, "DiffuseColor") == 0) {
+        // Get the color properties
+        App::PropertyColorList prop;
+        prop.setValues(vp->ShapeAppearance.getDiffuseColors());
+        return prop.getPyObject();
+    }
+    return nullptr;
+}
+
+int ViewProviderPartExtPy::setCustomAttributes(const char* attr, PyObject* obj)
+{
+    ViewProviderPartExt* vp = getViewProviderPartExtPtr();
+    if (strcmp(attr, "DiffuseColor") == 0) {
+        // Set the color properties
+        App::PropertyColorList prop;
+        prop.setPyObject(obj);
+        vp->ShapeAppearance.setDiffuseColors(prop.getValues());
+        return 1;
+    }
+    return 0;
+}

--- a/src/Mod/Part/Gui/ViewProviderMirror.cpp
+++ b/src/Mod/Part/Gui/ViewProviderMirror.cpp
@@ -263,17 +263,18 @@ void ViewProviderFillet::updateData(const App::Property* prop)
 
             auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                std::vector<App::Color> colBase = vpBase->DiffuseColor.getValues();
-                std::vector<App::Color> colFill;
-                colFill.resize(fillMap.Extent(), vpBase->ShapeAppearance.getDiffuseColor());
-                applyTransparency(vpBase->Transparency.getValue(),colBase);
+                // std::vector<App::Color> colBase = vpBase->DiffuseColor.getValues();
+                std::vector<App::Material> colFill;
+                colFill.resize(fillMap.Extent(), vpBase->ShapeAppearance[0]);
+                vpBase->ShapeAppearance.setTransparency(vpBase->Transparency.getValue());
 
-                if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
-                    applyColor(hist[0], colBase, colFill);
+                if (static_cast<int>(vpBase->ShapeAppearance.getSize()) == baseMap.Extent()) {
+                    applyMaterial(hist[0], vpBase->ShapeAppearance, colFill);
                 }
-                else if (!colBase.empty() && colBase[0] != this->ShapeAppearance.getDiffuseColor()) {
-                    colBase.resize(baseMap.Extent(), colBase[0]);
-                    applyColor(hist[0], colBase, colFill);
+                else if (vpBase->ShapeAppearance.getSize() > 0
+                         && vpBase->ShapeAppearance[0] != this->ShapeAppearance[0]) {
+                    vpBase->ShapeAppearance.setSize(baseMap.Extent(), vpBase->ShapeAppearance[0]);
+                    applyMaterial(hist[0], vpBase->ShapeAppearance, colFill);
                 }
 
                 // If the view provider has set a transparency then override the values
@@ -282,7 +283,7 @@ void ViewProviderFillet::updateData(const App::Property* prop)
                     applyTransparency(Transparency.getValue(), colFill);
                 }
 
-                this->DiffuseColor.setValues(colFill);
+                this->ShapeAppearance.setValues(colFill);
             }
         }
     }
@@ -373,17 +374,18 @@ void ViewProviderChamfer::updateData(const App::Property* prop)
 
             auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                std::vector<App::Color> colBase = static_cast<PartGui::ViewProviderPart*>(vpBase)->DiffuseColor.getValues();
-                std::vector<App::Color> colCham;
-                colCham.resize(chamMap.Extent(), static_cast<PartGui::ViewProviderPart*>(vpBase)->ShapeAppearance.getDiffuseColor());
-                applyTransparency(static_cast<PartGui::ViewProviderPart*>(vpBase)->Transparency.getValue(),colBase);
+                // std::vector<App::Color> colBase = static_cast<PartGui::ViewProviderPart*>(vpBase)->DiffuseColor.getValues();
+                auto& colBase = static_cast<PartGui::ViewProviderPart*>(vpBase)->ShapeAppearance;
+                std::vector<App::Material> colCham;
+                colCham.resize(chamMap.Extent(), colBase[0]);
+                colBase.setTransparency(static_cast<PartGui::ViewProviderPart*>(vpBase)->Transparency.getValue());
 
-                if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
-                    applyColor(hist[0], colBase, colCham);
+                if (static_cast<int>(colBase.getSize()) == baseMap.Extent()) {
+                    applyMaterial(hist[0], colBase, colCham);
                 }
-                else if (!colBase.empty() && colBase[0] != this->ShapeAppearance.getDiffuseColor()) {
-                    colBase.resize(baseMap.Extent(), colBase[0]);
-                    applyColor(hist[0], colBase, colCham);
+                else if (colBase.getSize() > 0 && colBase[0] != this->ShapeAppearance[0]) {
+                    colBase.setSize(baseMap.Extent(), colBase[0]);
+                    applyMaterial(hist[0], colBase, colCham);
                 }
 
                 // If the view provider has set a transparency then override the values
@@ -392,7 +394,7 @@ void ViewProviderChamfer::updateData(const App::Property* prop)
                     applyTransparency(Transparency.getValue(), colCham);
                 }
 
-                this->DiffuseColor.setValues(colCham);
+                this->ShapeAppearance.setValues(colCham);
             }
         }
     }

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -255,11 +255,11 @@ void ViewProviderBody::updateData(const App::Property* prop)
 }
 
 void ViewProviderBody::copyColorsfromTip(App::DocumentObject* tip) {
-    // update DiffuseColor
+    // update ShapeAppearance
     Gui::ViewProvider* vptip = Gui::Application::Instance->getViewProvider(tip);
     if (vptip && vptip->isDerivedFrom(PartGui::ViewProviderPartExt::getClassTypeId())) {
-        auto colors = static_cast<PartGui::ViewProviderPartExt*>(vptip)->DiffuseColor.getValues();
-        this->DiffuseColor.setValues(colors);
+        auto materials = static_cast<PartGui::ViewProviderPartExt*>(vptip)->ShapeAppearance.getValues();
+        this->ShapeAppearance.setValues(materials);
     }
 }
 
@@ -426,7 +426,6 @@ void ViewProviderBody::unifyVisualProperty(const App::Property* prop) {
     if (prop == &Visibility ||
         prop == &Selectable ||
         prop == &DisplayModeBody ||
-        prop == &DiffuseColor ||
         prop == &PointColorArray ||
         prop == &LineColorArray) {
         return;

--- a/src/Mod/PartDesign/Gui/ViewProviderDressUp.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDressUp.cpp
@@ -100,13 +100,13 @@ void ViewProviderDressUp::highlightReferences(const bool on)
     std::vector<std::string> edges = pcDressUp->Base.getSubValuesStartsWith("Edge");
 
     if (on) {
-        if (!faces.empty() && originalFaceColors.empty()) {
-            originalFaceColors = vp->DiffuseColor.getValues();
-            std::vector<App::Color> colors = originalFaceColors;
+        if (!faces.empty() && originalFaceMaterials.empty()) {
+            originalFaceMaterials = vp->ShapeAppearance.getValues();
+            std::vector<App::Material> materials = originalFaceMaterials;
 
             PartGui::ReferenceHighlighter highlighter(base->Shape.getValue(), ShapeAppearance.getDiffuseColor());
-            highlighter.getFaceColors(faces, colors);
-            vp->DiffuseColor.setValues(colors);
+            highlighter.getFaceMaterials(faces, materials);
+            vp->ShapeAppearance.setValues(materials);
         }
         if (!edges.empty() && originalLineColors.empty()) {
             originalLineColors = vp->LineColorArray.getValues();
@@ -117,9 +117,9 @@ void ViewProviderDressUp::highlightReferences(const bool on)
             vp->LineColorArray.setValues(colors);
         }
     } else {
-        if (!faces.empty() && !originalFaceColors.empty()) {
-            vp->DiffuseColor.setValues(originalFaceColors);
-            originalFaceColors.clear();
+        if (!faces.empty() && !originalFaceMaterials.empty()) {
+            vp->ShapeAppearance.setValues(originalFaceMaterials);
+            originalFaceMaterials.clear();
         }
         if (!edges.empty() && !originalLineColors.empty()) {
             vp->LineColorArray.setValues(originalLineColors);

--- a/src/Mod/PartDesign/Gui/ViewProviderDressUp.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderDressUp.h
@@ -60,7 +60,7 @@ protected:
     bool setEdit(int ModNum) override;
 
 private:
-    std::vector<App::Color> originalFaceColors;
+    std::vector<App::Material> originalFaceMaterials;
     std::vector<App::Color> originalLineColors;
 
 };

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -161,9 +161,9 @@ void ViewProviderShapeBinder::highlightReferences(bool on)
             lcolors.resize(eMap.Extent(), svp->LineColor.getValue());
 
             TopExp::MapShapes(static_cast<Part::Feature*>(obj)->Shape.getValue(), TopAbs_FACE, eMap);
-            originalFaceColors = svp->DiffuseColor.getValues();
-            std::vector<App::Color> fcolors = originalFaceColors;
-            fcolors.resize(eMap.Extent(), svp->ShapeAppearance.getDiffuseColor());
+            originalFaceAppearance = svp->ShapeAppearance.getValues();
+            std::vector<App::Material> fcolors = originalFaceAppearance;
+            fcolors.resize(eMap.Extent(), svp->ShapeAppearance[0]);
 
             for (const std::string& e : subs) {
                 // Note: stoi may throw, but it strictly shouldn't happen
@@ -177,11 +177,11 @@ void ViewProviderShapeBinder::highlightReferences(bool on)
                     int idx = std::stoi(e.substr(4)) - 1;
                     assert(idx >= 0);
                     if (idx < static_cast<int>(fcolors.size()))
-                        fcolors[idx] = App::Color(1.0, 0.0, 1.0); // magenta
+                        fcolors[idx].diffuseColor = App::Color(1.0, 0.0, 1.0); // magenta
                 }
             }
             svp->LineColorArray.setValues(lcolors);
-            svp->DiffuseColor.setValues(fcolors);
+            svp->ShapeAppearance.setValues(fcolors);
         }
     }
     else {
@@ -189,8 +189,8 @@ void ViewProviderShapeBinder::highlightReferences(bool on)
             svp->LineColorArray.setValues(originalLineColors);
             originalLineColors.clear();
 
-            svp->DiffuseColor.setValues(originalFaceColors);
-            originalFaceColors.clear();
+            svp->ShapeAppearance.setValues(originalFaceAppearance);
+            originalFaceAppearance.clear();
         }
     }
 }

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
@@ -48,7 +48,7 @@ protected:
 
 private:
     std::vector<App::Color> originalLineColors;
-    std::vector<App::Color> originalFaceColors;
+    std::vector<App::Material> originalFaceAppearance;
 
 };
 

--- a/src/Mod/Surface/Gui/TaskFilling.cpp
+++ b/src/Mod/Surface/Gui/TaskFilling.cpp
@@ -161,22 +161,23 @@ void ViewProviderFilling::highlightReferences(ShapeType type, const References& 
                         break;
                     case ViewProviderFilling::Face:
                         if (on) {
-                            std::vector<App::Color> colors;
+                            std::vector<App::Material> materials;
                             TopTools_IndexedMapOfShape fMap;
                             TopExp::MapShapes(base->Shape.getValue(), TopAbs_FACE, fMap);
-                            colors.resize(fMap.Extent(), svp->ShapeAppearance.getDiffuseColor());
+                            materials.resize(fMap.Extent(), svp->ShapeAppearance[0]);
 
                             for (const auto& jt : it.second) {
                                 std::size_t idx =
                                     static_cast<std::size_t>(std::stoi(jt.substr(4)) - 1);
                                 // check again that the index is in range because it's possible that
                                 // the sub-names are invalid
-                                if (idx < colors.size()) {
-                                    colors[idx] = App::Color(1.0, 0.0, 1.0);  // magenta
+                                if (idx < materials.size()) {
+                                    materials[idx].diffuseColor =
+                                        App::Color(1.0, 0.0, 1.0);  // magenta
                                 }
                             }
 
-                            svp->setHighlightedFaces(colors);
+                            svp->setHighlightedFaces(materials);
                         }
                         else {
                             svp->unsetHighlightedFaces();

--- a/src/Mod/Surface/Gui/TaskSections.cpp
+++ b/src/Mod/Surface/Gui/TaskSections.cpp
@@ -161,22 +161,23 @@ void ViewProviderSections::highlightReferences(ShapeType type, const References&
                         break;
                     case ViewProviderSections::Face:
                         if (on) {
-                            std::vector<App::Color> colors;
+                            std::vector<App::Material> materials;
                             TopTools_IndexedMapOfShape fMap;
                             TopExp::MapShapes(base->Shape.getValue(), TopAbs_FACE, fMap);
-                            colors.resize(fMap.Extent(), svp->ShapeAppearance.getDiffuseColor());
+                            materials.resize(fMap.Extent(), svp->ShapeAppearance[0]);
 
                             for (const auto& jt : it.second) {
                                 std::size_t idx =
                                     static_cast<std::size_t>(std::stoi(jt.substr(4)) - 1);
                                 // check again that the index is in range because it's possible that
                                 // the sub-names are invalid
-                                if (idx < colors.size()) {
-                                    colors[idx] = App::Color(1.0, 0.0, 1.0);  // magenta
+                                if (idx < materials.size()) {
+                                    materials[idx].diffuseColor =
+                                        App::Color(1.0, 0.0, 1.0);  // magenta
                                 }
                             }
 
-                            svp->setHighlightedFaces(colors);
+                            svp->setHighlightedFaces(materials);
                         }
                         else {
                             svp->unsetHighlightedFaces();


### PR DESCRIPTION
Improves the use of the ShapeAppearance property for the Part workbench.

- removes DiffuseColor property
  - adds Python compatibility using custom attributes
  - transitions DiffuseColor to ShapeAppearance on open
- Improved UI elements for setting object appearance, and appearance per face
- Lays the foundation for future texture support