### PR TITLE
Revert: "Sketcher: Joint Line and Polyline in a command group."

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
+++ b/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
@@ -81,12 +81,11 @@ CmdSketcherToggleConstruction::CmdSketcherToggleConstruction()
     // list of toggle construction commands
     Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreateLine");
-    rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreatePolyline");
-    rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CompLine");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreateRectangle");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreateRectangle_Center");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreateOblong");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CompCreateRectangles");
+    rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreatePolyline");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreateArcSlot");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CreateSlot");
     rcCmdMgr.addCommandMode("ToggleConstruction", "Sketcher_CompSlot");

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -102,60 +102,6 @@ GeometryCreationMode geometryCreationMode = GeometryCreationMode::Normal;
 
 /* Sketch commands =======================================================*/
 
-// Comp for line tools =============================================
-
-class CmdSketcherCompLine: public Gui::GroupCommand
-{
-public:
-    CmdSketcherCompLine()
-        : GroupCommand("Sketcher_CompLine")
-    {
-        sAppModule = "Sketcher";
-        sGroup = "Sketcher";
-        sMenuText = QT_TR_NOOP("Create polyline");
-        sToolTipText = QT_TR_NOOP("Create a polyline in the sketch. 'M' Key cycles behaviour");
-        sWhatsThis = "Sketcher_CompLine";
-        sStatusTip = sToolTipText;
-        eType = ForEdit;
-
-        setCheckable(false);
-
-        addCommand("Sketcher_CreatePolyline");
-        addCommand("Sketcher_CreateLine");
-    }
-
-    void updateAction(int mode) override
-    {
-        Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(getAction());
-        if (!pcAction) {
-            return;
-        }
-
-        QList<QAction*> al = pcAction->actions();
-        int index = pcAction->property("defaultAction").toInt();
-        switch (static_cast<GeometryCreationMode>(mode)) {
-            case GeometryCreationMode::Normal:
-                al[0]->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreatePolyline"));
-                al[1]->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreateLine"));
-                getAction()->setIcon(al[index]->icon());
-                break;
-            case GeometryCreationMode::Construction:
-                al[0]->setIcon(
-                    Gui::BitmapFactory().iconFromTheme("Sketcher_CreatePolyline_Constr"));
-                al[1]->setIcon(Gui::BitmapFactory().iconFromTheme("Sketcher_CreateLine_Constr"));
-                getAction()->setIcon(al[index]->icon());
-                break;
-        }
-    }
-
-    const char* className() const override
-    {
-        return "CmdSketcherCompLine";
-    }
-};
-
-// Line ================================================================
-
 DEF_STD_CMD_AU(CmdSketcherCreateLine)
 
 CmdSketcherCreateLine::CmdSketcherCreateLine()
@@ -181,37 +127,6 @@ void CmdSketcherCreateLine::activated(int iMsg)
 }
 
 bool CmdSketcherCreateLine::isActive()
-{
-    return isCommandActive(getActiveGuiDocument());
-}
-
-// Polyline ================================================================
-
-DEF_STD_CMD_AU(CmdSketcherCreatePolyline)
-
-CmdSketcherCreatePolyline::CmdSketcherCreatePolyline()
-    : Command("Sketcher_CreatePolyline")
-{
-    sAppModule = "Sketcher";
-    sGroup = "Sketcher";
-    sMenuText = QT_TR_NOOP("Create polyline");
-    sToolTipText = QT_TR_NOOP("Create a polyline in the sketch. 'M' Key cycles behaviour");
-    sWhatsThis = "Sketcher_CreatePolyline";
-    sStatusTip = sToolTipText;
-    sPixmap = "Sketcher_CreatePolyline";
-    sAccel = "G, M";
-    eType = ForEdit;
-}
-
-CONSTRUCTION_UPDATE_ACTION(CmdSketcherCreatePolyline, "Sketcher_CreatePolyline")
-
-void CmdSketcherCreatePolyline::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-    ActivateHandler(getActiveGuiDocument(), new DrawSketchHandlerLineSet());
-}
-
-bool CmdSketcherCreatePolyline::isActive()
 {
     return isCommandActive(getActiveGuiDocument());
 }
@@ -445,6 +360,38 @@ bool CmdSketcherCompCreateRectangles::isActive()
 {
     return isCommandActive(getActiveGuiDocument());
 }
+
+// ======================================================================================
+
+DEF_STD_CMD_AU(CmdSketcherCreatePolyline)
+
+CmdSketcherCreatePolyline::CmdSketcherCreatePolyline()
+    : Command("Sketcher_CreatePolyline")
+{
+    sAppModule = "Sketcher";
+    sGroup = "Sketcher";
+    sMenuText = QT_TR_NOOP("Create polyline");
+    sToolTipText = QT_TR_NOOP("Create a polyline in the sketch. 'M' Key cycles behaviour");
+    sWhatsThis = "Sketcher_CreatePolyline";
+    sStatusTip = sToolTipText;
+    sPixmap = "Sketcher_CreatePolyline";
+    sAccel = "G, M";
+    eType = ForEdit;
+}
+
+CONSTRUCTION_UPDATE_ACTION(CmdSketcherCreatePolyline, "Sketcher_CreatePolyline")
+
+void CmdSketcherCreatePolyline::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    ActivateHandler(getActiveGuiDocument(), new DrawSketchHandlerLineSet());
+}
+
+bool CmdSketcherCreatePolyline::isActive()
+{
+    return isCommandActive(getActiveGuiDocument());
+}
+
 
 // ======================================================================================
 
@@ -2018,5 +1965,4 @@ void CreateSketcherCommandsCreateGeo()
     rcCmdMgr.addCommand(new CmdSketcherCompCurveEdition());
     rcCmdMgr.addCommand(new CmdSketcherExternal());
     rcCmdMgr.addCommand(new CmdSketcherCarbonCopy());
-    rcCmdMgr.addCommand(new CmdSketcherCompLine());
 }

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -286,22 +286,6 @@ template<typename T>
 void SketcherAddWorkbenchGeometries(T& geom);
 
 template<typename T>
-void SketcherAddWorkspaceLines(T& geom);
-
-template<>
-inline void SketcherAddWorkspaceLines<Gui::MenuItem>(Gui::MenuItem& geom)
-{
-    geom << "Sketcher_CreatePolyline"
-         << "Sketcher_CreateLine";
-}
-
-template<>
-inline void SketcherAddWorkspaceLines<Gui::ToolBarItem>(Gui::ToolBarItem& geom)
-{
-    geom << "Sketcher_CompLine";
-}
-
-template<typename T>
 void SketcherAddWorkspaceArcs(T& geom);
 
 template<>
@@ -421,9 +405,11 @@ inline void SketcherAddWorkspaceCurveEdition<Gui::ToolBarItem>(Gui::ToolBarItem&
 template<typename T>
 inline void SketcherAddWorkbenchGeometries(T& geom)
 {
-    geom << "Sketcher_CreatePoint";
-    SketcherAddWorkspaceLines(geom);
+    geom << "Sketcher_CreatePoint"
+         << "Sketcher_CreateLine";
     SketcherAddWorkspaceArcs(geom);
+    geom << "Separator"
+         << "Sketcher_CreatePolyline";
     SketcherAddWorkspaceRectangles(geom);
     SketcherAddWorkspaceRegularPolygon(geom);
     SketcherAddWorkspaceslots(geom);


### PR DESCRIPTION
This reverts commit cb0a2d28098dd7505087b4efccf64efac0da5b66.

the commit 6bb7775, groups the line- and polyline-tool in a submenu, saving a tiny bit a space in the toolbar but clearly reduces the usability of the most-used sketcher tools considerably. 
The main argument for this commit is, that _sometimes in the future_, the polyline-tool will be improved and replace the line-tool. None of this improvement can be seen now and there does not seem to be a clear understanding of how this new polyline-tool should work at all.
So, at the moment it is a degredation. The UI-change should be made when the polyline/line-improvement has happend.

For details see the discussion on
https://github.com/FreeCAD/FreeCAD/pull/13509
and
https://forum.freecad.org/viewtopic.php?p=759200 [german]