### PR TITLE
[Sketcher] Change HeadlightIntensity entering and exiting Edit Mode

### DIFF
--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -69,6 +69,13 @@ int View3DSettings::stopAnimatingIfDeactivated() const
 
 void View3DSettings::applySettings()
 {
+    // Check if Sketcher Edit Mode exited cleanly
+    auto sketcherEditLastExit = hGrp->GetInt("HeadlightIntensityExisting", 101);
+    if (sketcherEditLastExit != 101) {
+        // must mean a seg fault or abnormal exit last time
+        hGrp->SetInt("HeadlightIntensity", sketcherEditLastExit);
+        hGrp->RemoveInt("HeadlightIntensityExisting");
+    }
     // apply the user settings
     OnChange(*hGrp,"EyeDistance");
     OnChange(*hGrp,"CornerCoordSystem");

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -70,8 +70,9 @@ int View3DSettings::stopAnimatingIfDeactivated() const
 void View3DSettings::applySettings()
 {
     // Check if Sketcher Edit Mode exited cleanly
-    auto sketcherEditLastExit = hGrp->GetInt("HeadlightIntensityExisting", 101);
-    if (sketcherEditLastExit != 101) {
+    int overMaxHeadlightIntensity = 101;
+    int sketcherEditLastExit = hGrp->GetInt("HeadlightIntensityExisting", overMaxHeadlightIntensity);
+    if (sketcherEditLastExit != overMaxHeadlightIntensity) {
         // must mean a seg fault or abnormal exit last time
         hGrp->SetInt("HeadlightIntensity", sketcherEditLastExit);
         hGrp->RemoveInt("HeadlightIntensityExisting");

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -70,7 +70,7 @@ int View3DSettings::stopAnimatingIfDeactivated() const
 void View3DSettings::applySettings()
 {
     // Check if Sketcher Edit Mode exited cleanly
-    int overMaxHeadlightIntensity = 101;
+    const int overMaxHeadlightIntensity = 101;
     int sketcherEditLastExit = hGrp->GetInt("HeadlightIntensityExisting", overMaxHeadlightIntensity);
     if (sketcherEditLastExit != overMaxHeadlightIntensity) {
         // must mean a seg fault or abnormal exit last time

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3225,6 +3225,13 @@ void ViewProviderSketch::unsetEdit(int ModNum)
         selection.reset();
         this->detachSelection();
 
+        ParameterGrp::handle hGrpView = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/View");
+
+        auto headlightIntensityExisting = hGrpView->GetInt("HeadlightIntensityExisting", 100);
+        hGrpView->SetInt("HeadlightIntensity", headlightIntensityExisting);
+        hGrpView->RemoveInt("HeadlightIntensityExisting");
+
         App::AutoTransaction trans("Sketch recompute");
         try {
             // and update the sketch
@@ -3294,6 +3301,20 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
                 e.what());
         }
     }
+
+    ParameterGrp::handle hGrpView = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/View");
+
+    // This should not be needed but just incase
+    auto sketcherEditLastExit = hGrpView->GetInt("HeadlightIntensityExisting", 101);
+    if (sketcherEditLastExit != 101) {
+        // must mean a seg fault or abnormal exit last time
+        hGrpView->SetInt("HeadlightIntensity", sketcherEditLastExit);
+    }
+    auto headlightIntensityExisting = hGrpView->GetInt("HeadlightIntensity", 100);
+    auto headlightIntensityTemp = 50;
+    hGrpView->SetInt("HeadlightIntensity", headlightIntensityTemp);
+    hGrpView->SetInt("HeadlightIntensityExisting", headlightIntensityExisting);
 
     auto editDoc = Gui::Application::Instance->editDocument();
     editDocName.clear();

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3306,8 +3306,9 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
         "User parameter:BaseApp/Preferences/View");
 
     // This should not be needed but just incase
-    auto sketcherEditLastExit = hGrpView->GetInt("HeadlightIntensityExisting", 101);
-    if (sketcherEditLastExit != 101) {
+    int overMaxHeadlightIntensity = 101;
+    int sketcherEditLastExit = hGrpView->GetInt("HeadlightIntensityExisting", overMaxHeadlightIntensity);
+    if (sketcherEditLastExit != overMaxHeadlightIntensity) {
         // must mean a seg fault or abnormal exit last time
         hGrpView->SetInt("HeadlightIntensity", sketcherEditLastExit);
     }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3305,13 +3305,6 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
     ParameterGrp::handle hGrpView = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View");
 
-    // This should not be needed but just incase
-    int overMaxHeadlightIntensity = 101;
-    int sketcherEditLastExit = hGrpView->GetInt("HeadlightIntensityExisting", overMaxHeadlightIntensity);
-    if (sketcherEditLastExit != overMaxHeadlightIntensity) {
-        // must mean a seg fault or abnormal exit last time
-        hGrpView->SetInt("HeadlightIntensity", sketcherEditLastExit);
-    }
     auto headlightIntensityExisting = hGrpView->GetInt("HeadlightIntensity", 100);
     auto headlightIntensityTemp = 50;
     hGrpView->SetInt("HeadlightIntensity", headlightIntensityTemp);


### PR DESCRIPTION
Handle the situation where the user has a hard crash in Edit Mode by resetting parameter on entering 3D view.

Fixes https://github.com/FreeCAD/FreeCAD/issues/13989


With PR applied to default material:

![HeadlightIntensity50](https://github.com/FreeCAD/FreeCAD/assets/46537884/d06f1616-c738-46df-a9df-0bdf94630cd5)

versus current situation of being unable to determine where the sketch geometry is against the object behind.
