### PR TITLE
BIM: change default for defaultWP to Top

### DIFF
--- a/src/Mod/BIM/bimcommands/BimSetup.py
+++ b/src/Mod/BIM/bimcommands/BimSetup.py
@@ -489,7 +489,7 @@ class BIM_Setup:
             ).GetInt("gridEvery", 10)
             wp = FreeCAD.ParamGet(
                 "User parameter:BaseApp/Preferences/Mod/Draft"
-            ).GetInt("defaultWP", 0)
+            ).GetInt("defaultWP", 1)
             tsize = FreeCAD.ParamGet(
                 "User parameter:BaseApp/Preferences/Mod/Draft"
             ).GetFloat("textheight", 10)


### PR DESCRIPTION
Setting the WP to "Auto" is confusing for beginners. That is why this was changed to "Top" in the Draft WB. The same should happen in the BIM WB.
