### PR TITLE
[BIM] fix BimView Qt6 Support

### DIFF
--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -23,8 +23,10 @@
 """The BIM Views command"""
 
 import sys
-import FreeCAD
+
 import FreeCADGui
+
+import FreeCAD
 
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 translate = FreeCAD.Qt.translate
@@ -82,13 +84,18 @@ class BIM_Views:
             toolbar = QtGui.QToolBar()
             toolbar.setIconSize(QtCore.QSize(size, size))
             dialog.horizontalLayout.addWidget(toolbar)
-            for button in ["AddLevel","AddProxy",
-                           "Delete","Toggle",
-                           "Isolate","SaveView",
-                           "Rename",]:
+            for button in [
+                "AddLevel",
+                "AddProxy",
+                "Delete",
+                "Toggle",
+                "Isolate",
+                "SaveView",
+                "Rename",
+            ]:
                 action = QtGui.QAction()
                 toolbar.addAction(action)
-                setattr(dialog,"button"+button, action)
+                setattr(dialog, "button" + button, action)
 
             # # set button icons
             dialog.buttonAddLevel.setIcon(QtGui.QIcon(":/icons/Arch_Floor_Tree.svg"))
@@ -100,15 +107,29 @@ class BIM_Views:
             dialog.buttonRename.setIcon(
                 QtGui.QIcon(":/icons/accessories-text-editor.svg")
             )
-            
+
             # set tooltips
-            dialog.buttonAddLevel.setToolTip(translate("BIM","Creates a new level"))
-            dialog.buttonAddProxy.setToolTip(translate("BIM","Creates a new Working Plane Proxy"))
-            dialog.buttonDelete.setToolTip(translate("BIM","Deletes the selected item"))
-            dialog.buttonToggle.setToolTip(translate("BIM","Toggles selected items on/off"))
-            dialog.buttonIsolate.setToolTip(translate("BIM","Turns all items off except the selected ones"))
-            dialog.buttonSaveView.setToolTip(translate("BIM","Saves the current camera position to the selected items"))
-            dialog.buttonRename.setToolTip(translate("BIM","Renames the selected item"))
+            dialog.buttonAddLevel.setToolTip(translate("BIM", "Creates a new level"))
+            dialog.buttonAddProxy.setToolTip(
+                translate("BIM", "Creates a new Working Plane Proxy")
+            )
+            dialog.buttonDelete.setToolTip(
+                translate("BIM", "Deletes the selected item")
+            )
+            dialog.buttonToggle.setToolTip(
+                translate("BIM", "Toggles selected items on/off")
+            )
+            dialog.buttonIsolate.setToolTip(
+                translate("BIM", "Turns all items off except the selected ones")
+            )
+            dialog.buttonSaveView.setToolTip(
+                translate(
+                    "BIM", "Saves the current camera position to the selected items"
+                )
+            )
+            dialog.buttonRename.setToolTip(
+                translate("BIM", "Renames the selected item")
+            )
 
             # connect signals
             dialog.buttonAddLevel.triggered.connect(self.addLevel)
@@ -169,7 +190,7 @@ class BIM_Views:
 
         vm = findWidget()
         if vm and FreeCAD.ActiveDocument:
-            if vm.isVisible() and (vm.tree.state() != vm.tree.EditingState):
+            if vm.isVisible() and (vm.tree.state().name != "EditingState"):
                 vm.tree.clear()
                 import Draft
 
@@ -178,13 +199,28 @@ class BIM_Views:
                 soloProxyHold = []
                 for obj in FreeCAD.ActiveDocument.Objects:
                     t = Draft.getType(obj)
-                    if obj and (t in ["Building", "BuildingPart", "IfcBuilding", "IfcBuildingStorey"]):
-                        if t in ["Building", "IfcBuilding"] or getattr(obj, "IfcType", "") == "Building":
+                    if obj and (
+                        t
+                        in [
+                            "Building",
+                            "BuildingPart",
+                            "IfcBuilding",
+                            "IfcBuildingStorey",
+                        ]
+                    ):
+                        if (
+                            t in ["Building", "IfcBuilding"]
+                            or getattr(obj, "IfcType", "") == "Building"
+                        ):
                             building, _ = getTreeViewItem(obj)
                             subObjs = obj.Group
                             # find every levels belongs to the building
                             for subObj in subObjs:
-                                if Draft.getType(subObj) in ["BuildingPart", "Building Storey", "IfcBuildingStorey"]:
+                                if Draft.getType(subObj) in [
+                                    "BuildingPart",
+                                    "Building Storey",
+                                    "IfcBuildingStorey",
+                                ]:
                                     lv, lvH = getTreeViewItem(subObj)
                                     subSubObjs = subObj.Group
                                     # find every working plane proxy belongs to the level
@@ -203,8 +239,15 @@ class BIM_Views:
                             treeViewItems.append(building)
                             lvHold.clear()
 
-                        if t in ["Building Storey", "IfcBuildingStorey"] or getattr(obj, "IfcType", "") == "Building Storey":
-                            if Draft.getType(getParent(obj)) in ["Building", "IfcBuilding"] or getattr(getParent(obj), "IfcType", "") == "Building":
+                        if (
+                            t in ["Building Storey", "IfcBuildingStorey"]
+                            or getattr(obj, "IfcType", "") == "Building Storey"
+                        ):
+                            if (
+                                Draft.getType(getParent(obj))
+                                in ["Building", "IfcBuilding"]
+                                or getattr(getParent(obj), "IfcType", "") == "Building"
+                            ):
                                 continue
                             lv, lvH = getTreeViewItem(obj)
                             subObjs = obj.Group
@@ -442,7 +485,7 @@ def getTreeViewItem(obj):
             lvHStr = FreeCAD.Units.Quantity(
                 obj.Elevation, FreeCAD.Units.Length
             ).UserString
-    lvH = round(float(lvHStr.replace(",",".").split(" ")[0]), 2)
+    lvH = round(float(lvHStr.replace(",", ".").split(" ")[0]), 2)
     it = QtGui.QTreeWidgetItem([obj.Label, lvHStr])
     it.setFlags(it.flags() | QtCore.Qt.ItemIsEditable)
     it.setToolTip(0, obj.Name)

--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -190,7 +190,7 @@ class BIM_Views:
 
         vm = findWidget()
         if vm and FreeCAD.ActiveDocument:
-            if vm.isVisible() and (vm.tree.state().name != "EditingState"):
+            if vm.isVisible() and (vm.tree.state() != vm.tree.State.EditingState):
                 vm.tree.clear()
                 import Draft
 


### PR DESCRIPTION
when I compile in Qt6
it appears the error below:
```
10:37:43  Traceback (most recent call last):
10:37:43    File "/home/***/Documents/Project/FreeCAD/build/Mod/BIM/bimcommands/BimViews.py", line 172, in update
10:37:43      if vm.isVisible() and (vm.tree.state() != vm.tree.EditingState):
10:37:43                                                ^^^^^^^^^^^^^^^^^^^^
10:37:43  AttributeError: 'PySide6.QtWidgets.QTreeWidget' object has no attribute 'EditingState'
```
in PySide6
EditingState is under `PySide6.QtWidgets.QtreeWidget.State.EditingState`
so just  need to change to vm.tree.State.EditingState
and I think this is also work at PySide2 when compile in Qt5  as well
