### PR TITLE
PartDesign: hide Suppressed property with FC_USE_TNP_FIX flag

### DIFF
--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -61,7 +61,9 @@ Feature::Feature()
     BaseFeature.setStatus(App::Property::Hidden, true);
 
     App::SuppressibleExtension::initExtension(this);
-    Suppressed.setStatus(App::Property::Status::Hidden, true); //Todo: remove when TNP fixed
+#ifndef FC_USE_TNP_FIX
+    Suppressed.setStatus(App::Property::Status::Hidden, true);
+#endif
 }
 
 App::DocumentObjectExecReturn* Feature::recompute()


### PR DESCRIPTION
fix #11212 

Suppressed is shown when compiled with FC_USE_TNP_FIX