### PR TITLE
[TD]Expose DimExtent in Python (2nd attempt, replaces PR #13976)

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -867,10 +867,15 @@ private:
             throw Py::Exception(Part::PartExceptionOCCError, e.GetMessageString());
         }
 
+        DrawViewDimension* dvde =
         DrawDimHelper::makeExtentDim(dvp,
                                      edgeList,
                                      direction);
-        return Py::None();
+        if (!dvde){
+            return Py::None();
+        }
+        PyObject* dvdePy = dvde->getPyObject();
+        return Py::asObject(dvdePy);
     }
 
     Py::Object makeDistanceDim(const Py::Tuple& args)


### PR DESCRIPTION
Solves issue #13728, 2nd attempt.

The function DrawDimHelper::makeExtentDim() now returns an object to Python, which properties can be used.

Macro to test:
`'''
- Select an existing view
- Start the macro

A horizontal Extent Dimension is created.
The view's scale, and the extent dimension's raw value is printed.
'''
import TechDraw
import TechDrawTools.TDToolsUtil as Utils
view = Utils.getSelView()
scale = view.getScale()
extentDim = TechDraw.makeExtentDim(view,[],0)
value = extentDim.getRawValue()
print(scale,value)
view.requestPaint()`