### PR TITLE
Select code page during STEP Import 

### DIFF
--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.h
@@ -25,8 +25,10 @@
 
 #include <QWindow>
 #include <QOpenGLExtraFunctions>
+
+#include <QtGui/qpainter.h>
 #include <QPainter>
-#include <QOpenGLPaintDevice>
+
 
 
 namespace MillSim
@@ -89,7 +91,6 @@ private:
     bool mNeedsInitialize = false;
 
     QOpenGLContext* mContext = nullptr;
-    QOpenGLPaintDevice* mDevice = nullptr;
     MillSim::MillSimulation* mMillSimulator = nullptr;
     static DlgCAMSimulator* mInstance;
     SimStock mStock = {0, 0, 0, 1, 1, 1, 1};

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -157,9 +157,10 @@ private:
             hApp->NewDocument(TCollection_ExtendedString("MDTV-CAF"), hDoc);
 
             if (file.hasExtension({"stp", "step"})) {
+                Resource_FormatType cp = Resource_FormatType_UTF8;
                 try {
                     Import::ReaderStep reader(file);
-                    reader.read(hDoc);
+                    reader.read(hDoc, cp);
                 }
                 catch (OSD_Exception& e) {
                     Base::Console().Error("%s\n", e.GetMessageString());

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -160,7 +160,11 @@ private:
                 Resource_FormatType cp = Resource_FormatType_UTF8;
                 try {
                     Import::ReaderStep reader(file);
+#if OCC_VERSION_HEX < 0x070800
+                    reader.read(hDoc);
+#else
                     reader.read(hDoc, cp);
+#endif
                 }
                 catch (OSD_Exception& e) {
                     Base::Console().Error("%s\n", e.GetMessageString());

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -157,7 +157,9 @@ private:
             hApp->NewDocument(TCollection_ExtendedString("MDTV-CAF"), hDoc);
 
             if (file.hasExtension({"stp", "step"})) {
+#if OCC_VERSION_HEX >= 0x070800
                 Resource_FormatType cp = Resource_FormatType_UTF8;
+#endif
                 try {
                     Import::ReaderStep reader(file);
 #if OCC_VERSION_HEX < 0x070800

--- a/src/Mod/Import/App/ReaderStep.cpp
+++ b/src/Mod/Import/App/ReaderStep.cpp
@@ -42,7 +42,11 @@ ReaderStep::ReaderStep(const Base::FileInfo& file)  // NOLINT
     : file {file}
 {}
 
-void ReaderStep::read(Handle(TDocStd_Document) hDoc, Resource_FormatType codePage)  // NOLINT
+#if OCC_VERSION_HEX < 0x070800
+void ReaderStep::read(Handle(TDocStd_Document) hDoc) // NOLINT
+#else
+void ReaderStep::read(Handle(TDocStd_Document) hDoc, Resource_FormatType codePage) // NOLINT
+#endif
 {
     std::string utf8Name = file.filePath();
     std::string name8bit = Part::encodeFilename(utf8Name);

--- a/src/Mod/Import/App/ReaderStep.cpp
+++ b/src/Mod/Import/App/ReaderStep.cpp
@@ -42,7 +42,7 @@ ReaderStep::ReaderStep(const Base::FileInfo& file)  // NOLINT
     : file {file}
 {}
 
-void ReaderStep::read(Handle(TDocStd_Document) hDoc,Resource_FormatType codePage)   // NOLINT
+void ReaderStep::read(Handle(TDocStd_Document) hDoc, Resource_FormatType codePage)  // NOLINT
 {
     std::string utf8Name = file.filePath();
     std::string name8bit = Part::encodeFilename(utf8Name);
@@ -57,7 +57,7 @@ void ReaderStep::read(Handle(TDocStd_Document) hDoc,Resource_FormatType codePage
     Handle(StepData_StepModel) aStepModel = new StepData_StepModel;
     aStepModel->InternalParameters.InitFromStatic();
     aStepModel->SetSourceCodePage(codePage);
-    if (aReader.ReadFile(name8bit.c_str(),aStepModel->InternalParameters) != IFSelect_RetDone) {
+    if (aReader.ReadFile(name8bit.c_str(), aStepModel->InternalParameters) != IFSelect_RetDone) {
 #endif
         throw Base::FileException("Cannot read STEP file", file);
     }

--- a/src/Mod/Import/App/ReaderStep.cpp
+++ b/src/Mod/Import/App/ReaderStep.cpp
@@ -42,7 +42,7 @@ ReaderStep::ReaderStep(const Base::FileInfo& file)  // NOLINT
     : file {file}
 {}
 
-void ReaderStep::read(Handle(TDocStd_Document) hDoc)  // NOLINT
+void ReaderStep::read(Handle(TDocStd_Document) hDoc,Resource_FormatType codePage)   // NOLINT
 {
     std::string utf8Name = file.filePath();
     std::string name8bit = Part::encodeFilename(utf8Name);
@@ -51,7 +51,14 @@ void ReaderStep::read(Handle(TDocStd_Document) hDoc)  // NOLINT
     aReader.SetNameMode(true);
     aReader.SetLayerMode(true);
     aReader.SetSHUOMode(true);
+#if OCC_VERSION_HEX < 0x070800
     if (aReader.ReadFile(name8bit.c_str()) != IFSelect_RetDone) {
+#else
+    Handle(StepData_StepModel) aStepModel = new StepData_StepModel;
+    aStepModel->InternalParameters.InitFromStatic();
+    aStepModel->SetSourceCodePage(codePage);
+    if (aReader.ReadFile(name8bit.c_str(),aStepModel->InternalParameters) != IFSelect_RetDone) {
+#endif
         throw Base::FileException("Cannot read STEP file", file);
     }
 

--- a/src/Mod/Import/App/ReaderStep.h
+++ b/src/Mod/Import/App/ReaderStep.h
@@ -27,6 +27,7 @@
 #include <Mod/Import/ImportGlobal.h>
 #include <Base/FileInfo.h>
 #include <TDocStd_Document.hxx>
+#include <StepData_StepModel.hxx>
 
 namespace Import
 {
@@ -36,7 +37,7 @@ class ImportExport ReaderStep
 public:
     explicit ReaderStep(const Base::FileInfo& file);
 
-    void read(Handle(TDocStd_Document) hDoc);
+    void read(Handle(TDocStd_Document) hDoc, Resource_FormatType codePage);
 
 private:
     Base::FileInfo file;

--- a/src/Mod/Import/App/ReaderStep.h
+++ b/src/Mod/Import/App/ReaderStep.h
@@ -28,6 +28,7 @@
 #include <Base/FileInfo.h>
 #include <TDocStd_Document.hxx>
 #include <StepData_StepModel.hxx>
+#include <Standard_Version.hxx>
 
 namespace Import
 {
@@ -36,8 +37,11 @@ class ImportExport ReaderStep
 {
 public:
     explicit ReaderStep(const Base::FileInfo& file);
-
+#if OCC_VERSION_HEX < 0x070800
+    void read(Handle(TDocStd_Document) hDoc);
+#else
     void read(Handle(TDocStd_Document) hDoc, Resource_FormatType codePage);
+#endif
 
 private:
     Base::FileInfo file;

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -165,10 +165,11 @@ private:
                     mode = ocaf.getMode();
                 }
 #if OCC_VERSION_HEX >= 0x070800
-                auto handle = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Import/hSTEP");
-                if(handle->GetBool("ReadShowDialogImport", false))
-                {
-                    Gui::Command::doCommand(Gui::Command::Gui,"Gui.showPreferences('Import-Export', 8)");
+                auto handle = App::GetApplication().GetParameterGroupByPath(
+                    "User parameter:BaseApp/Preferences/Mod/Import/hSTEP");
+                if (handle->GetBool("ReadShowDialogImport", false)) {
+                    Gui::Command::doCommand(Gui::Command::Gui,
+                                            "Gui.showPreferences('Import-Export', 8)");
                 }
                 Part::OCAF::ImportExportSettings settings;
                 Resource_FormatType cp = settings.getImportCodePage();

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -172,7 +172,10 @@ private:
                 }
                 Part::OCAF::ImportExportSettings settings;
                 Resource_FormatType cp = settings.getImportCodePage();
+#else
+                Resource_FormatType cp = Resource_FormatType_UTF8;
 #endif
+
                 if (mode && !pcDoc->isSaved()) {
                     auto gdoc = Gui::Application::Instance->getDocument(pcDoc);
                     if (!gdoc->save()) {

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -173,10 +173,7 @@ private:
                 }
                 Part::OCAF::ImportExportSettings settings;
                 Resource_FormatType cp = settings.getImportCodePage();
-#else
-                Resource_FormatType cp = Resource_FormatType_UTF8;
 #endif
-
                 if (mode && !pcDoc->isSaved()) {
                     auto gdoc = Gui::Application::Instance->getDocument(pcDoc);
                     if (!gdoc->save()) {

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -186,7 +186,11 @@ private:
 
                 try {
                     Import::ReaderStep reader(file);
+#if OCC_VERSION_HEX < 0x070800
+                    reader.read(hDoc);
+#else
                     reader.read(hDoc, cp);
+#endif
                 }
                 catch (OSD_Exception& e) {
                     Base::Console().Error("%s\n", e.GetMessageString());
@@ -496,7 +500,11 @@ private:
 
             if (file.hasExtension({"stp", "step"})) {
                 Import::ReaderStep reader(file);
+#if OCC_VERSION_HEX < 0x070800
+                reader.read(hDoc);
+#else
                 reader.read(hDoc, Resource_FormatType_UTF8);
+#endif
             }
             else if (file.hasExtension({"igs", "iges"})) {
                 Import::ReaderIges reader(file);

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -164,6 +164,15 @@ private:
                 if (mode < 0) {
                     mode = ocaf.getMode();
                 }
+#if OCC_VERSION_HEX >= 0x070800
+                auto handle = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Import/hSTEP");
+                if(handle->GetBool("ReadShowDialogImport", false))
+                {
+                    Gui::Command::doCommand(Gui::Command::Gui,"Gui.showPreferences('Import-Export', 8)");
+                }
+                Part::OCAF::ImportExportSettings settings;
+                Resource_FormatType cp = settings.getImportCodePage();
+#endif
                 if (mode && !pcDoc->isSaved()) {
                     auto gdoc = Gui::Application::Instance->getDocument(pcDoc);
                     if (!gdoc->save()) {
@@ -173,7 +182,7 @@ private:
 
                 try {
                     Import::ReaderStep reader(file);
-                    reader.read(hDoc);
+                    reader.read(hDoc, cp);
                 }
                 catch (OSD_Exception& e) {
                     Base::Console().Error("%s\n", e.GetMessageString());
@@ -483,7 +492,7 @@ private:
 
             if (file.hasExtension({"stp", "step"})) {
                 Import::ReaderStep reader(file);
-                reader.read(hDoc);
+                reader.read(hDoc, Resource_FormatType_UTF8);
             }
             else if (file.hasExtension({"igs", "iges"})) {
                 Import::ReaderIges reader(file);

--- a/src/Mod/Part/App/OCAF/ImportExportSettings.cpp
+++ b/src/Mod/Part/App/OCAF/ImportExportSettings.cpp
@@ -99,6 +99,44 @@ void ImportExportSettings::initIGES(Base::Reference<ParameterGrp> hGrp)
     }
 }
 
+void ImportExportSettings::setImportCodePage(int cpIndex)
+{
+    pGroup->SetInt("ImportCodePage", cpIndex);
+}
+
+Resource_FormatType ImportExportSettings::getImportCodePage() const
+{
+    Resource_FormatType result;
+    int codePageIndex = pGroup->GetInt("ImportCodePage", 0);
+    int i=0;
+    for (const auto& codePageIt : codePageList) {
+        if (i == codePageIndex)
+        {
+            result = codePageIt.codePage;
+            break;
+        }
+        i++;
+    }
+    return result;
+}
+
+std::list<ImportExportSettings::CodePage> ImportExportSettings::getCodePageList() const
+{
+    return codePageList;
+}
+
+void ImportExportSettings::setReadShowDialogImport(bool on)
+{
+    auto grp = pGroup->GetGroup("hSTEP");
+    grp->SetBool("ReadShowDialogImport", on);
+}
+
+bool ImportExportSettings::getReadShowDialogImport() const
+{
+    auto grp = pGroup->GetGroup("hSTEP");
+    return grp->GetBool("ReadShowDialogImport", false);
+}
+
 void ImportExportSettings::initSTEP(Base::Reference<ParameterGrp> hGrp)
 {
     //STEP handling

--- a/src/Mod/Part/App/OCAF/ImportExportSettings.cpp
+++ b/src/Mod/Part/App/OCAF/ImportExportSettings.cpp
@@ -22,7 +22,7 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <Interface_Static.hxx>
+#include <Interface_Static.hxx>
 #endif
 
 #include "ImportExportSettings.h"
@@ -99,6 +99,8 @@ void ImportExportSettings::initIGES(Base::Reference<ParameterGrp> hGrp)
     }
 }
 
+#if OCC_VERSION_HEX >= 0x070800
+
 void ImportExportSettings::setImportCodePage(int cpIndex)
 {
     pGroup->SetInt("ImportCodePage", cpIndex);
@@ -136,6 +138,8 @@ bool ImportExportSettings::getReadShowDialogImport() const
     auto grp = pGroup->GetGroup("hSTEP");
     return grp->GetBool("ReadShowDialogImport", false);
 }
+
+#endif
 
 void ImportExportSettings::initSTEP(Base::Reference<ParameterGrp> hGrp)
 {

--- a/src/Mod/Part/App/OCAF/ImportExportSettings.h
+++ b/src/Mod/Part/App/OCAF/ImportExportSettings.h
@@ -26,7 +26,10 @@
 #include <memory>
 #include <Mod/Part/App/Interface.h>
 #include <Base/Parameter.h>
+#include <Standard_Version.hxx>
+#if OCC_VERSION_HEX >= 0x070800
 #include <Resource_FormatType.hxx>
+#endif
 
 namespace Part
 {
@@ -54,12 +57,12 @@ public:
         ObjectPerDocument = 3,
         ObjectPerDirectory = 4,
     };
-
+#if OCC_VERSION_HEX >= 0x070800
     struct CodePage {
         std::string codePageName;
         Resource_FormatType codePage;
     };
-
+#endif
     static void initialize();
     ImportExportSettings();
 
@@ -99,13 +102,14 @@ public:
     void setImportMode(ImportMode);
     ImportMode getImportMode() const;
 
+#if OCC_VERSION_HEX >= 0x070800
     void setReadShowDialogImport(bool);
     bool getReadShowDialogImport() const;
 
     void setImportCodePage(int);
     Resource_FormatType getImportCodePage() const;
     std::list<ImportExportSettings::CodePage> getCodePageList() const;
-
+#endif
 private:
     static void initGeneral(Base::Reference<ParameterGrp> hGrp);
     static void initSTEP(Base::Reference<ParameterGrp> hGrp);
@@ -115,6 +119,7 @@ private:
     mutable STEP::ImportExportSettingsPtr step;
     mutable IGES::ImportExportSettingsPtr iges;
     ParameterGrp::handle pGroup;
+#if OCC_VERSION_HEX >= 0x070800
     std::list<CodePage> codePageList {
                                       {"No conversion", Resource_FormatType_NoConversion},
                                       {"Multi-byte UTF-8 encoding", Resource_FormatType_UTF8},
@@ -144,6 +149,7 @@ private:
                                       {"CP1257 (Baltic) encoding", Resource_FormatType_CP1257},
                                       {"CP1258 (Vietnamese) encoding", Resource_FormatType_CP1258},
                                       };
+#endif
 };
 
 } //namespace OCAF

--- a/src/Mod/Part/App/OCAF/ImportExportSettings.h
+++ b/src/Mod/Part/App/OCAF/ImportExportSettings.h
@@ -26,7 +26,7 @@
 #include <memory>
 #include <Mod/Part/App/Interface.h>
 #include <Base/Parameter.h>
-
+#include <Resource_FormatType.hxx>
 
 namespace Part
 {
@@ -53,6 +53,11 @@ public:
         GroupPerDirectory = 2,
         ObjectPerDocument = 3,
         ObjectPerDirectory = 4,
+    };
+
+    struct CodePage {
+        std::string codePageName;
+        Resource_FormatType codePage;
     };
 
     static void initialize();
@@ -94,6 +99,13 @@ public:
     void setImportMode(ImportMode);
     ImportMode getImportMode() const;
 
+    void setReadShowDialogImport(bool);
+    bool getReadShowDialogImport() const;
+
+    void setImportCodePage(int);
+    Resource_FormatType getImportCodePage() const;
+    std::list<ImportExportSettings::CodePage> getCodePageList() const;
+
 private:
     static void initGeneral(Base::Reference<ParameterGrp> hGrp);
     static void initSTEP(Base::Reference<ParameterGrp> hGrp);
@@ -103,6 +115,35 @@ private:
     mutable STEP::ImportExportSettingsPtr step;
     mutable IGES::ImportExportSettingsPtr iges;
     ParameterGrp::handle pGroup;
+    std::list<CodePage> codePageList {
+                                      {"No conversion", Resource_FormatType_NoConversion},
+                                      {"Multi-byte UTF-8 encoding", Resource_FormatType_UTF8},
+                                      {"SJIS (Shift Japanese Industrial Standards) encoding", Resource_FormatType_SJIS},
+                                      {"EUC (Extended Unix Code) ", Resource_FormatType_EUC},
+                                      {"GB (Guobiao) encoding for Simplified Chinese", Resource_FormatType_GB},
+                                      {"GBK (Unified Chinese) encoding", Resource_FormatType_GBK},
+                                      {"Big5 (Traditional Chinese) encoding", Resource_FormatType_Big5},
+                                      //{"active system-defined locale; this value is strongly NOT recommended to use", Resource_FormatType_SystemLocale},
+                                      {"ISO 8859-1 (Western European) encoding", Resource_FormatType_iso8859_1},
+                                      {"ISO 8859-2 (Central European) encoding", Resource_FormatType_iso8859_2},
+                                      {"ISO 8859-3 (Turkish) encoding", Resource_FormatType_iso8859_3},
+                                      {"ISO 8859-4 (Northern European) encoding", Resource_FormatType_iso8859_4},
+                                      {"ISO 8859-5 (Cyrillic) encoding", Resource_FormatType_iso8859_5},
+                                      {"ISO 8859-6 (Arabic) encoding", Resource_FormatType_iso8859_6},
+                                      {"ISO 8859-7 (Greek) encoding", Resource_FormatType_iso8859_7},
+                                      {"ISO 8859-8 (Hebrew) encoding", Resource_FormatType_iso8859_8},
+                                      {"ISO 8859-9 (Turkish) encoding", Resource_FormatType_iso8859_9},
+                                      {"ISO 850 (Western European) encoding", Resource_FormatType_CP850},
+                                      {"CP1250 (Central European) encoding", Resource_FormatType_CP1250},
+                                      {"CP1251 (Cyrillic) encoding", Resource_FormatType_CP1251},
+                                      {"CP1252 (Western European) encoding", Resource_FormatType_CP1252},
+                                      {"CP1253 (Greek) encoding", Resource_FormatType_CP1253},
+                                      {"CP1254 (Turkish) encoding", Resource_FormatType_CP1254},
+                                      {"CP1255 (Hebrew) encoding", Resource_FormatType_CP1255},
+                                      {"CP1256 (Arabic) encoding", Resource_FormatType_CP1256},
+                                      {"CP1257 (Baltic) encoding", Resource_FormatType_CP1257},
+                                      {"CP1258 (Vietnamese) encoding", Resource_FormatType_CP1258},
+                                      };
 };
 
 } //namespace OCAF

--- a/src/Mod/Part/Gui/DlgImportStep.cpp
+++ b/src/Mod/Part/Gui/DlgImportStep.cpp
@@ -37,7 +37,6 @@ DlgImportStep::DlgImportStep(QWidget* parent)
 {
     ui->setupUi(this);
     Part::OCAF::ImportExportSettings settings;
-    ui->checkBoxShowOnImport->setChecked(settings.getReadShowDialogImport());
     ui->checkBoxMergeCompound->setChecked(settings.getReadShapeCompoundMode());
     ui->checkBoxImportHiddenObj->setChecked(settings.getImportHiddenObject());
     ui->checkBoxUseLinkGroup->setChecked(settings.getUseLinkGroup());
@@ -45,12 +44,14 @@ DlgImportStep::DlgImportStep(QWidget* parent)
     ui->checkBoxReduceObjects->setChecked(settings.getReduceObjects());
     ui->checkBoxExpandCompound->setChecked(settings.getExpandCompound());
     ui->checkBoxShowProgress->setChecked(settings.getShowProgress());
+#if OCC_VERSION_HEX >= 0x070800
+    ui->checkBoxShowOnImport->setChecked(settings.getReadShowDialogImport());
     std::list<Part::OCAF::ImportExportSettings::CodePage> codepagelist;
     codepagelist = settings.getCodePageList();
     for (const auto& codePage : codepagelist) {
         ui->comboBoxImportCodePage->addItem(QString::fromStdString(codePage.codePageName));
     }
-#if OCC_VERSION_HEX < 0x070800
+#else
     // hide options that not supported in this OCCT version (7.8.0)
     ui->label_6->hide();
     ui->checkBoxShowOnImport->hide();
@@ -67,7 +68,10 @@ DlgImportStep::~DlgImportStep() = default;
 void DlgImportStep::saveSettings()
 {
     // (h)STEP of Import module
+#if OCC_VERSION_HEX >= 0x070800
     ui->checkBoxShowOnImport->onSave();
+    ui->comboBoxImportCodePage->onSave();
+#endif
     ui->checkBoxMergeCompound->onSave();
     ui->checkBoxImportHiddenObj->onSave();
     ui->checkBoxUseLinkGroup->onSave();
@@ -76,13 +80,15 @@ void DlgImportStep::saveSettings()
     ui->checkBoxExpandCompound->onSave();
     ui->checkBoxShowProgress->onSave();
     ui->comboBoxImportMode->onSave();
-    ui->comboBoxImportCodePage->onSave();
 }
 
 void DlgImportStep::loadSettings()
 {
     // (h)STEP of Import module
+#if OCC_VERSION_HEX >= 0x070800
     ui->checkBoxShowOnImport->onRestore();
+    ui->comboBoxImportCodePage->onRestore();
+#endif
     ui->checkBoxMergeCompound->onRestore();
     ui->checkBoxImportHiddenObj->onRestore();
     ui->checkBoxUseLinkGroup->onRestore();
@@ -91,7 +97,6 @@ void DlgImportStep::loadSettings()
     ui->checkBoxExpandCompound->onRestore();
     ui->checkBoxShowProgress->onRestore();
     ui->comboBoxImportMode->onRestore();
-    ui->comboBoxImportCodePage->onRestore();
 }
 
 /**

--- a/src/Mod/Part/Gui/DlgImportStep.cpp
+++ b/src/Mod/Part/Gui/DlgImportStep.cpp
@@ -52,6 +52,7 @@ DlgImportStep::DlgImportStep(QWidget* parent)
     }
 #if OCC_VERSION_HEX < 0x070800
     // hide options that not supported in this OCCT version (7.8.0)
+    ui->label_6->hide();
     ui->checkBoxShowOnImport->hide();
     ui->comboBoxImportCodePage->hide();
 #endif

--- a/src/Mod/Part/Gui/DlgImportStep.cpp
+++ b/src/Mod/Part/Gui/DlgImportStep.cpp
@@ -27,7 +27,7 @@
 
 #include "DlgImportStep.h"
 #include "ui_DlgImportStep.h"
-
+#include <Standard_Version.hxx>
 
 using namespace PartGui;
 
@@ -36,8 +36,8 @@ DlgImportStep::DlgImportStep(QWidget* parent)
   , ui(new Ui_DlgImportStep)
 {
     ui->setupUi(this);
-
     Part::OCAF::ImportExportSettings settings;
+    ui->checkBoxShowOnImport->setChecked(settings.getReadShowDialogImport());
     ui->checkBoxMergeCompound->setChecked(settings.getReadShapeCompoundMode());
     ui->checkBoxImportHiddenObj->setChecked(settings.getImportHiddenObject());
     ui->checkBoxUseLinkGroup->setChecked(settings.getUseLinkGroup());
@@ -45,6 +45,17 @@ DlgImportStep::DlgImportStep(QWidget* parent)
     ui->checkBoxReduceObjects->setChecked(settings.getReduceObjects());
     ui->checkBoxExpandCompound->setChecked(settings.getExpandCompound());
     ui->checkBoxShowProgress->setChecked(settings.getShowProgress());
+    std::list<Part::OCAF::ImportExportSettings::CodePage> codepagelist;
+    codepagelist = settings.getCodePageList();
+    for (const auto& codePage : codepagelist) {
+        ui->comboBoxImportCodePage->addItem(QString::fromStdString(codePage.codePageName));
+    }
+#if OCC_VERSION_HEX < 0x070800
+    // hide options that not supported in this OCCT version (7.8.0)
+    ui->checkBoxShowOnImport->hide();
+    ui->comboBoxImportCodePage->hide();
+#endif
+
 }
 
 /**
@@ -55,6 +66,7 @@ DlgImportStep::~DlgImportStep() = default;
 void DlgImportStep::saveSettings()
 {
     // (h)STEP of Import module
+    ui->checkBoxShowOnImport->onSave();
     ui->checkBoxMergeCompound->onSave();
     ui->checkBoxImportHiddenObj->onSave();
     ui->checkBoxUseLinkGroup->onSave();
@@ -63,11 +75,13 @@ void DlgImportStep::saveSettings()
     ui->checkBoxExpandCompound->onSave();
     ui->checkBoxShowProgress->onSave();
     ui->comboBoxImportMode->onSave();
+    ui->comboBoxImportCodePage->onSave();
 }
 
 void DlgImportStep::loadSettings()
 {
     // (h)STEP of Import module
+    ui->checkBoxShowOnImport->onRestore();
     ui->checkBoxMergeCompound->onRestore();
     ui->checkBoxImportHiddenObj->onRestore();
     ui->checkBoxUseLinkGroup->onRestore();
@@ -76,6 +90,7 @@ void DlgImportStep::loadSettings()
     ui->checkBoxExpandCompound->onRestore();
     ui->checkBoxShowProgress->onRestore();
     ui->comboBoxImportMode->onRestore();
+    ui->comboBoxImportCodePage->onRestore();
 }
 
 /**

--- a/src/Mod/Part/Gui/DlgImportStep.ui
+++ b/src/Mod/Part/Gui/DlgImportStep.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>445</width>
-    <height>292</height>
+    <height>365</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,6 +20,22 @@
       <string>Import</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxShowOnImport">
+        <property name="toolTip">
+         <string>If checked, this Dialog will be shown during Import</string>
+        </property>
+        <property name="text">
+         <string>Show this Dialog when importing</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ReadShowDialogImport</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Import/hSTEP</cstring>
+        </property>
+       </widget>
+      </item>
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxMergeCompound">
         <property name="toolTip">
@@ -134,6 +150,42 @@ during file reading (slower but higher details).</string>
        </widget>
       </item>
       <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_6">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>197</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>CodePage</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="comboBoxImportCodePage">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ImportCodePage</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Import</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="label_5">
@@ -208,7 +260,6 @@ during file reading (slower but higher details).</string>
   <tabstop>checkBoxImportHiddenObj</tabstop>
   <tabstop>checkBoxReduceObjects</tabstop>
   <tabstop>checkBoxExpandCompound</tabstop>
-  <tabstop>checkBoxShowProgress</tabstop>
   <tabstop>checkBoxUseBaseName</tabstop>
   <tabstop>comboBoxImportMode</tabstop>
  </tabstops>


### PR DESCRIPTION
Added the ability to select the encoding of the source file when importing.
Requires OCCT version 7.8.0 and higher

Fix https://github.com/FreeCAD/FreeCAD/issues/7987