### PR TITLE
Gui: Add privacy policy to About

### DIFF
--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -291,5 +291,6 @@
     </qresource>
     <qresource prefix="/doc">
         <file alias="CONTRIBUTORS">../../Doc/CONTRIBUTORS</file>
+        <file alias="PRIVACY_POLICY">../../../PRIVACY_POLICY.md</file>
     </qresource>
 </RCC>

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -341,6 +341,7 @@ AboutDialog::AboutDialog(bool showLic, QWidget* parent)
     showLicenseInformation();
     showLibraryInformation();
     showCollectionInformation();
+    showPrivacyPolicy();
     showOrHideImage(rect);
 }
 
@@ -765,6 +766,31 @@ void AboutDialog::showCollectionInformation()
     textField->setOpenExternalLinks(true);
     hlayout->addWidget(textField);
     textField->setSource(path);
+}
+
+void AboutDialog::showPrivacyPolicy()
+{
+    auto policyFileURL = QLatin1String(":/doc/PRIVACY_POLICY");
+    QFile policyFile(policyFileURL);
+
+    if (!policyFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        return;
+    }
+    auto text = QString::fromUtf8(policyFile.readAll());
+    auto tabPrivacyPolicy = new QWidget();
+    tabPrivacyPolicy->setObjectName(QString::fromLatin1("tabPrivacyPolicy"));
+    ui->tabWidget->addTab(tabPrivacyPolicy, tr("Privacy Policy"));
+    auto hLayout = new QVBoxLayout(tabPrivacyPolicy);
+    auto textField = new QTextBrowser(tabPrivacyPolicy);
+    textField->setOpenExternalLinks(true);
+    hLayout->addWidget(textField);
+
+#if QT_VERSION < QT_VERSION_CHECK(5,15,0)
+    // We can't actually render the markdown, so just display it as text
+    textField->setText(text);
+#else
+    textField->setMarkdown(text);
+#endif
 }
 
 void AboutDialog::linkActivated(const QUrl& link)

--- a/src/Gui/Splashscreen.h
+++ b/src/Gui/Splashscreen.h
@@ -107,6 +107,7 @@ protected:
     QString getAdditionalLicenseInformation() const;
     void showLibraryInformation();
     void showCollectionInformation();
+    void showPrivacyPolicy();
     void showOrHideImage(const QRect& rect);
 
 protected:


### PR DESCRIPTION
Add a tab to the About FreeCAD dialog that embeds the contents of PRIVACY_POLICY.md. Third-party providers should ensure that they replace that file with their own policy when building. @sliptonic 