### PR TITLE
UI: Revert UI command change in Sketcher and PartDesign

### DIFF
--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -551,6 +551,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
           << "Separator"
           << datums
           << "PartDesign_CoordinateSystem"
+          << "PartDesign_ShapeBinder"
           << "PartDesign_SubShapeBinder"
           << "PartDesign_Clone"
           << "Separator"

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -298,7 +298,8 @@ inline void SketcherAddWorkspaceLines<Gui::MenuItem>(Gui::MenuItem& geom)
 template<>
 inline void SketcherAddWorkspaceLines<Gui::ToolBarItem>(Gui::ToolBarItem& geom)
 {
-    geom << "Sketcher_CompLine";
+    geom << "Sketcher_CreatePolyline"
+         << "Sketcher_CreateLine";
 }
 
 template<typename T>


### PR DESCRIPTION
Based on discussion in: https://github.com/FreeCAD/FreeCAD/pull/14118 and https://github.com/FreeCAD/FreeCAD/pull/13833
- Replaces toolbar command group for lines (grouped Polyline + Line) with separate commands
- Adds PartDesign_ShapeBinder back to the menu

If possible, polyline can be improved for feature freeze, otherwise maybe a setting (like the new dimension tool).
Shapebinder will not be fully integrated until feature freeze.
@berberic2 Is that change ok for you? So I'd rather leave the CommmandGroup in for working with it, the toolbar are restored.

@FreeCAD/design-working-group FYI