### PR TITLE
Fix crash described in 14370 (issue comment)

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -257,6 +257,11 @@ void TaskDressUpParameters::setSelection(QListWidgetItem* current) {
     // executed when the user selected an item in the list (but double-clicked it)
     // highlights the currently selected item
 
+    if (current == nullptr){
+        setSelectionMode(none);
+        return;
+    }
+
     if (!wasDoubleClicked) {
         // we treat it as single-click event once the QApplication double-click time is passed
         QTimer::singleShot(QApplication::doubleClickInterval(), this, &TaskDressUpParameters::itemClickedTimeout);


### PR DESCRIPTION
The crash occured because `PartDesignGui::TaskDressUpParameters::setSelection` was invoked with `nullptr`.

This commit compares _current_ with `nullptr` and exits selection mode if nothing is selected. The crash is described in the issue comment. [^1]

Here is the backtrace. 

<details><summary>Backtrace</summary>


```cpp
Process 1813 stopped
* thread #1, name = 'FreeCAD', stop reason = signal SIGSEGV: address not mapped to object (fault address: 0x0)
    frame #0: 0x00007ffff6e4e6f1 libFreeCADGui.so`QListWidgetItem::text(this=0x0000000000000000) const at qlistwidget.h:85:22
   82       void setFlags(Qt::ItemFlags flags);
   83  
   84       inline QString text() const
-> 85           { return data(Qt::DisplayRole).toString(); }
   86       inline void setText(const QString &text);
   87  
   88       inline QIcon icon() const
(lldb) bt
* thread #1, name = 'FreeCAD', stop reason = signal SIGSEGV: address not mapped to object (fault address: 0x0)
  * frame #0: 0x00007ffff6e4e6f1 libFreeCADGui.so`QListWidgetItem::text(this=0x0000000000000000) const at qlistwidget.h:85:22
    frame #1: 0x00007fffa22126a9 PartDesignGui.so`PartDesignGui::TaskDressUpParameters::setSelection(this=0x0000555558b51550, current=0x0000000000000000) at TaskDressUpParameters.cpp:265:44
    frame #2: 0x00007fffa2209925 PartDesignGui.so`QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<QListWidgetItem*>, void, void (PartDesignGui::TaskDressUpParameters::*)(QListWidgetItem*)>::call(f=<unavailable>, o=<unavailable>, arg=<unavailable>) at qobjectdefs_impl.h:152:20
    frame #3: 0x00007fffa2209963 PartDesignGui.so`QtPrivate::QSlotObject<void (PartDesignGui::TaskDressUpParameters::*)(QListWidgetItem*), QtPrivate::List<QListWidgetItem*>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) [inlined] void QtPrivate::FunctionPointer<void (PartDesignGui::TaskDressUpParameters::*)(QListWidgetItem*)>::call<QtPrivate::List<QListWidgetItem*>, void>(arg=<unavailable>, o=<unavailable>, f=<unavailable>) at qobjectdefs_impl.h:185:95
    frame #4: 0x00007fffa220995b PartDesignGui.so`QtPrivate::QSlotObject<void (PartDesignGui::TaskDressUpParameters::*)(QListWidgetItem*), QtPrivate::List<QListWidgetItem*>, void>::impl(which=<unavailable>, this_=<unavailable>, r=<unavailable>, a=<unavailable>, ret=<unavailable>) at qobjectdefs_impl.h:418:49
    frame #5: 0x00007ffff3cf819f libQt5Core.so.5`void doActivate<false>(QObject*, int, void**) [inlined] QtPrivate::QSlotObjectBase::call(a=0x00007fffffffa300, r=0x0000555558b51550, this=0x0000555558a63220) at qobjectdefs_impl.h:398:57
    frame #6: 0x00007ffff3cf8183 libQt5Core.so.5`void doActivate<false>(sender=0x0000555558a856e0, signal_index=21, argv=0x00007fffffffa300) at qobject.cpp:3925:30
    frame #7: 0x00007ffff3cef16f libQt5Core.so.5`QMetaObject::activate(sender=0x0000555558a856e0, m=0x000000000074a400, local_signal_index=6, argv=0x00007fffffffa300) at qobject.cpp:3985:26
    frame #8: 0x00007ffff4c936ca libQt5Widgets.so.5`QListWidget::currentItemChanged(this=0x0000555558a856e0, _t1=<unavailable>, _t2=<unavailable>) at moc_qlistwidget.cpp:403:26
    frame #9: 0x00007ffff4c942de libQt5Widgets.so.5`QListWidgetPrivate::_q_emitCurrentItemChanged(this=0x0000555558a09200, current=<unavailable>, previous=0x00007fffffffa580) at qlistwidget.cpp:1227:31
    frame #10: 0x00007ffff4c981ee libQt5Widgets.so.5`QListWidget::qt_static_metacall(_o=<unavailable>, _c=<unavailable>, _id=<unavailable>, _a=<unavailable>) at moc_qlistwidget.cpp:197:57
    frame #11: 0x00007ffff3cf8340 libQt5Core.so.5`void doActivate<false>(sender=0x00005555584a8310, signal_index=4, argv=0x00007fffffffa4a0) at qobject.cpp:3937:33
    frame #12: 0x00007ffff3cef16f libQt5Core.so.5`QMetaObject::activate(sender=<unavailable>, m=0x00000000005a6720, local_signal_index=1, argv=0x00007fffffffa4a0) at qobject.cpp:3985:26
    frame #13: 0x00007ffff3c6a474 libQt5Core.so.5`QItemSelectionModel::currentChanged(this=<unavailable>, _t1=<unavailable>, _t2=<unavailable>) at moc_qitemselectionmodel.cpp:482:26
    frame #14: 0x00007ffff3c72c7b libQt5Core.so.5`QItemSelectionModelPrivate::_q_rowsAboutToBeRemoved(this=0x0000555558b53d70, parent=0x00007fffffffa800, start=0, end=0) at qitemselectionmodel.cpp:738:31
    frame #15: 0x00007ffff3c7551b libQt5Core.so.5`QItemSelectionModel::qt_static_metacall(_o=<unavailable>, _c=<unavailable>, _id=<unavailable>, _a=0x00007fffffffa750) at moc_qitemselectionmodel.cpp:276:55
    frame #16: 0x00007ffff3cf8340 libQt5Core.so.5`void doActivate<false>(sender=0x0000555558a76ee0, signal_index=14, argv=0x00007fffffffa750) at qobject.cpp:3937:33
    frame #17: 0x00007ffff3cef16f libQt5Core.so.5`QMetaObject::activate(sender=0x0000555558a76ee0, m=0x00000000005a6620, local_signal_index=11, argv=0x00007fffffffa750) at qobject.cpp:3985:26
    frame #18: 0x00007ffff3c59c0e libQt5Core.so.5`QAbstractItemModel::rowsAboutToBeRemoved(this=0x0000555558a76ee0, _t1=0x00007fffffffa800, _t2=<unavailable>, _t3=<unavailable>, _t4=QPrivateSignal @ 0x00007fffffffa790) at moc_qabstractitemmodel.cpp:599:26
    frame #19: 0x00007ffff3c61b4b libQt5Core.so.5`QAbstractItemModel::beginRemoveRows(this=0x0000555558a76ee0, parent=0x00007fffffffa800, first=0, last=0) at qabstractitemmodel.cpp:2818:30
    frame #20: 0x00007ffff4c95bb2 libQt5Widgets.so.5`QListModel::take(this=0x0000555558a76ee0, row=0) at qlistwidget.cpp:161:20
    frame #21: 0x00007ffff4c95d92 libQt5Widgets.so.5`QListWidget::takeItem(this=<unavailable>, row=0) at qlistwidget.cpp:1561:32
    frame #22: 0x00007fffa22124fc PartDesignGui.so`PartDesignGui::TaskDressUpParameters::removeItemFromListWidget(widget=0x0000555558a856e0, itemstr=<unavailable>) at TaskDressUpParameters.cpp:366:51
    frame #23: 0x00007fffa2212e04 PartDesignGui.so`PartDesignGui::TaskDressUpParameters::referenceSelected(this=0x0000555558b51550, msg=0x00007fffffffaf50, widget=0x0000555558a856e0) at TaskDressUpParameters.cpp:131:33
    frame #24: 0x00007fffa22060e3 PartDesignGui.so`PartDesignGui::TaskChamferParameters::onSelectionChanged(this=<unavailable>, msg=<unavailable>) at TaskChamferParameters.cpp:158:30
    frame #25: 0x00007ffff71ce7dd libFreeCADGui.so`Gui::SelectionObserver::_onSelectionChanged(this=<unavailable>, msg=<unavailable>) at Selection.cpp:152:27
    frame #26: 0x00007ffff71dd089 libFreeCADGui.so`void std::__invoke_impl<void, void (Gui::SelectionObserver::*&)(Gui::SelectionChanges const&), Gui::SelectionObserver*&, Gui::SelectionChanges const&>((null)=__invoke_memfun_deref @ 0x00007fffffffabb0, __f=<unavailable>, __t=<unavailable>, (null)=<unavailable>) at invoke.h:74:46
    frame #27: 0x00007ffff71dd0a7 libFreeCADGui.so`boost::detail::function::void_function_obj_invoker1<std::_Bind<void (Gui::SelectionObserver::* (Gui::SelectionObserver*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>, void, Gui::SelectionChanges const&>::invoke(boost::detail::function::function_buffer&, Gui::SelectionChanges const&) [inlined] std::__invoke_result<void (Gui::SelectionObserver::*&)(Gui::SelectionChanges const&), Gui::SelectionObserver*&, Gui::SelectionChanges const&>::type std::__invoke<void (Gui::SelectionObserver::*&)(Gui::SelectionChanges const&), Gui::SelectionObserver*&, Gui::SelectionChanges const&>((null)=0x00007fffffffaf50, (null)=<unavailable>, __fn=<unavailable>) at invoke.h:96:40
    frame #28: 0x00007ffff71dd0a2 libFreeCADGui.so`boost::detail::function::void_function_obj_invoker1<std::_Bind<void (Gui::SelectionObserver::* (Gui::SelectionObserver*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>, void, Gui::SelectionChanges const&>::invoke(boost::detail::function::function_buffer&, Gui::SelectionChanges const&) [inlined] void std::_Bind<void (Gui::SelectionObserver::* (Gui::SelectionObserver*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>::__call<void, Gui::SelectionChanges const&, 0ul, 1ul>((null)=<unavailable>, __args=0x00007fffffffabb8, this=<unavailable>) at functional:506:24
    frame #29: 0x00007ffff71dd09e libFreeCADGui.so`boost::detail::function::void_function_obj_invoker1<std::_Bind<void (Gui::SelectionObserver::* (Gui::SelectionObserver*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>, void, Gui::SelectionChanges const&>::invoke(boost::detail::function::function_buffer&, Gui::SelectionChanges const&) [inlined] void std::_Bind<void (Gui::SelectionObserver::* (Gui::SelectionObserver*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>::operator()<Gui::SelectionChanges const&, void>((null)=0x00007fffffffaf50, this=<unavailable>) at functional:591:32
    frame #30: 0x00007ffff71dd09a libFreeCADGui.so`boost::detail::function::void_function_obj_invoker1<std::_Bind<void (Gui::SelectionObserver::* (Gui::SelectionObserver*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>, void, Gui::SelectionChanges const&>::invoke(function_obj_ptr=<unavailable>, a0=0x00007fffffffaf50) at function_template.hpp:158:11
    frame #31: 0x00007ffff6f20af7 libFreeCADGui.so`boost::function1<void, Gui::SelectionChanges const&>::operator()(this=<unavailable>, a0=<unavailable>) const at function_template.hpp:763:28
    frame #32: 0x00007ffff6f20bb5 libFreeCADGui.so`boost::signals2::detail::void_type boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>::operator()<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>> const&) const [inlined] boost::signals2::detail::void_type boost::signals2::detail::call_with_tuple_args<boost::signals2::detail::void_type>::m_invoke<boost::function<void (Gui::SelectionChanges const&)>, 0u, Gui::SelectionChanges const&>((null)=0x0000000000000000, args=0x00007fffffffae70, (null)=<unavailable>, func=<unavailable>, this=<unavailable>) const at variadic_slot_invoker.hpp:105:15
    frame #33: 0x00007ffff6f20ba9 libFreeCADGui.so`boost::signals2::detail::void_type boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>::operator()<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>> const&) const [inlined] boost::signals2::detail::void_type boost::signals2::detail::call_with_tuple_args<boost::signals2::detail::void_type>::operator()<boost::function<void (Gui::SelectionChanges const&)>, Gui::SelectionChanges const&, 1ul>((null)=<unavailable>, args=0x00007fffffffae70, func=<unavailable>, this=<unavailable>) const at variadic_slot_invoker.hpp:90:32
    frame #34: 0x00007ffff6f20ba9 libFreeCADGui.so`boost::signals2::detail::void_type boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>::operator()<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(this=0x00007fffffffae70, connectionBody=<unavailable>) const at variadic_slot_invoker.hpp:133:53
    frame #35: 0x00007ffff6f20be9 libFreeCADGui.so`boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>::dereference(this=0x00007fffffffac60) const at slot_call_iterator.hpp:110:43
    frame #36: 0x00007ffff6f2323c libFreeCADGui.so`void boost::signals2::optional_last_value<void>::operator()<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>) const [inlined] boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>::reference boost::iterators::iterator_core_access::dereference<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(f=0x00007fffffffac60) at iterator_facade.hpp:550:31
    frame #37: 0x00007ffff6f23233 libFreeCADGui.so`void boost::signals2::optional_last_value<void>::operator()<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>) const [inlined] boost::iterators::detail::iterator_facade_base<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>, boost::signals2::detail::void_type, boost::iterators::single_pass_traversal_tag, boost::signals2::detail::void_type const&, long, false, false>::operator*(this=0x00007fffffffac60) const at iterator_facade.hpp:656:53
    frame #38: 0x00007ffff6f23233 libFreeCADGui.so`void boost::signals2::optional_last_value<void>::operator()<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(this=<unavailable>, first=slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, const Gui::SelectionChanges&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > @ 0x00007fffffffac60, last=slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, const Gui::SelectionChanges&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > @ 0x00007fffffffac80) const at optional_last_value.hpp:57:13
    frame #39: 0x00007ffff6f234a9 libFreeCADGui.so`boost::signals2::detail::signal_impl<void (Gui::SelectionChanges const&), boost::signals2::optional_last_value<void>, int, std::less<int>, boost::function<void (Gui::SelectionChanges const&)>, boost::function<void (boost::signals2::connection const&, Gui::SelectionChanges const&)>, boost::signals2::mutex>::operator()(Gui::SelectionChanges const&) [inlined] void boost::signals2::detail::combiner_invoker<void>::operator()<boost::signals2::optional_last_value<void>, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(last=slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, const Gui::SelectionChanges&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > @ 0x00007fffffffad40, first=slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, const Gui::SelectionChanges&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > @ 0x00007fffffffad20, combiner=<unavailable>, this=<unavailable>) const at result_type_wrapper.hpp:64:19
    frame #40: 0x00007ffff6f23479 libFreeCADGui.so`boost::signals2::detail::signal_impl<void (Gui::SelectionChanges const&), boost::signals2::optional_last_value<void>, int, std::less<int>, boost::function<void (Gui::SelectionChanges const&)>, boost::function<void (boost::signals2::connection const&, Gui::SelectionChanges const&)>, boost::signals2::mutex>::operator()(this=<unavailable>, args#0=0x00007fffffffaf50) at signal_template.hpp:243:13
    frame #41: 0x00007ffff6f23578 libFreeCADGui.so`boost::signals2::signal<void (Gui::SelectionChanges const&), boost::signals2::optional_last_value<void>, int, std::less<int>, boost::function<void (Gui::SelectionChanges const&)>, boost::function<void (boost::signals2::connection const&, Gui::SelectionChanges const&)>, boost::signals2::mutex>::operator()(this=<unavailable>, args#0=0x00007fffffffaf50) at signal_template.hpp:722:25
    frame #42: 0x00007ffff71cfba0 libFreeCADGui.so`Gui::SelectionSingleton::slotSelectionChanged(this=0x0000555555b955f0, msg=0x0000555558a049b0) at Selection.cpp:581:36
    frame #43: 0x00007ffff71dd16f libFreeCADGui.so`void std::__invoke_impl<void, void (Gui::SelectionSingleton::*&)(Gui::SelectionChanges const&), Gui::SelectionSingleton*&, Gui::SelectionChanges const&>((null)=__invoke_memfun_deref @ 0x00007fffffffb0b0, __f=<unavailable>, __t=<unavailable>, (null)=<unavailable>) at invoke.h:74:46
    frame #44: 0x00007ffff71dd18d libFreeCADGui.so`boost::detail::function::void_function_obj_invoker1<std::_Bind<void (Gui::SelectionSingleton::* (Gui::SelectionSingleton*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>, void, Gui::SelectionChanges const&>::invoke(boost::detail::function::function_buffer&, Gui::SelectionChanges const&) [inlined] std::__invoke_result<void (Gui::SelectionSingleton::*&)(Gui::SelectionChanges const&), Gui::SelectionSingleton*&, Gui::SelectionChanges const&>::type std::__invoke<void (Gui::SelectionSingleton::*&)(Gui::SelectionChanges const&), Gui::SelectionSingleton*&, Gui::SelectionChanges const&>((null)=0x0000555558a049b0, (null)=<unavailable>, __fn=<unavailable>) at invoke.h:96:40
    frame #45: 0x00007ffff71dd188 libFreeCADGui.so`boost::detail::function::void_function_obj_invoker1<std::_Bind<void (Gui::SelectionSingleton::* (Gui::SelectionSingleton*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>, void, Gui::SelectionChanges const&>::invoke(boost::detail::function::function_buffer&, Gui::SelectionChanges const&) [inlined] void std::_Bind<void (Gui::SelectionSingleton::* (Gui::SelectionSingleton*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>::__call<void, Gui::SelectionChanges const&, 0ul, 1ul>((null)=<unavailable>, __args=0x00007fffffffb0b8, this=<unavailable>) at functional:506:24
    frame #46: 0x00007ffff71dd184 libFreeCADGui.so`boost::detail::function::void_function_obj_invoker1<std::_Bind<void (Gui::SelectionSingleton::* (Gui::SelectionSingleton*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>, void, Gui::SelectionChanges const&>::invoke(boost::detail::function::function_buffer&, Gui::SelectionChanges const&) [inlined] void std::_Bind<void (Gui::SelectionSingleton::* (Gui::SelectionSingleton*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>::operator()<Gui::SelectionChanges const&, void>((null)=0x0000555558a049b0, this=<unavailable>) at functional:591:32
    frame #47: 0x00007ffff71dd180 libFreeCADGui.so`boost::detail::function::void_function_obj_invoker1<std::_Bind<void (Gui::SelectionSingleton::* (Gui::SelectionSingleton*, std::_Placeholder<1>))(Gui::SelectionChanges const&)>, void, Gui::SelectionChanges const&>::invoke(function_obj_ptr=<unavailable>, a0=0x0000555558a049b0) at function_template.hpp:158:11
    frame #48: 0x00007ffff6f20af7 libFreeCADGui.so`boost::function1<void, Gui::SelectionChanges const&>::operator()(this=<unavailable>, a0=<unavailable>) const at function_template.hpp:763:28
    frame #49: 0x00007ffff6f20bb5 libFreeCADGui.so`boost::signals2::detail::void_type boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>::operator()<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>> const&) const [inlined] boost::signals2::detail::void_type boost::signals2::detail::call_with_tuple_args<boost::signals2::detail::void_type>::m_invoke<boost::function<void (Gui::SelectionChanges const&)>, 0u, Gui::SelectionChanges const&>((null)=0x0000000000000000, args=0x00007fffffffb370, (null)=<unavailable>, func=<unavailable>, this=<unavailable>) const at variadic_slot_invoker.hpp:105:15
    frame #50: 0x00007ffff6f20ba9 libFreeCADGui.so`boost::signals2::detail::void_type boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>::operator()<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>> const&) const [inlined] boost::signals2::detail::void_type boost::signals2::detail::call_with_tuple_args<boost::signals2::detail::void_type>::operator()<boost::function<void (Gui::SelectionChanges const&)>, Gui::SelectionChanges const&, 1ul>((null)=<unavailable>, args=0x00007fffffffb370, func=<unavailable>, this=<unavailable>) const at variadic_slot_invoker.hpp:90:32
    frame #51: 0x00007ffff6f20ba9 libFreeCADGui.so`boost::signals2::detail::void_type boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>::operator()<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(this=0x00007fffffffb370, connectionBody=<unavailable>) const at variadic_slot_invoker.hpp:133:53
    frame #52: 0x00007ffff6f20be9 libFreeCADGui.so`boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>::dereference(this=0x00007fffffffb160) const at slot_call_iterator.hpp:110:43
    frame #53: 0x00007ffff6f2323c libFreeCADGui.so`void boost::signals2::optional_last_value<void>::operator()<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>) const [inlined] boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>::reference boost::iterators::iterator_core_access::dereference<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(f=0x00007fffffffb160) at iterator_facade.hpp:550:31
    frame #54: 0x00007ffff6f23233 libFreeCADGui.so`void boost::signals2::optional_last_value<void>::operator()<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>) const [inlined] boost::iterators::detail::iterator_facade_base<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>, boost::signals2::detail::void_type, boost::iterators::single_pass_traversal_tag, boost::signals2::detail::void_type const&, long, false, false>::operator*(this=0x00007fffffffb160) const at iterator_facade.hpp:656:53
    frame #55: 0x00007ffff6f23233 libFreeCADGui.so`void boost::signals2::optional_last_value<void>::operator()<boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(this=<unavailable>, first=slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, const Gui::SelectionChanges&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > @ 0x00007fffffffb160, last=slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, const Gui::SelectionChanges&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > @ 0x00007fffffffb180) const at optional_last_value.hpp:57:13
    frame #56: 0x00007ffff6f234a9 libFreeCADGui.so`boost::signals2::detail::signal_impl<void (Gui::SelectionChanges const&), boost::signals2::optional_last_value<void>, int, std::less<int>, boost::function<void (Gui::SelectionChanges const&)>, boost::function<void (boost::signals2::connection const&, Gui::SelectionChanges const&)>, boost::signals2::mutex>::operator()(Gui::SelectionChanges const&) [inlined] void boost::signals2::detail::combiner_invoker<void>::operator()<boost::signals2::optional_last_value<void>, boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, Gui::SelectionChanges const&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (Gui::SelectionChanges const&), boost::function<void (Gui::SelectionChanges const&)>>, boost::signals2::mutex>>>(last=slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, const Gui::SelectionChanges&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > @ 0x00007fffffffb240, first=slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, const Gui::SelectionChanges&>, std::_List_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > >, boost::signals2::detail::connection_body<std::pair<boost::signals2::detail::slot_meta_group, boost::optional<int> >, boost::signals2::slot<void(const Gui::SelectionChanges&), boost::function<void(const Gui::SelectionChanges&)> >, boost::signals2::mutex> > @ 0x00007fffffffb220, combiner=<unavailable>, this=<unavailable>) const at result_type_wrapper.hpp:64:19
    frame #57: 0x00007ffff6f23479 libFreeCADGui.so`boost::signals2::detail::signal_impl<void (Gui::SelectionChanges const&), boost::signals2::optional_last_value<void>, int, std::less<int>, boost::function<void (Gui::SelectionChanges const&)>, boost::function<void (boost::signals2::connection const&, Gui::SelectionChanges const&)>, boost::signals2::mutex>::operator()(this=<unavailable>, args#0=0x0000555558a049b0) at signal_template.hpp:243:13
    frame #58: 0x00007ffff6f23578 libFreeCADGui.so`boost::signals2::signal<void (Gui::SelectionChanges const&), boost::signals2::optional_last_value<void>, int, std::less<int>, boost::function<void (Gui::SelectionChanges const&)>, boost::function<void (boost::signals2::connection const&, Gui::SelectionChanges const&)>, boost::signals2::mutex>::operator()(this=<unavailable>, args#0=0x0000555558a049b0) at signal_template.hpp:722:25
    frame #59: 0x00007ffff71d2956 libFreeCADGui.so`Gui::SelectionSingleton::notify(this=0x0000555555b955f0, Chng=0x00007fffffffb5b0) at Selection.cpp:424:39
    frame #60: 0x00007ffff71d4472 libFreeCADGui.so`Gui::SelectionSingleton::addSelection(this=0x0000555555b955f0, pDocName="mfinclock", pObjectName="Body", pSubName=<unavailable>, x=33.5203896, y=-4.00000429, z=31.5308876, pickedList=<unavailable>, clearPreselect=true) at Selection.cpp:964:11
    frame #61: 0x00007ffff6f8d648 libFreeCADGui.so`Gui::SoFCUnifiedSelection::setSelection(this=0x0000555557309490, infos=<unavailable>, ctrlDown=<unavailable>) at SoFCUnifiedSelection.cpp:662:44
    frame #62: 0x00007ffff6f8de28 libFreeCADGui.so`Gui::SoFCUnifiedSelection::handleEvent(this=0x0000555557309490, action=0x0000555557cb40b0) at SoFCUnifiedSelection.cpp:746:28
    frame #63: 0x00007ffff2d8514a libCoin.so.80`SoNode::handleEventS(action=0x0000555557cb40b0, node=0x0000555557309490) at SoNode.cpp:1117:20
    frame #64: 0x00007ffff2b5e91c libCoin.so.80`SoAction::traverse(this=0x0000555557cb40b0, node=0x0000555557309490) at SoAction.cpp:949:7
    frame #65: 0x00007ffff2d2923b libCoin.so.80`SoChildList::traverse(this=0x0000555557c8dbc0, action=0x0000555557cb40b0, first=0, last=3) at SoChildList.cpp:380:23
    frame #66: 0x00007ffff2d29433 libCoin.so.80`SoChildList::traverse(this=<unavailable>, action=0x0000555557cb40b0) at SoChildList.cpp:450:17
    frame #67: 0x00007ffff2d7b777 libCoin.so.80`SoGroup::doAction(this=0x0000555555cae630, action=0x0000555557cb40b0) at SoGroup.cpp:550:34
    frame #68: 0x00007ffff2d98582 libCoin.so.80`SoSeparator::doAction(this=0x0000555555cae630, action=0x0000555557cb40b0) at SoSeparator.cpp:489:22
    frame #69: 0x00007ffff2d985a5 libCoin.so.80`SoSeparator::handleEvent(this=<unavailable>, action=<unavailable>) at SoSeparator.cpp:818:24
    frame #70: 0x00007ffff2d8514a libCoin.so.80`SoNode::handleEventS(action=0x0000555557cb40b0, node=0x0000555555cae630) at SoNode.cpp:1117:20
    frame #71: 0x00007ffff2b5e91c libCoin.so.80`SoAction::traverse(this=0x0000555557cb40b0, node=0x0000555555cae630) at SoAction.cpp:949:7
    frame #72: 0x00007ffff2b6a1af libCoin.so.80`SoHandleEventAction::beginTraversal(this=0x0000555557cb40b0, node=0x0000555555cae630) at SoHandleEventAction.cpp:382:19
    frame #73: 0x00007ffff2b5ee27 libCoin.so.80`SoAction::apply(this=0x0000555557cb40b0, root=0x0000555555cae630) at SoAction.cpp:565:25
    frame #74: 0x00007ffff2d418fb libCoin.so.80`SoEventManager::actuallyProcessEvent(this=0x0000555557d40830, event=0x0000555557c8f960) at SoEventManager.cpp:366:44
    frame #75: 0x00007ffff2d41cdb libCoin.so.80`SoEventManager::processEvent(this=0x0000555557d40830, event=0x0000555557c8f960) at SoEventManager.cpp:316:40
    frame #76: 0x00007ffff7028996 libFreeCADGui.so`SIM::Coin3D::Quarter::QuarterWidget::processSoEvent(this=0x0000555557c8f270, event=0x0000555557c8f960) at QuarterWidget.cpp:1028:48
    frame #77: 0x00007ffff702ff1a libFreeCADGui.so`SIM::Coin3D::Quarter::SoQTQuarterAdaptor::processSoEvent(this=0x0000555557c8f270, event=0x0000555557c8f960) at SoQTQuarterAdaptor.cpp:752:63
    frame #78: 0x00007ffff7064dbd libFreeCADGui.so`Gui::View3DInventorViewer::processSoEventBase(this=<unavailable>, ev=0x0000555557c8f960) at View3DInventorViewer.cpp:2582:37
    frame #79: 0x00007ffff7036d7d libFreeCADGui.so`Gui::NavigationStyle::processSoEvent(this=0x0000555557c68900, ev=0x0000555557c8f960) at NavigationStyle.cpp:1522:47
    frame #80: 0x00007ffff703e160 libFreeCADGui.so`Gui::CADNavigationStyle::processSoEvent(this=0x0000555557c68900, ev=0x0000555557c8f960) at CADNavigationStyle.cpp:325:46
    frame #81: 0x00007ffff703a56b libFreeCADGui.so`Gui::NavigationStyle::processEvent(this=0x0000555557c68900, ev=0x0000555557c8f960) at NavigationStyle.cpp:1493:37
    frame #82: 0x00007ffff7064d35 libFreeCADGui.so`Gui::View3DInventorViewer::processSoEvent(this=0x0000555557c8f270, ev=0x0000555557c8f960) at View3DInventorViewer.cpp:2577:36
    frame #83: 0x00007ffff7023f12 libFreeCADGui.so`SIM::Coin3D::Quarter::EventFilter::eventFilter(this=0x0000555557ca2b50, obj=<unavailable>, qevent=0x00007fffffffc3b0) at EventFilter.cpp:167:64
    frame #84: 0x00007ffff3cb3a13 libQt5Core.so.5`QCoreApplicationPrivate::sendThroughObjectEventFilters(receiver=0x0000555557c8f270, event=0x00007fffffffc3b0) at qcoreapplication.cpp:1190:33
    frame #85: 0x00007ffff496eed3 libQt5Widgets.so.5`QApplicationPrivate::notify_helper(this=<unavailable>, receiver=0x0000555557c8f270, e=0x00007fffffffc3b0) at qapplication.cpp:3634:38
    frame #86: 0x00007ffff4977cda libQt5Widgets.so.5`QApplication::notify(this=<unavailable>, receiver=0x0000555557c9bd40, e=0x00007fffffffc850) at qapplication.cpp:3084:43
    frame #87: 0x00007ffff6d22968 libFreeCADGui.so`Gui::GUIApplication::notify(this=0x00007fffffffd7a0, receiver=0x0000555557c9bd40, event=0x00007fffffffc850) at GuiApplication.cpp:83:40
    frame #88: 0x00007ffff3cb3cdd libQt5Core.so.5`QCoreApplication::notifyInternal2(receiver=0x0000555557c9bd40, event=0x00007fffffffc850) at qcoreapplication.cpp:1064:24
    frame #89: 0x00007ffff3cb3f78 libQt5Core.so.5`QCoreApplication::sendSpontaneousEvent(receiver=0x0000555557c9bd40, event=0x00007fffffffc850) at qcoreapplication.cpp:1474:27
    frame #90: 0x00007ffff4976a4b libQt5Widgets.so.5`QApplicationPrivate::sendMouseEvent(receiver=0x0000555557c9bd40, event=0x00007fffffffc850, alienWidget=0x0000555557c9bd40, nativeWidget=0x00007fffffffd7e0, buttonDown=0x00007ffff4f57a30, lastMouseReceiver=0x00007ffff4f57a10, spontaneous=true, onlyDispatchEnterLeave=false) at qapplication.cpp:2622:56
    frame #91: 0x00007ffff49d84eb libQt5Widgets.so.5`QWidgetWindow::handleMouseEvent(this=0x000055555676a610, event=0x00007fffffffceb0) at qwidgetwindow.cpp:684:44
    frame #92: 0x00007ffff49dbf0a libQt5Widgets.so.5`QWidgetWindow::event(this=0x000055555676a610, event=0x00007fffffffceb0) at qwidgetwindow.cpp:300:25
    frame #93: 0x00007ffff496eee3 libQt5Widgets.so.5`QApplicationPrivate::notify_helper(this=0x00005555559418a0, receiver=0x000055555676a610, e=0x00007fffffffceb0) at qapplication.cpp:3640:31
    frame #94: 0x00007ffff497788e libQt5Widgets.so.5`QApplication::notify(this=0x00007fffffffd7a0, receiver=0x000055555676a610, e=0x00007fffffffceb0) at qapplication.cpp:2980:31
    frame #95: 0x00007ffff6d22968 libFreeCADGui.so`Gui::GUIApplication::notify(this=0x00007fffffffd7a0, receiver=0x000055555676a610, event=0x00007fffffffceb0) at GuiApplication.cpp:83:40
    frame #96: 0x00007ffff3cb3cdd libQt5Core.so.5`QCoreApplication::notifyInternal2(receiver=0x000055555676a610, event=0x00007fffffffceb0) at qcoreapplication.cpp:1064:24
    frame #97: 0x00007ffff3cb3f78 libQt5Core.so.5`QCoreApplication::sendSpontaneousEvent(receiver=<unavailable>, event=<unavailable>) at qcoreapplication.cpp:1474:27
    frame #98: 0x00007ffff412abf3 libQt5Gui.so.5`QGuiApplicationPrivate::processMouseEvent(e=0x0000555555f04870) at qguiapplication.cpp:2285:42
    frame #99: 0x00007ffff412c5e8 libQt5Gui.so.5`QGuiApplicationPrivate::processWindowSystemEvent(e=0x0000555555f04870) at qguiapplication.cpp:2005:50
    frame #100: 0x00007ffff4106188 libQt5Gui.so.5`QWindowSystemInterface::sendWindowSystemEvents(flags=(i = 36)) at qwindowsysteminterface.cpp:1169:61
    frame #101: 0x00007fffedebb104 libQt5XcbQpa.so.5`xcbSourceDispatch(source=<unavailable>, (null)=<unavailable>, (null)=<unavailable>) at qxcbeventdispatcher.cpp:105:51
    frame #102: 0x00007ffff351bd3b libglib-2.0.so.0`g_main_context_dispatch + 619
    frame #103: 0x00007ffff35712b8 libglib-2.0.so.0`___lldb_unnamed_symbol2709 + 488
    frame #104: 0x00007ffff35193e3 libglib-2.0.so.0`g_main_context_iteration + 51
    frame #105: 0x00007ffff3d20d83 libQt5Core.so.5`QEventDispatcherGlib::processEvents(this=0x00005555558a9f80, flags=(i = 36)) at qeventdispatcher_glib.cpp:423:43
    frame #106: 0x00007fffedebb4c4 libQt5XcbQpa.so.5`QXcbGlibEventDispatcher::processEvents(this=<unavailable>, flags=<unavailable>) at qxcbeventdispatcher.cpp:143:47
    frame #107: 0x00007ffff3cb165f libQt5Core.so.5`QEventLoop::processEvents(this=0x00007fffffffd2a0, flags=<unavailable>) at qeventloop.cpp:142:68
    frame #108: 0x00007ffff3cb1d00 libQt5Core.so.5`QEventLoop::exec(this=0x00007fffffffd2a0, flags=(i = 0)) at qeventloop.cpp:235:22
    frame #109: 0x00007ffff3cbc6a3 libQt5Core.so.5`QCoreApplication::exec() at qcoreapplication.cpp:1375:36
    frame #110: 0x00007ffff411dca6 libQt5Gui.so.5`QGuiApplication::exec() at qguiapplication.cpp:1870:34
    frame #111: 0x00007ffff496ee4d libQt5Widgets.so.5`QApplication::exec() at qapplication.cpp:2832:33
    frame #112: 0x00007ffff6c75fcb libFreeCADGui.so`(anonymous namespace)::tryRunEventLoop(mainApp=0x00007fffffffd7a0) at Application.cpp:2042:23
    frame #113: 0x00007ffff6c76294 libFreeCADGui.so`(anonymous namespace)::runEventLoop(mainApp=0x00007fffffffd7a0) at Application.cpp:2062:24
    frame #114: 0x00007ffff6c7a10e libFreeCADGui.so`Gui::Application::runApplication() at Application.cpp:2139:17
    frame #115: 0x000055555556a3a5 FreeCAD`main(argc=<unavailable>, argv=<unavailable>) at MainGui.cpp:300:45
    frame #116: 0x00007ffff3229d90 libc.so.6`__libc_start_call_main(main=(FreeCAD`main at MainGui.cpp:107:1), argc=1, argv=0x00007fffffffdd78) at libc_start_call_main.h:58:16
    frame #117: 0x00007ffff3229e40 libc.so.6`__libc_start_main_impl(main=(FreeCAD`main at MainGui.cpp:107:1), argc=1, argv=0x00007fffffffdd78, init=<unavailable>, fini=<unavailable>, rtld_fini=<unavailable>, stack_end=0x00007fffffffdd68) at libc-start.c:392:3
    frame #118: 0x0000555555569c05 FreeCAD`_start + 37
(lldb)
```


</details>

[^1]: https://github.com/FreeCAD/FreeCAD/issues/14370#issuecomment-2171575682