### PR TITLE
TD: Use new Qt6.5 interface for setContent

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewSymbol.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSymbol.cpp
@@ -188,6 +188,7 @@ bool DrawViewSymbol::loadQDomDocument(QDomDocument& symbolDocument)
     if (qba.isEmpty()) {
         return false;
     }
+#if QT_VERSION < QT_VERSION_CHECK(6,5,0) // New setContent interface added in Qt 6.5
     QString errorMsg;
     int errorLine;
     int errorCol;
@@ -202,6 +203,18 @@ bool DrawViewSymbol::loadQDomDocument(QDomDocument& symbolDocument)
                             errorLine, errorCol);
     }
     return rc;
+#else
+    QDomDocument::ParseResult rc = symbolDocument.setContent(qba); // Use the default ParseOptions
+    if (!rc) {
+        //invalid SVG message
+        Base::Console().Warning("DrawViewSymbol - %s - SVG for Symbol is not valid. See log.\n",
+                                getNameInDocument());
+        Base::Console().Log("DrawViewSymbol - %s - len: %d error: %s line: %d col: %d\n",
+                            getNameInDocument(), strlen(symbol), qPrintable(rc.errorMessage),
+                            rc.errorLine, rc.errorColumn);
+    }
+    return static_cast<bool>(rc);
+#endif
 }
 
 PyObject* DrawViewSymbol::getPyObject()


### PR DESCRIPTION
Qt 6.5 and later provide a new interface for setContent, and the old interface will be deprecated as of Qt 6.8.