### PR TITLE
Assembly: Add validation step during dragging to ignore bad solves

### DIFF
--- a/src/Mod/Assembly/App/AssemblyObject.h
+++ b/src/Mod/Assembly/App/AssemblyObject.h
@@ -155,6 +155,8 @@ public:
 
     void exportAsASMT(std::string fileName);
 
+    Base::Placement getMbdPlacement(std::shared_ptr<MbD::ASMTPart> mbdPart);
+    bool validateNewPlacements();
     void setNewPlacements();
     void recomputeJointPlacements(std::vector<App::DocumentObject*> joints);
     void redrawJointPlacements(std::vector<App::DocumentObject*> joints);


### PR DESCRIPTION
This adds a validation step before applying the placement returned by the solver to avoid applying bad solutions.

This first PR implement the mechanism and add a first validation : That the grounded objects do not move. If the solver tries to move a grounded object, then the solution will be ignored and the dragging continue.

Further tests can be added later. For example we could test if the joints are still correctly aligned (for fixed/slider/revolute/cylindrical).