### PR TITLE
BIM: IFC: Export non-solids as Breps

### DIFF
--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -1987,6 +1987,12 @@ def getRepresentation(
     tostore = False
     subplacement = None
 
+    # enable forcebrep for non-solids
+    if hasattr(obj,"Shape"):
+        if obj.Shape:
+            if not obj.Shape.Solids:
+                forcebrep = True
+
     # check for clones
 
     if ((not subtraction) and (not forcebrep)) or forceclone:


### PR DESCRIPTION
When exporting to IFC, extrusions (BIM/Arch extruded objects or Part Extrudes) are detected as such and exported as extrusions. This is intended for solids, as all IFC objects are supposed to be solids. However, in FreeCAD one can also use Part Extrusions to extrude lines to form faces. Since extruding lines is badly (or not at all?) supported by IFC, and it's not the intention anyway, it's best to export those not as extrusions but as Breps, which support non-solids well.