### PR TITLE
[Sketcher] Fix external edges selection

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -1415,6 +1415,26 @@ void TaskSketcherElements::onSelectionChanged(const Gui::SelectionChanges& msg)
                         }
                     }
                 }
+                else if (shapetype.size() > 12 && shapetype.substr(0, 12) == "ExternalEdge") {
+                    QRegularExpression rx(QString::fromLatin1("^ExternalEdge(\\d+)$"));
+                    QRegularExpressionMatch match;
+                    boost::ignore_unused(expr.indexOf(rx, 0, &match));
+                    if (match.hasMatch()) {
+                        bool ok;
+                        int ElementId = -match.captured(1).toInt(&ok) - 2;
+                        if (ok) {
+                            int countItems = ui->listWidgetElements->count();
+                            for (int i = 0; i < countItems; i++) {
+                                ElementItem* item =
+                                    static_cast<ElementItem*>(ui->listWidgetElements->item(i));
+                                if (item->ElementNbr == ElementId) {
+                                    item->isLineSelected = select;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
                 else if (shapetype.size() > 6 && shapetype.substr(0, 6) == "Vertex") {
                     QRegularExpression rx(QString::fromLatin1("^Vertex(\\d+)$"));
                     QRegularExpressionMatch match;
@@ -1607,7 +1627,12 @@ void TaskSketcherElements::onListWidgetElementsItemPressed(QListWidgetItem* it)
 
 
             if (item->isLineSelected) {
-                ss << "Edge" << item->ElementNbr + 1;
+                if (item->ElementNbr >= 0) {
+                    ss << "Edge" << item->ElementNbr + 1;
+                }
+                else {
+                    ss << "ExternalEdge" << -item->ElementNbr - 2;
+                }
                 elementSubNames.push_back(ss.str());
             }
 
@@ -1708,7 +1733,12 @@ void TaskSketcherElements::onListWidgetElementsMouseMoveOnItem(QListWidgetItem* 
         else if (item->hovered == SubElementType::mid)
             preselectvertex(item->ElementNbr, Sketcher::PointPos::mid);
         else if (item->hovered == SubElementType::edge) {
-            ss << "Edge" << item->ElementNbr + 1;
+            if (item->ElementNbr >= 0) {
+                ss << "Edge" << item->ElementNbr + 1;
+            }
+            else {
+                ss << "ExternalEdge" << -item->ElementNbr - 2;
+            }
             Gui::Selection().setPreselect(doc_name.c_str(), obj_name.c_str(), ss.str().c_str());
         }
     }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2209,6 +2209,16 @@ void ViewProviderSketch::onSelectionChanged(const Gui::SelectionChanges& msg)
                             sketchHandler->applyCursor();
                         this->updateColor();
                     }
+                    else if (shapetype.size() > 12 && shapetype.substr(0, 12) == "ExternalEdge") {
+                        int GeoId = std::atoi(&shapetype[12]) - 1;
+                        GeoId = -GeoId - 3;
+                        resetPreselectPoint();
+                        preselection.PreselectCurve = GeoId;
+
+                        if (sketchHandler)
+                            sketchHandler->applyCursor();
+                        this->updateColor();
+                    }
                     else if (shapetype.size() > 6 && shapetype.substr(0, 6) == "Vertex") {
                         int PtIndex = std::atoi(&shapetype[6]) - 1;
                         setPreselectPoint(PtIndex);
@@ -2449,7 +2459,12 @@ void ViewProviderSketch::doBoxSelection(const SbVec2s& startPos, const SbVec2s& 
 
     auto selectEdge = [this](int edgeid) {
         std::stringstream ss;
-        ss << "Edge" << edgeid;
+        if (edgeid >= 0) {
+            ss << "Edge" << edgeid;
+        }
+        else {
+            ss << "ExternalEdge" << -edgeid - 1;
+        }
         addSelection2(ss.str());
     };
 


### PR DESCRIPTION
related to #13009

with TNP code enabled the selection of external geometries doesn't work as for the issue above.

This PR should fix the issue, probably without importing all the code related to #13310