### PR TITLE
UI: Add Std_AlignToSelevtion to menu bar and context menu

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1229,6 +1229,7 @@ QMenu* NaviCubeImplementation::createNaviCubeMenu() {
         commands.emplace_back("Separator");
         commands.emplace_back("Std_ViewFitAll");
         commands.emplace_back("Std_ViewFitSelection");
+        commands.emplace_back("Std_AlignToSelection");
         commands.emplace_back("Separator");
         commands.emplace_back("NaviCubeDraggableCmd");
     }

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -590,7 +590,7 @@ void StdWorkbench::setupContextMenu(const char* recipient, MenuItem* item) const
                   << "Std_ViewRear" << "Std_ViewBottom" << "Std_ViewLeft"
                   << "Separator" << "Std_ViewRotateLeft" << "Std_ViewRotateRight";
 
-        *item << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_DrawStyle"
+        *item << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_AlignToSelection" << "Std_DrawStyle"
               << StdViews << "Separator"
               << "Std_ViewDockUndockFullscreen";
 
@@ -654,12 +654,11 @@ MenuItem* StdWorkbench::setupMenuBar() const
     // Standard views
     auto stdviews = new MenuItem;
     stdviews->setCommand("Standard views");
-    *stdviews << "Std_ViewFitAll" << "Std_ViewFitSelection" << axoviews
+    *stdviews << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_AlignToSelection" << axoviews
               << "Separator" << "Std_ViewHome" << "Std_ViewFront" << "Std_ViewTop"
-              << "Std_ViewRight" << "Std_ViewRear"
-              << "Std_ViewBottom" << "Std_ViewLeft"
-              << "Separator" << "Std_ViewRotateLeft" << "Std_ViewRotateRight"
-              << "Separator" << "Std_StoreWorkingView" << "Std_RecallWorkingView";
+              << "Std_ViewRight" << "Std_ViewRear" << "Std_ViewBottom" << "Std_ViewLeft"
+              << "Separator" << "Std_ViewRotateLeft" << "Std_ViewRotateRight" << "Separator"
+              << "Std_StoreWorkingView" << "Std_RecallWorkingView";
 
     // stereo
     auto view3d = new MenuItem;


### PR DESCRIPTION
Adding the new command to align the view to the selection (currently only available in the toolbar) to the menu and context menu.
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/e50e1c15-1d2a-4825-a643-bef0596d55f6)

![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/b4fea825-619b-43c2-9391-77dfb37225e2)
