### PR TITLE
Fix accessibility of some group commands

### DIFF
--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -892,7 +892,15 @@ public:
         addCommand(new StdCmdLinkImportAll());
     }
 
-    const char* className() const override {return "StdCmdLinkActions";}
+    const char* className() const override
+    {
+        return "StdCmdLinkActions";
+    }
+
+    bool isActive() override
+    {
+        return hasActiveDocument();
+    }
 };
 
 //===========================================================================

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1648,6 +1648,11 @@ public:
     {
         return "StdCmdViewGroup";
     }
+
+    bool isActive() override
+    {
+        return hasActiveDocument();
+    }
 };
 
 //===========================================================================

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -2422,6 +2422,11 @@ public:
     {
         return "CmdPartDesignCompDatums";
     }
+
+    bool isActive() override
+    {
+        return hasActiveDocument();
+    }
 };
 
 // Command group for datums =============================================
@@ -2451,6 +2456,11 @@ public:
     const char* className() const override
     {
         return "CmdPartDesignCompSketches";
+    }
+
+    bool isActive() override
+    {
+        return hasActiveDocument();
     }
 };
 


### PR DESCRIPTION
Several group commands are active but require an active document to work. This PR overrides the method isActive() to disable the commands if no active document exists.

The affected commands are:
* Std_ViewGroup
* Std_LinkActions
* PartDesign_CompDatums
* PartDesign_CompSketches