### PR TITLE
Gui: fix use of deprecated setMargin in toolbarmanager

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -181,7 +181,7 @@ public:
         , _conn(conn)
     {
         _layout = new QHBoxLayout(this);
-        _layout->setMargin(0);
+        _layout->setContentsMargins(0,0,0,0);
     }
 
     void addWidget(QWidget *w)


### PR DESCRIPTION
the function has been removed from qt6, fixes qt6 compilation failure after https://github.com/FreeCAD/FreeCAD/commit/c24ace7f7317418c14ed2cadabfd1226ea604977