### PR TITLE
Fix too large spaces in two Draft Shape2DView property descriptions

### DIFF
--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -93,15 +93,13 @@ class Shape2DView(DraftObject):
             obj.Tessellation = False
         if not "InPlace" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
-                    "For Cutlines and Cutfaces modes, \
-                    this leaves the faces at the cut location")
+                    "For Cutlines and Cutfaces modes, this leaves the faces at the cut location")
             obj.addProperty("App::PropertyBool", "InPlace",
                             "Draft", _tip)
             obj.InPlace = True
         if not "SegmentLength" in pl:
             _tip = QT_TRANSLATE_NOOP("App::Property",
-                    "Length of line segments if tessellating Ellipses or B-splines \
-                    into line segments")
+                    "Length of line segments if tessellating Ellipses or B-splines into line segments")
             obj.addProperty("App::PropertyFloat", "SegmentLength",
                             "Draft", _tip)
             obj.SegmentLength = .05


### PR DESCRIPTION
before:

![before 1](https://github.com/FreeCAD/FreeCAD/assets/59876896/4493a895-e78d-4aea-9bd9-96c483dc9640)
![before 2](https://github.com/FreeCAD/FreeCAD/assets/59876896/cd629906-9917-44b2-9f0a-501108ec9539)

after:

![after 1](https://github.com/FreeCAD/FreeCAD/assets/59876896/df65d5c2-0715-49d1-9e82-1bdfed3ddfd2)
![after 2](https://github.com/FreeCAD/FreeCAD/assets/59876896/3fdbb8e7-add5-49eb-9712-e08c6e59ba6e)
