### PR TITLE
TechDraw: Smart dimension: Fix initial selection handling.

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -967,12 +967,10 @@ protected:
     void makeCts_1Circle(bool& selAllowed)
     {
         if (availableDimension == AvailableDimension::FIRST) {
-            restartCommand(QT_TRANSLATE_NOOP("Command", "Add Radius dimension"));
             createRadiusDiameterDimension(selCircleArc[0], true);
             selAllowed = true;
         }
         if (availableDimension == AvailableDimension::SECOND) {
-            restartCommand(QT_TRANSLATE_NOOP("Command", "Add Radius dimension"));
             createRadiusDiameterDimension(selCircleArc[0], false);
             if (selCircleArc[0].geomEdgeType() != TechDraw::ARCOFCIRCLE) {
                 availableDimension = AvailableDimension::RESET;
@@ -1003,12 +1001,10 @@ protected:
     void makeCts_1Ellipse(bool& selAllowed)
     {
         if (availableDimension == AvailableDimension::FIRST) {
-            restartCommand(QT_TRANSLATE_NOOP("Command", "Add Radius dimension"));
             createRadiusDiameterDimension(selEllipseArc[0], true);
             selAllowed = true;
         }
         if (availableDimension == AvailableDimension::SECOND) {
-            restartCommand(QT_TRANSLATE_NOOP("Command", "Add Radius dimension"));
             createRadiusDiameterDimension(selEllipseArc[0], false);
             if (selEllipseArc[0].geomEdgeType() != TechDraw::ARCOFELLIPSE) {
                 availableDimension = AvailableDimension::RESET;
@@ -1067,11 +1063,9 @@ protected:
     }
 
     void createRadiusDiameterDimension(ReferenceEntry ref, bool firstCstr) {
-        bool isCircleGeom = true;
-
         int GeoId(TechDraw::DrawUtil::getIndexFromName(ref.getSubName()));
         TechDraw::BaseGeomPtr geom = partFeat->getGeomByIndex(GeoId);
-        isCircleGeom = (geom->getGeomType() == TechDraw::CIRCLE) || (geom->getGeomType() == TechDraw::ELLIPSE);
+        bool isCircleGeom = (geom->getGeomType() == TechDraw::CIRCLE) || (geom->getGeomType() == TechDraw::ELLIPSE);
 
         // Use same preference as in sketcher?
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/TechDraw/dimensioning");
@@ -1083,9 +1077,11 @@ protected:
             (!firstCstr && !dimensioningRadius && dimensioningDiameter) ||
             (firstCstr && dimensioningRadius && dimensioningDiameter && !isCircleGeom) ||
             (!firstCstr && dimensioningRadius && dimensioningDiameter && isCircleGeom)) {
+            restartCommand(QT_TRANSLATE_NOOP("Command", "Add Radius dimension"));
             dim = dimMaker(partFeat, "Radius", { ref }, {});
         }
         else {
+            restartCommand(QT_TRANSLATE_NOOP("Command", "Add Diameter dimension"));
             dim = dimMaker(partFeat, "Diameter", { ref }, {});
         }
 

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -34,6 +34,7 @@
 #include <QPixmap>
 #endif//#ifndef _PreComp_
 
+#include <App/AutoTransaction.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <Base/Console.h>
@@ -1405,11 +1406,13 @@ CmdTechDrawDimension::CmdTechDrawDimension()
     sStatusTip = sToolTipText;
     sPixmap = "TechDraw_Dimension";
     sAccel = "D";
+    eType = ForEdit;
 }
 
 void CmdTechDrawDimension::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+    App::AutoTransaction::setEnable(false);
 
     ReferenceVector references2d;
     ReferenceVector references3d;

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -1404,6 +1404,7 @@ CmdTechDrawDimension::CmdTechDrawDimension()
     sWhatsThis = "TechDraw_Dimension";
     sStatusTip = sToolTipText;
     sPixmap = "TechDraw_Dimension";
+    sAccel = "D";
 }
 
 void CmdTechDrawDimension::activated(int iMsg)
@@ -1491,8 +1492,6 @@ CmdTechDrawRadiusDimension::CmdTechDrawRadiusDimension()
     sWhatsThis = "TechDraw_RadiusDimension";
     sStatusTip = sToolTipText;
     sPixmap = "TechDraw_RadiusDimension";
-    sAccel = "D";
-    eType = ForEdit;
 }
 
 void CmdTechDrawRadiusDimension::activated(int iMsg)

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -291,12 +291,6 @@ void QGVPage::activateHandler(TechDrawHandler* newHandler)
 
     toolHandler = std::unique_ptr<TechDrawHandler>(newHandler);
     toolHandler->activate(this);
-
-    // make sure receiver has focus so immediately pressing Escape will be handled by
-    // ViewProviderSketch::keyPressed() and dismiss the active handler, and not the entire
-    // sketcher editor
-    //Gui::MDIView* mdi = Gui::Application::Instance->activeDocument()->getActiveView();
-    //mdi->setFocus();
 }
 
 void QGVPage::deactivateHandler()


### PR DESCRIPTION
- Fixes https://github.com/FreeCAD/FreeCAD/issues/14328 : initial selection handling
- fix D shortcut that was wrongly assigned to radius.
- fix radius/diameter command names (it was always named 'radius')
- Remove some useless leftover comments