### PR TITLE
macOS: Add symlink to /Applications and use bigger icons

### DIFF
--- a/src/Tools/dmg_settings.py
+++ b/src/Tools/dmg_settings.py
@@ -1,0 +1,6 @@
+files = [f"{containing_folder}/FreeCAD.app"]
+symlinks = {"Applications": "/Applications"}
+badge_icon = f"{containing_folder}/FreeCAD.app/Contents/Resources/freecad.icns"
+window_rect = ((200, 200), (600, 400))
+icon_locations = {"FreeCAD.app": (180, 150), "Applications": (420, 150)}
+size = "3g"

--- a/src/Tools/macos_sign_and_notarize.sh
+++ b/src/Tools/macos_sign_and_notarize.sh
@@ -53,7 +53,8 @@ run_codesign "${CONTAINING_FOLDER}/FreeCAD.app"
 # Create a disk image from the folder
 DMG_NAME="FreeCAD-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-mac-${ARCH}.dmg"
 echo "Creating disk image ${DMG_NAME}"
-hdiutil create -srcfolder "${CONTAINING_FOLDER}" "${DMG_NAME}"
+pip3 install "dmgbuild[badge_icons]>=1.6.0,<1.7.0"
+dmgbuild -s dmg_settings.py -Dcontaining_folder="${CONTAINING_FOLDER}" "FreeCAD" "${DMG_NAME}.dmg"
 
 # Submit it for notarization (requires that an App Store API Key has been set up in the notarytool)
 xcrun notarytool submit --wait --keychain-profile "FreeCAD" ${DMG_NAME}


### PR DESCRIPTION
This uses dmgbuild to create a DMG with bigger icons and a symlink to /Applications. As it does not yet contain a background image or color, it adapts to dark and light mode settings:

<img width="712" alt="Screenshot 2024-06-14 at 10 16 52" src="https://github.com/FreeCAD/FreeCAD/assets/814785/75e41bde-894c-4b45-ad25-64f51493cb98">

<img width="712" alt="Screenshot 2024-06-14 at 10 17 10" src="https://github.com/FreeCAD/FreeCAD/assets/814785/b49df34e-031c-450d-ba3c-f0db8980d911">

Partially addresses https://github.com/FreeCAD/FreeCAD-Bundle/issues/242.
See also the related pull request for the weekly builds: https://github.com/FreeCAD/FreeCAD-Bundle/pull/251