### PR TITLE
Gui: Add Std_ReloadStyleSheet command

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2188,6 +2188,7 @@ void Application::setStyleSheet(const QString& qssFile, bool tiledBackground)
     }
 
     mw->setProperty("fc_currentStyleSheet", qssFile);
+    mw->setProperty("fc_tiledBackground", tiledBackground);
 
     if (!qssFile.isEmpty()) {
         // Search for stylesheet in user-defined search paths.

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -952,6 +952,33 @@ bool StdCmdUserEditMode::isActive()
     return true;
 }
 
+//===========================================================================
+// Std_ReloadStylesheet
+//===========================================================================
+DEF_STD_CMD(StdCmdReloadStyleSheet)
+
+StdCmdReloadStyleSheet::StdCmdReloadStyleSheet()
+  : Command("Std_ReloadStyleSheet")
+{
+    sGroup        = "View";
+    sMenuText     = QT_TR_NOOP("&Reload stylesheet");
+    sToolTipText  = QT_TR_NOOP("Reloads the current stylesheet");
+    sWhatsThis    = "Std_ReloadStyleSheet";
+    sStatusTip    = QT_TR_NOOP("Reloads the current stylesheet");
+    sPixmap       = "view-refresh";
+    sWhatsThis    = "Std_ReloadStyleSheet";
+}
+
+void StdCmdReloadStyleSheet::activated(int iMsg)
+{
+    auto mw = getMainWindow();
+
+    auto qssFile = mw->property("fc_currentStyleSheet").toString();
+    auto tiledBackground = mw->property("fc_tiledBackground").toBool();
+
+    Gui::Application::Instance->setStyleSheet(qssFile, tiledBackground);
+}
+
 namespace Gui {
 
 void CreateStdCommands()
@@ -983,6 +1010,7 @@ void CreateStdCommands()
     rcCmdMgr.addCommand(new StdCmdTextDocument());
     rcCmdMgr.addCommand(new StdCmdUnitsCalculator());
     rcCmdMgr.addCommand(new StdCmdUserEditMode());
+    rcCmdMgr.addCommand(new StdCmdReloadStyleSheet());
     //rcCmdMgr.addCommand(new StdCmdMeasurementSimple());
     //rcCmdMgr.addCommand(new StdCmdDownloadOnlineHelp());
     //rcCmdMgr.addCommand(new StdCmdDescription());


### PR DESCRIPTION
This adds a command that will reload currently active stylesheet - a must have for stylesheet developers.

It is not exposed in any default toolbar or menu - you have to add it manually.

![image](https://github.com/FreeCAD/FreeCAD/assets/747404/978a8136-84e9-4c72-9047-823796c88530)
![image](https://github.com/FreeCAD/FreeCAD/assets/747404/17f5e0f9-8bc3-4ec4-a60b-b37634a30a1f)
