### PR TITLE
BIM: Move urls outside translated strings

### DIFF
--- a/src/Mod/BIM/bimcommands/BimPreflight.py
+++ b/src/Mod/BIM/bimcommands/BimPreflight.py
@@ -319,8 +319,8 @@ class BIM_Preflight_TaskPanel:
                 msg = (
                     translate(
                         "BIM",
-                        "ifcopenshell is not installed on your system or not available to FreeCAD. This library is responsible for IFC support in FreeCAD, and therefore IFC support is currently disabled. Check https://www.freecadweb.org/wiki/Extra_python_modules#IfcOpenShell to obtain more information.",
-                    )
+                        "ifcopenshell is not installed on your system or not available to FreeCAD. This library is responsible for IFC support in FreeCAD, and therefore IFC support is currently disabled. Check %1 to obtain more information.",
+                    ).replace("%1", "https://www.freecadweb.org/wiki/Extra_python_modules#IfcOpenShell")
                     + " "
                 )
                 self.failed(test)
@@ -892,8 +892,8 @@ class BIM_Preflight_TaskPanel:
                     "\n"
                     + translate(
                         "BIM",
-                        "Verify which properties a certain property set must contain on http://www.buildingsmart-tech.org/ifc/IFC4/Add2/html/annex/annex-b/alphabeticalorder_psets.htm",
-                    )
+                        "Verify which properties a certain property set must contain on %1",
+                    ).replace("%1", "https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/annex/annex-b/alphabeticalorder_psets.htm")
                     + "\n\n"
                 )
                 msg += translate(

--- a/src/Mod/BIM/importers/importSHP.py
+++ b/src/Mod/BIM/importers/importSHP.py
@@ -132,13 +132,13 @@ def checkShapeFileLibrary():
             from PySide import QtGui
             reply = QtGui.QMessageBox.question(FreeCADGui.getMainWindow(),
                                                translate("Arch","Shapefile module not found"),
-                                               translate("Arch","The shapefile Python library was not found on your system. Would you like to download it now from <a href=\"https://github.com/GeospatialPython/pyshp\">https://github.com/GeospatialPython/pyshp</a>? It will be placed in your macros folder."),
+                                               translate("Arch","The shapefile Python library was not found on your system. Would you like to download it now from %1? It will be placed in your macros folder.").replace("%1","<a href=\"https://github.com/GeospatialPython/pyshp\">https://github.com/GeospatialPython/pyshp</a>"),
                                                QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
                                                QtGui.QMessageBox.No)
             if reply == QtGui.QMessageBox.Yes:
                 u = addonmanager_utilities.urlopen(url)
                 if not u:
-                    FreeCAD.Console.PrintError(translate("Arch","Error: Unable to download from:")+" "+url+"\n")
+                    FreeCAD.Console.PrintError(translate("Arch","Error: Unable to download from %1").replace("%1",url)+"\n")
                     return False
                 b = u.read()
                 fp = os.path.join(FreeCAD.getUserMacroDir(True),"shapefile.py")


### PR DESCRIPTION
Leaving urls outside translated strings prevents translations from being updated on url change.
[Python F-strings](https://docs.python.org/3/tutorial/inputoutput.html#formatted-string-literals) suggested by @furgo16