### PR TITLE
Core: Make sure that PropertyMaterialList cannot become empty

### DIFF
--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -2651,6 +2651,18 @@ PropertyMaterialList::~PropertyMaterialList() = default;
 //**************************************************************************
 // Base class implementer
 
+void PropertyMaterialList::setValues(const std::vector<App::Material>& newValues)
+{
+    if (!newValues.empty()) {
+        PropertyListsT<Material>::setValues(newValues);
+    }
+    else {
+        aboutToSetValue();
+        setSize(1);
+        hasSetValue();
+    }
+}
+
 PyObject* PropertyMaterialList::getPyObject()
 {
     Py::Tuple tuple(getSize());

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -1118,6 +1118,7 @@ public:
     {
         PropertyListsT<Material>::setValue(materials);
     }
+    void setValues(const std::vector<App::Material>& newValues = std::vector<App::Material>()) override;
     void setValue(const Material& mat);
     void setValue(int index, const Material& mat);
 


### PR DESCRIPTION
The PropertyMaterialList is supposed to guarantee that it always has at least one element