### PR TITLE
Draft: revert #14206 to fix WP alignment

### DIFF
--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -1246,7 +1246,7 @@ class PlaneGui(PlaneBase):
         if not FreeCAD.GuiUp:
             return False
 
-        sels = FreeCADGui.Selection.getSelectionEx("", 1)
+        sels = FreeCADGui.Selection.getSelectionEx("", 0)
         if not sels:
             return False
 


### PR DESCRIPTION
#14206 was an intermediate solution. Now that  `Part.getShape` can handle the new `SubElementNames` it needs to be removed as it breaks the handling of subelements in links.
