### PR TITLE
[Part] Attachment Editor correct Python 2 reference

### DIFF
--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
@@ -66,7 +66,7 @@ def linkSubList_convertToOldStyle(references):
                 result.append((tup[0], subname))
             if len(tup[1]) == 0:
                 result.append((tup[0], ''))
-        elif isinstance(tup[1],basestring):
+        elif isinstance(tup[1],str):
             # old style references, no conversion required
             result.append(tup)
     return result


### PR DESCRIPTION
This regression was brought to light by https://github.com/FreeCAD/FreeCAD/pull/12885 but appears to have been missed in the Python 2 to 3 migration.

Fixes https://github.com/FreeCAD/FreeCAD/issues/13804 `name 'basestring' is not defined` message box error. This wasn't just affecting PartDesign sketches, I was getting it triggered opening 0.20 files with just standard unattached sketches using 0.22dev.

