### PR TITLE
Adding parallel running to the multi_fuse operation

### DIFF
--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -134,7 +134,7 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
 
             mkFuse.SetArguments(shapeArguments);
             mkFuse.SetTools(shapeTools);
-            mkFuse.SetParallelRun(true);
+            mkFuse.SetRunParallel(true);
             mkFuse.Build();
             if (!mkFuse.IsDone())
                 throw Base::RuntimeError("MultiFusion failed");

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -134,6 +134,7 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
 
             mkFuse.SetArguments(shapeArguments);
             mkFuse.SetTools(shapeTools);
+            mkFuse.SetParallelRun(true);
             mkFuse.Build();
             if (!mkFuse.IsDone())
                 throw Base::RuntimeError("MultiFusion failed");


### PR DESCRIPTION
This pull request add a minor modification. It allows to speed up the multi_fuse operation by setting the parallel flag given by OpenCascade to true.