### PR TITLE
BIM: Restored original copyright header of ArchCutPlane command

### DIFF
--- a/src/Mod/BIM/bimcommands/BimCutPlane.py
+++ b/src/Mod/BIM/bimcommands/BimCutPlane.py
@@ -1,26 +1,27 @@
-# ***************************************************************************
-# *                                                                         *
-# *   Copyright (c) 2024 Yorik van Havre <yorik@uncreated.net>              *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   This program is distributed in the hope that it will be useful,       *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Library General Public License for more details.                  *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with this program; if not, write to the Free Software   *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
+#*****************************************************************************
+#*   Copyright (c) 2014 Jonathan Wiedemann <wood.galaxy@gmail.com> (cutplan) *
+#*   Copyright (c) 2019 Jerome Laverroux <jerome.laverroux@free.fr> (cutline)*
+#*   Copyright (c) 2023 FreeCAD Project Association                          *
+#*                                                                           *
+#*   This program is free software; you can redistribute it and/or modify    *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)      *
+#*   as published by the Free Software Foundation; either version 2 of       *
+#*   the License, or (at your option) any later version.                     *
+#*   for detail see the LICENCE text file.                                   *
+#*                                                                           *
+#*   This program is distributed in the hope that it will be useful,         *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+#*   GNU Library General Public License for more details.                    *
+#*                                                                           *
+#*   You should have received a copy of the GNU Library General Public       *
+#*   License along with this program; if not, write to the Free Software     *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307    *
+#*   USA                                                                     *
+#*                                                                           *
+#*****************************************************************************
 
-"""Misc Arch util commands"""
+"""The Arch CutPlane command"""
 
 
 import os


### PR DESCRIPTION
Restored the original copyright header of the Arch_CutPlane command that was rewritten by mistake