### PR TITLE
Fem: Create own base class for Python objects - fixes #14637

### DIFF
--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -609,6 +609,7 @@ SET(FemGuiViewProvider_SRCS
     femviewprovider/__init__.py
     femviewprovider/view_base_femconstraint.py
     femviewprovider/view_base_femelement.py
+    femviewprovider/view_base_femmaterial.py
     femviewprovider/view_base_femmeshelement.py
     femviewprovider/view_base_femobject.py
     femviewprovider/view_constant_vacuumpermittivity.py

--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -170,6 +170,7 @@ SET(FemMesh_SRCS
 SET(FemObjects_SRCS
     femobjects/__init__.py
     femobjects/base_femelement.py
+    femobjects/base_femmeshelement.py
     femobjects/base_fempythonobject.py
     femobjects/constant_vacuumpermittivity.py
     femobjects/constraint_bodyheatsource.py
@@ -608,6 +609,7 @@ SET(FemGuiViewProvider_SRCS
     femviewprovider/__init__.py
     femviewprovider/view_base_femconstraint.py
     femviewprovider/view_base_femelement.py
+    femviewprovider/view_base_femmeshelement.py
     femviewprovider/view_base_femobject.py
     femviewprovider/view_constant_vacuumpermittivity.py
     femviewprovider/view_constraint_bodyheatsource.py

--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -169,6 +169,7 @@ SET(FemMesh_SRCS
 
 SET(FemObjects_SRCS
     femobjects/__init__.py
+    femobjects/base_femelement.py
     femobjects/base_fempythonobject.py
     femobjects/constant_vacuumpermittivity.py
     femobjects/constraint_bodyheatsource.py
@@ -606,6 +607,7 @@ SET(FemGuiUtils_SRCS
 SET(FemGuiViewProvider_SRCS
     femviewprovider/__init__.py
     femviewprovider/view_base_femconstraint.py
+    femviewprovider/view_base_femelement.py
     femviewprovider/view_base_femobject.py
     femviewprovider/view_constant_vacuumpermittivity.py
     femviewprovider/view_constraint_bodyheatsource.py

--- a/src/Mod/Fem/femobjects/base_femelement.py
+++ b/src/Mod/Fem/femobjects/base_femelement.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+#/***************************************************************************
+# *   Copyright (c) 2024 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# **************************************************************************
+
+__title__ = "FreeCAD FEM base element object"
+__author__ = "Mario Passaglia"
+__url__ = "https://www.freecad.org"
+
+## @package base_femelement
+#  \ingroup FEM
+#  \brief base object for FEM Element Features
+
+
+from . import base_fempythonobject
+
+_PropHelper = base_fempythonobject._PropHelper
+
+class BaseFemElement(base_fempythonobject.BaseFemPythonObject):
+
+    BaseType = "Fem::BaseFemElement"
+
+    def __init__(self, obj):
+        super().__init__(obj)
+
+        for prop in self._get_properties():
+            prop.add_to_object(obj)
+
+
+    def _get_properties(self):
+        prop = []
+
+        prop.append(_PropHelper(
+            type  = "App::PropertyLinkSubList",
+            name  = "References",
+            group = "Element",
+            doc   = "List of element shapes",
+            value = []
+            )
+        )
+
+        return prop

--- a/src/Mod/Fem/femobjects/base_femmeshelement.py
+++ b/src/Mod/Fem/femobjects/base_femmeshelement.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+#/***************************************************************************
+# *   Copyright (c) 2024 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# **************************************************************************
+
+__title__ = "FreeCAD FEM base element object"
+__author__ = "Mario Passaglia"
+__url__ = "https://www.freecad.org"
+
+## @package base_femmeshelement
+#  \ingroup FEM
+#  \brief base object for FEM Mesh Element Features
+
+
+from . import base_fempythonobject
+
+_PropHelper = base_fempythonobject._PropHelper
+
+class BaseFemMeshElement(base_fempythonobject.BaseFemPythonObject):
+
+    BaseType = "Fem::BaseFemMeshElement"
+
+    def __init__(self, obj):
+        super().__init__(obj)
+
+        for prop in self._get_properties():
+            prop.add_to_object(obj)
+
+
+    def _get_properties(self):
+        prop = []
+
+        prop.append(_PropHelper(
+            type  = "App::PropertyLinkSubList",
+            name  = "References",
+            group = "Mesh Element",
+            doc   = "List of reference shapes",
+            value = []
+            )
+        )
+
+        return prop

--- a/src/Mod/Fem/femobjects/element_fluid1D.py
+++ b/src/Mod/Fem/femobjects/element_fluid1D.py
@@ -31,10 +31,10 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief element fluid 1D object
 
-from . import base_fempythonobject
+from . import base_femelement
 
 
-class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
+class ElementFluid1D(base_femelement.BaseFemElement):
     """
     The element_fluid1D object
     """
@@ -62,14 +62,6 @@ class ElementFluid1D(base_fempythonobject.BaseFemPythonObject):
 
     def __init__(self, obj):
         super(ElementFluid1D, self).__init__(obj)
-
-        obj.addProperty(
-            "App::PropertyLinkSubList",
-            "References",
-            "FluidSection",
-            "List of fluid section shapes"
-        )
-        obj.setPropertyStatus("References", "LockDynamic")
 
         obj.addProperty(
             "App::PropertyEnumeration",

--- a/src/Mod/Fem/femobjects/element_geometry1D.py
+++ b/src/Mod/Fem/femobjects/element_geometry1D.py
@@ -29,10 +29,10 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief element geometry 1D object
 
-from . import base_fempythonobject
+from . import base_femelement
 
 
-class ElementGeometry1D(base_fempythonobject.BaseFemPythonObject):
+class ElementGeometry1D(base_femelement.BaseFemElement):
     """
     The ElementGeometry1D object
     """
@@ -91,12 +91,5 @@ class ElementGeometry1D(base_fempythonobject.BaseFemPythonObject):
         )
         obj.setPropertyStatus("SectionType", "LockDynamic")
 
-        obj.addProperty(
-            "App::PropertyLinkSubList",
-            "References",
-            "BeamSection",
-            "List of beam section shapes"
-        )
-        obj.setPropertyStatus("References", "LockDynamic")
         obj.SectionType = ElementGeometry1D.known_beam_types
         obj.SectionType = "Rectangular"

--- a/src/Mod/Fem/femobjects/element_geometry2D.py
+++ b/src/Mod/Fem/femobjects/element_geometry2D.py
@@ -29,10 +29,10 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief element geometry 2D object
 
-from . import base_fempythonobject
+from . import base_femelement
 
 
-class ElementGeometry2D(base_fempythonobject.BaseFemPythonObject):
+class ElementGeometry2D(base_femelement.BaseFemElement):
     """
     The ElementGeometry2D object
     """
@@ -49,11 +49,3 @@ class ElementGeometry2D(base_fempythonobject.BaseFemPythonObject):
             "set thickness of the shell elements"
         )
         obj.setPropertyStatus("Thickness", "LockDynamic")
-
-        obj.addProperty(
-            "App::PropertyLinkSubList",
-            "References",
-            "ShellThickness",
-            "List of shell thickness shapes"
-        )
-        obj.setPropertyStatus("References", "LockDynamic")

--- a/src/Mod/Fem/femobjects/element_rotation1D.py
+++ b/src/Mod/Fem/femobjects/element_rotation1D.py
@@ -29,10 +29,10 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief element rotation 1D object
 
-from . import base_fempythonobject
+from . import base_femelement
 
 
-class ElementRotation1D(base_fempythonobject.BaseFemPythonObject):
+class ElementRotation1D(base_femelement.BaseFemElement):
     """
     The ElementRotation1D object
     """
@@ -49,11 +49,3 @@ class ElementRotation1D(base_fempythonobject.BaseFemPythonObject):
             "Set the rotation of beam elements"
         )
         obj.setPropertyStatus("Rotation", "LockDynamic")
-
-        obj.addProperty(
-            "App::PropertyLinkSubList",
-            "References",
-            "BeamRotation",
-            "List of beam rotation shapes"
-        )
-        obj.setPropertyStatus("References", "LockDynamic")

--- a/src/Mod/Fem/femobjects/mesh_boundarylayer.py
+++ b/src/Mod/Fem/femobjects/mesh_boundarylayer.py
@@ -29,10 +29,10 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief mesh boundary layer object
 
-from . import base_fempythonobject
+from . import base_femmeshelement
 
 
-class MeshBoundaryLayer(base_fempythonobject.BaseFemPythonObject):
+class MeshBoundaryLayer(base_femmeshelement.BaseFemMeshElement):
     """
     The MeshBoundaryLayer object
     """
@@ -68,11 +68,3 @@ class MeshBoundaryLayer(base_fempythonobject.BaseFemPythonObject):
         )
         obj.setPropertyStatus("GrowthRate", "LockDynamic")
         obj.GrowthRate = 1.5
-
-        obj.addProperty(
-            "App::PropertyLinkSubList",
-            "References",
-            "MeshBoundaryLayerShapes",
-            "List of FEM mesh region shapes"
-        )
-        obj.setPropertyStatus("References", "LockDynamic")

--- a/src/Mod/Fem/femobjects/mesh_group.py
+++ b/src/Mod/Fem/femobjects/mesh_group.py
@@ -29,10 +29,10 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief mesh group object
 
-from . import base_fempythonobject
+from . import base_femmeshelement
 
 
-class MeshGroup(base_fempythonobject.BaseFemPythonObject):
+class MeshGroup(base_femmeshelement.BaseFemMeshElement):
     """
     The MeshGroup object
     """
@@ -49,11 +49,3 @@ class MeshGroup(base_fempythonobject.BaseFemPythonObject):
             "The identifier used for export (True: Label, False: Name)"
         )
         obj.setPropertyStatus("UseLabel", "LockDynamic")
-
-        obj.addProperty(
-            "App::PropertyLinkSubList",
-            "References",
-            "MeshGroupShapes",
-            "List of FEM mesh group shapes"
-        )
-        obj.setPropertyStatus("References", "LockDynamic")

--- a/src/Mod/Fem/femobjects/mesh_region.py
+++ b/src/Mod/Fem/femobjects/mesh_region.py
@@ -29,10 +29,10 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief mesh region object
 
-from . import base_fempythonobject
+from . import base_femmeshelement
 
 
-class MeshRegion(base_fempythonobject.BaseFemPythonObject):
+class MeshRegion(base_femmeshelement.BaseFemMeshElement):
     """
     The FemMeshRegion object
     """
@@ -49,11 +49,3 @@ class MeshRegion(base_fempythonobject.BaseFemPythonObject):
             "set characteristic length of FEM elements for this refinement"
         )
         obj.setPropertyStatus("CharacteristicLength", "LockDynamic")
-
-        obj.addProperty(
-            "App::PropertyLinkSubList",
-            "References",
-            "MeshRegionShapes",
-            "List of FEM mesh refinement shapes"
-        )
-        obj.setPropertyStatus("References", "LockDynamic")

--- a/src/Mod/Fem/femviewprovider/view_base_femconstraint.py
+++ b/src/Mod/Fem/femviewprovider/view_base_femconstraint.py
@@ -30,8 +30,6 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief view provider for Python base constraint object
 
-from pivy import coin
-
 from FreeCAD import getResourceDir
 from femviewprovider import view_base_femobject
 
@@ -40,7 +38,3 @@ class VPBaseFemConstraint(view_base_femobject.VPBaseFemObject):
     """Proxy View Provider for Pythons base constraint."""
 
     resource_symbol_dir = getResourceDir() + "Mod/Fem/Resources/symbols/"
-
-    def attach(self, vobj):
-        # used on various places, claim childreens, get icon, etc.
-        self.Object = vobj.Object

--- a/src/Mod/Fem/femviewprovider/view_base_femelement.py
+++ b/src/Mod/Fem/femviewprovider/view_base_femelement.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+#/***************************************************************************
+# *   Copyright (c) 2024 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# **************************************************************************
+
+__title__ = "FreeCAD FEM base element ViewProvider"
+__author__ = "Mario Passaglia"
+__url__ = "https://www.freecad.org"
+
+## @package view_base_femelement
+#  \ingroup FEM
+#  \brief view provider for Python base element object
+
+from femviewprovider import view_base_femobject
+
+
+class VPBaseFemElement(view_base_femobject.VPBaseFemObject):
+    """Proxy View Provider for Python base element."""
+
+    def isShow(self):
+        return self.ViewObject.Visibility

--- a/src/Mod/Fem/femviewprovider/view_base_femmaterial.py
+++ b/src/Mod/Fem/femviewprovider/view_base_femmaterial.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+#/***************************************************************************
+# *   Copyright (c) 2024 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# **************************************************************************
+
+__title__ = "FreeCAD FEM base materlia ViewProvider"
+__author__ = "Mario Passaglia"
+__url__ = "https://www.freecad.org"
+
+## @package view_base_femmeshelement
+#  \ingroup FEM
+#  \brief view provider for Python base material object
+
+from femviewprovider import view_base_femobject
+
+
+class VPBaseFemMaterial(view_base_femobject.VPBaseFemObject):
+    """Proxy View Provider for Python base material."""
+
+    def isShow(self):
+        return self.ViewObject.Visibility

--- a/src/Mod/Fem/femviewprovider/view_base_femmeshelement.py
+++ b/src/Mod/Fem/femviewprovider/view_base_femmeshelement.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+#/***************************************************************************
+# *   Copyright (c) 2024 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# **************************************************************************
+
+__title__ = "FreeCAD FEM base mesh element ViewProvider"
+__author__ = "Mario Passaglia"
+__url__ = "https://www.freecad.org"
+
+## @package view_base_femmeshelement
+#  \ingroup FEM
+#  \brief view provider for Python base mesh element object
+
+from femviewprovider import view_base_femobject
+
+
+class VPBaseFemMeshElement(view_base_femobject.VPBaseFemObject):
+    """Proxy View Provider for Python base mesh element."""
+
+    def isShow(self):
+        return self.ViewObject.Visibility

--- a/src/Mod/Fem/femviewprovider/view_base_femobject.py
+++ b/src/Mod/Fem/femviewprovider/view_base_femobject.py
@@ -73,7 +73,7 @@ class VPBaseFemObject(object):
 
     def attach(self, vobj):
         self.Object = vobj.Object  # used on various places, claim childreens, get icon, etc.
-        # self.ViewObject = vobj  # not used ATM
+        self.ViewObject = vobj
 
     def setEdit(self, vobj, mode=0, TaskPanel=None, hide_mesh=True):
         if TaskPanel is None:

--- a/src/Mod/Fem/femviewprovider/view_element_fluid1D.py
+++ b/src/Mod/Fem/femviewprovider/view_element_fluid1D.py
@@ -32,17 +32,16 @@ __url__ = "https://www.freecad.org"
 #  \brief view provider for element fluid 1D object
 
 from femtaskpanels import task_element_fluid1D
-from . import view_base_femconstraint
+from . import view_base_femelement
 
 
-class VPElementFluid1D(view_base_femconstraint.VPBaseFemConstraint):
+class VPElementFluid1D(view_base_femelement.VPBaseFemElement):
     """
     A View Provider for the ElementFluid1D object
     """
 
     def setEdit(self, vobj, mode=0):
-        view_base_femconstraint.VPBaseFemConstraint.setEdit(
-            self,
+        super().setEdit(
             vobj,
             mode,
             task_element_fluid1D._TaskPanel

--- a/src/Mod/Fem/femviewprovider/view_element_geometry1D.py
+++ b/src/Mod/Fem/femviewprovider/view_element_geometry1D.py
@@ -30,17 +30,16 @@ __url__ = "https://www.freecad.org"
 #  \brief view provider for element geometry 1D object
 
 from femtaskpanels import task_element_geometry1D
-from . import view_base_femconstraint
+from . import view_base_femelement
 
 
-class VPElementGeometry1D(view_base_femconstraint.VPBaseFemConstraint):
+class VPElementGeometry1D(view_base_femelement.VPBaseFemElement):
     """
     A View Provider for the ElementGeometry1D object
     """
 
     def setEdit(self, vobj, mode=0):
-        view_base_femconstraint.VPBaseFemConstraint.setEdit(
-            self,
+        super().setEdit(
             vobj,
             mode,
             task_element_geometry1D._TaskPanel

--- a/src/Mod/Fem/femviewprovider/view_element_geometry2D.py
+++ b/src/Mod/Fem/femviewprovider/view_element_geometry2D.py
@@ -30,17 +30,16 @@ __url__ = "https://www.freecad.org"
 #  \brief view provider for element geometry 2D object
 
 from femtaskpanels import task_element_geometry2D
-from . import view_base_femconstraint
+from . import view_base_femelement
 
 
-class VPElementGeometry2D(view_base_femconstraint.VPBaseFemConstraint):
+class VPElementGeometry2D(view_base_femelement.VPBaseFemElement):
     """
     A View Provider for the ElementGeometry2D object
     """
 
     def setEdit(self, vobj, mode=0):
-        view_base_femconstraint.VPBaseFemConstraint.setEdit(
-            self,
+        super().setEdit(
             vobj,
             mode,
             task_element_geometry2D._TaskPanel

--- a/src/Mod/Fem/femviewprovider/view_element_rotation1D.py
+++ b/src/Mod/Fem/femviewprovider/view_element_rotation1D.py
@@ -30,10 +30,10 @@ __url__ = "https://www.freecad.org"
 #  \brief view provider for element rotation 1D object
 
 # from femtaskpanels import task_element_rotation1D
-from . import view_base_femconstraint
+from . import view_base_femelement
 
 
-class VPElementRotation1D(view_base_femconstraint.VPBaseFemConstraint):
+class VPElementRotation1D(view_base_femelement.VPBaseFemElement):
     """
     A View Provider for the ElementRotation1D object
     """

--- a/src/Mod/Fem/femviewprovider/view_material_common.py
+++ b/src/Mod/Fem/femviewprovider/view_material_common.py
@@ -34,10 +34,10 @@ __url__ = "https://www.freecad.org"
 import FreeCAD
 
 from femtaskpanels import task_material_common
-from . import view_base_femconstraint
+from . import view_base_femmaterial
 
 
-class VPMaterialCommon(view_base_femconstraint.VPBaseFemConstraint):
+class VPMaterialCommon(view_base_femmaterial.VPBaseFemMaterial):
     """
     A View Provider for the MaterialCommon object
     """
@@ -55,8 +55,7 @@ class VPMaterialCommon(view_base_femconstraint.VPBaseFemConstraint):
             return ""
 
     def setEdit(self, vobj, mode=0):
-        view_base_femconstraint.VPBaseFemConstraint.setEdit(
-            self,
+        super().setEdit(
             vobj,
             mode,
             task_material_common._TaskPanel

--- a/src/Mod/Fem/femviewprovider/view_material_mechanicalnonlinear.py
+++ b/src/Mod/Fem/femviewprovider/view_material_mechanicalnonlinear.py
@@ -29,10 +29,10 @@ __url__ = "https://www.freecad.org"
 #  \ingroup FEM
 #  \brief view provider for material mechanical nonlinear object
 
-from . import view_base_femconstraint
+from . import view_base_femmaterial
 
 
-class VPMaterialMechanicalNonlinear(view_base_femconstraint.VPBaseFemConstraint):
+class VPMaterialMechanicalNonlinear(view_base_femmaterial.VPBaseFemMaterial):
     """
     A View Provider for the MaterialMechanicalNonlinear object
     """

--- a/src/Mod/Fem/femviewprovider/view_material_reinforced.py
+++ b/src/Mod/Fem/femviewprovider/view_material_reinforced.py
@@ -30,17 +30,16 @@ __url__ = "https://www.freecad.org"
 #  \brief view provider for reinforced material object
 
 from femtaskpanels import task_material_reinforced
-from . import view_base_femconstraint
+from . import view_base_femmaterial
 
 
-class VPMaterialReinforced(view_base_femconstraint.VPBaseFemConstraint):
+class VPMaterialReinforced(view_base_femmaterial.VPBaseFemMaterial):
     """
     A View Provider for the MaterialReinforced object
     """
 
     def setEdit(self, vobj, mode=0):
-        view_base_femconstraint.VPBaseFemConstraint.setEdit(
-            self,
+        super().setEdit(
             vobj,
             mode,
             task_material_reinforced._TaskPanel

--- a/src/Mod/Fem/femviewprovider/view_mesh_boundarylayer.py
+++ b/src/Mod/Fem/femviewprovider/view_mesh_boundarylayer.py
@@ -30,17 +30,16 @@ __url__ = "https://www.freecad.org"
 #  \brief view provider for mesh boundary object
 
 from femtaskpanels import task_mesh_boundarylayer
-from . import view_base_femconstraint
+from . import view_base_femmeshelement
 
 
-class VPMeshBoundaryLayer(view_base_femconstraint.VPBaseFemConstraint):
+class VPMeshBoundaryLayer(view_base_femmeshelement.VPBaseFemMeshElement):
     """
     A View Provider for the MeshBoundaryLayer object
     """
 
     def setEdit(self, vobj, mode=0):
-        view_base_femconstraint.VPBaseFemConstraint.setEdit(
-            self,
+        super().setEdit(
             vobj,
             mode,
             task_mesh_boundarylayer._TaskPanel

--- a/src/Mod/Fem/femviewprovider/view_mesh_group.py
+++ b/src/Mod/Fem/femviewprovider/view_mesh_group.py
@@ -30,17 +30,16 @@ __url__ = "https://www.freecad.org"
 #  \brief view provider for mesh group object
 
 from femtaskpanels import task_mesh_group
-from . import view_base_femconstraint
+from . import view_base_femmeshelement
 
 
-class VPMeshGroup(view_base_femconstraint.VPBaseFemConstraint):
+class VPMeshGroup(view_base_femmeshelement.VPBaseFemMeshElement):
     """
     A View Provider for the MeshGroup object
     """
 
     def setEdit(self, vobj, mode=0):
-        view_base_femconstraint.VPBaseFemConstraint.setEdit(
-            self,
+        super().setEdit(
             vobj,
             mode,
             task_mesh_group._TaskPanel

--- a/src/Mod/Fem/femviewprovider/view_mesh_region.py
+++ b/src/Mod/Fem/femviewprovider/view_mesh_region.py
@@ -30,17 +30,16 @@ __url__ = "https://www.freecad.org"
 #  \brief view provider for mesh region object
 
 from femtaskpanels import task_mesh_region
-from . import view_base_femconstraint
+from . import view_base_femmeshelement
 
 
-class VPMeshRegion(view_base_femconstraint.VPBaseFemConstraint):
+class VPMeshRegion(view_base_femmeshelement.VPBaseFemMeshElement):
     """
     A View Provider for the FemMeshRegion object
     """
 
     def setEdit(self, vobj, mode=0):
-        view_base_femconstraint.VPBaseFemConstraint.setEdit(
-            self,
+        super().setEdit(
             vobj,
             mode,
             task_mesh_region._TaskPanel


### PR DESCRIPTION
Create own base class for Python objects for future improvements. Also, this fixes #14637.

@FEA-eng 