### PR TITLE
[Icons]Applying Icon Size Rules to TechDraw

### DIFF
--- a/src/Mod/TechDraw/Gui/Resources/icons/arrow-ccw.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrow-ccw.svg
@@ -1,35 +1,86 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg3000" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="arrow-ccw.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1">
-  <defs id="defs3002">
-    <linearGradient id="linearGradient3393">
-      <stop style="stop-color:#06989a;stop-opacity:1" offset="0" id="stop3395"/>
-      <stop style="stop-color:#34e0e2;stop-opacity:1" offset="1" id="stop3397"/>
+
+<svg
+   width="64px"
+   height="64px"
+   id="svg3000"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3002">
+    <linearGradient
+       id="linearGradient3393">
+      <stop
+         style="stop-color:#06989a;stop-opacity:1"
+         offset="0"
+         id="stop3395" />
+      <stop
+         style="stop-color:#16d0d2;stop-opacity:1"
+         offset="1"
+         id="stop3397" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3393" id="linearGradient3399" x1="1699.6969" y1="1840.5964" x2="2044.969" y2="1629.2852" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.25534521,-0.95296128,0.96517316,0.25861737,-283.46374,3042.7301)"/>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective3008"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3393-7" id="linearGradient3399-1" x1="1669.7314" y1="1726.0585" x2="2067.1702" y2="1726.0585" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.98657811,0,0,0.99922078,20.129251,-2.6811697)"/>
-    <linearGradient id="linearGradient3393-7">
-      <stop style="stop-color:#003ddd;stop-opacity:1;" offset="0" id="stop3395-4"/>
-      <stop style="stop-color:#639ef0;stop-opacity:1;" offset="1" id="stop3397-0"/>
+    <linearGradient
+       xlink:href="#linearGradient3393"
+       id="linearGradient3399"
+       x1="1699.6969"
+       y1="1840.5964"
+       x2="1959.5931"
+       y2="1675.062"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25626439,-0.95300302,0.96864752,0.25862871,-291.17162,3042.754)" />
+    <linearGradient
+       xlink:href="#linearGradient3393-7"
+       id="linearGradient3399-1"
+       x1="1669.7314"
+       y1="1726.0585"
+       x2="2067.1702"
+       y2="1726.0585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98657811,0,0,0.99922078,20.129251,-2.6811697)" />
+    <linearGradient
+       id="linearGradient3393-7">
+      <stop
+         style="stop-color:#003ddd;stop-opacity:1;"
+         offset="0"
+         id="stop3395-4" />
+      <stop
+         style="stop-color:#639ef0;stop-opacity:1;"
+         offset="1"
+         id="stop3397-0" />
     </linearGradient>
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="11.283648" inkscape:cx="11.6776" inkscape:cy="30.967582" inkscape:current-layer="g3405" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1920" inkscape:window-height="1137" inkscape:window-x="0" inkscape:window-y="27" inkscape:snap-bbox="true" inkscape:snap-nodes="true" inkscape:snap-global="true" inkscape:window-maximized="1">
-    <inkscape:grid type="xygrid" id="grid2990" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-  </sodipodi:namedview>
-  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
-    <g id="g3405" transform="matrix(0.1369365,0,0,0.1369365,-222.21754,-203.36512)">
-      <path id="path2396" d="m 1880.5373,1902.9135 c 106.1484,-2.3589 189.8111,-89.4894 186.7502,-194.4908 -3.0611,-105.0013 -91.6921,-188.303 -197.8404,-185.9442 -55.9403,1.2433 -105.6257,26.0285 -139.6708,64.565 l -44.1198,-35.1059 -37.4604,176.0561 178.5573,-51.1979 -41.4836,-45.5767 c 22.1039,-24.0141 53.73,-39.3793 89.2346,-40.1684 69.1228,-1.536 126.8308,52.7017 128.824,121.0778 1.9931,68.3762 -52.4788,125.1377 -121.6017,126.6738 -19.7778,0.4394 -38.6039,-3.7029 -55.475,-11.4237 l -31.3948,57.7752 c 26.0336,11.9963 55.1182,18.4389 85.6804,17.7597 z" style="fill:url(#linearGradient3399);fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:14.60531044;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" inkscape:connector-curvature="0" sodipodi:nodetypes="ssscccccsssccs"/>
-      <path id="path2396-9" d="m 1885.0707,1887.6865 c 78.8923,-1.5361 138.9163,-54.9141 161.631,-130.1829 32.4053,-107.38 -55.6977,-196.5384 -121.2835,-214.3605 -100.7263,-27.3711 -169.4379,33.3038 -195.1926,62.9466 l -32.9948,-25.9656 -28.5313,126.5336 130.8309,-37.2342 -36.266,-37.8417 c 59.0149,-55.9052 101.9936,-63.2133 153.0445,-50.3357 52.2393,13.1775 118.2783,78.5389 98.4143,164.5079 -17.2644,74.7179 -82.9486,105.1278 -134.9353,106.5777 -17.3999,2.1436 -33.9339,-2.2822 -47.106,-6.2036 l -17.5742,32.2101 c 20.5378,6.6037 46.0171,9.8144 69.963,9.3483 z" style="fill:none;stroke:#34e0e2;stroke-width:14.60530949;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" inkscape:connector-curvature="0" sodipodi:nodetypes="ssscccccsscccs"/>
+  <g
+     id="layer1"
+     transform="matrix(1.008406,0,0,1.1110228,-0.45120732,-2.6203247)">
+    <g
+       id="g3405"
+       transform="matrix(0.1369365,0,0,0.1369365,-222.21754,-203.36512)">
+      <path
+         id="path2396"
+         d="m 1880.6192,1902.8875 c 106.5305,-2.359 190.4943,-89.4933 187.4224,-194.4994 -3.0721,-105.0059 -92.0221,-188.3111 -198.5526,-185.9523 -56.1417,1.2434 -106.0058,26.0297 -140.1736,64.5678 l -44.2785,-35.1074 -37.5953,176.0638 179.2001,-51.2001 -41.6329,-45.5788 c 22.1834,-24.0151 53.9233,-39.3809 89.5558,-40.1701 69.3716,-1.536 127.2873,52.7039 129.2877,121.0831 2.0003,68.3792 -52.6678,125.1432 -122.0395,126.6793 -19.8489,0.4395 -38.7428,-3.703 -55.6747,-11.4241 l -31.5077,57.7776 c 26.1273,11.9969 55.3165,18.4398 85.9888,17.7606 z"
+         style="display:inline;overflow:visible;visibility:visible;fill:#34e0e2;fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:13.79849041;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <path
+         id="path1"
+         d="m 1869.793,1536.2305 c 99.057,-2.1934 181.6079,75.2444 184.455,172.5625 2.8436,97.2001 -74.9913,178.1078 -173.9335,180.2988 -23.2633,0.5151 -45.5592,-3.4369 -66.168,-10.9316 l 18.2617,-33.4864 c 15.5521,5.4378 32.2974,8.2801 49.709,7.8946 76.9628,-1.7042 137.7559,-64.6954 135.5273,-140.8789 -2.2287,-76.1836 -66.4264,-136.1767 -143.3847,-134.4727 -39.4741,0.8743 -74.7043,17.8811 -99.3868,44.6016 l -8.5996,9.3105 35.1524,38.4844 -135.6953,38.7715 28.1582,-131.8614 37.0859,29.4063 8.6641,-9.7715 c 31.6564,-35.7055 77.951,-58.7716 130.1543,-59.9277 z"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3399);fill-opacity:1;fill-rule:evenodd;stroke:#34e0e2;stroke-width:13.79849041;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     </g>
   </g>
-  <metadata id="metadata5324">
+  <metadata
+     id="metadata5324">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
-        <cc:license rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html"/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html" />
         <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
         <dc:creator>
           <cc:Agent>
@@ -62,7 +113,6 @@
             <rdf:li>rotate</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:title>arrow-ccw</dc:title>
         <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
       </cc:Work>
     </rdf:RDF>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrow-cw.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrow-cw.svg
@@ -2,22 +2,16 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64px"
    height="64px"
    id="svg3000"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="arrow-cw.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3002">
     <linearGradient
@@ -32,24 +26,6 @@
          id="stop3397" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3393"
-       id="linearGradient3399"
-       x1="1650.4493"
-       y1="1752.9712"
-       x2="2052.8906"
-       y2="1767.5603"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.25534521,-0.95296128,-0.96517316,0.25861737,3999.0287,3042.7301)" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective3008" />
-    <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3393-7"
        id="linearGradient3399-1"
        x1="1669.7314"
@@ -69,56 +45,42 @@
          offset="1"
          id="stop3397-0" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3393-4"
+       id="linearGradient3399-4"
+       x1="1699.6969"
+       y1="1840.5964"
+       x2="1959.5931"
+       y2="1675.062"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25626439,-0.95300302,0.96864752,0.25862871,-291.17162,3042.754)" />
+    <linearGradient
+       id="linearGradient3393-4">
+      <stop
+         style="stop-color:#06989a;stop-opacity:1"
+         offset="0"
+         id="stop3395-3" />
+      <stop
+         style="stop-color:#16d0d2;stop-opacity:1"
+         offset="1"
+         id="stop3397-1" />
+    </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.989372"
-     inkscape:cx="-14.680107"
-     inkscape:cy="32.691314"
-     inkscape:current-layer="g3405"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="745"
-     inkscape:window-height="464"
-     inkscape:window-x="1173"
-     inkscape:window-y="522"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="true"
-     inkscape:snap-global="true"
-     inkscape:window-maximized="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2990"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1-7"
+     transform="matrix(-1.008406,0,0,1.1110228,64.449335,-2.6223732)"
+     style="display:inline">
     <g
-       id="g3405"
+       id="g3405-4"
        transform="matrix(0.1369365,0,0,0.1369365,-222.21754,-203.36512)">
       <path
-         id="path2396"
-         d="m 1835.0277,1902.9135 c -106.1484,-2.3589 -189.8111,-89.4894 -186.7502,-194.4908 3.0611,-105.0013 91.6921,-188.303 197.8404,-185.9442 55.9403,1.2433 105.6257,26.0285 139.6708,64.565 l 44.1198,-35.1059 37.4604,176.0561 -178.5573,-51.1979 41.4836,-45.5767 c -22.1039,-24.0141 -53.73,-39.3793 -89.2346,-40.1684 -69.1228,-1.536 -126.8308,52.7017 -128.824,121.0778 -1.9931,68.3762 52.4788,125.1377 121.6017,126.6738 19.7778,0.4394 38.6039,-3.7029 55.475,-11.4237 l 31.3948,57.7752 c -26.0336,11.9963 -55.1182,18.4389 -85.6804,17.7597 z"
-         style="fill:url(#linearGradient3399);fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:14.60531044000000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ssscccccsssccs" />
+         id="path2396-94"
+         d="m 1880.6192,1902.8875 c 106.5305,-2.359 190.4943,-89.4933 187.4224,-194.4994 -3.0721,-105.0059 -92.0221,-188.3111 -198.5526,-185.9523 -56.1417,1.2434 -106.0058,26.0297 -140.1736,64.5678 l -44.2785,-35.1074 -37.5953,176.0638 179.2001,-51.2001 -41.6329,-45.5788 c 22.1834,-24.0151 53.9233,-39.3809 89.5558,-40.1701 69.3716,-1.536 127.2873,52.7039 129.2877,121.0831 2.0003,68.3792 -52.6678,125.1432 -122.0395,126.6793 -19.8489,0.4395 -38.7428,-3.703 -55.6747,-11.4241 l -31.5077,57.7776 c 26.1273,11.9969 55.3165,18.4398 85.9888,17.7606 z"
+         style="display:inline;overflow:visible;visibility:visible;fill:#34e0e2;fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:13.7985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       <path
-         id="path2396-9"
-         d="m 1830.4943,1887.6865 c -78.8923,-1.5361 -138.9163,-54.9141 -161.631,-130.1829 -32.4053,-107.38 55.6977,-196.5384 121.2835,-214.3605 100.7263,-27.3711 169.4379,33.3038 195.1926,62.9466 l 32.9948,-25.9656 28.5313,126.5336 -130.8309,-37.2342 36.266,-37.8417 c -59.0149,-55.9052 -101.9936,-63.2133 -153.0445,-50.3357 -52.2393,13.1775 -118.2783,78.5389 -98.4143,164.5079 17.2644,74.7179 82.9486,105.1278 134.9353,106.5777 17.3999,2.1436 33.9339,-2.2822 47.106,-6.2036 l 17.5742,32.2101 c -20.5378,6.6037 -46.0171,9.8144 -69.963,9.3483 z"
-         style="fill:none;stroke:#34e0e2;stroke-width:14.60530949;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ssscccccsscccs" />
+         id="path1"
+         d="m 1869.793,1536.2305 c 99.057,-2.1934 181.6079,75.2444 184.455,172.5625 2.8436,97.2001 -74.9913,178.1078 -173.9335,180.2988 -23.2633,0.5151 -45.5592,-3.4369 -66.168,-10.9316 l 18.2617,-33.4864 c 15.5521,5.4378 32.2974,8.2801 49.709,7.8946 76.9628,-1.7042 137.7559,-64.6954 135.5273,-140.8789 -2.2287,-76.1836 -66.4264,-136.1767 -143.3847,-134.4727 -39.4741,0.8743 -74.7043,17.8811 -99.3868,44.6016 l -8.5996,9.3105 35.1524,38.4844 -135.6953,38.7715 28.1582,-131.8614 37.0859,29.4063 8.6641,-9.7715 c 31.6564,-35.7055 77.951,-58.7716 130.1543,-59.9277 z"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3399-4);fill-opacity:1;fill-rule:evenodd;stroke:#34e0e2;stroke-width:13.7985;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     </g>
   </g>
   <metadata
@@ -129,7 +91,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
         <cc:license
            rdf:resource="https://www.gnu.org/licenses/lgpl-3.0.en.html" />
         <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrow-down.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrow-down.svg
@@ -2,22 +2,16 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64px"
    height="64px"
    id="svg6248"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="arrow-down.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs6250">
     <linearGradient
@@ -25,7 +19,7 @@
       <stop
          id="stop3808"
          offset="0"
-         style="stop-color:#34e0e2;stop-opacity:1" />
+         style="stop-color:#16d0d2;stop-opacity:1" />
       <stop
          id="stop3810"
          offset="1"
@@ -43,7 +37,6 @@
          id="stop3257" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253"
        id="radialGradient3270"
        gradientUnits="userSpaceOnUse"
@@ -54,7 +47,6 @@
        fy="25.129232"
        r="27.986705" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient6816">
       <stop
          style="stop-color:#000000;stop-opacity:1;"
@@ -76,15 +68,7 @@
          offset="1"
          id="stop6785" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective6256" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient6816"
        id="radialGradient6822"
        cx="33.369828"
@@ -95,7 +79,6 @@
        gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3393"
        id="linearGradient3399"
        x1="1669.7314"
@@ -123,10 +106,8 @@
        gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3270"
-       xlink:href="#linearGradient3393"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3393" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253"
        id="radialGradient3293"
        gradientUnits="userSpaceOnUse"
@@ -156,10 +137,8 @@
        gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-2.1599239,-18.716253)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient3337"
-       xlink:href="#linearGradient3253-6"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3253-6" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253-6-5"
        id="radialGradient3270-0-1"
        gradientUnits="userSpaceOnUse"
@@ -188,8 +167,7 @@
        x1="56.172409"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3036"
-       xlink:href="#linearGradient3895"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3895" />
     <linearGradient
        id="linearGradient3895">
       <stop
@@ -204,42 +182,13 @@
     <linearGradient
        y2="29.156361"
        x2="58.053288"
-       y1="36.080002"
-       x1="21.940434"
-       gradientTransform="matrix(0,1.4500001,-1.4705882,0,79.05882,-27.45)"
+       y1="33.933491"
+       x1="33.836514"
+       gradientTransform="matrix(0,1.4500047,-1.3529524,0,75.294479,-27.450166)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3012"
-       xlink:href="#linearGradient3806"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3806" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.5"
-     inkscape:cx="-39.80793"
-     inkscape:cy="28.947943"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1278"
-     inkscape:window-height="691"
-     inkscape:window-x="640"
-     inkscape:window-y="86"
-     inkscape:window-maximized="0"
-     inkscape:snap-global="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3011"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata6253">
     <rdf:RDF>
@@ -248,7 +197,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[WandererFan]</dc:title>
@@ -286,26 +234,14 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <path
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 57,35 -16.000001,0 0,-32 -18,0 0,32 L 7,35 32,61 z"
-       id="path3343"
-       sodipodi:nodetypes="cccccccc"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
-       inkscape:export-xdpi="4.1683898"
-       inkscape:export-ydpi="4.1683898" />
+       style="fill:#34e0e2;fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 55.00019,35.000035 H 40.280067 V 2.999931 H 23.719931 V 35.000035 H 8.9998092 L 31.999999,61.000119 Z"
+       id="path3343" />
     <path
-       inkscape:connector-curvature="0"
-       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 52.25713,37 -13.257131,0 0,-32 -14,0 0,32 L 11.710728,37 32,58 z"
-       id="path3343-2"
-       sodipodi:nodetypes="cccccccc"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
-       inkscape:export-xdpi="4.1683898"
-       inkscape:export-ydpi="4.1683898" />
+       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 25.720703,5 h 12.558594 v 32 h 12.28125 L 32,57.982422 13.439453,37 h 12.28125 z"
+       id="path1" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrow-left.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrow-left.svg
@@ -2,22 +2,16 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64px"
    height="64px"
    id="svg6248"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="arrow-left.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs6250">
     <linearGradient
@@ -43,7 +37,6 @@
          id="stop3257" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253"
        id="radialGradient3270"
        gradientUnits="userSpaceOnUse"
@@ -54,7 +47,6 @@
        fy="25.129232"
        r="27.986705" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient6816">
       <stop
          style="stop-color:#000000;stop-opacity:1;"
@@ -76,15 +68,7 @@
          offset="1"
          id="stop6785" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective6256" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient6816"
        id="radialGradient6822"
        cx="33.369828"
@@ -95,7 +79,6 @@
        gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3393"
        id="linearGradient3399"
        x1="1669.7314"
@@ -123,10 +106,8 @@
        gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3270"
-       xlink:href="#linearGradient3393"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3393" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253"
        id="radialGradient3293"
        gradientUnits="userSpaceOnUse"
@@ -156,10 +137,8 @@
        gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-2.1599239,-18.716253)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient3337"
-       xlink:href="#linearGradient3253-6"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3253-6" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253-6-5"
        id="radialGradient3270-0-1"
        gradientUnits="userSpaceOnUse"
@@ -188,8 +167,7 @@
        x1="56.172409"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3036"
-       xlink:href="#linearGradient3895"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3895" />
     <linearGradient
        id="linearGradient3895">
       <stop
@@ -202,44 +180,26 @@
          id="stop3899" />
     </linearGradient>
     <linearGradient
-       y2="19.265453"
-       x2="40.373039"
-       y1="44.981819"
-       x1="42.755482"
-       gradientTransform="matrix(-1.4500001,0,0,-1.4705882,91.45,79.05882)"
+       y2="29.156361"
+       x2="58.053288"
+       y1="33.933491"
+       x1="33.836514"
+       gradientTransform="matrix(0,1.4500047,-1.3529524,0,75.294479,-27.450166)"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3012"
-       xlink:href="#linearGradient3806"
-       inkscape:collect="always" />
+       id="linearGradient3012-6"
+       xlink:href="#linearGradient3806-2" />
+    <linearGradient
+       id="linearGradient3806-2">
+      <stop
+         id="stop3808-1"
+         offset="0"
+         style="stop-color:#16d0d2;stop-opacity:1" />
+      <stop
+         id="stop3810-6"
+         offset="1"
+         style="stop-color:#06989a;stop-opacity:1" />
+    </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.5"
-     inkscape:cx="-39.80793"
-     inkscape:cy="28.947943"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1278"
-     inkscape:window-height="691"
-     inkscape:window-x="640"
-     inkscape:window-y="86"
-     inkscape:window-maximized="0"
-     inkscape:snap-global="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3011"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata6253">
     <rdf:RDF>
@@ -248,7 +208,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[WandererFan]</dc:title>
@@ -286,26 +245,16 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1-3"
+     transform="rotate(90,32,32.000068)"
+     style="display:inline">
     <path
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 29,57 0,-16.000001 32,0 0,-18 -32,0 L 29,7 3,32 z"
-       id="path3343"
-       sodipodi:nodetypes="cccccccc"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
-       inkscape:export-xdpi="4.1683898"
-       inkscape:export-ydpi="4.1683898" />
+       style="fill:#34e0e2;fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 55.00019,35.000035 H 40.280067 V 2.999931 H 23.719931 V 35.000035 H 8.9998092 L 31.999999,61.000119 Z"
+       id="path3343-21" />
     <path
-       inkscape:connector-curvature="0"
-       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 27,52.25713 0,-13.257131 32,0 0,-14 -32,0 L 27,11.710728 6,32 z"
-       id="path3343-2"
-       sodipodi:nodetypes="cccccccc"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
-       inkscape:export-xdpi="4.1683898"
-       inkscape:export-ydpi="4.1683898" />
+       style="fill:url(#linearGradient3012-6);fill-opacity:1;fill-rule:evenodd;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 25.720703,5 h 12.558594 v 32 h 12.28125 L 32,57.982422 13.439453,37 h 12.28125 z"
+       id="path1" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrow-right.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrow-right.svg
@@ -2,22 +2,16 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64px"
    height="64px"
    id="svg6248"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="arrow-right.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs6250">
     <linearGradient
@@ -43,7 +37,6 @@
          id="stop3257" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253"
        id="radialGradient3270"
        gradientUnits="userSpaceOnUse"
@@ -54,7 +47,6 @@
        fy="25.129232"
        r="27.986705" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient6816">
       <stop
          style="stop-color:#000000;stop-opacity:1;"
@@ -76,15 +68,7 @@
          offset="1"
          id="stop6785" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective6256" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient6816"
        id="radialGradient6822"
        cx="33.369828"
@@ -95,7 +79,6 @@
        gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3393"
        id="linearGradient3399"
        x1="1669.7314"
@@ -123,10 +106,8 @@
        gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3270"
-       xlink:href="#linearGradient3393"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3393" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253"
        id="radialGradient3293"
        gradientUnits="userSpaceOnUse"
@@ -156,10 +137,8 @@
        gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-2.1599239,-18.716253)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient3337"
-       xlink:href="#linearGradient3253-6"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3253-6" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253-6-5"
        id="radialGradient3270-0-1"
        gradientUnits="userSpaceOnUse"
@@ -188,8 +167,7 @@
        x1="56.172409"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3036"
-       xlink:href="#linearGradient3895"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3895" />
     <linearGradient
        id="linearGradient3895">
       <stop
@@ -202,44 +180,26 @@
          id="stop3899" />
     </linearGradient>
     <linearGradient
-       y2="44.610909"
-       x2="42.379307"
-       y1="20.996365"
-       x1="39.996861"
-       gradientTransform="matrix(1.4500001,0,0,1.4705882,-27.45,-15.05882)"
+       y2="29.156361"
+       x2="58.053288"
+       y1="33.933491"
+       x1="33.836514"
+       gradientTransform="matrix(0,1.4500047,-1.3529524,0,75.294479,-27.450166)"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3012"
-       xlink:href="#linearGradient3806"
-       inkscape:collect="always" />
+       id="linearGradient3012-5"
+       xlink:href="#linearGradient3806-4" />
+    <linearGradient
+       id="linearGradient3806-4">
+      <stop
+         id="stop3808-3"
+         offset="0"
+         style="stop-color:#16d0d2;stop-opacity:1" />
+      <stop
+         id="stop3810-1"
+         offset="1"
+         style="stop-color:#06989a;stop-opacity:1" />
+    </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.5"
-     inkscape:cx="-39.80793"
-     inkscape:cy="28.947943"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1278"
-     inkscape:window-height="691"
-     inkscape:window-x="640"
-     inkscape:window-y="86"
-     inkscape:window-maximized="0"
-     inkscape:snap-global="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3011"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata6253">
     <rdf:RDF>
@@ -248,7 +208,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[WandererFan]</dc:title>
@@ -286,26 +245,15 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1-0"
+     transform="rotate(-90,32.000069,32)">
     <path
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 35,7 0,16.000001 -32,0 0,18 32,0 L 35,57 61,32 z"
-       id="path3343"
-       sodipodi:nodetypes="cccccccc"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
-       inkscape:export-xdpi="4.1683898"
-       inkscape:export-ydpi="4.1683898" />
+       style="fill:#34e0e2;fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 55.00019,35.000035 H 40.280067 V 2.999931 H 23.719931 V 35.000035 H 8.9998092 L 31.999999,61.000119 Z"
+       id="path3343-3" />
     <path
-       inkscape:connector-curvature="0"
-       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 37,11.74287 0,13.257131 -32,0 0,14 32,0 0,13.289271 L 58,32 z"
-       id="path3343-2"
-       sodipodi:nodetypes="cccccccc"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
-       inkscape:export-xdpi="4.1683898"
-       inkscape:export-ydpi="4.1683898" />
+       style="fill:url(#linearGradient3012-5);fill-opacity:1;fill-rule:evenodd;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 25.720703,5 h 12.558594 v 32 h 12.28125 L 32,57.982422 13.439453,37 h 12.28125 z"
+       id="path1" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrow-up.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrow-up.svg
@@ -2,22 +2,16 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="64px"
    height="64px"
    id="svg6248"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="arrow-up.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs6250">
     <linearGradient
@@ -43,7 +37,6 @@
          id="stop3257" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253"
        id="radialGradient3270"
        gradientUnits="userSpaceOnUse"
@@ -54,7 +47,6 @@
        fy="25.129232"
        r="27.986705" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient6816">
       <stop
          style="stop-color:#000000;stop-opacity:1;"
@@ -76,15 +68,7 @@
          offset="1"
          id="stop6785" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective6256" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient6816"
        id="radialGradient6822"
        cx="33.369828"
@@ -95,7 +79,6 @@
        gradientTransform="matrix(1.1581633,0,0,0.6558985,-7.29237,16.126077)"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3393"
        id="linearGradient3399"
        x1="1669.7314"
@@ -123,10 +106,8 @@
        gradientTransform="matrix(0.9135837,0,0,0.9135837,138.63723,130.60625)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3270"
-       xlink:href="#linearGradient3393"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3393" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253"
        id="radialGradient3293"
        gradientUnits="userSpaceOnUse"
@@ -156,10 +137,8 @@
        gradientTransform="matrix(0.9781457,0.0053484,-0.00460223,0.8416912,-2.1599239,-18.716253)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient3337"
-       xlink:href="#linearGradient3253-6"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3253-6" />
     <radialGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient3253-6-5"
        id="radialGradient3270-0-1"
        gradientUnits="userSpaceOnUse"
@@ -188,8 +167,7 @@
        x1="56.172409"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3036"
-       xlink:href="#linearGradient3895"
-       inkscape:collect="always" />
+       xlink:href="#linearGradient3895" />
     <linearGradient
        id="linearGradient3895">
       <stop
@@ -202,44 +180,26 @@
          id="stop3899" />
     </linearGradient>
     <linearGradient
-       y2="34.472725"
-       x2="20.937302"
-       y1="30.763638"
-       x1="56.799366"
-       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       y2="29.156361"
+       x2="58.053288"
+       y1="33.933491"
+       x1="33.836514"
+       gradientTransform="matrix(0,1.4500047,-1.3529524,0,75.294479,-27.450166)"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3012"
-       xlink:href="#linearGradient3806"
-       inkscape:collect="always" />
+       id="linearGradient3012-3"
+       xlink:href="#linearGradient3806-5" />
+    <linearGradient
+       id="linearGradient3806-5">
+      <stop
+         id="stop3808-3"
+         offset="0"
+         style="stop-color:#16d0d2;stop-opacity:1" />
+      <stop
+         id="stop3810-4"
+         offset="1"
+         style="stop-color:#06989a;stop-opacity:1" />
+    </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.5"
-     inkscape:cx="-39.80793"
-     inkscape:cy="28.947943"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1278"
-     inkscape:window-height="691"
-     inkscape:window-x="640"
-     inkscape:window-y="86"
-     inkscape:window-maximized="0"
-     inkscape:snap-global="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3011"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata6253">
     <rdf:RDF>
@@ -248,7 +208,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[WandererFan]</dc:title>
@@ -286,26 +245,16 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1-9"
+     transform="matrix(1,0,0,-1,6.8880416e-5,64.000068)"
+     style="display:inline">
     <path
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 7,29 16.000001,0 0,32 18,0 0,-32 L 57,29 32,3 z"
-       id="path3343"
-       sodipodi:nodetypes="cccccccc"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
-       inkscape:export-xdpi="4.1683898"
-       inkscape:export-ydpi="4.1683898" />
+       style="fill:#34e0e2;fill-opacity:1;fill-rule:evenodd;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 55.00019,35.000035 H 40.280067 V 2.999931 H 23.719931 V 35.000035 H 8.9998092 L 31.999999,61.000119 Z"
+       id="path3343-22" />
     <path
-       inkscape:connector-curvature="0"
-       style="fill:none;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 11.74287,27 13.257131,0 0,32 14,0 0,-32 13.289271,0 L 32,6 z"
-       id="path3343-2"
-       sodipodi:nodetypes="cccccccc"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/changeprop.png"
-       inkscape:export-xdpi="4.1683898"
-       inkscape:export-ydpi="4.1683898" />
+       style="fill:url(#linearGradient3012-3);fill-opacity:1;fill-rule:evenodd;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 25.720703,5 h 12.558594 v 32 h 12.28125 L 32,57.982422 13.439453,37 h 12.28125 z"
+       id="path1" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrowdot.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrowdot.svg
@@ -2,15 +2,17 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="48"
-   height="48"
-   id="svg4024">
+   width="64"
+   height="64"
+   id="svg4024"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title1">arrow-cw</title>
   <defs
      id="defs4026" />
   <metadata
@@ -21,12 +23,13 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title>arrow-cw</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
+     id="layer1"
+     transform="matrix(1.6983356,0,0,1.6983387,-7.6446704,-8.7601245)">
     <g
        transform="translate(-1.0575472,0.61016946)"
        id="g4020">
@@ -34,7 +37,7 @@
          d="m -18.999999,35.857143 a 11.714286,11.428572 0 1 1 -23.428572,0 11.714286,11.428572 0 1 1 23.428572,0 z"
          transform="matrix(0.74568413,0,0,0.76432623,53.996092,-4.0167247)"
          id="path3769"
-         style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:5.4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:5.4;stroke-opacity:1;marker:none;enable-background:accumulate" />
       <rect
          width="24.142857"
          height="8.7142859"
@@ -43,7 +46,7 @@
          x="6.8774428"
          y="19.809925"
          id="rect3805"
-         style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrowfilled.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrowfilled.svg
@@ -2,15 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="48"
-   height="48"
-   id="svg3942">
+   width="64"
+   height="64"
+   id="svg3942"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3944" />
   <metadata
@@ -21,12 +21,12 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
+     id="layer1"
+     transform="matrix(1.7220226,0,0,1.7220195,-12.141132,-9.3018233)">
     <g
        transform="translate(5.495789,-0.12462666)"
        id="g3801">
@@ -38,14 +38,14 @@
          x="2.8571429"
          y="19.642857"
          id="rect3803"
-         style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       <g
          id="g3938">
         <path
-           d="M 19,31.428572 8.3448741,16.437454 26.655126,14.705404 z"
+           d="M 19,31.428572 8.3448741,16.437454 26.655126,14.705404 Z"
            transform="matrix(0.82772257,0.51753701,-0.59559817,0.71923839,18.136046,-0.16490738)"
            id="path2993"
-           style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:5.4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:5.4;stroke-opacity:1;marker:none;enable-background:accumulate" />
         <rect
            width="24.142857"
            height="8.7142859"
@@ -54,7 +54,7 @@
            x="2.8571429"
            y="19.642857"
            id="rect3805"
-           style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       </g>
     </g>
   </g>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrowfork.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrowfork.svg
@@ -2,39 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="48"
-   height="48"
+   width="64"
+   height="64"
    id="svg2985"
-   sodipodi:docname="arrowfork.svg"
-   inkscape:version="0.92.4 (unknown)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1358"
-     inkscape:window-height="703"
-     id="namedview922"
-     showgrid="false"
-     inkscape:zoom="10.708333"
-     inkscape:cx="24"
-     inkscape:cy="24.612345"
-     inkscape:window-x="0"
-     inkscape:window-y="26"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2985" />
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs2987" />
   <metadata
@@ -45,18 +21,17 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
      id="g945"
-     transform="translate(-1.864559)">
+     transform="matrix(1.3697993,0,0,1.3697867,-3.4292572,-0.87488359)">
     <g
        transform="translate(3.4375,-0.13060184)"
        id="g3796">
       <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          id="rect3763"
          y="19.642857"
          x="2.8571429"
@@ -65,7 +40,7 @@
          height="8.7142859"
          width="24.142857" />
       <rect
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
          id="rect3799"
          y="19.642857"
          x="2.8571429"
@@ -75,7 +50,7 @@
          width="24.142857" />
     </g>
     <rect
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect3773"
        transform="matrix(-0.70710678,0.70710678,0.70710678,0.70710678,0,0)"
        y="31.853426"
@@ -85,7 +60,7 @@
        height="8.7142859"
        width="24.142857" />
     <rect
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="rect3775"
        transform="rotate(-135)"
        y="-2.0876999"
@@ -95,8 +70,7 @@
        height="8.7142859"
        width="24.142857" />
     <path
-       inkscape:connector-curvature="0"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;stroke:#000000;stroke-width:0.28200001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;stroke:#000000;stroke-width:0.282;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        id="path3792"
        d="m 30.550202,20.79387 2.874999,3.071429 -3.035714,3.303571" />
   </g>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrownone.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrownone.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    id="svg3942"
-   height="48"
-   width="48"
-   version="1.1">
+   height="64"
+   width="64"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3944" />
   <metadata
@@ -19,20 +19,19 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     transform="translate(1.6490345,-1.6458526)"
+     transform="matrix(1.2287304,0,0,1.2274052,4.536693,0.52401729)"
      id="g881">
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.72050047;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 2.2263108,45.766302 42.468226,5.5381284"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.25714963;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 2.0069669,46.01205 42.694958,5.2766089"
        id="path70" />
     <path
        id="path72"
-       d="M 2.2342858,5.5186032 42.475039,45.773102"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.72166395;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       d="M 2.0069317,5.2765737 42.694993,46.01208"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.25714963;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrowopen.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrowopen.svg
@@ -2,15 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="48"
-   height="48"
-   id="svg2985">
+   width="64"
+   height="64"
+   id="svg2985"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs2987" />
   <metadata
@@ -21,12 +21,12 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
+     id="layer1"
+     transform="matrix(1.4701202,0,0,1.4701082,-3.3205948,-3.2825965)">
     <g
        transform="translate(3.4375,-0.13060184)"
        id="g3807">
@@ -40,7 +40,7 @@
            x="2.8571429"
            y="19.642857"
            id="rect3763"
-           style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
         <rect
            width="24.142857"
            height="8.7142859"
@@ -49,7 +49,7 @@
            x="2.8571429"
            y="19.642857"
            id="rect3799"
-           style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       </g>
       <rect
          width="24.142857"
@@ -58,9 +58,9 @@
          ry="1.7378116"
          x="17.57655"
          y="-10.165521"
-         transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,0,0)"
+         transform="rotate(45)"
          id="rect3773"
-         style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       <rect
          width="24.142857"
          height="8.7142859"
@@ -70,15 +70,15 @@
          y="-44.272964"
          transform="matrix(0.70710678,-0.70710678,-0.70710678,-0.70710678,0,0)"
          id="rect3775"
-         style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       <path
          d="m 35.392858,21.017857 2.874999,3.071429 -3.035714,3.303571"
          id="path3792"
-         style="color:#000000;fill:#000000;stroke:#000000;stroke-width:0.28200001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;stroke:#000000;stroke-width:0.282;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       <path
-         d="m 35.200831,24.273314 -0.129031,-0.129898 0.133942,-0.133048 0.133942,-0.133048 0,0.262945 c 0,0.144621 -0.0022,0.262946 -0.0049,0.262946 -0.0027,0 -0.06298,-0.05845 -0.133942,-0.129897 z"
+         d="M 35.200831,24.273314 35.0718,24.143416 35.205742,24.010368 35.339684,23.87732 v 0.262945 c 0,0.144621 -0.0022,0.262946 -0.0049,0.262946 -0.0027,0 -0.06298,-0.05845 -0.133942,-0.129897 z"
          id="path3794"
-         style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.10714286;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:5.4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.107143;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:5.4;stroke-opacity:1;marker:none;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrowopendot.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrowopendot.svg
@@ -2,15 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="48"
-   height="48"
-   id="svg3816">
+   width="64"
+   height="64"
+   id="svg3816"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3818" />
   <metadata
@@ -21,14 +21,14 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
+     id="layer1"
+     transform="matrix(1.6614424,0,0,1.6614316,-8.0919586,-7.8743705)">
     <g
-       transform="translate(3.3580721,4.7683716e-7)"
+       transform="translate(3.3580721)"
        id="g3801">
       <rect
          width="24.142857"
@@ -38,7 +38,7 @@
          x="2.8571429"
          y="19.642857"
          id="rect3803"
-         style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       <rect
          width="24.142857"
          height="8.7142859"
@@ -47,12 +47,12 @@
          x="2.8571429"
          y="19.642857"
          id="rect3805"
-         style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     </g>
     <path
        d="m -18.999999,35.857143 a 11.714286,11.428572 0 1 1 -23.428572,0 11.714286,11.428572 0 1 1 23.428572,0 z"
        transform="matrix(0.74568413,0,0,0.76432623,54.118369,-3.4065552)"
        id="path3771"
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:5.4;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:5.4;stroke-opacity:1;marker:none;enable-background:accumulate" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrowpyramid.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrowpyramid.svg
@@ -2,39 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="48"
-   height="48"
+   width="64"
+   height="64"
    id="svg3942"
-   sodipodi:docname="arrowpyramid.svg"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1027"
-     id="namedview11"
-     showgrid="false"
-     inkscape:zoom="4.9166667"
-     inkscape:cx="-16.677966"
-     inkscape:cy="23.186441"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3942" />
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3944" />
   <metadata
@@ -45,35 +21,22 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
      id="g4527"
      style="fill:#000000"
-     transform="matrix(1,0,0,1.44,-2.8474576,-14.832851)">
+     transform="matrix(1.3285914,0,0,1.91316,-3.6693008,-19.592678)">
     <g
        id="g1461"
        transform="translate(4.1150473,2.9827342)">
       <path
-         sodipodi:type="star"
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.02752149"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.02752"
          id="path4521"
-         sodipodi:sides="3"
-         sodipodi:cx="35.837807"
-         sodipodi:cy="23.984524"
-         sodipodi:r1="14.433757"
-         sodipodi:r2="7.2168779"
-         sodipodi:arg1="-1.0471976"
-         sodipodi:arg2="0"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
-         d="m 43.054685,11.484523 10e-7,25.000001 -21.650636,-12.5 z"
-         inkscape:transform-center-x="3.6084379" />
+         d="m 43.054685,11.484523 10e-7,25.000001 -21.650636,-12.5 z" />
       <rect
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.48466444"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.48466"
          id="rect4523"
          width="30.697916"
          height="6.2105837"

--- a/src/Mod/TechDraw/Gui/Resources/icons/arrowtick.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/arrowtick.svg
@@ -2,15 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="48"
-   height="48"
-   id="svg2985">
+   width="64"
+   height="64"
+   id="svg2985"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs2987" />
   <metadata
@@ -21,12 +21,11 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     transform="translate(-1.2369402,2.0609187)"
+     transform="matrix(2.2108626,0,0,2.2108441,-23.795408,-16.503889)"
      id="g3106">
     <g
        transform="translate(10.308369,-1.9117699)"
@@ -39,7 +38,7 @@
          x="2.8571429"
          y="19.642857"
          id="rect3763"
-         style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
       <rect
          width="24.142857"
          height="8.7142859"
@@ -48,7 +47,7 @@
          x="2.8571429"
          y="19.642857"
          id="rect3799"
-         style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.28200001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.282;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     </g>
     <rect
        width="12.071428"
@@ -59,7 +58,7 @@
        y="31.798487"
        transform="matrix(-0.70710678,0.70710678,0.70710678,0.70710678,0,0)"
        id="rect3773"
-       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.141;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.141;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <rect
        width="12.071428"
        height="4.3571429"
@@ -69,6 +68,6 @@
        y="31.541357"
        transform="matrix(-0.70710678,0.70710678,0.70710678,0.70710678,0,0)"
        id="rect3104"
-       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.141;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.141;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/bottomline.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/bottomline.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="48"
-   height="48"
-   id="svg4024">
+   width="64"
+   height="64"
+   id="svg4024"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -19,16 +19,15 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     transform="translate(-0.97881415)"
+     style="stroke:#000000;stroke-width:6.4673;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     transform="matrix(1.5301491,0,0,1,-6.221311,14.499651)"
      id="g863">
     <path
-       style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;stroke:#000000;stroke-width:6.4673;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M 5.3728823,36 H 44.584748"
        id="path819-8-8-7" />
   </g>

--- a/src/Mod/TechDraw/Gui/Resources/icons/circular.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/circular.svg
@@ -2,41 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="48"
-   height="48"
+   width="64"
+   height="64"
    id="svg4024"
-   sodipodi:docname="circular.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1121"
-     id="namedview9"
-     showgrid="true"
-     inkscape:zoom="13.906433"
-     inkscape:cx="37.330109"
-     inkscape:cy="20.212742"
-     inkscape:window-x="1920"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4024"
-     showguides="false"
-     inkscape:lockguides="false" />
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -47,20 +21,11 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:6;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:10;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="path3733"
-     sodipodi:type="arc"
-     sodipodi:cx="23.931456"
-     sodipodi:cy="24.140453"
-     sodipodi:rx="17"
-     sodipodi:ry="17"
-     sodipodi:start="0.00034116474"
-     sodipodi:end="6.981317e-05"
-     sodipodi:open="true"
-     d="M 40.931455,24.146253 A 17,17 0 0 1 23.926809,41.140453 17,17 0 0 1 6.931456,24.13696 17,17 0 0 1 23.933796,7.1404535 17,17 0 0 1 40.931456,24.14164" />
+     d="M 57.000376,32.008529 A 25.000378,25.00038 0 0 1 31.993167,57.000379 25.000378,25.00038 0 0 1 6.9996229,31.994863 25.000378,25.00038 0 0 1 32.003441,6.9996207 25.000378,25.00038 0 0 1 57.000378,32.001745" />
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/continuous-line.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/continuous-line.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="48"
-   height="48"
-   id="svg4024">
+   width="64"
+   height="64"
+   id="svg4024"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -19,17 +19,16 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     transform="translate(-0.97881415)"
+     style="stroke:#000000;stroke-width:4.85048;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     transform="matrix(1.5299989,0,0,1,-6.2205038,8.00024)"
      id="g863">
     <path
-       style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 5.3728823,24 H 44.584748"
+       style="fill:none;stroke:#000000;stroke-width:8.08452;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.3728823,23.99952 H 44.584748"
        id="path819-8-8-7" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/dash-line.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/dash-line.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="48"
-   height="48"
-   id="svg4024">
+   width="64"
+   height="64"
+   id="svg4024"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -19,17 +19,16 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:10,5;stroke-opacity:1;stroke-dashoffset:0"
+     style="stroke:#000000;stroke-width:8;stroke-miterlimit:4;stroke-dasharray:16,8;stroke-dashoffset:2;stroke-opacity:1"
      transform="translate(-0.97881415)"
      id="g863">
     <path
-       style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:10,5;stroke-opacity:1;stroke-dashoffset:0"
-       d="M 5.3728823,24 H 44.584748"
+       style="fill:none;stroke:#000000;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:16, 8;stroke-dashoffset:2;stroke-opacity:1"
+       d="M 2.9788142,32 H 62.978814"
        id="path819-8-8-7" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/dashDot-line.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/dashDot-line.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="48"
-   height="48"
-   id="svg4024">
+   width="64"
+   height="64"
+   id="svg4024"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -19,28 +19,28 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
+     id="layer1"
+     transform="matrix(1.7438423,0,0,1,-9.8522159,1.8596059)">
     <g
-       style="stroke:#000000;stroke-opacity:1;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none"
+       style="stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="g863"
        transform="translate(-0.08474595)">
       <path
          id="path819"
-         d="M 6.8813559,24 H 16.644068"
-         style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
+         d="M 6.8813559,30.140204 H 16.644068"
+         style="fill:none;stroke:#000000;stroke-width:7.57262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          id="path819-1"
-         d="m 31.525423,24 h 9.762713"
-         style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
+         d="m 31.525423,30.140204 h 9.762713"
+         style="fill:none;stroke:#000000;stroke-width:7.57262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          id="path819-8-8"
-         d="m 22.372881,24 h 3.711865"
-         style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none" />
+         d="m 22.372881,30.140204 h 3.711865"
+         style="fill:none;stroke:#000000;stroke-width:7.57262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/dashDotDot-line.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/dashDotDot-line.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="48"
-   height="48"
-   id="svg4024">
+   width="64"
+   height="64"
+   id="svg4024"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -19,33 +19,33 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke:#000000;stroke-opacity:1"
-     id="layer1">
+     style="stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="layer1"
+     transform="matrix(1.5622242,0,0,1,-5.4933801,1.4055604)">
     <g
-       style="stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke:#000000;stroke-opacity:1"
+       style="stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="g863"
        transform="translate(-0.08474595)">
       <path
          id="path819"
-         d="M 4.8813559,24 H 14.644068"
-         style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="M 4.8813559,30.59429 H 14.644067"
+         style="fill:none;stroke:#000000;stroke-width:8.0007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          id="path819-8"
-         d="m 18.525423,24 h 3.711865"
-         style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 18.525423,30.59429 h 3.711864"
+         style="fill:none;stroke:#000000;stroke-width:8.0007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          id="path819-1"
-         d="m 33.525423,24 h 9.762713"
-         style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 33.525423,30.59429 h 9.762712"
+         style="fill:none;stroke:#000000;stroke-width:8.0007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          id="path819-8-8"
-         d="m 25.847457,24 h 3.711865"
-         style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         d="m 25.847456,30.59429 h 3.711865"
+         style="fill:none;stroke:#000000;stroke-width:8.0007;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/dot-line.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/dot-line.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    id="svg4024"
-   height="48"
-   width="48"
-   version="1.1">
+   height="64"
+   width="64"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -19,7 +19,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -27,7 +26,7 @@
      id="layer1">
     <path
        id="path819-8-8-7"
-       d="M 6.3940684,24 H 45.605934"
-       style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:5.00000013, 10.00000026;stroke-dashoffset:0;stroke-opacity:1" />
+       d="M 2,32 H 62"
+       style="fill:none;stroke:#000000;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:8, 16;stroke-dashoffset:22;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/hexagon.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/hexagon.svg
@@ -2,81 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="48"
-   height="48"
+   width="64"
+   height="64"
    id="svg4024"
-   sodipodi:docname="hexagon.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1121"
-     id="namedview9"
-     showgrid="true"
-     inkscape:zoom="13.906433"
-     inkscape:cx="25.179163"
-     inkscape:cy="21.702017"
-     inkscape:window-x="1920"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4024"
-     showguides="true"
-     inkscape:lockguides="false"
-     inkscape:guide-bbox="true">
-    <sodipodi:guide
-       position="15,35"
-       orientation="1,0"
-       id="guide4943"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       position="30,35"
-       orientation="1,0"
-       id="guide4945"
-       inkscape:locked="false" />
-    <inkscape:grid
-       type="xygrid"
-       id="grid4947" />
-    <sodipodi:guide
-       position="14,40"
-       orientation="0,1"
-       id="guide4949"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       position="19,20"
-       orientation="0,1"
-       id="guide4951"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       position="22,30"
-       orientation="0,1"
-       id="guide4953"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       position="9,30"
-       orientation="1,0"
-       id="guide4955"
-       inkscape:locked="false" />
-    <sodipodi:guide
-       position="36,30"
-       orientation="1,0"
-       id="guide4957"
-       inkscape:locked="false" />
-  </sodipodi:namedview>
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -87,13 +21,11 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     style="fill:none;stroke:#000000;stroke-width:5.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 7.0000007,23.5 14.428572,7.9999993 H 33 L 40.428571,23.5 33,39 H 14.428572 Z"
-     id="path4965"
-     inkscape:connector-curvature="0" />
+     style="fill:none;stroke:#000000;stroke-width:8.08344;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 9.4819248,32 19.489958,11.11772 H 44.510045 L 54.518078,32 44.510045,52.88228 H 19.489958 Z"
+     id="path4965" />
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/inspection.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/inspection.svg
@@ -2,41 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="48"
-   height="48"
+   width="64"
+   height="64"
    id="svg4024"
-   sodipodi:docname="inspection.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1121"
-     id="namedview9"
-     showgrid="true"
-     inkscape:zoom="13.906433"
-     inkscape:cx="37.330109"
-     inkscape:cy="20.212742"
-     inkscape:window-x="1920"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4024"
-     showguides="false"
-     inkscape:lockguides="false" />
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -47,43 +21,28 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <path
-     style="fill:none;stroke:#000000;stroke-width:6.00000048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 14.07441,15.176999 33.296063,15.033181"
-     id="path4561"
-     inkscape:connector-curvature="0" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:6;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path4567"
-     sodipodi:type="arc"
-     sodipodi:cx="15.470214"
-     sodipodi:cy="24.556917"
-     sodipodi:rx="9.9536495"
-     sodipodi:ry="9.3841457"
-     sodipodi:start="1.5626439"
-     sodipodi:end="4.6823693"
-     sodipodi:open="true"
-     d="M 15.551359,33.940751 A 9.9536495,9.3841457 0 0 1 5.5183773,24.736013 9.9536495,9.3841457 0 0 1 15.171453,15.177" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:6;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path4567-3"
-     sodipodi:type="arc"
-     sodipodi:cx="-32.631432"
-     sodipodi:cy="24.413099"
-     sodipodi:rx="10.008474"
-     sodipodi:ry="9.3841457"
-     sodipodi:start="1.5626439"
-     sodipodi:end="4.6823693"
-     sodipodi:open="true"
-     d="m -32.549839,33.796933 a 10.008474,9.3841457 0 0 1 -10.088244,-9.204738 10.008474,9.3841457 0 0 1 9.706245,-9.559013"
-     transform="scale(-1,1)" />
-  <path
-     style="fill:none;stroke:#000000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 15.133592,33.94075 33.38428,33.796932"
-     id="path4561-6"
-     inkscape:connector-curvature="0" />
+  <g
+     id="g1"
+     transform="matrix(1.3913716,0,0,1.3913716,-1.501428,-2.0707431)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 14.07441,15.176999 33.296063,15.033181"
+       id="path4561" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:6;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4567"
+       d="M 15.551359,33.940751 A 9.9536495,9.3841457 0 0 1 5.5183773,24.736013 9.9536495,9.3841457 0 0 1 15.171453,15.177" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:6;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4567-3"
+       d="m -32.549839,33.796933 a 10.008474,9.3841457 0 0 1 -10.088244,-9.204738 10.008474,9.3841457 0 0 1 9.706245,-9.559013"
+       transform="scale(-1,1)" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 15.133592,33.94075 33.38428,33.796932"
+       id="path4561-6" />
+  </g>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/none.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/none.svg
@@ -2,43 +2,36 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="48"
-   height="48"
+   width="64"
+   height="64"
    id="svg4024"
-   sodipodi:docname="none.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1121"
-     id="namedview9"
-     showgrid="true"
-     inkscape:zoom="13.906433"
-     inkscape:cx="21.941547"
-     inkscape:cy="20.212742"
-     inkscape:window-x="1920"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4024"
-     showguides="false"
-     inkscape:lockguides="false" />
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs4026" />
+     id="defs4026">
+    <rect
+       x="5.6808241"
+       y="38.902859"
+       width="54.865967"
+       height="17.958967"
+       id="rect3" />
+    <rect
+       x="4.5302775"
+       y="34.660218"
+       width="42.785954"
+       height="26.462573"
+       id="rect2" />
+    <rect
+       x="6.3999158"
+       y="35.307401"
+       width="37.96804"
+       height="25.8873"
+       id="rect1" />
+  </defs>
   <metadata
      id="metadata4029">
     <rdf:RDF>
@@ -47,8 +40,15 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <text
+     xml:space="preserve"
+     id="text2"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.33333px;font-family:sans-serif;-inkscape-font-specification:sans-serif;white-space:pre;shape-inside:url(#rect3);display:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:8;stroke-linejoin:round;stroke-dasharray:8, 16;stroke-dashoffset:22;stroke-opacity:1"
+     transform="translate(-6.1016951,18.711865)"><tspan
+       x="5.6816406"
+       y="43.754976"
+       id="tspan1"> reqrefusion fuit hic</tspan></text>
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/rectangle.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/rectangle.svg
@@ -2,41 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="48"
-   height="48"
+   width="64"
+   height="64"
    id="svg4024"
-   sodipodi:docname="rectangle.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1121"
-     id="namedview9"
-     showgrid="true"
-     inkscape:zoom="13.906433"
-     inkscape:cx="37.330109"
-     inkscape:cy="20.212742"
-     inkscape:window-x="1920"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4024"
-     showguides="false"
-     inkscape:lockguides="false" />
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -47,15 +21,14 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <rect
-     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:6;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:8.05636;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect4752"
-     width="36.755505"
-     height="21.788477"
-     x="5.3113585"
-     y="13.986965" />
+     width="51.943642"
+     height="30.791643"
+     x="6.0281792"
+     y="16.604179" />
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/square.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/square.svg
@@ -2,41 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="48"
-   height="48"
+   width="64"
+   height="64"
    id="svg4024"
-   sodipodi:docname="square.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1121"
-     id="namedview9"
-     showgrid="true"
-     inkscape:zoom="13.906433"
-     inkscape:cx="37.330109"
-     inkscape:cy="20.212742"
-     inkscape:window-x="1920"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4024"
-     showguides="false"
-     inkscape:lockguides="false" />
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -47,15 +21,14 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <rect
-     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:6;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:7.99974;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect4752"
-     width="34.742046"
-     height="30.41758"
-     x="6.533814"
-     y="7.8746858" />
+     width="46.000259"
+     height="40.319263"
+     x="8.9998693"
+     y="11.84037" />
 </svg>

--- a/src/Mod/TechDraw/Gui/Resources/icons/triangle.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/triangle.svg
@@ -2,41 +2,15 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   width="48"
-   height="48"
+   width="64"
+   height="64"
    id="svg4024"
-   sodipodi:docname="triangle.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1121"
-     id="namedview9"
-     showgrid="true"
-     inkscape:zoom="13.906433"
-     inkscape:cx="37.330109"
-     inkscape:cy="20.212742"
-     inkscape:window-x="1920"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4024"
-     showguides="false"
-     inkscape:lockguides="false" />
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4026" />
   <metadata
@@ -47,13 +21,11 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     style="fill:none;stroke:#000000;stroke-width:5.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 24.424112,11.071 8.832708,37.464806 39.750129,37.597107 Z"
-     id="path4540"
-     inkscape:connector-curvature="0" />
+     style="fill:none;stroke:#000000;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 32.194133,16.763835 11.991029,50.964296 52.053353,51.135729 Z"
+     id="path4540" />
 </svg>


### PR DESCRIPTION
When starting the change in TechDraw, I first resized the slightly boring ones. The aspect ratios of the black icons have not changed, only the 48x48 area they are in has been changed and enlarged to fit it. And one or two more boring changes.