### PR TITLE
Toponaming: Fix crash with invalid external geometry

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -7403,6 +7403,11 @@ void SketchObject::validateExternalLinks()
             Base::Console().Warning(
                 this->getFullLabel(), (indexError.getMessage() + "\n").c_str());
         }
+        catch ( Base::ValueError& valueError ) {
+            removeBadLink = true;
+            Base::Console().Warning(
+                this->getFullLabel(), (valueError.getMessage() + "\n").c_str());
+        }
         catch (Standard_Failure&) {
             removeBadLink = true;
         }


### PR DESCRIPTION
Fix #14563.   Could not devise a test to trigger this fail, which comes as a result of mouse movement triggering a redraw of a sketch in edit mode that contains invalid external geometry because the validation when the sketch goes into edit mode was failing to catch the correct exception type thrown by TNP code.