### PR TITLE
Conda: pin zstd==1.5.6 to fix Windows CI failures.

### DIFF
--- a/conda/conda-env.yaml
+++ b/conda/conda-env.yaml
@@ -5,3 +5,4 @@ dependencies:
 - conda-devenv
 - mamba
 - python==3.11.*
+- zstd==1.5.6

--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -99,3 +99,4 @@ dependencies:
 - xerces-c
 - yaml-cpp
 - zlib
+- zstd==1.5.6


### PR DESCRIPTION
I believe this fix will address the intermittent failures of Windows Conda CI.

The issue is that under Windows when the dynamic library the executable is linked against is deleted, there is a risk of a segmentation fault.  The `libmamba` library brings in `libzstd` to decompress files, and when it upgrades `zstd` from 1.5.5 to 1.5.6 this deletes the version it is linked to, sometimes while it is still using the library.

By pinning zstd to the latest version, we prevent the upgrade and the threat of deleting the library still in-use.

This issue does not affect Linux and macOS as those systems simply [`unlink()`](https://www.man7.org/linux/man-pages/man2/unlink.2.html) the deleted files upon deletion, and perform the actual deletion when the number of open file handles drops to 0.

@adrianinsaval @chennes 