### PR TITLE
Fem: Reset field color bar - fixes #13695

### DIFF
--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -1703,6 +1703,11 @@ void setupFilter(Gui::Command* cmd, std::string Name)
                    "App.activeDocument().ActiveObject.ViewObject.VectorMode = \"%s\"",
                    selObjectView->VectorMode.getValueAsString());
 
+    // hide selected filter
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().%s.ViewObject.Visibility = False",
+                   selObject->getNameInDocument());
+
     cmd->updateActive();
     // open the dialog to edit the filter
     cmd->doCommand(Gui::Command::Gui, "Gui.activeDocument().setEdit('%s')", FeatName.c_str());

--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -58,6 +58,7 @@
 
 #ifdef FC_USE_VTK
 #include <Mod/Fem/App/FemPostPipeline.h>
+#include <Mod/Fem/Gui/ViewProviderFemPostObject.h>
 #endif
 
 
@@ -1690,6 +1691,17 @@ void setupFilter(Gui::Command* cmd, std::string Name)
     if (!selectionIsPipeline) {
         femFilter->Input.setValue(selObject);
     }
+
+    femFilter->Data.setValue(static_cast<Fem::FemPostObject*>(selObject)->Data.getValue());
+    auto selObjectView = static_cast<FemGui::ViewProviderFemPostObject*>(
+        Gui::Application::Instance->getViewProvider(selObject));
+
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().ActiveObject.ViewObject.Field = \"%s\"",
+                   selObjectView->Field.getValueAsString());
+    cmd->doCommand(Gui::Command::Doc,
+                   "App.activeDocument().ActiveObject.ViewObject.VectorMode = \"%s\"",
+                   selObjectView->VectorMode.getValueAsString());
 
     cmd->updateActive();
     // open the dialog to edit the filter

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -1041,7 +1041,7 @@ void ViewProviderFemPostObject::show()
 
 void ViewProviderFemPostObject::OnChange(Base::Subject<int>& /*rCaller*/, int /*rcReason*/)
 {
-    bool ResetColorBarRange = false;
+    bool ResetColorBarRange = true;
     WriteColorData(ResetColorBarRange);
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -811,11 +811,13 @@ void ViewProviderFemPostObject::filterArtifacts(vtkDataSet* dset)
             m_surface->SetInputData(dset);
         }
     }
+
+    m_blockPropertyChanges = false;
+
     // restore initial vsibility
     if (!visibility) {
         this->Visibility.setValue(visibility);
     }
-    m_blockPropertyChanges = false;
 }
 
 bool ViewProviderFemPostObject::setupPipeline()


### PR DESCRIPTION
This fixes #13695 by resetting the color bar and setting the Data property of the new filter from the input filter.
To be consistent, the field displayed in the created filter is the same as the one used in the input filter.
With the second commit,  the input filter is hidden if a new filter is created.

@maxwxyz 