### PR TITLE
Help: Removes use of WebGui

### DIFF
--- a/src/Mod/Help/Help.py
+++ b/src/Mod/Help/Help.py
@@ -49,7 +49,7 @@ Preferences keys (in "User parameter:BaseApp/Preferences/Mod/Help"):
     Location (string): offline location
     Suffix (string): a suffix to add to the URL, ex: /fr
     StyleSheet (string): optional CSS stylesheet to style the output
-    
+
 Defaults are to open the wiki in the desktop browser
 """
 
@@ -112,13 +112,13 @@ def show(page, view=None, conv=None):
     pagename = os.path.basename(page.replace("_", " ").replace(".md", ""))
     title = translate("Help", "Help") + ": " + pagename
     if FreeCAD.GuiUp:
-        if PREFS.GetBool("optionTab", False) and get_qtwebwidgets():  
+        if PREFS.GetBool("optionTab", False) and get_qtwebwidgets():
             # MDI tab
             show_tab(html, baseurl, title, view)
-        elif PREFS.GetBool("optionDialog", False)  and get_qtwebwidgets():
+        elif PREFS.GetBool("optionDialog", False) and get_qtwebwidgets():
             # floating dock window
             show_dialog(html, baseurl, title, view)
-        else:  
+        else:
             # desktop web browser - default
             show_browser(location)
     else:
@@ -237,7 +237,7 @@ def show_tab(html, baseurl, title, view=None):
         view.setHtml(html, baseUrl=QtCore.QUrl(baseurl))
         view.parent().parent().setWindowTitle(title)
     else:
-        openBrowserHTML(html,baseurl,title,ICON)
+        openBrowserHTML(html, baseurl, title, ICON)
 
 
 def get_qtwebwidgets():

--- a/src/Mod/Help/Help.py
+++ b/src/Mod/Help/Help.py
@@ -49,6 +49,8 @@ Preferences keys (in "User parameter:BaseApp/Preferences/Mod/Help"):
     Location (string): offline location
     Suffix (string): a suffix to add to the URL, ex: /fr
     StyleSheet (string): optional CSS stylesheet to style the output
+    
+Defaults are to open the wiki in the desktop browser
 """
 
 import os
@@ -110,12 +112,15 @@ def show(page, view=None, conv=None):
     pagename = os.path.basename(page.replace("_", " ").replace(".md", ""))
     title = translate("Help", "Help") + ": " + pagename
     if FreeCAD.GuiUp:
-        if PREFS.GetBool("optionBrowser", False):  # desktop web browser
-            show_browser(location)
-        elif PREFS.GetBool("optionDialog", False):  # floating dock window
-            show_dialog(html, baseurl, title, view)
-        else:  # MDI tab - default
+        if PREFS.GetBool("optionTab", False) and get_qtwebwidgets():  
+            # MDI tab
             show_tab(html, baseurl, title, view)
+        elif PREFS.GetBool("optionDialog", False)  and get_qtwebwidgets():
+            # floating dock window
+            show_dialog(html, baseurl, title, view)
+        else:  
+            # desktop web browser - default
+            show_browser(location)
     else:
         # console mode, we just print the output
         print(md)
@@ -216,12 +221,11 @@ def show_dialog(html, baseurl, title, view=None):
 
     from PySide import QtCore
 
-    if get_qtwebwidgets(html, baseurl, title):
-        if view:  # reusing existing view
-            view.setHtml(html, baseUrl=QtCore.QUrl(baseurl))
-            view.parent().parent().setWindowTitle(title)
-        else:
-            openBrowserHTML(html, baseurl, title, ICON, dialog=True)
+    if view:  # reusing existing view
+        view.setHtml(html, baseUrl=QtCore.QUrl(baseurl))
+        view.parent().parent().setWindowTitle(title)
+    else:
+        openBrowserHTML(html, baseurl, title, ICON, dialog=True)
 
 
 def show_tab(html, baseurl, title, view=None):
@@ -229,28 +233,20 @@ def show_tab(html, baseurl, title, view=None):
 
     from PySide import QtCore
 
-    if get_qtwebwidgets(html, baseurl, title):
-        if view:  # reusing existing view
-            view.setHtml(html, baseUrl=QtCore.QUrl(baseurl))
-            view.parent().parent().setWindowTitle(title)
-        else:
-            # the line below causes a crash with current Qt5 version
-            # openBrowserHTML(html,baseurl,title,ICON)
-            # so ATM we use the WebGui browser instead
-            import WebGui
-
-            WebGui.openBrowserHTML(html, baseurl, title, ICON)
+    if view:  # reusing existing view
+        view.setHtml(html, baseUrl=QtCore.QUrl(baseurl))
+        view.parent().parent().setWindowTitle(title)
+    else:
+        openBrowserHTML(html,baseurl,title,ICON)
 
 
-def get_qtwebwidgets(html, baseurl, title):
-    """opens a web module view if qtwebwidgets module is not available, and returns False"""
-    from PySide import QtGui
+def get_qtwebwidgets():
+    """verifies if qtwebengine is available"""
 
     try:
         from PySide import QtWebEngineWidgets
     except:
         FreeCAD.Console.PrintLog(LOGTXT + "\n")
-        QtGui.QDesktopServices.openUrl(baseurl)
         return False
     else:
         return True

--- a/src/Mod/Help/dlgPreferencesHelp.ui
+++ b/src/Mod/Help/dlgPreferencesHelp.ui
@@ -82,15 +82,15 @@ to get French translation of the documentation.</string>
       </item>
       <item row="6" column="1">
        <widget class="Gui::PrefFileChooser" name="fileChooser">
-        <property name="mode">
-         <enum>Gui::FileChooser::Directory</enum>
-        </property>
         <property name="toolTip">
          <string>Set this to a custom URL or the folder where the help files are located.
 You can easily download the documentation for offline use by using the Addon
 Manager and installing the &quot;offline-documentation&quot; addon. If this
 field is left blank, FreeCAD will automatically search for the help files at
 the default location ($USERAPPDATADIR/Mod/offline-documentation).</string>
+        </property>
+        <property name="mode">
+         <enum>Gui::FileChooser::Directory</enum>
         </property>
         <property name="fileName">
          <string/>
@@ -165,25 +165,6 @@ custom stylesheet below and can look nicer than the wiki option. The 'Markdown' 
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <widget class="Gui::PrefRadioButton" name="radioTab">
-        <property name="toolTip">
-         <string>The documentation will open in a new tab inside the FreeCAD interface.</string>
-        </property>
-        <property name="text">
-         <string>In a FreeCAD tab</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>optionTab</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Help</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="Gui::PrefRadioButton" name="radioBrowser">
         <property name="toolTip">
          <string>The documentation will open in your default web browser.</string>
@@ -191,8 +172,30 @@ custom stylesheet below and can look nicer than the wiki option. The 'Markdown' 
         <property name="text">
          <string>In your default web browser</string>
         </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
         <property name="prefEntry" stdset="0">
          <cstring>optionBrowser</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Help</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefRadioButton" name="radioTab">
+        <property name="toolTip">
+         <string>The documentation will open in a new tab inside the FreeCAD interface. This requires the PySide QtWebengineWidgets component</string>
+        </property>
+        <property name="text">
+         <string>In a FreeCAD tab</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>optionTab</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Help</cstring>
@@ -206,7 +209,7 @@ custom stylesheet below and can look nicer than the wiki option. The 'Markdown' 
         </property>
         <property name="toolTip">
          <string>The documentation will open in a dockable dialog inside the FreeCAD window,
-which allows you to keep it open whlle working in the 3D view.</string>
+which allows you to keep it open whlle working in the 3D view. This requires the PySide QtWebengineWidgets component</string>
         </property>
         <property name="text">
          <string>In a separate, embeddable dialog</string>


### PR DESCRIPTION
If PySide webenginewidgets is not available, the Help module now defaults to opening the doc in the desktop browser.

Fixes #13788