### PR TITLE
[MeasureGui] Add measurement value to label text

### DIFF
--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -282,6 +282,10 @@ void ViewProviderMeasureBase::updateData(const App::Property* prop)
         return;
     }
 
+    if (strcmp(prop->getName(), "Label") == 0) {
+        doUpdate = true;
+    }
+
     // Check if one of the input properties has been changed
     auto inputProps = obj->getInputProps();
     if (std::find(inputProps.begin(), inputProps.end(), std::string(prop->getName())) != inputProps.end()) {
@@ -299,6 +303,11 @@ void ViewProviderMeasureBase::updateData(const App::Property* prop)
 
     if (doUpdate) {
         redrawAnnotation();
+
+        // Update label
+        std::string userLabel(obj->Label.getValue());
+        std::string name = userLabel.substr(0, userLabel.find(":"));
+        obj->Label.setValue((name + ": ") + obj->getResultString().toStdString());
     }
 
     ViewProviderDocumentObject::updateData(prop);


### PR DESCRIPTION
This PR adds the value of measurements to the end of the label as proposed in #13707.

The value is placed after a colon character. When the user edits the label everything after the first occurrence of a colon character gets overwritten. The label is rewritten whenever the measurement is updated.

![image](https://github.com/FreeCAD/FreeCAD/assets/64740362/11af94a6-edb6-4e38-8852-1dfc06325ea1)
