### PR TITLE
PD: Fix Qt warning at runtime

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -247,8 +247,6 @@ void TaskExtrudeParameters::connectSlots()
         this, &TaskExtrudeParameters::onUpdateView);
     connect(ui->buttonShapeFace, &QToolButton::toggled,
         this, &TaskExtrudeParameters::onSelectShapeFacesToggle);
-    connect(ui->listWidgetReferences, &QListWidget::item,
-        this, &TaskExtrudeParameters::onSelectShapeFacesToggle);
     connect(unselectShapeFaceAction, &QAction::triggered,
         this, &TaskExtrudeParameters::onUnselectShapeFacesTrigger);
 }


### PR DESCRIPTION
QListWidget::item is not declared as Q_SIGNALS and thus cannot be used as sender in QObject::connect()