### PR TITLE
BIM: Reworked menus and toolbars

### DIFF
--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -88,7 +88,6 @@ class BIMWorkbench(Workbench):
         ]
 
         self.annotationtools = [
-            #"BIM_ImagePlane",
             "BIM_Text",
             "Draft_ShapeString",
             "BIM_DimensionAligned",
@@ -128,6 +127,7 @@ class BIMWorkbench(Workbench):
             "Arch_Frame",
             "Arch_Fence",
             "Arch_Truss",
+            "Arch_Equipment",
             "Arch_Rebar",
         ]
         
@@ -141,12 +141,15 @@ class BIMWorkbench(Workbench):
             "Arch_Reference",
         ]
 
-        self.modify = [
+        self.modify_gen = [
             "Draft_Move",
             "BIM_Copy",
             "Draft_Rotate",
             "BIM_Clone",
-            "BIM_Unclone",
+            "BIM_SimpleCopy",
+            "BIM_Compound",
+        ]
+        self.modify_2d = [
             "Draft_Offset",
             "BIM_Offset2D",
             "Draft_Trimex",
@@ -154,26 +157,29 @@ class BIMWorkbench(Workbench):
             "Draft_Split",
             "Draft_Scale",
             "Draft_Stretch",
-            "BIM_Rewire",
-            "BIM_Glue",
+            "Draft_Draft2Sketch",
+        ]
+        self.modify_obj = [
             "Draft_Upgrade",
             "Draft_Downgrade",
-            "Draft_Draft2Sketch",
-            "Arch_CutPlane",
             "Arch_Add",
             "Arch_Remove",
-            "BIM_Reextrude",
+        ]
+        self.modify_3d = [
             "Draft_OrthoArray",
             "Draft_PathArray",
+            "Draft_CircularArray",
             "Draft_PointArray",
+            "Arch_CutPlane",
             "Draft_Mirror",
             "BIM_Extrude",
             "BIM_Cut",
             "BIM_Fuse",
             "BIM_Common",
-            "BIM_Compound",
-            "BIM_SimpleCopy",
         ]
+
+        sep = ["Separator"]
+        self.modify = self.modify_gen + sep + self.modify_2d + sep + self.modify_obj + sep + self.modify_3d
 
         self.manage = [
             "BIM_Setup",
@@ -211,6 +217,12 @@ class BIMWorkbench(Workbench):
             "Arch_Survey",
             "BIM_Diff",
             "BIM_IfcExplorer",
+            "BIM_ImagePlane",
+            "BIM_Unclone",
+            "BIM_Rewire",
+            "BIM_Glue",
+            "BIM_Reextrude",
+            "BIM_PanelTools"
         ]
 
         nudge = [
@@ -388,13 +400,19 @@ class BIMWorkbench(Workbench):
         t2 = QT_TRANSLATE_NOOP("Workbench", "Draft snap")
         t3 = QT_TRANSLATE_NOOP("Workbench", "3D/BIM tools")
         t4 = QT_TRANSLATE_NOOP("Workbench", "Annotation tools")
-        t5 = QT_TRANSLATE_NOOP("Workbench", "Modification tools")
+        t5 = QT_TRANSLATE_NOOP("Workbench", "2D modification tools")
         t6 = QT_TRANSLATE_NOOP("Workbench", "Manage tools")
+        t7 = QT_TRANSLATE_NOOP("Workbench", "General modification tools")
+        t8 = QT_TRANSLATE_NOOP("Workbench", "Object modification tools")
+        t9 = QT_TRANSLATE_NOOP("Workbench", "3D modification tools")
         self.appendToolbar(t1, self.draftingtools)
         self.appendToolbar(t2, self.snapbar)
         self.appendToolbar(t3, self.bimtools)
         self.appendToolbar(t4, self.annotationtools)
-        self.appendToolbar(t5, self.modify)
+        self.appendToolbar(t7, self.modify_gen)
+        self.appendToolbar(t5, self.modify_2d)
+        self.appendToolbar(t8, self.modify_obj)
+        self.appendToolbar(t9, self.modify_3d)
         self.appendToolbar(t6, self.manage)
 
         # create menus
@@ -406,7 +424,7 @@ class BIMWorkbench(Workbench):
         t5 =  QT_TRANSLATE_NOOP("Workbench", "&Snapping")
         t6 =  QT_TRANSLATE_NOOP("Workbench", "&Modify")
         t7 =  QT_TRANSLATE_NOOP("Workbench", "&Manage")
-        t8 =  QT_TRANSLATE_NOOP("Workbench", "&IFC")
+        #t8 =  QT_TRANSLATE_NOOP("Workbench", "&IFC")
         t9 =  QT_TRANSLATE_NOOP("Workbench", "&Flamingo")
         t10 = QT_TRANSLATE_NOOP("Workbench", "&Fasteners")
         t11 = QT_TRANSLATE_NOOP("Workbench", "&Utils")
@@ -423,13 +441,13 @@ class BIMWorkbench(Workbench):
         self.appendMenu(t5, self.snapmenu)
         self.appendMenu(t6, self.modify)
         self.appendMenu(t7, self.manage)
-        if ifctools:
-            self.appendMenu(t8, ifctools)
+        #if ifctools:
+        #    self.appendMenu(t8, ifctools)
         if flamingo:
             self.appendMenu(t9, flamingo)
         if fasteners:
             self.appendMenu(t10, fasteners)
-        self.appendMenu(t11, self.utils)
+        self.appendMenu(t11, self.utils + ifctools)
         self.appendMenu([t11, t12], nudge)
 
     def loadPreferences(self):

--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -222,7 +222,8 @@ class BIMWorkbench(Workbench):
             "BIM_Rewire",
             "BIM_Glue",
             "BIM_Reextrude",
-            "BIM_PanelTools"
+            "Arch_PanelTools",
+            "Arch_StructureTools",
         ]
 
         nudge = [


### PR DESCRIPTION
Following up on #13783, this is a rework of the toolbars and menus in the BIM workbench.

Basically:

* All Arch and all BIM tools are there
* Menus and toolbars are reorganized into broad categories, each with as few as possible submenus:
   * 2D/Drafting (Draft tools)
   * 3D/BIM (BIM tools + some generic 3D tools)
   * Modify (contains generic move/rotate/copy, 2D modif tools and 3D modif tools)
   * Manage (these are all from BIM)
   * Utils (kind of dirty at the moment, all the tools that didn't fit in the other categories, the idea is basically that everything is there for 1.0. That menu needs further discussion)
* The toolbars are split into smaller toolbars so users can turn on/off parts of them to use less space. It is then possible to have either a "large toolbars layout", a "minimal toolbars layout" or anything in between.

Menus structure from arch:

![arch-menus](https://github.com/FreeCAD/FreeCAD/assets/1136856/8f8bd79a-0150-4dc6-bc7d-a52f952858de)

Menus from BIM (panel tools and structure tools are missing from that image, they are both in the Utils menu for now):

![bim-menus](https://github.com/FreeCAD/FreeCAD/assets/1136856/83980593-bdab-4618-a472-acb97eac1756)

Further things that should be discussed:

* The Arch StructuralSystem tool should be discarded, because one can now simply use the "Axis" property of structural tools, it's even more powerful than the Structural system tool, as it can work with any object, not just axes
* The Arch MultipleStructure tool should be reworked and merge in the base Structure tool (used by columns and beams) so one can simply select a profile and one or more edges and create a series of beams.
* Panel tools: These tools are not really for BIM, but for panel construction (furniture, wikihouse...). Not sure where they should fit.
* Reorganize the utils menu (maybe Mesh tools, IFC tools, Panel tools, etc...)