### PR TITLE
BIM: Fixed IsActive of BIM commands

### DIFF
--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -197,7 +197,8 @@ class CommandStructuresFromSelection:
                 'ToolTip': QT_TRANSLATE_NOOP("Arch_StructuresFromSelection", "Create multiple Arch Structures from a selected base, using each selected edge as an extrusion path")}
 
     def IsActive(self):
-        return not FreeCAD.ActiveDocument is None
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
 
     def Activated(self):
         selex = FreeCADGui.Selection.getSelectionEx()

--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -246,7 +246,8 @@ class BIMWorkbench(Workbench):
                 t = QT_TRANSLATE_NOOP("BIM_GenericTools", "Generic 3D tools")
                 return { "MenuText": t, "ToolTip": t, "Icon": "BIM_Box"}
             def IsActive(self):
-                return not FreeCAD.ActiveDocument is None
+                v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+                return v
         FreeCADGui.addCommand("BIM_GenericTools", BIM_GenericTools(self.generictools))
         self.bimtools.append("BIM_GenericTools")
 
@@ -274,7 +275,8 @@ class BIMWorkbench(Workbench):
                     }
 
                 def IsActive(self):
-                    return not FreeCAD.ActiveDocument is None
+                    v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+                    return v
 
             FreeCADGui.addCommand("Arch_RebarTools", RebarGroupCommand())
             self.bimtools[self.bimtools.index("Arch_Rebar")] = "Arch_RebarTools"

--- a/src/Mod/BIM/bimcommands/BimBeam.py
+++ b/src/Mod/BIM/bimcommands/BimBeam.py
@@ -37,6 +37,10 @@ class BIM_Beam(ArchStructure._CommandStructure):
         super().__init__()
         self.beammode = True
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def GetResources(self):
         return {
             "Pixmap": "BIM_Beam",

--- a/src/Mod/BIM/bimcommands/BimColumn.py
+++ b/src/Mod/BIM/bimcommands/BimColumn.py
@@ -37,6 +37,10 @@ class BIM_Column(ArchStructure._CommandStructure):
         super().__init__()
         self.beammode = False
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def GetResources(self):
         return {
             "Pixmap": "BIM_Column",

--- a/src/Mod/BIM/bimcommands/BimCommon.py
+++ b/src/Mod/BIM/bimcommands/BimCommon.py
@@ -42,6 +42,10 @@ class BIM_Common:
             ),
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
         import PartGui
         FreeCADGui.runCommand("Part_Common")

--- a/src/Mod/BIM/bimcommands/BimCompound.py
+++ b/src/Mod/BIM/bimcommands/BimCompound.py
@@ -42,6 +42,10 @@ class BIM_Compound:
             ),
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
         import PartGui
         FreeCADGui.runCommand("Part_Compound")

--- a/src/Mod/BIM/bimcommands/BimCut.py
+++ b/src/Mod/BIM/bimcommands/BimCut.py
@@ -41,6 +41,10 @@ class BIM_Cut:
             ),
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
         import PartGui
         FreeCADGui.runCommand("Part_Cut")

--- a/src/Mod/BIM/bimcommands/BimExtrude.py
+++ b/src/Mod/BIM/bimcommands/BimExtrude.py
@@ -40,6 +40,10 @@ class BIM_Extrude:
             "ToolTip": QT_TRANSLATE_NOOP("BIM_Extrude", "Extrudes a selected 2D shape"),
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
         import PartGui
         FreeCADGui.runCommand("Part_Extrude")

--- a/src/Mod/BIM/bimcommands/BimFuse.py
+++ b/src/Mod/BIM/bimcommands/BimFuse.py
@@ -39,6 +39,10 @@ class BIM_Fuse:
             "ToolTip": QT_TRANSLATE_NOOP("Part_Fuse", "Make a union of several shapes"),
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
         import PartGui
         FreeCADGui.runCommand("Part_Fuse")

--- a/src/Mod/BIM/bimcommands/BimLayers.py
+++ b/src/Mod/BIM/bimcommands/BimLayers.py
@@ -58,6 +58,10 @@ class BIM_Layers:
             ),
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
 
         from PySide import QtCore, QtGui

--- a/src/Mod/BIM/bimcommands/BimMaterial.py
+++ b/src/Mod/BIM/bimcommands/BimMaterial.py
@@ -60,6 +60,10 @@ class BIM_Material:
             ),
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
 
         self.dlg = None

--- a/src/Mod/BIM/bimcommands/BimOffset.py
+++ b/src/Mod/BIM/bimcommands/BimOffset.py
@@ -41,6 +41,10 @@ class BIM_Offset2D:
             ),
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
         import PartGui
         FreeCADGui.runCommand("Part_Offset2D")

--- a/src/Mod/BIM/bimcommands/BimPreflight.py
+++ b/src/Mod/BIM/bimcommands/BimPreflight.py
@@ -68,6 +68,10 @@ class BIM_Preflight:
             ),
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
         FreeCADGui.BIMPreflightDone = False
         FreeCADGui.Control.showDialog(BIM_Preflight_TaskPanel())

--- a/src/Mod/BIM/bimcommands/BimRewire.py
+++ b/src/Mod/BIM/bimcommands/BimRewire.py
@@ -44,6 +44,10 @@ class BIM_Rewire:
             "Accel": "R,W",
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
         import Part
         import Draft

--- a/src/Mod/BIM/bimcommands/BimSimpleCopy.py
+++ b/src/Mod/BIM/bimcommands/BimSimpleCopy.py
@@ -42,6 +42,10 @@ class BIM_SimpleCopy:
             ),
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
         import PartGui
         FreeCADGui.runCommand("Part_SimpleCopy")

--- a/src/Mod/BIM/bimcommands/BimWindows.py
+++ b/src/Mod/BIM/bimcommands/BimWindows.py
@@ -41,6 +41,10 @@ class BIM_Windows:
             ),
         }
 
+    def IsActive(self):
+        v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+        return v
+
     def Activated(self):
         FreeCADGui.Control.showDialog(BIM_Windows_TaskPanel())
 


### PR DESCRIPTION
This makes BIM commands inactive when the active view is not a 3D view (most were already, some were missing)