### PR TITLE
Measure: Fix MeasureLength failure when measuring circles/arcs

### DIFF
--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -268,17 +268,7 @@ MeasureLengthInfoPtr MeasureLengthHandler(const App::SubObjectT& subject)
     BRepGProp::LinearProperties(shape, gprops);
     auto origin = gprops.CentreOfMass();
 
-    // Get rotation of line
-    auto edge = TopoDS::Edge(shape);
-    ShapeAnalysis_Edge edgeAnalyzer;
-    gp_Pnt firstPoint = BRep_Tool::Pnt(edgeAnalyzer.FirstVertex(edge));
-    gp_Pnt lastPoint = BRep_Tool::Pnt(edgeAnalyzer.LastVertex(edge));
-    auto dir = (lastPoint.XYZ() - firstPoint.XYZ()).Normalized();
-    Base::Vector3d elementDirection(dir.X(), dir.Y(), dir.Z());
-    Base::Vector3d axisUp(0.0, 0.0, 1.0);
-    Base::Rotation rot(axisUp, elementDirection);
-
-    Base::Placement placement(Base::Vector3d(origin.X(), origin.Y(), origin.Z()), rot);
+    Base::Placement placement(Base::Vector3d(origin.X(), origin.Y(), origin.Z()), Base::Rotation());
     return std::make_shared<MeasureLengthInfo>(true, getLength(shape), placement);
 }
 


### PR DESCRIPTION
Currently MeasureLength fails when trying to measure circles and arcs. The relevant code where the exception occurs can actually be be simplified as the rotation of the measured element is not needed to place the measure label.

Fixes #14411 
Fixes #14534 