### PR TITLE
Gui: Fix NaviCube drawing and interaction with Qt6

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -926,6 +926,7 @@ NaviCubeImplementation::PickId NaviCubeImplementation::pickFace(short x, short y
     GLubyte pixels[4] = {0};
     if (m_PickingFramebuffer && std::abs(x) <= m_CubeWidgetSize / 2 &&
         std::abs(y) <= m_CubeWidgetSize / 2) {
+        static_cast<QtGLWidget*>(m_View3DInventorViewer->viewport())->makeCurrent();
         m_PickingFramebuffer->bind();
 
         glViewport(0, 0, m_CubeWidgetSize * 2, m_CubeWidgetSize * 2);
@@ -936,6 +937,7 @@ NaviCubeImplementation::PickId NaviCubeImplementation::pickFace(short x, short y
         glReadPixels(2 * x + m_CubeWidgetSize, 2 * y + m_CubeWidgetSize, 1, 1,
                      GL_RGBA, GL_UNSIGNED_BYTE, &pixels);
         m_PickingFramebuffer->release();
+        static_cast<QtGLWidget*>(m_View3DInventorViewer->viewport())->doneCurrent();
     }
     return pixels[3] == 255 ? static_cast<PickId>(pixels[0]) : PickId::None;
 }


### PR DESCRIPTION
I've noticed that while debugging the NaviCube with a FreeCAD Qt6 build OpenGL errors are produced when picking faces or buttons. It turns out that these errors are produced because the underlying framebuffer object has a different context than the one that was created with, more specifically, QtWebEngine changes it before the mouse event is processed. I've fixed this by setting making the proper context current explicitly at the 3D Inventor viewer when Navicube has to process the event. Please test this and give your comments before merging. Fixes #13494.
