### PR TITLE
Measure: Fix exception handling

### DIFF
--- a/src/Mod/Measure/App/Measurement.cpp
+++ b/src/Mod/Measure/App/Measurement.cpp
@@ -313,6 +313,10 @@ TopoDS_Shape Measurement::getShape(App::DocumentObject *obj , const char *subNam
         }
         return shape;
     }
+    catch (const Base::Exception&) {
+        // re-throw original exception
+        throw;
+    }
     catch (Standard_Failure& e) {
         throw Base::CADKernelError(e.GetMessageString());
     }


### PR DESCRIPTION
If a Base::Exception is thrown in Measurement::getShape() then it's handled by the catch(...) handler and converted into a Base::RuntimeError. This behaviour hides the original Base::Exception.

Example:
Selecting a datum plane raises the error 'Measurement: Unknown error retrieving shape' because the original Base::ValueError isn't forwarded.