### PR TITLE
MeasureGui: Paint icons in textcolor

### DIFF
--- a/src/Gui/SoTextLabel.cpp
+++ b/src/Gui/SoTextLabel.cpp
@@ -385,6 +385,7 @@ SoFrameLabel::SoFrameLabel()
 void SoFrameLabel::setIcon(const QPixmap &pixMap)
 {
     iconPixmap = pixMap;
+    drawImage();
 }
 
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -213,6 +213,7 @@ void ViewProviderMeasureBase::onChanged(const App::Property* prop)
     if (prop == &TextColor) {
         const App::Color& color = TextColor.getValue();
         pLabel->textColor.setValue(color.r, color.g, color.b);
+        updateIcon();
     }
     else if (prop == &TextBackgroundColor) {
         const App::Color& color = TextBackgroundColor.getValue();
@@ -281,14 +282,22 @@ void ViewProviderMeasureBase::positionAnno(const Measure::MeasureBase* measureOb
 }
 
 
+void ViewProviderMeasureBase::updateIcon() {
+    // This assumes the icons main color is black
+
+    Gui::ColorMap colorMap {
+        { 0x000000, TextColor.getValue().getPackedRGB() >> 8 },
+    };
+    pLabel->setIcon(Gui::BitmapFactory().pixmapFromSvg(sPixmap, QSize(20, 20), colorMap));
+}
+
+
 void ViewProviderMeasureBase::attach(App::DocumentObject *pcObj)
 {
     ViewProviderDocumentObject::attach(pcObj);
     auto measureObj = static_cast<MeasureBase*>(pcObj);
     positionAnno(measureObj);
-
-    // Set the icon
-    pLabel->setIcon(Gui::BitmapFactory().pixmapFromSvg(sPixmap, QSize(20, 20)));
+    updateIcon();
 }
 
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.h
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.h
@@ -121,6 +121,7 @@ protected:
     void setLabelValue(const Base::Quantity& value);
     void setLabelValue(const QString& value);
     void setLabelTranslation(const SbVec3f& position);
+    void updateIcon();
 
     SoPickStyle* getSoPickStyle();
     SoDrawStyle* getSoLineStylePrimary();


### PR DESCRIPTION
Currently the icons in measurement labels are always black which can be a problem when the background color is changed. With this PR  the icon's color is is updated whenever the textcolor property changes.