### PR TITLE
CAM: replace import of PySide2 with PySide

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
+++ b/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
@@ -32,7 +32,7 @@ import math
 import os
 
 from FreeCAD import Vector, Base
-from PySide2.QtWidgets import QDialogButtonBox
+from PySide.QtGui import QDialogButtonBox
 
 # lazily loaded modules
 from lazy_loader.lazy_loader import LazyLoader


### PR DESCRIPTION
The new CAM simulator imports `QDialogButtonBox` from `PySide2.QtWidgets`. This causes the CAM workbench to fail when Qt6 is used. Importing fom `PySide` instead fixes the issue.