### PR TITLE
Gui: Do not reset placement when reordering top-level objects

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1419,6 +1419,7 @@ void Document::RestoreDocFile(Base::Reader &reader)
         for (int i=0; i<Cnt; i++) {
             localreader->readElement("ViewProvider");
             std::string name = localreader->getAttribute("name");
+
             bool expanded = false;
             if (!hasExpansion && localreader->hasAttribute("expanded")) {
                 const char* attr = localreader->getAttribute("expanded");
@@ -1426,15 +1427,24 @@ void Document::RestoreDocFile(Base::Reader &reader)
                     expanded = true;
                 }
             }
-            ViewProvider* pObj = getViewProviderByName(name.c_str());
+
+            int treeRank = -1;
+            if (localreader->hasAttribute("treeRank")) {
+                treeRank = int(localreader->getAttributeAsInteger("treeRank"));
+            }
+
+            auto pObj = dynamic_cast<ViewProviderDocumentObject*>(getViewProviderByName(name.c_str()));
             // check if this feature has been registered
-            if (pObj){
+            if (pObj) {
                 pObj->Restore(*localreader);
             }
 
+            if (pObj && treeRank >= 0) {
+                pObj->setTreeRank(treeRank);
+            }
+
             if (pObj && expanded) {
-                auto vp = static_cast<Gui::ViewProviderDocumentObject*>(pObj);
-                this->signalExpandObject(*vp, TreeItemMode::ExpandItem,0,0);
+                this->signalExpandObject(*pObj, TreeItemMode::ExpandItem, 0, 0);
             }
             localreader->readEndElement("ViewProvider");
         }
@@ -1536,8 +1546,6 @@ void Document::SaveDocFile (Base::Writer &writer) const
     if(!hasExpansion)
         writer.Stream() << ">" << std::endl;
 
-    std::map<const App::DocumentObject*,ViewProviderDocumentObject*>::const_iterator it;
-
     // writing the view provider names itself
     writer.Stream() << writer.ind() << "<ViewProviderData Count=\""
                     << d->_ViewProviderMap.size() <<"\">" << std::endl;
@@ -1545,12 +1553,13 @@ void Document::SaveDocFile (Base::Writer &writer) const
     bool xml = writer.isForceXML();
     //writer.setForceXML(true);
     writer.incInd(); // indentation for 'ViewProvider name'
-    for(it = d->_ViewProviderMap.begin(); it != d->_ViewProviderMap.end(); ++it) {
-        const App::DocumentObject* doc = it->first;
-        ViewProvider* obj = it->second;
+    for(const auto& it : d->_ViewProviderMap) {
+        const App::DocumentObject* doc = it.first;
+        ViewProviderDocumentObject* obj = it.second;
         writer.Stream() << writer.ind() << "<ViewProvider name=\""
-                        << doc->getNameInDocument() << "\" "
-                        << "expanded=\"" << (doc->testStatus(App::Expand) ? 1:0) << "\"";
+                        << doc->getNameInDocument() << "\""
+                        << " expanded=\"" << (doc->testStatus(App::Expand) ? 1:0) << "\""
+                        << " treeRank=\"" << obj->getTreeRank() << "\"";
         if (obj->hasExtensions())
             writer.Stream() << " Extensions=\"True\"";
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1983,7 +1983,8 @@ TreeWidget::TargetItemInfo TreeWidget::getTargetInfo(QEvent* ev)
     return targetInfo;
 }
 
-bool TreeWidget::dropInDocument(QDropEvent* event, TargetItemInfo& targetInfo, std::vector<std::pair<DocumentObjectItem*, std::vector<std::string> > > items)
+bool TreeWidget::dropInDocument(QDropEvent* event, TargetItemInfo& targetInfo,
+                                std::vector<TreeWidget::ObjectItemSubname> items)
 {
     std::string errMsg;
     auto da = event->dropAction();
@@ -2187,7 +2188,8 @@ bool TreeWidget::dropInDocument(QDropEvent* event, TargetItemInfo& targetInfo, s
     return touched;
 }
 
-bool TreeWidget::dropInObject(QDropEvent* event, TargetItemInfo& targetInfo, std::vector<std::pair<DocumentObjectItem*, std::vector<std::string> > > items)
+bool TreeWidget::dropInObject(QDropEvent* event, TargetItemInfo& targetInfo,
+                              std::vector<TreeWidget::ObjectItemSubname> items)
 {
     std::string errMsg;
     auto da = event->dropAction();
@@ -2554,7 +2556,7 @@ void TreeWidget::dropEvent(QDropEvent* event)
     }
 
     // filter out the selected items we cannot handle
-    std::vector<std::pair<DocumentObjectItem*, std::vector<std::string> > > items;
+    std::vector<ObjectItemSubname> items;
     items = DropHandler::filterItems(selectedItems(), targetInfo.targetItem);
     if (items.empty()) {
         return; // nothing needs to be done
@@ -3035,7 +3037,9 @@ void TreeWidget::onItemEntered(QTreeWidgetItem* item)
         Selection().rmvPreselect();
 }
 
-void TreeWidget::leaveEvent(QEvent*) {
+void TreeWidget::leaveEvent(QEvent* event)
+{
+    Q_UNUSED(event)
     if (!updateBlocked && TreeParams::getPreSelection()) {
         preselectTimer->stop();
         Selection().rmvPreselect();

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -2143,7 +2143,8 @@ bool TreeWidget::dropInDocument(QDropEvent* event, TargetItemInfo& targetInfo,
                 }
                 else if (da == Qt::MoveAction && obj->getDocument() == targetInfo.targetDoc) {
                     // Moving a object within the document root.
-                    res = obj;
+                    // Do not set 'res' as changing the placement is not desired: #13690
+                    droppedObjs.push_back(obj);
                 }
                 else {
                     // Moving a object from another document.

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -2638,7 +2638,7 @@ void TreeWidget::sortDroppedObjects(TargetItemInfo& targetInfo, std::vector<App:
             auto vpA = dynamic_cast<Gui::ViewProviderDocumentObject*>(Gui::Application::Instance->getViewProvider(a));
             auto vpB = dynamic_cast<Gui::ViewProviderDocumentObject*>(Gui::Application::Instance->getViewProvider(b));
             if (vpA && vpB) {
-                return vpA->TreeRank.getValue() < vpB->TreeRank.getValue();
+                return vpA->getTreeRank() < vpB->getTreeRank();
             }
             return false; // Keep the original order if either vpA or vpB is nullptr
         });
@@ -2646,10 +2646,10 @@ void TreeWidget::sortDroppedObjects(TargetItemInfo& targetInfo, std::vector<App:
         // Then we move dropped objects to their correct position
         sortIntoList(objList);
 
-        // Then we update the TreeRank properties
+        // Then we set the tree rank
         for (size_t i = 0; i < sortedObjList.size(); ++i) {
             auto vp = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(sortedObjList[i]));
-            vp->TreeRank.setValue(i);
+            vp->setTreeRank(i);
         }
 
         // Lastly we refresh the tree
@@ -4058,10 +4058,10 @@ int DocumentItem::findRootIndex(App::DocumentObject* childObj) {
     int first, last;
 
     auto getTreeRank = [](Gui::ViewProviderDocumentObject* vp) -> int {
-        if (vp->TreeRank.getValue() == -1) {
-            vp->TreeRank.setValue(vp->getObject()->getID());
+        if (vp->getTreeRank() == -1) {
+            vp->setTreeRank(vp->getObject()->getID());
         }
-        return vp->TreeRank.getValue();
+        return vp->getTreeRank();
     };
 
     auto vpc = dynamic_cast<ViewProviderDocumentObject*>(Application::Instance->getViewProvider(childObj));
@@ -4103,7 +4103,7 @@ int DocumentItem::findRootIndex(App::DocumentObject* childObj) {
             if (citem->type() != TreeWidget::ObjectType)
                 continue;
             auto vp = static_cast<DocumentObjectItem*>(citem)->object();
-            if (vp->TreeRank.getValue() < childTreeRank) {
+            if (vp->getTreeRank() < childTreeRank) {
                 first = ++pos;
                 count -= step + 1;
             }
@@ -4135,7 +4135,7 @@ void DocumentItem::sortObjectItems()
 
     std::stable_sort(sortedItems.begin(), sortedItems.end(),
         [](DocumentObjectItem* a, DocumentObjectItem* b) {
-        return a->object()->TreeRank.getValue() < b->object()->TreeRank.getValue();
+        return a->object()->getTreeRank() < b->object()->getTreeRank();
     });
 
     int sortedIndex = 0;

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -141,6 +141,8 @@ protected:
     void dragLeaveEvent(QDragLeaveEvent * event) override;
     void dragMoveEvent(QDragMoveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
+
+private:
     struct TargetItemInfo {
         QTreeWidgetItem* targetItem = nullptr; //target may be the parent of underMouse
         QTreeWidgetItem* underMouseItem = nullptr;
@@ -150,19 +152,23 @@ protected:
         bool inThresholdZone = false;
     };
     TargetItemInfo getTargetInfo(QEvent* ev);
-    bool dropInObject(QDropEvent* event, TargetItemInfo& targetInfo, std::vector<std::pair<DocumentObjectItem*, std::vector<std::string> > > items);
-    bool dropInDocument(QDropEvent* event, TargetItemInfo& targetInfo, std::vector<std::pair<DocumentObjectItem*, std::vector<std::string> > > items);
+    using ObjectItemSubname = std::pair<DocumentObjectItem*, std::vector<std::string>>;
+    bool dropInObject(QDropEvent* event, TargetItemInfo& targetInfo, std::vector<ObjectItemSubname> items);
+    bool dropInDocument(QDropEvent* event, TargetItemInfo& targetInfo, std::vector<ObjectItemSubname> items);
     void sortDroppedObjects(TargetItemInfo& targetInfo, std::vector<App::DocumentObject*> draggedObjects);
     //@}
+
+protected:
     bool event(QEvent *e) override;
     void keyPressEvent(QKeyEvent *event) override;
     void mousePressEvent(QMouseEvent * event) override;
     void mouseDoubleClickEvent(QMouseEvent * event) override;
 
-protected:
-    void showEvent(QShowEvent *) override;
-    void hideEvent(QHideEvent *) override;
-    void leaveEvent(QEvent *) override;
+    void showEvent(QShowEvent *ev) override;
+    void hideEvent(QHideEvent *ev) override;
+    void leaveEvent(QEvent *event) override;
+
+private:
     void _updateStatus(bool delay=true);
 
 protected Q_SLOTS:

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -77,8 +77,6 @@ ViewProviderDocumentObject::ViewProviderDocumentObject()
             "Element: On top only if some sub-element of the object is selected");
     OnTopWhenSelected.setEnums(OnTopEnum);
 
-    ADD_PROPERTY_TYPE(TreeRank, (-1), dogroup, App::Prop_Hidden, "Tree view item ordering key");
-
     sPixmap = "Feature";
 }
 

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -64,9 +64,6 @@ public:
     App::PropertyEnumeration OnTopWhenSelected;
     App::PropertyEnumeration SelectionStyle;
 
-    // Hidden properties
-    App::PropertyInteger TreeRank;
-
     virtual void attach(App::DocumentObject *pcObject);
     virtual void reattach(App::DocumentObject *);
     void update(const App::Property*) override;
@@ -124,6 +121,18 @@ public:
     //@{
     virtual void startRestoring();
     virtual void finishRestoring();
+    //@}
+
+    /** @name Tree rank */
+    //@{
+    int getTreeRank() const
+    {
+        return treeRank;
+    }
+    void setTreeRank(int value)
+    {
+        treeRank = value;
+    }
     //@}
 
     bool removeDynamicProperty(const char* prop) override;
@@ -220,6 +229,7 @@ protected:
 
 private:
     bool _Showable = true;
+    int treeRank = -1;
 
     std::vector<const char*> aDisplayEnumsArray;
     std::vector<std::string> aDisplayModesArray;


### PR DESCRIPTION
This fixes #13690: Reordering top level objects destroys the Placement