### PR TITLE
[TD]Allow greedy selection for complex selection (fix #14052, #14054)

### DIFF
--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -612,3 +612,16 @@ Base::Vector3d DrawGuiUtil::toGuiPoint(DrawView* obj, const Base::Vector3d& toCo
     return result;
 }
 
+
+//! true if targetObj is in the selection list
+bool DrawGuiUtil::findObjectInSelection(const std::vector<Gui::SelectionObject>& selection,
+                                        const App::DocumentObject& targetObject)
+{
+    for (auto& selObj : selection) {
+        if (&targetObject == selObj.getObject()) {
+            return true;
+        }
+    }
+    return false;
+}
+

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.h
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.h
@@ -27,17 +27,15 @@
 #include <QCoreApplication>
 #include <QGraphicsItem>
 
+#include <App/DocumentObject.h>
 #include <Base/Vector3D.h>
+#include <Gui/Selection.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
 
 class QComboBox;
 class QPointF;
 class QRectF;
-
-namespace App {
-class DocumentObject;
-}
 
 namespace Part {
 class Feature;
@@ -85,6 +83,9 @@ class TechDrawGuiExport DrawGuiUtil {
     static Base::Vector3d fromSceneCoords(const Base::Vector3d& sceneCoord, bool invert = true);
     static Base::Vector3d toSceneCoords(const Base::Vector3d& pageCoord, bool invert = true);
     static Base::Vector3d toGuiPoint(TechDraw::DrawView* obj, const Base::Vector3d& toConvert);
+
+    static bool findObjectInSelection(const std::vector<Gui::SelectionObject>& selection,
+                                      const App::DocumentObject& targetObject);
 };
 
 } //end namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -39,10 +39,12 @@
 #include "QGIPrimPath.h"
 #include "PreferencesGui.h"
 #include "QGIView.h"
+#include "DrawGuiUtil.h"
 
 
 using namespace TechDrawGui;
 using namespace TechDraw;
+using DGU = DrawGuiUtil;
 
 QGIPrimPath::QGIPrimPath():
     m_width(0),
@@ -251,9 +253,9 @@ void QGIPrimPath::mousePressEvent(QGraphicsSceneMouseEvent *event)
         auto parent = dynamic_cast<QGIView *>(parentItem());
         if (parent) {
             std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
-            if (selection.size() == 1
-                && selection.front().getObject() == parent->getViewObject()) {
-
+            if (DGU::findObjectInSelection(selection, *(parent->getViewObject()))) {
+                // if our parent is already in the selection, then allow addition
+                // primitives to be selected.
                 multiselectActivated = true;
                 event->setModifiers(originalModifiers | Qt::ControlModifier);
             }

--- a/src/Mod/TechDraw/Gui/TaskDimRepair.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDimRepair.cpp
@@ -90,7 +90,6 @@ void TaskDimRepair::saveDimState()
 {
     m_saveMeasureType = m_dim->MeasureType.getValue();
     m_saveDimType = m_dim->Type.getValue();
-    m_dimType = m_dim->Type.getValue();
     m_saveRefs3d = m_dim->getReferences3d();
     m_saveRefs2d = m_dim->getReferences2d();
     m_saveDvp = m_dim->getViewPart();
@@ -152,7 +151,6 @@ void TaskDimRepair::slotUseSelection()
         }
     }
 
-    m_dimType = mapGeometryTypeToDimType(m_dim->Type.getValue(), geometryRefs2d, geometryRefs3d);
     m_toApply2d = references2d;
     if (references3d.empty()) {
         m_toApply3d.clear();
@@ -238,7 +236,6 @@ bool TaskDimRepair::accept()
 
     Gui::Command::openCommand(Base::Tools::toStdString(tr("Repair Dimension")).c_str());
     replaceReferences();
-    m_dim->Type.setValue(m_dimType);
     Gui::Command::commitCommand();
 
     m_dim->recomputeFeature();

--- a/src/Mod/TechDraw/Gui/TaskDimRepair.h
+++ b/src/Mod/TechDraw/Gui/TaskDimRepair.h
@@ -72,7 +72,6 @@ protected:
 private:
     std::unique_ptr<Ui_TaskDimRepair> ui;
     TechDraw::DrawViewDimension* m_dim;
-    long int m_dimType;
 
     long int m_saveMeasureType;
     long int m_saveDimType;


### PR DESCRIPTION
This PR implements a fix for issue #14052 where greedy selection was not supported
if the view was not the first item in the selection.

This PR also include a fix for issue #14054 where the dimension type was being 
changed incorrectly.