### PR TITLE
BIM: Allow to export groups as assemblies

### DIFF
--- a/src/Mod/BIM/Resources/ui/preferences-ifc-export.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-ifc-export.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>630</width>
-    <height>614</height>
+    <width>534</width>
+    <height>691</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -274,9 +274,7 @@ If this is your case, you can disable this and then all profiles will be exporte
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBox_17">
         <property name="toolTip">
-         <string>Some IFC types such as IfcWall or IfcBeam have special standard versions
-like IfcWallStandardCase or IfcBeamStandardCase.
-If this option is turned on, FreeCAD will automatically export such objects
+         <string>Some IFC types such as IfcWall or IfcBeam have special standard versions like IfcWallStandardCase or IfcBeamStandardCase. If this option is turned on, FreeCAD will automatically export such objects
 as standard cases when the necessary conditions are met.</string>
         </property>
         <property name="text">
@@ -301,27 +299,6 @@ A site is not mandatory but a common practice is to have at least one in the fil
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>IfcAddDefaultSite</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_21">
-        <property name="toolTip">
-         <string>If no building is found in the FreeCAD document, a default one will be added.
-Warning: The IFC standard asks for at least one building in each file. By turning this option off, you will produce a non-standard IFC file.
-However, at FreeCAD, we believe having a building should not be mandatory, and this option is there to have a chance to demonstrate our point of view.</string>
-        </property>
-        <property name="text">
-         <string>Add default building if one is not found in the document (no standard)</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>IfcAddDefaultBuilding</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>Mod/Arch</cstring>
@@ -391,6 +368,55 @@ unit to work with when opening the file.</string>
          </widget>
         </item>
        </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>IFC standard compliance</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_21">
+        <property name="toolTip">
+         <string>If no building is found in the FreeCAD document, a default one will be added.
+Warning: The IFC standard asks for at least one building in each file. By turning this option off, you will produce a non-standard IFC file.
+However, at FreeCAD, we believe having a building should not be mandatory, and this option is there to have a chance to demonstrate our point of view.</string>
+        </property>
+        <property name="text">
+         <string>Add default building if one is not found in the document</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>IfcAddDefaultBuilding</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_2">
+        <property name="toolTip">
+         <string>In FreeCAD, it is possible to nest groups inside buildings or storeys. If this option is disabled, FreeCAD groups will be saved as IfcGroups and aggregated to the building structure. Aggregating non-building elements such as IfcGroups is however not recommended by the IFC standards. It is therefore also possible to export these groups as IfcElementAssemblies, which produces an IFC-compliant file. However, at FreeCAD, we believe nesting groups inside structures should be possible, and this option is there to have a chance to demonstrate our point of view.</string>
+        </property>
+        <property name="text">
+         <string>Export nested groups as assemblies</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>IfcGroupsAsAssemblies</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -331,8 +331,14 @@ def assign_groups(children):
 
     for child in children:
         if child.is_a("IfcGroup"):
+            mode = "IsGroupedBy"
+        elif child.is_a("IfcElementAssembly"):
+            mode = "IsDecomposedBy"
+        else:
+            mode = None
+        if mode:
             grobj = get_object(child)
-            for rel in child.IsGroupedBy:
+            for rel in getattr(child, mode):
                 for elem in rel.RelatedObjects:
                     elobj = get_object(elem)
                     if elobj:


### PR DESCRIPTION
Following a discussion on https://community.osarch.org/discussion/comment/20540#Comment_20540 , it appears what we are currently doing at FreeCAD, that is, aggregating groups inside a building structure, is illegal.

With this PR, groups nested inside building structures will now by default be exported as IfcElementAssemblies. 

However, since we (okay, I) firmly believe groups nested inside building structures are a good idea, and so far most BIM apps have no problems with it, there is an option under Edit -> Preferences -> I/O -> IFC export to disable this and get back to the previous behaviour (groups exported as IfcGroups and aggregated). This option is clearly marked as non-standard compliant.