### PR TITLE
FEM: Further improvement of the misleading constraint descriptions regarding the geometry selection

### DIFF
--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.ui
@@ -38,7 +38,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Select geometric element(s), click Add or Remove</string>
+      <string>Click Add or Remove and select geometric element(s)</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Select geometric element(s), click Add or Remove</string>
+      <string>Click Add or Remove and select geometric element(s)</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.ui
@@ -29,7 +29,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Select geometric element(s), click Add or Remove</string>
+      <string>Click Add or Remove and select geometric element(s)</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_references">
      <property name="text">
-      <string>Select multiple face(s), click Add or Remove:</string>
+      <string>Click Add or Remove and select face(s)</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Select multiple face(s), click Add or Remove</string>
+      <string>Click Add or Remove and select face(s)</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Select multiple face(s), click Add or Remove</string>
+      <string>Click Add or Remove and select face(s)</string>
      </property>
     </widget>
    </item>

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.ui
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLabel" name="lbl_info">
      <property name="text">
-      <string>Select geometric element(s), click Add or Remove</string>
+      <string>Click Add or Remove and select geometric element(s)</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Continuation of #13921, a small step towards #11666

Changes the constraint task panel tips to suggest correct selection order and removes the misleading suggestions that multiple faces have to be selected.

@marioalexis84 FYI