### PR TITLE
Import: Avoid modal dialog inside ImportGui.open()

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -601,8 +601,16 @@ void Application::open(const char* FileName, const char* Module)
                 // issue module loading
                 Command::doCommand(Command::App, "import %s", Module);
 
-                // load the file with the module
-                Command::doCommand(Command::App, "%s.open(u\"%s\")", Module, unicodepath.c_str());
+                // check for additional import options
+                std::stringstream str;
+                str << "if hasattr(" << Module << ", \"importOptions\"):\n"
+                    << "    options = " << Module << ".importOptions(u\"" << unicodepath << "\")\n"
+                    << "    " << Module << ".open(u\"" << unicodepath << "\", options = options)\n"
+                    << "else:\n"
+                    << "    " << Module << ".open(u\"" << unicodepath << "\")\n";
+
+                std::string code = str.str();
+                Gui::Command::runCommand(Gui::Command::App, code.c_str());
 
                 // ViewFit
                 if (sendHasMsgToActiveView("ViewFit")) {
@@ -663,14 +671,25 @@ void Application::importFrom(const char* FileName, const char* DocName, const ch
                         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Import"));
                 }
 
+                // check for additional import options
+                std::stringstream str;
                 if (DocName) {
-                    Command::doCommand(Command::App, "%s.insert(u\"%s\",\"%s\")"
-                                                   , Module, unicodepath.c_str(), DocName);
+                    str << "if hasattr(" << Module << ", \"importOptions\"):\n"
+                        << "    options = " << Module << ".importOptions(u\"" << unicodepath << "\")\n"
+                        << "    " << Module << ".insert(u\"" << unicodepath << "\", \"" << DocName << "\", options = options)\n"
+                        << "else:\n"
+                        << "    " << Module << ".insert(u\"" << unicodepath << "\", \"" << DocName << "\")\n";
                 }
                 else {
-                    Command::doCommand(Command::App, "%s.insert(u\"%s\")"
-                                                   , Module, unicodepath.c_str());
+                    str << "if hasattr(" << Module << ", \"importOptions\"):\n"
+                        << "    options = " << Module << ".importOptions(u\"" << unicodepath << "\")\n"
+                        << "    " << Module << ".insert(u\"" << unicodepath << "\", options = options)\n"
+                        << "else:\n"
+                        << "    " << Module << ".insert(u\"" << unicodepath << "\")\n";
                 }
+
+                std::string code = str.str();
+                Gui::Command::runCommand(Gui::Command::App, code.c_str());
 
                 // Commit the transaction
                 if (doc && !pendingCommand) {

--- a/src/Mod/Fem/Gui/TaskCreateElementSet.cpp
+++ b/src/Mod/Fem/Gui/TaskCreateElementSet.cpp
@@ -33,7 +33,6 @@
 #include <QMessageBox>
 #include <SMESH_Mesh.hxx>
 #include <SMESHDS_Mesh.hxx>
-#include <Standard_math.hxx>
 #include <SMESH_MeshEditor.hxx>
 #endif
 

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -157,16 +157,9 @@ private:
             hApp->NewDocument(TCollection_ExtendedString("MDTV-CAF"), hDoc);
 
             if (file.hasExtension({"stp", "step"})) {
-#if OCC_VERSION_HEX >= 0x070800
-                Resource_FormatType cp = Resource_FormatType_UTF8;
-#endif
                 try {
                     Import::ReaderStep reader(file);
-#if OCC_VERSION_HEX < 0x070800
                     reader.read(hDoc);
-#else
-                    reader.read(hDoc, cp);
-#endif
                 }
                 catch (OSD_Exception& e) {
                     Base::Console().Error("%s\n", e.GetMessageString());

--- a/src/Mod/Import/App/ReaderStep.cpp
+++ b/src/Mod/Import/App/ReaderStep.cpp
@@ -40,13 +40,13 @@ using namespace Import;
 
 ReaderStep::ReaderStep(const Base::FileInfo& file)  // NOLINT
     : file {file}
-{}
-
-#if OCC_VERSION_HEX < 0x070800
-void ReaderStep::read(Handle(TDocStd_Document) hDoc)  // NOLINT
-#else
-void ReaderStep::read(Handle(TDocStd_Document) hDoc, Resource_FormatType codePage)  // NOLINT
+{
+#if OCC_VERSION_HEX >= 0x070800
+    codePage = Resource_FormatType_UTF8;
 #endif
+}
+
+void ReaderStep::read(Handle(TDocStd_Document) hDoc)  // NOLINT
 {
     std::string utf8Name = file.filePath();
     std::string name8bit = Part::encodeFilename(utf8Name);

--- a/src/Mod/Import/App/ReaderStep.h
+++ b/src/Mod/Import/App/ReaderStep.h
@@ -26,6 +26,7 @@
 
 #include <Mod/Import/ImportGlobal.h>
 #include <Base/FileInfo.h>
+#include <Resource_FormatType.hxx>
 #include <TDocStd_Document.hxx>
 #include <StepData_StepModel.hxx>
 #include <Standard_Version.hxx>
@@ -37,14 +38,15 @@ class ImportExport ReaderStep
 {
 public:
     explicit ReaderStep(const Base::FileInfo& file);
-#if OCC_VERSION_HEX < 0x070800
+    void setCodePage(Resource_FormatType cp)
+    {
+        codePage = cp;
+    }
     void read(Handle(TDocStd_Document) hDoc);
-#else
-    void read(Handle(TDocStd_Document) hDoc, Resource_FormatType codePage);
-#endif
 
 private:
     Base::FileInfo file;
+    Resource_FormatType codePage {};
 };
 
 }  // namespace Import

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -74,6 +74,7 @@
 #include <Mod/Part/App/ProgressIndicator.h>
 #include <Mod/Part/App/encodeFilename.h>
 #include <Mod/Part/Gui/DlgExportStep.h>
+#include <Mod/Part/Gui/DlgImportStep.h>
 #include <Mod/Part/Gui/ViewProvider.h>
 
 
@@ -98,6 +99,9 @@ public:
                            &Module::readDXF,
                            "readDXF(filename,[document,ignore_errors,option_source]): Imports a "
                            "DXF file into the given document. ignore_errors is True by default.");
+        add_varargs_method("importOptions",
+                           &Module::importOptions,
+                           "importOptions(string) -- Return the import options of a file type.");
         add_varargs_method("exportOptions",
                            &Module::exportOptions,
                            "exportOptions(string) -- Return the export options of a file type.");
@@ -109,23 +113,63 @@ public:
     }
 
 private:
+    Py::Object importOptions(const Py::Tuple& args)
+    {
+        char* Name {};
+        if (!PyArg_ParseTuple(args.ptr(), "et", "utf-8", &Name)) {
+            throw Py::Exception();
+        }
+
+        std::string Utf8Name = std::string(Name);
+        PyMem_Free(Name);
+        std::string name8bit = Part::encodeFilename(Utf8Name);
+
+        Py::Dict options;
+        Base::FileInfo file(name8bit.c_str());
+        if (file.hasExtension({"stp", "step"})) {
+            PartGui::TaskImportStep dlg(Gui::getMainWindow());
+            if (!dlg.showDialog() || dlg.exec()) {
+                auto stepSettings = dlg.getSettings();
+                options.setItem("merge", Py::Boolean(stepSettings.merge));
+                options.setItem("useLinkGroup", Py::Boolean(stepSettings.useLinkGroup));
+                options.setItem("useBaseName", Py::Boolean(stepSettings.useBaseName));
+                options.setItem("importHidden", Py::Boolean(stepSettings.importHidden));
+                options.setItem("reduceObjects", Py::Boolean(stepSettings.reduceObjects));
+                options.setItem("showProgress", Py::Boolean(stepSettings.showProgress));
+                options.setItem("expandCompound", Py::Boolean(stepSettings.expandCompound));
+                options.setItem("mode", Py::Long(stepSettings.mode));
+                options.setItem("codePage", Py::Long(stepSettings.codePage));
+            }
+        }
+        return options;
+    }
+
     Py::Object insert(const Py::Tuple& args, const Py::Dict& kwds)
     {
         char* Name;
         char* DocName = nullptr;
+        PyObject* pyoptions = nullptr;
         PyObject* importHidden = Py_None;
         PyObject* merge = Py_None;
         PyObject* useLinkGroup = Py_None;
         int mode = -1;
-        static const std::array<const char*, 7>
-            kwd_list {"name", "docName", "importHidden", "merge", "useLinkGroup", "mode", nullptr};
+        static const std::array<const char*, 8> kwd_list {"name",
+                                                          "docName",
+                                                          "options",
+                                                          "importHidden",
+                                                          "merge",
+                                                          "useLinkGroup",
+                                                          "mode",
+                                                          nullptr};
         if (!Base::Wrapped_ParseTupleAndKeywords(args.ptr(),
                                                  kwds.ptr(),
-                                                 "et|sO!O!O!i",
+                                                 "et|sO!O!O!O!i",
                                                  kwd_list,
                                                  "utf-8",
                                                  &Name,
                                                  &DocName,
+                                                 &PyDict_Type,
+                                                 &pyoptions,
                                                  &PyBool_Type,
                                                  &importHidden,
                                                  &PyBool_Type,
@@ -138,7 +182,6 @@ private:
 
         std::string Utf8Name = std::string(Name);
         PyMem_Free(Name);
-        std::string name8bit = Part::encodeFilename(Utf8Name);
 
         try {
             Base::FileInfo file(Utf8Name.c_str());
@@ -165,15 +208,52 @@ private:
                     mode = ocaf.getMode();
                 }
 #if OCC_VERSION_HEX >= 0x070800
-                auto handle = App::GetApplication().GetParameterGroupByPath(
-                    "User parameter:BaseApp/Preferences/Mod/Import/hSTEP");
-                if (handle->GetBool("ReadShowDialogImport", false)) {
-                    Gui::Command::doCommand(Gui::Command::Gui,
-                                            "Gui.showPreferences('Import-Export', 8)");
-                }
-                Part::OCAF::ImportExportSettings settings;
-                Resource_FormatType cp = settings.getImportCodePage();
+                Resource_FormatType cp = Resource_FormatType_UTF8;
 #endif
+
+                // new way
+                if (pyoptions) {
+                    Py::Dict options(pyoptions);
+                    if (options.hasKey("merge")) {
+                        ocaf.setMerge(static_cast<bool>(Py::Boolean(options.getItem("merge"))));
+                    }
+                    if (options.hasKey("useLinkGroup")) {
+                        ocaf.setUseLinkGroup(
+                            static_cast<bool>(Py::Boolean(options.getItem("useLinkGroup"))));
+                    }
+                    if (options.hasKey("useBaseName")) {
+                        ocaf.setBaseName(
+                            static_cast<bool>(Py::Boolean(options.getItem("useBaseName"))));
+                    }
+                    if (options.hasKey("importHidden")) {
+                        ocaf.setImportHiddenObject(
+                            static_cast<bool>(Py::Boolean(options.getItem("importHidden"))));
+                    }
+                    if (options.hasKey("reduceObjects")) {
+                        ocaf.setReduceObjects(
+                            static_cast<bool>(Py::Boolean(options.getItem("reduceObjects"))));
+                    }
+                    if (options.hasKey("showProgress")) {
+                        ocaf.setShowProgress(
+                            static_cast<bool>(Py::Boolean(options.getItem("showProgress"))));
+                    }
+                    if (options.hasKey("expandCompound")) {
+                        ocaf.setExpandCompound(
+                            static_cast<bool>(Py::Boolean(options.getItem("expandCompound"))));
+                    }
+                    if (options.hasKey("mode")) {
+                        ocaf.setMode(static_cast<int>(Py::Long(options.getItem("mode"))));
+                    }
+                    if (options.hasKey("codePage")) {
+#if OCC_VERSION_HEX >= 0x070800
+                        int codePage = static_cast<int>(Py::Long(options.getItem("codePage")));
+                        if (codePage >= 0) {
+                            cp = static_cast<Resource_FormatType>(codePage);
+                        }
+#endif
+                    }
+                }
+
                 if (mode && !pcDoc->isSaved()) {
                     auto gdoc = Gui::Application::Instance->getDocument(pcDoc);
                     if (!gdoc->save()) {

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -244,14 +244,14 @@ private:
                     if (options.hasKey("mode")) {
                         ocaf.setMode(static_cast<int>(Py::Long(options.getItem("mode"))));
                     }
-                    if (options.hasKey("codePage")) {
 #if OCC_VERSION_HEX >= 0x070800
+                    if (options.hasKey("codePage")) {
                         int codePage = static_cast<int>(Py::Long(options.getItem("codePage")));
                         if (codePage >= 0) {
                             cp = static_cast<Resource_FormatType>(codePage);
                         }
-#endif
                     }
+#endif
                 }
 
                 if (mode && !pcDoc->isSaved()) {
@@ -263,11 +263,10 @@ private:
 
                 try {
                     Import::ReaderStep reader(file);
-#if OCC_VERSION_HEX < 0x070800
-                    reader.read(hDoc);
-#else
-                    reader.read(hDoc, cp);
+#if OCC_VERSION_HEX >= 0x070800
+                    reader.setCodePage(cp);
 #endif
+                    reader.read(hDoc);
                 }
                 catch (OSD_Exception& e) {
                     Base::Console().Error("%s\n", e.GetMessageString());
@@ -577,11 +576,7 @@ private:
 
             if (file.hasExtension({"stp", "step"})) {
                 Import::ReaderStep reader(file);
-#if OCC_VERSION_HEX < 0x070800
                 reader.read(hDoc);
-#else
-                reader.read(hDoc, Resource_FormatType_UTF8);
-#endif
             }
             else if (file.hasExtension({"igs", "iges"})) {
                 Import::ReaderIges reader(file);

--- a/src/Mod/Part/App/OCAF/ImportExportSettings.cpp
+++ b/src/Mod/Part/App/OCAF/ImportExportSettings.cpp
@@ -99,8 +99,6 @@ void ImportExportSettings::initIGES(Base::Reference<ParameterGrp> hGrp)
     }
 }
 
-#if OCC_VERSION_HEX >= 0x070800
-
 void ImportExportSettings::setImportCodePage(int cpIndex)
 {
     pGroup->SetInt("ImportCodePage", cpIndex);
@@ -108,12 +106,11 @@ void ImportExportSettings::setImportCodePage(int cpIndex)
 
 Resource_FormatType ImportExportSettings::getImportCodePage() const
 {
-    Resource_FormatType result;
-    int codePageIndex = pGroup->GetInt("ImportCodePage", 0);
-    int i=0;
+    Resource_FormatType result {};
+    long codePageIndex = pGroup->GetInt("ImportCodePage", 0L);
+    long i = 0L;
     for (const auto& codePageIt : codePageList) {
-        if (i == codePageIndex)
-        {
+        if (i == codePageIndex) {
             result = codePageIt.codePage;
             break;
         }
@@ -126,8 +123,6 @@ std::list<ImportExportSettings::CodePage> ImportExportSettings::getCodePageList(
 {
     return codePageList;
 }
-
-#endif
 
 void ImportExportSettings::initSTEP(Base::Reference<ParameterGrp> hGrp)
 {

--- a/src/Mod/Part/App/OCAF/ImportExportSettings.cpp
+++ b/src/Mod/Part/App/OCAF/ImportExportSettings.cpp
@@ -127,18 +127,6 @@ std::list<ImportExportSettings::CodePage> ImportExportSettings::getCodePageList(
     return codePageList;
 }
 
-void ImportExportSettings::setReadShowDialogImport(bool on)
-{
-    auto grp = pGroup->GetGroup("hSTEP");
-    grp->SetBool("ReadShowDialogImport", on);
-}
-
-bool ImportExportSettings::getReadShowDialogImport() const
-{
-    auto grp = pGroup->GetGroup("hSTEP");
-    return grp->GetBool("ReadShowDialogImport", false);
-}
-
 #endif
 
 void ImportExportSettings::initSTEP(Base::Reference<ParameterGrp> hGrp)

--- a/src/Mod/Part/App/OCAF/ImportExportSettings.h
+++ b/src/Mod/Part/App/OCAF/ImportExportSettings.h
@@ -27,9 +27,7 @@
 #include <Mod/Part/App/Interface.h>
 #include <Base/Parameter.h>
 #include <Standard_Version.hxx>
-#if OCC_VERSION_HEX >= 0x070800
 #include <Resource_FormatType.hxx>
-#endif
 
 namespace Part
 {
@@ -57,12 +55,10 @@ public:
         ObjectPerDocument = 3,
         ObjectPerDirectory = 4,
     };
-#if OCC_VERSION_HEX >= 0x070800
     struct CodePage {
         std::string codePageName;
         Resource_FormatType codePage;
     };
-#endif
     static void initialize();
     ImportExportSettings();
 
@@ -102,11 +98,10 @@ public:
     void setImportMode(ImportMode);
     ImportMode getImportMode() const;
 
-#if OCC_VERSION_HEX >= 0x070800
     void setImportCodePage(int);
     Resource_FormatType getImportCodePage() const;
     std::list<ImportExportSettings::CodePage> getCodePageList() const;
-#endif
+
 private:
     static void initGeneral(Base::Reference<ParameterGrp> hGrp);
     static void initSTEP(Base::Reference<ParameterGrp> hGrp);
@@ -116,37 +111,39 @@ private:
     mutable STEP::ImportExportSettingsPtr step;
     mutable IGES::ImportExportSettingsPtr iges;
     ParameterGrp::handle pGroup;
-#if OCC_VERSION_HEX >= 0x070800
+    // clang-format off
     std::list<CodePage> codePageList {
-                                      {"No conversion", Resource_FormatType_NoConversion},
-                                      {"Multi-byte UTF-8 encoding", Resource_FormatType_UTF8},
-                                      {"SJIS (Shift Japanese Industrial Standards) encoding", Resource_FormatType_SJIS},
-                                      {"EUC (Extended Unix Code) ", Resource_FormatType_EUC},
-                                      {"GB (Guobiao) encoding for Simplified Chinese", Resource_FormatType_GB},
-                                      {"GBK (Unified Chinese) encoding", Resource_FormatType_GBK},
-                                      {"Big5 (Traditional Chinese) encoding", Resource_FormatType_Big5},
-                                      //{"active system-defined locale; this value is strongly NOT recommended to use", Resource_FormatType_SystemLocale},
-                                      {"ISO 8859-1 (Western European) encoding", Resource_FormatType_iso8859_1},
-                                      {"ISO 8859-2 (Central European) encoding", Resource_FormatType_iso8859_2},
-                                      {"ISO 8859-3 (Turkish) encoding", Resource_FormatType_iso8859_3},
-                                      {"ISO 8859-4 (Northern European) encoding", Resource_FormatType_iso8859_4},
-                                      {"ISO 8859-5 (Cyrillic) encoding", Resource_FormatType_iso8859_5},
-                                      {"ISO 8859-6 (Arabic) encoding", Resource_FormatType_iso8859_6},
-                                      {"ISO 8859-7 (Greek) encoding", Resource_FormatType_iso8859_7},
-                                      {"ISO 8859-8 (Hebrew) encoding", Resource_FormatType_iso8859_8},
-                                      {"ISO 8859-9 (Turkish) encoding", Resource_FormatType_iso8859_9},
-                                      {"ISO 850 (Western European) encoding", Resource_FormatType_CP850},
-                                      {"CP1250 (Central European) encoding", Resource_FormatType_CP1250},
-                                      {"CP1251 (Cyrillic) encoding", Resource_FormatType_CP1251},
-                                      {"CP1252 (Western European) encoding", Resource_FormatType_CP1252},
-                                      {"CP1253 (Greek) encoding", Resource_FormatType_CP1253},
-                                      {"CP1254 (Turkish) encoding", Resource_FormatType_CP1254},
-                                      {"CP1255 (Hebrew) encoding", Resource_FormatType_CP1255},
-                                      {"CP1256 (Arabic) encoding", Resource_FormatType_CP1256},
-                                      {"CP1257 (Baltic) encoding", Resource_FormatType_CP1257},
-                                      {"CP1258 (Vietnamese) encoding", Resource_FormatType_CP1258},
-                                      };
+#if OCC_VERSION_HEX >= 0x070800
+        {"No conversion", Resource_FormatType_NoConversion},
+        {"Multi-byte UTF-8 encoding", Resource_FormatType_UTF8},
+        {"SJIS (Shift Japanese Industrial Standards) encoding", Resource_FormatType_SJIS},
+        {"EUC (Extended Unix Code) ", Resource_FormatType_EUC},
+        {"GB (Guobiao) encoding for Simplified Chinese", Resource_FormatType_GB},
+        {"GBK (Unified Chinese) encoding", Resource_FormatType_GBK},
+        {"Big5 (Traditional Chinese) encoding", Resource_FormatType_Big5},
+        //{"active system-defined locale; this value is strongly NOT recommended to use", Resource_FormatType_SystemLocale},
+        {"ISO 8859-1 (Western European) encoding", Resource_FormatType_iso8859_1},
+        {"ISO 8859-2 (Central European) encoding", Resource_FormatType_iso8859_2},
+        {"ISO 8859-3 (Turkish) encoding", Resource_FormatType_iso8859_3},
+        {"ISO 8859-4 (Northern European) encoding", Resource_FormatType_iso8859_4},
+        {"ISO 8859-5 (Cyrillic) encoding", Resource_FormatType_iso8859_5},
+        {"ISO 8859-6 (Arabic) encoding", Resource_FormatType_iso8859_6},
+        {"ISO 8859-7 (Greek) encoding", Resource_FormatType_iso8859_7},
+        {"ISO 8859-8 (Hebrew) encoding", Resource_FormatType_iso8859_8},
+        {"ISO 8859-9 (Turkish) encoding", Resource_FormatType_iso8859_9},
+        {"ISO 850 (Western European) encoding", Resource_FormatType_CP850},
+        {"CP1250 (Central European) encoding", Resource_FormatType_CP1250},
+        {"CP1251 (Cyrillic) encoding", Resource_FormatType_CP1251},
+        {"CP1252 (Western European) encoding", Resource_FormatType_CP1252},
+        {"CP1253 (Greek) encoding", Resource_FormatType_CP1253},
+        {"CP1254 (Turkish) encoding", Resource_FormatType_CP1254},
+        {"CP1255 (Hebrew) encoding", Resource_FormatType_CP1255},
+        {"CP1256 (Arabic) encoding", Resource_FormatType_CP1256},
+        {"CP1257 (Baltic) encoding", Resource_FormatType_CP1257},
+        {"CP1258 (Vietnamese) encoding", Resource_FormatType_CP1258},
 #endif
+    };
+    // clang-format on
 };
 
 } //namespace OCAF

--- a/src/Mod/Part/App/OCAF/ImportExportSettings.h
+++ b/src/Mod/Part/App/OCAF/ImportExportSettings.h
@@ -103,9 +103,6 @@ public:
     ImportMode getImportMode() const;
 
 #if OCC_VERSION_HEX >= 0x070800
-    void setReadShowDialogImport(bool);
-    bool getReadShowDialogImport() const;
-
     void setImportCodePage(int);
     Resource_FormatType getImportCodePage() const;
     std::list<ImportExportSettings::CodePage> getCodePageList() const;

--- a/src/Mod/Part/App/STEP/ImportExportSettings.cpp
+++ b/src/Mod/Part/App/STEP/ImportExportSettings.cpp
@@ -47,6 +47,15 @@ bool ImportExportSettings::isVisibleExportDialog() const
     return pGroup->GetBool("VisibleExportDialog", true);
 }
 
+void ImportExportSettings::setVisibleImportDialog(bool on)
+{
+    pGroup->SetBool("VisibleImportDialog", on);
+}
+
+bool ImportExportSettings::isVisibleImportDialog() const
+{
+    return pGroup->GetBool("VisibleImportDialog", true);
+}
 
 void ImportExportSettings::setWriteSurfaceCurveMode(bool on)
 {

--- a/src/Mod/Part/App/STEP/ImportExportSettings.h
+++ b/src/Mod/Part/App/STEP/ImportExportSettings.h
@@ -40,6 +40,9 @@ public:
     void setVisibleExportDialog(bool);
     bool isVisibleExportDialog() const;
 
+    void setVisibleImportDialog(bool);
+    bool isVisibleImportDialog() const;
+
     void setWriteSurfaceCurveMode(bool);
     bool getWriteSurfaceCurveMode() const;
 

--- a/src/Mod/Part/Gui/DlgImportStep.cpp
+++ b/src/Mod/Part/Gui/DlgImportStep.cpp
@@ -22,6 +22,10 @@
 
 #include "PreCompiled.h"
 
+#ifndef _PreComp_
+# include <QDialogButtonBox>
+#endif
+
 #include <Mod/Part/App/OCAF/ImportExportSettings.h>
 #include <Mod/Part/App/STEP/ImportExportSettings.h>
 
@@ -45,7 +49,6 @@ DlgImportStep::DlgImportStep(QWidget* parent)
     ui->checkBoxExpandCompound->setChecked(settings.getExpandCompound());
     ui->checkBoxShowProgress->setChecked(settings.getShowProgress());
 #if OCC_VERSION_HEX >= 0x070800
-    ui->checkBoxShowOnImport->setChecked(settings.getReadShowDialogImport());
     std::list<Part::OCAF::ImportExportSettings::CodePage> codepagelist;
     codepagelist = settings.getCodePageList();
     for (const auto& codePage : codepagelist) {
@@ -54,10 +57,8 @@ DlgImportStep::DlgImportStep(QWidget* parent)
 #else
     // hide options that not supported in this OCCT version (7.8.0)
     ui->label_6->hide();
-    ui->checkBoxShowOnImport->hide();
     ui->comboBoxImportCodePage->hide();
 #endif
-
 }
 
 /**
@@ -69,7 +70,6 @@ void DlgImportStep::saveSettings()
 {
     // (h)STEP of Import module
 #if OCC_VERSION_HEX >= 0x070800
-    ui->checkBoxShowOnImport->onSave();
     ui->comboBoxImportCodePage->onSave();
 #endif
     ui->checkBoxMergeCompound->onSave();
@@ -86,7 +86,6 @@ void DlgImportStep::loadSettings()
 {
     // (h)STEP of Import module
 #if OCC_VERSION_HEX >= 0x070800
-    ui->checkBoxShowOnImport->onRestore();
     ui->comboBoxImportCodePage->onRestore();
 #endif
     ui->checkBoxMergeCompound->onRestore();
@@ -97,6 +96,25 @@ void DlgImportStep::loadSettings()
     ui->checkBoxExpandCompound->onRestore();
     ui->checkBoxShowProgress->onRestore();
     ui->comboBoxImportMode->onRestore();
+}
+
+StepImportSettings DlgImportStep::getSettings() const
+{
+    StepImportSettings set;
+    Part::OCAF::ImportExportSettings settings;
+    set.merge = settings.getReadShapeCompoundMode();
+    set.useLinkGroup = settings.getUseLinkGroup();
+    set.useBaseName = settings.getUseBaseName();
+    set.importHidden = settings.getImportHiddenObject();
+    set.reduceObjects = settings.getReduceObjects();
+    set.showProgress = settings.getShowProgress();
+    set.expandCompound = settings.getExpandCompound();
+    set.mode = static_cast<int>(settings.getImportMode());
+#if OCC_VERSION_HEX >= 0x070800
+    Resource_FormatType cp = settings.getImportCodePage();
+    set.codePage = static_cast<int>(cp);
+#endif
+    return set;
 }
 
 /**
@@ -110,6 +128,58 @@ void DlgImportStep::changeEvent(QEvent *e)
     else {
         QWidget::changeEvent(e);
     }
+}
+
+// ----------------------------------------------------------------------------
+
+TaskImportStep::TaskImportStep(QWidget* parent)
+  : QDialog(parent)
+  , ui(new DlgImportStep(this))
+{
+    QApplication::setOverrideCursor(Qt::ArrowCursor);
+
+    ui->loadSettings();
+    setWindowTitle(ui->windowTitle());
+
+    QVBoxLayout* layout = new QVBoxLayout(this);
+    layout->addWidget(ui.get());
+    setLayout(layout);
+
+    showThis = new QCheckBox(this);
+    showThis->setText(tr("Don't show this dialog again"));
+    layout->addWidget(showThis);
+
+    QDialogButtonBox* buttonBox = new QDialogButtonBox(this);
+    buttonBox->setStandardButtons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    layout->addWidget(buttonBox);
+
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &TaskImportStep::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &TaskImportStep::reject);
+}
+
+TaskImportStep::~TaskImportStep()
+{
+    QApplication::restoreOverrideCursor();
+}
+
+void TaskImportStep::accept()
+{
+    QDialog::accept();
+    ui->saveSettings();
+
+    Part::STEP::ImportExportSettings settings;
+    settings.setVisibleImportDialog(!showThis->isChecked());
+}
+
+bool TaskImportStep::showDialog() const
+{
+    Part::STEP::ImportExportSettings settings;
+    return settings.isVisibleImportDialog();
+}
+
+StepImportSettings TaskImportStep::getSettings() const
+{
+    return ui->getSettings();
 }
 
 

--- a/src/Mod/Part/Gui/DlgImportStep.h
+++ b/src/Mod/Part/Gui/DlgImportStep.h
@@ -24,12 +24,27 @@
 #ifndef PARTGUI_DLGIMPORTSTEP_H
 #define PARTGUI_DLGIMPORTSTEP_H
 
+#include <Mod/Part/PartGlobal.h>
 #include <Gui/PropertyPage.h>
+#include <QDialog>
 
 class QButtonGroup;
 class QCheckBox;
 
 namespace PartGui {
+
+struct StepImportSettings
+{
+    bool merge = false;
+    bool useLinkGroup = false;
+    bool useBaseName = true;
+    bool importHidden = true;
+    bool reduceObjects = false;
+    bool showProgress = false;
+    bool expandCompound = false;
+    int mode = 0;
+    int codePage = -1;
+};
 
 class Ui_DlgImportStep;
 class DlgImportStep : public Gui::Dialog::PreferencePage
@@ -43,11 +58,32 @@ public:
     void saveSettings() override;
     void loadSettings() override;
 
+    StepImportSettings getSettings() const;
+
 protected:
     void changeEvent(QEvent *e) override;
 
 private:
     std::unique_ptr<Ui_DlgImportStep> ui;
+};
+
+// ----------------------------------------------------------------------------
+
+class PartGuiExport TaskImportStep : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit TaskImportStep(QWidget* parent = nullptr);
+    ~TaskImportStep() override;
+
+    bool showDialog() const;
+    void accept() override;
+    StepImportSettings getSettings() const;
+
+private:
+    QCheckBox* showThis;
+    std::unique_ptr<DlgImportStep> ui;
 };
 
 } // namespace PartGui

--- a/src/Mod/Part/Gui/DlgImportStep.ui
+++ b/src/Mod/Part/Gui/DlgImportStep.ui
@@ -21,22 +21,6 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="Gui::PrefCheckBox" name="checkBoxShowOnImport">
-        <property name="toolTip">
-         <string>If checked, this Dialog will be shown during Import</string>
-        </property>
-        <property name="text">
-         <string>Show this Dialog when importing</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ReadShowDialogImport</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Import/hSTEP</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxMergeCompound">
         <property name="toolTip">
          <string>If checked, no Compound merge will be done


### PR DESCRIPTION
Currently a modal dialog is used directly in ImportGui.open()/ImportGui.insert() that makes it impossible to use the functions in a script because they will be blocked

* Support of import options
* Move options handling to ImportGui.importOptions
* Simplify handling of Resource_FormatType