### PR TITLE
Draft: Fix 2 issues to make Draft_Fillet handle arcs properly

### DIFF
--- a/src/Mod/Draft/draftgeoutils/fillets.py
+++ b/src/Mod/Draft/draftgeoutils/fillets.py
@@ -118,7 +118,7 @@ def fillet(lEdges, r, chamfer=False):
         dirVect.scale(dToTangent, dToTangent, dToTangent)
         arcPt3 = lVertexes[1].Point.add(dirVect)
 
-        if (dToTangent > lEdges[0].Length) or (dToTangent > lEdges[1].Length):
+        if (dToTangent > rndEdges[0].Length) or (dToTangent > rndEdges[1].Length):
             print("DraftGeomUtils.fillet: Error: radius value ", r,
                   " is too high")
             return rndEdges
@@ -144,7 +144,7 @@ def fillet(lEdges, r, chamfer=False):
 
     elif len(curveType['Arc']) == 1:
         # Deals with lists containing an arc and a line
-        if lEdges[0] in curveType['Arc']:
+        if rndEdges[0] in curveType['Arc']:
             lineEnd = lVertexes[2]
             arcEnd = lVertexes[0]
             arcFirst = True

--- a/src/Mod/Draft/draftmake/make_fillet.py
+++ b/src/Mod/Draft/draftmake/make_fillet.py
@@ -48,20 +48,12 @@ DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 # @{
 
 def _extract_edge(obj):
-    """Extract the edge from an object, Draft line or Part.Edge."""
-    edge = None
-    if hasattr(obj, "PropertiesList"):
-        if "Proxy" in obj.PropertiesList:
-            if hasattr(obj.Proxy, "Type"):
-                if obj.Proxy.Type in ("Wire", "Fillet"):
-                    edge = obj.Shape.Edges[0]
-        elif "Shape" in obj.PropertiesList:
-            if obj.Shape.ShapeType in ("Wire", "Edge"):
-                edge = obj.Shape
-    elif hasattr(obj, "ShapeType"):
-        if obj.ShapeType in "Edge":
-            edge = obj
-    return edge
+    """Extract the 1st edge from an object or shape."""
+    if hasattr(obj, "Shape"):
+        obj = obj.Shape
+    if hasattr(obj, "ShapeType") and obj.ShapeType in ("Wire", "Edge"):
+        return obj.Edges[0]
+    return None
 
 
 def _preprocess(objs, radius, chamfer):
@@ -79,7 +71,7 @@ def _preprocess(objs, radius, chamfer):
 
     edges = DraftGeomUtils.fillet([edge1, edge2], radius, chamfer)
     if len(edges) < 3:
-        _err(translate("draft", "Radius is too large") + ", r={}".format(radius))
+        _err(translate("draft", "Edges are not connected or radius is too large."))
         return None
 
     return edges


### PR DESCRIPTION
Fixes #11435

Draft_Fillet could already handle arcs, provided they were not Draft_Arcs. The `_extract_edge` function in make_fillet.py had a strange logic, and could also return a wire which would result in problems later.

Another issue was that the `fillet` function in fillets.py did not handle the order of the edges correctly if one of the edges was an arc and the other a straight edge. The arch had to be selected first to prevent this error.
