### PR TITLE
PD: Rename duplicated test method

### DIFF
--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -503,7 +503,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 50)
 
-    def testPartDesignElementMapSketch(self):
+    def testPartDesignElementPadSketch(self):
         # Arrange
         body = self.Doc.addObject('PartDesign::Body', 'Body')
         sketch = self.Doc.addObject('Sketcher::SketchObject', 'Sketch')


### PR DESCRIPTION
Fixes #14795: testPartDesignElementMapSketch: Duplicate test method name