### PR TITLE
Fix the crash when closing a document

### DIFF
--- a/src/Gui/Quarter/QuarterWidget.cpp
+++ b/src/Gui/Quarter/QuarterWidget.cpp
@@ -164,9 +164,8 @@ public:
 #endif
         setFormat(surfaceFormat);
     }
-    ~CustomGLWidget() override
-    {
-    }
+    ~CustomGLWidget() override = default;
+
     void initializeGL() override
     {
         QOpenGLContext *context = QOpenGLContext::currentContext();
@@ -179,10 +178,7 @@ public:
                 logger->startLogging(QOpenGLDebugLogger::SynchronousLogging);
         }
 #endif
-        if (context) {
-            connect(context, &QOpenGLContext::aboutToBeDestroyed,
-                this, &CustomGLWidget::aboutToDestroyGLContext, Qt::DirectConnection);
-        }
+
         connect(this, &CustomGLWidget::resized, this, &CustomGLWidget::slotResized);
     }
     // paintGL() is invoked when e.g. using the method grabFramebuffer of this class
@@ -200,17 +196,7 @@ public:
             qw->redraw();
         }
     }
-    void aboutToDestroyGLContext()
-    {
-        // With Qt 5.9 a signal is emitted while the QuarterWidget is being destroyed.
-        // At this state its type is a QWidget, not a QuarterWidget any more.
-        QuarterWidget* qw = qobject_cast<QuarterWidget*>(parent());
-        if (!qw)
-            return;
-        QMetaObject::invokeMethod(parent(), "aboutToDestroyGLContext",
-            Qt::DirectConnection,
-            QGenericReturnArgument());
-    }
+
     bool event(QEvent *e) override
     {
         // If a debug logger is activated then Qt's default implementation
@@ -332,11 +318,6 @@ QuarterWidget::replaceViewport()
 
   setAutoFillBackground(false);
   viewport()->setAutoFillBackground(false);
-}
-
-void
-QuarterWidget::aboutToDestroyGLContext()
-{
 }
 
 /*! destructor */

--- a/src/Gui/Quarter/QuarterWidget.h
+++ b/src/Gui/Quarter/QuarterWidget.h
@@ -193,7 +193,6 @@ Q_SIGNALS:
 
 private Q_SLOTS:
   void replaceViewport();
-  virtual void aboutToDestroyGLContext();
 
 protected:
   void paintEvent(QPaintEvent*) override;

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -490,7 +490,7 @@ private:
     static void drawArrow();
     static void drawSingleBackground(const QColor&);
     void setCursorRepresentation(int mode);
-    void aboutToDestroyGLContext() override;
+    void aboutToDestroyGLContext();
     void createStandardCursors(double);
 
 private:


### PR DESCRIPTION
Closes #14189. This commit partially reverts d15c7d067341eacd10245b58465902546cdedea6 and fb372012991c3b6da359115f3e329f3166ebc5bc.

This pull request must be carefully checked before merge; perhaps, ven. @wwmayer might want to look at it.

I don't know the cause of the crash.