### PR TITLE
Sketcher: Add a guard for not asking information of a point of a curve which doesn't exist

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -833,6 +833,12 @@ void DSHArcController::addConstraints()
         }
     }
     else {  // Valid diagnosis. Must check which constraints may be added.
+
+        // if no curve exists a crash occurs #12755
+        if (firstCurve < 0) {
+            return;
+        }
+
         auto startpointinfo = handler->getPointInfo(GeoElementId(firstCurve, pos1));
 
         if (x0set && startpointinfo.isXDoF()) {


### PR DESCRIPTION
Fix #12755