### PR TITLE
Gui: Remove redundant overlay header

### DIFF
--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -1594,15 +1594,19 @@ void OverlayManager::onDockVisibleChange(bool visible)
 void OverlayManager::onDockFeaturesChange(QDockWidget::DockWidgetFeatures features)
 {
     Q_UNUSED(features);
+
     auto dw = qobject_cast<QDockWidget*>(sender());
-    if (!dw)
+
+    if (!dw) {
         return;
+    }
 
     // Rebuild the title widget as it may have a different set of buttons shown.
-    if (QWidget *titleBarWidget = dw->titleBarWidget()) {
+    if (auto *titleBarWidget = qobject_cast<OverlayTitleBar*>(dw->titleBarWidget())) {
         dw->setTitleBarWidget(nullptr);
         delete titleBarWidget;
     }
+
     setupTitleBar(dw);
 }
 


### PR DESCRIPTION
Problem was caused by replacing the widget even if it should be invisible. 

Fixes: #13349 