### PR TITLE
[MeasureGui] Make initial measurement placement scale with viewport zoom

### DIFF
--- a/src/Mod/Measure/Gui/ViewProviderMeasureAngle.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureAngle.cpp
@@ -334,6 +334,6 @@ Measure::MeasureAngle* ViewProviderMeasureAngle::getMeasureAngle()
 
 void ViewProviderMeasureAngle::positionAnno(const Measure::MeasureBase* measureObject) {
     (void)measureObject;
-    setLabelTranslation(SbVec3f(0, 10, 0));
+    setLabelTranslation(SbVec3f(0, 0.1 * getViewScale(), 0));
 }
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -37,6 +37,7 @@
 # include <Inventor/engines/SoComposeMatrix.h>
 # include <Inventor/engines/SoTransformVec3f.h>
 # include <Inventor/engines/SoConcatenate.h>
+# include <Inventor/SbViewportRegion.h>
 #endif
 
 #include <App/DocumentObject.h>
@@ -455,6 +456,28 @@ void ViewProviderMeasureBase::onSubjectVisibilityChanged(const App::DocumentObje
 }
 
 
+float ViewProviderMeasureBase::getViewScale() {
+    float scale = 1.0;
+
+    Gui::View3DInventor* view = dynamic_cast<Gui::View3DInventor*>(this->getActiveView());
+    if (!view) {
+        Base::Console().Log("ViewProviderMeasureBase::getViewScale: Could not get active view\n");
+        return scale;
+    }
+    Gui::View3DInventorViewer* viewer = view->getViewer();
+
+    SoCamera * const camera = viewer->getSoRenderManager()->getCamera();
+    if (!camera)
+        return false;
+
+    SbViewVolume volume(camera->getViewVolume());
+    SbVec3f center(volume.getSightPoint(camera->focalDistance.getValue()));
+    scale = volume.getWorldToScreenScale(center, 1.0);
+    return scale;
+}
+
+
+
 //NOLINTBEGIN
 PROPERTY_SOURCE(MeasureGui::ViewProviderMeasure, MeasureGui::ViewProviderMeasureBase)
 //NOLINTEND
@@ -587,12 +610,20 @@ Base::Vector3d ViewProviderMeasure::getBasePosition(){
 
 
 Base::Vector3d ViewProviderMeasure::getTextPosition(){
-    constexpr float DefaultLeaderLength{20.0};
     auto basePoint = getBasePosition();
-    Base::Vector3d textDirection(1.0, 1.0, 1.0);
-    textDirection.Normalize();
 
-    return basePoint + textDirection * DefaultLeaderLength;
+    Gui::View3DInventor* view = dynamic_cast<Gui::View3DInventor*>(this->getActiveView());
+    if (!view) {
+        Base::Console().Log("ViewProviderMeasureBase::getTextPosition: Could not get active view\n");
+        return Base::Vector3d();
+    }
+    
+    Gui::View3DInventorViewer* viewer = view->getViewer();    
+
+    // Convert to screenspace, offset and convert back to world space
+    SbVec2s screenPos = viewer->getPointOnViewport(SbVec3f(basePoint.x, basePoint.y, basePoint.z));
+    SbVec3f textPos = viewer->getPointOnFocalPlane(screenPos + SbVec2s(30.0, 30.0));
+    return Base::Vector3d(textPos[0], textPos[1], textPos[2]);
 }
 
 //! called by the system when it is time to display this measure

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.h
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.h
@@ -110,7 +110,7 @@ protected:
 
     static constexpr double defaultTolerance = 10e-6;
     virtual Base::Vector3d getTextDirection(Base::Vector3d elementDirection, double tolerance = defaultTolerance);
-
+    float getViewScale();
 
     // TODO: getters & setters and move variables to private?
     bool _mShowTree = true;

--- a/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
@@ -218,5 +218,5 @@ void ViewProviderMeasureDistance::redrawAnnotation()
 
 void ViewProviderMeasureDistance::positionAnno(const Measure::MeasureBase* measureObject) {
     (void)measureObject;
-    setLabelTranslation(SbVec3f(0, 10, 0));
+    setLabelTranslation(SbVec3f(0, 0.1 * getViewScale(), 0));
 }


### PR DESCRIPTION
Currently the initial positioning of UMF measurements is static which often feels out of place as described in #13808.

This PR improves the behavior by:
- scaling the distance/angle measurement offsets with openinventors "getWorldToScreenScale" factor
- offsetting the annotation label text in screenspace and converting it to a 3d location