### PR TITLE
Gui: Refactor DlgMaterialPropertiesImp

### DIFF
--- a/src/Gui/DlgMaterialPropertiesImp.h
+++ b/src/Gui/DlgMaterialPropertiesImp.h
@@ -27,7 +27,7 @@
 #include <QDialog>
 #include <memory>
 #include <vector>
-#include <FCGlobal.h>
+#include <App/Material.h>
 
 namespace App
 {
@@ -48,17 +48,16 @@ class GuiExport DlgMaterialPropertiesImp: public QDialog
     Q_OBJECT
 
 public:
-    explicit DlgMaterialPropertiesImp(const std::string& mat,
-                                      QWidget* parent = nullptr,
+    explicit DlgMaterialPropertiesImp(QWidget* parent = nullptr,
                                       Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgMaterialPropertiesImp() override;
-    void setViewProviders(const std::vector<Gui::ViewProvider*>&);
-    QColor diffuseColor() const;
+    App::Material getCustomMaterial() const;
+    void setCustomMaterial(const App::Material& mat);
+    App::Material getDefaultMaterial() const;
+    void setDefaultMaterial(const App::Material& mat);
 
-protected:
+private:
     void setupConnections();
-    App::Material getMaterial();
-    App::Color getColor(const QColor& color) const;
     void onAmbientColorChanged();
     void onDiffuseColorChanged();
     void onEmissiveColorChanged();
@@ -66,25 +65,12 @@ protected:
     void onShininessValueChanged(int);
     void onButtonReset();
     void onButtonDefault();
-    void setButtonColors();
+    void setButtonColors(const App::Material& mat);
 
-protected:
+private:
     std::unique_ptr<Ui_DlgMaterialProperties> ui;
-    std::string material;
-    std::vector<Gui::ViewProvider*> Objects;
-    bool updateColors;
-};
-
-class GuiExport DlgFaceMaterialPropertiesImp: public DlgMaterialPropertiesImp
-{
-    Q_OBJECT
-
-public:
-    explicit DlgFaceMaterialPropertiesImp(const std::string& mat,
-                                          QWidget* parent = nullptr,
-                                          Qt::WindowFlags fl = Qt::WindowFlags());
-    ~DlgFaceMaterialPropertiesImp() override;
-    App::Material getCustomAppearance() const;
+    App::Material customMaterial;
+    App::Material defaultMaterial;
 };
 
 }  // namespace Dialog

--- a/src/Mod/Material/Gui/DlgDisplayPropertiesImp.h
+++ b/src/Mod/Material/Gui/DlgDisplayPropertiesImp.h
@@ -75,7 +75,7 @@ private Q_SLOTS:
     void onButtonPointColorChanged();
     void onSpinLineWidthValueChanged(int);
     void onSpinLineTransparencyValueChanged(int);
-    void onbuttonCustomAppearanceClicked();
+    void onButtonCustomAppearanceClicked();
     void onButtonColorPlotClicked();
     void onMaterialSelected(const std::shared_ptr<Materials::Material>& material);
 

--- a/src/Mod/Part/Gui/TaskFaceAppearances.cpp
+++ b/src/Mod/Part/Gui/TaskFaceAppearances.cpp
@@ -418,21 +418,30 @@ void FaceAppearances::updatePanel()
     d->ui->buttonCustomAppearance->setDisabled(d->index.isEmpty());
 }
 
+int FaceAppearances::getFirstIndex() const
+{
+    if (!d->index.isEmpty()) {
+        return *(d->index.begin());
+    }
+
+    return 0;
+}
+
 /**
  * Opens a dialog that allows to modify the 'ShapeMaterial' property of all selected view providers.
  */
 void FaceAppearances::onButtonCustomAppearanceClicked()
 {
-    std::vector<Gui::ViewProvider*> Provider;
-    Provider.push_back(d->vp);
-    Gui::Dialog::DlgFaceMaterialPropertiesImp dlg("ShapeAppearance", this);
-    dlg.setViewProviders(Provider);
+    Gui::Dialog::DlgMaterialPropertiesImp dlg(this);
+    App::Material mat = d->perface[getFirstIndex()];
+    dlg.setCustomMaterial(mat);
+    dlg.setDefaultMaterial(mat);
     dlg.exec();
 
     // Set the face appearance
     if (!d->index.isEmpty()) {
         for (int it : d->index) {
-            d->perface[it] = dlg.getCustomAppearance();
+            d->perface[it] = dlg.getCustomMaterial();
         }
         d->vp->ShapeAppearance.setValues(d->perface);
         // new color has been applied, unselect so that users can see this

--- a/src/Mod/Part/Gui/TaskFaceAppearances.h
+++ b/src/Mod/Part/Gui/TaskFaceAppearances.h
@@ -65,6 +65,7 @@ protected:
     void slotDeleteDocument(const Gui::Document&);
     void slotDeleteObject(const Gui::ViewProvider&);
     void updatePanel();
+    int getFirstIndex() const;
 
 private:
     class Private;


### PR DESCRIPTION
Because a PropertyMaterialList property is used now it makes no sense any more to pass a list of view providers to the dialog as it's impossible to set the material at a certain index. Therefore the dialog has been simplified and setting the material property must be done by the calling instance.