### PR TITLE
Update ToolBarManager.cpp for QT 6.7

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -181,7 +181,7 @@ public:
         , _conn(conn)
     {
         _layout = new QHBoxLayout(this);
-        _layout->setMargin(0);
+        _layout->setContentsMargins(QMargins());
     }
 
     void addWidget(QWidget *w)


### PR DESCRIPTION
Replace method call obsoleted in QT5 so that QT6 compiles work.