### PR TITLE
Draft: Draft_SetStyle new Material handling

### DIFF
--- a/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
@@ -13,9 +13,9 @@
   <property name="windowTitle">
    <string>Style settings</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_1">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QHBoxLayout" name="horizontalLayout_1">
      <item>
       <widget class="QComboBox" name="comboPresets">
        <property name="toolTip">
@@ -51,434 +51,524 @@
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Shapes</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout" columnstretch="1,0" columnminimumwidth="0,120">
-      <property name="sizeConstraint">
-       <enum>QLayout::SetDefaultConstraint</enum>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_ShapeColor">
-        <property name="text">
-         <string>Shape color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="Gui::ColorButton" name="ShapeColor">
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_Transparency">
-        <property name="text">
-         <string>Transparency</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="Transparency">
-        <property name="suffix">
-         <string notr="true"> %</string>
-        </property>
-        <property name="maximum">
-         <number>100</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_LineColor">
-        <property name="text">
-         <string>Line color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="Gui::ColorButton" name="LineColor">
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_LineWidth">
-        <property name="text">
-         <string>Line width</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QSpinBox" name="LineWidth">
-        <property name="suffix">
-         <string> px</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_PointColor">
-        <property name="text">
-         <string>Point color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="Gui::ColorButton" name="PointColor">
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_PointSize">
-        <property name="text">
-         <string>Point size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QSpinBox" name="PointSize">
-        <property name="suffix">
-         <string> px</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_DrawStyle">
-        <property name="text">
-         <string>Draw style</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QComboBox" name="DrawStyle">
-        <item>
-         <property name="text">
-          <string>Solid</string>
+    <widget class="QTabWidget" name="tabs">
+     <widget class="QWidget" name="tab_Shape">
+      <attribute name="title">
+       <string>Shape</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QGroupBox" name="groupBox_1">
+         <property name="title">
+          <string>Shape appearance</string>
          </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Dashed</string>
+         <layout class="QGridLayout" name="gridLayout_1" columnstretch="1,0" columnminimumwidth="0,100">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_ShapeColor">
+            <property name="text">
+             <string>Shape color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="Gui::ColorButton" name="ShapeColor">
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_AmbientColor">
+            <property name="text">
+             <string>Ambient shape color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="Gui::ColorButton" name="AmbientColor">
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_EmissiveColor">
+            <property name="text">
+             <string>Emissive shape color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="Gui::ColorButton" name="EmissiveColor">
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_SpecularColor">
+            <property name="text">
+             <string>Specular shape color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="Gui::ColorButton" name="SpecularColor">
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_Transparency">
+            <property name="text">
+             <string>Shape transparency</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QSpinBox" name="Transparency">
+            <property name="suffix">
+             <string notr="true"> %</string>
+            </property>
+            <property name="maximum">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_Shininess">
+            <property name="text">
+             <string>Shape shininess</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="Shininess">
+            <property name="suffix">
+             <string notr="true"> %</string>
+            </property>
+            <property name="maximum">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Other</string>
          </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Dotted</string>
+         <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0" columnminimumwidth="0,100">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_LineColor">
+            <property name="text">
+             <string>Line color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="Gui::ColorButton" name="LineColor">
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_LineWidth">
+            <property name="text">
+             <string>Line width</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="LineWidth">
+            <property name="suffix">
+             <string> px</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_PointColor">
+            <property name="text">
+             <string>Point color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="Gui::ColorButton" name="PointColor">
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_PointSize">
+            <property name="text">
+             <string>Point size</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="PointSize">
+            <property name="suffix">
+             <string> px</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_DrawStyle">
+            <property name="text">
+             <string>Draw style</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="DrawStyle">
+            <item>
+             <property name="text">
+              <string>Solid</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Dashed</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Dotted</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>DashDot</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_DisplayMode">
+            <property name="text">
+             <string>Display mode</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QComboBox" name="DisplayMode">
+            <item>
+             <property name="text">
+              <string>Flat Lines</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Shaded</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Wireframe</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Points</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_1">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>DashDot</string>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_Annotation">
+      <attribute name="title">
+       <string>Annotation</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="title">
+          <string>Texts</string>
          </property>
-        </item>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="label_DisplayMode">
-        <property name="text">
-         <string>Display mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="QComboBox" name="DisplayMode">
-        <item>
-         <property name="text">
-          <string>Flat Lines</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Shaded</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Wireframe</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Points</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Annotations</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0" columnminimumwidth="0,120">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_TextColor">
-        <property name="text">
-         <string>Text color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="Gui::ColorButton" name="TextColor">
-        <property name="toolTip">
-         <string>The color for texts, dimension texts and label texts</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_TextFont">
-        <property name="text">
-         <string>Font name</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QFontComboBox" name="TextFont">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>The font for texts, dimensions and labels</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_TextSize">
-        <property name="text">
-         <string>Font size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="Gui::InputField" name="TextSize">
-        <property name="toolTip">
-         <string>The height for texts, dimension texts and label texts</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_LineSpacing">
-        <property name="text">
-         <string>Line spacing</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QDoubleSpinBox" name="LineSpacing">
-        <property name="toolTip">
-         <string>The line spacing for multi-line texts and labels (relative to the font size)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_ScaleMultiplier">
-        <property name="text">
-         <string>Scale multiplier</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QDoubleSpinBox" name="ScaleMultiplier">
-        <property name="toolTip">
-         <string>The annotation scale multiplier is the inverse of the scale set in the 
+         <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,0" columnminimumwidth="0,100">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_TextFont">
+            <property name="text">
+             <string>Font name</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QFontComboBox" name="TextFont">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>The font for texts, dimensions and labels</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_TextSize">
+            <property name="text">
+             <string>Font size</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="Gui::InputField" name="TextSize">
+            <property name="toolTip">
+             <string>The height for texts, dimension texts and label texts</string>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true"/>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_LineSpacing">
+            <property name="text">
+             <string>Line spacing factor</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="LineSpacing">
+            <property name="toolTip">
+             <string>The line spacing for multi-line texts and labels (relative to the font size)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_ScaleMultiplier">
+            <property name="text">
+             <string>Scale multiplier</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="ScaleMultiplier">
+            <property name="toolTip">
+             <string>The annotation scale multiplier is the inverse of the scale set in the
 Annotation scale widget. If the scale is 1:100 the multiplier is 100.</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Dimensions</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,0" columnminimumwidth="0,120">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_AnnoLineColor">
-        <property name="text">
-         <string>Line and arrow color</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="Gui::ColorButton" name="AnnoLineColor">
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_AnnoLineWidth">
-        <property name="text">
-         <string>Line width</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="AnnoLineWidth">
-        <property name="suffix">
-         <string> px</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_ArrowStyle">
-        <property name="text">
-         <string>Arrow type</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="ArrowStyle">
-        <item>
-         <property name="text">
-          <string>Dot</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_TextColor">
+            <property name="text">
+             <string>Text color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="Gui::ColorButton" name="TextColor">
+            <property name="toolTip">
+             <string>The color for texts, dimension texts and label texts</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_4">
+         <property name="title">
+          <string>Lines and arrows</string>
          </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Circle</string>
+         <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,0" columnminimumwidth="0,100">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_AnnoLineWidth">
+            <property name="text">
+             <string>Line width</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="AnnoLineWidth">
+            <property name="suffix">
+             <string> px</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_ArrowStyle">
+            <property name="text">
+             <string>Arrow type</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="ArrowStyle">
+            <item>
+             <property name="text">
+              <string>Dot</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Circle</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Arrow</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Tick</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Tick-2</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_ArrowSize">
+            <property name="text">
+             <string>Arrow size</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="Gui::InputField" name="ArrowSize">
+            <property name="unit" stdset="0">
+             <string notr="true"/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_AnnoLineColor">
+            <property name="text">
+             <string>Line and arrow color</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="Gui::ColorButton" name="AnnoLineColor">
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_5">
+         <property name="title">
+          <string>Dimensions</string>
          </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Arrow</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Tick</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Tick-2</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_ArrowSize">
-        <property name="text">
-         <string>Arrow size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="Gui::InputField" name="ArrowSize">
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_ShowUnit">
-        <property name="text">
-         <string>Show unit</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QCheckBox" name="ShowUnit">
-        <property name="toolTip">
-         <string>If checked, a unit symbol is added to dimension texts</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_UnitOverride">
-        <property name="text">
-         <string>Unit override</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QLineEdit" name="UnitOverride">
-        <property name="toolTip">
-         <string>The unit override for dimensions. Leave blank to use the current FreeCAD unit.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_DimOvershoot">
-        <property name="text">
-         <string>Dim overshoot</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="Gui::InputField" name="DimOvershoot">
-        <property name="toolTip">
-         <string>The distance the dimension line is extended past the extension lines</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="label_ExtLines">
-        <property name="text">
-         <string>Ext lines</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="Gui::InputField" name="ExtLines">
-        <property name="toolTip">
-         <string>The length of extension lines. Use 0 for full extension lines. A negative value
+         <layout class="QGridLayout" name="gridLayout_5" columnstretch="1,0" columnminimumwidth="0,100">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_ShowUnit">
+            <property name="text">
+             <string>Show unit</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="ShowUnit">
+            <property name="toolTip">
+             <string>If checked, a unit symbol is added to dimension texts</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_UnitOverride">
+            <property name="text">
+             <string>Unit override</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="UnitOverride">
+            <property name="toolTip">
+             <string>The unit override for dimensions. Leave blank to use the current FreeCAD unit.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_DimOvershoot">
+            <property name="text">
+             <string>Dim line overshoot</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="Gui::InputField" name="DimOvershoot">
+            <property name="toolTip">
+             <string>The distance the dimension line is extended past the extension lines</string>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true"/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_ExtLines">
+            <property name="text">
+             <string>Ext line length</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="Gui::InputField" name="ExtLines">
+            <property name="toolTip">
+             <string>The length of extension lines. Use 0 for full extension lines. A negative value
 defines the gap between the ends of the extension lines and the measured points.
 A positive value defines the maximum length of the extension lines. Only used
 for linear dimensions.</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="label_ExtOvershoot">
-        <property name="text">
-         <string>Ext overshoot</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1">
-       <widget class="Gui::InputField" name="ExtOvershoot">
-        <property name="toolTip">
-         <string>The length of extension lines above the dimension line</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="0">
-       <widget class="QLabel" name="label_TextSpacing">
-        <property name="text">
-         <string>Text spacing</string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="1">
-       <widget class="Gui::InputField" name="TextSpacing">
-        <property name="toolTip">
-         <string>The space between the dimension line and the dimension text</string>
-        </property>
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-     </layout>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true"/>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_ExtOvershoot">
+            <property name="text">
+             <string>Ext line overshoot</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="Gui::InputField" name="ExtOvershoot">
+            <property name="toolTip">
+             <string>The length of extension lines above the dimension line</string>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true"/>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_TextSpacing">
+            <property name="text">
+             <string>Text spacing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="Gui::InputField" name="TextSpacing">
+            <property name="toolTip">
+             <string>The space between the dimension line and the dimension text</string>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true"/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QPushButton" name="applyButton">
        <property name="toolTip">

--- a/src/Mod/Draft/draftguitools/gui_setstyle.py
+++ b/src/Mod/Draft/draftguitools/gui_setstyle.py
@@ -83,18 +83,25 @@ class Draft_SetStyle_TaskPanel:
         self.form.annotButton.setIcon(QtGui.QIcon(":/icons/Draft_Text.svg"))
 
         self.form.ShapeColor.setProperty("color", self.getColor(params.get_param_view("DefaultShapeColor")))
+        self.form.AmbientColor.setProperty("color", self.getColor(params.get_param_view("DefaultAmbientColor")))
+        self.form.EmissiveColor.setProperty("color", self.getColor(params.get_param_view("DefaultEmissiveColor")))
+        self.form.SpecularColor.setProperty("color", self.getColor(params.get_param_view("DefaultSpecularColor")))
         self.form.Transparency.setValue(params.get_param_view("DefaultShapeTransparency"))
+        self.form.Shininess.setValue(params.get_param_view("DefaultShapeShininess"))
+
         self.form.LineColor.setProperty("color", self.getColor(params.get_param_view("DefaultShapeLineColor")))
         self.form.LineWidth.setValue(params.get_param_view("DefaultShapeLineWidth"))
         self.form.PointColor.setProperty("color", self.getColor(params.get_param_view("DefaultShapeVertexColor")))
         self.form.PointSize.setValue(params.get_param_view("DefaultShapePointSize"))
         self.form.DrawStyle.setCurrentIndex(params.get_param("DefaultDrawStyle"))
         self.form.DisplayMode.setCurrentIndex(params.get_param("DefaultDisplayMode"))
+
         self.form.TextColor.setProperty("color", self.getColor(params.get_param("DefaultTextColor")))
         self.form.TextFont.setCurrentFont(QtGui.QFont(params.get_param("textfont")))
         self.form.TextSize.setText(U.Quantity(params.get_param("textheight"), U.Length).UserString)
         self.form.LineSpacing.setValue(params.get_param("LineSpacing"))
         self.form.ScaleMultiplier.setValue(params.get_param("DefaultAnnoScaleMultiplier"))
+
         self.form.AnnoLineColor.setProperty("color", self.getColor(params.get_param("DefaultAnnoLineColor")))
         self.form.AnnoLineWidth.setValue(params.get_param("DefaultAnnoLineWidth"))
         self.form.ArrowStyle.setCurrentIndex(params.get_param("dimsymbol"))
@@ -133,33 +140,40 @@ class Draft_SetStyle_TaskPanel:
 
     def getValues(self):
 
-        preset = {}
-        preset["ShapeColor"] = utils.argb_to_rgba(self.form.ShapeColor.property("color").rgba())
-        preset["Transparency"] = self.form.Transparency.value()
-        preset["LineColor"] = utils.argb_to_rgba(self.form.LineColor.property("color").rgba())
-        preset["LineWidth"] = self.form.LineWidth.value()
-        preset["PointColor"] = utils.argb_to_rgba(self.form.PointColor.property("color").rgba())
-        preset["PointSize"] = self.form.PointSize.value()
-        preset["DrawStyle"] = self.form.DrawStyle.currentIndex()
-        preset["DisplayMode"] = self.form.DisplayMode.currentIndex()
-        preset["TextColor"] = utils.argb_to_rgba(self.form.TextColor.property("color").rgba())
-        preset["TextFont"] = self.form.TextFont.currentFont().family()
-        preset["TextSize"] = U.Quantity(self.form.TextSize.text()).Value
-        preset["LineSpacing"] = self.form.LineSpacing.value()
-        preset["ScaleMultiplier"] = self.form.ScaleMultiplier.value()
-        preset["AnnoLineColor"] = utils.argb_to_rgba(self.form.AnnoLineColor.property("color").rgba())
-        preset["AnnoLineWidth"] = self.form.AnnoLineWidth.value()
-        preset["ArrowStyle"] = self.form.ArrowStyle.currentIndex()
-        preset["ArrowSize"] = U.Quantity(self.form.ArrowSize.text()).Value
-        preset["ShowUnit"] = self.form.ShowUnit.isChecked()
-        preset["UnitOverride"] = self.form.UnitOverride.text()
-        preset["DimOvershoot"] = U.Quantity(self.form.DimOvershoot.text()).Value
-        preset["ExtLines"] = U.Quantity(self.form.ExtLines.text()).Value
-        preset["ExtOvershoot"] = U.Quantity(self.form.ExtOvershoot.text()).Value
-        preset["TextSpacing"] = U.Quantity(self.form.TextSpacing.text()).Value
-        return preset
+        return {
+            "ShapeColor":      utils.argb_to_rgba(self.form.ShapeColor.property("color").rgba()),
+            "AmbientColor":    utils.argb_to_rgba(self.form.AmbientColor.property("color").rgba()),
+            "EmissiveColor":   utils.argb_to_rgba(self.form.EmissiveColor.property("color").rgba()),
+            "SpecularColor":   utils.argb_to_rgba(self.form.SpecularColor.property("color").rgba()),
+            "Transparency":    self.form.Transparency.value(),
+            "Shininess":       self.form.Shininess.value(),
 
-    def setValues(self,preset):
+            "LineColor":       utils.argb_to_rgba(self.form.LineColor.property("color").rgba()),
+            "LineWidth":       self.form.LineWidth.value(),
+            "PointColor":      utils.argb_to_rgba(self.form.PointColor.property("color").rgba()),
+            "PointSize":       self.form.PointSize.value(),
+            "DrawStyle":       self.form.DrawStyle.currentIndex(),
+            "DisplayMode":     self.form.DisplayMode.currentIndex(),
+
+            "TextColor":       utils.argb_to_rgba(self.form.TextColor.property("color").rgba()),
+            "TextFont":        self.form.TextFont.currentFont().family(),
+            "TextSize":        U.Quantity(self.form.TextSize.text()).Value,
+            "LineSpacing":     self.form.LineSpacing.value(),
+            "ScaleMultiplier": self.form.ScaleMultiplier.value(),
+
+            "AnnoLineColor":   utils.argb_to_rgba(self.form.AnnoLineColor.property("color").rgba()),
+            "AnnoLineWidth":   self.form.AnnoLineWidth.value(),
+            "ArrowStyle":      self.form.ArrowStyle.currentIndex(),
+            "ArrowSize":       U.Quantity(self.form.ArrowSize.text()).Value,
+            "ShowUnit":        self.form.ShowUnit.isChecked(),
+            "UnitOverride":    self.form.UnitOverride.text(),
+            "DimOvershoot":    U.Quantity(self.form.DimOvershoot.text()).Value,
+            "ExtLines":        U.Quantity(self.form.ExtLines.text()).Value,
+            "ExtOvershoot":    U.Quantity(self.form.ExtOvershoot.text()).Value,
+            "TextSpacing":     U.Quantity(self.form.TextSpacing.text()).Value
+        }
+
+    def setValues(self, preset):
 
         # For compatibility with <= V0.21 some properties, if missing, reference others:
         #     'new' prop    -> old prop
@@ -168,29 +182,113 @@ class Draft_SetStyle_TaskPanel:
         #     PointSize     -> LineWidth
         #     AnnoLineColor -> LineColor
         #     AnnoLineWidth -> LineWidth
-        self.form.ShapeColor.setProperty("color", self.getColor(preset.get("ShapeColor", 3435973887)))
-        self.form.Transparency.setValue(preset.get("Transparency", 0))
-        self.form.LineColor.setProperty("color", self.getColor(preset.get("LineColor", 255)))
-        self.form.LineWidth.setValue(preset.get("LineWidth", 2))
-        self.form.PointColor.setProperty("color", self.getColor(preset.get("PointColor", preset.get("LineColor", 255))))
-        self.form.PointSize.setValue(preset.get("PointSize", preset.get("LineWidth", 2)))
-        self.form.DrawStyle.setCurrentIndex(preset.get("DrawStyle", 0))
-        self.form.DisplayMode.setCurrentIndex(preset.get("DisplayMode", 0))
-        self.form.TextColor.setProperty("color", self.getColor(preset.get("TextColor", 255)))
-        self.form.TextFont.setCurrentFont(QtGui.QFont(preset.get("TextFont", "Sans")))
-        self.form.TextSize.setText(U.Quantity(preset.get("TextSize", 3.5),U.Length).UserString)
-        self.form.LineSpacing.setValue(preset.get("LineSpacing", 1))
-        self.form.ScaleMultiplier.setValue(preset.get("ScaleMultiplier", 1))
-        self.form.AnnoLineColor.setProperty("color", self.getColor(preset.get("AnnoLineColor", preset.get("LineColor", 255))))
-        self.form.AnnoLineWidth.setValue(preset.get("AnnoLineWidth", preset.get("LineWidth", 2)))
-        self.form.ArrowStyle.setCurrentIndex(preset.get("ArrowStyle", 0))
-        self.form.ArrowSize.setText(U.Quantity(preset.get("ArrowSize", 1), U.Length).UserString)
-        self.form.ShowUnit.setChecked(preset.get("ShowUnit", True))
-        self.form.UnitOverride.setText(preset.get("UnitOverride", ""))
-        self.form.DimOvershoot.setText(U.Quantity(preset.get("DimOvershoot", 0), U.Length).UserString)
-        self.form.ExtLines.setText(U.Quantity(preset.get("ExtLines", -0.5), U.Length).UserString)
-        self.form.ExtOvershoot.setText(U.Quantity(preset.get("ExtOvershoot", 2), U.Length).UserString)
-        self.form.TextSpacing.setText(U.Quantity(preset.get("TextSpacing", 1), U.Length).UserString)
+
+        def getDefDraft(entry):
+            return params.get_param(entry, ret_default=True)
+
+        def getDefView(entry):
+            return params.get_param_view(entry, ret_default=True)
+
+        # ---------------------------------------------------------------------
+
+        self.form.ShapeColor.setProperty(
+            "color",
+            self.getColor(preset.get("ShapeColor", getDefView("DefaultShapeColor")))
+        )
+        self.form.AmbientColor.setProperty(
+            "color",
+            self.getColor(preset.get("AmbientColor", getDefView("DefaultAmbientColor")))
+        )
+        self.form.EmissiveColor.setProperty(
+            "color",
+            self.getColor(preset.get("EmissiveColor", getDefView("DefaultEmissiveColor")))
+        )
+        self.form.SpecularColor.setProperty(
+            "color",
+            self.getColor(preset.get("SpecularColor", getDefView("DefaultSpecularColor")))
+        )
+        self.form.Transparency.setValue(
+            preset.get("Transparency", getDefView("DefaultShapeTransparency"))
+        )
+        self.form.Shininess.setValue(
+            preset.get("Shininess", getDefView("DefaultShapeShininess"))
+        )
+
+        # ---------------------------------------------------------------------
+
+        self.form.LineColor.setProperty(
+            "color",
+            self.getColor(preset.get("LineColor", getDefView("DefaultShapeLineColor")))
+        )
+        self.form.LineWidth.setValue(
+            preset.get("LineWidth", getDefView("DefaultShapeLineWidth"))
+        )
+        self.form.PointColor.setProperty(
+            "color",
+            self.getColor(preset.get("PointColor", preset.get("LineColor", getDefView("DefaultShapeVertexColor"))))
+        )
+        self.form.PointSize.setValue(
+            preset.get("PointSize", preset.get("LineWidth", getDefView("DefaultShapePointSize")))
+        )
+        self.form.DrawStyle.setCurrentIndex(
+            preset.get("DrawStyle", getDefDraft("DefaultDrawStyle"))
+        )
+        self.form.DisplayMode.setCurrentIndex(
+            preset.get("DisplayMode", getDefDraft("DefaultDisplayMode"))
+        )
+
+        # ---------------------------------------------------------------------
+
+        self.form.TextColor.setProperty(
+            "color",
+            self.getColor(preset.get("TextColor", getDefDraft("DefaultTextColor")))
+        )
+        self.form.TextFont.setCurrentFont(
+            QtGui.QFont(preset.get("TextFont", getDefDraft("textfont")))
+        )
+        self.form.TextSize.setText(
+            U.Quantity(preset.get("TextSize", getDefDraft("textheight")),U.Length).UserString
+        )
+        self.form.LineSpacing.setValue(
+            preset.get("LineSpacing", getDefDraft("LineSpacing"))
+        )
+        self.form.ScaleMultiplier.setValue(
+            preset.get("ScaleMultiplier", getDefDraft("DefaultAnnoScaleMultiplier"))
+        )
+
+        # ---------------------------------------------------------------------
+
+        self.form.AnnoLineColor.setProperty(
+            "color",
+            self.getColor(preset.get("AnnoLineColor", preset.get("LineColor", getDefDraft("DefaultAnnoLineColor"))))
+        )
+        self.form.AnnoLineWidth.setValue(
+            preset.get("AnnoLineWidth", preset.get("LineWidth", getDefDraft("DefaultAnnoLineWidth")))
+        )
+        self.form.ArrowStyle.setCurrentIndex(
+            preset.get("ArrowStyle", getDefDraft("dimsymbol"))
+        )
+        self.form.ArrowSize.setText(
+            U.Quantity(preset.get("ArrowSize", getDefDraft("arrowsize")), U.Length).UserString
+        )
+        self.form.ShowUnit.setChecked(
+            preset.get("ShowUnit", getDefDraft("showUnit"))
+        )
+        self.form.UnitOverride.setText(
+            preset.get("UnitOverride", getDefDraft("overrideUnit"))
+        )
+        self.form.DimOvershoot.setText(
+            U.Quantity(preset.get("DimOvershoot", getDefDraft("dimovershoot")), U.Length).UserString
+        )
+        self.form.ExtLines.setText(
+            U.Quantity(preset.get("ExtLines", getDefDraft("extlines")), U.Length).UserString
+        )
+        self.form.ExtOvershoot.setText(
+            U.Quantity(preset.get("ExtOvershoot", getDefDraft("extovershoot")), U.Length).UserString
+        )
+        self.form.TextSpacing.setText(
+            U.Quantity(preset.get("TextSpacing", getDefDraft("dimspacing")), U.Length).UserString
+        )
 
     def reject(self):
 
@@ -199,18 +297,25 @@ class Draft_SetStyle_TaskPanel:
     def accept(self):
 
         params.set_param_view("DefaultShapeColor", utils.argb_to_rgba(self.form.ShapeColor.property("color").rgba()))
+        params.set_param_view("DefaultAmbientColor", utils.argb_to_rgba(self.form.AmbientColor.property("color").rgba()))
+        params.set_param_view("DefaultEmissiveColor", utils.argb_to_rgba(self.form.EmissiveColor.property("color").rgba()))
+        params.set_param_view("DefaultSpecularColor", utils.argb_to_rgba(self.form.SpecularColor.property("color").rgba()))
         params.set_param_view("DefaultShapeTransparency", self.form.Transparency.value())
+        params.set_param_view("DefaultShapeShininess", self.form.Shininess.value())
+
         params.set_param_view("DefaultShapeLineColor", utils.argb_to_rgba(self.form.LineColor.property("color").rgba()))
         params.set_param_view("DefaultShapeLineWidth", self.form.LineWidth.value())
         params.set_param_view("DefaultShapeVertexColor", utils.argb_to_rgba(self.form.PointColor.property("color").rgba()))
         params.set_param_view("DefaultShapePointSize", self.form.PointSize.value())
         params.set_param("DefaultDrawStyle", self.form.DrawStyle.currentIndex())
         params.set_param("DefaultDisplayMode", self.form.DisplayMode.currentIndex())
+
         params.set_param("DefaultTextColor", utils.argb_to_rgba(self.form.TextColor.property("color").rgba()))
         params.set_param("textfont", self.form.TextFont.currentFont().family())
         params.set_param("textheight", U.Quantity(self.form.TextSize.text()).Value)
         params.set_param("LineSpacing", self.form.LineSpacing.value())
         params.set_param("DefaultAnnoScaleMultiplier", self.form.ScaleMultiplier.value())
+
         params.set_param("DefaultAnnoLineColor", utils.argb_to_rgba(self.form.AnnoLineColor.property("color").rgba()))
         params.set_param("DefaultAnnoLineWidth", self.form.AnnoLineWidth.value())
         params.set_param("dimsymbol", self.form.ArrowStyle.currentIndex())
@@ -221,6 +326,7 @@ class Draft_SetStyle_TaskPanel:
         params.set_param("extlines", U.Quantity(self.form.ExtLines.text()).Value)
         params.set_param("extovershoot", U.Quantity(self.form.ExtOvershoot.text()).Value)
         params.set_param("dimspacing", U.Quantity(self.form.TextSpacing.text()).Value)
+
         self.reject()
 
     def onApplyStyle(self):
@@ -246,10 +352,15 @@ class Draft_SetStyle_TaskPanel:
 
         properties = vobj.PropertiesList
         if "FontName" not in properties:  # Shapes
-            if "ShapeColor" in properties:
-                vobj.ShapeColor = self.form.ShapeColor.property("color").getRgbF()[:3] # Remove Alpha (which is 1 instead of 0).
-            if "Transparency" in properties:
-                vobj.Transparency = self.form.Transparency.value()
+            if "ShapeAppearance" in properties:
+                material = App.Material()
+                material.DiffuseColor = self.form.ShapeColor.property("color").getRgbF()[:3]  # Remove Alpha (which is 1 instead of 0).
+                material.AmbientColor = self.form.AmbientColor.property("color").getRgbF()[:3]
+                material.EmissiveColor = self.form.EmissiveColor.property("color").getRgbF()[:3]
+                material.SpecularColor = self.form.SpecularColor.property("color").getRgbF()[:3]
+                material.Transparency = self.form.Transparency.value() / 100
+                material.Shininess = self.form.Shininess.value() / 100
+                vobj.ShapeAppearance = (material, )
             if "LineColor" in properties:
                 vobj.LineColor = self.form.LineColor.property("color").getRgbF()[:3]
             if "LineWidth" in properties:

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -486,12 +486,16 @@ def _get_param_dictionary():
         "BackgroundColor":             ("unsigned",  336897023),
         "BackgroundColor2":            ("unsigned",  859006463),
         "BackgroundColor3":            ("unsigned",  2543299327),
+        "DefaultAmbientColor":         ("unsigned",  1431655935),
+        "DefaultEmissiveColor":        ("unsigned",  255),
         "DefaultShapeColor":           ("unsigned",  3435980543),
         "DefaultShapeLineColor":       ("unsigned",  421075455),
         "DefaultShapeLineWidth":       ("int",       2),
         "DefaultShapePointSize":       ("int",       2),
+        "DefaultShapeShininess":       ("int",       90),
         "DefaultShapeTransparency":    ("int",       0),
         "DefaultShapeVertexColor":     ("unsigned",  421075455),
+        "DefaultSpecularColor":        ("unsigned",  2290649343),
         "EnableSelection":             ("bool",      True),
         "Gradient":                    ("bool",      True),
         "MarkerSize":                  ("int",       9),
@@ -580,7 +584,7 @@ def _get_param_dictionary():
 PARAM_DICT = _get_param_dictionary()
 
 
-def get_param(entry, path="Mod/Draft"):
+def get_param(entry, path="Mod/Draft", ret_default=False):
     """Return a stored parameter value or its default.
 
     Parameters
@@ -591,6 +595,9 @@ def get_param(entry, path="Mod/Draft"):
         Defaults to "Mod/Draft".
         The path where the parameter can be found.
         This string is appended to "User parameter:BaseApp/Preferences/".
+    ret_default: bool, optional
+        Defaults to `False`.
+        If `True`, always return the default value even if a stored value is available.
 
     Returns
     -------
@@ -601,6 +608,8 @@ def get_param(entry, path="Mod/Draft"):
         return None
     param_grp = App.ParamGet("User parameter:BaseApp/Preferences/" + path)
     typ, default = PARAM_DICT[path][entry]
+    if ret_default:
+        return default
     if typ == "bool":
         return param_grp.GetBool(entry, default)
     if typ == "float":
@@ -614,12 +623,12 @@ def get_param(entry, path="Mod/Draft"):
     return None
 
 
-def get_param_arch(entry):
-    return get_param(entry, path="Mod/Arch")
+def get_param_arch(entry, ret_default=False):
+    return get_param(entry, path="Mod/Arch", ret_default=ret_default)
 
 
-def get_param_view(entry):
-    return get_param(entry, path="View")
+def get_param_view(entry, ret_default=False):
+    return get_param(entry, path="View", ret_default=ret_default)
 
 
 def set_param(entry, value, path="Mod/Draft"):

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -88,15 +88,33 @@ def get_default_shape_style():
     display_mode_index = params.get_param("DefaultDisplayMode")
     draw_style_index = params.get_param("DefaultDrawStyle")
     return {
-        "DisplayMode":  ("index", display_mode_index, DISPLAY_MODES[display_mode_index]),
-        "DrawStyle":    ("index", draw_style_index, DRAW_STYLES[draw_style_index]),
-        "LineColor":    ("color", params.get_param_view("DefaultShapeLineColor")),
-        "LineWidth":    ("int",   params.get_param_view("DefaultShapeLineWidth")),
-        "PointColor":   ("color", params.get_param_view("DefaultShapeVertexColor")),
-        "PointSize":    ("int",   params.get_param_view("DefaultShapePointSize")),
-        "ShapeColor":   ("color", params.get_param_view("DefaultShapeColor")),
-        "Transparency": ("int",   params.get_param_view("DefaultShapeTransparency"))
+        "DisplayMode":     ("index",    display_mode_index, DISPLAY_MODES[display_mode_index]),
+        "DrawStyle":       ("index",    draw_style_index, DRAW_STYLES[draw_style_index]),
+        "LineColor":       ("color",    params.get_param_view("DefaultShapeLineColor")),
+        "LineWidth":       ("int",      params.get_param_view("DefaultShapeLineWidth")),
+        "PointColor":      ("color",    params.get_param_view("DefaultShapeVertexColor")),
+        "PointSize":       ("int",      params.get_param_view("DefaultShapePointSize")),
+        "ShapeAppearance": ("material", (get_appearance_material(), ))
     }
+
+
+def get_appearance_material(ret_default=False):
+    """Return a ShapeAppearance material with properties based on the preferences.
+
+    Parameters
+    ----------
+    ret_default: bool, optional
+        Defaults to `False`.
+        If `True`, always use default preference values even if stored values are available.
+    """
+    material = App.Material()
+    material.AmbientColor = params.get_param_view("DefaultAmbientColor", ret_default=ret_default)
+    material.DiffuseColor = params.get_param_view("DefaultShapeColor", ret_default=ret_default)
+    material.EmissiveColor = params.get_param_view("DefaultEmissiveColor", ret_default=ret_default)
+    material.Shininess = params.get_param_view("DefaultShapeShininess", ret_default=ret_default) / 100
+    material.SpecularColor = params.get_param_view("DefaultSpecularColor", ret_default=ret_default)
+    material.Transparency = params.get_param_view("DefaultShapeTransparency", ret_default=ret_default) / 100
+    return material
 
 
 def string_encode_coin(ustr):

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -94,26 +94,19 @@ def get_default_shape_style():
         "LineWidth":       ("int",      params.get_param_view("DefaultShapeLineWidth")),
         "PointColor":      ("color",    params.get_param_view("DefaultShapeVertexColor")),
         "PointSize":       ("int",      params.get_param_view("DefaultShapePointSize")),
-        "ShapeAppearance": ("material", (get_appearance_material(), ))
+        "ShapeAppearance": ("material", (get_view_material(), ))
     }
 
 
-def get_appearance_material(ret_default=False):
-    """Return a ShapeAppearance material with properties based on the preferences.
-
-    Parameters
-    ----------
-    ret_default: bool, optional
-        Defaults to `False`.
-        If `True`, always use default preference values even if stored values are available.
-    """
+def get_view_material():
+    """Return a ShapeAppearance material with properties based on the preferences."""
     material = App.Material()
-    material.AmbientColor = params.get_param_view("DefaultAmbientColor", ret_default=ret_default)
-    material.DiffuseColor = params.get_param_view("DefaultShapeColor", ret_default=ret_default)
-    material.EmissiveColor = params.get_param_view("DefaultEmissiveColor", ret_default=ret_default)
-    material.Shininess = params.get_param_view("DefaultShapeShininess", ret_default=ret_default) / 100
-    material.SpecularColor = params.get_param_view("DefaultSpecularColor", ret_default=ret_default)
-    material.Transparency = params.get_param_view("DefaultShapeTransparency", ret_default=ret_default) / 100
+    material.AmbientColor  = params.get_param_view("DefaultAmbientColor") & 0xFFFFFF00
+    material.DiffuseColor  = params.get_param_view("DefaultShapeColor") & 0xFFFFFF00
+    material.EmissiveColor = params.get_param_view("DefaultEmissiveColor") & 0xFFFFFF00
+    material.Shininess     = params.get_param_view("DefaultShapeShininess") / 100
+    material.SpecularColor = params.get_param_view("DefaultSpecularColor") & 0xFFFFFF00
+    material.Transparency  = params.get_param_view("DefaultShapeTransparency") / 100
     return material
 
 


### PR DESCRIPTION
Discussion: #13657.

To accommodate the new properties the task panel now has a tabbed interface. The properties on the Annotation tab have been reordered to match the related Preference page.

The order of the Shape appearance properties matches the related Preference page as well. I do not understand why these properties have have different order in the Properties view (if you expand the ShapeAppearance node). @davesrocketshop Do you know the reason for this?

![Draft_SetStyle_Taskpanel_Tab_Shape](https://github.com/FreeCAD/FreeCAD/assets/70520633/2e87e431-e889-44a4-8f32-e4e67eeced41) ![Draft_SetStyle_Taskpanel_Tab_Annotation](https://github.com/FreeCAD/FreeCAD/assets/70520633/9f6c1cd4-a257-43d8-9330-c784f689301b)
