### PR TITLE
Part/Toponaming: makeElementWires - import from LS3 fork

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -3079,7 +3079,7 @@ TopoShape& TopoShape::makeElementWires(const std::vector<TopoShape>& shapes,
         std::vector<TopoShape> wires;
         for (int i = 1; i <= hWires->Length(); i++) {
             auto wire = hWires->Value(i);
-            wires.push_back(TopoShape(Tag,Hasher,wire));
+            wires.emplace_back(Tag,Hasher,wire);
             wires.back().mapSubElement(shapes, op);
         }
         return makeElementCompound(wires, "", SingleShapeCompoundCreationPolicy::returnShape);

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -1925,7 +1925,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
          PartDesignTestTNP1#Sketch002.AttachmentSupport missing element
          reference PartDesignTestTNP1#Pad001 ;g815v1;SKT;:H976,V;:L#2;PSM;
         :H976:9,E;:L#8;PSM;:H976:9,F;:H-977,F.Face11 is only temporary and can be ignored."""
-        self.assertTrue(self.Sketch002.Support[0][1][0] == "Face11")
+        self.assertTrue(self.Sketch002.AttachmentSupport[0][1][0] == "Face11")
         self.assertGreaterEqual(self.Body.Shape.Volume, 20126)
 
     def tearDown(self):

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -1501,6 +1501,433 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         del geo_list, con_list
         self.Doc.recompute()
 
+    def testRectanglewithArcChangeinGlobalCenter(self):
+        # Arrange
+        self.Body = self.Doc.addObject("PartDesign::Body", "Body")
+        # Make first offset cube Pad
+        self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (-50, -25), (100, 50))
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 10
+        self.Doc.recompute()
+
+        self.Sketch001 = self.Body.newObject("Sketcher::SketchObject", "Sketch001")
+        self.Sketch001.AttachmentSupport = (
+            self.Doc.getObject("Pad"),
+            [
+                "Face6",
+            ],
+        )
+        self.Sketch001.MapMode = "FlatFace"
+
+        TestSketcherApp.CreateRectangleSketch(self.Sketch001, (-40, -20), (80, 40))
+        self.Doc.recompute()
+        self.Pad1 = self.Doc.addObject("PartDesign::Pad", "Pad1")
+        self.Body.addObject(self.Pad1)
+        self.Pad1.Profile = self.Sketch001
+        self.Pad1.Length = 10
+        self.Doc.recompute()
+
+        self.geoList = []
+        self.geoList.append(
+            Part.ArcOfCircle(
+                Part.Circle(
+                    App.Vector(0.000000, -109.419670, 0.000000),
+                    App.Vector(0.000000, 0.000000, 1.000000),
+                    88.713871,
+                ),
+                1.258384,
+                1.886112,
+            )
+        )
+        self.PadSketch.addGeometry(self.geoList, False)
+        del self.geoList
+
+        self.constraintList = []
+        self.constraintList.append(Sketcher.Constraint("PointOnObject", 4, 3, -2))
+        self.constraintList.append(Sketcher.Constraint("PointOnObject", 4, 1, 2))
+        self.constraintList.append(Sketcher.Constraint("PointOnObject", 4, 2, 2))
+        self.PadSketch.addConstraint(self.constraintList)
+        del self.constraintList
+
+        self.PadSketch.trim(2, App.Vector(7.337847, -25.000000, 0))
+        self.PadSketch.addConstraint(Sketcher.Constraint("Equal", 3, 1))
+        self.PadSketch.addConstraint(Sketcher.Constraint("Horizontal", 5))
+        self.PadSketch.addConstraint(Sketcher.Constraint("Radius", 4, 73.031111))
+        self.PadSketch.setDatum(18, App.Units.Quantity("70.000000 mm"))
+        self.PadSketch.addConstraint(
+            Sketcher.Constraint("DistanceY", 4, 3, -1, 1, 88.867210)
+        )
+        self.PadSketch.setDatum(19, App.Units.Quantity("80.000000 mm"))
+
+        self.Doc.recompute()
+        self.assertTrue(self.Sketch001.isValid())
+
+    def testRectanglewithArcChangeinGlobalUpperRight(self):
+        # Arrange
+        self.Body = self.Doc.addObject("PartDesign::Body", "Body")
+        # Make first offset cube Pad
+        self.PadSketch = self.Body.newObject("Sketcher::SketchObject", "Sketch")
+        self.PadSketch.AttachmentSupport = (self.Doc.getObject("XY_Plane"), [""])
+        self.PadSketch.MapMode = "FlatFace"
+        self.Doc.recompute()
+
+        lastGeoId = len(self.PadSketch.Geometry)
+
+        self.geoList = []
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(6.565019, 5.821458, 0.000000),
+                App.Vector(131.750198, 5.821458, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(131.750198, 5.821458, 0.000000),
+                App.Vector(131.750198, 75.265900, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(131.750198, 75.265900, 0.000000),
+                App.Vector(6.565019, 75.265900, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(6.565019, 75.265900, 0.000000),
+                App.Vector(6.565019, 5.821458, 0.000000),
+            )
+        )
+        self.PadSketch.addGeometry(self.geoList, False)
+        del self.geoList
+        self.constraintList = []
+        self.constraintList.append(Sketcher.Constraint("Coincident", 0, 2, 1, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 1, 2, 2, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 2, 2, 3, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 3, 2, 0, 1))
+        self.constraintList.append(Sketcher.Constraint("Horizontal", 0))
+        self.constraintList.append(Sketcher.Constraint("Horizontal", 2))
+        self.constraintList.append(Sketcher.Constraint("Vertical", 1))
+        self.constraintList.append(Sketcher.Constraint("Vertical", 3))
+        self.PadSketch.addConstraint(self.constraintList)
+        del self.constraintList
+
+        self.Doc.recompute()
+
+        self.Pad = self.Body.newObject("PartDesign::Pad", "Pad")
+        self.Pad.Profile = (
+            self.Doc.getObject("Sketch"),
+            [
+                "",
+            ],
+        )
+        self.Pad.Length = 10
+        self.Doc.recompute()
+        self.Pad.ReferenceAxis = (self.Doc.getObject("Sketch"), ["N_Axis"])
+        self.Doc.recompute()
+
+        self.Pad.Length = 10.000000
+        self.Pad.TaperAngle = 0.000000
+        self.Pad.UseCustomVector = 0
+        self.Pad.Direction = (0, 0, 1)
+        self.Pad.ReferenceAxis = (self.Doc.getObject("Sketch"), ["N_Axis"])
+        self.Pad.AlongSketchNormal = 1
+        self.Pad.Type = 0
+        self.Pad.UpToFace = None
+        self.Pad.Reversed = 0
+        self.Pad.Midplane = 0
+        self.Pad.Offset = 0
+        self.Doc.recompute()
+
+        self.Sketch001 = self.Body.newObject("Sketcher::SketchObject", "Sketch001")
+        self.Sketch001.AttachmentSupport = (
+            self.Doc.getObject("Pad"),
+            [
+                "Face6",
+            ],
+        )
+        self.Sketch001.MapMode = "FlatFace"
+        self.Doc.recompute()
+
+        lastGeoId = len(self.Sketch001.Geometry)
+
+        self.geoList = []
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(33.048996, 24.872660, 0.000000),
+                App.Vector(125.086029, 24.872660, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(125.086029, 24.872660, 0.000000),
+                App.Vector(125.086029, 72.835625, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(125.086029, 72.835625, 0.000000),
+                App.Vector(33.048996, 72.835625, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(33.048996, 72.835625, 0.000000),
+                App.Vector(33.048996, 24.872660, 0.000000),
+            )
+        )
+        self.Sketch001.addGeometry(self.geoList, False)
+        del self.geoList
+
+        self.constraintList = []
+        self.constraintList.append(Sketcher.Constraint("Coincident", 0, 2, 1, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 1, 2, 2, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 2, 2, 3, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 3, 2, 0, 1))
+        self.constraintList.append(Sketcher.Constraint("Horizontal", 0))
+        self.constraintList.append(Sketcher.Constraint("Horizontal", 2))
+        self.constraintList.append(Sketcher.Constraint("Vertical", 1))
+        self.constraintList.append(Sketcher.Constraint("Vertical", 3))
+        self.Sketch001.addConstraint(self.constraintList)
+        del self.constraintList
+
+        self.Doc.recompute()
+
+        self.Pad1 = self.Body.newObject("PartDesign::Pad", "Pad001")
+        self.Pad1.Profile = (
+            self.Doc.getObject("Sketch001"),
+            [
+                "",
+            ],
+        )
+        self.Pad1.Length = 10
+        self.Doc.recompute()
+        self.Pad1.ReferenceAxis = (self.Doc.getObject("Sketch001"), ["N_Axis"])
+
+        self.Doc.recompute()
+
+        self.Pad1.Length = 10.000000
+        self.Pad1.TaperAngle = 0.000000
+        self.Pad1.UseCustomVector = 0
+        self.Pad1.Direction = (0, 0, 1)
+        self.Pad1.ReferenceAxis = (self.Doc.getObject("Sketch001"), ["N_Axis"])
+        self.Pad1.AlongSketchNormal = 1
+        self.Pad1.Type = 0
+        self.Pad1.UpToFace = None
+        self.Pad1.Reversed = 0
+        self.Pad1.Midplane = 0
+        self.Pad1.Offset = 0
+        self.Doc.recompute()
+
+        lastGeoId = len(self.Sketch001.Geometry)
+
+        self.geoList = []
+        self.geoList.append(
+            Part.ArcOfCircle(
+                Part.Circle(
+                    App.Vector(73.611900, -60.502949, 0.000000),
+                    App.Vector(0.000000, 0.000000, 1.000000),
+                    80.806032,
+                ),
+                0.997061,
+                2.178808,
+            )
+        )
+        self.PadSketch.addGeometry(self.geoList, False)
+        del self.geoList
+
+        self.constraintList = []
+        self.constraintList.append(Sketcher.Constraint("PointOnObject", 4, 2, 0))
+        self.constraintList.append(Sketcher.Constraint("PointOnObject", 4, 1, 0))
+        self.PadSketch.addConstraint(self.constraintList)
+        del self.constraintList
+        self.Doc.recompute()
+        self.PadSketch.trim(0, App.Vector(69.157609, 5.865876, 0))
+        self.Doc.recompute()
+        self.assertTrue(self.Sketch001.isValid())
+
+    def testPadChange_UpToFirst_to_Dimension(self):
+        # Arrange
+        self.Body = self.Doc.addObject("PartDesign::Body", "Body")
+        # Make first offset cube Pad
+        self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (-42.5, -42.5), (85, 85))
+        self.Doc.recompute()
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (-37.5, -37.5), (75, 75))
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 10
+        self.Doc.recompute()
+
+        self.Sketch001 = self.Body.newObject("Sketcher::SketchObject", "Sketch001")
+        self.Sketch001.AttachmentSupport = (
+            self.Doc.getObject("Pad"),
+            [
+                "Face5",
+            ],
+        )
+        self.Sketch001.MapMode = "FlatFace"
+        self.Doc.recompute()
+        lastGeoId = len(self.Sketch001.Geometry)
+
+        self.geoList = []
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(-33.953453, 7.680901, 0.000000),
+                App.Vector(-33.953453, 2.543239, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(-33.953453, 2.543239, 0.000000),
+                App.Vector(33.282925, 2.543239, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(33.282925, 2.543239, 0.000000),
+                App.Vector(33.282925, 7.680901, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(33.282925, 7.680901, 0.000000),
+                App.Vector(-33.953453, 7.680901, 0.000000),
+            )
+        )
+        self.Sketch001.addGeometry(self.geoList, False)
+        del self.geoList
+
+        self.constraintList = []
+        self.constraintList.append(Sketcher.Constraint("Coincident", 0, 2, 1, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 1, 2, 2, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 2, 2, 3, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 3, 2, 0, 1))
+        self.constraintList.append(Sketcher.Constraint("Vertical", 0))
+        self.constraintList.append(Sketcher.Constraint("Vertical", 2))
+        self.constraintList.append(Sketcher.Constraint("Horizontal", 1))
+        self.constraintList.append(Sketcher.Constraint("Horizontal", 3))
+        self.Sketch001.addConstraint(self.constraintList)
+        del self.constraintList
+
+        self.Doc.recompute()
+        self.Pad001 = self.Body.newObject("PartDesign::Pad", "Pad001")
+        self.Pad001.Profile = (
+            self.Doc.getObject("Sketch001"),
+            [
+                "",
+            ],
+        )
+        self.Pad001.Length = 10
+        self.Doc.recompute()
+        self.Pad001.ReferenceAxis = (self.Doc.getObject("Sketch001"), ["N_Axis"])
+        self.Doc.recompute()
+        self.Pad001.UseCustomVector = 0
+        self.Pad001.Direction = (0, -1, 0)
+        self.Pad001.ReferenceAxis = (self.Doc.getObject("Sketch001"), ["N_Axis"])
+        self.Pad001.AlongSketchNormal = 1
+        self.Pad001.Type = 2
+        self.Pad001.UpToFace = None
+        self.Pad001.Reversed = 0
+        self.Pad001.Midplane = 0
+        self.Pad001.Offset = 0
+        self.Doc.recompute()
+        self.Sketch002 = self.Body.newObject("Sketcher::SketchObject", "Sketch002")
+        self.Sketch002.AttachmentSupport = (
+            self.Doc.getObject("Pad001"),
+            [
+                "Face11",
+            ],
+        )
+        self.Sketch002.MapMode = "FlatFace"
+        self.Doc.recompute()
+        lastGeoId = len(self.Sketch002.Geometry)
+
+        self.geoList = []
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(-30.826233, 35.070259, 0.000000),
+                App.Vector(-30.826233, 30.602728, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(-30.826233, 30.602728, 0.000000),
+                App.Vector(30.602348, 30.602728, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(30.602348, 30.602728, 0.000000),
+                App.Vector(30.602348, 35.070259, 0.000000),
+            )
+        )
+        self.geoList.append(
+            Part.LineSegment(
+                App.Vector(30.602348, 35.070259, 0.000000),
+                App.Vector(-30.826233, 35.070259, 0.000000),
+            )
+        )
+        self.Sketch002.addGeometry(self.geoList, False)
+        del self.geoList
+
+        self.constraintList = []
+        self.constraintList.append(Sketcher.Constraint("Coincident", 0, 2, 1, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 1, 2, 2, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 2, 2, 3, 1))
+        self.constraintList.append(Sketcher.Constraint("Coincident", 3, 2, 0, 1))
+        self.constraintList.append(Sketcher.Constraint("Vertical", 0))
+        self.constraintList.append(Sketcher.Constraint("Vertical", 2))
+        self.constraintList.append(Sketcher.Constraint("Horizontal", 1))
+        self.constraintList.append(Sketcher.Constraint("Horizontal", 3))
+        self.Sketch002.addConstraint(self.constraintList)
+        del self.constraintList
+
+        self.Doc.recompute()
+
+        self.Pad002 = self.Body.newObject("PartDesign::Pad", "Pad002")
+        self.Pad002.Profile = (
+            self.Doc.getObject("Sketch002"),
+            [
+                "",
+            ],
+        )
+        self.Pad002.Length = 10
+        self.Doc.recompute()
+        self.Pad002.ReferenceAxis = (self.Doc.getObject("Sketch002"), ["N_Axis"])
+
+        self.Doc.recompute()
+        self.Pad002.Length = 10.000000
+        self.Pad002.TaperAngle = 0.000000
+        self.Pad002.UseCustomVector = 0
+        self.Pad002.Direction = (0, 0, 1)
+        self.Pad002.ReferenceAxis = (self.Doc.getObject("Sketch002"), ["N_Axis"])
+        self.Pad002.AlongSketchNormal = 1
+        self.Pad002.Type = 0
+        self.Pad002.UpToFace = None
+        self.Pad002.Reversed = 0
+        self.Pad002.Midplane = 0
+        self.Pad002.Offset = 0
+        self.Doc.recompute()
+
+        self.Pad001.Type = "Length"
+        self.Pad001.Length = "4 mm"
+        self.Doc.recompute()
+        """Assumption: the warning <PropertyLinks> PropertyLinks.cpp(453):
+         PartDesignTestTNP1#Sketch002.AttachmentSupport missing element
+         reference PartDesignTestTNP1#Pad001 ;g815v1;SKT;:H976,V;:L#2;PSM;
+        :H976:9,E;:L#8;PSM;:H976:9,F;:H-977,F.Face11 is only temporary and can be ignored."""
+        self.assertTrue(self.Sketch002.Support[0][1][0] == "Face11")
+        self.assertGreaterEqual(self.Body.Shape.Volume, 20126)
+
     def tearDown(self):
         """ Close our test document """
         App.closeDocument(self.Doc.Name)

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -582,16 +582,16 @@ TEST_F(TopoShapeExpansionTest, makeElementWiresCombinesWires)
     // Assert map is correct
     EXPECT_TRUE(allElementsMatch(topoShape,
                                  {
-                                     "Edge1;:C1;:H4:4,E;WIR;:H4:4,E;WIR;:H4:4,E",
-                                     "Edge1;:H1,E;WIR;:H1:4,E;WIR;:H1:4,E",
-                                     "Edge1;:H2,E;WIR;:H2:4,E;WIR;:H2:4,E",
-                                     "Edge1;:H4,E;WIR;:H4:4,E;WIR;:H4:4,E",
-                                     "Vertex1;:H1,V;WIR;:H1:4,V;WIR;:H1:4,V",
-                                     "Vertex1;:H4,V;WIR;:H4:4,V;WIR;:H4:4,V",
-                                     "Vertex2;:C1;:H4:4,V;WIR;:H4:4,V;WIR;:H4:4,V",
-                                     "Vertex2;:H1,V;WIR;:H1:4,V;WIR;:H1:4,V",
-                                     "Vertex2;:H2,V;WIR;:H2:4,V;WIR;:H2:4,V",
-                                     "Vertex2;:H4,V;WIR;:H4:4,V;WIR;:H4:4,V",
+                                     "Edge1;WIR;:H1:4,E;WIR;:H1:4,E",
+                                     "Edge1;WIR;:H2:4,E;WIR;:H2:4,E",
+                                     "Edge1;WIR;:H4:4,E;D1;:H4:3,E;WIR;:H4:4,E",
+                                     "Edge1;WIR;:H4:4,E;WIR;:H4:4,E",
+                                     "Vertex1;WIR;:H1:4,V;WIR;:H1:4,V",
+                                     "Vertex1;WIR;:H4:4,V;WIR;:H4:4,V",
+                                     "Vertex2;WIR;:H1:4,V;WIR;:H1:4,V",
+                                     "Vertex2;WIR;:H2:4,V;WIR;:H2:4,V",
+                                     "Vertex2;WIR;:H4:4,V;D1;:H4:3,V;WIR;:H4:4,V",
+                                     "Vertex2;WIR;:H4:4,V;WIR;:H4:4,V",
                                  }));  // Changed with PR#12471. Probably will change again after
                                        // importing other TopoNaming logics
 }
@@ -2358,12 +2358,12 @@ TEST_F(TopoShapeExpansionTest, makeElementSlice)
                               {
                                   "Face1;:G2;SLC;:H1:8,V;SLC;:H1:4,V",
                                   "Face1;:G3;SLC;:H1:8,V;SLC;:H1:4,V",
-                                  "Face1;:G4;SLC;:H1:8,V;D1;:H1:3,V;SLC;:H1:4,V",
                                   "Face1;:G4;SLC;:H1:8,V;SLC;:H1:4,V",
                                   "Face1;:G5;SLC;:H1:8,E;SLC;:H1:4,E",
                                   "Face1;:G6;SLC;:H1:8,E;SLC;:H1:4,E",
                                   "Face1;:G7;SLC;:H1:8,E;SLC;:H1:4,E",
                                   "Face1;:G8;SLC;:H1:8,E;SLC;:H1:4,E",
+                                  "Face1;:G;SLC;:H1:7,V;SLC;:H1:4,V",
                               }));
 }
 
@@ -2388,34 +2388,33 @@ TEST_F(TopoShapeExpansionTest, makeElementSlices)
     EXPECT_EQ(TopAbs_ShapeEnum::TopAbs_WIRE, subTopoShapes[2].getShape().ShapeType());
     // Assert that we're creating a correct element map
     EXPECT_TRUE(result.getMappedChildElements().empty());
-    EXPECT_TRUE(
-        elementsMatch(result,
-                      {
-                          "Edge10;:G(Face1;K-2;:H1:4,F);SLC;:H1:1a,V;SLC;:H1:4,V",
-                          "Edge10;:G(Face1;K-2;:H2:4,F);SLC_2;:H1:1c,V;SLC_2;:H1:6,V",
-                          "Edge10;:G(Face1;K-2;:H3:4,F);SLC_3;:H1:1c,V;SLC_3;:H1:6,V",
-                          "Edge11;:G(Face1;K-3;:H1:4,F);SLC;:H1:1a,V;SLC;:H1:4,V",
-                          "Edge11;:G(Face1;K-3;:H2:4,F);SLC_2;:H1:1c,V;SLC_2;:H1:6,V",
-                          "Edge11;:G(Face1;K-3;:H3:4,F);SLC_3;:H1:1c,V;SLC_3;:H1:6,V",
-                          "Edge12;:G(Face1;K-4;:H1:4,F);SLC;:H1:1a,V;D1;:H1:3,V;SLC;:H1:4,V",
-                          "Edge12;:G(Face1;K-4;:H1:4,F);SLC;:H1:1a,V;SLC;:H1:4,V",
-                          "Edge12;:G(Face1;K-4;:H2:4,F);SLC_2;:H1:1c,V;D1;:H1:3,V;SLC_2;:H1:6,V",
-                          "Edge12;:G(Face1;K-4;:H2:4,F);SLC_2;:H1:1c,V;SLC_2;:H1:6,V",
-                          "Edge12;:G(Face1;K-4;:H3:4,F);SLC_3;:H1:1c,V;D1;:H1:3,V;SLC_3;:H1:6,V",
-                          "Edge12;:G(Face1;K-4;:H3:4,F);SLC_3;:H1:1c,V;SLC_3;:H1:6,V",
-                          "Face1;:G5(Face3;K-1;:H1:4,F);SLC;:H1:1b,E;SLC;:H1:4,E",
-                          "Face1;:G6(Face4;K-1;:H1:4,F);SLC;:H1:1b,E;SLC;:H1:4,E",
-                          "Face1;:G7(Face5;K-1;:H1:4,F);SLC;:H1:1b,E;SLC;:H1:4,E",
-                          "Face1;:G8(Face6;K-1;:H1:4,F);SLC;:H1:1b,E;SLC;:H1:4,E",
-                          "Face3;:G(Face1;K-5;:H2:4,F);SLC_2;:H1:1c,E;SLC_2;:H1:6,E",
-                          "Face3;:G(Face1;K-5;:H3:4,F);SLC_3;:H1:1c,E;SLC_3;:H1:6,E",
-                          "Face4;:G(Face1;K-6;:H2:4,F);SLC_2;:H1:1c,E;SLC_2;:H1:6,E",
-                          "Face4;:G(Face1;K-6;:H3:4,F);SLC_3;:H1:1c,E;SLC_3;:H1:6,E",
-                          "Face5;:G(Face1;K-7;:H2:4,F);SLC_2;:H1:1c,E;SLC_2;:H1:6,E",
-                          "Face5;:G(Face1;K-7;:H3:4,F);SLC_3;:H1:1c,E;SLC_3;:H1:6,E",
-                          "Face6;:G(Face1;K-8;:H2:4,F);SLC_2;:H1:1c,E;SLC_2;:H1:6,E",
-                          "Face6;:G(Face1;K-8;:H3:4,F);SLC_3;:H1:1c,E;SLC_3;:H1:6,E",
-                      }));
+    EXPECT_TRUE(elementsMatch(result,
+                              {
+                                  "Edge10;:G(Face1;K-2;:H1:4,F);SLC;:H1:1a,V;SLC;:H1:4,V",
+                                  "Edge10;:G(Face1;K-2;:H2:4,F);SLC_2;:H1:1c,V;SLC_2;:H1:6,V",
+                                  "Edge10;:G(Face1;K-2;:H3:4,F);SLC_3;:H1:1c,V;SLC_3;:H1:6,V",
+                                  "Edge11;:G(Face1;K-3;:H1:4,F);SLC;:H1:1a,V;SLC;:H1:4,V",
+                                  "Edge11;:G(Face1;K-3;:H2:4,F);SLC_2;:H1:1c,V;SLC_2;:H1:6,V",
+                                  "Edge11;:G(Face1;K-3;:H3:4,F);SLC_3;:H1:1c,V;SLC_3;:H1:6,V",
+                                  "Edge12;:G(Face1;K-4;:H1:4,F);SLC;:H1:1a,V;SLC;:H1:4,V",
+                                  "Edge12;:G(Face1;K-4;:H2:4,F);SLC_2;:H1:1c,V;SLC_2;:H1:6,V",
+                                  "Edge12;:G(Face1;K-4;:H3:4,F);SLC_3;:H1:1c,V;SLC_3;:H1:6,V",
+                                  "Edge9;:G(Face1;K-1;:H1:4,F);SLC;:H1:1a,V;SLC;:H1:4,V",
+                                  "Edge9;:G(Face1;K-1;:H2:4,F);SLC_2;:H1:1c,V;SLC_2;:H1:6,V",
+                                  "Edge9;:G(Face1;K-1;:H3:4,F);SLC_3;:H1:1c,V;SLC_3;:H1:6,V",
+                                  "Face1;:G5(Face3;K-1;:H1:4,F);SLC;:H1:1b,E;SLC;:H1:4,E",
+                                  "Face1;:G6(Face4;K-1;:H1:4,F);SLC;:H1:1b,E;SLC;:H1:4,E",
+                                  "Face1;:G7(Face5;K-1;:H1:4,F);SLC;:H1:1b,E;SLC;:H1:4,E",
+                                  "Face1;:G8(Face6;K-1;:H1:4,F);SLC;:H1:1b,E;SLC;:H1:4,E",
+                                  "Face3;:G(Face1;K-5;:H2:4,F);SLC_2;:H1:1c,E;SLC_2;:H1:6,E",
+                                  "Face3;:G(Face1;K-5;:H3:4,F);SLC_3;:H1:1c,E;SLC_3;:H1:6,E",
+                                  "Face4;:G(Face1;K-6;:H2:4,F);SLC_2;:H1:1c,E;SLC_2;:H1:6,E",
+                                  "Face4;:G(Face1;K-6;:H3:4,F);SLC_3;:H1:1c,E;SLC_3;:H1:6,E",
+                                  "Face5;:G(Face1;K-7;:H2:4,F);SLC_2;:H1:1c,E;SLC_2;:H1:6,E",
+                                  "Face5;:G(Face1;K-7;:H3:4,F);SLC_3;:H1:1c,E;SLC_3;:H1:6,E",
+                                  "Face6;:G(Face1;K-8;:H2:4,F);SLC_2;:H1:1c,E;SLC_2;:H1:6,E",
+                                  "Face6;:G(Face1;K-8;:H3:4,F);SLC_3;:H1:1c,E;SLC_3;:H1:6,E",
+                              }));
     EXPECT_FALSE(
         subTopoShapes[0].getElementMap().empty());  // Changed with PR#12471. Probably will change
                                                     // again after importing other TopoNaming logics


### PR DESCRIPTION
Change the definitions of the `makeElementWires` methods, aligning them with LS3 fork.

For reference:
https://github.com/realthunder/FreeCAD/blob/0e9cf4aa7c7bac94a83edd07b4bd74a71a26446c/src/Mod/Part/App/TopoShapeEx.cpp#L3004
https://github.com/realthunder/FreeCAD/blob/0e9cf4aa7c7bac94a83edd07b4bd74a71a26446c/src/Mod/Part/App/TopoShapeEx.cpp#L3181

In my tests this fixes #14436