### PR TITLE
Sketcher: Modernize SketchObject.cpp

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1884,7 +1884,7 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
     }
 
     // Add a vertex to preserve the original intersection of the filleted lines
-    Part::GeomPoint* originalCorner = new Part::GeomPoint(getPoint(geoId1, posId1));
+    auto* originalCorner = new Part::GeomPoint(getPoint(geoId1, posId1));
     int originalCornerId = addGeometry(originalCorner);
     delete originalCorner;
 
@@ -2518,10 +2518,10 @@ int SketchObject::fillet(int GeoId1, int GeoId2, const Base::Vector3d& refPnt1,
         Base::Console().Log("radius: %f\n", radius);
 #endif
 
-        Part::GeomOffsetCurve* ocurve1 = new Part::GeomOffsetCurve(
+        auto* ocurve1 = new Part::GeomOffsetCurve(
             Handle(Geom_Curve)::DownCast(curve1->handle()), (sdir1 < 0) ? radius : -radius, vn);
 
-        Part::GeomOffsetCurve* ocurve2 = new Part::GeomOffsetCurve(
+        auto* ocurve2 = new Part::GeomOffsetCurve(
             Handle(Geom_Curve)::DownCast(curve2->handle()), (sdir2 < 0) ? radius : -radius, vn);
 
 #ifdef DEBUG
@@ -4096,7 +4096,7 @@ int SketchObject::join(int geoId1, Sketcher::PointPos posId1, int geoId2, Sketch
                     std::make_move_iterator(mults2.begin()),
                     std::make_move_iterator(mults2.end()));
 
-    Part::GeomBSplineCurve* newSpline = new Part::GeomBSplineCurve(
+    auto* newSpline = new Part::GeomBSplineCurve(
         newPoles, newWeights, newKnots, newMults, bsp1->getDegree(), false, true);
 
     int newGeoId = addGeometry(newSpline);
@@ -4330,7 +4330,7 @@ int SketchObject::addSymmetric(const std::vector<int>& geoIdList, int refGeoId,
     else {
         for (auto* constr : constrvals) {
             if (constr->First == refGeoId
-                && (constr->Type == Sketcher::Vertical || constr->Type == Sketcher::Horizontal)){
+                && (constr->Type == Sketcher::Vertical || constr->Type == Sketcher::Horizontal)) {
                 refIsAxisAligned = true;
             }
         }
@@ -4518,7 +4518,7 @@ int SketchObject::addSymmetric(const std::vector<int>& geoIdList, int refGeoId,
             }
         }
 
-        if (newconstrVals.size() > constrvals.size()){
+        if (newconstrVals.size() > constrvals.size()) {
             Constraints.setValues(std::move(newconstrVals));
         }
     }
@@ -5281,7 +5281,7 @@ int SketchObject::addCopy(const std::vector<int>& geoIdList, const Base::Vector3
                 if (constraindisplacement) {
 
                     // add a construction line
-                    Part::GeomLineSegment* constrline = new Part::GeomLineSegment();
+                    auto* constrline = new Part::GeomLineSegment();
 
                     // position of the reference point
                     Base::Vector3d sp = getPoint(refgeoid, refposId)
@@ -5671,12 +5671,12 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         Base::Vector3d focus2P = center - df * majdir;
 
         if (!major) {
-            Part::GeomLineSegment* lmajor = new Part::GeomLineSegment();
+            auto* lmajor = new Part::GeomLineSegment();
             lmajor->setPoints(majorpositiveend, majornegativeend);
 
             igeo.push_back(lmajor);
 
-            Sketcher::Constraint* newConstr = new Sketcher::Constraint();
+            auto* newConstr = new Sketcher::Constraint();
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = EllipseMajorDiameter;
             newConstr->First = currentgeoid + incrgeo + 1;
@@ -5686,12 +5686,12 @@ int SketchObject::exposeInternalGeometry(int GeoId)
             incrgeo++;
         }
         if (!minor) {
-            Part::GeomLineSegment* lminor = new Part::GeomLineSegment();
+            auto* lminor = new Part::GeomLineSegment();
             lminor->setPoints(minorpositiveend, minornegativeend);
 
             igeo.push_back(lminor);
 
-            Sketcher::Constraint* newConstr = new Sketcher::Constraint();
+            auto* newConstr = new Sketcher::Constraint();
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = EllipseMinorDiameter;
             newConstr->First = currentgeoid + incrgeo + 1;
@@ -5701,12 +5701,12 @@ int SketchObject::exposeInternalGeometry(int GeoId)
             incrgeo++;
         }
         if (!focus1) {
-            Part::GeomPoint* pf1 = new Part::GeomPoint();
+            auto* pf1 = new Part::GeomPoint();
             pf1->setPoint(focus1P);
 
             igeo.push_back(pf1);
 
-            Sketcher::Constraint* newConstr = new Sketcher::Constraint();
+            auto* newConstr = new Sketcher::Constraint();
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = EllipseFocus1;
             newConstr->First = currentgeoid + incrgeo + 1;
@@ -5717,11 +5717,11 @@ int SketchObject::exposeInternalGeometry(int GeoId)
             incrgeo++;
         }
         if (!focus2) {
-            Part::GeomPoint* pf2 = new Part::GeomPoint();
+            auto* pf2 = new Part::GeomPoint();
             pf2->setPoint(focus2P);
             igeo.push_back(pf2);
 
-            Sketcher::Constraint* newConstr = new Sketcher::Constraint();
+            auto* newConstr = new Sketcher::Constraint();
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = EllipseFocus2;
             newConstr->First = currentgeoid + incrgeo + 1;
@@ -5734,14 +5734,12 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         this->addGeometry(igeo, true);
         this->addConstraints(icon);
 
-        for (std::vector<Part::Geometry*>::iterator it = igeo.begin(); it != igeo.end(); ++it) {
-            if (*it)
-                delete *it;
+        for (auto* geo : igeo) {
+            delete geo;
         }
 
-        for (std::vector<Constraint*>::iterator it = icon.begin(); it != icon.end(); ++it) {
-            if (*it)
-                delete *it;
+        for (auto* constr : icon) {
+            delete constr;
         }
 
         icon.clear();
@@ -5755,12 +5753,9 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         bool minor = false;
         bool focus = false;
 
-        const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
-
-        for (std::vector<Sketcher::Constraint*>::const_iterator it = vals.begin(); it != vals.end();
-             ++it) {
-            if ((*it)->Type == Sketcher::InternalAlignment && (*it)->Second == GeoId) {
-                switch ((*it)->AlignmentType) {
+        for (const auto* constr : Constraints.getValues()) {
+            if (constr->Type == Sketcher::InternalAlignment && constr->Second == GeoId) {
+                switch (constr->AlignmentType) {
                     case Sketcher::HyperbolaMajor:
                         major = true;
                         break;
@@ -5779,7 +5774,7 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         int currentgeoid = getHighestCurveIndex();
         int incrgeo = 0;
 
-        const Part::GeomArcOfHyperbola* aoh = static_cast<const Part::GeomArcOfHyperbola*>(geo);
+        auto* aoh = static_cast<const Part::GeomArcOfHyperbola*>(geo);
 
         Base::Vector3d center = aoh->getCenter();
         double majord = aoh->getMajorRadius();
@@ -5801,12 +5796,12 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         Base::Vector3d focus1P = center + df * majdir;
 
         if (!major) {
-            Part::GeomLineSegment* lmajor = new Part::GeomLineSegment();
+            auto* lmajor = new Part::GeomLineSegment();
             lmajor->setPoints(majorpositiveend, majornegativeend);
 
             igeo.push_back(lmajor);
 
-            Sketcher::Constraint* newConstr = new Sketcher::Constraint();
+            auto* newConstr = new Sketcher::Constraint();
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = Sketcher::HyperbolaMajor;
             newConstr->First = currentgeoid + incrgeo + 1;
@@ -5816,12 +5811,12 @@ int SketchObject::exposeInternalGeometry(int GeoId)
             incrgeo++;
         }
         if (!minor) {
-            Part::GeomLineSegment* lminor = new Part::GeomLineSegment();
+            auto* lminor = new Part::GeomLineSegment();
             lminor->setPoints(minorpositiveend, minornegativeend);
 
             igeo.push_back(lminor);
 
-            Sketcher::Constraint* newConstr = new Sketcher::Constraint();
+            auto* newConstr = new Sketcher::Constraint();
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = Sketcher::HyperbolaMinor;
             newConstr->First = currentgeoid + incrgeo + 1;
@@ -5832,12 +5827,12 @@ int SketchObject::exposeInternalGeometry(int GeoId)
             incrgeo++;
         }
         if (!focus) {
-            Part::GeomPoint* pf1 = new Part::GeomPoint();
+            auto* pf1 = new Part::GeomPoint();
             pf1->setPoint(focus1P);
 
             igeo.push_back(pf1);
 
-            Sketcher::Constraint* newConstr = new Sketcher::Constraint();
+            auto* newConstr = new Sketcher::Constraint();
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = Sketcher::HyperbolaFocus;
             newConstr->First = currentgeoid + incrgeo + 1;
@@ -5851,13 +5846,13 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         this->addGeometry(igeo, true);
         this->addConstraints(icon);
 
-        for (std::vector<Part::Geometry*>::iterator it = igeo.begin(); it != igeo.end(); ++it)
-            if (*it)
-                delete *it;
+        for (auto* geo : igeo) {
+            delete geo;
+        }
 
-        for (std::vector<Constraint*>::iterator it = icon.begin(); it != icon.end(); ++it)
-            if (*it)
-                delete *it;
+        for (auto* constr : icon) {
+            delete constr;
+        }
 
         icon.clear();
         igeo.clear();
@@ -5869,12 +5864,9 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         bool focus = false;
         bool focus_to_vertex = false;
 
-        const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
-
-        for (std::vector<Sketcher::Constraint*>::const_iterator it = vals.begin(); it != vals.end();
-             ++it) {
-            if ((*it)->Type == Sketcher::InternalAlignment && (*it)->Second == GeoId) {
-                switch ((*it)->AlignmentType) {
+        for (const auto* constr : Constraints.getValues()) {
+            if (constr->Type == Sketcher::InternalAlignment && constr->Second == GeoId) {
+                switch (constr->AlignmentType) {
                     case Sketcher::ParabolaFocus:
                         focus = true;
                         break;
@@ -5890,7 +5882,7 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         int currentgeoid = getHighestCurveIndex();
         int incrgeo = 0;
 
-        const Part::GeomArcOfParabola* aop = static_cast<const Part::GeomArcOfParabola*>(geo);
+        auto* aop = static_cast<const Part::GeomArcOfParabola*>(geo);
 
         Base::Vector3d center = aop->getCenter();
         Base::Vector3d focusp = aop->getFocus();
@@ -5899,12 +5891,12 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         std::vector<Constraint*> icon;
 
         if (!focus) {
-            Part::GeomPoint* pf1 = new Part::GeomPoint();
+            auto* pf1 = new Part::GeomPoint();
             pf1->setPoint(focusp);
 
             igeo.push_back(pf1);
 
-            Sketcher::Constraint* newConstr = new Sketcher::Constraint();
+            auto* newConstr = new Sketcher::Constraint();
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = Sketcher::ParabolaFocus;
             newConstr->First = currentgeoid + incrgeo + 1;
@@ -5916,12 +5908,12 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         }
 
         if (!focus_to_vertex) {
-            Part::GeomLineSegment* paxis = new Part::GeomLineSegment();
+            auto* paxis = new Part::GeomLineSegment();
             paxis->setPoints(center, focusp);
 
             igeo.push_back(paxis);
 
-            Sketcher::Constraint* newConstr = new Sketcher::Constraint();
+            auto* newConstr = new Sketcher::Constraint();
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = Sketcher::ParabolaFocalAxis;
             newConstr->First = currentgeoid + incrgeo + 1;
@@ -5936,14 +5928,12 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         this->addGeometry(igeo, true);
         this->addConstraints(icon);
 
-        for (std::vector<Part::Geometry*>::iterator it = igeo.begin(); it != igeo.end(); ++it) {
-            if (*it)
-                delete *it;
+        for (auto* geo : igeo) {
+            delete geo;
         }
 
-        for (std::vector<Constraint*>::iterator it = icon.begin(); it != icon.end(); ++it) {
-            if (*it)
-                delete *it;
+        for (auto* constr : icon) {
+            delete constr;
         }
 
         icon.clear();
@@ -5953,7 +5943,7 @@ int SketchObject::exposeInternalGeometry(int GeoId)
     }
     else if (geo->is<Part::GeomBSplineCurve>()) {
 
-        const Part::GeomBSplineCurve* bsp = static_cast<const Part::GeomBSplineCurve*>(geo);
+        auto* bsp = static_cast<const Part::GeomBSplineCurve*>(geo);
         // First we search what has to be restored
         std::vector<bool> controlpoints(bsp->countPoles());
         std::vector<int> controlpointgeoids(bsp->countPoles());
@@ -5983,17 +5973,16 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
         // search for existing poles
-        for (std::vector<Sketcher::Constraint*>::const_iterator it = vals.begin(); it != vals.end();
-             ++it) {
-            if ((*it)->Type == Sketcher::InternalAlignment && (*it)->Second == GeoId) {
-                switch ((*it)->AlignmentType) {
+        for (const auto* constr : vals) {
+            if (constr->Type == Sketcher::InternalAlignment && constr->Second == GeoId) {
+                switch (constr->AlignmentType) {
                     case Sketcher::BSplineControlPoint:
-                        controlpoints[(*it)->InternalAlignmentIndex] = true;
-                        controlpointgeoids[(*it)->InternalAlignmentIndex] = (*it)->First;
+                        controlpoints[constr->InternalAlignmentIndex] = true;
+                        controlpointgeoids[constr->InternalAlignmentIndex] = constr->First;
                         break;
                     case Sketcher::BSplineKnotPoint:
-                        knotpoints[(*it)->InternalAlignmentIndex] = true;
-                        knotgeoids[(*it)->InternalAlignmentIndex] = (*it)->First;
+                        knotpoints[constr->InternalAlignmentIndex] = true;
+                        knotgeoids[constr->InternalAlignmentIndex] = constr->First;
                         break;
                     default:
                         return -1;
@@ -6003,10 +5992,8 @@ int SketchObject::exposeInternalGeometry(int GeoId)
 
         if (controlpoints[0]) {
             // search for first pole weight constraint
-            for (std::vector<Sketcher::Constraint*>::const_iterator it = vals.begin();
-                 it != vals.end();
-                 ++it) {
-                if ((*it)->Type == Sketcher::Weight && (*it)->First == controlpointgeoids[0]) {
+            for (const auto* constr : vals) {
+                if (constr->Type == Sketcher::Weight && constr->First == controlpointgeoids[0]) {
                     isfirstweightconstrained = true;
                 }
             }
@@ -6032,13 +6019,13 @@ int SketchObject::exposeInternalGeometry(int GeoId)
 
             if (!(*itb))// if controlpoint not existing
             {
-                Part::GeomCircle* pc = new Part::GeomCircle();
+                auto* pc = new Part::GeomCircle();
                 pc->setCenter(poles[index]);
                 pc->setRadius(distance_p0_p1 / 6);
 
                 igeo.push_back(pc);
 
-                Sketcher::Constraint* newConstr = new Sketcher::Constraint();
+                auto* newConstr = new Sketcher::Constraint();
                 newConstr->Type = Sketcher::InternalAlignment;
                 newConstr->AlignmentType = Sketcher::BSplineControlPoint;
                 newConstr->First = currentgeoid + incrgeo + 1;
@@ -6052,7 +6039,7 @@ int SketchObject::exposeInternalGeometry(int GeoId)
                     if (isfirstweightconstrained && weights[0] == weights[index]) {
                         // if pole-weight newly created AND first weight is radius-constrained,
                         // AND these weights are equal, constrain them to be equal
-                        Sketcher::Constraint* newConstr2 = new Sketcher::Constraint();
+                        auto* newConstr2 = new Sketcher::Constraint();
                         newConstr2->Type = Sketcher::Equal;
                         newConstr2->First = currentgeoid + incrgeo + 1;
                         newConstr2->FirstPos = Sketcher::PointPos::none;
@@ -6066,7 +6053,7 @@ int SketchObject::exposeInternalGeometry(int GeoId)
                     controlpointgeoids[0] = currentgeoid + incrgeo + 1;
                     if (weights[0] == 1.0) {
                         // if the first weight is 1.0 it's probably going to be non-rational
-                        Sketcher::Constraint* newConstr3 = new Sketcher::Constraint();
+                        auto* newConstr3 = new Sketcher::Constraint();
                         newConstr3->Type = Sketcher::Weight;
                         newConstr3->First = controlpointgeoids[0];
                         newConstr3->setValue(weights[0]);
@@ -6088,13 +6075,13 @@ int SketchObject::exposeInternalGeometry(int GeoId)
 
             if (!(*itb))// if knot point not existing
             {
-                Part::GeomPoint* kp = new Part::GeomPoint();
+                auto* kp = new Part::GeomPoint();
 
                 kp->setPoint(bsp->pointAtParameter(knots[index]));
 
                 igeo.push_back(kp);
 
-                Sketcher::Constraint* newConstr = new Sketcher::Constraint();
+                auto* newConstr = new Sketcher::Constraint();
                 newConstr->Type = Sketcher::InternalAlignment;
                 newConstr->AlignmentType = Sketcher::BSplineKnotPoint;
                 newConstr->First = currentgeoid + incrgeo + 1;
@@ -6113,13 +6100,13 @@ int SketchObject::exposeInternalGeometry(int GeoId)
         this->addGeometry(igeo, true);
         this->addConstraints(icon);
 
-        for (std::vector<Part::Geometry*>::iterator it = igeo.begin(); it != igeo.end(); ++it)
-            if (*it)
-                delete *it;
+        for (auto* geo : igeo) {
+            delete geo;
+        }
 
-        for (std::vector<Constraint*>::iterator it = icon.begin(); it != icon.end(); ++it)
-            if (*it)
-                delete *it;
+        for (auto* constr : icon) {
+            delete constr;
+        }
 
         icon.clear();
         igeo.clear();
@@ -6240,15 +6227,14 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
 
         const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
-        for (std::vector<Sketcher::Constraint*>::const_iterator it = vals.begin(); it != vals.end();
-             ++it) {
-            if ((*it)->Type == Sketcher::InternalAlignment && (*it)->Second == GeoId) {
-                switch ((*it)->AlignmentType) {
+        for (const auto* constr : vals) {
+            if (constr->Type == Sketcher::InternalAlignment && constr->Second == GeoId) {
+                switch (constr->AlignmentType) {
                     case Sketcher::ParabolaFocus:
-                        focus1elementindex = (*it)->First;
+                        focus1elementindex = constr->First;
                         break;
                     case Sketcher::ParabolaFocalAxis:
-                        majorelementindex = (*it)->First;
+                        majorelementindex = constr->First;
                         break;
                     default:
                         return -1;
@@ -6262,28 +6248,30 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
         int majorconstraints = 0;
         int focus1constraints = 0;
 
-        for (std::vector<Sketcher::Constraint*>::const_iterator it = vals.begin(); it != vals.end();
-             ++it) {
-            if ((*it)->Second == majorelementindex || (*it)->First == majorelementindex
-                || (*it)->Third == majorelementindex)
+        for (const auto* constr : vals) {
+            if (constr->Second == majorelementindex || constr->First == majorelementindex
+                || constr->Third == majorelementindex)
                 majorconstraints++;
-            else if ((*it)->Second == focus1elementindex || (*it)->First == focus1elementindex
-                     || (*it)->Third == focus1elementindex)
+            else if (constr->Second == focus1elementindex || constr->First == focus1elementindex
+                     || constr->Third == focus1elementindex)
                 focus1constraints++;
         }
 
         std::vector<int> delgeometries;
 
         // major has minimum one constraint, the specific internal alignment constraint
-        if (majorelementindex != -1 && majorconstraints < 2)
+        if (majorelementindex != -1 && majorconstraints < 2) {
             delgeometries.push_back(majorelementindex);
+        }
 
         // focus has minimum one constraint now, the specific internal alignment constraint
-        if (focus1elementindex != -1 && focus1constraints < 2)
+        if (focus1elementindex != -1 && focus1constraints < 2) {
             delgeometries.push_back(focus1elementindex);
+        }
 
-        if (delgeoid)
+        if (delgeoid) {
             delgeometries.push_back(GeoId);
+        }
 
         // indices over an erased element get automatically updated!!
         std::sort(delgeometries.begin(), delgeometries.end());
@@ -6304,7 +6292,7 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
     }
     else if (geo->is<Part::GeomBSplineCurve>()) {
 
-        const Part::GeomBSplineCurve* bsp = static_cast<const Part::GeomBSplineCurve*>(geo);
+        auto* bsp = static_cast<const Part::GeomBSplineCurve*>(geo);
 
         // First we search existing IA
         std::vector<int> controlpointgeoids(bsp->countPoles());
@@ -6333,15 +6321,14 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
         const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
         // search for existing poles
-        for (std::vector<Sketcher::Constraint*>::const_iterator jt = vals.begin(); jt != vals.end();
-             ++jt) {
-            if ((*jt)->Type == Sketcher::InternalAlignment && (*jt)->Second == GeoId) {
-                switch ((*jt)->AlignmentType) {
+        for (const auto* constr : vals) {
+            if (constr->Type == Sketcher::InternalAlignment && constr->Second == GeoId) {
+                switch (constr->AlignmentType) {
                     case Sketcher::BSplineControlPoint:
-                        controlpointgeoids[(*jt)->InternalAlignmentIndex] = (*jt)->First;
+                        controlpointgeoids[constr->InternalAlignmentIndex] = constr->First;
                         break;
                     case Sketcher::BSplineKnotPoint:
-                        knotgeoids[(*jt)->InternalAlignmentIndex] = (*jt)->First;
+                        knotgeoids[constr->InternalAlignmentIndex] = constr->First;
                         break;
                     default:
                         return -1;
@@ -6397,11 +6384,9 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
              ++it, ++ita) {
             if ((*it) != -1) {
                 // look for a point at geoid index
-                for (std::vector<Sketcher::Constraint*>::const_iterator itc = vals.begin();
-                     itc != vals.end();
-                     ++itc) {
-                    if ((*itc)->Second == (*it) || (*itc)->First == (*it)
-                        || (*itc)->Third == (*it)) {
+                for (const auto* constr : vals) {
+                    if (constr->Second == (*it) || constr->First == (*it)
+                        || constr->Third == (*it)) {
                         (*ita)++;
                     }
                 }
@@ -6413,8 +6398,9 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
         }
 
 
-        if (delgeoid)
+        if (delgeoid) {
             delgeometries.push_back(GeoId);
+        }
 
         int ndeleted = delGeometriesExclusiveList(delgeometries);
 
@@ -6440,7 +6426,7 @@ bool SketchObject::convertToNURBS(int GeoId)
     if (geo->is<Part::GeomPoint>())
         return false;
 
-    const Part::GeomCurve* geo1 = static_cast<const Part::GeomCurve*>(geo);
+    auto* geo1 = static_cast<const Part::GeomCurve*>(geo);
 
     Part::GeomBSplineCurve* bspline;
 
@@ -6448,7 +6434,7 @@ bool SketchObject::convertToNURBS(int GeoId)
         bspline = geo1->toNurbs(geo1->getFirstParameter(), geo1->getLastParameter());
 
         if (geo1->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())) {
-            const Part::GeomArcOfConic* geoaoc = static_cast<const Part::GeomArcOfConic*>(geo1);
+            auto* geoaoc = static_cast<const Part::GeomArcOfConic*>(geo1);
 
             if (geoaoc->isReversed())
                 bspline->reverse();
@@ -7416,12 +7402,12 @@ Part::Geometry* projectLine(const BRepAdaptor_Curve& curve, const Handle(Geom_Pl
 
     if (Base::DistanceP2(p1, p2) < Precision::SquareConfusion()) {
         Base::Vector3d p = (p1 + p2) / 2;
-        Part::GeomPoint* point = new Part::GeomPoint(p);
+        auto* point = new Part::GeomPoint(p);
         GeometryFacade::setConstruction(point, true);
         return point;
     }
     else {
-        Part::GeomLineSegment* line = new Part::GeomLineSegment();
+        auto* line = new Part::GeomLineSegment();
         line->setPoints(p1, p2);
         GeometryFacade::setConstruction(line, true);
         return line;
@@ -7558,8 +7544,8 @@ void SketchObject::rebuildExternalGeometry()
         if (*it)
             delete *it;
     ExternalGeo.clear();
-    Part::GeomLineSegment* HLine = new Part::GeomLineSegment();
-    Part::GeomLineSegment* VLine = new Part::GeomLineSegment();
+    auto* HLine = new Part::GeomLineSegment();
+    auto* VLine = new Part::GeomLineSegment();
     HLine->setPoints(Base::Vector3d(0, 0, 0), Base::Vector3d(1, 0, 0));
     VLine->setPoints(Base::Vector3d(0, 0, 0), Base::Vector3d(0, 1, 0));
     GeometryFacade::setConstruction(HLine, true);
@@ -7578,7 +7564,7 @@ void SketchObject::rebuildExternalGeometry()
         }
         else if (Obj->isDerivedFrom<Part::Feature>()) {
             try {
-                const Part::Feature* refObj = static_cast<const Part::Feature*>(Obj);
+                auto* refObj = static_cast<const Part::Feature*>(Obj);
                 const Part::TopoShape& refShape = refObj->Shape.getShape();
                 refSubShape = refShape.getSubShape(SubElement.c_str());
             }
@@ -7672,11 +7658,11 @@ void SketchObject::rebuildExternalGeometry()
                     if (vec1.IsNormal(vec2, Precision::Angular())) {
                         if (beg.SquareDistance(end) < Precision::SquareConfusion()) {
                             Base::Vector3d p = (vBeg + vEnd) / 2;
-                            Part::GeomPoint* point = new Part::GeomPoint(p);
+                            auto* point = new Part::GeomPoint(p);
                             ExternalGeo.push_back(point);
                         }
                         else {
-                            Part::GeomLineSegment* line = new Part::GeomLineSegment();
+                            auto* line = new Part::GeomLineSegment();
                             line->setPoints(vBeg, vEnd);
                             GeometryFacade::setConstruction(line, true);
                             ExternalGeo.push_back(line);
@@ -7697,14 +7683,14 @@ void SketchObject::rebuildExternalGeometry()
                         circle.Transform(mov);
 
                         if (curve.IsClosed()) {
-                            Part::GeomCircle* gCircle = new Part::GeomCircle();
+                            auto* gCircle = new Part::GeomCircle();
                             gCircle->setRadius(circle.Radius());
                             gCircle->setCenter(Base::Vector3d(cnt.X(), cnt.Y(), cnt.Z()));
                             GeometryFacade::setConstruction(gCircle, true);
                             ExternalGeo.push_back(gCircle);
                         }
                         else {
-                            Part::GeomArcOfCircle* gArc = new Part::GeomArcOfCircle();
+                            auto* gArc = new Part::GeomArcOfCircle();
                             Handle(Geom_Curve) hCircle = new Geom_Circle(circle);
                             Handle(Geom_TrimmedCurve) tCurve = new Geom_TrimmedCurve(
                                 hCircle, curve.FirstParameter(), curve.LastParameter());
@@ -7726,7 +7712,7 @@ void SketchObject::rebuildExternalGeometry()
                             gp_Dir dirOrientation = gp_Dir(vec1 ^ vec2);
                             gp_Dir dirLine(dirOrientation);
 
-                            Part::GeomLineSegment* projectedSegment = new Part::GeomLineSegment();
+                            auto* projectedSegment = new Part::GeomLineSegment();
                             Geom_Line ligne(cnt, dirLine);// helper object to compute end points
                             gp_Pnt P1, P2;                // end points of the segment, OCC style
 
@@ -7772,13 +7758,13 @@ void SketchObject::rebuildExternalGeometry()
                             Handle(Geom_Ellipse) hEllipse =
                                 new Geom_Ellipse(refFrameEllipse, origCircle.Radius(), minorRadius);
                             if (curve.IsClosed()) {
-                                Part::GeomEllipse* ellipse = new Part::GeomEllipse();
+                                auto* ellipse = new Part::GeomEllipse();
                                 ellipse->setHandle(hEllipse);
                                 GeometryFacade::setConstruction(ellipse, true);
                                 ExternalGeo.push_back(ellipse);
                             }
                             else {
-                                Part::GeomArcOfEllipse* aoe = new Part::GeomArcOfEllipse();
+                                auto* aoe = new Part::GeomArcOfEllipse();
                                 GeomAPI_ProjectPointOnCurve pFirst(beg, hEllipse);
                                 GeomAPI_ProjectPointOnCurve pLast(end, hEllipse);
                                 Handle(Geom_TrimmedCurve) tCurve =
@@ -7858,12 +7844,12 @@ void SketchObject::rebuildExternalGeometry()
                             destCurveAx2, 0.5 * (rDest + RDest));
 
                         if (curve.IsClosed()) {
-                            Part::GeomCircle* circle = new Part::GeomCircle(hCircle);
+                            auto* circle = new Part::GeomCircle(hCircle);
                             GeometryFacade::setConstruction(circle, true);
                             ExternalGeo.push_back(circle);
                         }
                         else {
-                            Part::GeomArcOfCircle* arc = new Part::GeomArcOfCircle();
+                            auto* arc = new Part::GeomArcOfCircle();
                             GeomAPI_ProjectPointOnCurve pFirst(beg, hCircle);
                             GeomAPI_ProjectPointOnCurve pLast(end, hCircle);
                             Handle(Geom_TrimmedCurve) tCurve =
@@ -7880,7 +7866,7 @@ void SketchObject::rebuildExternalGeometry()
                         gp_Vec start = gp_Vec(destCenter.XYZ()) + destAxisMajor;
                         gp_Vec end = gp_Vec(destCenter.XYZ()) - destAxisMajor;
 
-                        Part::GeomLineSegment* projectedSegment = new Part::GeomLineSegment();
+                        auto* projectedSegment = new Part::GeomLineSegment();
                         projectedSegment->setPoints(
                             Base::Vector3d(start.X(), start.Y(), start.Z()),
                             Base::Vector3d(end.X(), end.Y(), end.Z()));
@@ -7892,13 +7878,13 @@ void SketchObject::rebuildExternalGeometry()
                             destCurveAx2, destAxisMajor.Magnitude(), destAxisMinor.Magnitude());
 
                         if (curve.IsClosed()) {
-                            Part::GeomEllipse* ellipse = new Part::GeomEllipse();
+                            auto* ellipse = new Part::GeomEllipse();
                             ellipse->setHandle(hEllipse);
                             GeometryFacade::setConstruction(ellipse, true);
                             ExternalGeo.push_back(ellipse);
                         }
                         else {
-                            Part::GeomArcOfEllipse* aoe = new Part::GeomArcOfEllipse();
+                            auto* aoe = new Part::GeomArcOfEllipse();
                             GeomAPI_ProjectPointOnCurve pFirst(beg, hEllipse);
                             GeomAPI_ProjectPointOnCurve pLast(end, hEllipse);
                             Handle(Geom_TrimmedCurve) tCurve =
@@ -7932,12 +7918,12 @@ void SketchObject::rebuildExternalGeometry()
 
                                     if (P1.SquareDistance(P2) < Precision::SquareConfusion()) {
                                         Base::Vector3d p = (p1 + p2) / 2;
-                                        Part::GeomPoint* point = new Part::GeomPoint(p);
+                                        auto* point = new Part::GeomPoint(p);
                                         GeometryFacade::setConstruction(point, true);
                                         ExternalGeo.push_back(point);
                                     }
                                     else {
-                                        Part::GeomLineSegment* line = new Part::GeomLineSegment();
+                                        auto* line = new Part::GeomLineSegment();
                                         line->setPoints(p1, p2);
                                         GeometryFacade::setConstruction(line, true);
                                         ExternalGeo.push_back(line);
@@ -7950,7 +7936,7 @@ void SketchObject::rebuildExternalGeometry()
                                     gp_Pnt P2 = projCurve.Value(projCurve.LastParameter());
 
                                     if (P1.SquareDistance(P2) < Precision::SquareConfusion()) {
-                                        Part::GeomCircle* circle = new Part::GeomCircle();
+                                        auto* circle = new Part::GeomCircle();
                                         circle->setRadius(c.Radius());
                                         circle->setCenter(Base::Vector3d(p.X(), p.Y(), p.Z()));
 
@@ -7958,7 +7944,7 @@ void SketchObject::rebuildExternalGeometry()
                                         ExternalGeo.push_back(circle);
                                     }
                                     else {
-                                        Part::GeomArcOfCircle* arc = new Part::GeomArcOfCircle();
+                                        auto* arc = new Part::GeomArcOfCircle();
                                         Handle(Geom_Curve) curve = new Geom_Circle(c);
                                         Handle(Geom_TrimmedCurve) tCurve =
                                             new Geom_TrimmedCurve(curve,
@@ -7970,8 +7956,7 @@ void SketchObject::rebuildExternalGeometry()
                                     }
                                 }
                                 else if (projCurve.GetType() == GeomAbs_BSplineCurve) {
-                                    Part::GeomBSplineCurve* bspline =
-                                        new Part::GeomBSplineCurve(projCurve.BSpline());
+                                    auto* bspline = new Part::GeomBSplineCurve(projCurve.BSpline());
                                     GeometryFacade::setConstruction(bspline, true);
                                     ExternalGeo.push_back(bspline);
                                 }
@@ -7986,7 +7971,7 @@ void SketchObject::rebuildExternalGeometry()
                                     gp_Ax2 xdirref(p, normal);
 
                                     if (P1.SquareDistance(P2) < Precision::SquareConfusion()) {
-                                        Part::GeomHyperbola* hyperbola = new Part::GeomHyperbola();
+                                        auto* hyperbola = new Part::GeomHyperbola();
                                         hyperbola->setMajorRadius(e.MajorRadius());
                                         hyperbola->setMinorRadius(e.MinorRadius());
                                         hyperbola->setCenter(Base::Vector3d(p.X(), p.Y(), p.Z()));
@@ -8019,7 +8004,7 @@ void SketchObject::rebuildExternalGeometry()
                                     gp_Ax2 xdirref(p, normal);
 
                                     if (P1.SquareDistance(P2) < Precision::SquareConfusion()) {
-                                        Part::GeomParabola* parabola = new Part::GeomParabola();
+                                        auto* parabola = new Part::GeomParabola();
                                         parabola->setFocal(e.Focal());
                                         parabola->setCenter(Base::Vector3d(p.X(), p.Y(), p.Z()));
                                         parabola->setAngleXU(
@@ -8028,8 +8013,7 @@ void SketchObject::rebuildExternalGeometry()
                                         ExternalGeo.push_back(parabola);
                                     }
                                     else {
-                                        Part::GeomArcOfParabola* aop =
-                                            new Part::GeomArcOfParabola();
+                                        auto* aop = new Part::GeomArcOfParabola();
                                         Handle(Geom_Curve) curve = new Geom_Parabola(e);
                                         Handle(Geom_TrimmedCurve) tCurve =
                                             new Geom_TrimmedCurve(curve,
@@ -8050,14 +8034,14 @@ void SketchObject::rebuildExternalGeometry()
                                     gp_Ax2 xdirref(p, normal);
 
                                     if (P1.SquareDistance(P2) < Precision::SquareConfusion()) {
-                                        Part::GeomEllipse* ellipse = new Part::GeomEllipse();
+                                        auto* ellipse = new Part::GeomEllipse();
                                         Handle(Geom_Ellipse) curve = new Geom_Ellipse(e);
                                         ellipse->setHandle(curve);
                                         GeometryFacade::setConstruction(ellipse, true);
                                         ExternalGeo.push_back(ellipse);
                                     }
                                     else {
-                                        Part::GeomArcOfEllipse* aoe = new Part::GeomArcOfEllipse();
+                                        auto* aoe = new Part::GeomArcOfEllipse();
                                         Handle(Geom_Curve) curve = new Geom_Ellipse(e);
                                         Handle(Geom_TrimmedCurve) tCurve =
                                             new Geom_TrimmedCurve(curve,
@@ -8087,7 +8071,7 @@ void SketchObject::rebuildExternalGeometry()
                 Base::Vector3d p(P.X(), P.Y(), P.Z());
                 invPlm.multVec(p, p);
 
-                Part::GeomPoint* point = new Part::GeomPoint(p);
+                auto* point = new Part::GeomPoint(p);
                 GeometryFacade::setConstruction(point, true);
                 ExternalGeo.push_back(point);
             } break;


### PR DESCRIPTION
While going to fix a build error of GeomAPI_ProjectPointOnCurve (see other PR), I couldn't help myself and modernized some stuff  in SketchObject.cpp : 
- for loops
- some auto
- add some {} to ifs.