### PR TITLE
Fix Ubuntu 20.04 CI failing

### DIFF
--- a/src/Mod/Assembly/CommandCreateBom.py
+++ b/src/Mod/Assembly/CommandCreateBom.py
@@ -29,7 +29,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 if App.GuiUp:
     import FreeCADGui as Gui
-    from PySide import QtCore, QtGui, QtWidgets, QtUiTools
+    from PySide import QtCore, QtGui, QtWidgets
     from PySide.QtWidgets import QPushButton, QMenu
 
 import UtilsAssembly


### PR DESCRIPTION
Fix Ubuntu 20.04 CI failing that was due to an unecessary import.