### PR TITLE
[Start] Fix Button Issues and Stylesheet lookup

### DIFF
--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -80,13 +80,10 @@ gsl::owner<QPushButton*> createNewButton(const NewButton& newButton)
     iconLabel->setPixmap(baseIcon.pixmap(newFileIconSize, newFileIconSize));
 
     auto textLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout);
-    auto textLabelLine1 = gsl::owner<QLabel*>(new QLabel(button));
-    textLabelLine1->setText(QLatin1String("<b>") + newButton.heading + QLatin1String("</b>"));
-    auto textLabelLine2 = gsl::owner<QLabel*>(new QLabel(button));
-    textLabelLine2->setText(newButton.description);
-    textLabelLine2->setWordWrap(true);
-    textLayout->addWidget(textLabelLine1);
-    textLayout->addWidget(textLabelLine2);
+    auto textLabelLine = gsl::owner<QLabel*>(new QLabel(button));
+    textLabelLine->setText(newButton.description);
+    textLabelLine->setWordWrap(true);
+    textLayout->addWidget(textLabelLine);
     textLayout->setSpacing(0);
     mainLayout->addItem(textLayout);
 
@@ -224,7 +221,10 @@ void StartView::configureNewFileButtons(QLayout* layout) const
 
 QString StartView::fileCardStyle() const
 {
-    if (!qApp->styleSheet().isEmpty()) {
+    auto hGrpView = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/MainWindow");
+    auto qssFile = hGrpView->GetASCII("StyleSheet", "");
+    if (!qssFile.empty()) {
         return {};
     }
 
@@ -256,6 +256,10 @@ QString StartView::fileCardStyle() const
                                "}"
                                "QPushButton:pressed {"
                                " border: 2px solid rgb(%7, %8, %9);"
+                               "}"
+                               "QLabel {"
+                               " font-size: 12px;"
+                               " font-weight: bold;"
                                "}")
         .arg(background.red())
         .arg(background.green())


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/14039 and https://github.com/FreeCAD/FreeCAD/issues/13991

It has meant the heading and description have been changed to description only.

Current:
![Screenshot from 2024-05-25 20-08-15](https://github.com/FreeCAD/FreeCAD/assets/46537884/1344f1ff-20eb-4add-a23e-04701d39b46f)

With this PR:
![Screenshot from 2024-05-25 20-11-36](https://github.com/FreeCAD/FreeCAD/assets/46537884/5b5f7668-d041-42f0-9f84-3987fa3eb2dc)

