### PR TITLE
Themes: Explicitly remove Editor/Text setting in Classic

### DIFF
--- a/src/Gui/PreferencePacks/Classic/post.FCMacro
+++ b/src/Gui/PreferencePacks/Classic/post.FCMacro
@@ -1,0 +1,5 @@
+# Classic theme must delete any set value for the editor text so that it is calculated dynamically when needed
+import FreeCAD
+
+editorPrefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Editor")
+editorPrefs.RemInt("Text")


### PR DESCRIPTION
In order for the "Classic" preference pack to work as expected, it must actually *remove* any value set for the Editor/Text, not just set it to a default value.