### PR TITLE
[TD]revert to v0.21 hatch exporting (fix #14027)

### DIFF
--- a/src/Mod/TechDraw/Gui/PagePrinter.cpp
+++ b/src/Mod/TechDraw/Gui/PagePrinter.cpp
@@ -165,12 +165,14 @@ void PagePrinter::printPdf(std::string file)
     QPainter painter(&pdfWriter);
 
     // render the page
+    m_scene->setExportingPdf(true);
     QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
     double dpmm = pdfWriter.resolution() / mmPerInch;
     int twide = int(std::round(width * dpmm));
     int thigh = int(std::round(height * dpmm));
     QRect targetRect(0, 0, twide, thigh);
     renderPage(m_vpPage, painter, sourceRect, targetRect);
+    m_scene->setExportingPdf(false);
 }
 
 
@@ -291,6 +293,10 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
         if (!vpp) {
             continue;// can't print this one
         }
+
+        auto scene = vpp->getQGSPage();
+        scene->setExportingPdf(true);
+
         auto dPage = static_cast<TechDraw::DrawPage*>(obj);
         double width{0};
         double height{0};
@@ -304,6 +310,7 @@ void PagePrinter::printAllPdf(QPrinter* printer, App::Document* doc)
         QRectF sourceRect(0.0, Rez::guiX(-height), Rez::guiX(width), Rez::guiX(height));
         QRect targetRect(0, 0, width * dpmm, height * dpmm);
         renderPage(vpp, painter, sourceRect, targetRect);
+        scene->setExportingPdf(false);
     }
 }
 

--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -524,6 +524,7 @@ bool QGIFace::exporting() const
     if (!tdScene) {
         return false;
     }
-    return tdScene->getExportingSvg();
+    return tdScene->getExportingSvg() ||
+           tdScene->getExportingPdf();
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -337,7 +337,6 @@ void QGIViewPart::drawAllFaces(void)
             if (fHatch->isSvgHatch()) {
                 // svg tile hatch
                 newFace->setFillMode(QGIFace::SvgFill);
-                newFace->hideSvg(false);
             } else {
                 //bitmap hatch
                 newFace->setFillMode(QGIFace::BitmapFill);

--- a/src/Mod/TechDraw/Gui/QGSPage.h
+++ b/src/Mod/TechDraw/Gui/QGSPage.h
@@ -132,6 +132,10 @@ public:
 
     void setExportingSvg(bool enable);
     bool getExportingSvg() { return m_exportingSvg; }
+
+    void setExportingPdf(bool enable) { m_exportingPdf = enable; };
+    bool getExportingPdf() const { return m_exportingPdf; }
+
     virtual void refreshViews();
 
     /// Renders the page to SVG with filename.
@@ -153,6 +157,7 @@ private:
     ViewProviderPage* m_vpPage;
 
     bool m_exportingSvg{false};
+    bool m_exportingPdf{false};
 };
 
 }// namespace TechDrawGui


### PR DESCRIPTION
This PR implements a fix for issue #14027.   It reverts Svg hatch exporting to the method used in v021.

Additional forum discussions: https://forum.freecad.org/viewtopic.php?t=87667 and 
https://forum.freecad.org/viewtopic.php?t=86643