### PR TITLE
TechDraw: make the dimension tool the default

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.cpp
@@ -167,7 +167,7 @@ void DlgPrefsTechDrawDimensionsImp::loadSettings()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/TechDraw/dimensioning");
     bool singleTool = hGrp->GetBool("SingleDimensioningTool", true);
-    bool SeparatedTools = hGrp->GetBool("SeparatedDimensioningTools", true);
+    bool SeparatedTools = hGrp->GetBool("SeparatedDimensioningTools", false);
     int index = SeparatedTools ? (singleTool ? 2 : 1) : 0;
     ui->dimensioningMode->setCurrentIndex(index);
     setProperty("dimensioningMode", index);

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -311,7 +311,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/TechDraw/dimensioning");
-    bool separatedTools = hGrp->GetBool("SeparatedDimensioningTools", true);
+    bool separatedTools = hGrp->GetBool("SeparatedDimensioningTools", false);
     if (hGrp->GetBool("SingleDimensioningTool", true)) {
         if (separatedTools) {
             *dims << "TechDraw_Dimension";


### PR DESCRIPTION
Make the smart dimension tool the default one, all current tools grouped under this.
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/9921881f-3190-4a21-9e44-d08749fbf2a3)
