### PR TITLE
BIM: Fix left/right aligned wall based on reversed collinear edges

### DIFF
--- a/src/Mod/Draft/draftgeoutils/faces.py
+++ b/src/Mod/Draft/draftgeoutils/faces.py
@@ -118,7 +118,7 @@ def bind(w1, w2, per_segment=False):
     avoids problems with walls based on wires that selfintersect, or that have
     a loop that ends in a T-connection (f.e. a wire shaped like a number 6).
 
-    2 wires can result in multple faces:
+    2 wires can result in multiple faces:
 
     w1 ----------+
                  |


### PR DESCRIPTION
Fixes #14564.

Note that the return value of the bind function becomes a list with this PR. Since this function is only used by Arch_Wall this seems acceptable. But it may be problematic if external workbenches and user macros also rely on this function. I am not sure.

Pending further testing this is a draft PR.
