### PR TITLE
Part: Handle zero scale in TopoShape::_makeTransform

### DIFF
--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -4198,7 +4198,8 @@ bool TopoShape::_makeTransform(const TopoShape &shape,
     if(checkScale) {
         try {
             auto type = rclTrf.hasScale();
-            if (type != Base::ScaleType::Uniform && type != Base::ScaleType::NoScaling) {
+            if ((type != Base::ScaleType::Uniform && type != Base::ScaleType::NoScaling)
+                || (type == Base::ScaleType::Uniform && rclTrf.determinant3() == 0.0)) {
                 makeGTransform(shape,rclTrf,op,copy);
                 return true;
             }


### PR DESCRIPTION
With this commit the TopoShape::_makeTransform() use makeGTransform() if scale is zero to avoid crash according to issue #14562