### PR TITLE
CI: Add Conda Python 3.12 Qt6 to CI.

### DIFF
--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -63,6 +63,12 @@ jobs:
     with:
       artifactBasename: Ubuntu_22-04_Conda-${{ github.run_id }}
 
+  Ubuntu_22-04_Conda_Qt6:
+    needs: [Prepare]
+    uses: ./.github/workflows/sub_buildUbuntu2204CondaQt6.yml
+    with:
+      artifactBasename: Ubuntu_22-04_Conda-Qt6-${{ github.run_id }}
+
   Windows:
     needs: [Prepare]
     uses: ./.github/workflows/sub_buildWindows.yml

--- a/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
+++ b/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2023 0penBrain.                                         *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+# This is a build and test workflow for CI of FreeCAD.
+# This workflow aims at building and testing FreeCAD on a Conda environment on Linux.
+
+name: Build Ubuntu 22.04 (Conda)
+on:
+  workflow_call:
+    inputs:
+      artifactBasename:
+        type: string
+        required: true
+      testOnBuildDir:
+        default: false
+        type: boolean
+        required: false
+      allowedToFail:
+        default: false
+        type: boolean
+        required: false
+    outputs:
+      reportFile:
+        value: ${{ jobs.Build.outputs.reportFile }}
+
+jobs:
+  Build:
+    runs-on: ubuntu-22.04
+    continue-on-error: ${{ inputs.allowedToFail }}
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/ccache
+      CCACHE_CONFIGPATH: ${{ github.workspace }}/ccache/config
+      CCACHE_MAXSIZE: 1G
+      CCACHE_COMPILERCHECK: "%compiler% -dumpfullversion -dumpversion" # default:mtime
+      CCACHE_COMPRESS: true
+      CCACHE_COMPRESSLEVEL: 1
+      builddir: ${{ github.workspace }}/build/release/
+      logdir: /tmp/logs/
+      reportdir: /tmp/report/
+      reportfilename: ${{ inputs.artifactBasename }}-report.md
+    defaults:
+      run:
+        shell: bash -l {0}
+    outputs:
+      reportFile: ${{ steps.Init.outputs.reportFile }}
+
+    steps:
+      - name: Checking out source code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Miniconda
+        env:
+          CONDA_VERBOSITY: 2
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: .conda/freecad
+          environment-file: conda/conda-env-qt6.yaml
+          channels: conda-forge,defaults
+          channel-priority: true
+          miniforge-version: latest
+      - name: Install FreeCAD dependencies
+        env:
+          CONDA_VERBOSITY: 2
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libegl1                                       \
+            libgl1                                        \
+            libglx0                                       \
+            libopengl0
+          ./conda/setup-environment-qt6.sh
+      - name: Set Environment Variables
+        run: |
+          echo "CC=$CC" >> "$GITHUB_ENV"
+          echo "CXX=$CXX" >> "$GITHUB_ENV"
+      - name: Make needed directories, files and initializations
+        id: Init
+        run: |
+          mkdir -p ${{ env.CCACHE_DIR }}
+          mkdir -p ${{ env.CCACHE_CONFIGPATH }}
+          mkdir -p ${{ env.builddir }}
+          mkdir -p ${{ env.logdir }}
+          mkdir -p ${{ env.reportdir }}
+          echo "reportFile=${{ env.reportfilename }}" >> $GITHUB_OUTPUT
+      - name: Generate cache key
+        id: genCacheKey
+        uses: ./.github/workflows/actions/linux/generateCacheKey
+        with:
+          compiler: ${{ env.CXX }}
+      - name: Restore Compiler Cache
+        uses: actions/cache@v4
+        with:
+          save-always: true
+          path: ${{ env.CCACHE_DIR }}
+          key: FC-${{ steps.genCacheKey.outputs.cacheKey }}-${{ github.ref }}-${{ github.run_id }}-qt6
+          restore-keys: |
+            FC-${{ steps.genCacheKey.outputs.cacheKey }}-${{ github.ref }}-qt6-
+            FC-${{ steps.genCacheKey.outputs.cacheKey }}-qt6-
+      - name: Print CCache statistics before build, reset stats and print config
+        run: |
+          ccache -s
+          ccache -z
+          ccache -p
+      - name: CMake Configure
+        uses: ./.github/workflows/actions/linux/configure
+        with:
+          extraParameters: >
+            --preset conda-linux-release
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/.conda/freecad/opt/freecad
+            -DQT_HOST_PATH=${{ github.workspace }}/.conda/freecad/
+            -DFREECAD_QT_VERSION=6
+            -DBUILD_REVERSEENGINEERING=OFF
+          builddir: ${{ env.builddir }}
+          logFile: ${{ env.logdir }}Cmake.log
+          errorFile: ${{ env.logdir }}CmakeErrors.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+      - name: CMake Build
+        uses: ./.github/workflows/actions/linux/build
+        with:
+          builddir: ${{ env.builddir }}
+          logFile: ${{ env.logdir }}Build.log
+          errorFile: ${{ env.logdir }}BuildErrors.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+      - name: Print ccache statistics after Build
+        run: |
+          ccache -s
+      - name: FreeCAD CLI tests on build dir
+        if: inputs.testOnBuildDir
+        timeout-minutes: 10
+        uses: ./.github/workflows/actions/runPythonTests
+        with:
+          testDescription: "CLI tests on build dir"
+          testCommand: ${{ env.builddir }}/bin/FreeCADCmd -t 0
+          logFile: ${{ env.logdir }}TestCLIBuild.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+      - name: FreeCAD GUI tests on build dir
+        if: inputs.testOnBuildDir
+        timeout-minutes: 15
+        uses: ./.github/workflows/actions/runPythonTests
+        with:
+          testDescription: "GUI tests on build dir"
+          testCommand: xvfb-run ${{ env.builddir }}/bin/FreeCAD -t 0
+          logFile: ${{ env.logdir }}TestGUIBuild.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+      - name: C++ tests
+        timeout-minutes: 1
+        uses: ./.github/workflows/actions/runCPPTests/runAllTests
+        with:
+          reportdir: ${{ env.reportdir }}
+          builddir: ${{ env.builddir }}
+          reportFile: ${{ env.reportdir }}${{ env.reportfilename }}
+      - name: CMake Install
+        uses: ./.github/workflows/actions/linux/install
+        with:
+          builddir: ${{ env.builddir }}
+          logFile: ${{ env.logdir }}Install.log
+          errorFile: ${{ env.logdir }}InstallErrors.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+      - name: FreeCAD CLI tests on install
+        timeout-minutes: 10
+        uses: ./.github/workflows/actions/runPythonTests
+        with:
+          testDescription: "CLI tests on install"
+          testCommand: ${{ github.workspace }}/.conda/freecad/opt/freecad/bin/FreeCADCmd -t 0
+          logFile: ${{ env.logdir }}TestCLIInstall.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+      - name: FreeCAD GUI tests on install
+        timeout-minutes: 15
+        uses: ./.github/workflows/actions/runPythonTests
+        with:
+          testDescription: "GUI tests on install"
+          testCommand: xvfb-run ${{ github.workspace }}/.conda/freecad/opt/freecad/bin/FreeCAD -t 0
+          logFile: ${{ env.logdir }}TestGUIInstall.log
+          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifactBasename }}-Logs
+          path: |
+            ${{ env.logdir }}
+            /var/crash/*FreeCAD*
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.reportfilename }}
+          path: |
+            ${{env.reportdir}}${{ env.reportfilename }}

--- a/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
+++ b/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
@@ -37,6 +37,10 @@ macro(SetupShibokenAndPyside)
             message(STATUS "PYTHON_CONFIG_SUFFIX: ${PYTHON_CONFIG_SUFFIX}")
             find_package(Shiboken${SHIBOKEN_MAJOR_VERSION} QUIET)
         endif()
+
+        if(SHIBOKEN_MAJOR_VERSION EQUAL 6)
+            set_target_properties(Shiboken6::libshiboken PROPERTIES INTERFACE_COMPILE_DEFINITIONS "NDEBUG")
+        endif()
     endif()
 
     # pyside2 changed its cmake files, this is the dance we have

--- a/conda/conda-env-qt6.yaml
+++ b/conda/conda-env-qt6.yaml
@@ -1,0 +1,8 @@
+name: freecad
+channels:
+- conda-forge
+dependencies:
+- conda-devenv
+- mamba
+- python==3.12.*
+- zstd

--- a/conda/environment-qt6.devenv.yml
+++ b/conda/environment-qt6.devenv.yml
@@ -1,6 +1,7 @@
 name: freecad
 channels:
 - conda-forge
+- conda-forge/label/pivy_rc
 dependencies:
 - libspnav                             # [linux]
 - kernel-headers_linux-64              # [linux and x86_64]
@@ -80,6 +81,7 @@ dependencies:
 - openssl
 - pcl
 - pip
+- conda-forge/label/pivy_rc::pivy
 - pkg-config
 - ply
 - pre-commit

--- a/conda/environment-qt6.devenv.yml
+++ b/conda/environment-qt6.devenv.yml
@@ -1,0 +1,98 @@
+name: freecad
+channels:
+- conda-forge
+dependencies:
+- libspnav                             # [linux]
+- kernel-headers_linux-64              # [linux and x86_64]
+- libdrm-cos7-x86_64                   # [linux and x86_64]
+- libselinux-cos7-x86_64               # [linux and x86_64]
+- libsepol-cos7-x86_64                 # [linux and x86_64]
+- libx11-common-cos7-x86_64            # [linux and x86_64]
+- libx11-cos7-x86_64                   # [linux and x86_64]
+- libxau-cos7-x86_64                   # [linux and x86_64]
+- libxcb-cos7-x86_64                   # [linux and x86_64]
+- libxdamage-cos7-x86_64               # [linux and x86_64]
+- libxext-cos7-x86_64                  # [linux and x86_64]
+- libxfixes-cos7-x86_64                # [linux and x86_64]
+- libxi-cos7-x86_64                    # [linux and x86_64]
+- libxi-devel-cos7-x86_64              # [linux and x86_64]
+- libxxf86vm-cos7-x86_64               # [linux and x86_64]
+- mesa-dri-drivers-cos7-x86_64         # [linux and x86_64]
+- mesa-libegl-cos7-x86_64              # [linux and x86_64]
+- mesa-libegl-devel-cos7-x86_64        # [linux and x86_64]
+- mesa-libgl-cos7-x86_64               # [linux and x86_64]
+- mesa-libgl-devel-cos7-x86_64         # [linux and x86_64]
+- pixman-cos7-x86_64                   # [linux and x86_64]
+- sysroot_linux-64                     # [linux and x86_64]
+- xorg-x11-server-common-cos7-x86_64   # [linux and x86_64]
+- xorg-x11-server-xvfb-cos7-x86_64     # [linux and x86_64]
+- kernel-headers_linux-aarch64         # [linux and aarch64]
+- libdrm-cos7-aarch64                  # [linux and aarch64]
+- libglvnd-cos7-aarch64                # [linux and aarch64]
+- libglvnd-glx-cos7-aarch64            # [linux and aarch64]
+- libselinux-cos7-aarch64              # [linux and aarch64]
+- libsepol-cos7-aarch64                # [linux and aarch64]
+- libx11-common-cos7-aarch64           # [linux and aarch64]
+- libx11-cos7-aarch64                  # [linux and aarch64]
+- libxau-cos7-aarch64                  # [linux and aarch64]
+- libxcb-cos7-aarch64                  # [linux and aarch64]
+- libxdamage-cos7-aarch64              # [linux and aarch64]
+- libxext-cos7-aarch64                 # [linux and aarch64]
+- libxfixes-cos7-aarch64               # [linux and aarch64]
+- libxi-cos7-aarch64                   # [linux and aarch64]
+- libxi-devel-cos7-aarch64             # [linux and aarch64]
+- libxxf86vm-cos7-aarch64              # [linux and aarch64]
+- mesa-dri-drivers-cos7-aarch64        # [linux and aarch64]
+- mesa-khr-devel-cos7-aarch64          # [linux and aarch64]
+- mesa-libegl-cos7-aarch64             # [linux and aarch64]
+- mesa-libegl-devel-cos7-aarch64       # [linux and aarch64]
+- mesa-libgbm-cos7-aarch64             # [linux and aarch64]
+- mesa-libgl-cos7-aarch64              # [linux and aarch64]
+- mesa-libgl-devel-cos7-aarch64        # [linux and aarch64]
+- mesa-libglapi-cos7-aarch64           # [linux and aarch64]
+- pixman-cos7-aarch64                  # [linux and aarch64]
+- sysroot_linux-aarch64                # [linux and aarch64]
+- xorg-x11-server-common-cos7-aarch64  # [linux and aarch64]
+- xorg-x11-server-xvfb-cos7-aarch64    # [linux and aarch64]
+- sed                                  # [unix]
+- ccache
+- cmake
+- coin3d
+- compilers
+- conda
+- conda-devenv
+- debugpy
+- doxygen
+- eigen
+- fmt
+- freetype
+- git
+- gmsh
+- graphviz
+- hdf5
+- libboost-devel
+- libcxx
+- mamba
+- matplotlib
+- ninja
+- numpy
+- occt
+- openssl
+- pcl
+- pip
+- pkg-config
+- ply
+- pre-commit
+- pybind11
+- pyside6
+- python==3.12.*
+- pyyaml
+- qt6-main
+- six
+- smesh
+- swig
+- vtk==9.2.6
+- xerces-c
+- yaml-cpp
+- zlib
+- zstd

--- a/conda/setup-environment-qt6.sh
+++ b/conda/setup-environment-qt6.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# create the conda environment as a subdirectory
+mamba env create -p .conda/freecad -f conda/conda-env.yaml
+
+# add the environment subdirectory to the conda configuration
+conda config --add envs_dirs $CONDA_PREFIX/envs
+conda config --add envs_dirs $(pwd)/.conda
+conda config --set env_prompt "({name})"
+
+# install the FreeCAD dependencies into the environment
+mamba run --live-stream -n freecad mamba-devenv --no-prune -f conda/environment-qt6.devenv.yml


### PR DESCRIPTION
Adds Python 3.12 and Qt6 build to CI.

TODO:

* [ ] harmonize Python 3.11/Qt5 and Python 3.12/Qt6 configurations to permit building both

    I believe this could be performed by installing both Qt5 and Qt6 within the `devenv` and selecting the version of python when establishing the environment.  Use of Qt6 would may be performed by using the `-DFREECAD_QT_VERSION=6` CMake configuration option.
    

* [ ] migrate the `apt` installed libraries to `conda-forge` libraries, if possible

    Qt6 depends upon several libraries provided by `mesa` that are not available using the `conda-forge` libraries currently installed.  Qt5 dependencies are satisfied without requiring these packages to be installed in the host environment, and it is unclear as to why.  When installing the `conda-forge` package `mesa-libegl-devel-cos7-*` the libraries are installed as `libEGL_mesa.so.0` instead of `libEGL.so.1` as expected by Qt6.

    * `libegl1`
    * `libgl1`
    * `libglx0`
    * `libopengl0`

* [ ] get Reverse Engineering Workbench to compile

    To get the build to work `-DBUILD_REVERSEENGINEERING=OFF` was set on the CMake command line.

* [ ] Enable CLI and GUI tests

    * `pivy` is not built for Qt6 and Python 3.12, causing the tests to fail.  See: https://github.com/conda-forge/pivy-feedstock/pull/44