### PR TITLE
VSCode: Use port 39999 to test for debugger readiness.

### DIFF
--- a/contrib/.vscode/scripts/VSCodeAutostartDebug.FCMacro
+++ b/contrib/.vscode/scripts/VSCodeAutostartDebug.FCMacro
@@ -11,8 +11,8 @@ debugpy.listen(('localhost', 5678))
 
 # Turns out you cannot probe debugpy to see if it is up:
 # https://github.com/microsoft/debugpy/issues/974
-# Open another port that the script WaitForDebugpy can probe to see if 
+# Open another port that the script WaitForDebugpy can probe to see if
 # debugpy is running
-listener = Listener(('localhost', 6000), backlog=10)
+listener = Listener(('localhost', 39999), backlog=10)
 
 debugpy.wait_for_client()

--- a/contrib/.vscode/scripts/WaitForDebugpy.py
+++ b/contrib/.vscode/scripts/WaitForDebugpy.py
@@ -1,7 +1,7 @@
 import socket
 from contextlib import closing
 import time
-   
+
 TIMEOUT_TIME_S = 30
 RETRY_DELAY_S = 0.1
 
@@ -16,7 +16,7 @@ def main():
     # DO NOT CHECK 5678 or debugpy will break
     # Check other port manually opened instead
     attempt_counter = 0
-    while (not check_socket('localhost', 6000)) and attempt_counter < MAX_ATTEMPTS:
+    while (not check_socket('localhost', 39999)) and attempt_counter < MAX_ATTEMPTS:
         time.sleep(RETRY_DELAY_S)
         attempt_counter += 1
 


### PR DESCRIPTION
Port 6000 has conflicts with some software.  Set the port to 39999, which unreserved by IANA and should make it far less likely to falsely report debug readiness.

@Pesc0 