### PR TITLE
Change property view panel title to sentence case

### DIFF
--- a/src/Gui/PropertyView.cpp
+++ b/src/Gui/PropertyView.cpp
@@ -559,7 +559,7 @@ void PropertyView::changeEvent(QEvent *e)
 PropertyDockView::PropertyDockView(Gui::Document* pcDocument, QWidget *parent)
   : DockWindow(pcDocument,parent)
 {
-    setWindowTitle(tr("Property View"));
+    setWindowTitle(tr("Property view"));
 
     auto view = new PropertyView(this);
     auto pLayout = new QGridLayout(this);


### PR DESCRIPTION
To be consistent with the rest of "view" panels, change "Property View" to sentence case ("Property view")
![image](https://github.com/FreeCAD/FreeCAD/assets/148809153/53d91416-53ab-45ab-ab30-4e0748d2eaeb)
