### PR TITLE
include translations of the FreeCAD App & Base

### DIFF
--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -317,7 +317,15 @@ SET(FreeCADApp_HPP_SRCS
     StringHasher.h
 )
 
+# auto-generate resource file with all available translations
+set (FreeCADApp_TR_QRC ${CMAKE_CURRENT_BINARY_DIR}/Resources/App_translation.qrc)
+qt_find_and_add_translation(QM_SRCS "Resources/translations/*_*.ts"
+    ${CMAKE_CURRENT_BINARY_DIR}/Resources/translations)
+qt_create_resource_file(${FreeCADApp_TR_QRC} ${QM_SRCS})
+qt_add_resources(FreeCADApp_QRC_SRCS ${FreeCADApp_TR_QRC})
+
 SET(FreeCADApp_SRCS
+    ${FreeCADApp_QRC_SRCS}
     ${FreeCADApp_CPP_SRCS}
     ${FreeCADApp_HPP_SRCS}
     ${FreeCADApp_XML_SRCS}

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -152,16 +152,12 @@ endif ()
 
 SOURCE_GROUP("pycxx" FILES ${PYCXX_SOURCES})
 
+# auto-generate resource file with all available translations
 set (FreeCADBase_TR_QRC ${CMAKE_CURRENT_BINARY_DIR}/Resources/Base_translation.qrc)
-qt_find_and_add_translation(QM_SRCS "Resources/translations/Base_*.ts"
-        ${CMAKE_CURRENT_BINARY_DIR}/Resources/translations)
-qt_create_resource_file_prefix(${FreeCADBase_TR_QRC} ${QM_SRCS})
-set(FreeCADBase_RES_SRCS
-        Resources/translation.qrc
-        ${FreeCADBase_TR_QRC}
-        )
-
-qt_add_resources(FreeCADBase_QRC_SRCS ${FreeCADBase_RES_SRCS})
+qt_find_and_add_translation(QM_SRCS "Resources/translations/*_*.ts"
+    ${CMAKE_CURRENT_BINARY_DIR}/Resources/translations)
+qt_create_resource_file(${FreeCADBase_TR_QRC} ${QM_SRCS})
+qt_add_resources(FreeCADBase_QRC_SRCS ${FreeCADBase_TR_QRC})
 
 SET(FreeCADBase_XML_SRCS
     AxisPy.xml
@@ -344,6 +340,7 @@ SET(FreeCADBase_HPP_SRCS
 
 SET(FreeCADBase_SRCS
     ${PYCXX_SOURCES}
+    ${FreeCADBase_QRC_SRCS}
     ${FreeCADBase_CPP_SRCS}
     ${FreeCADBase_HPP_SRCS}
     ${FreeCADBase_XML_SRCS}


### PR DESCRIPTION
The translations of the FreeCAD App & Base were not included in the build process. This patch fixes this issue.