### PR TITLE
Gui: Fix Gesture navigation rotation mode

### DIFF
--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -492,9 +492,10 @@ public:
     explicit RotateState(my_context ctx):my_base(ctx)
     {
         auto &ns = this->outermost_context().ns;
-        ns.setRotationCenter(ns.getFocalPoint());
+        const auto inventorEvent = static_cast<const NS::Event*>(this->triggering_event())->inventor_event;
+        ns.saveCursorPosition(inventorEvent);
         ns.setViewingMode(NavigationStyle::DRAGGING);
-        this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
+        this->base_pos = inventorEvent->getPosition();
         if (ns.logging)
             Base::Console().Log(" -> RotateState\n");
     }

--- a/src/Gui/MayaGestureNavigationStyle.cpp
+++ b/src/Gui/MayaGestureNavigationStyle.cpp
@@ -448,7 +448,7 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
 
                     // start DRAGGING mode (orbit)
                     // if not pressing left mouse button then it assumes is right mouse button and starts ZOOMING mode
-                    setRotationCenter(getFocalPoint());
+                    saveCursorPosition(ev);
                     setViewingMode(this->button1down ? NavigationStyle::DRAGGING : NavigationStyle::ZOOMING);
                     processed = true;
                 } else {
@@ -477,7 +477,7 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
                     processed = true;
                 } else if (type.isDerivedFrom(SoGesturePinchEvent::getClassTypeId())) {
                     setupPanningPlane(viewer->getSoRenderManager()->getCamera());//set up panning plane
-                    setRotationCenter(getFocalPoint());
+                    saveCursorPosition(ev);
                     setViewingMode(NavigationStyle::DRAGGING);
                     processed = true;
                 } //all other gestures - ignore!
@@ -504,7 +504,12 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
                 case SoMouseButtonEvent::BUTTON3: // allows to release button3 into SELECTION mode
                     if(comboAfter & BUTTON1DOWN || comboAfter & BUTTON2DOWN) {
                         //don't leave navigation till all buttons have been released
-                        setRotationCenter(getFocalPoint());
+                        if (comboAfter & BUTTON1DOWN && comboAfter & BUTTON2DOWN) {
+                            setRotationCenter(getFocalPoint());
+                        }
+                        else {
+                            saveCursorPosition(ev);
+                        }
                         setViewingMode((comboAfter & BUTTON1DOWN) ? NavigationStyle::DRAGGING : NavigationStyle::PANNING);
                         processed = true;
                     } else { //all buttons are released


### PR DESCRIPTION
The Gesture and MayaGesture navigation styles ignored the rotation mode (window center, drag at cursor, object center). This PR fixes that. Besides, this may fix #9105 or part of it but I am not sure.