### PR TITLE
Preselection preference text improvement

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3543,7 +3543,7 @@ StdTreePreSelection::StdTreePreSelection()
 {
     sGroup       = "TreeView";
     sMenuText    = QT_TR_NOOP("Pre-selection");
-    sToolTipText = QT_TR_NOOP("Preselect the object in 3D view when mouse over the tree item");
+    sToolTipText = QT_TR_NOOP("Preselect the object in 3D view when hovering the cursor over the tree item");
     sStatusTip   = sToolTipText;
     sWhatsThis   = "Std_TreePreSelection";
     sPixmap      = "tree-pre-sel";

--- a/src/Gui/PreferencePages/DlgSettingsSelection.ui
+++ b/src/Gui/PreferencePages/DlgSettingsSelection.ui
@@ -202,7 +202,7 @@ Larger value eases to pick things, but can make small features impossible to sel
    <item row="5" column="0" colspan="2">
     <widget class="Gui::PrefCheckBox" name="checkBoxPreselect">
      <property name="text">
-      <string>Preselect the object in 3D view when mouse over the tree item</string>
+      <string>Preselect the object in 3D view when hovering the cursor over the tree item</string>
      </property>
      <property name="prefEntry" stdset="0">
       <cstring>PreSelection</cstring>


### PR DESCRIPTION
Small improvement of the preference text

before: "Preselect the object in 3D view when mouse over the tree item"
after: "Preselect the object in 3D view when hovering the cursor over the tree item"