### PR TITLE
Part: Add ParallelPlane attachment mode

### DIFF
--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -31,6 +31,7 @@
 # include <BRepGProp.hxx>
 # include <BRepIntCurveSurface_Inter.hxx>
 # include <BRepLProp_SLProps.hxx>
+# include <Geom_Line.hxx>
 # include <Geom_Plane.hxx>
 # include <GeomAdaptor.hxx>
 # include <GeomAPI.hxx>
@@ -132,6 +133,8 @@ const char* AttachEngine::eMapModeStrings[]= {
     "OXZ",
     "OYZ",
     "OYX",
+
+    "ParallelPlane",
 
     nullptr};
 
@@ -1041,6 +1044,11 @@ AttachEngine3D::AttachEngine3D()
     modeRefTypes[mmObjectXZ] = ss;
     modeRefTypes[mmObjectYZ] = ss;
 
+    modeRefTypes[mmParallelPlane].push_back(
+        cat(eRefType(rtFlatFace | rtFlagHasPlacement), rtVertex));
+    modeRefTypes[mmParallelPlane].push_back(
+        cat(eRefType(rtAnything | rtFlagHasPlacement), rtVertex));
+
     modeRefTypes[mmInertialCS].push_back(cat(rtAnything));
     modeRefTypes[mmInertialCS].push_back(cat(rtAnything,rtAnything));
     modeRefTypes[mmInertialCS].push_back(cat(rtAnything,rtAnything,rtAnything));
@@ -1194,7 +1202,8 @@ AttachEngine3D::_calculateAttachedPlacement(const std::vector<App::DocumentObjec
         } break;
         case mmObjectXY:
         case mmObjectXZ:
-        case mmObjectYZ: {
+        case mmObjectYZ:
+        case mmParallelPlane: {
             // DeepSOIC: could have been done much more efficiently, but I'm lazy...
             gp_Dir dirX, dirY, dirZ;
             if (types[0] & rtFlagHasPlacement) {
@@ -1254,6 +1263,32 @@ AttachEngine3D::_calculateAttachedPlacement(const std::vector<App::DocumentObjec
                     SketchNormal = dirX;
                     SketchXAxis = gp_Vec(dirY);
                     break;
+                case mmParallelPlane: {
+                    if (shapes.size() < 2) {
+                        throw Base::ValueError("AttachEngine3D::calculateAttachedPlacement: not "
+                                               "enough subshapes (need one plane and one vertex).");
+                    }
+
+                    TopoDS_Vertex vertex;
+                    try {
+                        vertex = TopoDS::Vertex(*(shapes[1]));
+                    }
+                    catch (...) {
+                    }
+                    if (vertex.IsNull()) {
+                        throw Base::ValueError(
+                            "Null vertex in AttachEngine3D::calculateAttachedPlacement()!");
+                    }
+
+                    SketchNormal = dirZ;
+                    SketchXAxis = gp_Vec(dirX);
+
+                    // The new origin will be the vertex projected onto the normal.
+                    Handle(Geom_Line) hCurve(new Geom_Line(SketchBasePoint, dirZ));
+                    gp_Pnt p = BRep_Tool::Pnt(vertex);
+                    GeomAPI_ProjectPointOnCurve projector(p, hCurve);
+                    SketchBasePoint = projector.NearestPoint();
+                } break;
                 default:
                     break;
             }
@@ -1360,7 +1395,7 @@ AttachEngine3D::_calculateAttachedPlacement(const std::vector<App::DocumentObjec
         case mmTangentPlane: {
             if (shapes.size() < 2) {
                 throw Base::ValueError("AttachEngine3D::calculateAttachedPlacement: not enough "
-                                       "subshapes (need one false and one vertex).");
+                                       "subshapes (need one face and one vertex).");
             }
 
             bool bThruVertex = false;

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -107,6 +107,8 @@ enum eMapMode {
     mmOYZ,
     mmOYX,
 
+    mmParallelPlane,
+
     mmDummy_NumberOfModes//a value useful to check the validity of mode value
 };//see also eMapModeStrings[] definition in .cpp
 

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -63,6 +63,9 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
         case mmObjectYZ:
             return TwoStrings(qApp->translate("Attacher3D", "Object's Y Z X","Attachment3D mode caption"),
                               qApp->translate("Attacher3D", "X', Y', Z' axes are matched with object's local Y, Z, X, respectively.","Attachment3D mode tooltip"));
+        case mmParallelPlane:
+            return TwoStrings(qApp->translate("Attacher3D", "XY parallel to plane","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "X' Y' plane is parallel to the plane (object's XY) and passes through the vertex.","Attachment3D mode tooltip"));
         case mmFlatFace:
             return TwoStrings(qApp->translate("Attacher3D", "XY on plane","Attachment3D mode caption"),
                               qApp->translate("Attacher3D", "X' Y' plane is aligned to coincide planar face.","Attachment3D mode tooltip"));
@@ -138,6 +141,9 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
         case mmObjectYZ:
             return TwoStrings(qApp->translate("Attacher2D", "Object's YZ","AttachmentPlane mode caption"),
                               qApp->translate("Attacher2D", "Plane is aligned to YZ local plane of linked object.","AttachmentPlane mode tooltip"));
+        case mmParallelPlane:
+            return TwoStrings(qApp->translate("Attacher2D", "XY parallel to plane","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "X' Y' plane is parallel to the plane (object's XY) and passes through the vertex","AttachmentPlane mode tooltip"));
         case mmFlatFace:
             return TwoStrings(qApp->translate("Attacher2D", "Plane face","AttachmentPlane mode caption"),
                               qApp->translate("Attacher2D", "Plane is aligned to coincide planar face.","AttachmentPlane mode tooltip"));

--- a/tests/src/Mod/Part/App/Attacher.cpp
+++ b/tests/src/Mod/Part/App/Attacher.cpp
@@ -171,6 +171,8 @@ TEST_F(AttacherTest, TestAllStringModesValid)
         "OXZ",
         "OYZ",
         "OYX",
+
+        "ParallelPlane",
     };
     int index = 0;
     for (auto mode : modes) {
@@ -197,6 +199,9 @@ TEST_F(AttacherTest, TestAllModesBoundaries)
     _boxes[1]->recomputeFeature();
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
 
+    _boxes[1]->MapMode.setValue(mmParallelPlane);
+    _boxes[1]->recomputeFeature();
+    EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));
     _boxes[1]->MapMode.setValue(mmFlatFace);
     _boxes[1]->recomputeFeature();
     EXPECT_TRUE(boxesMatch(_boxes[1]->Shape.getBoundingBox(), Base::BoundBox3d(0, 0, 0, 3, 1, 2)));


### PR DESCRIPTION
## Description

Add ParallelPlane attachment/map mode

It results in an attachment similar to ObjectXY but with the XY plane translated to pass through a selected vertex.

It is most useful to place sketches: pick a plane (XY, XZ, YZ) or another sketch then select a vertex to automatically translate the sketch in its Z/normal-direction. In contrast to the Translate attachment/map mode it does not move the origin in 2D/Sketcher.

Here's a screenshot:
![ParallelPlane](https://github.com/FreeCAD/FreeCAD/assets/299015/5e1d4ceb-8271-40ff-92cc-8ac8f8a00056)

Selected (in green) is the vertex (Sketch:Vertex3) to translate the TestSketch (also green) which contains and X and Y for visual reference. Note how X and Y are lifted from the origin XY plane.

And another screenshot showing attaching against YZ and the same vertex:
![ParallelPlaneYZ](https://github.com/FreeCAD/FreeCAD/assets/299015/0750da5d-79d9-42d4-8fa3-a3cb5e7f3542)


"Why is this needed? Can't you achieve the same with:"
"Translate attachment/map mode": No, Translate moves the projection of the origin onto the XY plane, invalidating sketch constraints that involve the origin
"Attachment Offset/Position": Yes but you either have to manually specify the height which is error prone or put in effort to figure out the correct formula (which is hard and error prone if angles are involved)

## Testing

Tested it's toponaming safe - works even when I somewhat destructively edit the referenced Sketch.
Tested works against XY, XZ, YZ planes, existing XY, XZ, YZ sketches, datum plane, even with attachment angle.

## Related issues

While it doesn't fix #8719 it provides an easy way to attach a correctly oriented sketch in basically the same place by picking the right plane and vertex