### PR TITLE
[TD]fix scene and tree selection sync

### DIFF
--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -727,6 +727,17 @@ bool DrawGuiUtil::findObjectInSelection(const std::vector<Gui::SelectionObject>&
     return false;
 }
 
+std::vector<std::string>  DrawGuiUtil::getSubsForSelectedObject(const std::vector<Gui::SelectionObject>& selection,
+                                                                App::DocumentObject* selectedObj)
+{
+    for (auto& selObj : selection) {
+        if (selectedObj == selObj.getObject()) {
+            return selObj.getSubNames();
+        }
+    }
+    return {};
+}
+
 bool DrawGuiUtil::isStyleSheetDark(std::string curStyleSheet)
 {
     if (curStyleSheet.find("dark") != std::string::npos ||

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.h
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.h
@@ -91,6 +91,8 @@ class TechDrawGuiExport DrawGuiUtil {
 
     static bool findObjectInSelection(const std::vector<Gui::SelectionObject>& selection,
                                       const App::DocumentObject& targetObject);
+    static std::vector<std::string>  getSubsForSelectedObject(const std::vector<Gui::SelectionObject>& selection,
+                                                                App::DocumentObject* selectedObj);
 };
 
 } //end namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -62,6 +62,7 @@
 #include "ViewProviderDrawingView.h"
 #include "ViewProviderPage.h"
 #include "ZVALUE.h"
+#include "DrawGuiUtil.h"
 
 
 using namespace TechDrawGui;
@@ -194,10 +195,8 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
     if (change == ItemSelectedHasChanged && scene()) {
         if(isSelected()) {
             m_colCurrent = getSelectColor();
-//            m_selectState = 2;
         } else {
             m_colCurrent = PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
-//            m_selectState = 0;
         }
         drawBorder();
     }
@@ -290,7 +289,6 @@ void QGIView::snapPosition(QPointF& mPos)
 
 void QGIView::mousePressEvent(QGraphicsSceneMouseEvent * event)
 {
-//    Base::Console().Message("QGIV::mousePressEvent() - %s\n", getViewName());
     Qt::KeyboardModifiers originalModifiers = event->modifiers();
     if (event->button()&Qt::LeftButton) {
         m_multiselectActivated = false;
@@ -298,10 +296,8 @@ void QGIView::mousePressEvent(QGraphicsSceneMouseEvent * event)
 
     if (event->button() == Qt::LeftButton && PreferencesGui::multiSelection()) {
         std::vector<Gui::SelectionObject> selection = Gui::Selection().getSelectionEx();
-        if (selection.size() == 1
-            && selection.front().getObject() == getViewObject()
-            && selection.front().hasSubNames()) {
-
+        if (!DrawGuiUtil::getSubsForSelectedObject(selection, getViewObject()).empty()) {
+            // we have already selected geometry for this view
             m_multiselectActivated = true;
             event->setModifiers(originalModifiers | Qt::ControlModifier);
         }
@@ -319,7 +315,6 @@ void QGIView::mouseMoveEvent(QGraphicsSceneMouseEvent * event)
 
 void QGIView::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
 {
-//    Base::Console().Message("QGIV::mouseReleaseEvent() - %s\n", getViewName());
     Qt::KeyboardModifiers originalModifiers = event->modifiers();
     if ((event->button()&Qt::LeftButton) && m_multiselectActivated) {
         if (PreferencesGui::multiSelection()) {

--- a/src/Mod/TechDraw/Gui/QGSPage.h
+++ b/src/Mod/TechDraw/Gui/QGSPage.h
@@ -149,6 +149,9 @@ public:
 
 
 protected:
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+
     QColor getBackgroundColor();
     bool orphanExists(const char* viewName, const std::vector<App::DocumentObject*>& list);
 


### PR DESCRIPTION
This PR implements a fix for issue #14051.  The QGraphicsScene and tree selection
states were getting out of sync when multi-select was active in the scene.