### PR TITLE
Draft: fix _get_shapes in shape2dview.py

### DIFF
--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -200,7 +200,7 @@ class Shape2DView(DraftObject):
             return shape.Solids
         if shape.ShapeType == "Compound":
             return shape.SubShapes
-        return [shape]
+        return [shape.copy()]
 
     def execute(self, obj):
         if self.props_changed_placement_only(obj) \


### PR DESCRIPTION
Fixes #14312.

The `new _get_shapes` function could return the original object shape. This caused a problem if `sh.reverse()` executed.

Note that the file in the linked issue does not produce the error as it does not contain a shape with a negative volume.
