### PR TITLE
Part: Not needed translation for STEP

### DIFF
--- a/src/Mod/Part/Gui/DlgExportHeaderStep.ui
+++ b/src/Mod/Part/Gui/DlgExportHeaderStep.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>STEP</string>
+   <string notr="true">STEP</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <item row="1" column="0">

--- a/src/Mod/Part/Gui/DlgExportStep.ui
+++ b/src/Mod/Part/Gui/DlgExportStep.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>STEP</string>
+   <string notr="true">STEP</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <item row="0" column="0">

--- a/src/Mod/Part/Gui/DlgImportStep.ui
+++ b/src/Mod/Part/Gui/DlgImportStep.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>STEP</string>
+   <string notr="true">STEP</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <item row="1" column="0">

--- a/src/Mod/Part/Gui/DlgPartImportStepImp.cpp
+++ b/src/Mod/Part/Gui/DlgPartImportStepImp.cpp
@@ -64,7 +64,7 @@ void DlgPartImportStepImp::onChooseFileName()
 {
     QString fn = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(),
         QString::fromLatin1("%1 (*.stp *.step);;%2 (*.*)"))
-        .arg(tr("STEP"),
+        .arg(QLatin1String("STEP"),
              tr("All Files"));
     if (!fn.isEmpty()) {
         ui->FileName->setText(fn);

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
@@ -170,7 +170,7 @@ DlgImportExportStep::DlgImportExportStep(QWidget* parent)
   , importStep(new DlgImportStep(this))
   , headerStep(new DlgExportHeaderStep(this))
 {
-    setWindowTitle(tr("STEP"));
+    setWindowTitle(QLatin1String("STEP"));
     QVBoxLayout* layout = new QVBoxLayout(this);
     layout->setSpacing(0);
     layout->setContentsMargins(0, 0, 0, 0);


### PR DESCRIPTION
Currently it translated into some languages

src/Mod/Part/Gui/Resources/translations/

```
./Part_ru.ts-2554-      <translation>ШАГ</translation>
./Part_ru.ts-3134-      <translation>ШАГ</translation>
./Part_ru.ts-3142-      <translation>ШАГ</translation>
./Part_id.ts-2631-      <translation>LANGKAH</translation>
./Part_id.ts-2664-      <translation>LANGKAH</translation>
./Part_id.ts-3245-      <translation>LANGKAH</translation>
./Part_id.ts-3253-      <translation>LANGKAH</translation>
./Part_id.ts-3504-      <translation>LANGKAH</translation>
./Part_vi.ts-2660-      <translation>BƯỚC</translation>
./Part_vi.ts-2693-      <translation>BƯỚC</translation>
./Part_vi.ts-3271-      <translation>BƯỚC</translation>
./Part_vi.ts-3279-      <translation>BƯỚC</translation>
./Part_vi.ts-3530-      <translation>BƯỚC</translation>
```