### PR TITLE
[TD]Fix selection issue in DimensionRepair(partial fix #14051)

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -71,7 +71,6 @@
 #include "TechDrawHandler.h"
 #include "ViewProviderDimension.h"
 #include "ViewProviderDrawingView.h"
-#include "ViewProviderDrawingView.h"
 
 
 using namespace TechDrawGui;
@@ -2636,12 +2635,6 @@ void CmdTechDrawDimensionRepair::activated(int iMsg)
         dim = static_cast<TechDraw::DrawViewDimension*>(dimObjs.at(0));
     }
 
-    //    ReferenceVector references2d;
-    //    ReferenceVector references3d;
-    //    //TechDraw::DrawViewPart* partFeat =
-    //    TechDraw::getReferencesFromSelection(references2d, references3d);
-
-    //    Gui::Control().showDialog(new TaskDlgDimReference(dim, references2d, references3d));
     Gui::Control().showDialog(new TaskDlgDimReference(dim));
 }
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -130,7 +130,7 @@ protected:
     void onDeleteObject(const App::DocumentObject& obj);
 
     bool compareSelections(std::vector<Gui::SelectionObject> treeSel, QList<QGraphicsItem*> sceneSel);
-    void addSceneToTreeSel(QGraphicsItem* scene, std::vector<Gui::SelectionObject> treeSel);
+    void addSceneItemToTreeSel(QGraphicsItem* sceneItem, std::vector<Gui::SelectionObject> treeSel);
     void removeSelFromTreeSel(QList<QGraphicsItem*> sceneSel, Gui::SelectionObject& sel);
     std::string getSceneSubName(QGraphicsItem* scene);
     void setTreeToSceneSelect();
@@ -156,7 +156,7 @@ private:
     QString m_currentPath;
     ViewProviderPage* m_vpPage;
 
-    QList<QGraphicsItem*> m_qgSceneSelected;        //items in selection order
+    QList<QGraphicsItem*> m_orderedSceneSelection;        //items in selection order
 
     void getPaperAttributes();
     PagePrinter* m_pagePrinter;

--- a/src/Mod/TechDraw/Gui/TaskDimRepair.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimRepair.cpp
@@ -236,12 +236,13 @@ bool TaskDimRepair::accept()
 {
     Gui::Command::doCommand(Gui::Command::Gui, "Gui.ActiveDocument.resetEdit()");
 
-    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Repair Dimension"));
+    Gui::Command::openCommand(Base::Tools::toStdString(tr("Repair Dimension")).c_str());
     replaceReferences();
     m_dim->Type.setValue(m_dimType);
     Gui::Command::commitCommand();
 
     m_dim->recomputeFeature();
+    Gui::Selection().clearSelection();
     return true;
 }
 
@@ -249,6 +250,7 @@ bool TaskDimRepair::reject()
 {
     restoreDimState();
     Gui::Command::doCommand(Gui::Command::Gui, "Gui.ActiveDocument.resetEdit()");
+    Gui::Selection().clearSelection();
     return false;
 }
 


### PR DESCRIPTION
This PR implements a fix for one of the items raised in #14051.  Specifically it ensures that the selection state is left clean for the next operation.