### PR TITLE
Resolves missing TechDraw include for GCC14 compilers

### DIFF
--- a/src/Mod/TechDraw/App/LineGenerator.h
+++ b/src/Mod/TechDraw/App/LineGenerator.h
@@ -39,7 +39,7 @@
 #define DASHEDLINEGENERATOR_H
 
 #include <Mod/TechDraw/TechDrawGlobal.h>
-
+#include <map>
 #include <QPen>
 
 namespace TechDraw {


### PR DESCRIPTION
Addresses the missing #include <map> from LineGenerator.cpp.

This was prompted by a compiler error on Linux systems utilizing gcc14.

Also reported in this issue: https://github.com/FreeCAD/FreeCAD/issues/14245