### PR TITLE
Added types to Attacher Type tooltip

### DIFF
--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -42,7 +42,9 @@ AttachExtension::AttachExtension()
                                 ("Attacher::AttachEngine3D"),
                                 "Attachment",
                                 (App::PropertyType)(App::Prop_None),
-                                "Class name of attach engine object driving the attachment.");
+                                "Class name of attach engine object driving the attachment.\n"
+				"Attacher::AttachEngine3D  Attacher::AttachEnginePlane\n"
+				"Attacher::AttachEngineLine  Attacher::AttachEnginePoint");
     this->AttacherType.setStatus(App::Property::Status::Hidden, true);
 
     EXTENSION_ADD_PROPERTY_TYPE(


### PR DESCRIPTION
The Attacher Type is a text string, To modify it you need to know the allowed possibilities. This adds it to the tooltip.

See  [https://forum.freecad.org/viewtopic.php?p=761923#p761923](https://forum.freecad.org/viewtopic.php?p=761923#p761923)