### PR TITLE
Fem: Increase size of reference node symbol in rigid body constraint - fixes #14133

### DIFF
--- a/src/Mod/Fem/Gui/Resources/symbols/ConstraintRigidBody.iv
+++ b/src/Mod/Fem/Gui/Resources/symbols/ConstraintRigidBody.iv
@@ -6,26 +6,26 @@ Separator {
   Separator {
 
     Translation {
-      translation 0 2.5 0
+      translation 0 3 0
     }
     Sphere {
-      radius 0.5
+      radius 0.3
 
     }
     Translation {
-      translation 0 -1.25 0
+      translation 0 -1.5 0
 
     }
     Cylinder {
-      radius 0.25
-      height 2.5
+      radius 0.15
+      height 3
 
     }
   }
   Separator {
 
     Sphere {
-      radius 0.25
+      radius 0.5
 
     }
   }


### PR DESCRIPTION
Fixes #14133
@FEA-eng The sticks are a little thinner and the node a little bigger.