### PR TITLE
CAM: Fix issue #14513 - simulation of partially selected operations not working

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
+++ b/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
@@ -179,13 +179,14 @@ class CAMSimulation:
         self._populateJobSelection(form)
         form.comboJobs.currentIndexChanged.connect(self.onJobChange)
         self.onJobChange()
+        form.listOperations.itemChanged.connect(self.onOperationItemChange)
         FreeCADGui.Control.showDialog(self.taskForm)
         self.disableAnim = False
         self.firstDrill = True
         self.millSim = CAMSimulator.PathSim()
         self.initdone = True
         self.job = self.jobs[self.taskForm.form.comboJobs.currentIndex()]
-        self.SetupSimulation()
+        # self.SetupSimulation()
 
     def _populateJobSelection(self, form):
         # Make Job selection combobox
@@ -250,8 +251,6 @@ class CAMSimulation:
                 listItem.setCheckState(QtCore.Qt.CheckState.Checked)
                 self.operations.append(op)
                 form.listOperations.addItem(listItem)
-        if self.initdone:
-            self.SetupSimulation()
 
     def onAccuracyBarChange(self):
         form = self.taskForm.form
@@ -263,7 +262,17 @@ class CAMSimulation:
             qualText = QtCore.QT_TRANSLATE_NOOP("CAM_Simulator", "Medium")
         form.labelAccuracy.setText(qualText)
 
+    def onOperationItemChange(self, _item):
+        playvalid = False
+        form = self.taskForm.form
+        for i in range(form.listOperations.count()):
+            if form.listOperations.item(i).checkState() == QtCore.Qt.CheckState.Checked:
+                playvalid = True
+                break
+        form.toolButtonPlay.setEnabled(playvalid)
+
     def SimPlay(self):
+        self.SetupSimulation()
         self.millSim.ResetSimulation()
         for op in self.activeOps:
             tool = PathDressup.toolController(op).Tool

--- a/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
+++ b/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
@@ -92,18 +92,24 @@ class CAMSimulation:
         for edge in edges:
             p1 = edge.FirstParameter
             p2 = edge.LastParameter
-            rad = RadiusAt(edge, p1)
-            z = edge.valueAt(p1).z
-            if IsSame(px, rad) and IsSame(pz, z):
+            rad1 = RadiusAt(edge, p1)
+            z1 = edge.valueAt(p1).z
+            if IsSame(px, rad1) and IsSame(pz, z1):
                 return edge, p1, p2
-            rad = RadiusAt(edge, p2)
-            z = edge.valueAt(p2).z
-            if IsSame(px, rad) and IsSame(pz, z):
+            rad2 = RadiusAt(edge, p2)
+            z2 = edge.valueAt(p2).z
+            if IsSame(px, rad2) and IsSame(pz, z2):
                 return edge, p2, p1
+            # sometimes a flat circle is without edge, so return edge with 
+            # same height and later a connecting edge will be interpolated
+            if IsSame(pz, z1):
+                return edge, p1, p2
+            if IsSame(pz, z2):
+                return edge, p2, p1           
         return None, 0.0, 0.0
 
     def FindTopMostEdge(self, edges):
-        maxz = 0.0
+        maxz = -99999999.0
         topedge = None
         top_p1 = 0.0
         top_p2 = 0.0
@@ -137,7 +143,6 @@ class CAMSimulation:
                 sideEdgeList.append(edge)
 
         # sort edges as a single 3d line on the x-z plane
-        profile = [0.0, 0.0]
 
         # first find the topmost edge
         edge, p1, p2 = self.FindTopMostEdge(sideEdgeList)
@@ -167,6 +172,12 @@ class CAMSimulation:
             edge, p1, p2 =  self.FindClosestEdge(sideEdgeList, endrad, endz)
             if edge is None:
                 break
+            startrad = RadiusAt(edge, p1)
+            if not IsSame(startrad, endrad):
+                profile.append(startrad)
+                startz = edge.valueAt(p1).z
+                profile.append(startz)
+                        
         return profile
 
     def Activate(self):

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -205,6 +205,8 @@ DlgCAMSimulator* DlgCAMSimulator::GetInstance()
 {
     if (mInstance == nullptr) {
         QSurfaceFormat format;
+        format.setVersion(4, 1);                         // Request OpenGL 4.1 - for MacOS
+        format.setProfile(QSurfaceFormat::CoreProfile);  // Use the core profile = for MacOS
         format.setSamples(16);
         format.setSwapInterval(2);
         format.setDepthBufferSize(24);

--- a/src/Mod/CAM/PathSimulator/AppGL/EndMill.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/EndMill.cpp
@@ -62,7 +62,8 @@ EndMill::EndMill(const std::vector<float>& toolProfile, int toolid, float diamet
         profilePoints[i] = toolProfile[i] + 0.01F;  // add some width to reduce simulation artifacts
     }
     if (missingCenterPoint) {
-        profilePoints[srcBuffSize] = profilePoints[srcBuffSize + 1] = 0.0F;
+        profilePoints[srcBuffSize] = 0.0F;
+        profilePoints[srcBuffSize + 1] = profilePoints[srcBuffSize - 1];
     }
 
     MirrorPointBuffer();


### PR DESCRIPTION
Bug: Cam simulation always shows all operations even if only partial items are selected. 
This a fix to Issue #14513 
I have also restricted the opengl version to 4.1 core, and this might fix the issue in MacOS where the display is an empty window (Issue #14348). I do not have MacOS to test it so hopefully it will be tested by the community later.
Fixes also issue #14613: some tools are not displayed correctly.
