### PR TITLE
Base: Fix compiler warning

### DIFF
--- a/src/Base/MatrixPyImp.cpp
+++ b/src/Base/MatrixPyImp.cpp
@@ -991,7 +991,7 @@ Py::Sequence MatrixPy::getA() const
     for (int i = 0; i < 16; i++) {
         tuple[i] = Py::Float(mat[i]);
     }
-    return std::move(tuple);
+    return tuple;
 }
 
 void MatrixPy::setA(Py::Sequence arg)


### PR DESCRIPTION
No need for a std::move here.