### PR TITLE
Arch: adapt materials to new Materials path scheme

### DIFF
--- a/src/Mod/Arch/ArchMaterial.py
+++ b/src/Mod/Arch/ArchMaterial.py
@@ -652,7 +652,7 @@ class _ArchMaterialTaskPanel:
         "sets self.material from a card"
         if card in self.cards:
             import importFCMat
-            self.material = importFCMat.read(self.cards[card])
+            self.material = importFCMat.read(self.cards[card][0], self.cards[card][1])
             self.setFields()
 
     def fromExisting(self,index):
@@ -690,16 +690,31 @@ class _ArchMaterialTaskPanel:
         "fills the combo with the existing FCMat cards"
         # look for cards in both resources dir and a Materials sub-folder in the user folder.
         # User cards with same name will override system cards
-        paths = [FreeCAD.getResourceDir() + os.sep + "Mod" + os.sep + "Material" + os.sep + "StandardMaterial"]
-        ap = FreeCAD.ConfigGet("UserAppData") + os.sep + "Materials"
-        if os.path.exists(ap):
-            paths.append(ap)
+        resources_mat_path = os.path.join(FreeCAD.getResourceDir(), "Mod", "Material", "Resources", "Materials")
+        resources_mat_path_std = os.path.join(resources_mat_path, "Standard")
+        user_mat_path = os.path.join(FreeCAD.ConfigGet("UserAppData"), "Material")
+
+        paths = [resources_mat_path_std]        
+        if os.path.exists(user_mat_path):
+            paths.append(user_mat_path)
         self.cards = {}
+        library = None
         for p in paths:
-            for f in os.listdir(p):
-                b,e = os.path.splitext(f)
-                if e.upper() == ".FCMAT":
-                    self.cards[b] = p + os.sep + f
+            for root, _, f_names in os.walk(p):
+                for f in f_names:
+                    b,e = os.path.splitext(f)
+                    if e.upper() == ".FCMAT":
+                        if p == resources_mat_path_std:
+                            root_removed = root.replace(resources_mat_path, '')
+                            library = "System"
+                        else:
+                            root_removed = root.replace(p, '')
+                            library = "User"
+                        mat_path = os.path.join(root_removed, f)
+                        # Material paths follow the OS' filesystem hierarchy but
+                        # are stored internally separated by '/', regardless of the platform
+                        # E.g. '/Standard/Metal/Steel/CalculiX-Steel.FCMat'
+                        self.cards[b] = (mat_path.replace(os.sep, '/'), library)
         if self.cards:
             for k in sorted(self.cards):
                 self.form.comboBox_MaterialsInDir.addItem(k)

--- a/src/Mod/Arch/ArchMaterial.py
+++ b/src/Mod/Arch/ArchMaterial.py
@@ -694,27 +694,16 @@ class _ArchMaterialTaskPanel:
         resources_mat_path_std = os.path.join(resources_mat_path, "Standard")
         user_mat_path = os.path.join(FreeCAD.ConfigGet("UserAppData"), "Material")
 
-        paths = [resources_mat_path_std]        
+        paths = [resources_mat_path_std]
         if os.path.exists(user_mat_path):
             paths.append(user_mat_path)
         self.cards = {}
-        library = None
         for p in paths:
             for root, _, f_names in os.walk(p):
                 for f in f_names:
                     b,e = os.path.splitext(f)
                     if e.upper() == ".FCMAT":
-                        if p == resources_mat_path_std:
-                            root_removed = root.replace(resources_mat_path, '')
-                            library = "System"
-                        else:
-                            root_removed = root.replace(p, '')
-                            library = "User"
-                        mat_path = os.path.join(root_removed, f)
-                        # Material paths follow the OS' filesystem hierarchy but
-                        # are stored internally separated by '/', regardless of the platform
-                        # E.g. '/Standard/Metal/Steel/CalculiX-Steel.FCMat'
-                        self.cards[b] = (mat_path.replace(os.sep, '/'), library)
+                        self.cards[b] = os.path.join(root, f)
         if self.cards:
             for k in sorted(self.cards):
                 self.form.comboBox_MaterialsInDir.addItem(k)

--- a/src/Mod/Arch/ArchMaterial.py
+++ b/src/Mod/Arch/ArchMaterial.py
@@ -652,7 +652,7 @@ class _ArchMaterialTaskPanel:
         "sets self.material from a card"
         if card in self.cards:
             import importFCMat
-            self.material = importFCMat.read(self.cards[card][0], self.cards[card][1])
+            self.material = importFCMat.read(self.cards[card])
             self.setFields()
 
     def fromExisting(self,index):

--- a/src/Mod/Material/importFCMat.py
+++ b/src/Mod/Material/importFCMat.py
@@ -97,9 +97,9 @@ def decode(name):
 # as we had and we might will have problems again and again
 # https://github.com/berndhahnebach/FreeCAD_bhb/commits/materialdev
 
-def read(filename):
+def read(filename, library):
     materialManager = Materials.MaterialManager()
-    material = materialManager.getMaterialByPath(filename)
+    material = materialManager.getMaterialByPath(filename, library)
     return material.Properties
 
 # Metainformation

--- a/src/Mod/Material/importFCMat.py
+++ b/src/Mod/Material/importFCMat.py
@@ -97,9 +97,9 @@ def decode(name):
 # as we had and we might will have problems again and again
 # https://github.com/berndhahnebach/FreeCAD_bhb/commits/materialdev
 
-def read(filename, library):
+def read(filename):
     materialManager = Materials.MaterialManager()
-    material = materialManager.getMaterialByPath(filename, library)
+    material = materialManager.getMaterialByPath(filename)
     return material.Properties
 
 # Metainformation


### PR DESCRIPTION
Fixes #13821 by adapting the old material paths to the new scheme:

1. Update the materials filesystem path when reading them
2. Materials can now be in subfolders: traverse directories to read all materials

I'm aware of https://github.com/FreeCAD/FreeCAD/issues/13821#issuecomment-2094225362. I've addressed this as a quicker way to get back the Materials function before https://github.com/FreeCAD/FreeCAD/pull/13783 gets merged, which might take longer. The intention is certainly not to step on anyone's toes, so if this is already being worked on, or can be fixed in a better way, feel free to close this PR.