### PR TITLE
UI: Change splashscreen text color to the new FreeCAD blue

### DIFF
--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -172,8 +172,8 @@ int main(int argc, char** argv)
     App::Application::Config()["StartWorkbench"] = "PartDesignWorkbench";
     // App::Application::Config()["HiddenDockWindow"] = "Property editor";
     App::Application::Config()["SplashAlignment"] = "Bottom|Left";
-    App::Application::Config()["SplashTextColor"] = "#8aadf4";  // light blue
-    App::Application::Config()["SplashInfoColor"] = "#8aadf4";  // light blue
+    App::Application::Config()["SplashTextColor"] = "#418FDE";
+    App::Application::Config()["SplashInfoColor"] = "#418FDE";
     App::Application::Config()["SplashInfoPosition"] = "6,75";
 
     QGuiApplication::setDesktopFileName(QStringLiteral("org.freecad.FreeCAD"));


### PR DESCRIPTION
Changing the splashscreen text color from an arbitrary light blue to the new FreeCAD primary blue according to the guideline.
I'm sure there will be a new splash screen image for 1.0 but this changes just the text color so we won't forget. If needed, it can be changed with a different image if it should not fit the chosen image.
@FreeCAD/design-working-group FYI

New:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/7e7b7393-af65-480b-ac27-81f5435ecf61)
