### PR TITLE
Tree: Add 'Go To Linked Obj' to context menu of Links

### DIFF
--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -55,6 +55,7 @@
 #include <Base/PlacementPy.h>
 #include <Base/Tools.h>
 
+#include "Action.h"
 #include "MainWindow.h"
 #include "ViewProviderLink.h"
 #include "ViewProviderLinkPy.h"
@@ -2619,6 +2620,9 @@ void ViewProviderLink::_setupContextMenu(
             act->setData(QVariant((int)ViewProvider::Color));
         }
     }
+
+    auto cmd = Application::Instance->commandManager().getCommandByName("Std_LinkSelectLinked");
+    menu->addAction(cmd->getAction()->action());
 }
 
 bool ViewProviderLink::initDraggingPlacement() {


### PR DESCRIPTION
Add 'Go To Linked Obj' to Tree context menu of Links.
Fixes #12167

![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/266741fe-5e26-4e21-bc9c-26d0f5def0a8)
