### PR TITLE
BIM: Fix base edge direction for Arch_Stairs

### DIFF
--- a/src/Mod/BIM/ArchStairs.py
+++ b/src/Mod/BIM/ArchStairs.py
@@ -304,6 +304,9 @@ class _Stairs(ArchComponent.Component):
                     if isinstance(edge.Curve,(Part.LineSegment,Part.Line)):
                         # preparing for multi-edges landing / segment staircase
                         if obj.NumberOfSteps > 1:
+                            # if the edge has a delta Z the start point must have lowest Z:
+                            if edge.Vertexes[0].Point.z > edge.Vertexes[1].Point.z:
+                                edge = Part.LineSegment(edge.Vertexes[1].Point,edge.Vertexes[0].Point).toShape()
                             self.makeStraightStairsWithLanding(obj,edge)    # all cases use makeStraightStairsWithLanding()
 
                         # preparing for multi-edges landing / segment staircase


### PR DESCRIPTION
Fixes #14377

If the base edge of a stairs has a delta Z, the start point must have lowest Z. The `makeStraightStairsWithLanding` code fails otherwise.

Using `edge = Part.LineSegment().toShape()` is not the most efficient, but matches the pattern used elsewhere in the code.
