### PR TITLE
Conda: Remove Qt WebEngine.

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -90,9 +90,7 @@ dependencies:
 - pyside2
 - python==3.11.*
 - pyyaml
-- qt
 - qt-main
-- qt-webengine
 - six
 - smesh
 - swig


### PR DESCRIPTION
Qt WebEngine is no longer a necessary dependency.