### PR TITLE
[Gui] Fix BehaveDark StatusBar Flickering Border...

### DIFF
--- a/src/Gui/Stylesheets/Behave-dark.qss
+++ b/src/Gui/Stylesheets/Behave-dark.qss
@@ -250,6 +250,45 @@ QMenu QCheckBox::indicator:disabled {
     border: 1px solid  @ThemeAccentColor3;
 }
 
+/* QStatusBar -------------------------------------------------------------
+
+https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qstatusbar
+
+--------------------------------------------------------------------------- */
+QStatusBar {
+  border: 0px solid #3c3c3c;
+  /* Fixes Spyder #9120, #9121 */
+  background: transparent;
+  /* Fixes #205, white vertical borders separating items */
+}
+
+QStatusBar::item {
+  border: none;
+}
+
+
+QStatusBar > QToolButton:checked:disabled {
+  background-color: #b65555;
+  color: #b8aba0;
+  border-radius: 1.9px;
+  padding: 0px;
+  outline: none;
+}
+
+QStatusBar QToolTip {
+  color: #61D29D;
+  background-color: #2C333D;
+  border: 1px solid #696968;
+  /* Remove padding, for fix combo box tooltip */
+  padding: 0px;
+  /* Reducing transparency to read better */
+  opacity: 230;
+}
+
+QStatusBar QLabel {
+  /* Fixes Spyder #9120, #9121 */
+  background: transparent;
+}
 
 /*==================================================================================================
 Tool bar
@@ -328,11 +367,12 @@ QGroupBox::indicator:unchecked {
 Tooltip
 ==================================================================================================*/
 QToolTip {
-    color: #1e1e1e;
-    background-color: #b4b4b4;
+    color: #61D29D;
+    background-color: #2C333D;
     /*opacity: 90%; doesn't correctly work */
     padding: 4px;
     border-radius: 3px; /* has no effect */
+    font: 8pt;
 }
 
 


### PR DESCRIPTION
...found on Qt5.15.3 and sync tooltip colours and size

Found when testing using:

```
OS: Linux Mint 21.3 (X-Cinnamon/cinnamon)
Word size of FreeCAD: 64-bit
Version: 0.22.0dev.37649 (Git)
Build type: Release
Branch: main
Hash: 681e8c9d2f95d4341e48cec629267182b2f7e586
Python 3.10.12, Qt 5.15.3, Coin 4.0.0, Vtk 7.1.1, OCC 7.6.3
Locale: English/United Kingdom (en_GB)
```
Before PR:
![BeforeSSfix](https://github.com/FreeCAD/FreeCAD/assets/46537884/b96c39ab-7cbe-4102-8102-badcde972e9b)

With PR:
![AfterSSfix](https://github.com/FreeCAD/FreeCAD/assets/46537884/031d953f-0cef-4510-b367-6b7b4a727a60)



Must be the particular version of Qt, tested change on existing non-flickering systems and it's not caused any regressions that I can find.