### PR TITLE
Tux: Detect and fix BIM addon

### DIFF
--- a/src/Mod/Tux/InitGui.py
+++ b/src/Mod/Tux/InitGui.py
@@ -33,3 +33,19 @@ if p.GetGroup("PersistentToolbars").GetBool("Enabled", 1):
     import PersistentToolbarsGui
 else:
     pass
+
+# Temporary - for FreeCAD v1.0
+# Detect a possible clash between the built-in BIM WB in v1.0
+# and the BIM addon. Resolve this by renaming the BIM add-on path
+try:
+    import Arch_rc
+    # we could import Arch_rc, nothing to be done, either we are
+    # running built-in BIM without the addon, or the addon without built-in BIM
+except:
+    # Arch_rc not importable: We have both the BIM addon and the built-in BIM
+    import os
+    import FreeCAD
+    modpath = os.path.join(FreeCAD.getUserAppDataDir(), "Mod")
+    if "BIM" in os.listdir(modpath):
+        os.rename(os.path.join(modpath, "BIM"), os.path.join(modpath, "BIM021"))
+        FreeCAD.Console.PrintWarning("BIM addon path has been renamed to BIM021 to avoid conflicts with the builtin BIM workbench. Please restart FreeCAD\n")

--- a/src/Mod/Tux/InitGui.py
+++ b/src/Mod/Tux/InitGui.py
@@ -39,13 +39,17 @@ else:
 # and the BIM addon. Resolve this by renaming the BIM add-on path
 try:
     import Arch_rc
+
     # we could import Arch_rc, nothing to be done, either we are
     # running built-in BIM without the addon, or the addon without built-in BIM
 except:
     # Arch_rc not importable: We have both the BIM addon and the built-in BIM
     import os
     import FreeCAD
+
     modpath = os.path.join(FreeCAD.getUserAppDataDir(), "Mod")
     if "BIM" in os.listdir(modpath):
         os.rename(os.path.join(modpath, "BIM"), os.path.join(modpath, "BIM021"))
-        FreeCAD.Console.PrintWarning("BIM addon path has been renamed to BIM021 to avoid conflicts with the builtin BIM workbench. Please restart FreeCAD\n")
+        FreeCAD.Console.PrintWarning(
+            "BIM addon path has been renamed to BIM021 to avoid conflicts with the builtin BIM workbench. Please restart FreeCAD\n"
+        )


### PR DESCRIPTION
This PR uses the Tux addon (which in any case is already used to tweak stuff in Draft/Arch/BIM...) to detect a situation where both the BIM addon and the built-in BIM workbench are present.

If such a situation is met, the BIM addon path is renamed from UserAppDataDir/Mod/BIM to UserAppDataDir/Mod/BIM021 and the user gets a warning to restart FreeCAD.

Fixes #14072