### PR TITLE
Sketcher: Changes override draw style when entering sketch edit mode.

### DIFF
--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -69,14 +69,6 @@ int View3DSettings::stopAnimatingIfDeactivated() const
 
 void View3DSettings::applySettings()
 {
-    // Check if Sketcher Edit Mode exited cleanly
-    const int overMaxHeadlightIntensity = 101;
-    int sketcherEditLastExit = hGrp->GetInt("HeadlightIntensityExisting", overMaxHeadlightIntensity);
-    if (sketcherEditLastExit != overMaxHeadlightIntensity) {
-        // must mean a seg fault or abnormal exit last time
-        hGrp->SetInt("HeadlightIntensity", sketcherEditLastExit);
-        hGrp->RemoveInt("HeadlightIntensityExisting");
-    }
     // apply the user settings
     OnChange(*hGrp,"EyeDistance");
     OnChange(*hGrp,"CornerCoordSystem");

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -107,6 +107,7 @@ void SketcherSettings::saveSettings()
     ui->checkBoxAdvancedSolverTaskBox->onSave();
     ui->checkBoxRecalculateInitialSolutionWhileDragging->onSave();
     ui->checkBoxEnableEscape->onSave();
+    ui->checkBoxDisableShading->onSave();
     ui->checkBoxNotifyConstraintSubstitutions->onSave();
     ui->checkBoxAutoRemoveRedundants->onSave();
     ui->checkBoxUnifiedCoincident->onSave();
@@ -178,6 +179,7 @@ void SketcherSettings::loadSettings()
     ui->checkBoxAdvancedSolverTaskBox->onRestore();
     ui->checkBoxRecalculateInitialSolutionWhileDragging->onRestore();
     ui->checkBoxEnableEscape->onRestore();
+    ui->checkBoxDisableShading->onRestore();
     ui->checkBoxNotifyConstraintSubstitutions->onRestore();
     ui->checkBoxAutoRemoveRedundants->onRestore();
     ui->checkBoxUnifiedCoincident->onRestore();

--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -141,6 +141,25 @@ Requires to re-enter edit mode to take effect.</string>
        </widget>
       </item>
       <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxDisableShading">
+        <property name="toolTip">
+         <string>Disables the shaded view when entering the sketch edit mode.</string>
+        </property>
+        <property name="text">
+         <string>Disable shading in edit mode</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="1">
+         <cstring>DisableShadedView</cstring>
+        </property>
+        <property name="prefPath" stdset="1">
+         <cstring>Mod/Sketcher/General</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxNotifyConstraintSubstitutions">
         <property name="toolTip">
          <string>Notifies about automatic constraint substitutions</string>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3226,14 +3226,24 @@ void ViewProviderSketch::unsetEdit(int ModNum)
             deactivateHandler();
 
         // Resets the override draw style mode when leaving the sketch edit mode.
-        // TODO: This could maybe also be a preference (enable auto switch of draw style). Additionally the previous override draw style could be saved and applied when leaving the edit mode.
-        Gui::MDIView* mdi = Gui::Application::Instance->editViewOfNode(editCoinManager->getRootEditNode());
-        Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(mdi)->getViewer();
-        if (viewer)
+        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+        auto disableShadedView = hGrp->GetBool("DisableShadedView", true);
+        if (disableShadedView) {
+            Gui::Document* doc = Gui::Application::Instance->activeDocument();
+            Gui::MDIView* mdi = doc->getActiveView();
+            Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(mdi)->getViewer();
+
+            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+            auto OverrideMode = hGrp->GetASCII("OverrideMode", "As Is");
+
+            if (viewer)
             {
-                viewer->updateOverrideMode("As Is");
-                viewer->setOverrideMode("As Is");
+                viewer->updateOverrideMode(OverrideMode);
+                viewer->setOverrideMode(OverrideMode);
             }
+        }
 
         editCoinManager = nullptr;
         snapManager = nullptr;
@@ -3312,12 +3322,22 @@ void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int Mo
     }
 
     // Sets the view mode to no shading to prevent visibility issues against parallel surfaces with shininess when entering the sketch mode.
-    // TODO: This could maybe also be a preference (enable auto switch of draw style) and further improved if the user has already an override draw style enabled which has no shading (e.g. wireframe). Additionally the current override draw style could be saved and applied when leaving the edit mode.
-    if (viewer)
-    {
-        viewer->updateOverrideMode("No Shading");
-        viewer->setOverrideMode("No Shading");
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+    auto disableShadedView = hGrp->GetBool("DisableShadedView", true);
+
+    hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+    hGrp->SetASCII("OverrideMode", viewer->getOverrideMode());
+
+    if (disableShadedView) {
+
+
+            viewer->updateOverrideMode("No Shading");
+            viewer->setOverrideMode("No Shading");
+
     }
+
 
     auto editDoc = Gui::Application::Instance->editDocument();
     editDocName.clear();


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/13989
And reverts changes from https://github.com/FreeCAD/FreeCAD/pull/14013 as this did not solve https://github.com/FreeCAD/FreeCAD/issues/13989 This solution works in all themes and with all colors and shininess values without making the document darker or changing light direction.

The idea is:
- change to the override draw style `No Shading` when entering a sketch. Therefore, no light needs to be changed and the sketch is always visible
- change back to the previous override draw style when leaving the sketch

A new preference is introduced: `Disable shading in edit mode`, default activated.
If this setting is checked, the override draw style switches to `No Shading` when entering the sketch edit mode.
The previous override draw style is stored and applied when leaving the sketch edit mode.

Demo:

https://github.com/FreeCAD/FreeCAD/assets/6246609/b82f8f62-b75c-466d-bbc0-2ea5533d7937





@FreeCAD/design-working-group FYI