### PR TITLE
Sketcher: Fix build failure due to missing header

### DIFF
--- a/src/Mod/Sketcher/App/PreCompiled.h
+++ b/src/Mod/Sketcher/App/PreCompiled.h
@@ -57,6 +57,7 @@
 #include <BRep_Builder.hxx>
 #include <BRep_Tool.hxx>
 #include <GC_MakeCircle.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
 #include <GeomAPI_ProjectPointOnSurf.hxx>
 #include <GeomConvert_BSplineCurveKnotSplitting.hxx>
 #include <Geom_BSplineCurve.hxx>


### PR DESCRIPTION
Main is not building anymore on windows with precompiled.

Add missing GeomAPI_ProjectPointOnCurvee header in precompiled.h

@wwmayer @chennes whoever come first please get this in to fix the build.