### PR TITLE
Fix backwards-compatible Qt6 warnings

### DIFF
--- a/src/Gui/DlgParameterImp.cpp
+++ b/src/Gui/DlgParameterImp.cpp
@@ -160,7 +160,7 @@ void DlgParameterImp::onFindGroupTtextChanged(const QString &SearchStr)
 
     // at first reset all items to the default font and expand state
     if (!foundList.empty()) {
-        for (QTreeWidgetItem* item : qAsConst(foundList)) {
+        for (QTreeWidgetItem* item : std::as_const(foundList)) {
             item->setFont(0, defaultFont);
             item->setForeground(0, defaultColor);
             ExpandItem = item;
@@ -191,7 +191,7 @@ void DlgParameterImp::onFindGroupTtextChanged(const QString &SearchStr)
         // reset background style sheet
         if (!ui->findGroupLE->styleSheet().isEmpty())
             ui->findGroupLE->setStyleSheet(QString());
-        for (QTreeWidgetItem* item : qAsConst(foundList)) {
+        for (QTreeWidgetItem* item : std::as_const(foundList)) {
             item->setFont(0, boldFont);
             item->setForeground(0, Qt::red);
             // expand its parent to see the item

--- a/src/Gui/DlgPropertyLink.cpp
+++ b/src/Gui/DlgPropertyLink.cpp
@@ -362,7 +362,7 @@ void DlgPropertyLink::init(const App::DocumentObjectT &prop, bool tryFilter) {
     // For link list type property, try to auto filter type
     if(tryFilter && isLinkList) {
         Base::Type objType;
-        for(const auto& link : qAsConst(oldLinks)) {
+        for(const auto& link : std::as_const(oldLinks)) {
             auto obj = link.getSubObject();
             if(!obj)
                 continue;

--- a/src/Gui/DocumentModel.cpp
+++ b/src/Gui/DocumentModel.cpp
@@ -489,7 +489,7 @@ void DocumentModel::slotChangeObject(const Gui::ViewProviderDocumentObject& obj,
             auto doc_index = static_cast<DocumentIndex*>(d->rootItem->child(row));
             QList<ViewProviderIndex*> views;
             doc_index->findViewProviders(obj, views);
-            for (const auto & view : qAsConst(views)) {
+            for (const auto & view : std::as_const(views)) {
                 DocumentModelIndex* parentitem = view->parent();
                 QModelIndex parent = createIndex(0,0,parentitem);
                 int row = view->row();
@@ -523,7 +523,7 @@ void DocumentModel::slotChangeObject(const Gui::ViewProviderDocumentObject& obj,
             // get all occurrences of the view provider in the tree structure
             QList<ViewProviderIndex*> obj_index;
             doc_index->findViewProviders(obj, obj_index);
-            for (const auto & it : qAsConst(obj_index)) {
+            for (const auto & it : std::as_const(obj_index)) {
                 QModelIndex parent = createIndex(it->row(),0,it);
                 int count_obj = it->childCount();
                 beginRemoveRows(parent, 0, count_obj);

--- a/src/Gui/DocumentRecovery.cpp
+++ b/src/Gui/DocumentRecovery.cpp
@@ -727,7 +727,7 @@ void DocumentRecoveryCleaner::subtractFiles(QStringList& files)
 void DocumentRecoveryCleaner::subtractDirs(QFileInfoList& dirs)
 {
     if (!ignoreDirs.isEmpty() && !dirs.isEmpty()) {
-        for (const auto& it : qAsConst(ignoreDirs)) {
+        for (const auto& it : std::as_const(ignoreDirs)) {
             dirs.removeOne(it);
         }
     }

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -454,7 +454,7 @@ bool GraphvizView::onMsg(const char* pMsg, const char**)
         formatMap << qMakePair(QString::fromLatin1("%1 (*.pdf)").arg(tr("PDF format")), QString::fromLatin1("pdf"));
 
         QStringList filter;
-        for (const auto & it : qAsConst(formatMap)) {
+        for (const auto & it : std::as_const(formatMap)) {
             filter << it.first;
         }
 
@@ -462,7 +462,7 @@ bool GraphvizView::onMsg(const char* pMsg, const char**)
         QString fn = Gui::FileDialog::getSaveFileName(this, tr("Export graph"), QString(), filter.join(QLatin1String(";;")), &selectedFilter);
         if (!fn.isEmpty()) {
             QString format;
-            for (const auto & it : qAsConst(formatMap)) {
+            for (const auto & it : std::as_const(formatMap)) {
                 if (selectedFilter == it.first) {
                     format = it.second;
                     break;

--- a/src/Gui/Language/Translator.cpp
+++ b/src/Gui/Language/Translator.cpp
@@ -221,7 +221,7 @@ TStringMap Translator::supportedLocales() const
 
     // List all .qm files
     for (const auto& domainMap : d->mapLanguageTopLevelDomain) {
-        for (const auto& directoryName : qAsConst(d->paths)) {
+        for (const auto& directoryName : std::as_const(d->paths)) {
             QDir dir(directoryName);
             QString filter = QString::fromLatin1("*_%1.qm").arg(QString::fromStdString(domainMap.second));
             QStringList fileNames = dir.entryList(QStringList(filter), QDir::Files, QDir::Name);

--- a/src/Gui/Macro.cpp
+++ b/src/Gui/Macro.cpp
@@ -84,7 +84,7 @@ bool MacroFile::commit()
     import << QString::fromLatin1("import FreeCAD");
     QStringList body;
 
-    for (const auto& it : qAsConst(this->macroInProgress)) {
+    for (const auto& it : std::as_const(this->macroInProgress)) {
         if (it.startsWith(QLatin1String("import ")) ||
             it.startsWith(QLatin1String("#import "))) {
             if (import.indexOf(it) == -1)
@@ -107,7 +107,7 @@ bool MacroFile::commit()
 
     // write the data to the text file
     str << header;
-    for (const auto& it : qAsConst(import)) {
+    for (const auto& it : std::as_const(import)) {
         str << it << QLatin1Char('\n');
     }
     str << QLatin1Char('\n');

--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -469,7 +469,7 @@ public:
 
     ~NotificationsAction() override
     {
-        for (auto* item : qAsConst(pushedItems)) {
+        for (auto* item : std::as_const(pushedItems)) {
             if (item) {
                 delete item; // NOLINT
             }
@@ -683,7 +683,7 @@ protected:
                 QMenu menu;
 
                 QAction* del = menu.addAction(tr("Delete"), this, [&]() {
-                    for (auto it : qAsConst(selectedItems)) {
+                    for (auto it : std::as_const(selectedItems)) {
                         delete it;
                     }
                 });

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -850,13 +850,13 @@ void AboutDialog::copyToClipboard()
         << '\n';
 #endif
     QLocale loc;
-    str << "Locale: " << loc.languageToString(loc.language()) << "/"
-        << loc.countryToString(loc.country())
+    str << "Locale: " << QLocale::languageToString(loc.language()) << "/"
+        << QLocale::countryToString(loc.country())
         << " (" << loc.name() << ")";
     if (loc != QLocale::system()) {
         loc = QLocale::system();
-        str << " [ OS: " << loc.languageToString(loc.language()) << "/"
-            << loc.countryToString(loc.country())
+        str << " [ OS: " << QLocale::languageToString(loc.language()) << "/"
+            << QLocale::countryToString(loc.country())
             << " (" << loc.name() << ") ]";
     }
     str << "\n";

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -446,7 +446,7 @@ void StartupPostProcess::showMainWindow()
     // stop splash screen and set immediately the active window that may be of interest
     // for scripts using Python binding for Qt
     mainWindow->stopSplasher();
-    qtApp->setActiveWindow(mainWindow);
+    mainWindow->activateWindow();
 }
 
 void StartupPostProcess::activateWorkbench()

--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -85,7 +85,7 @@ ToolBarItem* ToolBarItem::findItem(const std::string& name)
         return this;
     }
 
-    for (auto it : qAsConst(_items)) {
+    for (auto it : std::as_const(_items)) {
         if (it->_name == name) {
             return it;
         }
@@ -138,7 +138,7 @@ void ToolBarItem::removeItem(ToolBarItem* item)
 
 void ToolBarItem::clear()
 {
-    for (auto it : qAsConst(_items)) {
+    for (auto it : std::as_const(_items)) {
         delete it;
     }
 

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -134,7 +134,7 @@ void PropertyItem::reset()
 void PropertyItem::onChange()
 {
     if (hasExpression()) {
-        for(auto child : qAsConst(childItems)) {
+        for(auto child : std::as_const(childItems)) {
             if(child && child->hasExpression()) {
                 child->setExpression(std::shared_ptr<App::Expression>());
             }
@@ -309,7 +309,7 @@ int PropertyItem::columnCount() const
 void PropertyItem::setReadOnly(bool ro)
 {
     readonly = ro;
-    for (auto it : qAsConst(childItems)) {
+    for (auto it : std::as_const(childItems)) {
         it->setReadOnly(ro);
     }
 }
@@ -322,7 +322,7 @@ bool PropertyItem::isReadOnly() const
 void PropertyItem::setLinked(bool value)
 {
     linked = value;
-    for (auto it : qAsConst(childItems)) {
+    for (auto it : std::as_const(childItems)) {
         it->setLinked(value);
     }
 }

--- a/src/Mod/Drawing/Gui/Command.cpp
+++ b/src/Mod/Drawing/Gui/Command.cpp
@@ -100,7 +100,7 @@ CmdDrawingNewPage::CmdDrawingNewPage()
 void CmdDrawingNewPage::activated(int iMsg)
 {
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
-    QAction* a = qAsConst(pcAction)->actions()[iMsg];
+    QAction* a = std::as_const(pcAction)->actions()[iMsg];
 
     std::string FeatName = getUniqueObjectName(
         QCoreApplication::translate("Drawing_NewPage", "Page").toStdString().c_str());
@@ -204,7 +204,7 @@ Gui::Action* CmdDrawingNewPage::createAction(void)
         pcAction->setProperty("defaultAction", QVariant(defaultId));
     }
     else if (!pcAction->actions().isEmpty()) {
-        pcAction->setIcon(qAsConst(pcAction)->actions()[0]->icon());
+        pcAction->setIcon(std::as_const(pcAction)->actions()[0]->icon());
         pcAction->setProperty("defaultAction", QVariant(0));
     }
 

--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -524,7 +524,7 @@ QString Material::getAuthorAndLicense() const
 
 void Material::addModel(const QString& uuid)
 {
-    for (const auto& modelUUID : qAsConst(_allUuids)) {
+    for (const auto& modelUUID : std::as_const(_allUuids)) {
         if (modelUUID == uuid) {
             return;
         }

--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -285,7 +285,8 @@ void EditDatumDialog::drivingToggled(bool state)
 
 void EditDatumDialog::datumChanged()
 {
-    if (ui_ins_datum->labelEdit->text() != qAsConst(ui_ins_datum->labelEdit)->getHistory()[0]) {
+    if (ui_ins_datum->labelEdit->text()
+        != std::as_const(ui_ins_datum->labelEdit)->getHistory()[0]) {
         ui_ins_datum->cbDriving->setChecked(false);
     }
 }

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -833,7 +833,7 @@ TaskSketcherConstraints::TaskSketcherConstraints(ViewProviderSketch* sketchView)
     QWidgetAction* action = new QWidgetAction(this);
     filterList = new ConstraintFilterList(this);
     action->setDefaultWidget(filterList);
-    qAsConst(ui->filterButton)->addAction(action);
+    std::as_const(ui->filterButton)->addAction(action);
 
     // Create local settings menu
     // FIXME there is probably a smarter way to handle this menu
@@ -862,7 +862,7 @@ TaskSketcherConstraints::TaskSketcherConstraints(ViewProviderSketch* sketchView)
     }
     hGrp->Attach(this);
 
-    auto settingsBut = qAsConst(ui->settingsButton);
+    auto settingsBut = std::as_const(ui->settingsButton);
 
     settingsBut->addAction(action1);
     settingsBut->addAction(action2);
@@ -1040,8 +1040,8 @@ void TaskSketcherConstraints::onChangedSketchView(const Gui::ViewProvider& vp,
 {
     if (sketchView == &vp) {
         if (&sketchView->Autoconstraints == &prop) {
-            QSignalBlocker block(qAsConst(ui->settingsButton)->actions()[0]);
-            qAsConst(ui->settingsButton)
+            QSignalBlocker block(std::as_const(ui->settingsButton)->actions()[0]);
+            std::as_const(ui->settingsButton)
                 ->actions()[0]
                 ->setChecked(sketchView->Autoconstraints.getValue());
         }
@@ -1425,7 +1425,7 @@ void TaskSketcherConstraints::OnChange(Base::Subject<const char*>& rCaller, cons
     }
     if (actNum >= 0) {
         assert(actNum < static_cast<int>(ui->settingsButton->actions().size()));
-        qAsConst(ui->settingsButton)->actions()[actNum]->setChecked(hGrp->GetBool(rcReason, false));
+        std::as_const(ui->settingsButton)->actions()[actNum]->setChecked(hGrp->GetBool(rcReason, false));
     }
 }
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -492,7 +492,7 @@ private:
     {
         int hue, sat, val, alp;
         QIcon Normal = Gui::BitmapFactory().iconFromTheme(name);
-        QImage imgConstr(Normal.pixmap(qAsConst(Normal).availableSizes()[0]).toImage());
+        QImage imgConstr(Normal.pixmap(std::as_const(Normal).availableSizes()[0]).toImage());
         QImage imgExt(imgConstr);
         QImage imgInt(imgConstr);
 
@@ -1230,7 +1230,7 @@ void TaskSketcherElements::connectSignals()
                      &TaskSketcherElements::onFilterBoxStateChanged);
     QObject::connect(
         ui->settingsButton, &QToolButton::clicked, ui->settingsButton, &QToolButton::showMenu);
-    QObject::connect(qAsConst(ui->settingsButton)->actions()[0],
+    QObject::connect(std::as_const(ui->settingsButton)->actions()[0],
                      &QAction::changed,
                      this,
                      &TaskSketcherElements::onSettingsExtendedInformationChanged);
@@ -1250,7 +1250,7 @@ void TaskSketcherElements::createFilterButtonActions()
     auto* action = new QWidgetAction(this);
     filterList = new ElementFilterList(this);
     action->setDefaultWidget(filterList);
-    qAsConst(ui->filterButton)->addAction(action);
+    std::as_const(ui->filterButton)->addAction(action);
 }
 
 void TaskSketcherElements::onFilterBoxStateChanged(int val)

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.cpp
@@ -102,7 +102,7 @@ TaskSketcherMessages::TaskSketcherMessages(ViewProviderSketch* sketchView)
     action->setChecked(state);
     ui->manualUpdate->addAction(action);
 
-    QObject::connect(qAsConst(ui->manualUpdate)->actions()[0],
+    QObject::connect(std::as_const(ui->manualUpdate)->actions()[0],
                      &QAction::changed,
                      this,
                      &TaskSketcherMessages::onAutoUpdateStateChanged);
@@ -175,7 +175,7 @@ void TaskSketcherMessages::onLabelConstrainStatusLinkClicked(const QString& str)
 
 void TaskSketcherMessages::onAutoUpdateStateChanged()
 {
-    bool state = qAsConst(ui->manualUpdate)->actions()[0]->isChecked();
+    bool state = std::as_const(ui->manualUpdate)->actions()[0]->isChecked();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher");

--- a/src/Mod/Start/Gui/FlowLayout.cpp
+++ b/src/Mod/Start/Gui/FlowLayout.cpp
@@ -119,7 +119,7 @@ QSize FlowLayout::sizeHint() const
 QSize FlowLayout::minimumSize() const
 {
     QSize size;
-    for (auto item : qAsConst(itemList)) {
+    for (auto item : std::as_const(itemList)) {
         size = size.expandedTo(item->minimumSize());
     }
 
@@ -155,7 +155,7 @@ int FlowLayout::doLayout(const QRect& rect, bool testOnly) const
     int y = effectiveRect.y();
     int lineHeight = 0;
 
-    for (auto item : qAsConst(itemList)) {
+    for (auto item : std::as_const(itemList)) {
         QWidget* wid = item->widget();
         int spaceX = horizontalSpacing();
         if (spaceX == -1) {

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -717,7 +717,7 @@ void MDIViewPage::sceneSelectionManager()
     //add to m_qgSceneSelected anything that is in q_sceneSel
     for (auto qts : sceneSel) {
         bool found = false;
-        for (auto ms : qAsConst(m_qgSceneSelected)) {
+        for (auto ms : std::as_const(m_qgSceneSelected)) {
             if (qts == ms) {
                 found = true;
                 break;
@@ -731,7 +731,7 @@ void MDIViewPage::sceneSelectionManager()
 
     //remove items from m_qgSceneSelected that are not in q_sceneSel
     QList<QGraphicsItem*> m_new;
-    for (auto m : qAsConst(m_qgSceneSelected)) {
+    for (auto m : std::as_const(m_qgSceneSelected)) {
         for (auto q : sceneSel) {
             if (m == q) {
                 m_new.push_back(m);

--- a/src/Tools/updatecrowdin.py
+++ b/src/Tools/updatecrowdin.py
@@ -399,7 +399,7 @@ def updateTranslatorCpp(lncode):
 
     cppfile = os.path.join(os.path.dirname(__file__), "..", "Gui", "Language", "Translator.cpp")
     l = QtCore.QLocale(lncode)
-    lnname = l.languageToString(l.language())
+    lnname = QtCore.QLocale.languageToString(l.language())
 
     # read file contents
     f = open(cppfile, "r")

--- a/src/Tools/xmlformat/main.cpp
+++ b/src/Tools/xmlformat/main.cpp
@@ -87,7 +87,7 @@ int main(int argc, char* argv[])
         }
 
         // add the rest
-        for (const auto& it : qAsConst(attr)) {
+        for (const auto& it : std::as_const(attr)) {
             sorted.append(it);
         }
 


### PR DESCRIPTION
Nothing fancy, just some cleanup:
- `qAsConst` → `std::as_const`
- `QLocale::languageToString` instance → `QLocale::languageToString` static
- `QLocale::countryToString` instance → `QLocale::countryToString` static
- `QApplication::setActiveWindow` → `MainWindow::activateWindow`