### PR TITLE
BIM: Fix Copy tool stealing copy mode

### DIFF
--- a/src/Mod/BIM/bimcommands/BimCopy.py
+++ b/src/Mod/BIM/bimcommands/BimCopy.py
@@ -47,5 +47,14 @@ class BIM_Copy(DraftTools.Move):
             "Accel": "C,P",
         }
 
+    def Activated(self):
+        from draftutils import params
+        self.cmode = params.get_param("CopyMode")
+        DraftTools.Move.Activated(self)
+
+    def finish(self, cont=False):
+        from draftutils import params
+        DraftTools.Move.finish(self, cont)
+        params.set_param("CopyMode", self.cmode)
 
 FreeCADGui.addCommand("BIM_Copy", BIM_Copy())


### PR DESCRIPTION
When the BIM Copy tool is used, it turns on the "Copy" checkbox in the task panel. Consequently, when running other Draft tools afterwards (Move, Rotate..) their Copy checkbox stays turned on even if that was not the intent. This PR fixes that by having the BIM Copy tool restore the Copy checkbox state when it's finished