### PR TITLE
Gui: Fix rendering order of transorm gizmo

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1005,6 +1005,7 @@ SET(Inventor_CPP_SRCS
     SoFCSelectionAction.cpp
     SoFCVectorizeSVGAction.cpp
     SoFCVectorizeU3DAction.cpp
+    So3DAnnotation.cpp
     SoAxisCrossKit.cpp
     SoTextLabel.cpp
     SoDatumLabel.cpp

--- a/src/Gui/So3DAnnotation.cpp
+++ b/src/Gui/So3DAnnotation.cpp
@@ -1,0 +1,90 @@
+/***************************************************************************
+ *   Copyright (c) 2024 Kacper Donat <kacper@kadet.net>                    *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#include <QtOpenGL>
+#include <Inventor/elements/SoCacheElement.h>
+#endif
+
+#include "SoFCDB.h"
+#include "So3DAnnotation.h"
+
+using namespace Gui;
+
+SO_NODE_SOURCE(So3DAnnotation);
+
+So3DAnnotation::So3DAnnotation()
+{
+    SO_NODE_CONSTRUCTOR(So3DAnnotation);
+}
+
+void So3DAnnotation::initClass()
+{
+    SO_NODE_INIT_CLASS(So3DAnnotation, SoSeparator, "3DAnnotation");
+}
+
+void So3DAnnotation::GLRender(SoGLRenderAction* action)
+{
+    switch (action->getCurPathCode()) {
+        case SoAction::NO_PATH:
+        case SoAction::BELOW_PATH:
+            this->GLRenderBelowPath(action);
+            break;
+        case SoAction::OFF_PATH:
+            // do nothing. Separator will reset state.
+            break;
+        case SoAction::IN_PATH:
+            this->GLRenderInPath(action);
+            break;
+    }
+}
+
+void So3DAnnotation::GLRenderBelowPath(SoGLRenderAction* action)
+{
+    if (action->isRenderingDelayedPaths()) {
+        glClear(GL_DEPTH_BUFFER_BIT);
+        inherited::GLRenderBelowPath(action);
+    }
+    else {
+        SoCacheElement::invalidate(action->getState());
+        action->addDelayedPath(action->getCurPath()->copy());
+    }
+}
+
+void So3DAnnotation::GLRenderInPath(SoGLRenderAction* action)
+{
+    if (action->isRenderingDelayedPaths()) {
+        glClear(GL_DEPTH_BUFFER_BIT);
+        inherited::GLRenderInPath(action);
+    }
+    else {
+        SoCacheElement::invalidate(action->getState());
+        action->addDelayedPath(action->getCurPath()->copy());
+    }
+}
+
+void So3DAnnotation::GLRenderOffPath(SoGLRenderAction* /* action */)
+{
+    // should never render, this is a separator node
+}

--- a/src/Gui/So3DAnnotation.h
+++ b/src/Gui/So3DAnnotation.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+ *   Copyright (c) 2024 Kacper Donat <kacper@kadet.net>                    *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef GUI_SO3DANNOTATION_H
+#define GUI_SO3DANNOTATION_H
+
+#include <Inventor/actions/SoGLRenderAction.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <FCGlobal.h>
+
+namespace Gui
+{
+
+/*! @brief 3D Annotation Node - Annotation with depth buffer
+ *
+ * This class is just like SoAnnotation with the difference that it does not disable
+ * the depth buffer instead it clears it and renders on top of everything with proper
+ * depth control.
+ *
+ * It should be used with caution as it does clear the depth buffer for each annotation!
+ */
+class GuiExport So3DAnnotation: public SoSeparator
+{
+    typedef SoSeparator inherited;
+
+    SO_NODE_HEADER(So3DAnnotation);
+
+public:
+    static void initClass();
+    So3DAnnotation();
+
+    virtual void GLRender(SoGLRenderAction* action);
+    virtual void GLRenderBelowPath(SoGLRenderAction* action);
+    virtual void GLRenderInPath(SoGLRenderAction* action);
+    virtual void GLRenderOffPath(SoGLRenderAction* action);
+
+protected:
+    virtual ~So3DAnnotation() = default;
+};
+
+}  // namespace Gui
+
+#endif  // GUI_SO3DANNOTATION_H

--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -51,6 +51,8 @@
 #include <Base/Quantity.h>
 
 #include "SoFCCSysDragger.h"
+#include "So3DAnnotation.h"
+
 #include "MainWindow.h"
 #include "SoFCDB.h"
 
@@ -1006,7 +1008,7 @@ SoFCCSysDragger::SoFCCSysDragger()
 {
     SO_KIT_CONSTRUCTOR(SoFCCSysDragger);
 
-    SO_KIT_ADD_CATALOG_ENTRY(annotation, SoAnnotation, TRUE, geomSeparator, "", TRUE);
+    SO_KIT_ADD_CATALOG_ENTRY(annotation, So3DAnnotation, TRUE, geomSeparator, "", TRUE);
     SO_KIT_ADD_CATALOG_ENTRY(scaleNode, SoScale, TRUE, annotation, "", TRUE);
 
     // Translator

--- a/src/Gui/SoFCCSysDragger.h
+++ b/src/Gui/SoFCCSysDragger.h
@@ -35,6 +35,7 @@
 #include <Inventor/sensors/SoIdleSensor.h>
 #include <FCGlobal.h>
 
+#include "So3DAnnotation.h"
 
 class SoCamera;
 

--- a/src/Gui/SoFCDB.cpp
+++ b/src/Gui/SoFCDB.cpp
@@ -53,6 +53,7 @@
 #include "GestureNavigationStyle.h"
 #include "NavigationStyle.h"
 #include "SelectionObject.h"
+#include "So3DAnnotation.h"
 #include "SoAxisCrossKit.h"
 #include "SoFCBackgroundGradient.h"
 #include "SoFCBoundingBox.h"
@@ -141,6 +142,7 @@ void Gui::SoFCDB::init()
     SoFCSelectionRoot               ::initClass();
     SoFCPathAnnotation              ::initClass();
     SoMouseWheelEvent               ::initClass();
+    So3DAnnotation                  ::initClass();
 
     PropertyItem                    ::init();
     PropertySeparatorItem           ::init();


### PR DESCRIPTION
Transform gizmo (dragger) used SoAnnotation which disables GL_DEPTH_TEST resulting in rendering elements in wrong order. This PR introduces new coin node: So3DAnnotation that delays rendering and clears depth buffer before drawing which results in proper order of elements. As this destroys information in the depth buffer it is crucial to run this action after the scene is rendered.

If it causes problems I'll try to either delay it further or preserve depth buffer in FBO - but this will be slower.

Before:
![image](https://github.com/FreeCAD/FreeCAD/assets/747404/93561982-3ee0-4d43-bf42-303d6c875083)

After:
![image](https://github.com/FreeCAD/FreeCAD/assets/747404/ced9093b-095c-48cf-bcac-90f47c6cdfb5)

Fixes: #14302 

ping: 
 - @qewer33 - FYI
 - @PaddleStroke - I heard that you struggle with the same thing in assembly workbench. I'm not sure how to expose this to python - so I could use your help here.