### PR TITLE
CAM: Rename CW/CCW to Climb/Conventional for consistency

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageOpDeburrEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpDeburrEdit.ui
@@ -1,422 +1,422 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>350</width>
-    <height>450</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string notr="true">Form</string>
-  </property>
-  <layout class="QGridLayout" name="gridLayout_4">
-   <item row="0" column="0">
-    <widget class="QFrame" name="frame">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+    <class>Form</class>
+    <widget class="QWidget" name="Form">
+        <property name="geometry">
+            <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>350</width>
+                <height>450</height>
+            </rect>
         </property>
-        <property name="minimumSize">
-         <size>
-          <width>125</width>
-          <height>0</height>
-         </size>
+        <property name="windowTitle">
+            <string notr="true">Form</string>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>125</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Coolant Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+        <layout class="QGridLayout" name="gridLayout_4">
+            <item row="0" column="0">
+                <widget class="QFrame" name="frame">
+                    <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                        </sizepolicy>
+                    </property>
+                    <property name="frameShape">
+                        <enum>QFrame::StyledPanel</enum>
+                    </property>
+                    <property name="frameShadow">
+                        <enum>QFrame::Raised</enum>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_2">
+                        <item row="1" column="0">
+                            <widget class="QLabel" name="label">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                    <size>
+                                        <width>125</width>
+                                        <height>0</height>
+                                    </size>
+                                </property>
+                                <property name="maximumSize">
+                                    <size>
+                                        <width>16777215</width>
+                                        <height>16777215</height>
+                                    </size>
+                                </property>
+                                <property name="text">
+                                    <string>Tool Controller</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="1" column="1">
+                            <widget class="QComboBox" name="toolController">
+                                <property name="toolTip">
+                                    <string>The tool and its settings to be used for this operation.</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="2" column="0">
+                            <widget class="QLabel" name="label_5">
+                                <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                                        <horstretch>0</horstretch>
+                                        <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                </property>
+                                <property name="minimumSize">
+                                    <size>
+                                        <width>125</width>
+                                        <height>0</height>
+                                    </size>
+                                </property>
+                                <property name="maximumSize">
+                                    <size>
+                                        <width>16777215</width>
+                                        <height>16777215</height>
+                                    </size>
+                                </property>
+                                <property name="text">
+                                    <string>Coolant Mode</string>
+                                </property>
+                            </widget>
+                        </item>
+                        <item row="2" column="1">
+                            <widget class="QComboBox" name="coolantController">
+                                <property name="toolTip">
+                                    <string>The tool and its settings to be used for this operation.</string>
+                                </property>
+                            </widget>
+                        </item>
+                    </layout>
+                </widget>
+            </item>
+            <item row="1" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_5">
+                    <property name="spacing">
+                        <number>6</number>
+                    </property>
+                    <property name="leftMargin">
+                        <number>12</number>
+                    </property>
+                    <property name="rightMargin">
+                        <number>12</number>
+                    </property>
+                    <item>
+                        <widget class="QLabel" name="direction_label">
+                            <property name="sizePolicy">
+                                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                                    <horstretch>0</horstretch>
+                                    <verstretch>0</verstretch>
+                                </sizepolicy>
+                            </property>
+                            <property name="minimumSize">
+                                <size>
+                                    <width>125</width>
+                                    <height>0</height>
+                                </size>
+                            </property>
+                            <property name="maximumSize">
+                                <size>
+                                    <width>16777215</width>
+                                    <height>16777215</height>
+                                </size>
+                            </property>
+                            <property name="text">
+                                <string>Direction</string>
+                            </property>
+                        </widget>
+                    </item>
+                    <item>
+                        <widget class="QComboBox" name="direction">
+                            <property name="toolTip">
+                                <string>The direction in which the profile is performed, clockwise or counterclockwise.</string>
+                            </property>
+                            <property name="currentText">
+                                <string>Climb</string>
+                            </property>
+                            <property name="currentIndex">
+                                <number>0</number>
+                            </property>
+                            <item>
+                                <property name="text">
+                                    <string>Climb</string>
+                                </property>
+                            </item>
+                            <item>
+                                <property name="text">
+                                    <string>Conventional</string>
+                                </property>
+                            </item>
+                        </widget>
+                    </item>
+                </layout>
+            </item>
+            <item row="2" column="0">
+                <layout class="QHBoxLayout" name="horizontalLayout_4">
+                    <item>
+                        <widget class="QWidget" name="widget">
+                            <property name="minimumSize">
+                                <size>
+                                    <width>125</width>
+                                    <height>0</height>
+                                </size>
+                            </property>
+                            <property name="maximumSize">
+                                <size>
+                                    <width>16777215</width>
+                                    <height>16777215</height>
+                                </size>
+                            </property>
+                            <layout class="QGridLayout" name="gridLayout_5">
+                                <item row="0" column="0" colspan="2">
+                                    <layout class="QHBoxLayout" name="horizontalLayout">
+                                        <item>
+                                            <widget class="QLabel" name="label_3">
+                                                <property name="minimumSize">
+                                                    <size>
+                                                        <width>50</width>
+                                                        <height>0</height>
+                                                    </size>
+                                                </property>
+                                                <property name="text">
+                                                    <string notr="true">W =</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                        <item>
+                                            <widget class="Gui::InputField" name="value_W">
+                                                <property name="toolTip">
+                                                    <string>Width of chamfer cut.</string>
+                                                </property>
+                                                <property name="unit" stdset="0">
+                                                    <string>mm</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                    </layout>
+                                </item>
+                                <item row="1" column="0" colspan="2">
+                                    <layout class="QHBoxLayout" name="horizontalLayout_2">
+                                        <item>
+                                            <widget class="QLabel" name="label_4">
+                                                <property name="minimumSize">
+                                                    <size>
+                                                        <width>50</width>
+                                                        <height>0</height>
+                                                    </size>
+                                                </property>
+                                                <property name="text">
+                                                    <string notr="true">h = </string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                        <item>
+                                            <widget class="Gui::InputField" name="value_h">
+                                                <property name="toolTip">
+                                                    <string>Extra depth of tool immersion.</string>
+                                                </property>
+                                                <property name="unit" stdset="0">
+                                                    <string>mm</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                    </layout>
+                                </item>
+                                <item row="2" column="0">
+                                    <spacer name="verticalSpacer_3">
+                                        <property name="orientation">
+                                            <enum>Qt::Vertical</enum>
+                                        </property>
+                                        <property name="sizeType">
+                                            <enum>QSizePolicy::Fixed</enum>
+                                        </property>
+                                        <property name="sizeHint" stdset="0">
+                                            <size>
+                                                <width>20</width>
+                                                <height>13</height>
+                                            </size>
+                                        </property>
+                                    </spacer>
+                                </item>
+                                <item row="3" column="0" colspan="2">
+                                    <widget class="QFrame" name="joinFrame">
+                                        <property name="frameShape">
+                                            <enum>QFrame::StyledPanel</enum>
+                                        </property>
+                                        <property name="frameShadow">
+                                            <enum>QFrame::Raised</enum>
+                                        </property>
+                                        <layout class="QGridLayout" name="gridLayout">
+                                            <property name="leftMargin">
+                                                <number>0</number>
+                                            </property>
+                                            <property name="topMargin">
+                                                <number>6</number>
+                                            </property>
+                                            <property name="rightMargin">
+                                                <number>0</number>
+                                            </property>
+                                            <property name="bottomMargin">
+                                                <number>3</number>
+                                            </property>
+                                            <property name="horizontalSpacing">
+                                                <number>3</number>
+                                            </property>
+                                            <item row="0" column="0">
+                                                <layout class="QHBoxLayout" name="horizontalLayout_3">
+                                                    <item>
+                                                        <widget class="QLabel" name="label_2">
+                                                            <property name="minimumSize">
+                                                                <size>
+                                                                    <width>50</width>
+                                                                    <height>0</height>
+                                                                </size>
+                                                            </property>
+                                                            <property name="text">
+                                                                <string>Join:</string>
+                                                            </property>
+                                                        </widget>
+                                                    </item>
+                                                    <item>
+                                                        <widget class="QToolButton" name="joinRound">
+                                                            <property name="toolTip">
+                                                                <string>Round joint</string>
+                                                            </property>
+                                                            <property name="text">
+                                                                <string/>
+                                                            </property>
+                                                            <property name="checkable">
+                                                                <bool>true</bool>
+                                                            </property>
+                                                            <property name="checked">
+                                                                <bool>true</bool>
+                                                            </property>
+                                                            <property name="autoExclusive">
+                                                                <bool>true</bool>
+                                                            </property>
+                                                        </widget>
+                                                    </item>
+                                                    <item>
+                                                        <widget class="QToolButton" name="joinMiter">
+                                                            <property name="toolTip">
+                                                                <string>Miter joint</string>
+                                                            </property>
+                                                            <property name="text">
+                                                                <string/>
+                                                            </property>
+                                                            <property name="checkable">
+                                                                <bool>true</bool>
+                                                            </property>
+                                                            <property name="autoExclusive">
+                                                                <bool>true</bool>
+                                                            </property>
+                                                        </widget>
+                                                    </item>
+                                                    <item>
+                                                        <spacer name="horizontalSpacer">
+                                                            <property name="orientation">
+                                                                <enum>Qt::Horizontal</enum>
+                                                            </property>
+                                                            <property name="sizeHint" stdset="0">
+                                                                <size>
+                                                                    <width>40</width>
+                                                                    <height>20</height>
+                                                                </size>
+                                                            </property>
+                                                        </spacer>
+                                                    </item>
+                                                </layout>
+                                            </item>
+                                        </layout>
+                                    </widget>
+                                </item>
+                                <item row="4" column="1">
+                                    <spacer name="verticalSpacer_2">
+                                        <property name="orientation">
+                                            <enum>Qt::Vertical</enum>
+                                        </property>
+                                        <property name="sizeHint" stdset="0">
+                                            <size>
+                                                <width>20</width>
+                                                <height>154</height>
+                                            </size>
+                                        </property>
+                                    </spacer>
+                                </item>
+                            </layout>
+                        </widget>
+                    </item>
+                    <item>
+                        <widget class="QWidget" name="widget_2">
+                            <layout class="QGridLayout" name="gridLayout_3">
+                                <item row="0" column="0">
+                                    <layout class="QVBoxLayout" name="verticalLayout_2">
+                                        <item>
+                                            <widget class="QLabel" name="opImage">
+                                                <property name="sizePolicy">
+                                                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                                                        <horstretch>0</horstretch>
+                                                        <verstretch>0</verstretch>
+                                                    </sizepolicy>
+                                                </property>
+                                                <property name="minimumSize">
+                                                    <size>
+                                                        <width>150</width>
+                                                        <height>150</height>
+                                                    </size>
+                                                </property>
+                                                <property name="maximumSize">
+                                                    <size>
+                                                        <width>150</width>
+                                                        <height>150</height>
+                                                    </size>
+                                                </property>
+                                                <property name="text">
+                                                    <string>TextLabel</string>
+                                                </property>
+                                                <property name="scaledContents">
+                                                    <bool>true</bool>
+                                                </property>
+                                                <property name="alignment">
+                                                    <set>Qt::AlignCenter</set>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                        <item>
+                                            <spacer name="verticalSpacer">
+                                                <property name="orientation">
+                                                    <enum>Qt::Vertical</enum>
+                                                </property>
+                                                <property name="sizeHint" stdset="0">
+                                                    <size>
+                                                        <width>20</width>
+                                                        <height>40</height>
+                                                    </size>
+                                                </property>
+                                            </spacer>
+                                        </item>
+                                    </layout>
+                                </item>
+                            </layout>
+                        </widget>
+                    </item>
+                </layout>
+            </item>
+        </layout>
     </widget>
-   </item>
-   <item row="1" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_5">
-     <property name="spacing">
-      <number>6</number>
-     </property>
-     <property name="leftMargin">
-      <number>12</number>
-     </property>
-     <property name="rightMargin">
-      <number>12</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="direction_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>125</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Direction</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="direction">
-       <property name="toolTip">
-        <string>The direction in which the profile is performed, clockwise or counterclockwise.</string>
-       </property>
-       <property name="currentText">
-        <string>CW</string>
-       </property>
-       <property name="currentIndex">
-        <number>0</number>
-       </property>
-       <item>
-        <property name="text">
-         <string>CW</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>CCW</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QWidget" name="widget">
-       <property name="minimumSize">
-        <size>
-         <width>125</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_5">
-        <item row="0" column="0" colspan="2">
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QLabel" name="label_3">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string notr="true">W =</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="Gui::InputField" name="value_W">
-            <property name="toolTip">
-             <string>Width of chamfer cut.</string>
-            </property>
-            <property name="unit" stdset="0">
-             <string>mm</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="0" colspan="2">
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <item>
-           <widget class="QLabel" name="label_4">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string notr="true">h = </string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="Gui::InputField" name="value_h">
-            <property name="toolTip">
-             <string>Extra depth of tool immersion.</string>
-            </property>
-            <property name="unit" stdset="0">
-             <string>mm</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="2" column="0">
-         <spacer name="verticalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>13</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="3" column="0" colspan="2">
-         <widget class="QFrame" name="joinFrame">
-          <property name="frameShape">
-           <enum>QFrame::StyledPanel</enum>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Raised</enum>
-          </property>
-          <layout class="QGridLayout" name="gridLayout">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>6</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>3</number>
-           </property>
-           <property name="horizontalSpacing">
-            <number>3</number>
-           </property>
-           <item row="0" column="0">
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
-             <item>
-              <widget class="QLabel" name="label_2">
-               <property name="minimumSize">
-                <size>
-                 <width>50</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>Join:</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QToolButton" name="joinRound">
-               <property name="toolTip">
-                <string>Round joint</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-               <property name="autoExclusive">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QToolButton" name="joinMiter">
-               <property name="toolTip">
-                <string>Miter joint</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="checkable">
-                <bool>true</bool>
-               </property>
-               <property name="autoExclusive">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <spacer name="verticalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>154</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QWidget" name="widget_2">
-       <layout class="QGridLayout" name="gridLayout_3">
-        <item row="0" column="0">
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <widget class="QLabel" name="opImage">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>150</width>
-              <height>150</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>150</width>
-              <height>150</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>TextLabel</string>
-            </property>
-            <property name="scaledContents">
-             <bool>true</bool>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
-   </item>
-  </layout>
- </widget>
- <customwidgets>
-  <customwidget>
-   <class>Gui::InputField</class>
-   <extends>QLineEdit</extends>
-   <header>Gui/InputField.h</header>
-  </customwidget>
- </customwidgets>
- <resources/>
- <connections/>
+    <customwidgets>
+        <customwidget>
+            <class>Gui::InputField</class>
+            <extends>QLineEdit</extends>
+            <header>Gui/InputField.h</header>
+        </customwidget>
+    </customwidgets>
+    <resources/>
+    <connections/>
 </ui>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
@@ -1,175 +1,175 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Form</class>
- <widget class="QWidget" name="Form">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>365</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string notr="true">Form</string>
-  </property>
-  <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0">
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
+  <class>Form</class>
+  <widget class="QWidget" name="Form">
+    <property name="geometry">
+      <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>400</width>
+        <height>365</height>
+      </rect>
+    </property>
+    <property name="windowTitle">
+      <string notr="true">Form</string>
+    </property>
+    <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Tool Controller</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="toolController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
-        </property>
-       </widget>
+        <widget class="QFrame" name="frame">
+          <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+            <item row="0" column="0">
+              <widget class="QLabel" name="label">
+                <property name="text">
+                  <string>Tool Controller</string>
+                </property>
+              </widget>
+            </item>
+            <item row="0" column="1">
+              <widget class="QComboBox" name="toolController">
+                <property name="toolTip">
+                  <string>The tool and its settings to be used for this operation.</string>
+                </property>
+              </widget>
+            </item>
+            <item row="1" column="0">
+              <widget class="QLabel" name="label_5">
+                <property name="text">
+                  <string>Coolant</string>
+                </property>
+              </widget>
+            </item>
+            <item row="1" column="1">
+              <widget class="QComboBox" name="coolantController">
+                <property name="toolTip">
+                  <string>The tool and its settings to be used for this operation.</string>
+                </property>
+              </widget>
+            </item>
+          </layout>
+        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Coolant</string>
-        </property>
-       </widget>
+        <widget class="QWidget" name="widget">
+          <layout class="QFormLayout" name="formLayout">
+            <item row="0" column="0">
+              <widget class="QLabel" name="label_2">
+                <property name="text">
+                  <string>Start from</string>
+                </property>
+              </widget>
+            </item>
+            <item row="0" column="1">
+              <widget class="QComboBox" name="startSide">
+                <property name="toolTip">
+                  <string>Specify if the helix operation should start at the inside and work its way outwards, or start at the outside and work its way to the center.</string>
+                </property>
+                <item>
+                  <property name="text">
+                    <string>Inside</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Outside</string>
+                  </property>
+                </item>
+              </widget>
+            </item>
+            <item row="2" column="0">
+              <widget class="QLabel" name="label_3">
+                <property name="text">
+                  <string>Direction</string>
+                </property>
+              </widget>
+            </item>
+            <item row="2" column="1">
+              <widget class="QComboBox" name="direction">
+                <property name="toolTip">
+                  <string>The direction for the helix, clockwise or counterclockwise.</string>
+                </property>
+                <item>
+                  <property name="text">
+                    <string>Climb</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Conventional</string>
+                  </property>
+                </item>
+              </widget>
+            </item>
+            <item row="4" column="0">
+              <widget class="QLabel" name="label_4">
+                <property name="text">
+                  <string>Step over percent</string>
+                </property>
+              </widget>
+            </item>
+            <item row="4" column="1">
+              <widget class="QSpinBox" name="stepOverPercent">
+                <property name="toolTip">
+                  <string>Specify the percent of the tool diameter each helix will be offset to the previous one. A step over of 100% means no overlap of the individual cuts.</string>
+                </property>
+                <property name="minimum">
+                  <number>1</number>
+                </property>
+                <property name="maximum">
+                  <number>100</number>
+                </property>
+                <property name="singleStep">
+                  <number>10</number>
+                </property>
+                <property name="value">
+                  <number>100</number>
+                </property>
+              </widget>
+            </item>
+            <item row="5" column="0">
+              <widget class="QLabel" name="label_6">
+                <property name="text">
+                  <string>Extra Offset</string>
+                </property>
+              </widget>
+            </item>
+            <item row="5" column="1">
+              <widget class="Gui::InputField" name="extraOffset">
+                <property name="unit" stdset="0">
+                  <string notr="true"/>
+                </property>
+              </widget>
+            </item>
+          </layout>
+        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="coolantController">
-        <property name="toolTip">
-         <string>The tool and its settings to be used for this operation.</string>
-        </property>
-       </widget>
+      <item row="3" column="0">
+        <spacer name="verticalSpacer">
+          <property name="orientation">
+            <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+            <size>
+              <width>20</width>
+              <height>40</height>
+            </size>
+          </property>
+        </spacer>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QWidget" name="widget">
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Start from</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="startSide">
-        <property name="toolTip">
-         <string>Specify if the helix operation should start at the inside and work its way outwards, or start at the outside and work its way to the center.</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Inside</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Outside</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Direction</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="direction">
-        <property name="toolTip">
-         <string>The direction for the helix, clockwise or counterclockwise.</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>CW</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>CCW</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Step over percent</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QSpinBox" name="stepOverPercent">
-        <property name="toolTip">
-         <string>Specify the percent of the tool diameter each helix will be offset to the previous one. A step over of 100% means no overlap of the individual cuts.</string>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="singleStep">
-         <number>10</number>
-        </property>
-        <property name="value">
-         <number>100</number>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Extra Offset</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="Gui::InputField" name="extraOffset">
-        <property name="unit" stdset="0">
-         <string notr="true"/>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-  <item row="3" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   </layout>
- </widget>
- <customwidgets>
-  <customwidget>
-   <class>Gui::InputField</class>
-   <extends>QLineEdit</extends>
-   <header>Gui/InputField.h</header>
-  </customwidget>
- </customwidgets>
- <resources/>
- <connections/>
+    </layout>
+  </widget>
+  <customwidgets>
+    <customwidget>
+      <class>Gui::InputField</class>
+      <extends>QLineEdit</extends>
+      <header>Gui/InputField.h</header>
+    </customwidget>
+  </customwidgets>
+  <resources/>
+  <connections/>
 </ui>

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -45,7 +45,7 @@ def generate(
     step_over,
     tool_diameter,
     inner_radius=0.0,
-    direction="CW",
+    direction="Climb",
     startAt="Outside",
 ):
     """generate(edge, hole_radius, inner_radius, step_over) ... generate helix commands.
@@ -96,7 +96,7 @@ def generate(
     elif startAt not in ["Inside", "Outside"]:
         raise ValueError("Invalid value for parameter 'startAt'")
 
-    elif direction not in ["CW", "CCW"]:
+    elif direction not in ["Climb", "Conventional"]:
         raise ValueError("Invalid value for parameter 'direction'")
 
     if type(step_over) not in [float, int]:
@@ -145,7 +145,7 @@ def generate(
 
     def helix_cut_r(r):
         commandlist = []
-        arc_cmd = "G2" if direction == "CW" else "G3"
+        arc_cmd = "G2" if direction == "Climb" else "G3"
         commandlist.append(
             Path.Command("G0", {"X": startPoint.x + r, "Y": startPoint.y})
         )

--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -182,12 +182,12 @@ class ObjectDressup:
     def getDirectionOfPath(self, obj):
         op = PathDressup.baseOp(obj.Base)
         side = op.Side if hasattr(op, "Side") else "Inside"
-        direction = op.Direction if hasattr(op, "Direction") else "CCW"
+        direction = op.Direction if hasattr(op, "Direction") else "Conventional"
 
         if side == "Outside":
-            return "left" if direction == "CW" else "right"
+            return "left" if direction == "Climb" else "right"
         else:
-            return "right" if direction == "CW" else "left"
+            return "right" if direction == "Climb" else "left"
 
     def getArcDirection(self, obj):
         direction = self.getDirectionOfPath(obj)
@@ -328,7 +328,7 @@ class ObjectDressup:
             else:  # obj.StyleOff == "Perpendicular"
                 append(self.createStraightMove(obj, end, end + normal))
 
-            extend = obj.ExtendLeadOut.Value 
+            extend = obj.ExtendLeadOut.Value
             if extend != 0:
                 # append extension
                 extendend = end + normal / length * extend

--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -147,10 +147,10 @@ def getAngle(vector):
     return a
 
 
-def diffAngle(a1, a2, direction="CW"):
-    """diffAngle(a1, a2, [direction='CW'])
+def diffAngle(a1, a2, direction="Climb"):
+    """diffAngle(a1, a2, [direction='Climb'])
     Returns the difference between two angles (a1 -> a2) into a given direction."""
-    if direction == "CW":
+    if direction == "Climb":
         while a1 < a2:
             a1 += 2 * math.pi
         a = a1 - a2
@@ -466,7 +466,7 @@ def edgeForCmd(cmd, startPoint):
             cw = True
         else:
             cw = False
-        angle = diffAngle(getAngle(A), getAngle(B), "CW" if cw else "CCW")
+        angle = diffAngle(getAngle(A), getAngle(B), "Climb" if cw else "CCW")
         height = endPoint.z - startPoint.z
         pitch = height * math.fabs(2 * math.pi / angle)
         if angle > 0:

--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -340,7 +340,7 @@ class ObjectOp(PathOp.ObjectOp):
 
                 verts = hWire.Wires[0].Vertexes
                 idx = 0
-                if obj.Direction == "CCW":
+                if obj.Direction == "Conventional":
                     idx = len(verts) - 1
                 x = verts[idx].X
                 y = verts[idx].Y

--- a/src/Mod/CAM/Path/Op/Deburr.py
+++ b/src/Mod/CAM/Path/Op/Deburr.py
@@ -144,7 +144,7 @@ class ObjectDeburr(PathEngraveBase.ObjectOp):
             "Deburr",
             QT_TRANSLATE_NOOP("App::Property", "Direction of toolpath"),
         )
-        # obj.Direction = ["CW", "CCW"]
+        # obj.Direction = ["Climb", "Conventional"]
         obj.addProperty(
             "App::PropertyEnumeration",
             "Side",
@@ -181,8 +181,8 @@ class ObjectDeburr(PathEngraveBase.ObjectOp):
         # Enumeration lists for App::PropertyEnumeration properties
         enums = {
             "Direction": [
-                (translate("Path", "CW"), "CW"),
-                (translate("Path", "CCW"), "CCW"),
+                (translate("Path", "Climb"), "Climb"),
+                (translate("Path", "Conventional"), "Conventional"),
             ],  # this is the direction that the profile runs
             "Join": [
                 (translate("PathDeburr", "Round"), "Round"),
@@ -414,7 +414,7 @@ class ObjectDeburr(PathEngraveBase.ObjectOp):
                     wires.append(wire)
 
         # Set direction of op
-        forward = obj.Direction == "CW"
+        forward = obj.Direction == "Climb"
 
         # Set value of side
         obj.Side = side[0]
@@ -449,7 +449,7 @@ class ObjectDeburr(PathEngraveBase.ObjectOp):
         obj.Join = "Round"
         obj.setExpression("StepDown", "0 mm")
         obj.StepDown = "0 mm"
-        obj.Direction = "CW"
+        obj.Direction = "Climb"
         obj.Side = "Outside"
         obj.EntryPoint = 0
 

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -68,8 +68,8 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         # Enumeration lists for App::PropertyEnumeration properties
         enums = {
             "Direction": [
-                (translate("CAM_Helix", "CW"), "CW"),
-                (translate("CAM_Helix", "CCW"), "CCW"),
+                (translate("CAM_Helix", "Climb"), "Climb"),
+                (translate("CAM_Helix", "Conventional"), "Conventional"),
             ],  # this is the direction that the profile runs
             "StartSide": [
                 (translate("PathProfile", "Outside"), "Outside"),
@@ -105,7 +105,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "Helix Drill",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "The direction of the circular cuts, ClockWise (CW), or CounterClockWise (CCW)",
+                "The direction of the circular cuts, ClockWise (Climb), or CounterClockWise (Conventional)",
             ),
         )
 

--- a/src/Mod/CAM/Path/Op/PocketBase.py
+++ b/src/Mod/CAM/Path/Op/PocketBase.py
@@ -124,7 +124,7 @@ class ObjectPocket(PathAreaOp.ObjectOp):
             "Pocket",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "The direction that the toolpath should go around the part ClockWise (CW) or CounterClockWise (CCW)",
+                "The direction that the toolpath should go around the part ClockWise (Climb) or CounterClockWise (Conventional)",
             ),
         )
         obj.addProperty(

--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -104,7 +104,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                 "Profile",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "The direction that the toolpath should go around the part ClockWise (CW) or CounterClockWise (CCW)",
+                    "The direction that the toolpath should go around the part ClockWise (Climb) or CounterClockWise (Conventional)",
                 ),
             ),
             (
@@ -193,8 +193,8 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         # Enumeration lists for App::PropertyEnumeration properties
         enums = {
             "Direction": [
-                (translate("PathProfile", "CW"), "CW"),
-                (translate("PathProfile", "CCW"), "CCW"),
+                (translate("PathProfile", "Climb"), "Climb"),
+                (translate("PathProfile", "Conventional"), "Conventional"),
             ],  # this is the direction that the profile runs
             "HandleMultipleFeatures": [
                 (translate("PathProfile", "Collectively"), "Collectively"),
@@ -230,7 +230,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         """areaOpPropertyDefaults(obj, job) ... returns a dictionary of default values
         for the operation's properties."""
         return {
-            "Direction": "CW",
+            "Direction": "Climb",
             "HandleMultipleFeatures": "Collectively",
             "JoinType": "Round",
             "MiterLimit": 0.1,
@@ -343,11 +343,11 @@ class ObjectProfile(PathAreaOp.ObjectOp):
 
         # Reverse the direction for holes
         if isHole:
-            direction = "CW" if obj.Direction == "CCW" else "CCW"
+            direction = "Climb" if obj.Direction == "Conventional" else "Conventional"
         else:
             direction = obj.Direction
 
-        if direction == "CCW":
+        if direction == "Conventional":
             params["orientation"] = 0
         else:
             params["orientation"] = 1
@@ -356,7 +356,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         if obj.UseComp:
             offset = self.radius + obj.OffsetExtra.Value
         if offset == 0.0:
-            if direction == "CCW":
+            if direction == "Conventional":
                 params["orientation"] = 1
             else:
                 params["orientation"] = 0

--- a/src/Mod/CAM/Path/Post/scripts/heidenhain_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/heidenhain_post.py
@@ -378,11 +378,11 @@ def export(objectslist, filename, argstring):
             STORED_COMPENSATED_OBJ = commands
         # Find mill compensation
         if hasattr(obj, "Side") and hasattr(obj, "Direction"):
-            if obj.Side == "Outside" and obj.Direction == "CW":
+            if obj.Side == "Outside" and obj.Direction == "Climb":
                 Compensation = "L"
-            elif obj.Side == "Outside" and obj.Direction == "CCW":
+            elif obj.Side == "Outside" and obj.Direction == "Conventional":
                 Compensation = "R"
-            elif obj.Side != "Outside" and obj.Direction == "CW":
+            elif obj.Side != "Outside" and obj.Direction == "Climb":
                 Compensation = "R"
             else:
                 Compensation = "L"

--- a/src/Mod/CAM/Tests/PathTestUtils.py
+++ b/src/Mod/CAM/Tests/PathTestUtils.py
@@ -67,14 +67,14 @@ class PathTestBase(unittest.TestCase):
         for i in range(0, len(edges)):
             self.assertLine(edges[i], points[i], points[i + 1])
 
-    def assertArc(self, edge, pt1, pt2, direction="CW"):
+    def assertArc(self, edge, pt1, pt2, direction="Climb"):
         """Verify that edge is an arc between pt1 and pt2 with the given direction."""
         self.assertIs(type(edge.Curve), Part.Circle)
         self.assertCoincide(edge.valueAt(edge.FirstParameter), pt1)
         self.assertCoincide(edge.valueAt(edge.LastParameter), pt2)
         ptm = edge.valueAt((edge.LastParameter + edge.FirstParameter) / 2)
         side = Path.Geom.Side.of(pt2 - pt1, ptm - pt1)
-        if "CW" == direction:
+        if "Climb" == direction:
             self.assertEqual(side, Path.Geom.Side.Left)
         else:
             self.assertEqual(side, Path.Geom.Side.Right)

--- a/src/Mod/CAM/Tests/TestPathDressupDogbone.py
+++ b/src/Mod/CAM/Tests/TestPathDressupDogbone.py
@@ -59,7 +59,7 @@ class TestDressupDogbone(PathTestBase):
         """Verify bones are inserted for simple moves."""
         base = TestProfile(
             "Inside",
-            "CW",
+            "Climb",
             """
         G0 X10 Y10 Z10
         G1 Z0
@@ -84,7 +84,7 @@ class TestDressupDogbone(PathTestBase):
         """Verify bones are inserted if hole ends with rapid move out."""
         base = TestProfile(
             "Inside",
-            "CW",
+            "Climb",
             """
         G0 X10 Y10 Z10
         G1 Z0
@@ -177,7 +177,7 @@ class TestDressupDogbone(PathTestBase):
         """Verify no bone is inserted for straight move interrupted by plunge."""
         base = TestProfile(
             "Inside",
-            "CW",
+            "Climb",
             """
         G0 X10 Y10 Z10
         G1 Z0
@@ -199,7 +199,7 @@ class TestDressupDogbone(PathTestBase):
         """Verify can handle comments between moves"""
         base = TestProfile(
             "Inside",
-            "CW",
+            "Climb",
             """
         G0 X10 Y10 Z10
         G1 Z0
@@ -222,7 +222,7 @@ class TestDressupDogbone(PathTestBase):
 
         base = TestProfile(
             "Inside",
-            "CW",
+            "Climb",
             """
         G0 X10 Y10 Z10
         G1 Z0
@@ -248,7 +248,7 @@ class TestDressupDogbone(PathTestBase):
         """Verify can handle noops between moves"""
         base = TestProfile(
             "Inside",
-            "CW",
+            "Climb",
             """
         G0 X10 Y10 Z10
         G1 Z0
@@ -271,7 +271,7 @@ class TestDressupDogbone(PathTestBase):
 
         base = TestProfile(
             "Inside",
-            "CW",
+            "Climb",
             """
         G0 X10 Y10 Z10
         G1 Z0

--- a/src/Mod/CAM/Tests/TestPathGeom.py
+++ b/src/Mod/CAM/Tests/TestPathGeom.py
@@ -45,71 +45,71 @@ class TestPathGeom(PathTestBase):
     def test01(self):
         """Verify diffAngle functionality."""
         self.assertRoughly(
-            Path.Geom.diffAngle(0, +0 * math.pi / 4, "CW") / math.pi, 0 / 4.0
+            Path.Geom.diffAngle(0, +0 * math.pi / 4, "Climb") / math.pi, 0 / 4.0
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(0, +3 * math.pi / 4, "CW") / math.pi, 5 / 4.0
+            Path.Geom.diffAngle(0, +3 * math.pi / 4, "Climb") / math.pi, 5 / 4.0
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(0, -3 * math.pi / 4, "CW") / math.pi, 3 / 4.0
+            Path.Geom.diffAngle(0, -3 * math.pi / 4, "Climb") / math.pi, 3 / 4.0
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(0, +4 * math.pi / 4, "CW") / math.pi, 4 / 4.0
+            Path.Geom.diffAngle(0, +4 * math.pi / 4, "Climb") / math.pi, 4 / 4.0
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(0, +0 * math.pi / 4, "CCW") / math.pi, 0 / 4.0
+            Path.Geom.diffAngle(0, +0 * math.pi / 4, "Conventional") / math.pi, 0 / 4.0
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(0, +3 * math.pi / 4, "CCW") / math.pi, 3 / 4.0
+            Path.Geom.diffAngle(0, +3 * math.pi / 4, "Conventional") / math.pi, 3 / 4.0
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(0, -3 * math.pi / 4, "CCW") / math.pi, 5 / 4.0
+            Path.Geom.diffAngle(0, -3 * math.pi / 4, "Conventional") / math.pi, 5 / 4.0
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(0, +4 * math.pi / 4, "CCW") / math.pi, 4 / 4.0
-        )
-
-        self.assertRoughly(
-            Path.Geom.diffAngle(+math.pi / 4, +0 * math.pi / 4, "CW") / math.pi, 1 / 4.0
-        )
-        self.assertRoughly(
-            Path.Geom.diffAngle(+math.pi / 4, +3 * math.pi / 4, "CW") / math.pi, 6 / 4.0
-        )
-        self.assertRoughly(
-            Path.Geom.diffAngle(+math.pi / 4, -1 * math.pi / 4, "CW") / math.pi, 2 / 4.0
-        )
-        self.assertRoughly(
-            Path.Geom.diffAngle(-math.pi / 4, +0 * math.pi / 4, "CW") / math.pi, 7 / 4.0
-        )
-        self.assertRoughly(
-            Path.Geom.diffAngle(-math.pi / 4, +3 * math.pi / 4, "CW") / math.pi, 4 / 4.0
-        )
-        self.assertRoughly(
-            Path.Geom.diffAngle(-math.pi / 4, -1 * math.pi / 4, "CW") / math.pi, 0 / 4.0
+            Path.Geom.diffAngle(0, +4 * math.pi / 4, "Conventional") / math.pi, 4 / 4.0
         )
 
         self.assertRoughly(
-            Path.Geom.diffAngle(+math.pi / 4, +0 * math.pi / 4, "CCW") / math.pi,
+            Path.Geom.diffAngle(+math.pi / 4, +0 * math.pi / 4, "Climb") / math.pi, 1 / 4.0
+        )
+        self.assertRoughly(
+            Path.Geom.diffAngle(+math.pi / 4, +3 * math.pi / 4, "Climb") / math.pi, 6 / 4.0
+        )
+        self.assertRoughly(
+            Path.Geom.diffAngle(+math.pi / 4, -1 * math.pi / 4, "Climb") / math.pi, 2 / 4.0
+        )
+        self.assertRoughly(
+            Path.Geom.diffAngle(-math.pi / 4, +0 * math.pi / 4, "Climb") / math.pi, 7 / 4.0
+        )
+        self.assertRoughly(
+            Path.Geom.diffAngle(-math.pi / 4, +3 * math.pi / 4, "Climb") / math.pi, 4 / 4.0
+        )
+        self.assertRoughly(
+            Path.Geom.diffAngle(-math.pi / 4, -1 * math.pi / 4, "Climb") / math.pi, 0 / 4.0
+        )
+
+        self.assertRoughly(
+            Path.Geom.diffAngle(+math.pi / 4, +0 * math.pi / 4, "Conventional") / math.pi,
             7 / 4.0,
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(+math.pi / 4, +3 * math.pi / 4, "CCW") / math.pi,
+            Path.Geom.diffAngle(+math.pi / 4, +3 * math.pi / 4, "Conventional") / math.pi,
             2 / 4.0,
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(+math.pi / 4, -1 * math.pi / 4, "CCW") / math.pi,
+            Path.Geom.diffAngle(+math.pi / 4, -1 * math.pi / 4, "Conventional") / math.pi,
             6 / 4.0,
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(-math.pi / 4, +0 * math.pi / 4, "CCW") / math.pi,
+            Path.Geom.diffAngle(-math.pi / 4, +0 * math.pi / 4, "Conventional") / math.pi,
             1 / 4.0,
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(-math.pi / 4, +3 * math.pi / 4, "CCW") / math.pi,
+            Path.Geom.diffAngle(-math.pi / 4, +3 * math.pi / 4, "Conventional") / math.pi,
             4 / 4.0,
         )
         self.assertRoughly(
-            Path.Geom.diffAngle(-math.pi / 4, -1 * math.pi / 4, "CCW") / math.pi,
+            Path.Geom.diffAngle(-math.pi / 4, -1 * math.pi / 4, "Conventional") / math.pi,
             0 / 4.0,
         )
 
@@ -499,7 +499,7 @@ class TestPathGeom(PathTestBase):
             ),
             p1,
             p2,
-            "CW",
+            "Climb",
         )
         self.assertArc(
             Path.Geom.edgeForCmd(
@@ -510,7 +510,7 @@ class TestPathGeom(PathTestBase):
             ),
             p2,
             p1,
-            "CCW",
+            "Conventional",
         )
 
     def test30(self):

--- a/src/Mod/CAM/Tests/TestPathHelixGenerator.py
+++ b/src/Mod/CAM/Tests/TestPathHelixGenerator.py
@@ -44,7 +44,7 @@ def _resetArgs():
         "step_over": 0.5,
         "tool_diameter": 5.0,
         "inner_radius": 0.0,
-        "direction": "CW",
+        "direction": "Climb",
         "startAt": "Inside",
     }
 

--- a/src/Mod/CAM/Tests/TestPathProfile.py
+++ b/src/Mod/CAM/Tests/TestPathProfile.py
@@ -121,7 +121,7 @@ class TestPathProfile(PathTestBase):
         profile.processCircles = True
         profile.processHoles = True
         profile.UseComp = True
-        profile.Direction = "CW"
+        profile.Direction = "Climb"
         _addViewProvider(profile)
         self.doc.recompute()
 
@@ -158,7 +158,7 @@ class TestPathProfile(PathTestBase):
         profile.processCircles = True
         profile.processHoles = True
         profile.UseComp = False
-        profile.Direction = "CW"
+        profile.Direction = "Climb"
         _addViewProvider(profile)
         self.doc.recompute()
 
@@ -179,9 +179,9 @@ class TestPathProfile(PathTestBase):
 
         self.assertTrue(expected_moves == operationMoves,
                        "expected_moves: {}\noperationMoves: {}".format(expected_moves, operationMoves))
-        
+
     def test03(self):
-        """test03() Verify path generated on Face18, outside, 
+        """test03() Verify path generated on Face18, outside,
         with compensation and extra offset -radius."""
 
         # Instantiate a Profile operation and set Base Geometry
@@ -196,7 +196,7 @@ class TestPathProfile(PathTestBase):
         profile.processCircles = True
         profile.processHoles = True
         profile.UseComp = True
-        profile.Direction = "CW"
+        profile.Direction = "Climb"
         profile.OffsetExtra = -profile.OpToolDiameter / 2.0
         _addViewProvider(profile)
         self.doc.recompute()
@@ -227,4 +227,3 @@ def _addViewProvider(profileOp):
         profileOp.ViewObject.Proxy = PathOpGui.ViewProvider(
             profileOp.ViewObject, cmdRes
         )
-


### PR DESCRIPTION
As per title. I don't write much Python so I may have missed something silly, but the tests pass (locally anyway).

The translations were done with a naive find and replace. My editor stripped trailing whitespace which I can undo if it's significant, otherwise apologies for the diff noise. I'm unsure how to test if the translations are still correct.

Closes #14314 