### PR TITLE
Assembly: Add preference to enable debug files of dragging

### DIFF
--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -399,6 +399,10 @@ std::shared_ptr<ASMTAssembly> AssemblyObject::makeMbdAssembly()
     auto assembly = CREATE<ASMTAssembly>::With();
     assembly->setName("OndselAssembly");
 
+    ParameterGrp::handle hPgr = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Assembly");
+
+    assembly->setDebug(hPgr->GetBool("LogSolverDebug", false));
     return assembly;
 }
 

--- a/src/Mod/Assembly/Gui/Resources/preferences/Assembly.ui
+++ b/src/Mod/Assembly/Gui/Resources/preferences/Assembly.ui
@@ -34,13 +34,33 @@
     </widget>
    </item>
    <item row="1" column="0">
+    <widget class="Gui::PrefCheckBox" name="checkBoxSolverDebug">
+     <property name="toolTip">
+      <string>Log the dragging steps of the solver. Useful if you want to report a bug.
+The files are named "runPreDrag.asmt" and "dragging.log" and are located in the default directory of std::ofstream (on Windows it's the desktop)</string>
+     </property>
+     <property name="text">
+      <string>Log dragging steps</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <property name="prefEntry" stdset="0">
+      <cstring>LogSolverDebug</cstring>
+     </property>
+     <property name="prefPath" stdset="0">
+      <cstring>Mod/Assembly</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <widget class="QLabel" name="groundFirstPartLabel">
      <property name="text">
       <string>Ground first part:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="2" column="1">
     <widget class="QComboBox" name="groundFirstPart">
      <property name="toolTip">
       <string>When you insert the first part in the assembly, you can choose to ground the part automatically.</string>
@@ -50,7 +70,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="2">
+   <item row="2" column="2">
     <spacer name="horSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -63,7 +83,7 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Mod/Assembly/Preferences.py
+++ b/src/Mod/Assembly/Preferences.py
@@ -38,11 +38,13 @@ class PreferencesPage:
     def saveSettings(self):
         pref = preferences()
         pref.SetBool("LeaveEditWithEscape", self.form.checkBoxEnableEscape.isChecked())
+        pref.SetBool("LogSolverDebug", self.form.checkBoxSolverDebug.isChecked())
         pref.SetInt("GroundFirstPart", self.form.groundFirstPart.currentIndex())
 
     def loadSettings(self):
         pref = preferences()
         self.form.checkBoxEnableEscape.setChecked(pref.GetBool("LeaveEditWithEscape", True))
+        self.form.checkBoxSolverDebug.setChecked(pref.GetBool("LogSolverDebug", False))
         self.form.groundFirstPart.clear()
         self.form.groundFirstPart.addItem(translate("Assembly", "Ask"))
         self.form.groundFirstPart.addItem(translate("Assembly", "Always"))


### PR DESCRIPTION
Adds a preference to enable the Ondsel Solver debug.
When this preference is set to true, the solver will create "runPreDrag.asmt" and "dragging.log" files in the default directory of std::ofstream (on windows it is the desktop).

This will help users give bug reports when solving goes wrong, such as this https://github.com/FreeCAD/FreeCAD/issues/14185