### PR TITLE
Fem: Clean up constraint view providers

### DIFF
--- a/src/Mod/Fem/Gui/TaskFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraint.cpp
@@ -65,45 +65,10 @@ TaskFemConstraint::TaskFemConstraint(ViewProviderFemConstraint* ConstraintView,
     , cancelButton(nullptr)
 {
     selectionMode = selref;
-
-    // Setup the dialog inside the Shaft Wizard dialog
-    if ((ConstraintView->wizardWidget) && (ConstraintView->wizardSubLayout)) {
-        // Hide the shaft wizard table widget to make more space
-        ConstraintView->wizardSubLayout->itemAt(0)->widget()->hide();
-        QGridLayout* buttons = ConstraintView->wizardSubLayout->findChild<QGridLayout*>();
-        for (int b = 0; b < buttons->count(); b++) {
-            buttons->itemAt(b)->widget()->hide();
-        }
-
-        // Show this dialog for the FEM constraint
-        ConstraintView->wizardWidget->addWidget(this);
-
-        // Add buttons to finish editing the constraint without closing the shaft wizard dialog
-        okButton = new QPushButton(QObject::tr("Ok"));
-        cancelButton = new QPushButton(QObject::tr("Cancel"));
-        buttonBox = new QDialogButtonBox();
-        buttonBox->addButton(okButton, QDialogButtonBox::AcceptRole);
-        buttonBox->addButton(cancelButton, QDialogButtonBox::RejectRole);
-        QObject::connect(okButton, &QPushButton::clicked, this, &TaskFemConstraint::onButtonWizOk);
-        QObject::connect(cancelButton,
-                         &QPushButton::clicked,
-                         this,
-                         &TaskFemConstraint::onButtonWizCancel);
-        ConstraintView->wizardWidget->addWidget(buttonBox);
-    }
 }
 
 void TaskFemConstraint::keyPressEvent(QKeyEvent* ke)
 {
-    if ((ConstraintView->wizardWidget) && (ConstraintView->wizardSubLayout)) {
-        // Prevent <Enter> from closing this dialog AND the shaft wizard dialog
-        // TODO: This should trigger an update in the shaft wizard but its difficult to access a
-        // python dialog from here...
-        if (ke->key() == Qt::Key_Return) {
-            return;
-        }
-    }
-
     TaskBox::keyPressEvent(ke);
 }
 
@@ -170,37 +135,6 @@ void TaskFemConstraint::onButtonReference(const bool pressed)
         selectionMode = selnone;
     }
     Gui::Selection().clearSelection();
-}
-
-void TaskFemConstraint::onButtonWizOk()
-{
-    // Remove dialog elements
-    buttonBox->removeButton(okButton);
-    delete okButton;
-    buttonBox->removeButton(cancelButton);
-    delete cancelButton;
-    ConstraintView->wizardWidget->removeWidget(buttonBox);
-    delete buttonBox;
-    ConstraintView->wizardWidget->removeWidget(this);
-
-    // Show the wizard shaft dialog again
-    ConstraintView->wizardSubLayout->itemAt(0)->widget()->show();
-    QGridLayout* buttons = ConstraintView->wizardSubLayout->findChild<QGridLayout*>();
-    for (int b = 0; b < buttons->count(); b++) {
-        buttons->itemAt(b)->widget()->show();
-    }
-
-    Gui::Application::Instance->activeDocument()
-        ->resetEdit();  // Reaches ViewProviderFemConstraint::unsetEdit() eventually
-}
-
-void TaskFemConstraint::onButtonWizCancel()
-{
-    Fem::Constraint* pcConstraint = static_cast<Fem::Constraint*>(ConstraintView->getObject());
-    if (pcConstraint) {
-        pcConstraint->getDocument()->removeObject(pcConstraint->getNameInDocument());
-    }
-    onButtonWizOk();
 }
 
 const QString TaskFemConstraint::makeRefText(const std::string& objName,

--- a/src/Mod/Fem/Gui/TaskFemConstraint.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraint.h
@@ -61,9 +61,6 @@ protected Q_SLOTS:
     void onReferenceDeleted(const int row);
     void onButtonReference(const bool pressed = true);
     void setSelection(QListWidgetItem* item);
-    // Shaft Wizard integration
-    void onButtonWizOk();
-    void onButtonWizCancel();
 
 protected:
     void changeEvent(QEvent* e) override

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.h
@@ -25,9 +25,6 @@
 #ifndef GUI_VIEWPROVIDERFEMCONSTRAINT_H
 #define GUI_VIEWPROVIDERFEMCONSTRAINT_H
 
-#include <QObject>
-#include <QVBoxLayout>
-
 #include <Gui/ViewProviderGeometryObject.h>
 #include <Gui/ViewProviderPythonFeature.h>
 #include <Mod/Fem/FemGlobal.h>
@@ -35,14 +32,14 @@
 #include <Gui/ViewProviderSuppressibleExtension.h>
 
 
+class QMenu;
+class QObject;
 class SbRotation;
 class SoMultipleCopy;
 class SoTransform;
 
 namespace FemGui
 {
-
-class TaskFemConstraint;
 
 class FemGuiExport ViewProviderFemConstraint: public Gui::ViewProviderGeometryObject,
                                               public Gui::ViewProviderSuppressibleExtension
@@ -111,16 +108,6 @@ protected:
     const char* ivFile;
 
     static std::string resourceSymbolDir;
-
-    // Shaft design wizard integration
-protected:
-    friend class TaskFemConstraint;
-    QVBoxLayout* wizardWidget;
-    QVBoxLayout* wizardSubLayout;
-    TaskFemConstraint* constraintDialog;
-
-    void checkForWizard();
-    static QObject* findChildByName(const QObject* parent, const QString& name);
 };
 
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintBearing.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintBearing.cpp
@@ -27,7 +27,6 @@
 #include <Inventor/SbRotation.h>
 #include <Inventor/SbVec3f.h>
 #include <Inventor/nodes/SoSeparator.h>
-#include <QMessageBox>
 #endif
 
 #include "Gui/Control.h"
@@ -52,60 +51,16 @@ ViewProviderFemConstraintBearing::~ViewProviderFemConstraintBearing() = default;
 
 bool ViewProviderFemConstraintBearing::setEdit(int ModNum)
 {
-
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintBearing* constrDlg = qobject_cast<TaskDlgFemConstraintBearing*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            // This case will occur in the ShaftWizard application
-            checkForWizard();
-            if (!wizardWidget || !wizardSubLayout) {
-                // No shaft wizard is running
-                QMessageBox msgBox;
-                msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-                msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-                msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-                msgBox.setDefaultButton(QMessageBox::Yes);
-                int ret = msgBox.exec();
-                if (ret == QMessageBox::Yes) {
-                    Gui::Control().reject();
-                }
-                else {
-                    return false;
-                }
-            }
-            else if (constraintDialog) {
-                // Another FemConstraint* dialog is already open inside the Shaft Wizard
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintBearing(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
-
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintBearing(this));
-        }
+        Gui::Control().showDialog(new TaskDlgFemConstraintBearing(this));
 
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraint::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintContact.cpp
@@ -42,50 +42,23 @@ ViewProviderFemConstraintContact::ViewProviderFemConstraintContact()
 {
     sPixmap = "FEM_ConstraintContact";
     loadSymbol((resourceSymbolDir + "ConstraintContact.iv").c_str());
-    // Note change "Contact" in line above to new constraint name, make sure it is the same as in
-    // taskFem* cpp file
     ShapeAppearance.setDiffuseColor(0.2f, 0.3f, 0.2f);
 }
 
 ViewProviderFemConstraintContact::~ViewProviderFemConstraintContact() = default;
 
-// FIXME setEdit needs a careful review
 bool ViewProviderFemConstraintContact::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintContact* constrDlg = qobject_cast<TaskDlgFemConstraintContact*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            if (constraintDialog) {
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintContact(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
+        Gui::Control().showDialog(new TaskDlgFemConstraintContact(this));
 
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintContact(this));
-        }
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraint::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp
@@ -53,44 +53,18 @@ ViewProviderFemConstraintDisplacement::ViewProviderFemConstraintDisplacement()
 
 ViewProviderFemConstraintDisplacement::~ViewProviderFemConstraintDisplacement() = default;
 
-// FIXME setEdit needs a careful review
 bool ViewProviderFemConstraintDisplacement::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintDisplacement* constrDlg =
-            qobject_cast<TaskDlgFemConstraintDisplacement*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            if (constraintDialog) {
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintDisplacement(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
+        Gui::Control().showDialog(new TaskDlgFemConstraintDisplacement(this));
 
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintDisplacement(this));
-        }
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraintOnBoundary::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintFixed.cpp
@@ -24,7 +24,6 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-#include <QMessageBox>
 #endif
 
 #include "Gui/Control.h"
@@ -50,58 +49,15 @@ ViewProviderFemConstraintFixed::~ViewProviderFemConstraintFixed() = default;
 bool ViewProviderFemConstraintFixed::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintFixed* constrDlg = qobject_cast<TaskDlgFemConstraintFixed*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            // This case will occur in the ShaftWizard application
-            checkForWizard();
-            if (!wizardWidget || !wizardSubLayout) {
-                // No shaft wizard is running
-                QMessageBox msgBox;
-                msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-                msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-                msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-                msgBox.setDefaultButton(QMessageBox::Yes);
-                int ret = msgBox.exec();
-                if (ret == QMessageBox::Yes) {
-                    Gui::Control().reject();
-                }
-                else {
-                    return false;
-                }
-            }
-            else if (constraintDialog) {
-                // Another FemConstraint* dialog is already open inside the Shaft Wizard
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintFixed(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
-
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintFixed(this));
-        }
+        Gui::Control().showDialog(new TaskDlgFemConstraintFixed(this));
 
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraintOnBoundary::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.cpp
@@ -29,7 +29,6 @@
 #include <Inventor/nodes/SoMultipleCopy.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Precision.hxx>
-#include <QMessageBox>
 #endif
 
 #include "Gui/Control.h"
@@ -56,58 +55,15 @@ ViewProviderFemConstraintFluidBoundary::~ViewProviderFemConstraintFluidBoundary(
 bool ViewProviderFemConstraintFluidBoundary::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint,
-        // object unsets and sets its edit mode without closing the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintFluidBoundary* constrDlg =
-            qobject_cast<TaskDlgFemConstraintFluidBoundary*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            // This case will occur in the ShaftWizard application
-            checkForWizard();
-            if (!wizardWidget || !wizardSubLayout) {
-                // No shaft wizard is running
-                QMessageBox msgBox;
-                msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-                msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-                msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-                msgBox.setDefaultButton(QMessageBox::Yes);
-                int ret = msgBox.exec();
-                if (ret == QMessageBox::Yes) {
-                    Gui::Control().reject();
-                }
-                else {
-                    return false;
-                }
-            }
-            else if (constraintDialog) {
-                // Another FemConstraint* dialog is already open inside the Shaft Wizard
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintFluidBoundary(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
-
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintFluidBoundary(this));
-        }
+        Gui::Control().showDialog(new TaskDlgFemConstraintFluidBoundary(this));
 
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraintOnBoundary::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.cpp
@@ -27,7 +27,6 @@
 #include <Inventor/SbMatrix.h>
 #include <Inventor/SbRotation.h>
 #include <Inventor/SbVec3f.h>
-#include <QMessageBox>
 #endif
 
 #include "Gui/Control.h"
@@ -53,58 +52,15 @@ ViewProviderFemConstraintForce::~ViewProviderFemConstraintForce() = default;
 bool ViewProviderFemConstraintForce::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintForce* constrDlg = qobject_cast<TaskDlgFemConstraintForce*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            // This case will occur in the ShaftWizard application
-            checkForWizard();
-            if (!wizardWidget || !wizardSubLayout) {
-                // No shaft wizard is running
-                QMessageBox msgBox;
-                msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-                msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-                msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-                msgBox.setDefaultButton(QMessageBox::Yes);
-                int ret = msgBox.exec();
-                if (ret == QMessageBox::Yes) {
-                    Gui::Control().reject();
-                }
-                else {
-                    return false;
-                }
-            }
-            else if (constraintDialog) {
-                // Another FemConstraint* dialog is already open inside the Shaft Wizard
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintForce(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
-
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintForce(this));
-        }
+        Gui::Control().showDialog(new TaskDlgFemConstraintForce(this));
 
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraintOnBoundary::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintGear.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintGear.cpp
@@ -29,7 +29,6 @@
 #include <Inventor/SbVec3f.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Precision.hxx>
-#include <QMessageBox>
 #endif
 
 #include "Gui/Control.h"
@@ -56,58 +55,15 @@ ViewProviderFemConstraintGear::~ViewProviderFemConstraintGear() = default;
 bool ViewProviderFemConstraintGear::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintGear* constrDlg = qobject_cast<TaskDlgFemConstraintGear*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            // This case will occur in the ShaftWizard application
-            checkForWizard();
-            if (!wizardWidget || !wizardSubLayout) {
-                // No shaft wizard is running
-                QMessageBox msgBox;
-                msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-                msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-                msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-                msgBox.setDefaultButton(QMessageBox::Yes);
-                int ret = msgBox.exec();
-                if (ret == QMessageBox::Yes) {
-                    Gui::Control().reject();
-                }
-                else {
-                    return false;
-                }
-            }
-            else if (constraintDialog) {
-                // Another FemConstraint* dialog is already open inside the Shaft Wizard
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintGear(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
-
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintGear(this));
-        }
+        Gui::Control().showDialog(new TaskDlgFemConstraintGear(this));
 
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraint::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintHeatflux.cpp
@@ -49,43 +49,18 @@ ViewProviderFemConstraintHeatflux::ViewProviderFemConstraintHeatflux()
 
 ViewProviderFemConstraintHeatflux::~ViewProviderFemConstraintHeatflux() = default;
 
-// FIXME setEdit needs a careful review
 bool ViewProviderFemConstraintHeatflux::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintHeatflux* constrDlg = qobject_cast<TaskDlgFemConstraintHeatflux*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            if (constraintDialog) {
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintHeatflux(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
+        Gui::Control().showDialog(new TaskDlgFemConstraintHeatflux(this));
 
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintHeatflux(this));
-        }
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraintOnBoundary::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintInitialTemperature.cpp
@@ -46,44 +46,18 @@ ViewProviderFemConstraintInitialTemperature::ViewProviderFemConstraintInitialTem
 ViewProviderFemConstraintInitialTemperature::~ViewProviderFemConstraintInitialTemperature() =
     default;
 
-// FIXME setEdit needs a careful review
 bool ViewProviderFemConstraintInitialTemperature::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintInitialTemperature* constrDlg =
-            qobject_cast<TaskDlgFemConstraintInitialTemperature*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            if (constraintDialog) {
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintInitialTemperature(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
+        Gui::Control().showDialog(new TaskDlgFemConstraintInitialTemperature(this));
 
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintInitialTemperature(this));
-        }
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraint::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPlaneRotation.cpp
@@ -50,44 +50,18 @@ ViewProviderFemConstraintPlaneRotation::ViewProviderFemConstraintPlaneRotation()
 
 ViewProviderFemConstraintPlaneRotation::~ViewProviderFemConstraintPlaneRotation() = default;
 
-// FIXME setEdit needs a careful review
 bool ViewProviderFemConstraintPlaneRotation::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintPlaneRotation* constrDlg =
-            qobject_cast<TaskDlgFemConstraintPlaneRotation*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            if (constraintDialog) {
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintPlaneRotation(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
+        Gui::Control().showDialog(new TaskDlgFemConstraintPlaneRotation(this));
 
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintPlaneRotation(this));
-        }
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraint::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
@@ -50,43 +50,18 @@ ViewProviderFemConstraintPressure::ViewProviderFemConstraintPressure()
 
 ViewProviderFemConstraintPressure::~ViewProviderFemConstraintPressure() = default;
 
-// FIXME setEdit needs a careful review
 bool ViewProviderFemConstraintPressure::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintPressure* constrDlg = qobject_cast<TaskDlgFemConstraintPressure*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            if (constraintDialog) {
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintPressure(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
+        Gui::Control().showDialog(new TaskDlgFemConstraintPressure(this));
 
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintPressure(this));
-        }
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraintOnBoundary::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPulley.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPulley.cpp
@@ -28,7 +28,6 @@
 #include <Inventor/SbVec3f.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Precision.hxx>
-#include <QMessageBox>
 #endif
 
 #include "Gui/Control.h"
@@ -53,58 +52,15 @@ ViewProviderFemConstraintPulley::~ViewProviderFemConstraintPulley() = default;
 bool ViewProviderFemConstraintPulley::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintPulley* constrDlg = qobject_cast<TaskDlgFemConstraintPulley*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            // This case will occur in the ShaftWizard application
-            checkForWizard();
-            if (!wizardWidget || !wizardSubLayout) {
-                // No shaft wizard is running
-                QMessageBox msgBox;
-                msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-                msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-                msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-                msgBox.setDefaultButton(QMessageBox::Yes);
-                int ret = msgBox.exec();
-                if (ret == QMessageBox::Yes) {
-                    Gui::Control().reject();
-                }
-                else {
-                    return false;
-                }
-            }
-            else if (constraintDialog) {
-                // Another FemConstraint* dialog is already open inside the Shaft Wizard
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintPulley(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
-
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintPulley(this));
-        }
+        Gui::Control().showDialog(new TaskDlgFemConstraintPulley(this));
 
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraint::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintRigidBody.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintRigidBody.cpp
@@ -23,7 +23,6 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-#include <QMessageBox>
 #include <Inventor/nodes/SoTransform.h>
 #endif
 
@@ -52,59 +51,15 @@ ViewProviderFemConstraintRigidBody::~ViewProviderFemConstraintRigidBody() = defa
 bool ViewProviderFemConstraintRigidBody::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintRigidBody* constrDlg =
-            qobject_cast<TaskDlgFemConstraintRigidBody*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            // This case will occur in the ShaftWizard application
-            checkForWizard();
-            if (!wizardWidget || !wizardSubLayout) {
-                // No shaft wizard is running
-                QMessageBox msgBox;
-                msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-                msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-                msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-                msgBox.setDefaultButton(QMessageBox::Yes);
-                int ret = msgBox.exec();
-                if (ret == QMessageBox::Yes) {
-                    Gui::Control().reject();
-                }
-                else {
-                    return false;
-                }
-            }
-            else if (constraintDialog) {
-                // Another FemConstraint* dialog is already open inside the Shaft Wizard
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintRigidBody(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
-
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintRigidBody(this));
-        }
+        Gui::Control().showDialog(new TaskDlgFemConstraintRigidBody(this));
 
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraintOnBoundary::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintSpring.cpp
@@ -29,7 +29,7 @@
 #include "Mod/Fem/App/FemConstraintSpring.h"
 #include <Gui/Control.h>
 
-#include "TaskFemConstraintSpring.h"  //TODO  do next
+#include "TaskFemConstraintSpring.h"
 #include "ViewProviderFemConstraintSpring.h"
 
 
@@ -47,44 +47,18 @@ ViewProviderFemConstraintSpring::ViewProviderFemConstraintSpring()
 
 ViewProviderFemConstraintSpring::~ViewProviderFemConstraintSpring() = default;
 
-// FIXME setEdit needs a careful review
 bool ViewProviderFemConstraintSpring::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintSpring* constrDlg =
-            qobject_cast<TaskDlgFemConstraintSpring*>(dlg);  // check this out too
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            if (constraintDialog) {
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintSpring(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
+        Gui::Control().showDialog(new TaskDlgFemConstraintSpring(this));
 
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintSpring(this));
-        }
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraintOnBoundary::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintTemperature.cpp
@@ -48,44 +48,18 @@ ViewProviderFemConstraintTemperature::ViewProviderFemConstraintTemperature()
 
 ViewProviderFemConstraintTemperature::~ViewProviderFemConstraintTemperature() = default;
 
-// FIXME setEdit needs a careful review
 bool ViewProviderFemConstraintTemperature::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintTemperature* constrDlg =
-            qobject_cast<TaskDlgFemConstraintTemperature*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            if (constraintDialog) {
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintTemperature(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
+        Gui::Control().showDialog(new TaskDlgFemConstraintTemperature(this));
 
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintTemperature(this));
-        }
         return true;
     }
     else {
-        return ViewProviderDocumentObject::setEdit(ModNum);  // clazy:exclude=skipped-base-method
+        return ViewProviderFemConstraintOnBoundary::setEdit(ModNum);
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintTransform.cpp
@@ -53,40 +53,14 @@ ViewProviderFemConstraintTransform::ViewProviderFemConstraintTransform()
 
 ViewProviderFemConstraintTransform::~ViewProviderFemConstraintTransform() = default;
 
-// FIXME setEdit needs a careful review
 bool ViewProviderFemConstraintTransform::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
-        // When double-clicking on the item for this constraint the
-        // object unsets and sets its edit mode without closing
-        // the task panel
-        Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
-        TaskDlgFemConstraintTransform* constrDlg =
-            qobject_cast<TaskDlgFemConstraintTransform*>(dlg);
-        if (constrDlg && constrDlg->getConstraintView() != this) {
-            constrDlg = nullptr;  // another constraint left open its task panel
-        }
-        if (dlg && !constrDlg) {
-            if (constraintDialog) {
-                // Ignore the request to open another dialog
-                return false;
-            }
-            else {
-                constraintDialog = new TaskFemConstraintTransform(this);
-                return true;
-            }
-        }
-
+        Gui::Control().closeDialog();
         // clear the selection (convenience)
         Gui::Selection().clearSelection();
+        Gui::Control().showDialog(new TaskDlgFemConstraintTransform(this));
 
-        // start the edit dialog
-        if (constrDlg) {
-            Gui::Control().showDialog(constrDlg);
-        }
-        else {
-            Gui::Control().showDialog(new TaskDlgFemConstraintTransform(this));
-        }
         return true;
     }
     else {


### PR DESCRIPTION
 * Remove Shaft wizard code from `ViewProviderFemConstraint` class. Shaft wizard is a `PartDesign` functionality,  so there should be no associated code within a Fem class. In any case, the functionality does not work correctly.
* Remove task dialog checking from `setEdit` methods (and  consequent modal dialog). The check only works if the `unsetEdit` method of the current view provider in edit mode does not close the task dialog itself.