### PR TITLE
Test: make test for STEP import independent of user settings

### DIFF
--- a/src/Mod/Import/TestImportGui.py
+++ b/src/Mod/Import/TestImportGui.py
@@ -56,7 +56,7 @@ class ExportImportTest(unittest.TestCase):
         ImportGui.export([part], self.fileName)
 
         self.doc.clearDocument()
-        ImportGui.insert(name=self.fileName, docName=self.doc.Name, useLinkGroup=True)
+        ImportGui.insert(name=self.fileName, docName=self.doc.Name, merge=False, useLinkGroup=True)
 
         part_features = list(filter(lambda x: x.isDerivedFrom("Part::Feature"), self.doc.Objects))
         self.assertEqual(len(part_features), 1)


### PR DESCRIPTION
If the option 'Enable STEP compound merge' is active the test would fail