### PR TITLE
implement FORCE_BOOST_PY_SUFFIX

### DIFF
--- a/src/Mod/CAM/libarea/CMakeLists.txt
+++ b/src/Mod/CAM/libarea/CMakeLists.txt
@@ -21,7 +21,11 @@ link_directories(${OCC_LIBRARY_DIR})
 if(NOT FREECAD_USE_PYBIND11)
     if(NOT FREECAD_LIBPACK_USE OR FREECAD_LIBPACK_CHECKFILE_CLBUNDLER)
         # boost-python >= 1.67 on some platforms has suffix
-        set(BOOST_PY_SUFFIX ${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+        if (FORCE_BOOST_PY_SUFFIX)
+            set(BOOST_PY_SUFFIX ${FORCE_BOOST_PY_SUFFIX})
+        else ()
+            set(BOOST_PY_SUFFIX ${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+        endif ()
 
         find_package( Boost COMPONENTS python${BOOST_PY_SUFFIX} )
         if (NOT Boost_PYTHON${BOOST_PY_SUFFIX}_FOUND)

--- a/src/Mod/MeshPart/App/CMakeLists.txt
+++ b/src/Mod/MeshPart/App/CMakeLists.txt
@@ -115,7 +115,11 @@ if (BUILD_FLAT_MESH)
     else()
         if(NOT FREECAD_LIBPACK_USE OR FREECAD_LIBPACK_CHECKFILE_CLBUNDLER)
             # boost-python >= 1.67 on some platforms has suffix
-            set(BOOST_PY_SUFFIX ${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+            if (FORCE_BOOST_PY_SUFFIX)
+                set(BOOST_PY_SUFFIX ${FORCE_BOOST_PY_SUFFIX})
+            else ()
+                set(BOOST_PY_SUFFIX ${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+            endif ()
 
             find_package( Boost COMPONENTS python${BOOST_PY_SUFFIX} )
             if (NOT Boost_PYTHON${BOOST_PY_SUFFIX}_FOUND)


### PR DESCRIPTION
On some systems the boost-python suffix is not exactly as the code currently expects. To avoid getting even more guessing in the CMake files about how exactly the python component is named in the boost installation we introduce a variable FORCE_BOOST_PY_SUFFIX that can enforce a specific suffix. If the variable is not set the behavior is as before.