### PR TITLE
Toponaming: fix secondElementSelection and SelectionView

### DIFF
--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -71,6 +71,7 @@
 #endif
 
 #include <App/Document.h>
+#include <App/GeoFeature.h>
 #include <App/ElementNamingUtils.h>
 #include <Base/Tools.h>
 #include <Base/UnitsApi.h>
@@ -396,8 +397,14 @@ void SoFCUnifiedSelection::doAction(SoAction *action)
             if (vp && (useNewSelection.getValue()||vp->useNewSelectionModel()) && vp->isSelectable()) {
                 SoDetail *detail = nullptr;
                 detailPath->truncate(0);
+                auto subName = selaction->SelChange.pSubName;
+#ifdef FC_USE_TNP_FIX
+                std::pair<std::string, std::string> elementName;
+                App::GeoFeature::resolveElement(obj,subName,elementName);
+                subName = elementName.second.c_str();  // Use the shortened element name not the full one.
+#endif
                 if(!selaction->SelChange.pSubName || !selaction->SelChange.pSubName[0] ||
-                    vp->getDetailPath(selaction->SelChange.pSubName,detailPath,true,detail))
+                    vp->getDetailPath(subName,detailPath,true,detail))
                 {
                     SoSelectionElementAction::Type type = SoSelectionElementAction::None;
                     if (selaction->SelChange.Type == SelectionChanges::AddSelection) {

--- a/src/Gui/View3DInventorSelection.cpp
+++ b/src/Gui/View3DInventorSelection.cpp
@@ -34,6 +34,7 @@
 #include "View3DInventorSelection.h"
 #include "ViewProviderDocumentObject.h"
 #include <App/Document.h>
+#include <App/GeoFeature.h>
 #include <App/GeoFeatureGroupExtension.h>
 #include <Base/Console.h>
 
@@ -113,6 +114,11 @@ void View3DInventorSelection::checkGroupOnTop(const SelectionChanges &Reason)
     std::string key(obj->getNameInDocument());
     key += '.';
     auto subname = Reason.pSubName;
+#ifdef FC_USE_TNP_FIX
+    std::pair<std::string, std::string> element;
+    App::GeoFeature::resolveElement(obj,Reason.pSubName,element);
+    subname = element.second.c_str();
+#endif
     if(subname)
         key += subname;
     if(Reason.Type == SelectionChanges::RmvSelection) {


### PR DESCRIPTION
This fixes #14521 the reported bug first seen in selections of CAM model objects where only one selection could be made.

It also cleans up the Selection View to show short element names, and not full history names.

Fix #13248