### PR TITLE
[BIM] Fix QSvgWidget is not a child of QtSvg in PySide6

### DIFF
--- a/src/Mod/BIM/ArchPrecast.py
+++ b/src/Mod/BIM/ArchPrecast.py
@@ -777,14 +777,14 @@ class _PrecastTaskPanel:
     def __init__(self):
 
         import FreeCADGui
-        from PySide import QtCore,QtGui,QtSvg
+        from PySide import QtCore, QtGui, QtSvgWidgets
         self.form = QtGui.QWidget()
         self.grid = QtGui.QGridLayout(self.form)
         self.PrecastTypes = ["Beam","I-Beam","Pillar","Panel","Slab","Stairs"]
         self.SlabTypes = ["Champagne","Hat"]
 
         # image display
-        self.preview = QtSvg.QSvgWidget(":/ui/ParametersBeam.svg")
+        self.preview = QtSvgWidgets.QSvgWidget(":/ui/ParametersBeam.svg")
         self.preview.setMaximumWidth(200)
         self.preview.setMinimumHeight(120)
         self.grid.addWidget(self.preview,0,0,1,2)
@@ -1263,7 +1263,7 @@ class _DentsTaskPanel:
     def __init__(self):
 
         import FreeCADGui
-        from PySide import QtCore,QtGui,QtSvg
+        from PySide import QtCore, QtGui, QtSvgWidgets
         self.form = QtGui.QWidget()
         self.grid = QtGui.QGridLayout(self.form)
         self.Rotations = ["N","S","E","O"]
@@ -1282,7 +1282,7 @@ class _DentsTaskPanel:
         self.grid.addWidget(self.buttonRemove,2,1,1,1)
 
         # image display
-        self.preview = QtSvg.QSvgWidget(":/ui/ParametersDent.svg")
+        self.preview = QtSvgWidgets.QSvgWidget(":/ui/ParametersDent.svg")
         self.preview.setMaximumWidth(200)
         self.preview.setMinimumHeight(120)
         self.grid.addWidget(self.preview,3,0,1,2)

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -34,7 +34,7 @@ from draftutils.messages import _wrn
 
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from PySide import QtCore, QtGui, QtSvg
+    from PySide import QtCore, QtGui
     from draftutils.translate import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
     import draftguitools.gui_trackers as DraftTrackers

--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -258,7 +258,7 @@ class Arch_Window:
         "sets up a taskbox widget"
 
         from draftutils import params
-        from PySide import QtCore, QtGui, QtSvg
+        from PySide import QtCore, QtGui, QtSvgWidgets
         from ArchWindowPresets import WindowPresets
         w = QtGui.QWidget()
         ui = FreeCADGui.UiLoader()
@@ -322,7 +322,7 @@ class Arch_Window:
         self.pic.hide()
 
         # SVG display
-        self.im = QtSvg.QSvgWidget(":/ui/ParametersWindowFixed.svg")
+        self.im = QtSvgWidgets.QSvgWidget(":/ui/ParametersWindowFixed.svg")
         self.im.setMaximumWidth(200)
         self.im.setMinimumHeight(120)
         grid.addWidget(self.im,4,0,1,2)


### PR DESCRIPTION
Fix bug reported in the forum https://forum.freecad.org/viewtopic.php?t=88499 error raised using BimWindow:

```
15:42:45  Running the Python command 'Arch_Window' failed:
Traceback (most recent call last):
  File "/opt/freecad-source/freecad-build/Mod/BIM/bimcommands/BimWindow.py", line 135, in Activated
    FreeCADGui.Snapper.getPoint(callback=self.getPoint,movecallback=self.update,extradlg=self.taskbox())
                                                                                         ^^^^^^^^^^^^^^
  File "/opt/freecad-source/freecad-build/Mod/BIM/bimcommands/BimWindow.py", line 325, in taskbox
    self.im = QtSvg.QSvgWidget(":/ui/ParametersWindowFixed.svg")
              ^^^^^^^^^^^^^^^^

module 'PySide.QtSvg' has no attribute 'QSvgWidget'
```
Previous fix before BIM Wb integration: https://github.com/FreeCAD/FreeCAD/pull/13554