### PR TITLE
MeasureGui: Improve measure task wording

### DIFF
--- a/src/Gui/TaskMeasure.cpp
+++ b/src/Gui/TaskMeasure.cpp
@@ -104,15 +104,15 @@ TaskMeasure::~TaskMeasure(){
 void TaskMeasure::modifyStandardButtons(QDialogButtonBox* box) {
 
     QPushButton* btn = box->button(QDialogButtonBox::Apply);
-    btn->setText(tr("Annotate"));
-    btn->setToolTip(tr("Press the Annotate button to add measurement to the document."));
+    btn->setText(tr("Save"));
+    btn->setToolTip(tr("Save the measurement in the active document."));
     connect(btn, &QPushButton::released, this, &TaskMeasure::apply);
 
     // Disable button by default
     btn->setEnabled(false);
     btn = box->button(QDialogButtonBox::Abort);
     btn->setText(tr("Close"));
-    btn->setToolTip(tr("Press the Close button to exit."));
+    btn->setToolTip(tr("Close the measurement task."));
 
     // Connect reset button
     btn = box->button(QDialogButtonBox::Reset);

--- a/src/Gui/TaskMeasure.cpp
+++ b/src/Gui/TaskMeasure.cpp
@@ -74,8 +74,8 @@ TaskMeasure::TaskMeasure()
     // formLayout->setFieldGrowthPolicy(QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow);
     formLayout->setFormAlignment(Qt::AlignCenter);
 
-    formLayout->addRow(QString::fromLatin1("Mode:"), modeSwitch);
-    formLayout->addRow(QString::fromLatin1("Result:"), valueResult);
+    formLayout->addRow(tr("Mode:"), modeSwitch);
+    formLayout->addRow(tr("Result:"), valueResult);
     layout->addLayout(formLayout);
 
     Content.emplace_back(taskbox);
@@ -111,7 +111,7 @@ void TaskMeasure::modifyStandardButtons(QDialogButtonBox* box) {
     // Disable button by default
     btn->setEnabled(false);
     btn = box->button(QDialogButtonBox::Abort);
-    btn->setText(QString::fromLatin1("Close"));
+    btn->setText(tr("Close"));
     btn->setToolTip(tr("Press the Close button to exit."));
 
     // Connect reset button


### PR DESCRIPTION
This PR does two things:
- Add some remaining label strings (Mode/Result/Close) for translation
- Improve the wording of the annotate button as described in #13734
- Improve the tooltip for the close button