### PR TITLE
Draft: refactor TestDraftGeomUtils

### DIFF
--- a/src/Mod/Draft/drafttests/test_draftgeomutils.py
+++ b/src/Mod/Draft/drafttests/test_draftgeomutils.py
@@ -36,9 +36,32 @@ class TestDraftGeomUtils(unittest.TestCase):
         """Prepare the test. Nothing to do here, DraftGeomUtils doesn't need a document."""
         aux.draw_header()
 
-    def test_get_extended_wire(self):
+    def check_wire(self, wire):
+        offset_values = (2000.0, 0.0, -1000, -2000, -3000, -5500)
+        for offset_start in offset_values:
+            for offset_end in offset_values:
+                if offset_start + offset_end > -wire.Length:
+                    # print ("'start={0}, end={1}' failed".format(offset_start, offset_end))
+                    try:
+                        extended = DraftGeomUtils.get_extended_wire(wire, offset_start, offset_end)
+                        # Test that the extended wire's length is correctly changed
+                        self.assertAlmostEqual(extended.Length, wire.Length + offset_start + offset_end,
+                                               DraftGeomUtils.precision(), "'start={0}, end={1}' failed".format(offset_start, offset_end))
+                        if offset_start == 0.0:
+                            # If offset_start is 0.0, check that the wire's start point is unchanged
+                            self.assertAlmostEqual(extended.OrderedVertexes[0].Point.distanceToPoint(wire.OrderedVertexes[0].Point), 0.0,
+                                                   DraftGeomUtils.precision(), "'start={0}, end={1}' failed".format(offset_start, offset_end))
+                        if offset_end == 0.0:
+                            # If offset_end is 0.0, check that the wire's end point is unchanged
+                            self.assertAlmostEqual(extended.OrderedVertexes[-1].Point.distanceToPoint(wire.OrderedVertexes[-1].Point), 0.0,
+                                                   DraftGeomUtils.precision(), "'start={0}, end={1}' failed".format(offset_start, offset_end))
+                    except Exception as exc:
+                        print ("get_extended_wire failed for 'start={0}, end={1}'".format(offset_start, offset_end))
+                        raise exc
+
+    def test_get_extended_wire1(self):
         """Test the DraftGeomUtils.get_extended_wire function."""
-        operation = "DraftGeomUtils.get_extended_wire"
+        operation = "DraftGeomUtils.get_extended_wire1"
         _msg("  Test '{}'".format(operation))
 
         # Build wires made with straight edges and various combination of Orientation: the wires 1-4 are all equivalent
@@ -51,29 +74,71 @@ class TestDraftGeomUtils(unittest.TestCase):
         for start, end in zip(points[:-1], points[1:]):
             edge = Part.makeLine(start, end)
             edges.append(edge)
-        wire1 = Part.Wire(edges)
+        wire = Part.Wire(edges)
+        self.check_wire(wire)
+
+    def test_get_extended_wire2(self):
+        """Test the DraftGeomUtils.get_extended_wire function."""
+        operation = "DraftGeomUtils.get_extended_wire2"
+        _msg("  Test '{}'".format(operation))
+
+        # Build wires made with straight edges and various combination of Orientation: the wires 1-4 are all equivalent
+        points = [FreeCAD.Vector(0.0, 0.0, 0.0),
+                  FreeCAD.Vector(1500.0, 2000.0, 0.0),
+                  FreeCAD.Vector(4500.0, 2000.0, 0.0),
+                  FreeCAD.Vector(4500.0, 2000.0, 2500.0)]
 
         edges = []
         for start, end in zip(points[:-1], points[1:]):
             edge = Part.makeLine(end, start)
             edge.Orientation = "Reversed"
             edges.append(edge)
-        wire2 = Part.Wire(edges)
+        wire = Part.Wire(edges)
+        self.check_wire(wire)
+
+    def test_get_extended_wire3(self):
+        """Test the DraftGeomUtils.get_extended_wire function."""
+        operation = "DraftGeomUtils.get_extended_wire3"
+        _msg("  Test '{}'".format(operation))
+
+        # Build wires made with straight edges and various combination of Orientation: the wires 1-4 are all equivalent
+        points = [FreeCAD.Vector(0.0, 0.0, 0.0),
+                  FreeCAD.Vector(1500.0, 2000.0, 0.0),
+                  FreeCAD.Vector(4500.0, 2000.0, 0.0),
+                  FreeCAD.Vector(4500.0, 2000.0, 2500.0)]
 
         edges = []
         for start, end in zip(points[:-1], points[1:]):
             edge = Part.makeLine(start, end)
             edge.Orientation = "Reversed"
             edges.insert(0, edge)
-        wire3 = Part.Wire(edges)
-        wire3.Orientation = "Reversed"
+        wire = Part.Wire(edges)
+        wire.Orientation = "Reversed"
+        self.check_wire(wire)
+
+    def test_get_extended_wire4(self):
+        """Test the DraftGeomUtils.get_extended_wire function."""
+        operation = "DraftGeomUtils.get_extended_wire4"
+        _msg("  Test '{}'".format(operation))
+
+        # Build wires made with straight edges and various combination of Orientation: the wires 1-4 are all equivalent
+        points = [FreeCAD.Vector(0.0, 0.0, 0.0),
+                  FreeCAD.Vector(1500.0, 2000.0, 0.0),
+                  FreeCAD.Vector(4500.0, 2000.0, 0.0),
+                  FreeCAD.Vector(4500.0, 2000.0, 2500.0)]
 
         edges = []
         for start, end in zip(points[:-1], points[1:]):
             edge = Part.makeLine(end, start)
             edges.insert(0, edge)
-        wire4 = Part.Wire(edges)
-        wire4.Orientation = "Reversed"
+        wire = Part.Wire(edges)
+        wire.Orientation = "Reversed"
+        self.check_wire(wire)
+
+    def test_get_extended_wire5(self):
+        """Test the DraftGeomUtils.get_extended_wire function."""
+        operation = "DraftGeomUtils.get_extended_wire5"
+        _msg("  Test '{}'".format(operation))
 
         # Build wires made with arcs and various combination of Orientation: the wires 5-8 are all equivalent
         points = [FreeCAD.Vector(0.0, 0.0, 0.0),
@@ -86,53 +151,69 @@ class TestDraftGeomUtils(unittest.TestCase):
         for start, mid, end in zip(points[:-2], points[1:-1], points[2:]):
             edge = Part.Arc(start, mid, end).toShape()
             edges.append(edge)
-        wire5 = Part.Wire(edges)
+        wire = Part.Wire(edges)
+        self.check_wire(wire)
+
+    def test_get_extended_wire6(self):
+        """Test the DraftGeomUtils.get_extended_wire function."""
+        operation = "DraftGeomUtils.get_extended_wire6"
+        _msg("  Test '{}'".format(operation))
+
+        # Build wires made with arcs and various combination of Orientation: the wires 5-8 are all equivalent
+        points = [FreeCAD.Vector(0.0, 0.0, 0.0),
+                  FreeCAD.Vector(1000.0, 1000.0, 0.0),
+                  FreeCAD.Vector(2000.0, 0.0, 0.0),
+                  FreeCAD.Vector(3000.0, 0.0, 1000.0),
+                  FreeCAD.Vector(4000.0, 0.0, 0.0)]
 
         edges = []
         for start, mid, end in zip(points[:-2], points[1:-1], points[2:]):
             edge = Part.Arc(end, mid, start).toShape()
             edge.Orientation = "Reversed"
             edges.append(edge)
-        wire6 = Part.Wire(edges)
+        wire = Part.Wire(edges)
+        self.check_wire(wire)
+
+    def test_get_extended_wire7(self):
+        """Test the DraftGeomUtils.get_extended_wire function."""
+        operation = "DraftGeomUtils.get_extended_wire7"
+        _msg("  Test '{}'".format(operation))
+
+        # Build wires made with arcs and various combination of Orientation: the wires 5-8 are all equivalent
+        points = [FreeCAD.Vector(0.0, 0.0, 0.0),
+                  FreeCAD.Vector(1000.0, 1000.0, 0.0),
+                  FreeCAD.Vector(2000.0, 0.0, 0.0),
+                  FreeCAD.Vector(3000.0, 0.0, 1000.0),
+                  FreeCAD.Vector(4000.0, 0.0, 0.0)]
 
         edges = []
         for start, mid, end in zip(points[:-2], points[1:-1], points[2:]):
             edge = Part.Arc(start, mid, end).toShape()
             edge.Orientation = "Reversed"
             edges.insert(0, edge)
-        wire7 = Part.Wire(edges)
-        wire7.Orientation = "Reversed"
+        wire = Part.Wire(edges)
+        wire.Orientation = "Reversed"
+        self.check_wire(wire)
+
+    def test_get_extended_wire8(self):
+        """Test the DraftGeomUtils.get_extended_wire function."""
+        operation = "DraftGeomUtils.get_extended_wire8"
+        _msg("  Test '{}'".format(operation))
+
+        # Build wires made with arcs and various combination of Orientation: the wires 5-8 are all equivalent
+        points = [FreeCAD.Vector(0.0, 0.0, 0.0),
+                  FreeCAD.Vector(1000.0, 1000.0, 0.0),
+                  FreeCAD.Vector(2000.0, 0.0, 0.0),
+                  FreeCAD.Vector(3000.0, 0.0, 1000.0),
+                  FreeCAD.Vector(4000.0, 0.0, 0.0)]
 
         edges = []
         for start, mid, end in zip(points[:-2], points[1:-1], points[2:]):
             edge = Part.Arc(end, mid, start).toShape()
             edges.insert(0, edge)
-        wire8 = Part.Wire(edges)
-        wire8.Orientation = "Reversed"
-
-        # Run "get_extended_wire" for all the wires with various offset_start, offset_end combinations
-        num_subtests = 0
-        offset_values = (2000.0, 0.0, -1000, -2000, -3000, -5500)
-        for i, wire in enumerate((wire1, wire2, wire3, wire4, wire5, wire6, wire7, wire8)):
-            _msg("  Running tests with wire{}".format(i + 1))
-            for offset_start in offset_values:
-                for offset_end in offset_values:
-                    if offset_start + offset_end > -wire.Length:
-                        subtest = "get_extended_wire(wire{0}, {1}, {2})".format(i + 1, offset_start, offset_end)
-                        num_subtests += 1 # TODO: it should be "with self.subtest(subtest):" but then it doesn't report failures.
-                        extended = DraftGeomUtils.get_extended_wire(wire, offset_start, offset_end)
-                        # Test that the extended wire's length is correctly changed
-                        self.assertAlmostEqual(extended.Length, wire.Length + offset_start + offset_end,
-                                               DraftGeomUtils.precision(), "'{0}.{1}' failed".format(operation, subtest))
-                        if offset_start == 0.0:
-                            # If offset_start is 0.0, check that the wire's start point is unchanged
-                            self.assertAlmostEqual(extended.OrderedVertexes[0].Point.distanceToPoint(wire.OrderedVertexes[0].Point), 0.0,
-                                                   DraftGeomUtils.precision(), "'{0}.{1}' failed".format(operation, subtest))
-                        if offset_end == 0.0:
-                            # If offset_end is 0.0, check that the wire's end point is unchanged
-                            self.assertAlmostEqual(extended.OrderedVertexes[-1].Point.distanceToPoint(wire.OrderedVertexes[-1].Point), 0.0,
-                                                   DraftGeomUtils.precision(), "'{0}.{1}' failed".format(operation, subtest))
-        _msg("  Test completed, {} subtests run".format(num_subtests))
+        wire = Part.Wire(edges)
+        wire.Orientation = "Reversed"
+        self.check_wire(wire)
 
     def tearDown(self):
         """Finish the test. Nothing to do here, DraftGeomUtils doesn't need a document."""


### PR DESCRIPTION
While working on PR #13683 an exception was raised in `get_extended_wire` that caused the test function `test_get_extended_wire` to fail.

However, due to the complexity of the test code it was impossible to figure out for which wire and parameters the function failed. After refactoring the code it was possible.