### PR TITLE
Draft: _get_shapes in shape2dview.py did not handle null shapes

### DIFF
--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -198,6 +198,8 @@ class Shape2DView(DraftObject):
     def _get_shapes(self, shape, onlysolids=False):
         if onlysolids:
             return shape.Solids
+        if shape.isNull():
+            return []
         if shape.ShapeType == "Compound":
             return shape.SubShapes
         return [shape.copy()]


### PR DESCRIPTION
Null shapes do not have a ShapeType (strange IMO). The function did not take that into account.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=88397
