### PR TITLE
StartGui: Fix crash in GeneralSettingsWidget::onNavigationStyleChanged

### DIFF
--- a/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
+++ b/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
@@ -193,10 +193,10 @@ void GeneralSettingsWidget::onNavigationStyleChanged(int index)
     if (index < 0) {
         return;  // happens when clearing the combo box in retranslateUi()
     }
-    auto navStyleName = _navigationStyleComboBox->itemData(index).toByteArray().data();
+    auto navStyleName = _navigationStyleComboBox->itemData(index).toByteArray();
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    hGrp->SetASCII("NavigationStyle", navStyleName);
+    hGrp->SetASCII("NavigationStyle", navStyleName.constData());
 }
 
 bool GeneralSettingsWidget::eventFilter(QObject* object, QEvent* event)


### PR DESCRIPTION
It's not allowed to store the C string of a tmp. byte array as the pointer will become dangling and causes undefined behaviour