### PR TITLE
Core: Add read lock to fix for possible race conditions reading/writing config files

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1674,19 +1674,29 @@ void Application::cleanupUnits()
 void Application::destruct()
 {
     // saving system parameter
-    Base::Console().Log("Saving system parameter...\n");
-    _pcSysParamMngr->SaveDocument();
+    if (_pcSysParamMngr->IgnoreSave()) {
+        Base::Console().Warning("Discard system parameter\n");
+    }
+    else {
+        Base::Console().Log("Saving system parameter...\n");
+        _pcSysParamMngr->SaveDocument();
+        Base::Console().Log("Saving system parameter...done\n");
+    }
     // saving the User parameter
-    Base::Console().Log("Saving system parameter...done\n");
-    Base::Console().Log("Saving user parameter...\n");
-    _pcUserParamMngr->SaveDocument();
-    Base::Console().Log("Saving user parameter...done\n");
+    if (_pcUserParamMngr->IgnoreSave()) {
+        Base::Console().Warning("Discard user parameter\n");
+    }
+    else {
+        Base::Console().Log("Saving user parameter...\n");
+        _pcUserParamMngr->SaveDocument();
+        Base::Console().Log("Saving user parameter...done\n");
+    }
 
     // now save all other parameter files
     auto& paramMgr = _pcSingleton->mpcPramManager;
     for (auto it : paramMgr) {
         if ((it.second != _pcSysParamMngr) && (it.second != _pcUserParamMngr)) {
-            if (it.second->HasSerializer()) {
+            if (it.second->HasSerializer() && !it.second->IgnoreSave()) {
                 Base::Console().Log("Saving %s...\n", it.first.c_str());
                 it.second->SaveDocument();
                 Base::Console().Log("Saving %s...done\n", it.first.c_str());

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -1747,12 +1747,6 @@ int getTimeout()
     const int timeout = 5000;
     return timeout;
 }
-
-bool waitForReadAccess(const Base::FileInfo& file)
-{
-    QLockFile lock(getLockFile(file));
-    return lock.tryLock(getTimeout());
-}
 }  // namespace
 
 //**************************************************************************
@@ -1774,7 +1768,8 @@ int ParameterManager::LoadDocument(const char* sFileName)
 {
     try {
         Base::FileInfo file(sFileName);
-        if (!waitForReadAccess(file)) {
+        QLockFile lock(getLockFile(file));
+        if (!lock.tryLock(getTimeout())) {
             // Continue with empty config
             CreateDocument();
             SetIgnoreSave(true);

--- a/src/Base/Parameter.h
+++ b/src/Base/Parameter.h
@@ -434,12 +434,15 @@ public:
     bool LoadOrCreateDocument();
     /// Saves an XML document by calling the serializer's save method.
     void SaveDocument() const;
+    void SetIgnoreSave(bool value);
+    bool IgnoreSave() const;
     //@}
 
 private:
     XERCES_CPP_NAMESPACE_QUALIFIER DOMDocument* _pDocument {nullptr};
     ParameterSerializer* paramSerializer {nullptr};
 
+    bool gIgnoreSave;
     bool gDoNamespaces;
     bool gDoSchema;
     bool gSchemaFullChecking;

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -43,6 +43,7 @@
 #include "MainWindow.h"
 #include "Language/Translator.h"
 #include <App/Application.h>
+#include <Base/Console.h>
 
 
 using namespace Gui;
@@ -233,6 +234,7 @@ void StartupPostProcess::execute()
     setBranding();
     showMainWindow();
     activateWorkbench();
+    checkParameters();
 }
 
 void StartupPostProcess::setWindowTitle()
@@ -543,5 +545,17 @@ void StartupPostProcess::autoloadModules(const QStringList& wb)
         if (wb.contains(QString::fromLatin1(workbench.c_str()))) {
             guiApp.activateWorkbench(workbench.c_str());
         }
+    }
+}
+
+void StartupPostProcess::checkParameters()
+{
+    if (App::GetApplication().GetSystemParameter().IgnoreSave()) {
+        Base::Console().Warning("System parameter file couldn't be opened.\n"
+                                "Continue with an empty configuration that won't be saved.\n");
+    }
+    if (App::GetApplication().GetUserParameter().IgnoreSave()) {
+        Base::Console().Warning("User parameter file couldn't be opened.\n"
+                                "Continue with an empty configuration that won't be saved.\n");
     }
 }

--- a/src/Gui/StartupProcess.h
+++ b/src/Gui/StartupProcess.h
@@ -74,6 +74,7 @@ private:
     bool hiddenMainWindow() const;
     void showMainWindow();
     void activateWorkbench();
+    void checkParameters();
 
 private:
     bool loadFromPythonModule = false;


### PR DESCRIPTION
This PR includes #13845 but adds locking to reading a config file as well, as proposed in [this comment](https://github.com/FreeCAD/FreeCAD/pull/13845#issuecomment-2096090023).