### PR TITLE
[TD]Change template svg_namespace to www.freecad.org

### DIFF
--- a/src/Mod/TechDraw/Templates/A0_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A0_Landscape_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A0T - Advanced</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/A0_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A0_Landscape_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A0T - Minimal</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/A1_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A1_Landscape_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A1T - Advanced</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/A1_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A1_Landscape_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A1T - Minimal</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/A2_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A2_Landscape_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A2T - Advanced</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/A2_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A2_Landscape_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A2T - Minimal</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/A3_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A3_Landscape_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A3T - Advanced</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/A3_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A3_Landscape_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A3T - Minimal</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/A4_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A4_Landscape_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A4T - Advanced</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/A4_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A4_Landscape_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A4T - Minimal</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/A4_Portrait_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/A4_Portrait_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A4T - Advanced</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/A4_Portrait_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/A4_Portrait_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A4T - Minimal</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/ANSIC_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/ANSIC_Landscape.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="svg5464" width="559" height="432" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<svg id="svg5464" width="559" height="432" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
  <metadata id="metadata5469">
   <rdf:RDF>
    <cc:Work rdf:about="">

--- a/src/Mod/TechDraw/Templates/ANSIC_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/ANSIC_Portrait.svg
@@ -13,7 +13,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index0="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:index0="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
   <sodipodi:namedview

--- a/src/Mod/TechDraw/Templates/ANSID_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/ANSID_Landscape.svg
@@ -13,7 +13,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index0="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:index0="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
   <sodipodi:namedview

--- a/src/Mod/TechDraw/Templates/ANSID_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/ANSID_Portrait.svg
@@ -13,7 +13,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index0="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:index0="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
   <sodipodi:namedview

--- a/src/Mod/TechDraw/Templates/ANSIE_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/ANSIE_Landscape.svg
@@ -13,7 +13,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index0="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:index0="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
   <sodipodi:namedview

--- a/src/Mod/TechDraw/Templates/ANSIE_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/ANSIE_Portrait.svg
@@ -13,7 +13,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index0="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:index0="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
   <sodipodi:namedview

--- a/src/Mod/TechDraw/Templates/ISO 5457/A0_Landscape_ISO5457_notitleblock.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/A0_Landscape_ISO5457_notitleblock.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A0T</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/ISO 5457/A1_Landscape_ISO5457_notitleblock.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/A1_Landscape_ISO5457_notitleblock.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A1T</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/ISO 5457/A2_Landscape_ISO5457_notitleblock.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/A2_Landscape_ISO5457_notitleblock.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A2T</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/ISO 5457/A3_Landscape_ISO5457_notitleblock.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/A3_Landscape_ISO5457_notitleblock.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A3T</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/ISO 5457/A4_Landscape_ISO5457_notitleblock.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/A4_Landscape_ISO5457_notitleblock.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A4T</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/ISO 5457/A4_Portrait_ISO5457_notitleblock.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/A4_Portrait_ISO5457_notitleblock.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Drawing sheet ISO 5457 - A4T</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_1_minimal.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_1_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Title block ISO 7200 - Minimal</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_2.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_2.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Title block ISO 7200</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_3_advanced.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_3_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Title block ISO 7200 - Advanced</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_4.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_4.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Title block ISO 7200</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_5_maximal.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_5_maximal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title">Title block ISO 7200 - Maximal</title>
   <metadata id="metadata">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A0_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A0_Landscape_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A0T</title>
   <metadata id="metadata1">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A0_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A0_Landscape_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A0T</title>
   <metadata id="metadata1">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A1_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A1_Landscape_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A1T</title>
   <metadata id="metadata1">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A1_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A1_Landscape_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A1T</title>
   <metadata id="metadata1">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A2_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A2_Landscape_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A2T</title>
   <metadata id="metadata1">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A2_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A2_Landscape_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A2T</title>
   <metadata id="metadata1">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A3_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A3_Landscape_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A3T</title>
   <metadata id="metadata1">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A3_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A3_Landscape_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A3T</title>
   <metadata id="metadata1">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A4_Landscape_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A4_Landscape_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A4T</title>
   <metadata id="metadata1">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A4_Landscape_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A4_Landscape_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A4T</title>
   <metadata id="metadata1">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A4_Portrait_ISO5457_advanced.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A4_Portrait_ISO5457_advanced.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A4T</title>
   <metadata id="metadata1">
     <rdf:RDF>

--- a/src/Mod/TechDraw/Templates/locale/ca/A4_Portrait_ISO5457_minimal.svg
+++ b/src/Mod/TechDraw/Templates/locale/ca/A4_Portrait_ISO5457_minimal.svg
@@ -11,7 +11,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <title id="title1">Drawing sheet ISO 5457 - A4T</title>
   <metadata id="metadata1">
     <rdf:RDF>


### PR DESCRIPTION
This PR updates the svg namespace in templates from www.freecadweb.org to 
www.freecad.org.