### PR TITLE
PartGui: Remove remaining measure "clear all" and "toggle delta" commands

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3311,64 +3311,6 @@ void StdCmdDemoMode::activated(int iMsg)
     dlg->show();
 }
 
-//===========================================================================
-// Part_Measure_Clear_All
-//===========================================================================
-
-DEF_STD_CMD(CmdViewMeasureClearAll)
-
-CmdViewMeasureClearAll::CmdViewMeasureClearAll()
-  : Command("View_Measure_Clear_All")
-{
-    sGroup        = "Measure";
-    sMenuText     = QT_TR_NOOP("Clear measurement");
-    sToolTipText  = QT_TR_NOOP("Clear all visible measurements");
-    sWhatsThis    = "View_Measure_Clear_All";
-    sStatusTip    = sToolTipText;
-    sPixmap       = "Part_Measure_Clear_All";
-}
-
-void CmdViewMeasureClearAll::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-    auto view = dynamic_cast<Gui::View3DInventor*>(Gui::Application::Instance->
-        activeDocument()->getActiveView());
-    if (!view)
-        return;
-    Gui::View3DInventorViewer *viewer = view->getViewer();
-    if (!viewer)
-        return;
-    viewer->eraseAllDimensions();
-}
-
-//===========================================================================
-// Part_Measure_Toggle_All
-//===========================================================================
-
-DEF_STD_CMD(CmdViewMeasureToggleAll)
-
-CmdViewMeasureToggleAll::CmdViewMeasureToggleAll()
-  : Command("View_Measure_Toggle_All")
-{
-    sGroup        = "Measure";
-    sMenuText     = QT_TR_NOOP("Toggle measurement");
-    sToolTipText  = QT_TR_NOOP("Turn on or off the display of all measurements");
-    sWhatsThis    = "View_Measure_Toggle_All";
-    sStatusTip    = sToolTipText;
-    sPixmap       = "Part_Measure_Toggle_All";
-}
-
-void CmdViewMeasureToggleAll::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-    ParameterGrp::handle group = App::GetApplication().GetUserParameter().
-    GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("View");
-    bool visibility = group->GetBool("DimensionsVisible", true);
-    if (visibility)
-        group->SetBool("DimensionsVisible", false);
-    else
-      group->SetBool("DimensionsVisible", true);
-}
 
 //===========================================================================
 // Std_SelBack
@@ -4156,8 +4098,6 @@ void CreateViewStdCommands()
     rcCmdMgr.addCommand(new StdCmdDemoMode());
     rcCmdMgr.addCommand(new StdCmdToggleNavigation());
     rcCmdMgr.addCommand(new StdCmdAxisCross());
-    rcCmdMgr.addCommand(new CmdViewMeasureClearAll());
-    rcCmdMgr.addCommand(new CmdViewMeasureToggleAll());
     rcCmdMgr.addCommand(new StdCmdSelBoundingBox());
     rcCmdMgr.addCommand(new StdCmdTreeViewActions());
     rcCmdMgr.addCommand(new StdCmdDockOverlay());

--- a/src/Gui/PreferencePackTemplates/Shortcuts.cfg
+++ b/src/Gui/PreferencePackTemplates/Shortcuts.cfg
@@ -947,8 +947,6 @@
           <FCText Name="Test_TestDoc"></FCText>
           <FCText Name="Test_TestDocText"></FCText>
           <FCText Name="Test_TestWork"></FCText>
-          <FCText Name="View_Measure_Clear_All"></FCText>
-          <FCText Name="View_Measure_Toggle_All"></FCText>
           <FCText Name="Web_BrowserBack"></FCText>
           <FCText Name="Web_BrowserNext"></FCText>
           <FCText Name="Web_BrowserRefresh"></FCText>

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -590,13 +590,8 @@ void StdWorkbench::setupContextMenu(const char* recipient, MenuItem* item) const
                   << "Std_ViewRear" << "Std_ViewBottom" << "Std_ViewLeft"
                   << "Separator" << "Std_ViewRotateLeft" << "Std_ViewRotateRight";
 
-        auto measure = new MenuItem();
-        measure->setCommand("Measure");
-        *measure << "View_Measure_Toggle_All" << "View_Measure_Clear_All";
-
-
         *item << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_DrawStyle"
-              << StdViews << measure << "Separator"
+              << StdViews << "Separator"
               << "Std_ViewDockUndockFullscreen";
 
         if (Gui::Selection().countObjectsOfType(App::DocumentObject::getClassTypeId()) > 0) {
@@ -684,8 +679,7 @@ MenuItem* StdWorkbench::setupMenuBar() const
     *visu << "Std_ToggleVisibility" << "Std_ShowSelection" << "Std_HideSelection"
           << "Std_SelectVisibleObjects"
           << "Separator" << "Std_ToggleObjects" << "Std_ShowObjects" << "Std_HideObjects"
-          << "Separator" << "Std_ToggleSelectability"
-          << "Separator" << "View_Measure_Toggle_All" << "View_Measure_Clear_All";
+          << "Separator" << "Std_ToggleSelectability";
 
     // View
     auto view = new MenuItem( menuBar );


### PR DESCRIPTION
This removes two leftover commands from part's measure system.

![331158822-de7fdaa1-7fc0-442a-855d-03c71f837aa2](https://github.com/FreeCAD/FreeCAD/assets/64740362/59138026-1a4a-4abb-82a4-7dda5cdb93e1)
