### PR TITLE
BIM: Added square and rectangular profiles to pipes

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -442,6 +442,8 @@ def makePipe(baseobj=None,diameter=0,length=0,placement=None,name=None):
         obj.Diameter = diameter
     else:
         obj.Diameter = params.get_param_arch("PipeDiameter")
+    obj.Width = obj.Diameter
+    obj.Height = obj.Diameter
     if placement:
         obj.Placement = placement
     return obj


### PR DESCRIPTION
Pipe objects now have a *ProfileType* property that can be Circle (default), Square or Rectangle.