### PR TITLE
Draft: Draft_Hatch workaround for TD edge length limit

### DIFF
--- a/src/Mod/Draft/draftobjects/hatch.py
+++ b/src/Mod/Draft/draftobjects/hatch.py
@@ -116,16 +116,28 @@ class Hatch(DraftObject):
                     # If no suitable straight edge was found use a default matrix:
                     if not mtx:
                         cen = face.CenterOfMass
-                        rot = App.Rotation(App.Vector(0,0,1), w)
+                        rot = App.Rotation(App.Vector(0, 0, 1), w)
                         mtx = App.Placement(cen, rot).Matrix
-                    face = face.transformGeometry(mtx.inverse()).Faces[0]
+                    face = face.transformShape(mtx.inverse()).Faces[0]
+
+                    # In TechDraw edges longer than 9999.9 (ca. 10m) are considered 'crazy'.
+                    # Lines in a hatch pattern are also checked. In the code below 9999 is
+                    # used. With extra scaling based on that value a 1000m x 1000m rectangle
+                    # can be hatched. Tested with pattern: Diagonal4, and pattern scale: 1000.
+                    # With a limit of 9999.9 the same test fails.
+                    if face.BoundBox.DiagonalLength > 9999:
+                        extra_scale = 9999 / face.BoundBox.DiagonalLength
+                    else:
+                        extra_scale = 1.0
+                    face.scale(extra_scale)
                 if obj.Rotation.Value:
-                    face.rotate(App.Vector(), App.Vector(0,0,1), -obj.Rotation)
-                shape = TechDraw.makeGeomHatch(face, obj.Scale, obj.Pattern, obj.File)
+                    face.rotate(App.Vector(), App.Vector(0, 0, 1), -obj.Rotation)
+                shape = TechDraw.makeGeomHatch(face, obj.Scale * extra_scale, obj.Pattern, obj.File)
+                shape.scale(1 / extra_scale)
                 if obj.Rotation.Value:
-                    shape.rotate(App.Vector(), App.Vector(0,0,1), obj.Rotation)
+                    shape.rotate(App.Vector(), App.Vector(0, 0, 1), obj.Rotation)
                 if obj.Translate:
-                    shape = shape.transformGeometry(mtx)
+                    shape = shape.transformShape(mtx)
                 shapes.append(shape)
         if shapes:
             obj.Shape = Part.makeCompound(shapes)


### PR DESCRIPTION
Edges longer than ca. 10m are considered 'crazy' in the TD Workbench. Hatch patterns are also checked. As a workaround some intermediate scaling is applied.

Addionally: `transformShape` instead of `transformGeometry`. The latter results in B-splines.
