### PR TITLE
[TD]add style options for broken view (fix #13405)

### DIFF
--- a/src/Mod/TechDraw/App/DrawBrokenView.cpp
+++ b/src/Mod/TechDraw/App/DrawBrokenView.cpp
@@ -98,6 +98,11 @@ using SU = ShapeUtils;
 // DrawBrokenView
 //===========================================================================
 
+const char *DrawBrokenView::BreakTypeEnums[] = {
+    QT_TRANSLATE_NOOP("DrawBrokenView", "None"),
+    QT_TRANSLATE_NOOP("DrawBrokenView", "ZigZag"),
+    QT_TRANSLATE_NOOP("DrawBrokenView", "Simple"),
+    nullptr};
 PROPERTY_SOURCE(TechDraw::DrawBrokenView, TechDraw::DrawViewPart)
 
 DrawBrokenView::DrawBrokenView()

--- a/src/Mod/TechDraw/App/DrawBrokenView.h
+++ b/src/Mod/TechDraw/App/DrawBrokenView.h
@@ -60,6 +60,14 @@ class TechDrawExport DrawBrokenView: public TechDraw::DrawViewPart
     PROPERTY_HEADER_WITH_OVERRIDE(TechDraw::DrawBrokenView);
 
 public:
+    enum BreakType
+    {
+        NONE,
+        ZIGZAG,
+        SIMPLE
+    };
+    static const char* BreakTypeEnums[];
+
     DrawBrokenView();
     ~DrawBrokenView() override;
 

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -502,6 +502,11 @@ int Preferences::HiddenLineStyle()
     return getPreferenceGroup("Decorations")->GetInt("LineStyleHidden", 1) + 1;
 }
 
+int Preferences::BreakLineStyle()
+{
+    return getPreferenceGroup("Decorations")->GetInt("LineStyleBreak", 0) + 1;
+}
+
 int Preferences::LineSpacingISO()
 {
     return getPreferenceGroup("Dimensions")->GetInt("LineSpacingFactorISO", 2);
@@ -578,5 +583,9 @@ bool Preferences::useExactMatchOnDims()
     return getPreferenceGroup("Dimensions")->GetBool("UseMatcher", true);
 }
 
+int Preferences::BreakType()
+{
+    return getPreferenceGroup("Decorations")->GetInt("BreakType", 2);
+}
 
 

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -119,6 +119,7 @@ public:
     static int CenterLineStyle();
     static int HighlightLineStyle();
     static int HiddenLineStyle();
+    static int BreakLineStyle();
     static int LineCapStyle();
     static int LineCapIndex();
 
@@ -130,6 +131,8 @@ public:
     static int sectionLineConvention();
     static bool showSectionLine();
     static bool includeCutLine();
+
+    static int BreakType();
 
     static bool useExactMatchOnDims();
 };

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
@@ -65,6 +65,333 @@
           </property>
          </widget>
         </item>
+        <item row="6" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbDetailHighlight">
+          <property name="toolTip">
+           <string>This checkbox controls whether or not to display a highlight around the detail area in the detail's source view.</string>
+          </property>
+          <property name="text">
+           <string>Detail Source Show Highlight</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ShowDetailHighlight</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_19">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Section Cut Surface</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="2">
+         <widget class="Gui::PrefComboBox" name="pcbBalloonArrow">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Style for balloon leader line ends</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>BalloonArrow</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Balloon Leader End</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="Gui::PrefCheckBox" name="cb_IncludeCutLine">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>If checked, the cut line will be drawn on the Source view.  If unchecked, only the change marks, arrows and symbols will be displayed.</string>
+          </property>
+          <property name="text">
+           <string>Include Cut Line in Section Annotation</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>IncludeCutLine</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="3" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbComplexMarks">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Show or hide marks at direction changes on ComplexSection lines.</string>
+          </property>
+          <property name="text">
+           <string>Complex Section Line Marks</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>SectionLineMarks</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="Gui::PrefCheckBox" name="pcbDetailMatting">
+          <property name="toolTip">
+           <string>This checkbox controls whether or not to display the outline around a detail view.</string>
+          </property>
+          <property name="text">
+           <string>Detail View Show Matting</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ShowDetailMatting</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="Gui::PrefCheckBox" name="cb_ShowSectionLine">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>If checked, the section annotation will be drawn on the Source view.  If unchecked, no section line, arrows or symbol will be shown in the Source view.</string>
+          </property>
+          <property name="text">
+           <string>Show Section Line in Source View</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ShowSectionLine</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label">
+          <property name="font">
+           <font>
+            <italic>false</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Detail View Outline Shape</string>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbPyramidOrtho">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Restrict Filled Triangle line end to vertical or horizontal directions</string>
+          </property>
+          <property name="text">
+           <string>Balloon Orthogonal Triangle</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>PyramidOrtho</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="12" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbPrintCenterMarks">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Show arc centers in printed output</string>
+          </property>
+          <property name="text">
+           <string>Print Center Marks</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>PrintCenterMarks</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="10" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbAutoHoriz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Forces last leader line segment to be horizontal</string>
+          </property>
+          <property name="text">
+           <string>Leader Line Auto Horizontal</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>AutoHorizontal</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/LeaderLine</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="12" column="0">
+         <widget class="Gui::PrefCheckBox" name="cbShowCenterMarks">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Show arc center marks in views</string>
+          </property>
+          <property name="text">
+           <string>Show Center Marks</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ShowCenterMarks</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Balloon Shape</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="2">
          <widget class="Gui::PrefComboBox" name="cbCutSurface">
           <property name="minimumSize">
@@ -107,47 +434,47 @@
           </item>
          </widget>
         </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
+        <item row="4" column="2">
+         <widget class="Gui::PrefComboBox" name="pcbMatting">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="text">
-           <string>Balloon Leader End</string>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
           </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label">
-          <property name="font">
-           <font>
-            <italic>false</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Detail View Outline Shape</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="Gui::PrefCheckBox" name="pcbDetailMatting">
           <property name="toolTip">
-           <string>This checkbox controls whether or not to display the outline around a detail view.</string>
-          </property>
-          <property name="text">
-           <string>Detail View Show Matting</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
+           <string>Outline shape for detail views</string>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>ShowDetailMatting</cstring>
+           <cstring>MattingStyle</cstring>
           </property>
           <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/General</cstring>
+           <cstring>/Mod/TechDraw/Decorations</cstring>
           </property>
+          <item>
+           <property name="text">
+            <string>Circle</string>
+           </property>
+           <property name="icon">
+            <iconset resource="Resources/TechDraw.qrc">
+             <normaloff>:/icons/circular.svg</normaloff>:/icons/circular.svg</iconset>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Square</string>
+           </property>
+           <property name="icon">
+            <iconset resource="Resources/TechDraw.qrc">
+             <normaloff>:/icons/square.svg</normaloff>:/icons/square.svg</iconset>
+           </property>
+          </item>
          </widget>
         </item>
         <item row="7" column="2">
@@ -247,245 +574,6 @@
           </item>
          </widget>
         </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Balloon Shape</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="Gui::PrefComboBox" name="pcbMatting">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Outline shape for detail views</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>MattingStyle</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Decorations</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>Circle</string>
-           </property>
-           <property name="icon">
-            <iconset resource="Resources/TechDraw.qrc">
-             <normaloff>:/icons/circular.svg</normaloff>:/icons/circular.svg</iconset>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Square</string>
-           </property>
-           <property name="icon">
-            <iconset resource="Resources/TechDraw.qrc">
-             <normaloff>:/icons/square.svg</normaloff>:/icons/square.svg</iconset>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbComplexMarks">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Show or hide marks at direction changes on ComplexSection lines.</string>
-          </property>
-          <property name="text">
-           <string>Complex Section Line Marks</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SectionLineMarks</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbPyramidOrtho">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Restrict Filled Triangle line end to vertical or horizontal directions</string>
-          </property>
-          <property name="text">
-           <string>Balloon Orthogonal Triangle</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>PyramidOrtho</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="2">
-         <widget class="Gui::PrefComboBox" name="pcbBalloonArrow">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Style for balloon leader line ends</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>BalloonArrow</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbAutoHoriz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Forces last leader line segment to be horizontal</string>
-          </property>
-          <property name="text">
-           <string>Leader Line Auto Horizontal</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>AutoHorizontal</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/LeaderLine</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_19">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Section Cut Surface</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="Gui::PrefCheckBox" name="cb_ShowSectionLine">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>If checked, the section annotation will be drawn on the Source view.  If unchecked, no section line, arrows or symbol will be shown in the Source view.</string>
-          </property>
-          <property name="text">
-           <string>Show Section Line in Source View</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ShowSectionLine</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="6" column="0">
-         <widget class="Gui::PrefCheckBox" name="pcbDetailHighlight">
-          <property name="toolTip">
-           <string>This checkbox controls whether or not to display a highlight around the detail area in the detail's source view.</string>
-          </property>
-          <property name="text">
-           <string>Detail Source Show Highlight</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ShowDetailHighlight</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="9" column="0">
          <widget class="QLabel" name="label_18">
           <property name="font">
@@ -502,91 +590,43 @@
          </widget>
         </item>
         <item row="11" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbShowCenterMarks">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
+         <widget class="QLabel" name="label_11">
           <property name="font">
            <font>
             <italic>true</italic>
            </font>
           </property>
-          <property name="toolTip">
-           <string>Show arc center marks in views</string>
-          </property>
           <property name="text">
-           <string>Show Center Marks</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ShowCenterMarks</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
+           <string>Broken View Break Type</string>
           </property>
          </widget>
         </item>
         <item row="11" column="2">
-         <widget class="Gui::PrefCheckBox" name="cbPrintCenterMarks">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Show arc centers in printed output</string>
-          </property>
-          <property name="text">
-           <string>Print Center Marks</string>
+         <widget class="Gui::PrefComboBox" name="pcbBreakType">
+          <property name="currentIndex">
+           <number>2</number>
           </property>
           <property name="prefEntry" stdset="0">
-           <cstring>PrintCenterMarks</cstring>
+           <cstring>BreakType</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/Decorations</cstring>
           </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="Gui::PrefCheckBox" name="cb_IncludeCutLine">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>If checked, the cut line will be drawn on the Source view.  If unchecked, only the change marks, arrows and symbols will be displayed.</string>
-          </property>
-          <property name="text">
-           <string>Include Cut Line in Section Annotation</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>IncludeCutLine</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
+          <item>
+           <property name="text">
+            <string>No Break Lines</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ZigZag Lines</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Simple Lines</string>
+           </property>
+          </item>
          </widget>
         </item>
        </layout>
@@ -608,58 +648,6 @@
      <layout class="QGridLayout" name="gridLayout_5">
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_4" columnstretch="1,0,2">
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_6">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="text">
-           <string>Section Line Style</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="Gui::PrefComboBox" name="pcbSectionStyle">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maxVisibleItems">
-           <number>6</number>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>LineStyleSection</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_20">
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Line style of detail highlight on base view</string>
-          </property>
-          <property name="text">
-           <string>Detail Highlight Style</string>
-          </property>
-         </widget>
-        </item>
         <item row="2" column="2">
          <widget class="Gui::PrefComboBox" name="pcbHiddenStyle">
           <property name="sizePolicy">
@@ -700,56 +688,6 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="2">
-         <widget class="Gui::PrefComboBox" name="pcbCenterStyle">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maxVisibleItems">
-           <number>6</number>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>32</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>LineStyleCenter</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="Gui::PrefComboBox" name="pcbLineGroup">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>LineGroup</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Decorations</cstring>
-          </property>
-          <property name="text" stdset="0">
-           <string/>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="2">
          <widget class="Gui::PrefComboBox" name="pcbLineStandard">
           <property name="sizePolicy">
@@ -778,56 +716,28 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_13">
+        <item row="1" column="2">
+         <widget class="Gui::PrefComboBox" name="pcbLineGroup">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="font">
-           <font>
-            <italic>true</italic>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Line group used to set line widths</string>
-          </property>
-          <property name="text">
-           <string>Line Width Group</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Hidden Line Style</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
+          <property name="minimumSize">
            <size>
-            <width>40</width>
-            <height>20</height>
+            <width>0</width>
+            <height>22</height>
            </size>
           </property>
-         </spacer>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="font">
-           <font>
-            <italic>false</italic>
-           </font>
+          <property name="prefEntry" stdset="0">
+           <cstring>LineGroup</cstring>
           </property>
-          <property name="text">
-           <string>Line Standard</string>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Decorations</cstring>
+          </property>
+          <property name="text" stdset="0">
+           <string/>
           </property>
          </widget>
         </item>
@@ -856,19 +766,71 @@
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_9">
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_20">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Line style of detail highlight on base view</string>
+          </property>
+          <property name="text">
+           <string>Detail Highlight Style</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Section Line Style</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="Gui::PrefComboBox" name="pcbSectionStyle">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maxVisibleItems">
+           <number>6</number>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>32</width>
+            <height>32</height>
+           </size>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>LineStyleSection</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_2">
           <property name="font">
            <font>
             <italic>false</italic>
            </font>
           </property>
           <property name="text">
-           <string>Line End Cap Shape</string>
+           <string>Line Standard</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="2">
+        <item row="7" column="2">
          <widget class="Gui::PrefComboBox" name="cbEndCap">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -914,6 +876,109 @@ if you are planning to use a drawing as a 1:1 cutting guide.
             <string>Flat</string>
            </property>
           </item>
+         </widget>
+        </item>
+        <item row="5" column="2">
+         <widget class="Gui::PrefComboBox" name="pcbCenterStyle">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maxVisibleItems">
+           <number>6</number>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>32</width>
+            <height>32</height>
+           </size>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>LineStyleCenter</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Decorations</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_13">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="toolTip">
+           <string>Line group used to set line widths</string>
+          </property>
+          <property name="text">
+           <string>Line Width Group</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="font">
+           <font>
+            <italic>false</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Line End Cap Shape</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Hidden Line Style</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_10">
+          <property name="font">
+           <font>
+            <italic>true</italic>
+           </font>
+          </property>
+          <property name="text">
+           <string>Break Line Style</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="Gui::PrefComboBox" name="pcbBreakStyle">
+          <property name="toolTip">
+           <string>Style of line to be used in BrokenView.</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>LineStyleBreak</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Decorations</cstring>
+          </property>
          </widget>
         </item>
        </layout>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotationImp.cpp
@@ -118,6 +118,9 @@ void DlgPrefsTechDrawAnnotationImp::saveSettings()
 
     ui->pcbDetailMatting->onSave();
     ui->pcbDetailHighlight->onSave();
+
+    ui->pcbBreakType->onSave();
+    ui->pcbBreakStyle->onSave();
 }
 
 void DlgPrefsTechDrawAnnotationImp::loadSettings()
@@ -177,7 +180,10 @@ void DlgPrefsTechDrawAnnotationImp::loadSettings()
     ui->pcbCenterStyle->onRestore();
     ui->pcbHighlightStyle->onRestore();
     ui->pcbHiddenStyle->onRestore();
+    ui->pcbBreakStyle->onRestore();
     loadLineStyleBoxes();
+
+    ui->pcbBreakType->onRestore();
 }
 
 /**
@@ -264,6 +270,11 @@ void DlgPrefsTechDrawAnnotationImp::loadLineStyleBoxes()
     DrawGuiUtil::loadLineStyleChoices(ui->pcbHiddenStyle, m_lineGenerator);
     if (ui->pcbHiddenStyle->count() > Preferences::HiddenLineStyle()) {
         ui->pcbHiddenStyle->setCurrentIndex(Preferences::HiddenLineStyle() - 1);
+    }
+
+    DrawGuiUtil::loadLineStyleChoices(ui->pcbBreakStyle, m_lineGenerator);
+    if (ui->pcbBreakStyle->count() > Preferences::BreakLineStyle()) {
+        ui->pcbBreakStyle->setCurrentIndex(Preferences::BreakLineStyle() - 1);
     }
 }
 

--- a/src/Mod/TechDraw/Gui/QGIBreakLine.h
+++ b/src/Mod/TechDraw/Gui/QGIBreakLine.h
@@ -59,11 +59,18 @@ public:
     void setLinePen(QPen isoPen);
     void setBreakColor(QColor c);
 
+    void setBreakType(int style) { m_breakType = style; }
+    int  breakType() const { return m_breakType; }
+
 protected:
 
 private:
+    void drawLargeZigZag();
     QPainterPath makeHorizontalZigZag(Base::Vector3d start) const;
     QPainterPath makeVerticalZigZag(Base::Vector3d start) const;
+    void drawSimpleLines();
+    QPainterPath pathFromPoints(Base::Vector3d start, Base::Vector3d end);
+
     void setTools();
 
     QGraphicsPathItem* m_line0;
@@ -76,6 +83,8 @@ private:
     double             m_bottom;
     double             m_left;
     double             m_right;
+
+    int                m_breakType{0};
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -1046,6 +1046,7 @@ void QGIViewPart::drawBreakLines()
         return;
     }
 
+    auto breakType = vp->BreakLineType.getValue();
     auto breaks = dbv->Breaks.getValues();
     for (auto& breakObj : breaks) {
         QGIBreakLine* breakLine = new QGIBreakLine();
@@ -1061,8 +1062,9 @@ void QGIViewPart::drawBreakLines()
         breakLine->setBounds(topLeft, bottomRight);
         breakLine->setPos(0.0, 0.0);
         breakLine->setLinePen(
-            m_dashedLineGenerator->getLinePen(1, vp->HiddenWidth.getValue()));
+            m_dashedLineGenerator->getLinePen(vp->BreakLineStyle.getValue(), vp->HiddenWidth.getValue()));
         breakLine->setWidth(Rez::guiX(vp->HiddenWidth.getValue()));
+        breakLine->setBreakType(breakType);
         breakLine->setZValue(ZVALUE::SECTIONLINE);
         App::Color color = prefBreaklineColor();
         breakLine->setBreakColor(color.asValue<QColor>());

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -46,6 +46,7 @@
 #include <Mod/TechDraw/App/DrawViewDetail.h>
 #include <Mod/TechDraw/App/DrawViewDimension.h>
 #include <Mod/TechDraw/App/DrawViewMulti.h>
+#include <Mod/TechDraw/App/DrawBrokenView.h>
 #include <Mod/TechDraw/App/LineGroup.h>
 #include <Mod/TechDraw/App/Cosmetic.h>
 #include <Mod/TechDraw/App/CenterLine.h>
@@ -84,6 +85,7 @@ ViewProviderViewPart::ViewProviderViewPart()
     static const char *hgroup = "Highlight";
     static const char *sgroup = "Section Line";
     static const char *fgroup = "Faces";
+    static const char *bvgroup = "Broken View";
 
     //default line weights
 
@@ -128,6 +130,13 @@ ViewProviderViewPart::ViewProviderViewPart()
                         "Set highlight line color if applicable");
     ADD_PROPERTY_TYPE(HighlightAdjust, (0.0), hgroup, App::Prop_None, "Adjusts the rotation of the Detail highlight");
 
+    // properties that affect BrokenViews
+    BreakLineType.setEnums(DrawBrokenView::BreakTypeEnums);
+    ADD_PROPERTY_TYPE(BreakLineType, (Preferences::BreakType()), bvgroup, App::Prop_None,
+                        "Adjusts the type of break line depiction on broken views");
+    ADD_PROPERTY_TYPE(BreakLineStyle, (Preferences::BreakLineStyle()), bvgroup, App::Prop_None,
+                        "Set break line style if applicable");
+
     ADD_PROPERTY_TYPE(ShowAllEdges ,(false),dgroup, App::Prop_None, "Temporarily show invisible lines");
 
     // Faces related properties
@@ -141,12 +150,15 @@ ViewProviderViewPart::ViewProviderViewPart()
     if (bodyName == "ISO") {
         SectionLineStyle.setEnums(ISOLineName::ISOLineNameEnums);
         HighlightLineStyle.setEnums(ISOLineName::ISOLineNameEnums);
+        BreakLineStyle.setEnums(ISOLineName::ISOLineNameEnums);
     } else if (bodyName == "ANSI") {
         SectionLineStyle.setEnums(ANSILineName::ANSILineNameEnums);
         HighlightLineStyle.setEnums(ANSILineName::ANSILineNameEnums);
+        BreakLineStyle.setEnums(ANSILineName::ANSILineNameEnums);
     } else if (bodyName == "ASME") {
         SectionLineStyle.setEnums(ASMELineName::ASMELineNameEnums);
         HighlightLineStyle.setEnums(ASMELineName::ASMELineNameEnums);
+        BreakLineStyle.setEnums(ASMELineName::ASMELineNameEnums);
     }
 }
 
@@ -184,7 +196,9 @@ void ViewProviderViewPart::onChanged(const App::Property* prop)
         prop == &(HorizCenterLine) ||
         prop == &(VertCenterLine)  ||
         prop == &(FaceColor) ||
-        prop == &(FaceTransparency)) {
+        prop == &(FaceTransparency)  ||
+        prop == &(BreakLineType)   ||
+        prop == &(BreakLineStyle) ) {
         // redraw QGIVP
         QGIView* qgiv = getQView();
         if (qgiv) {

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
@@ -60,6 +60,8 @@ public:
     App::PropertyEnumeration   HighlightLineStyle;
     App::PropertyColor  HighlightLineColor;
     App::PropertyFloat  HighlightAdjust;
+    App::PropertyEnumeration BreakLineType;
+    App::PropertyEnumeration BreakLineStyle;
     App::PropertyBool   ShowAllEdges;
     App::PropertyColor   FaceColor;
     App::PropertyPercent FaceTransparency;


### PR DESCRIPTION
This PR implements a fix for #13405.  There are now 3 types of break lines - None, ZigZag and Simple.  Also a line style can be specified for ZigZag and Simple types.
![BreakStyleOptions](https://github.com/FreeCAD/FreeCAD/assets/3587161/918302d1-4e1f-4e87-a91b-ec0ee7abcb31)
