### PR TITLE
BIM: ArchComponent Only counts planar surfaces as vertical areas

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -1015,7 +1015,9 @@ class Component(ArchIFC.IfcProduct):
                 obj.PerimeterLength = 0
                 return
             else:
-                if (ang > 1.57) and (ang < 1.571):
+                if  ((ang > 1.57) and
+                    (ang < 1.571) and
+                    f.Surface.isPlanar()):
                     a += f.Area
                 else:
                     fset.append(f)


### PR DESCRIPTION
This is the easiest solution to #14687 I could come up with.