### PR TITLE
Align camera to faces and edges

### DIFF
--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -209,6 +209,13 @@ void GeoFeature::setMaterialAppearance(const App::Material& material)
     Q_UNUSED(material)
 }
 
+bool GeoFeature::getCameraAlignmentDirection(Base::Vector3d& direction, const char* subname) const
+{
+    Q_UNUSED(subname)
+    Q_UNUSED(direction)
+    return false;
+}
+
 #ifdef FC_USE_TNP_FIX
 bool GeoFeature::hasMissingElement(const char* subname)
 {

--- a/src/App/GeoFeature.h
+++ b/src/App/GeoFeature.h
@@ -141,6 +141,15 @@ public:
      * appearance from an App::Material object.
      */
     virtual void setMaterialAppearance(const App::Material& material);
+
+    /**
+     * @brief Virtual function to get the camera alignment direction
+     *
+     * Finds a direction to align the camera with.
+     *
+     * @return bool whether or not a direction is found.
+     */
+    virtual bool getCameraAlignmentDirection(Base::Vector3d& direction, const char* subname = nullptr) const;
 #ifdef FC_USE_TNP_FIX
     /** Search sub element using internal cached geometry
      *

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -4079,16 +4079,16 @@ bool StdRecallWorkingView::isActive()
 //===========================================================================
 // Std_AlignToSelection
 //===========================================================================
-
 DEF_STD_CMD_A(StdCmdAlignToSelection)
 
 StdCmdAlignToSelection::StdCmdAlignToSelection()
   : Command("Std_AlignToSelection")
 {
-    sGroup        = "Standard-View";
+    sGroup        = "View";
     sMenuText     = QT_TR_NOOP("Align to selection");
     sToolTipText  = QT_TR_NOOP("Align the view with the selection");
     sWhatsThis    = "Std_AlignToSelection";
+    sPixmap       = "align-to-selection";
     eType         = Alter3DView;
 }
 

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -4077,6 +4077,33 @@ bool StdRecallWorkingView::isActive()
 }
 
 //===========================================================================
+// Std_AlignToSelection
+//===========================================================================
+
+DEF_STD_CMD_A(StdCmdAlignToSelection)
+
+StdCmdAlignToSelection::StdCmdAlignToSelection()
+  : Command("Std_AlignToSelection")
+{
+    sGroup        = "Standard-View";
+    sMenuText     = QT_TR_NOOP("Align to selection");
+    sToolTipText  = QT_TR_NOOP("Align the view with the selection");
+    sWhatsThis    = "Std_AlignToSelection";
+    eType         = Alter3DView;
+}
+
+void StdCmdAlignToSelection::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    doCommand(Command::Gui,"Gui.SendMsgToActiveView(\"AlignToSelection\")");
+}
+
+bool StdCmdAlignToSelection::isActive()
+{
+    return getGuiApplication()->sendHasMsgToActiveView("AlignToSelection");
+}
+
+//===========================================================================
 // Instantiation
 //===========================================================================
 
@@ -4107,6 +4134,7 @@ void CreateViewStdCommands()
     rcCmdMgr.addCommand(new StdStoreWorkingView());
     rcCmdMgr.addCommand(new StdRecallWorkingView());
     rcCmdMgr.addCommand(new StdCmdViewGroup());
+    rcCmdMgr.addCommand(new StdCmdAlignToSelection());
 
     rcCmdMgr.addCommand(new StdCmdViewExample1());
     rcCmdMgr.addCommand(new StdCmdViewExample2());

--- a/src/Gui/Icons/align-to-selection.svg
+++ b/src/Gui/Icons/align-to-selection.svg
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   id="svg2869"
+   version="1.1"
+   viewBox="0 0 64 64"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2871">
+    <linearGradient
+       id="linearGradient5">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop19" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop20" />
+    </linearGradient>
+    <linearGradient
+       id="swatch18">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop18" />
+    </linearGradient>
+    <linearGradient
+       id="swatch15">
+      <stop
+         style="stop-color:#3d0000;stop-opacity:1;"
+         offset="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5-1">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1;"
+         offset="0"
+         id="stop5" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:0;"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-9">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3838-8" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3840-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3775">
+      <stop
+         style="stop-color:#16d0d2;stop-opacity:1"
+         offset="0"
+         id="stop3777" />
+      <stop
+         style="stop-color:#34e0e2;stop-opacity:1"
+         offset="1"
+         id="stop3779" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3775"
+       id="linearGradient3"
+       gradientUnits="userSpaceOnUse"
+       x1="44"
+       y1="40"
+       x2="40"
+       y2="8" />
+  </defs>
+  <metadata
+     id="metadata2874">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[maxwxyz]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>2024</dc:date>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer3"
+     style="display:inline">
+    <g
+       id="g22">
+      <g
+         id="g21">
+        <path
+           id="path3825-7"
+           d="M 25,5 59,9 V 43 L 25,39 Z"
+           style="font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient3);fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000" />
+        <path
+           id="path3825-7-7"
+           d="M 25,5 59,9 V 43 L 25,39 Z"
+           style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#042a2a;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      </g>
+      <path
+         style="color:#000000;fill:#042a2a;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+         d="m 42,21 a 3,3 0 0 0 -2.121094,0.878906 l -5.201172,5.199219 a 3,3 0 0 0 0,4.244141 3,3 0 0 0 4.244141,0 l 5.199219,-5.201172 a 3,3 0 0 0 0,-4.242188 A 3,3 0 0 0 42,21 Z M 31.599609,31.400391 a 3,3 0 0 0 -2.121093,0.878906 l -5.199219,5.199219 a 3,3 0 0 0 0,4.242187 3,3 0 0 0 4.242187,0 l 5.199219,-5.199219 a 3,3 0 0 0 0,-4.242187 3,3 0 0 0 -2.121094,-0.878906 z m -10.40039,10.40039 a 3,3 0 0 0 -2.121094,0.876953 l -5.199219,5.201172 a 3,3 0 0 0 0,4.242188 3,3 0 0 0 4.242188,0 l 5.201172,-5.199219 a 3,3 0 0 0 0,-4.244141 3,3 0 0 0 -2.123047,-0.876953 z"
+         id="path10" />
+      <path
+         style="color:#000000;fill:#042a2a;fill-rule:evenodd;stroke:#042a2a;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 6.6559887,59.344011 11.30168,41.970397 24.029603,54.69832 Z"
+         id="path7" />
+      <path
+         style="color:#000000;fill:#2bdbdd;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+         d="m 41.292969,23.292969 -5.199219,5.199218 a 1,1 0 0 0 0,1.414063 1,1 0 0 0 1.414062,0 l 5.199219,-5.199219 a 1,1 0 0 0 0,-1.414062 1,1 0 0 0 -1.414062,0 z m -10.400391,10.40039 -5.199219,5.199219 a 1,1 0 0 0 0,1.414063 1,1 0 0 0 1.414063,0 l 5.199219,-5.199219 a 1,1 0 0 0 0,-1.414063 1,1 0 0 0 -1.414063,0 z M 20.492187,44.09375 15.292969,49.292969 a 1,1 0 0 0 0,1.414062 1,1 0 0 0 1.414062,0 l 5.199219,-5.199219 a 1,1 0 0 0 0,-1.414062 1,1 0 0 0 -1.414063,0 z"
+         id="path15" />
+      <path
+         style="color:#000000;fill:#2bdbdd;fill-rule:evenodd;stroke:#2bdbdd;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+         d="m 12.337891,45.835937 7.826171,7.826172 -10.6835932,2.857422 z"
+         id="path20" />
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -235,6 +235,7 @@
         <file>colors.svg</file>
         <file>px.svg</file>
         <file>AddonManager.svg</file>
+        <file>align-to-selection.svg</file>
         <file>Group.svg</file>
         <file>Geofeaturegroup.svg</file>
         <file>Geoassembly.svg</file>

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -408,6 +408,10 @@ bool View3DInventor::onMsg(const char* pMsg, const char** ppReturn)
         getGuiDocument()->saveCopy();
         return true;
     }
+    else if (strcmp("AlignToSelection", pMsg) == 0) {
+        _viewer->alignToSelection();
+        return true;
+    }
     else if (strcmp("ZoomIn", pMsg) == 0) {
         View3DInventorViewer* viewer = getViewer();
         viewer->navigationStyle()->zoomIn();
@@ -509,6 +513,9 @@ bool View3DInventor::onHasMsg(const char* pMsg) const
         return true;
     }
     else if(strncmp("Dump",pMsg,4) == 0) {
+        return true;
+    }
+    else if (strcmp("AlignToSelection", pMsg) == 0) {
         return true;
     }
     if (strcmp("ZoomIn", pMsg) == 0) {

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3341,6 +3341,39 @@ void View3DInventorViewer::viewSelection()
     }
 }
 
+void View3DInventorViewer::alignToSelection()
+{
+    if (!getCamera()) {
+        return;
+    }
+
+    const auto selection = Selection().getSelection();
+
+    // Empty selection
+    if (selection.empty()) {
+        return;
+    }
+
+    // Too much selections
+    if (selection.size() > 1) {
+        return;
+    }
+
+    // Get the geo feature
+    App::GeoFeature* geoFeature = nullptr;
+    std::pair<std::string, std::string> elementName;
+    App::GeoFeature::resolveElement(selection[0].pObject, selection[0].SubName, elementName, false, App::GeoFeature::ElementNameType::Normal, nullptr, nullptr, &geoFeature);
+    if (!geoFeature) {
+        return;
+    }
+
+    Base::Vector3d direction;
+    if (geoFeature->getCameraAlignmentDirection(direction, selection[0].SubName)) {
+        const auto orientation = SbRotation(SbVec3f(0, 0, 1), Base::convertTo<SbVec3f>(direction));
+        setCameraOrientation(orientation);
+    }
+}
+
 /**
  * @brief Decide if it should be possible to start any animation
  *

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -414,6 +414,8 @@ public:
      */
     void viewSelection();
 
+    void alignToSelection();
+
     void setGradientBackground(Background);
     Background getGradientBackground() const;
     void setGradientBackgroundColor(const SbColor& fromColor,

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -810,7 +810,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // View
     auto view = new ToolBarItem( root );
     view->setCommand("View");
-    *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewGroup"
+    *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewGroup" << "Std_AlignToSelection"
           << "Separator" << "Std_DrawStyle" << "Std_TreeViewActions"
           << "Separator" << "Std_MeasureDistance" << "Std_Measure";
 

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -35,6 +35,7 @@
 # include <BRepBuilderAPI_MakeVertex.hxx>
 # include <BRepExtrema_DistShapeShape.hxx>
 # include <BRepGProp.hxx>
+# include <BRepGProp_Face.hxx>
 # include <BRepIntCurveSurface_Inter.hxx>
 # include <gce_MakeDir.hxx>
 # include <gce_MakeLin.hxx>
@@ -68,6 +69,7 @@
 #include <Base/Stream.h>
 #include <Mod/Material/App/MaterialManager.h>
 
+#include "Geometry.h"
 #include "PartFeature.h"
 #include "PartFeaturePy.h"
 #include "PartPyCXX.h"
@@ -1408,6 +1410,44 @@ bool Feature::isElementMappingDisabled(App::PropertyContainer* container)
 //        }
 //    }
 //    return false;
+}
+
+bool Feature::getCameraAlignmentDirection(Base::Vector3d& direction, const char* subname) const
+{
+    const auto topoShape = getTopoShape(this, subname, true);
+
+    if (topoShape.isNull()) {
+        return false;
+    }
+
+    // Face normal
+    if (topoShape.isPlanar()) {
+        try {
+            const auto face = TopoDS::Face(topoShape.getShape());
+            gp_Pnt point;
+            gp_Vec vector;
+            BRepGProp_Face(face).Normal(0, 0, point, vector);
+            direction = Base::Vector3d(vector.X(), vector.Y(), vector.Z()).Normalize();
+            return true;
+        }
+        catch (Standard_TypeMismatch&) {
+            // Shape is not a face, do nothing
+        }
+    }
+
+    // Edge direction
+    const size_t edgeCount = topoShape.countSubShapes(TopAbs_EDGE);
+    if (edgeCount == 1 && topoShape.isLinearEdge()) {
+        if (const std::unique_ptr<Geometry> geometry = Geometry::fromShape(topoShape.getSubShape(TopAbs_EDGE, 1), true)) {
+            const std::unique_ptr<GeomLine> geomLine(static_cast<GeomCurve*>(geometry.get())->toLine());
+            if (geomLine) {
+                direction = geomLine->getDir().Normalize();
+                return true;
+            }
+        }
+    }
+
+    return GeoFeature::getCameraAlignmentDirection(direction, subname);
 }
 
 // ---------------------------------------------------------

--- a/src/Mod/Part/App/PartFeature.h
+++ b/src/Mod/Part/App/PartFeature.h
@@ -152,6 +152,8 @@ public:
     create(const TopoShape& shape, const char* name = nullptr, App::Document* document = nullptr);
 
     static bool isElementMappingDisabled(App::PropertyContainer *container);
+
+    bool getCameraAlignmentDirection(Base::Vector3d& direction, const char* subname) const override;
 #ifdef FC_USE_TNP_FIX
 
     const std::vector<std::string>& searchElementCache(const std::string &element,


### PR DESCRIPTION
This PR introduces a first version for aligning the camera with the normal of a face or with the direction of an edge. I will continue improving its usability after this PR is merged and eventually implement all sub-features of #11234.

The code is inspired from realthunder's branch, however, I simplified it a bit.

@maxwxyz, can you provide the icon.

Currently, you can run the command by entering the line below in the Python console.
`Gui.SendMsgToActiveView("AlignToSelection")`