### PR TITLE
BIM: fix extrusion vector scaling for IFC export

### DIFF
--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -2108,7 +2108,7 @@ def getRepresentation(
             if l:
                 ev = FreeCAD.Vector(ev).normalize() # new since 0.20 - obj.Dir length is ignored
                 ev.multiply(l)
-                ev.multiply(preferences['SCALE_FACTOR'])
+            ev.multiply(preferences['SCALE_FACTOR'])
             ev = pl.Rotation.inverted().multVec(ev)
             xvc =       ifcbin.createIfcDirection(tuple(pl.Rotation.multVec(FreeCAD.Vector(1,0,0))))
             zvc =       ifcbin.createIfcDirection(tuple(pl.Rotation.multVec(FreeCAD.Vector(0,0,1))))

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -2103,10 +2103,10 @@ def getRepresentation(
             profile = getProfile(ifcfile,profile)
             if profile:
                 profiledefs[pstr] = profile
-            ev = obj.Dir
+            ev = FreeCAD.Vector(obj.Dir)
             l = obj.LengthFwd.Value
             if l:
-                ev = FreeCAD.Vector(ev).normalize() # new since 0.20 - obj.Dir length is ignored
+                ev = ev.normalize() # new since 0.20 - obj.Dir length is ignored
                 ev.multiply(l)
             ev.multiply(preferences['SCALE_FACTOR'])
             ev = pl.Rotation.inverted().multVec(ev)


### PR DESCRIPTION
The Dir vector of Part extrusions also needs to be scaled if obj.LengthFwd.Value is zero.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=88121
