### PR TITLE
Activate Part/Part Design check and refine preferences by default

### DIFF
--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -124,7 +124,7 @@ App::DocumentObjectExecReturn* Boolean::execute()
                                                  ->GetGroup("Preferences")
                                                  ->GetGroup("Mod/Part/Boolean");
 
-        if (hGrp->GetBool("CheckModel", false)) {
+        if (hGrp->GetBool("CheckModel", true)) {
             BRepCheck_Analyzer aChecker(resShape);
             if (!aChecker.IsValid()) {
                 return new App::DocumentObjectExecReturn("Resulting shape is invalid");

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -147,7 +147,7 @@ App::DocumentObjectExecReturn *MultiCommon::execute()
 
             Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
                 .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part/Boolean");
-            if (hGrp->GetBool("CheckModel", false)) {
+            if (hGrp->GetBool("CheckModel", true)) {
                  BRepCheck_Analyzer aChecker(resShape);
                  if (! aChecker.IsValid() ) {
                      return new App::DocumentObjectExecReturn("Resulting shape is invalid");
@@ -222,7 +222,7 @@ App::DocumentObjectExecReturn *MultiCommon::execute()
                                              .GetGroup("BaseApp")
                                              ->GetGroup("Preferences")
                                              ->GetGroup("Mod/Part/Boolean");
-    if (hGrp->GetBool("CheckModel", false)) {
+    if (hGrp->GetBool("CheckModel", true)) {
         BRepCheck_Analyzer aChecker(res.getShape());
         if (!aChecker.IsValid()) {
             return new App::DocumentObjectExecReturn("Resulting shape is invalid");

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -148,7 +148,7 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
 
             Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
                 .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part/Boolean");
-            if (hGrp->GetBool("CheckModel", false)) {
+            if (hGrp->GetBool("CheckModel", true)) {
                 BRepCheck_Analyzer aChecker(resShape);
                 if (! aChecker.IsValid() ) {
                     return new App::DocumentObjectExecReturn("Resulting shape is invalid");
@@ -268,7 +268,7 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
                                                      .GetGroup("BaseApp")
                                                      ->GetGroup("Preferences")
                                                      ->GetGroup("Mod/Part/Boolean");
-            if (hGrp->GetBool("CheckModel", false)) {
+            if (hGrp->GetBool("CheckModel", true)) {
                 BRepCheck_Analyzer aChecker(res.getShape());
                 if (!aChecker.IsValid()) {
                     return new App::DocumentObjectExecReturn("Resulting shape is invalid");

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -25,10 +25,10 @@
         <property name="text">
          <string>Automatically check model after boolean operation</string>
         </property>
-        <property name="prefEntry" stdset="0">
+        <property name="prefEntry" stdset="1">
          <cstring>CheckModel</cstring>
         </property>
-        <property name="prefPath" stdset="0">
+        <property name="prefPath" stdset="1">
          <cstring>Mod/Part/Boolean</cstring>
         </property>
        </widget>
@@ -38,10 +38,10 @@
         <property name="text">
          <string>Automatically refine model after boolean operation</string>
         </property>
-        <property name="prefEntry" stdset="0">
+        <property name="prefEntry" stdset="1">
          <cstring>RefineModel</cstring>
         </property>
-        <property name="prefPath" stdset="0">
+        <property name="prefPath" stdset="1">
          <cstring>Mod/Part/Boolean</cstring>
         </property>
        </widget>
@@ -51,10 +51,10 @@
         <property name="text">
          <string>Automatically refine model after sketch-based operation</string>
         </property>
-        <property name="prefEntry" stdset="0">
+        <property name="prefEntry" stdset="1">
          <cstring>RefineModel</cstring>
         </property>
-        <property name="prefPath" stdset="0">
+        <property name="prefPath" stdset="1">
          <cstring>Mod/PartDesign</cstring>
         </property>
        </widget>

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -25,10 +25,13 @@
         <property name="text">
          <string>Automatically check model after boolean operation</string>
         </property>
-        <property name="prefEntry" stdset="1">
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
          <cstring>CheckModel</cstring>
         </property>
-        <property name="prefPath" stdset="1">
+        <property name="prefPath" stdset="0">
          <cstring>Mod/Part/Boolean</cstring>
         </property>
        </widget>
@@ -38,10 +41,13 @@
         <property name="text">
          <string>Automatically refine model after boolean operation</string>
         </property>
-        <property name="prefEntry" stdset="1">
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
          <cstring>RefineModel</cstring>
         </property>
-        <property name="prefPath" stdset="1">
+        <property name="prefPath" stdset="0">
          <cstring>Mod/Part/Boolean</cstring>
         </property>
        </widget>
@@ -51,10 +57,13 @@
         <property name="text">
          <string>Automatically refine model after sketch-based operation</string>
         </property>
-        <property name="prefEntry" stdset="1">
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
          <cstring>RefineModel</cstring>
         </property>
-        <property name="prefPath" stdset="1">
+        <property name="prefPath" stdset="0">
          <cstring>Mod/PartDesign</cstring>
         </property>
        </widget>

--- a/src/Mod/PartDesign/App/FeatureAddSub.cpp
+++ b/src/Mod/PartDesign/App/FeatureAddSub.cpp
@@ -49,7 +49,7 @@ FeatureAddSub::FeatureAddSub()
     //init Refine property
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/PartDesign");
-    this->Refine.setValue(hGrp->GetBool("RefineModel", false));
+    this->Refine.setValue(hGrp->GetBool("RefineModel", true));
 }
 
 FeatureAddSub::Type FeatureAddSub::getAddSubType()

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -54,7 +54,7 @@ Boolean::Boolean()
     ADD_PROPERTY_TYPE(Refine,(0),"Part Design",(App::PropertyType)(App::Prop_None),"Refine shape (clean up redundant edges) after adding/subtracting");
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/PartDesign");
-    this->Refine.setValue(hGrp->GetBool("RefineModel", false));
+    this->Refine.setValue(hGrp->GetBool("RefineModel", true));
     ADD_PROPERTY_TYPE(UsePlacement,(0),"Part Design",(App::PropertyType)(App::Prop_None),"Apply the placement of the second ( tool ) object");
     this->UsePlacement.setValue(false);
 

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -78,13 +78,10 @@ Transformed::Transformed()
                       (App::PropertyType)(App::Prop_None),
                       "Refine shape (clean up redundant edges) after adding/subtracting");
 
-    // init Refine property
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
-                                             .GetUserParameter()
-                                             .GetGroup("BaseApp")
-                                             ->GetGroup("Preferences")
-                                             ->GetGroup("Mod/PartDesign");
-    this->Refine.setValue(hGrp->GetBool("RefineModel", false));
+    //init Refine property
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/PartDesign");
+    this->Refine.setValue(hGrp->GetBool("RefineModel", true));
 }
 
 void Transformed::positionBySupport()

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -387,7 +387,7 @@ void SubShapeBinder::setupObject() {
 
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/PartDesign");
-    this->Refine.setValue(hGrp->GetBool("RefineModel", false));
+    this->Refine.setValue(hGrp->GetBool("RefineModel", true));
 }
 
 App::DocumentObject* SubShapeBinder::getSubObject(const char* subname, PyObject** pyObj,

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -1428,7 +1428,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         edges = [name for name in reverseMap.keys() if name.startswith("Edge")]
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
-        self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 62)
+        self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 64)
         self.assertEqual(len(reverseMap),62)
         self.assertEqual(len(faces),12)
         self.assertEqual(len(edges),30)

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
@@ -528,8 +528,8 @@ class TestSketcherSolver(unittest.TestCase):
         CreateRectangleSketch(sketch2, (0, 0), (3, 3))
         body.addObject(sketch2)
         self.Doc.recompute()
-        sketch2.addExternal("Hole", "Edge35")  # Edge35 will disappear when we stop modeling threads
-        self.assertEqual(len(hole.Shape.Edges), 38)
+        sketch2.addExternal("Hole", "Edge29")  # Edge29 will disappear when we stop modeling threads
+        self.assertEqual(len(hole.Shape.Edges), 32)
         hole.ModelThread = False
         hole.Refine = True
         self.Doc.recompute()

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
@@ -519,7 +519,7 @@ class TestSketcherSolver(unittest.TestCase):
         hole.DrillForDepth = 0
         hole.Tapered = 0
         self.Doc.recompute()
-        self.assertEqual(len(hole.Shape.Edges), 13)
+        self.assertEqual(len(hole.Shape.Edges), 12)
         hole.Threaded = True
         hole.ModelThread = True
         body.addObject(hole)


### PR DESCRIPTION
fixes https://github.com/FreeCAD/FreeCAD/issues/13472

Makes these preferences activated by default to check and refine the model:
![grafik](https://github.com/FreeCAD/FreeCAD/assets/6246609/2de893fc-1d57-4e17-a270-58e2e6b7953c)

@howie-j FYI