### PR TITLE
UI: Change transform tool task box icon and heading

### DIFF
--- a/src/Gui/TaskCSysDragger.cpp
+++ b/src/Gui/TaskCSysDragger.cpp
@@ -80,8 +80,8 @@ void TaskCSysDragger::dragStartCallback(void *, SoDragger *)
 void TaskCSysDragger::setupGui()
 {
     auto incrementsBox = new Gui::TaskView::TaskBox(
-      Gui::BitmapFactory().pixmap("button_valid"),
-      tr("Increments"), true, nullptr);
+      Gui::BitmapFactory().pixmap("Std_TransformManip"),
+      tr("Transform"), true, nullptr);
 
     auto gridLayout = new QGridLayout();
   gridLayout->setColumnStretch(1, 1);


### PR DESCRIPTION
Changing the transform tool icon to use the Std_TransformManip icon instead of a checkmark and changing the heading from Increment to Transform.

Previously:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/2239d2d1-a80c-4785-8fe0-c006548c6e01)

PR:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/24e8a831-5be1-46ca-bba5-1fc67bcf709b)
