### PR TITLE
Remove unusable Help button from Preferences

### DIFF
--- a/src/Gui/DlgPreferences.ui
+++ b/src/Gui/DlgPreferences.ui
@@ -286,7 +286,7 @@
            <bool>false</bool>
           </property>
           <property name="standardButtons">
-           <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+           <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
           </property>
           <property name="centerButtons">
            <bool>false</bool>


### PR DESCRIPTION
fixes #13770

before:

![before](https://github.com/FreeCAD/FreeCAD/assets/59876896/58356656-e68f-47bd-bdd5-40123d7d631c)

after:

![after](https://github.com/FreeCAD/FreeCAD/assets/59876896/489f30ad-adf5-409f-9bb7-2aa55b2b4917)
