### PR TITLE
Gui: Add missing close paren in PythonWrapper.cpp

### DIFF
--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -588,7 +588,7 @@ qsizetype PythonWrapper::toEnum(PyObject* pyPtr)
 #if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
     return Shiboken::Enum::getValue(pyPtr);
 #else
-    return toEnum(Py::Object(pyPtr);
+    return toEnum(Py::Object(pyPtr));
 #endif
 }
 


### PR DESCRIPTION
Fix compilation problem.