### PR TITLE
PD: Fix crash in ViewProviderBody::unifyVisualProperty

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -453,8 +453,9 @@ void ViewProviderBody::unifyVisualProperty(const App::Property* prop) {
 
         //copy over the properties data
         if (Gui::ViewProvider* vp = gdoc->getViewProvider(feature)) {
-            auto fprop = vp->getPropertyByName(prop->getName());
-            fprop->Paste(*prop);
+            if (auto fprop = vp->getPropertyByName(prop->getName())) {
+                fprop->Paste(*prop);
+            }
         }
     }
 }


### PR DESCRIPTION
Make sure that the view provider of a body feature provides the requested property