### PR TITLE
Fix typo/accidental symbols (+) added out of place

### DIFF
--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -157,8 +157,8 @@ int main(int argc, char** argv)
         argv_.push_back(0);  // 0-terminated string
     }
 
-    +  // https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
-        +_putenv("QT_QPA_PLATFORM=windows:darkmode=1");
+    // https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
+    _putenv("QT_QPA_PLATFORM=windows:darkmode=1");
 #endif
 
     // Name and Version of the Application


### PR DESCRIPTION
Notice there is a recent similar fix: 2ad397e18e754aeb61b547507a35a039ca9bf2ab