### PR TITLE
Part: Fix several regressions

### DIFF
--- a/src/Mod/Part/Gui/ViewProvider.cpp
+++ b/src/Mod/Part/Gui/ViewProvider.cpp
@@ -71,7 +71,7 @@ void ViewProviderPart::applyColor(const Part::ShapeHistory& hist,
 }
 
 void ViewProviderPart::applyMaterial(const Part::ShapeHistory& hist,
-                                     const App::PropertyMaterialList& colBase,
+                                     const std::vector<App::Material>& colBase,
                                      std::vector<App::Material>& colBool)
 {
     std::map<int, std::vector<int>>::const_iterator jt;

--- a/src/Mod/Part/Gui/ViewProvider.cpp
+++ b/src/Mod/Part/Gui/ViewProvider.cpp
@@ -62,7 +62,6 @@ void ViewProviderPart::applyColor(const Part::ShapeHistory& hist,
                                   std::vector<App::Color>& colBool)
 {
     std::map<int, std::vector<int> >::const_iterator jt;
-    // apply color from modified faces
     for (jt = hist.shapeMap.begin(); jt != hist.shapeMap.end(); ++jt) {
         std::vector<int>::const_iterator kt;
         for (kt = jt->second.begin(); kt != jt->second.end(); ++kt) {
@@ -72,11 +71,10 @@ void ViewProviderPart::applyColor(const Part::ShapeHistory& hist,
 }
 
 void ViewProviderPart::applyMaterial(const Part::ShapeHistory& hist,
-                                  const App::PropertyMaterialList& colBase,
-                                  std::vector<App::Material>& colBool)
+                                     const App::PropertyMaterialList& colBase,
+                                     std::vector<App::Material>& colBool)
 {
     std::map<int, std::vector<int>>::const_iterator jt;
-    // apply color from modified faces
     for (jt = hist.shapeMap.begin(); jt != hist.shapeMap.end(); ++jt) {
         std::vector<int>::const_iterator kt;
         for (kt = jt->second.begin(); kt != jt->second.end(); ++kt) {
@@ -85,29 +83,27 @@ void ViewProviderPart::applyMaterial(const Part::ShapeHistory& hist,
     }
 }
 
-void ViewProviderPart::applyTransparency(const float& transparency,
-                                  std::vector<App::Color>& colors)
+void ViewProviderPart::applyTransparency(float transparency, std::vector<App::Color>& colors)
 {
-    if (transparency != 0.0) {
+    if (transparency != 0.0F) {
         // transparency has been set object-wide
         std::vector<App::Color>::iterator j;
         for (j = colors.begin(); j != colors.end(); ++j) {
-            // transparency hasn't been set for this face
-            if (j->a == 0.0)
-                j->a = transparency/100.0; // transparency comes in percent
+            if (j->a == 0.0F) {
+                j->a = transparency/100.0F; // transparency comes in percent
+            }
         }
     }
 }
 
-void ViewProviderPart::applyTransparency(const float& transparency, std::vector<App::Material>& colors)
+void ViewProviderPart::applyTransparency(float transparency, std::vector<App::Material>& colors)
 {
-    if (transparency != 0.0) {
+    if (transparency != 0.0F) {
         // transparency has been set object-wide
         std::vector<App::Material>::iterator j;
         for (j = colors.begin(); j != colors.end(); ++j) {
-            // transparency hasn't been set for this face
-            if (j->transparency == 0.0) {
-                j->transparency = transparency / 100.0;  // transparency comes in percent
+            if (j->transparency == 0.0F) {
+                j->transparency = transparency / 100.0F;  // transparency comes in percent
             }
         }
     }

--- a/src/Mod/Part/Gui/ViewProvider.h
+++ b/src/Mod/Part/Gui/ViewProvider.h
@@ -60,10 +60,8 @@ protected:
     void applyMaterial(const Part::ShapeHistory& hist,
                        const App::PropertyMaterialList& colBase,
                        std::vector<App::Material>& colBool);
-    void applyTransparency(const float& transparency,
-                    std::vector<App::Color>& colors);
-    void applyTransparency(const float& transparency,
-                    std::vector<App::Material>& colors);
+    void applyTransparency(float transparency, std::vector<App::Color>& colors);
+    void applyTransparency(float transparency, std::vector<App::Material>& colors);
 };
 
 } // namespace PartGui

--- a/src/Mod/Part/Gui/ViewProvider.h
+++ b/src/Mod/Part/Gui/ViewProvider.h
@@ -58,7 +58,7 @@ protected:
                     const std::vector<App::Color>& colBase,
                     std::vector<App::Color>& colBool);
     void applyMaterial(const Part::ShapeHistory& hist,
-                       const App::PropertyMaterialList& colBase,
+                       const std::vector<App::Material>& colBase,
                        std::vector<App::Material>& colBool);
     void applyTransparency(float transparency, std::vector<App::Color>& colors);
     void applyTransparency(float transparency, std::vector<App::Material>& colors);

--- a/src/Mod/Part/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/Part/Gui/ViewProviderBoolean.cpp
@@ -100,27 +100,27 @@ void ViewProviderBoolean::updateData(const App::Property* prop)
             auto vpTool = dynamic_cast<PartGui::ViewProviderPart*>(
                     Gui::Application::Instance->getViewProvider(objTool));
             if (vpBase && vpTool) {
+                std::vector<App::Material> colBase = vpBase->ShapeAppearance.getValues();
+                std::vector<App::Material> colTool = vpTool->ShapeAppearance.getValues();
                 std::vector<App::Material> colBool;
                 colBool.resize(boolMap.Extent(), this->ShapeAppearance[0]);
-                vpBase->ShapeAppearance.setTransparency(vpBase->Transparency.getValue());
-                vpTool->ShapeAppearance.setTransparency(vpTool->Transparency.getValue());
+                applyTransparency(vpBase->Transparency.getValue(),colBase);
+                applyTransparency(vpTool->Transparency.getValue(),colTool);
 
-                if (static_cast<int>(vpBase->ShapeAppearance.getSize()) == baseMap.Extent()) {
-                    applyMaterial(hist[0], vpBase->ShapeAppearance, colBool);
+                if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
+                    applyMaterial(hist[0], colBase, colBool);
                 }
-                else if (vpBase->ShapeAppearance.getSize() > 0
-                         && vpBase->ShapeAppearance[0] != this->ShapeAppearance[0]) {
-                    vpBase->ShapeAppearance.setSize(baseMap.Extent(), vpBase->ShapeAppearance[0]);
-                    applyMaterial(hist[0], vpBase->ShapeAppearance, colBool);
+                else if (!colBase.empty() && colBase[0] != this->ShapeAppearance[0]) {
+                    colBase.resize(baseMap.Extent(), colBase[0]);
+                    applyMaterial(hist[0], colBase, colBool);
                 }
 
-                if (static_cast<int>(vpTool->ShapeAppearance.getSize()) == toolMap.Extent()) {
-                    applyMaterial(hist[1], vpTool->ShapeAppearance, colBool);
+                if (static_cast<int>(colTool.size()) == toolMap.Extent()) {
+                    applyMaterial(hist[1], colTool, colBool);
                 }
-                else if (vpTool->ShapeAppearance.getSize() > 0
-                         && vpTool->ShapeAppearance[0] != this->ShapeAppearance[0]) {
-                    vpTool->ShapeAppearance.setSize(toolMap.Extent(), vpTool->ShapeAppearance[0]);
-                    applyMaterial(hist[1], vpTool->ShapeAppearance, colBool);
+                else if (!colTool.empty() && colTool[0] != this->ShapeAppearance[0]) {
+                    colTool.resize(toolMap.Extent(), colTool[0]);
+                    applyMaterial(hist[1], colTool, colBool);
                 }
 
                 // If the view provider has set a transparency then override the values
@@ -201,14 +201,14 @@ void ViewProviderMultiFuse::updateData(const App::Property* prop)
 
             auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                vpBase->ShapeAppearance.setTransparency(vpBase->Transparency.getValue());
-                if (static_cast<int>(vpBase->ShapeAppearance.getSize()) == baseMap.Extent()) {
-                    applyMaterial(hist[index], vpBase->ShapeAppearance, colBool);
+                std::vector<App::Material> colBase = vpBase->ShapeAppearance.getValues();
+                applyTransparency(vpBase->Transparency.getValue(),colBase);
+                if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
+                    applyMaterial(hist[index], colBase, colBool);
                 }
-                else if (vpBase->ShapeAppearance.getSize() > 0
-                         && vpBase->ShapeAppearance[0] != this->ShapeAppearance[0]) {
-                    vpBase->ShapeAppearance.setSize(baseMap.Extent(), vpBase->ShapeAppearance[0]);
-                    applyMaterial(hist[index], vpBase->ShapeAppearance, colBool);
+                else if (!colBase.empty() && colBase[0] != this->ShapeAppearance[0]) {
+                    colBase.resize(baseMap.Extent(), colBase[0]);
+                    applyMaterial(hist[index], colBase, colBool);
                 }
             }
         }
@@ -336,14 +336,14 @@ void ViewProviderMultiCommon::updateData(const App::Property* prop)
 
             auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                vpBase->ShapeAppearance.setTransparency(vpBase->Transparency.getValue());
-                if (static_cast<int>(vpBase->ShapeAppearance.getSize()) == baseMap.Extent()) {
-                    applyMaterial(hist[index], vpBase->ShapeAppearance, colBool);
+                std::vector<App::Material> colBase = vpBase->ShapeAppearance.getValues();
+                applyTransparency(vpBase->Transparency.getValue(),colBase);
+                if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
+                    applyMaterial(hist[index], colBase, colBool);
                 }
-                else if (vpBase->ShapeAppearance.getSize() > 0
-                         && vpBase->ShapeAppearance[0] != this->ShapeAppearance[0]) {
-                    vpBase->ShapeAppearance.setSize(baseMap.Extent(), vpBase->ShapeAppearance[0]);
-                    applyMaterial(hist[index], vpBase->ShapeAppearance, colBool);
+                else if (!colBase.empty() && colBase[0] != this->ShapeAppearance[0]) {
+                    colBase.resize(baseMap.Extent(), colBase[0]);
+                    applyMaterial(hist[index], colBase, colBool);
                 }
             }
         }

--- a/src/Mod/Part/Gui/ViewProviderCompound.cpp
+++ b/src/Mod/Part/Gui/ViewProviderCompound.cpp
@@ -111,14 +111,14 @@ void ViewProviderCompound::updateData(const App::Property* prop)
 
             auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                vpBase->ShapeAppearance.setTransparency(vpBase->Transparency.getValue());
-                if (static_cast<int>(vpBase->ShapeAppearance.getSize()) == baseMap.Extent()) {
-                    applyMaterial(hist[index], vpBase->ShapeAppearance, compCol);
+                std::vector<App::Material> baseCol = vpBase->ShapeAppearance.getValues();
+                applyTransparency(vpBase->Transparency.getValue(), baseCol);
+                if (static_cast<int>(baseCol.size()) == baseMap.Extent()) {
+                    applyMaterial(hist[index], baseCol, compCol);
                 }
-                else if (vpBase->ShapeAppearance.getSize() > 0
-                         && vpBase->ShapeAppearance[0] != this->ShapeAppearance[0]) {
-                    vpBase->ShapeAppearance.setSize(baseMap.Extent(), vpBase->ShapeAppearance[0]);
-                    applyMaterial(hist[index], vpBase->ShapeAppearance, compCol);
+                else if (!baseCol.empty() && baseCol[0] != this->ShapeAppearance[0]) {
+                    baseCol.resize(baseMap.Extent(), baseCol[0]);
+                    applyMaterial(hist[index], baseCol, compCol);
                 }
             }
         }

--- a/src/Mod/Part/Gui/ViewProviderMirror.cpp
+++ b/src/Mod/Part/Gui/ViewProviderMirror.cpp
@@ -263,18 +263,17 @@ void ViewProviderFillet::updateData(const App::Property* prop)
 
             auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                // std::vector<App::Color> colBase = vpBase->DiffuseColor.getValues();
+                auto colBase = static_cast<PartGui::ViewProviderPart*>(vpBase)->ShapeAppearance.getValues();
                 std::vector<App::Material> colFill;
-                colFill.resize(fillMap.Extent(), vpBase->ShapeAppearance[0]);
-                vpBase->ShapeAppearance.setTransparency(vpBase->Transparency.getValue());
+                colFill.resize(fillMap.Extent(), colBase[0]);
+                applyTransparency(static_cast<PartGui::ViewProviderPart*>(vpBase)->Transparency.getValue(), colBase);
 
-                if (static_cast<int>(vpBase->ShapeAppearance.getSize()) == baseMap.Extent()) {
-                    applyMaterial(hist[0], vpBase->ShapeAppearance, colFill);
+                if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
+                    applyMaterial(hist[0], colBase, colFill);
                 }
-                else if (vpBase->ShapeAppearance.getSize() > 0
-                         && vpBase->ShapeAppearance[0] != this->ShapeAppearance[0]) {
-                    vpBase->ShapeAppearance.setSize(baseMap.Extent(), vpBase->ShapeAppearance[0]);
-                    applyMaterial(hist[0], vpBase->ShapeAppearance, colFill);
+                else if (!colBase.empty() && colBase[0] != this->ShapeAppearance[0]) {
+                    colBase.resize(baseMap.Extent(), colBase[0]);
+                    applyMaterial(hist[0], colBase, colFill);
                 }
 
                 // If the view provider has set a transparency then override the values
@@ -374,17 +373,16 @@ void ViewProviderChamfer::updateData(const App::Property* prop)
 
             auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                // std::vector<App::Color> colBase = static_cast<PartGui::ViewProviderPart*>(vpBase)->DiffuseColor.getValues();
-                auto& colBase = static_cast<PartGui::ViewProviderPart*>(vpBase)->ShapeAppearance;
+                auto colBase = static_cast<PartGui::ViewProviderPart*>(vpBase)->ShapeAppearance.getValues();
                 std::vector<App::Material> colCham;
                 colCham.resize(chamMap.Extent(), colBase[0]);
-                colBase.setTransparency(static_cast<PartGui::ViewProviderPart*>(vpBase)->Transparency.getValue());
+                applyTransparency(static_cast<PartGui::ViewProviderPart*>(vpBase)->Transparency.getValue(), colBase);
 
-                if (static_cast<int>(colBase.getSize()) == baseMap.Extent()) {
+                if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
                     applyMaterial(hist[0], colBase, colCham);
                 }
-                else if (colBase.getSize() > 0 && colBase[0] != this->ShapeAppearance[0]) {
-                    colBase.setSize(baseMap.Extent(), colBase[0]);
+                else if (!colBase.empty() && colBase[0] != this->ShapeAppearance[0]) {
+                    colBase.resize(baseMap.Extent(), colBase[0]);
                     applyMaterial(hist[0], colBase, colCham);
                 }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -427,6 +427,7 @@ void ViewProviderBody::unifyVisualProperty(const App::Property* prop) {
     if (prop == &Visibility ||
         prop == &Selectable ||
         prop == &DisplayModeBody ||
+        prop == &ShapeAppearance ||
         prop == &PointColorArray ||
         prop == &LineColorArray) {
         return;


### PR DESCRIPTION
* do not register the private member '_diffuseColor' as property because it would be exposed to the
  public where it can be modified
* fix ViewProviderPartExt::finishRestoring() to correctly restore old project files
* fix ViewProviderPartExt::setHighlightedFaces() to correctly show face colours if VBO is enabled
* fix ViewProviderBoolean::updateData()
  fix ViewProviderMultiFuse::updateData()
  fix ViewProviderMultiCommon::updateData()
  fix ViewProviderCompound::updateData()
  fix ViewProviderFillet::updateData()
  fix ViewProviderChamfer::updateData()
  that all set invalid transparency values
* Filter ShapeAppearance in ViewProviderBody::unifyVisualProperty
  because body features usually have different number of faces than the body itself
* clean up code and remove duplicated code