### PR TITLE
[TD]fix #13992 - compile warnings

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -231,7 +231,7 @@ DrawViewDimension::DrawViewDimension()
     resetAngular();
     resetArc();
     m_hasGeometry = false;
-    m_matcher = new GeometryMatcher(this);
+    m_matcher = new GeometryMatcher();
     m_referencesCorrect = true;
     m_corrector = new DimensionAutoCorrect(this);
 }

--- a/src/Mod/TechDraw/App/GeometryMatcher.h
+++ b/src/Mod/TechDraw/App/GeometryMatcher.h
@@ -39,10 +39,7 @@ namespace TechDraw
 class TechDrawExport GeometryMatcher
 {
 public:
-    GeometryMatcher() :
-            m_dimension(nullptr)  {}
-    explicit GeometryMatcher(DrawViewDimension* dim) :
-            m_dimension(dim)    {}
+    GeometryMatcher() = default;
 
     bool compareGeometry(const Part::TopoShape& geom1, const Part::TopoShape& geom2);
 
@@ -70,7 +67,6 @@ private:
     static bool compareEllipseArcs(const TopoDS_Edge& edge1, const TopoDS_Edge& edge2);
     static bool compareEndPoints(const TopoDS_Edge& edge1, const TopoDS_Edge& edge2);
 
-    DrawViewDimension* m_dimension;
     double m_pointTolerance {EWTOLERANCE};
 };
 


### PR DESCRIPTION
This PR implements a fix for issue #13992.   

Note that I do not get compile warnings here.  A difference in options, perhaps.


OS: Linux Mint 20.3 (X-Cinnamon/cinnamon)
Word size of FreeCAD: 64-bit
Version: 0.22.0dev.37358 (Git)
Build type: debug
Branch: fixGeometryMatcherWarning
Hash: 3a0152b076dd7791c9724c286963d74b5814e24f
Python 3.8.10, Qt 5.12.8, Coin 4.0.0, Vtk , OCC 7.7.1
Locale: English/Canada (en_CA)
Installed mods: 
  * BOLTSFC 2022.11.5
  * sheetmetal 0.2.63
  * fasteners 0.4.56
  * FreeCAD_Electric
  * freecad.gears 1.0.0
  * Curves 0.6.29
  * Assembly4 0.50.9
  * A2plus 0.4.64
