### PR TITLE
Fix several compiler warnings

### DIFF
--- a/src/Mod/Fem/App/FemConstraintTransform.cpp
+++ b/src/Mod/Fem/App/FemConstraintTransform.cpp
@@ -175,7 +175,7 @@ void ConstraintTransform::handleChangedPropertyName(Base::XMLReader& reader,
                                                     const char* propName)
 {
     if (strcmp(propName, "X_rot") == 0) {
-        double xAngle;
+        double xAngle {};
         if (strcmp(typeName, "App::PropertyFloat") == 0) {
             App::PropertyFloat X_rotProperty;
             X_rotProperty.Restore(reader);
@@ -189,7 +189,7 @@ void ConstraintTransform::handleChangedPropertyName(Base::XMLReader& reader,
         anglesToRotation(xAngle, 0, 0);
     }
     else if (strcmp(propName, "Y_rot") == 0) {
-        double yAngle;
+        double yAngle {};
         if (strcmp(typeName, "App::PropertyFloat") == 0) {
             App::PropertyFloat Y_rotProperty;
             Y_rotProperty.Restore(reader);
@@ -203,7 +203,7 @@ void ConstraintTransform::handleChangedPropertyName(Base::XMLReader& reader,
         anglesToRotation(0, yAngle, 0);
     }
     else if (strcmp(propName, "Z_rot") == 0) {
-        double zAngle;
+        double zAngle {};
         if (strcmp(typeName, "App::PropertyFloat") == 0) {
             App::PropertyFloat Z_rotProperty;
             Z_rotProperty.Restore(reader);

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -446,7 +446,6 @@ void PartDesignGui::TaskExtrudeParameters::selectedShape(const Gui::SelectionCha
 
     Gui::Selection().clearSelection();
 
-    auto base = extrude->getBaseObject();
     auto ref = document->getObject(msg.pObjectName);
 
     extrude->UpToShape.setValue(ref);
@@ -487,7 +486,6 @@ void TaskExtrudeParameters::updateShapeName()
 
 void TaskExtrudeParameters::updateShapeFaces()
 {
-    auto extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
     auto faces = getShapeFaces();
 
     ui->listWidgetReferences->clear();


### PR DESCRIPTION
* variable 'xAngle' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
* variable 'yAngle' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
* variable 'zAngle' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
* unused variable 'base' [-Werror,-Wunused-variable]
* unused variable 'extrude' [-Werror,-Wunused-variable]