### PR TITLE
QuickMeasure: fix large selection slow down.

### DIFF
--- a/src/Mod/Measure/Gui/QuickMeasure.h
+++ b/src/Mod/Measure/Gui/QuickMeasure.h
@@ -29,6 +29,9 @@
 #include <Mod/Measure/MeasureGlobal.h>
 
 #include <Gui/Selection.h>
+
+class QTimer;
+
 namespace Measure {
     class Measurement;
 }
@@ -45,15 +48,19 @@ public:
 
 private:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
-    void tryMeasureSelection(const Gui::SelectionChanges& msg);
+    void tryMeasureSelection();
 
     bool canMeasureSelection(const Gui::SelectionChanges& msg) const;
     void addSelectionToMeasurement();
     void printResult();
     void print(const QString& message);
 
+    void processSelection();
+
     Measure::Measurement* measurement;
 
+    QTimer* selectionTimer;
+    bool pendingProcessing;
 };
 
 } //namespace MeasureGui


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/14618

Adds a timer so that quickmeasure excecute only once in the case of box selection.
Adds a limit to 100 objects/subnames as very large selection (1000 edges for example) can take a significant time. 100 edges does not seem to slow down selection.

@wwmayer 