### PR TITLE
Assembly: Makes sure deleting assembly deletes the joints and views

### DIFF
--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -55,6 +55,7 @@
 #include <Mod/Assembly/App/AssemblyObject.h>
 #include <Mod/Assembly/App/AssemblyUtils.h>
 #include <Mod/Assembly/App/JointGroup.h>
+#include <Mod/Assembly/App/ViewGroup.h>
 #include <Mod/PartDesign/App/Body.h>
 
 #include "ViewProviderAssembly.h"
@@ -887,10 +888,20 @@ void ViewProviderAssembly::onSelectionChanged(const Gui::SelectionChanges& msg)
 
 bool ViewProviderAssembly::onDelete(const std::vector<std::string>& subNames)
 {
-    // Delete the joingroup when assembly is deleted
+    // Delete the assembly goups when assembly is deleted
     for (auto obj : getObject()->getOutList()) {
-        if (obj->getTypeId() == Assembly::JointGroup::getClassTypeId()) {
-            obj->getDocument()->removeObject(obj->getNameInDocument());
+        if (obj->getTypeId() == Assembly::JointGroup::getClassTypeId()
+            || obj->getTypeId() == Assembly::ViewGroup::getClassTypeId()
+            /* || obj->getTypeId() == Assembly::BomGroup::getClassTypeId()*/) {
+
+            // Delete the group content first.
+            Gui::Command::doCommand(Gui::Command::Doc,
+                                    "doc = App.getDocument(\"%s\")\n"
+                                    "objName = \"%s\"\n"
+                                    "doc.getObject(objName).removeObjectsFromDocument()\n"
+                                    "doc.removeObject(objName)\n",
+                                    obj->getDocument()->getName(),
+                                    obj->getNameInDocument());
         }
     }
 


### PR DESCRIPTION
Makes sure deleting assembly deletes the joints, exploded views and the view group.

Fixes #https://github.com/FreeCAD/FreeCAD/issues/14606
Fixes #https://github.com/FreeCAD/FreeCAD/issues/14607