### PR TITLE
Unpin pcl on conda devenv and update to use libboost-devel

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -56,8 +56,6 @@ dependencies:
 - xorg-x11-server-common-cos7-aarch64  # [linux and aarch64]
 - xorg-x11-server-xvfb-cos7-aarch64    # [linux and aarch64]
 - sed                                  # [unix]
-- boost
-- boost-cpp
 - ccache
 - cmake
 - coin3d
@@ -73,6 +71,7 @@ dependencies:
 - gmsh
 - graphviz
 - hdf5
+- libboost-devel
 - libcxx
 - mamba
 - matplotlib
@@ -80,7 +79,7 @@ dependencies:
 - numpy
 - occt
 - openssl
-- pcl==1.13.1
+- pcl
 - pip
 - pivy
 - pkg-config


### PR DESCRIPTION
@oursland I think #13345 fixed windows compilation with latest pcl so we can update