### PR TITLE
Core: fix import of FreeCAD in a Python 3.12 interpreter

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2544,9 +2544,34 @@ void Application::initConfig(int argc, char ** argv)
     mConfig["Debug"] = "0";
 #   endif
 
-    // init python
-    PyImport_AppendInittab ("FreeCAD", init_freecad_module);
-    PyImport_AppendInittab ("__FreeCADBase__", init_freecad_base_module);
+    if (!Py_IsInitialized()) {
+        // init python
+        PyImport_AppendInittab ("FreeCAD", init_freecad_module);
+        PyImport_AppendInittab ("__FreeCADBase__", init_freecad_base_module);
+    }
+    else {
+        // "import FreeCAD" in a normal Python 3.12 interpreter would raise
+        //     Fatal Python error: PyImport_AppendInittab:
+        //         PyImport_AppendInittab() may not be called after Py_Initialize()
+        //  because the (external) interpreter is already initialized.
+        //  Therefore we use a workaround as described in https://stackoverflow.com/a/57019607
+
+        PyObject *sysModules = PyImport_GetModuleDict();
+
+        const char *moduleName = "FreeCAD";
+        PyImport_AddModule(moduleName);
+        ApplicationMethods = Application::Methods;
+        PyObject *pyModule = init_freecad_module();
+        PyDict_SetItemString(sysModules, moduleName, pyModule);
+        Py_DECREF(pyModule);
+
+        moduleName = "__FreeCADBase__";
+        PyImport_AddModule(moduleName);
+        pyModule = init_freecad_base_module();
+        PyDict_SetItemString(sysModules, moduleName, pyModule);
+        Py_DECREF(pyModule);
+    }
+
     const char* pythonpath = Base::Interpreter().init(argc,argv);
     if (pythonpath)
         mConfig["PythonSearchPath"] = pythonpath;


### PR DESCRIPTION
Importing FreeCAD as a module in a normal Python interpreter (e.g. /usr/bin/python3) stopped working with Python 3.12 (but works normally with Python 3.11).

When executing `import FreeCAD as App`, the Python 3.12 interpreter crashes with
"Fatal Python error: PyImport_AppendInittab: PyImport_AppendInittab() may not be called after Py_Initialize()".

I have tested this fix on Debian bookworm with Python 3.11 and Arch Linux with Python 3.12.