### PR TITLE
Assembly: BOM follow up

### DIFF
--- a/src/Mod/Assembly/Gui/Resources/panels/TaskAssemblyCreateBom.ui
+++ b/src/Mod/Assembly/Gui/Resources/panels/TaskAssemblyCreateBom.ui
@@ -14,13 +14,13 @@
    <string>Create Bill Of Materials</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
+   <item row="0" column="0" colspan="2">
     <widget class="Gui::PrefCheckBox" name="CheckBox_detailSubAssemblies">
      <property name="toolTip">
-      <string>If checked, Sub assemblies sub-components will be added to the bill of materials.</string>
+      <string>If checked, Sub assemblies children will be added to the bill of materials.</string>
      </property>
      <property name="text">
-      <string>Detail sub-assemblies</string>
+      <string>Sub-assemblies children</string>
      </property>
      <property name="checked">
       <bool>true</bool>
@@ -33,13 +33,13 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="1" column="0" colspan="2">
     <widget class="Gui::PrefCheckBox" name="CheckBox_detailParts">
      <property name="toolTip">
-      <string>If checked, Parts sub-components will be added to the bill of materials.</string>
+      <string>If checked, Parts children will be added to the bill of materials.</string>
      </property>
      <property name="text">
-      <string>Detail parts</string>
+      <string>Parts children</string>
      </property>
      <property name="checked">
       <bool>true</bool>
@@ -52,10 +52,10 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="2" column="0" colspan="2">
     <widget class="Gui::PrefCheckBox" name="CheckBox_onlyParts">
      <property name="toolTip">
-      <string>If checked, only Part containers will be added to the bill of materials. Solids like PartDesign Bodies will be ignored.</string>
+      <string>If checked, only Part containers and sub-assemblies will be added to the bill of materials. Solids like PartDesign Bodies, fasteners or Part workbench primitives will be ignored.</string>
      </property>
      <property name="text">
       <string>Only parts</string>
@@ -71,11 +71,8 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="3" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_1">
-     <property name="toolTip">
-      <string>Columns of the bill of materials</string>
-     </property>
      <property name="title">
       <string>Columns</string>
      </property>
@@ -97,6 +94,26 @@
     <widget class="QPushButton" name="btnExport">
      <property name="text">
       <string>Export</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QToolButton" name="helpButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>Help</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="Icons/resource.qrc">
+      <normaloff>:/icons/help-browser.svg</normaloff>:/icons/help-browser.svg</iconset>
      </property>
     </widget>
    </item>

--- a/src/Mod/Assembly/Gui/ViewProviderBom.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderBom.cpp
@@ -32,6 +32,7 @@
 
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
+#include <Gui/Command.h>
 
 #include <Base/Interpreter.h>
 
@@ -53,33 +54,16 @@ QIcon ViewProviderBom::getIcon() const
 
 bool ViewProviderBom::doubleClicked()
 {
-    try {
-        // Ensure the Python interpreter is initialized
-        if (!Py_IsInitialized()) {
-            Py_Initialize();
-        }
+    std::string obj_name = getObject()->getNameInDocument();
+    std::string doc_name = getObject()->getDocument()->getName();
 
-        // Acquire the GIL (Global Interpreter Lock)
-        PyGILState_STATE gstate;
-        gstate = PyGILState_Ensure();
-        std::string obj_name = getObject()->getNameInDocument();
-        std::string doc_name = getObject()->getDocument()->getName();
+    std::string pythonCommand = "import CommandCreateBom\n"
+                                "obj = App.getDocument('"
+        + doc_name + "').getObject('" + obj_name
+        + "')\n"
+          "Gui.Control.showDialog(CommandCreateBom.TaskAssemblyCreateBom(obj))";
 
-        // Call the Python function
-        std::string pythonCommand = "import CommandCreateBom\n"
-                                    "obj = App.getDocument('"
-            + doc_name + "').getObject('" + obj_name
-            + "')\n"
-              "Gui.Control.showDialog(CommandCreateBom.TaskAssemblyCreateBom(obj))";
-
-        PyRun_SimpleString(pythonCommand.c_str());
-
-        // Release the GIL
-        PyGILState_Release(gstate);
-    }
-    catch (...) {
-        PyErr_Print();
-    }
+    Gui::Command::runCommand(Gui::Command::App, pythonCommand.c_str());
 
     return true;
 }

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -145,7 +145,9 @@ void ViewProviderSheet::exportAsFile()
                                                         &selectedFilter);
     if (!fileName.isEmpty()) {
         if (sheet) {
-            char delim, quote, escape;
+            char delim = '\0';
+            char quote = '\0';
+            char escape = '\0';
             std::string errMsg = "Export";
             bool isValid = sheet->getCharsFromPrefs(delim, quote, escape, errMsg);
 
@@ -154,7 +156,6 @@ void ViewProviderSheet::exportAsFile()
             }
             else {
                 Base::Console().Error(errMsg.c_str());
-                return;
             }
         }
     }


### PR DESCRIPTION
- Fixes some comments from @wwmayer 
- Make auto-generated columns bold to differentiate them from custom columns
- Add a help button with details
- Rename 'Detail parts' to 'Parts children' as I think it's clearer.

![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/df96b9f3-f0ad-473c-bbff-60707ac8fdd8)
