### PR TITLE
Fix visibility icon for link elements

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1622,12 +1622,25 @@ void TreeWidget::mousePressEvent(QMouseEvent* event)
 
             // If the visibility icon was clicked, toggle the DocumentObject visibility
             if (iconRect.contains(mousePos)) {
-                auto vp = objitem->object();
-                if (vp->isShow()) {
-                    vp->hide();
-                } else {
-                    vp->show();
+                auto obj = objitem->object()->getObject();
+                char const* objname = obj->getNameInDocument();
+
+                App::DocumentObject* parent = nullptr;
+                std::ostringstream subName;
+                objitem->getSubName(subName, parent);
+
+                // Try the ElementVisible API, if that is not supported toggle the Visibility property
+                int visible = -1;
+                if (parent) {
+                    visible = parent->isElementVisible(objname);
                 }
+                if (parent && visible >= 0) {
+                    parent->setElementVisible(objname, !visible);
+                } else {
+                    visible = obj->Visibility.getValue();
+                    obj->Visibility.setValue(!visible);
+                }
+
                 event->setAccepted(true);
                 return;
             }


### PR DESCRIPTION
The visibility of link elements must be set with setElementVisible. This will first try to use that API otherwise it falls back to setting the Visibility property.

This seems to work, but I'm not sure if this is correct. I don't understand when to use `setElementVisible` and what the interactions are with sub elements and such. 

Fixes #14064