### PR TITLE
[CAM] VCarve improvements

### DIFF
--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -127,3 +127,4 @@
         <file>preferences/PathJob.ui</file>
     </qresource>
 </RCC>
+

--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -127,5 +127,3 @@
         <file>preferences/PathJob.ui</file>
     </qresource>
 </RCC>
-
-

--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -128,3 +128,4 @@
     </qresource>
 </RCC>
 
+

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpVcarveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpVcarveEdit.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>197</height>
+    <width>739</width>
+    <height>379</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -55,65 +55,94 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="widget">
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="toolTip">
-         <string></string>
-        </property>
-        <property name="text">
-         <string>Discretization Deflection</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="discretize">
-        <property name="toolTip">
-         <string>This value is used in discretizing arcs into segments. Smaller values will result in larger gcode. Larger values may cause unwanted segments in the medial line path.</string>
-        </property>
-        <property name="decimals">
-         <number>3</number>
-        </property>
-        <property name="minimum">
-         <double>0.001000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>1.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.010000000000000</double>
-        </property>
-        <property name="value">
-         <double>0.010000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="toolTip">
-         <string></string>
-        </property>
-        <property name="text">
-         <string>Filter Colinear lines</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="colinearFilter">
-        <property name="toolTip">
-         <string>Sets how aggressively colinear segments are filtered from the Voronoi diagram. Valid values are 0 - 90 degrees (larger numbers filter more). Default = 10</string>
-        </property>
-        <property name="maximum">
-         <number>90</number>
-        </property>
-        <property name="value">
-         <number>10</number>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Discretization Deflection</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QDoubleSpinBox" name="discretize">
+       <property name="toolTip">
+        <string>This value is used in discretizing arcs into segments. Smaller values will result in larger gcode. Larger values may cause unwanted segments in the medial line path.</string>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="minimum">
+        <double>0.001000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.010000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.010000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Filter Colinear lines</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="colinearFilter">
+       <property name="toolTip">
+        <string>Sets how aggressively colinear segments are filtered from the Voronoi diagram. Valid values are 0 - 90 degrees (larger numbers filter more). Default = 10</string>
+       </property>
+       <property name="maximum">
+        <number>90</number>
+       </property>
+       <property name="value">
+        <number>10</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="finishingPassLabel">
+       <property name="text">
+        <string>Finishing Pass</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="finishingPassEnabled">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="finishingPassZOffsetLabel">
+       <property name="text">
+        <string>Finishing pass Z offset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QDoubleSpinBox" name="finishingPassZOffset">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <spacer name="verticalSpacer">

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpVcarveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpVcarveEdit.ui
@@ -133,9 +133,12 @@
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="finishingPassZOffset">
-       <property name="enabled">
-        <bool>true</bool>
+      <widget class="Gui::QuantitySpinBox" name="finishingPassZOffset">
+       <property name="toolTip">
+        <string>Endmill offset for the finishing pass run. Use small value like -0.2 mm to help clean &quot;fuzzy skin&quot; or other artefacts.</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true"/>
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
@@ -159,6 +162,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpVcarveEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpVcarveEdit.ui
@@ -111,28 +111,14 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="finishingPassLabel">
-       <property name="text">
-        <string>Finishing Pass</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QCheckBox" name="finishingPassEnabled">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="finishingPassZOffsetLabel">
        <property name="text">
         <string>Finishing pass Z offset</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="Gui::QuantitySpinBox" name="finishingPassZOffset">
        <property name="toolTip">
         <string>Endmill offset for the finishing pass run. Use small value like -0.2 mm to help clean &quot;fuzzy skin&quot; or other artefacts.</string>
@@ -142,6 +128,32 @@
        </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="finishingPassEnabled">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>After carving travel again the path to remove artifacts and imperfections</string>
+       </property>
+       <property name="statusTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Finishing pass</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="optimizeMovementsEnabled">
+       <property name="toolTip">
+        <string>Optimize path to avoid raising endmill when moving to adjacent edges. May result in sub-millimeter inaccuracies. </string>
+       </property>
+       <property name="text">
+        <string>Optimize movements</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/CAM/Path/Log.py
+++ b/src/Mod/CAM/Path/Log.py
@@ -102,6 +102,7 @@ def _caller():
 def _log(level, module_line_func, msg):
     """internal function to do the logging"""
     module, line, func = module_line_func
+    
     if getLevel(module) >= level:
         message = "%s.%s: %s" % (module, Level.toString(level), msg)
         if _useConsole:

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -463,6 +463,15 @@ class ObjectOp(object):
                 QT_TRANSLATE_NOOP("App::Property", "Operations Cycle Time Estimation"),
             )
 
+        if FeatureStepDown & features and not hasattr(obj, "StepDown"):
+            obj.addProperty(
+                "App::PropertyDistance",
+                "StepDown",
+                "Depth",
+                QT_TRANSLATE_NOOP("App::Property", "Incremental Step Down of Tool"),
+            )
+            obj.StepDown = 0
+
         self.setEditorModes(obj, features)
         self.opOnDocumentRestored(obj)
 

--- a/src/Mod/CAM/Path/Op/Gui/Vcarve.py
+++ b/src/Mod/CAM/Path/Op/Gui/Vcarve.py
@@ -37,8 +37,9 @@ __author__ = "sliptonic (Brad Collette)"
 __url__ = "https://www.freecad.org"
 __doc__ = "Vcarve operation page controller and command implementation."
 
+# There is a bug in logging library. To enable debugging - set True also in Op/Vcarve.py
 
-if False:
+if True:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
     Path.Log.trackModule(Path.Log.thisModule())
 else:

--- a/src/Mod/CAM/Path/Op/Gui/Vcarve.py
+++ b/src/Mod/CAM/Path/Op/Gui/Vcarve.py
@@ -126,7 +126,30 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
     def getForm(self):
         """getForm() ... returns UI"""
-        return FreeCADGui.PySideUic.loadUi(":/panels/PageOpVcarveEdit.ui")
+        form = FreeCADGui.PySideUic.loadUi(":/panels/PageOpVcarveEdit.ui")
+        self.updateFormConditionalState(form)
+        return form
+
+    def updateFormConditionalState(self, form):
+        """
+        Update conditional form controls - i.e settings that should be
+        visible only under certain conditions (other settings enabled, etc).
+        """
+
+        if form.finishingPassEnabled.isChecked():
+            form.finishingPassZOffset.setVisible(True)
+            form.finishingPassZOffsetLabel.setVisible(True)
+        else:
+            form.finishingPassZOffset.setVisible(False)
+            form.finishingPassZOffsetLabel.setVisible(False)
+
+    def updateFormCallback(self):
+        return self.updateFormConditionalState(self.form)
+
+    def registerSignalHandlers(self, obj):
+        """Register signal handlers to update conditiona UI states"""
+
+        self.form.finishingPassEnabled.stateChanged.connect(self.updateFormCallback)
 
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
@@ -134,6 +157,13 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             obj.Discretize = self.form.discretize.value()
         if obj.Colinear != self.form.colinearFilter.value():
             obj.Colinear = self.form.colinearFilter.value()
+
+        if obj.FinishingPass != self.form.finishingPassEnabled.isChecked():
+            obj.FinishingPass = self.form.finishingPassEnabled.isChecked()
+
+        if obj.FinishingPassZOffset != self.form.finishingPassZOffset.value():
+            obj.FinishingPassZOffset = self.form.finishingPassZOffset.value()
+
         self.updateToolController(obj, self.form.toolController)
         self.updateCoolant(obj, self.form.coolantController)
 
@@ -141,6 +171,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         """setFields(obj) ... transfers obj's property values to UI"""
         self.form.discretize.setValue(obj.Discretize)
         self.form.colinearFilter.setValue(obj.Colinear)
+        self.form.finishingPassEnabled.setChecked(obj.FinishingPass)
+        self.form.finishingPassZOffset.setValue(obj.FinishingPassZOffset)
+
         self.setupToolController(obj, self.form.toolController)
         self.setupCoolant(obj, self.form.coolantController)
 
@@ -149,6 +182,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals = []
         signals.append(self.form.discretize.editingFinished)
         signals.append(self.form.colinearFilter.editingFinished)
+        signals.append(self.form.finishingPassEnabled.stateChanged)
+        signals.append(self.form.finishingPassZOffset.editingFinished)
+
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.coolantController.currentIndexChanged)
         return signals

--- a/src/Mod/CAM/Path/Op/Gui/Vcarve.py
+++ b/src/Mod/CAM/Path/Op/Gui/Vcarve.py
@@ -169,6 +169,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if obj.FinishingPass != self.form.finishingPassEnabled.isChecked():
             obj.FinishingPass = self.form.finishingPassEnabled.isChecked()
 
+        if obj.OptimizeMovements != self.form.optimizeMovementsEnabled.isChecked():
+             obj.OptimizeMovements = self.form.optimizeMovementsEnabled.isChecked()
+
         self.finishingPassZOffsetSpinBox.updateProperty()
 
         self.updateToolController(obj, self.form.toolController)
@@ -179,6 +182,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.discretize.setValue(obj.Discretize)
         self.form.colinearFilter.setValue(obj.Colinear)
         self.form.finishingPassEnabled.setChecked(obj.FinishingPass)
+        self.form.optimizeMovementsEnabled.setChecked(obj.OptimizeMovements)
 
         self.finishingPassZOffsetSpinBox.updateSpinBox()
 
@@ -194,6 +198,9 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.colinearFilter.editingFinished)
         signals.append(self.form.finishingPassEnabled.stateChanged)
         signals.append(self.form.finishingPassZOffset.editingFinished)
+
+        signals.append(self.form.optimizeMovementsEnabled.stateChanged)
+
 
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.coolantController.currentIndexChanged)

--- a/src/Mod/CAM/Path/Op/Gui/Vcarve.py
+++ b/src/Mod/CAM/Path/Op/Gui/Vcarve.py
@@ -25,6 +25,8 @@ import FreeCADGui
 import Path
 import Path.Op.Gui.Base as PathOpGui
 import Path.Op.Vcarve as PathVcarve
+import Path.Base.Gui.Util as PathGuiUtil
+
 import PathGui
 import PathScripts.PathUtils as PathUtils
 from PySide import QtCore, QtGui
@@ -124,6 +126,11 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
 class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     """Page controller class for the Vcarve operation."""
 
+    def initPage(self, obj):
+        self.finishingPassZOffsetSpinBox = PathGuiUtil.QuantitySpinBox(
+            self.form.finishingPassZOffset, obj, "FinishingPassZOffset"
+        )
+
     def getForm(self):
         """getForm() ... returns UI"""
         form = FreeCADGui.PySideUic.loadUi(":/panels/PageOpVcarveEdit.ui")
@@ -161,8 +168,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if obj.FinishingPass != self.form.finishingPassEnabled.isChecked():
             obj.FinishingPass = self.form.finishingPassEnabled.isChecked()
 
-        if obj.FinishingPassZOffset != self.form.finishingPassZOffset.value():
-            obj.FinishingPassZOffset = self.form.finishingPassZOffset.value()
+        self.finishingPassZOffsetSpinBox.updateProperty()
 
         self.updateToolController(obj, self.form.toolController)
         self.updateCoolant(obj, self.form.coolantController)
@@ -172,10 +178,13 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.discretize.setValue(obj.Discretize)
         self.form.colinearFilter.setValue(obj.Colinear)
         self.form.finishingPassEnabled.setChecked(obj.FinishingPass)
-        self.form.finishingPassZOffset.setValue(obj.FinishingPassZOffset)
+
+        self.finishingPassZOffsetSpinBox.updateSpinBox()
 
         self.setupToolController(obj, self.form.toolController)
         self.setupCoolant(obj, self.form.coolantController)
+
+        self.updateFormConditionalState(self.form)
 
     def getSignalsForUpdate(self, obj):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""

--- a/src/Mod/CAM/Tests/TestPathVcarve.py
+++ b/src/Mod/CAM/Tests/TestPathVcarve.py
@@ -111,3 +111,37 @@ class TestPathVcarve(PathTestBase):
         self.assertRoughly(geom.start, Scale45)
         self.assertRoughly(geom.stop, -3)
         self.assertRoughly(geom.scale, Scale45)
+
+    def test14(self):
+        """Verify if max dept is calculated properly when step-down is disabled"""
+
+        tool = VbitTool(10, 45, 2)
+        geom = PathVcarve._Geometry.FromTool(tool, zStart=0, zFinal=-3, zStepDown=0)
+
+        self.assertEqual(geom.maximumDepth, -3)
+        self.assertEqual(geom.maximumDepth, geom.stop)
+
+    def test15(self):
+        """Verify if step-down sections match final max depth"""
+
+        tool = VbitTool(10, 45, 2)
+        geom = PathVcarve._Geometry.FromTool(tool, zStart=0, zFinal=-3, zStepDown=0.13)
+
+        while geom.incrementStepDownDepth(maximumUsableDepth=-3):
+            pass
+
+        self.assertEqual(geom.maximumDepth, -3)
+
+    def test16(self):
+        """Verify 90 deg with tip dia depth calculation with step-down enabled"""
+        tool = VbitTool(10, 90, 2)
+        geom = PathVcarve._Geometry.FromTool(tool, zStart=0, zFinal=-10, zStepDown=0.13)
+
+        while geom.incrementStepDownDepth(maximumUsableDepth=-10):
+            pass
+
+        # in order for the width to be correct the height needs to be shifted
+        self.assertRoughly(geom.start, 1)
+        self.assertRoughly(geom.stop, -4)
+        self.assertRoughly(geom.scale, 1)
+        self.assertRoughly(geom.maximumDepth, -4)


### PR DESCRIPTION
Rework of Vcarve operation to include features mostly available in commercial software of this kind. Those features are used to drastically improve carved surface quality (especially on smaller and less rigid CNC machines) and increase carving speed up to 50%.

1) Step down - carve in small increments (similar to other CAM operations). Each depth steps are grouped by surface to limit X/Y movements.
2) Finishing pass - run last path again (with optional offset) to remove fuzzy skin and/or other imperfections
3) Head movement optimization - do not lift and reposition head (G0 command) if start of next edge is withing 0.5 mm XY distance. This makes whole operation at least 50% faster with negligible loss of edge precision.

Discussion and photo examples:

https://forum.freecad.org/viewtopic.php?t=87475
