### PR TITLE
Arch: Arch Schedule allow ^2 and ^3 in unit string

### DIFF
--- a/src/Mod/Arch/ArchSchedule.py
+++ b/src/Mod/Arch/ArchSchedule.py
@@ -332,6 +332,7 @@ class _ArchSchedule:
                     q = None
                     if obj.Unit[i]:
                         unit = obj.Unit[i]
+                        unit = unit.replace("^","")  # get rid of existing power symbol
                         unit = unit.replace("2","^2")
                         unit = unit.replace("3","^3")
                         unit = unit.replace("²","^2")


### PR DESCRIPTION
Fixes #13796.
