### PR TITLE
Draft: Add type check to Draft_Join

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_join.py
+++ b/src/Mod/Draft/draftguitools/gui_join.py
@@ -33,10 +33,10 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
 import Draft_rc
-import draftguitools.gui_base_original as gui_base_original
-import draftguitools.gui_tool_utils as gui_tool_utils
-
-from draftutils.messages import _msg, _toolmsg
+from draftguitools import gui_base_original
+from draftguitools import gui_tool_utils
+from draftutils import utils
+from draftutils.messages import _msg, _err, _toolmsg
 from draftutils.translate import translate
 
 # The module is used to prevent complaints from code checkers (flake8)
@@ -77,15 +77,18 @@ class Join(gui_base_original.Modifier):
             self.end_callbacks(self.call)
         if Gui.Selection.getSelection():
             self.print_selection()
-            Gui.addModule("Draft")
-            _cmd = "Draft.join_wires"
-            _cmd += "("
-            _cmd += "FreeCADGui.Selection.getSelection()"
-            _cmd += ")"
-            _cmd_list = ['j = ' + _cmd,
-                         'FreeCAD.ActiveDocument.recompute()']
-            self.commit(translate("draft", "Join lines"),
-                        _cmd_list)
+            if all(utils.get_type(o) == "Wire" for o in Gui.Selection.getSelection()):
+                Gui.addModule("Draft")
+                _cmd = "Draft.join_wires"
+                _cmd += "("
+                _cmd += "FreeCADGui.Selection.getSelection()"
+                _cmd += ")"
+                _cmd_list = ['j = ' + _cmd,
+                             'FreeCAD.ActiveDocument.recompute()']
+                self.commit(translate("draft", "Join lines"),
+                            _cmd_list)
+            else:
+                _err(translate("draft", "Only Draft Lines and Wires can be joined"))
         self.finish()
 
     def print_selection(self):


### PR DESCRIPTION
Add a type check for the selected objects. All must be Draft Wires.

Fixes #14727.
