### PR TITLE
[ArchCurtainWall] add self.Type definition like other Arch Objects

### DIFF
--- a/src/Mod/Arch/ArchCurtainWall.py
+++ b/src/Mod/Arch/ArchCurtainWall.py
@@ -259,6 +259,7 @@ class CurtainWall(ArchComponent.Component):
             obj.addProperty("App::PropertyVector","VerticalDirection","CurtainWall",
                             QT_TRANSLATE_NOOP("App::Property","The vertical direction reference to be used by this object to deduce vertical/horizontal directions. Keep it close to the actual vertical direction of your curtain wall"))
             obj.VerticalDirection = FreeCAD.Vector(0,0,1)
+        self.Type = "CurtainWall"
 
     def onDocumentRestored(self,obj):
 


### PR DESCRIPTION
All Arch Objects have self.Type defined, add here for Arch Curtain Wall.

        self.Type = "Axis"
        self.Type = "AxisSystem"
        self.Type = "Building"
        self.Type = "BuildingPart"
        self.Type = "Component"
        self.Type = "Equipment"
        self.Type = "Fence"
        self.Type = "Floor"
        self.Type = "Frame"
        self.Type = "Grid"
        self.Type = "MaterialContainer"
        self.Type = "Panel"
        self.Type = "Pipe"
        self.Type = "Precast"
        self.Type = "Profile"
        self.Type = "Project"
        self.Type = "Rebar"
        self.Type = "Reference"
        self.Type = "Roof"
        self.Type = "Schedule"
        self.Type = "SectionPlane"
        self.Type = "Site"
        self.Type = "Space"
        self.Type = "Stairs"
        self.Type = "Structure"
        self.Type = "Truss"
        self.Type = "Wall"
        self.Type = "Window"

FC Forum Discussion - https://forum.freecad.org/viewtopic.php?t=87210