### PR TITLE
Fem: fix searching 3rd-party binaries in system path

### DIFF
--- a/src/Mod/Fem/App/PreCompiled.h
+++ b/src/Mod/Fem/App/PreCompiled.h
@@ -54,6 +54,7 @@
 
 #include <Python.h>
 #include <QFileInfo>
+#include <QStandardPaths>
 
 // Salomesh
 #include <SMDSAbs_ElementType.hxx>

--- a/src/Mod/Fem/Gui/DlgSettingsFemGeneralImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemGeneralImp.cpp
@@ -43,7 +43,7 @@ DlgSettingsFemGeneralImp::DlgSettingsFemGeneralImp(QWidget* parent)
     ui->cmb_def_solver->clear();
     std::vector<std::string> Solvers = {"None"};
 
-    if (!Fem::Tools::checkIfBinaryExists("CCX", "ccx", "ccx").empty()) {
+    if (!Fem::Tools::checkIfBinaryExists("Ccx", "ccx", "ccx").empty()) {
         Solvers.emplace_back("CalculiX");
     }
     if (!Fem::Tools::checkIfBinaryExists("Elmer", "elmer", "ElmerSolver").empty()) {

--- a/src/Mod/Fem/Gui/Workbench.cpp
+++ b/src/Mod/Fem/Gui/Workbench.cpp
@@ -167,7 +167,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
 
     Gui::ToolBarItem* solve = new Gui::ToolBarItem(root);
     solve->setCommand("Solve");
-    if (!Fem::Tools::checkIfBinaryExists("CCX", "ccx", "ccx").empty()) {
+    if (!Fem::Tools::checkIfBinaryExists("Ccx", "ccx", "ccx").empty()) {
         *solve << "FEM_SolverCalculiXCcxTools";
     }
     if (!Fem::Tools::checkIfBinaryExists("Elmer", "elmer", "ElmerSolver").empty()) {


### PR DESCRIPTION
I think the original intention is to check if the mentioned executable exists in system path. Original method only checks if the given *full path*(absolute or relative) exists or not, and is not actually searching the executable in system path.

This patch switches to `QStandardPaths::findExecutable` to find a desired executable in system path.

There's a note caught my attention in QT's doc though:
> On Windows, the usual executable extensions (from the PATHEXT environment variable) are automatically appended. For example, the findExecutable("foo") call finds foo.exe or foo.bat if present.