### PR TITLE
[AddonManager] Fix Error on Existing Python Additional Packages Folder

### DIFF
--- a/src/Mod/AddonManager/manage_python_dependencies.py
+++ b/src/Mod/AddonManager/manage_python_dependencies.py
@@ -389,7 +389,7 @@ class PythonPackageManager:
             # Nothing to migrate
             return False
 
-        os.makedirs(new_directory, mode=0o777, exist_ok=False)
+        os.makedirs(new_directory, mode=0o777, exist_ok=True)
 
         for content_item in os.listdir(old_directory):
             if content_item == new_directory_name:

--- a/src/Mod/AddonManager/manage_python_dependencies.py
+++ b/src/Mod/AddonManager/manage_python_dependencies.py
@@ -389,8 +389,7 @@ class PythonPackageManager:
             # Nothing to migrate
             return False
 
-        if not os.path.exists(new_directory):
-            os.makedirs(new_directory)
+        os.makedirs(new_directory, mode=0o777, exist_ok=False)
 
         for content_item in os.listdir(old_directory):
             if content_item == new_directory_name:


### PR DESCRIPTION
...this is more likely to occur since the BIM workbench integration and new users installing ifcOpenShell by pip before running AddonManager.

Error raised:

```
13:59:19  Traceback (most recent call last):
13:59:19    File "/home/username/freecad-daily-build/Mod/AddonManager/AddonManager.py", line 420, in do_next_startup_phase
13:59:19      phase_runner()
13:59:19    File "/home/username/freecad-daily-build/Mod/AddonManager/AddonManager.py", line 661, in check_python_updates
13:59:19      PythonPackageManager.migrate_old_am_installations()  # Migrate 0.20 to 0.21
13:59:19    File "/home/username/freecad-daily-build/Mod/AddonManager/manage_python_dependencies.py", line 393, in migrate_old_am_installations
13:59:19      os.makedirs(new_directory)
13:59:19    File "/usr/lib/python3.10/os.py", line 225, in makedirs
13:59:19      mkdir(name, mode)
13:59:19  FileExistsError: [Errno 17] File exists: '/home/username/.local/share/FreeCAD/Mod/../AdditionalPythonPackages/py310'
```
