### PR TITLE
Materials: Set MaterialTreeWidget minimum size

### DIFF
--- a/src/Mod/Material/Gui/MaterialTreeWidget.cpp
+++ b/src/Mod/Material/Gui/MaterialTreeWidget.cpp
@@ -59,8 +59,9 @@ MaterialTreeWidget::MaterialTreeWidget(const std::shared_ptr<Materials::Material
                                        QWidget* parent)
     : QWidget(parent)
     , m_expanded(false)
-    , m_treeSizeHint(250, 500)
+    , m_treeSizeHint(minimumTreeWidth, minimumTreeHeight)
     , _filter(filter)
+    , _recentMax(defaultRecents)
 {
     setup();
 }
@@ -70,9 +71,10 @@ MaterialTreeWidget::MaterialTreeWidget(
     QWidget* parent)
     : QWidget(parent)
     , m_expanded(false)
-    , m_treeSizeHint(250, 500)
+    , m_treeSizeHint(minimumTreeWidth, minimumTreeHeight)
     , _filter(std::make_shared<Materials::MaterialFilter>())
     , _filterList(filterList)
+    , _recentMax(defaultRecents)
 {
     setup();
 }
@@ -80,8 +82,9 @@ MaterialTreeWidget::MaterialTreeWidget(
 MaterialTreeWidget::MaterialTreeWidget(QWidget* parent)
     : QWidget(parent)
     , m_expanded(false)
-    , m_treeSizeHint(250, 500)
+    , m_treeSizeHint(minimumTreeWidth, minimumTreeHeight)
     , _filter(std::make_shared<Materials::MaterialFilter>())
+    , _recentMax(defaultRecents)
 {
     setup();
 }
@@ -110,7 +113,7 @@ QSize MaterialTreeWidget::sizeHint() const
     if (!m_expanded) {
         // When not expanded, the size height is the same as m_material
         QSize size = m_material->sizeHint();
-        size.setWidth(250);
+        size.setWidth(minimumWidth);
         return size;
     }
     return QWidget::sizeHint();
@@ -397,7 +400,7 @@ void MaterialTreeWidget::setActiveFilter(const QString& name)
 
                 // Save the library/folder expansion state
                 saveMaterialTree();
-                
+
                 updateMaterialTree();
                 return;
             }
@@ -440,7 +443,7 @@ void MaterialTreeWidget::getRecents()
 
     auto param = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Material/Recent");
-    _recentMax = static_cast<int>(param->GetInt("RecentMax", 5));
+    _recentMax = static_cast<int>(param->GetInt("RecentMax", defaultRecents));
     auto count = param->GetInt("Recent", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QString::fromLatin1("MRU%1").arg(i);

--- a/src/Mod/Material/Gui/MaterialTreeWidget.h
+++ b/src/Mod/Material/Gui/MaterialTreeWidget.h
@@ -71,6 +71,8 @@ class MaterialTreeWidgetPy;
 class MatGuiExport MaterialTreeWidget: public QWidget, public Base::BaseClass
 {
     Q_OBJECT
+    Q_PROPERTY(QSize treeSizeHint READ treeSizeHint WRITE
+                   setTreeSizeHint)  // clazy:exclude=qproperty-without-notify
 
     TYPESYSTEM_HEADER_WITH_OVERRIDE();
 
@@ -158,10 +160,15 @@ public:
         _filterOptions.setIncludeLegacy(legacy);
     }
 
+    QSize sizeHint() const override;
+    QSize treeSizeHint() const;
+    void setTreeSizeHint(const QSize& hint);
+
 Q_SIGNALS:
     /** Emits this signal when a material has been selected */
     void materialSelected(const std::shared_ptr<Materials::Material>& material);
     void onMaterial(const QString& uuid);
+    void onExpanded(bool expanded);
 
 private Q_SLOTS:
     void expandClicked(bool checked);
@@ -179,6 +186,7 @@ private:
     QPushButton* m_editor;
     QComboBox* m_filterCombo;
     bool m_expanded;
+    QSize m_treeSizeHint;
 
     QString m_materialDisplay;
     QString m_uuid;

--- a/src/Mod/Material/Gui/MaterialTreeWidget.h
+++ b/src/Mod/Material/Gui/MaterialTreeWidget.h
@@ -96,7 +96,7 @@ public:
     void setFilter(const std::shared_ptr<Materials::MaterialFilter>& filter);
     void setFilter(
         const std::shared_ptr<std::list<std::shared_ptr<Materials::MaterialFilter>>>& filterList);
-    void setActiveFilter(const QString &name);
+    void setActiveFilter(const QString& name);
 
     void setExpanded(bool open);
     bool getExpanded()
@@ -178,6 +178,14 @@ private Q_SLOTS:
     void onFilter(const QString& text);
 
 private:
+    // UI minimum sizes
+    static const int minimumWidth = 250;
+    static const int minimumTreeWidth = 250;
+    static const int minimumTreeHeight = 500;
+
+    static const int defaultFavorites = 0;
+    static const int defaultRecents = 5;
+
     void setup();
 
     QLineEdit* m_material;
@@ -254,7 +262,8 @@ protected:
         const Base::Reference<ParameterGrp>& param);
     void setFilterVisible(bool open);
     void fillFilterCombo();
-    bool hasMultipleFilters() const {
+    bool hasMultipleFilters() const
+    {
         return (_filterList && _filterList->size() > 1);
     }
 };


### PR DESCRIPTION
Sets a minimum size for the material tree since it can't be resized when used in a task panel.

fixes #14686