### PR TITLE
Add <algorithm> include and remove explicit 3rdparty/GSL include reference

### DIFF
--- a/src/Base/PreCompiled.h
+++ b/src/Base/PreCompiled.h
@@ -76,6 +76,7 @@
 #include <memory>
 #include <mutex>
 #include <bitset>
+#include <algorithm>
 
 // streams
 #include <iostream>

--- a/src/Base/Sequencer.cpp
+++ b/src/Base/Sequencer.cpp
@@ -26,6 +26,7 @@
 #ifndef _PreComp_
 #include <mutex>
 #include <vector>
+#include <algorithm>
 #endif
 
 #include "Sequencer.h"

--- a/src/Mod/Start/Gui/GeneralSettingsWidget.h
+++ b/src/Mod/Start/Gui/GeneralSettingsWidget.h
@@ -25,7 +25,7 @@
 #define FREECAD_START_GENERALSETTINGSWIDGET_H
 
 #include <QWidget>
-#include <3rdParty/GSL/include/gsl/pointers>
+#include <gsl/pointers>
 
 class QLabel;
 class QComboBox;

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -31,7 +31,7 @@
 #endif
 
 #include "ThemeSelectorWidget.h"
-#include <3rdParty/GSL/include/gsl/pointers>
+#include <gsl/pointers>
 #include <App/Application.h>
 #include <Gui/Application.h>
 #include <Gui/PreferencePackManager.h>


### PR DESCRIPTION
Compilation fixes needed under Fedora 40

Justifications:

1. `std::find_if` and `std::reverse` are in `<algorithm>` but it was not explicitly included
2. The `3rdParty/GSL/include` usage in some GSL includes is inconsistent with other gsl includes
3. 