### PR TITLE
BIM: Update WP commands

### DIFF
--- a/src/Mod/BIM/bimcommands/BimWPCommands.py
+++ b/src/Mod/BIM/bimcommands/BimWPCommands.py
@@ -43,7 +43,8 @@ class BIM_SetWPFront:
         }
 
     def Activated(self):
-        FreeCADGui.doCommandGui("FreeCAD.DraftWorkingPlane.setFront()")
+        FreeCADGui.addModule("WorkingPlane")
+        FreeCADGui.doCommand("WorkingPlane.get_working_plane(update=False).set_to_front()")
 
 
 class BIM_SetWPSide:
@@ -59,7 +60,8 @@ class BIM_SetWPSide:
         }
 
     def Activated(self):
-        FreeCADGui.doCommandGui("FreeCAD.DraftWorkingPlane.setSide()")
+        FreeCADGui.addModule("WorkingPlane")
+        FreeCADGui.doCommand("WorkingPlane.get_working_plane(update=False).set_to_side()")
 
 
 class BIM_SetWPTop:
@@ -75,7 +77,8 @@ class BIM_SetWPTop:
         }
 
     def Activated(self):
-        FreeCADGui.doCommandGui("FreeCAD.DraftWorkingPlane.setTop()")
+        FreeCADGui.addModule("WorkingPlane")
+        FreeCADGui.doCommand("WorkingPlane.get_working_plane(update=False).set_to_top()")
 
 
 class BIM_WPView:


### PR DESCRIPTION
Update the BIM WP commands to use the new Draft code. This ensures correct GUI behavior.

This also fixes the BIM_SetWPSide command which would align to the left side instead of the right side. The right side matches the behavior of Draft_SelectPlane and also the icon of the command.
