### PR TITLE
Toponaming: Cleanup verified face calls

### DIFF
--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -260,7 +260,7 @@ App::DocumentObjectExecReturn *Groove::execute()
 
     TopoShape sketchshape;
     try {
-        sketchshape = getVerifiedFace();
+        sketchshape = getTopoShapeVerifiedFace();
     } catch (const Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());
     }

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -170,7 +170,7 @@ App::DocumentObjectExecReturn* Helix::execute()
         return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: unsupported mode"));
     }
 
-    TopoDS_Shape sketchshape;
+    TopoDS_Shape sketchshape;   // Fixme: Should this be TopoShape here and below?
     try {
         sketchshape = getVerifiedFace();
     }

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1654,7 +1654,7 @@ App::DocumentObjectExecReturn* Hole::execute()
 {
      TopoShape profileshape;
     try {
-        profileshape = getVerifiedFace();
+        profileshape = getTopoShapeVerifiedFace();
     }
     catch (const Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -99,7 +99,7 @@ App::DocumentObjectExecReturn* Revolution::execute()
 
     TopoShape sketchshape;
     try {
-        sketchshape = getVerifiedFace();
+        sketchshape = getTopoShapeVerifiedFace();
     }
     catch (const Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -108,6 +108,28 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         else:
             self.assertTrue(self.Pad2.isValid())    # TNP problem is not present with ElementMaps
 
+    def testPartDesignElementMapSketch(self):
+        """ Test that creating a sketch results in a correct element map.  """
+        # Arrange
+        body = self.Doc.addObject('PartDesign::Body', 'Body')
+        sketch = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad')
+        body.addObject(sketch)
+        TestSketcherApp.CreateRectangleSketch(sketch, (0, 0), (1, 1))
+        # Act
+        self.Doc.recompute()
+        if body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
+            return
+        reverseMap = sketch.Shape.ElementReverseMap
+        faces = [name for name in reverseMap.keys() if name.startswith("Face")]
+        edges = [name for name in reverseMap.keys() if name.startswith("Edge")]
+        vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
+        # Assert
+        self.assertEqual(sketch.Shape.ElementMapSize,9)
+        self.assertEqual(len(reverseMap),9)
+        self.assertEqual(len(faces),1)
+        self.assertEqual(len(edges),4)
+        self.assertEqual(len(vertexes),4)
+
     def testPartDesignElementMapPad(self):
         """ Test that padding a sketch results in a correct element map.  Note that comprehensive testing
             of the geometric functionality of the Pad is in TestPad.py """


### PR DESCRIPTION
Note moved, unchanged getVerifiedFace.  Aligning source position with LS3 for easier comparison.