### PR TITLE
Toponaming fix dress up shadow subs

### DIFF
--- a/src/Mod/PartDesign/App/FeatureDressUp.cpp
+++ b/src/Mod/PartDesign/App/FeatureDressUp.cpp
@@ -206,7 +206,7 @@ std::vector<TopoShape> DressUp::getContinuousEdges(const TopoShape& shape)
         const auto& ref = v.first.size() ? v.first : v.second;
         subshape = shape.getSubShape(ref.c_str(), true);
         if (subshape.IsNull()) {
-            FC_THROWM(Base::CADKernelError, "Invalid edge link: " << v.second);
+            FC_THROWM(Base::CADKernelError, "Invalid edge link: " << ref);
         }
 
         if (subshape.ShapeType() == TopAbs_EDGE) {

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -140,6 +140,36 @@ void TaskDressUpParameters::referenceSelected(const Gui::SelectionChanges& msg, 
 
 void TaskDressUpParameters::addAllEdges(QListWidget* widget)
 {
+#ifdef FC_USE_TNP_FIX
+    if (!DressUpView)
+        return;
+
+    PartDesign::DressUp* pcDressUp = static_cast<PartDesign::DressUp*>(DressUpView->getObject());
+    App::DocumentObject* base = pcDressUp->Base.getValue();
+    if (!base)
+        return;
+    int count = Part::Feature::getTopoShape(base).countSubShapes(TopAbs_EDGE);
+    auto subValues = pcDressUp->Base.getSubValues(false);
+    std::size_t len = subValues.size();
+    std::string name("Edge");
+    for (int i=0; i<count; ++i) {
+        name.resize(4);
+        name += std::to_string(i+1);
+        if (std::find(subValues.begin(), subValues.begin()+len, name) == subValues.begin()+len)
+            subValues.push_back(name);
+    }
+    if (subValues.size() == len)
+        return;
+    try {
+        setupTransaction();
+        pcDressUp->Base.setValue(base, subValues);
+//        recompute();
+//        populate(true);
+    }
+    catch (Base::Exception &e) {
+        e.ReportException();
+    }
+#else
     PartDesign::DressUp* pcDressUp = static_cast<PartDesign::DressUp*>(DressUpView->getObject());
 
     Gui::WaitCursor wait;
@@ -160,6 +190,7 @@ void TaskDressUpParameters::addAllEdges(QListWidget* widget)
     }
 
     updateFeature(pcDressUp, edgeNames);
+#endif
 }
 
 void TaskDressUpParameters::deleteRef(QListWidget* widget)

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -141,32 +141,34 @@ void TaskDressUpParameters::referenceSelected(const Gui::SelectionChanges& msg, 
 void TaskDressUpParameters::addAllEdges(QListWidget* widget)
 {
 #ifdef FC_USE_TNP_FIX
-    if (!DressUpView)
+    if (!DressUpView) {
         return;
+    }
 
     PartDesign::DressUp* pcDressUp = static_cast<PartDesign::DressUp*>(DressUpView->getObject());
     App::DocumentObject* base = pcDressUp->Base.getValue();
-    if (!base)
+    if (!base) {
         return;
+    }
     int count = Part::Feature::getTopoShape(base).countSubShapes(TopAbs_EDGE);
     auto subValues = pcDressUp->Base.getSubValues(false);
     std::size_t len = subValues.size();
     std::string name("Edge");
-    for (int i=0; i<count; ++i) {
-        name.resize(4);
-        name += std::to_string(i+1);
-        if (std::find(subValues.begin(), subValues.begin()+len, name) == subValues.begin()+len)
+    for (int i = 0; i < count; ++i) {
+        std::string name = "Edge" + std::to_string(i+1);
+        if (std::find(subValues.begin(), subValues.begin() + len, name)
+            == subValues.begin() + len) {
             subValues.push_back(name);
+        }
     }
-    if (subValues.size() == len)
+    if (subValues.size() == len) {
         return;
+    }
     try {
         setupTransaction();
         pcDressUp->Base.setValue(base, subValues);
-//        recompute();
-//        populate(true);
     }
-    catch (Base::Exception &e) {
+    catch (Base::Exception& e) {
         e.ReportException();
     }
 #else


### PR DESCRIPTION
This should solve many "invalid edge" warnings on chamfers and fillets.