### PR TITLE
AddonManager: Support selecting addon on start

### DIFF
--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -75,8 +75,11 @@ class PackageList(QtWidgets.QWidget):
         pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
         package_type = pref.GetInt("PackageTypeSelection", 1)
         status = pref.GetInt("StatusSelection", 0)
+        search_string = pref.GetString("SearchString", "")
         self.ui.view_bar.filter_selector.set_contents_filter(package_type)
         self.ui.view_bar.filter_selector.set_status_filter(status)
+        if search_string:
+            self.ui.view_bar.search.filter_line_edit.setText(search_string)
         self.item_filter.setPackageFilter(package_type)
         self.item_filter.setStatusFilter(status)
 


### PR DESCRIPTION
This PR supports the functionality to start the Addon Manager for a specific addon. 

The current implementation tries to be as unobtrusive to the original code as possible. This is accomplished by introducing a new preference that captures a search string and filter based on whether this preference is set. It also emits signals for when the Addon Manager is finished, allowing a client addon to reset the preferences to their original values.

For a client addon to open the Addon Manager, it can do the following (as taken from the Ondsel Lens addon):

``` python
class UpdateManager:
    def storePreferences(self):
        pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
        self.autocheck = pref.GetBool("AutoCheck")
        self.statusSelection = pref.GetInt("StatusSelection")
        self.packageTypeSelection = pref.GetInt("PackageTypeSelection")
        self.searchString = pref.GetString("SearchString")

    def setCustomPreferences(self):
        pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
        pref.SetBool("AutoCheck", True)
        pref.SetInt("StatusSelection", 3)
        pref.SetInt("PackageTypeSelection", 1)
        pref.SetString("SearchString", "Ondsel Lens")

    def restorePreferences(self):
        pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
        pref.SetBool("AutoCheck", self.autocheck)
        pref.SetInt("StatusSelection", self.statusSelection)
        pref.SetInt("PackageTypeSelection", self.packageTypeSelection)
        pref.SetString("SearchString", self.searchString)

    def openAddonManager(self, finishFunction):
        """Open the addon manager with custom preferences."""

        self.storePreferences()
        self.setCustomPreferences()

        addonManager = AddonManager.CommandAddonManager()
        addonManager.finished.connect(finishFunction)
        addonManager.Activated()

class YourAddonClass:
    def openAddonManager(self):
        self.updateManager = UpdateManager()
        self.updateManager.openAddonManager(self.addonManagerFinished)

    def addonManagerFinished(self):
        self.updateManager.restorePreferences()
        self.UpdateManager = None
```

I think there are better implementations possible for this functionality. For example, instead of using preferences, I would prefer static variables. I haven't implemented this because it requires more checking code than with the preferences as it is currently.

A video that shows the behavior for the Ondsel Lens addon is below. It shows that the Addon Manager behaves normally, then the update button opens the Addon Manager focusing on a specific Addon, then afterwards, it behaves normally again.


https://github.com/FreeCAD/FreeCAD/assets/5336482/9001637f-bb14-49fd-9319-2f16d3786430

Closes #14166