### PR TITLE
MSVC: Fix compiler warnings

### DIFF
--- a/src/Mod/Assembly/Gui/CMakeLists.txt
+++ b/src/Mod/Assembly/Gui/CMakeLists.txt
@@ -72,6 +72,11 @@ SET(AssemblyGuiIcon_SVG
 )
 
 add_library(AssemblyGui SHARED ${AssemblyGui_SRCS} ${AssemblyGuiIcon_SVG})
+
+if(WIN32)
+    target_compile_definitions(AssemblyGui PRIVATE _USE_MATH_DEFINES)
+endif(WIN32)
+
 target_link_libraries(AssemblyGui ${AssemblyGui_LIBS})
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(AssemblyGui)

--- a/src/Mod/Assembly/Gui/PreCompiled.h
+++ b/src/Mod/Assembly/Gui/PreCompiled.h
@@ -21,8 +21,8 @@
  *                                                                          *
  ***************************************************************************/
 
-#ifndef POINTSGUI_PRECOMPILED_H
-#define POINTSGUI_PRECOMPILED_H
+#ifndef ASSEMBLYGUI_PRECOMPILED_H
+#define ASSEMBLYGUI_PRECOMPILED_H
 
 #include <FCConfig.h>
 
@@ -30,6 +30,7 @@
 
 // STL
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <memory>
 
@@ -53,4 +54,4 @@
 
 #endif  //_PreComp_
 
-#endif  // POINTSGUI_PRECOMPILED_H
+#endif  // ASSEMBLYGUI_PRECOMPILED_H

--- a/src/Mod/CAM/PathSimulator/AppGL/EndMill.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/EndMill.cpp
@@ -38,7 +38,7 @@ EndMill::EndMill(const std::vector<float>& toolProfile, int toolid, float diamet
     profilePoints = nullptr;
     mHandleAllocation = false;
 
-    int srcBuffSize = toolProfile.size();
+    int srcBuffSize = static_cast<int>(toolProfile.size());
     nPoints = srcBuffSize / 2;
     if (nPoints < 2) {
         return;

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -398,7 +398,7 @@ Base::Vector3d ViewProviderMeasureBase::getTextDirection(Base::Vector3d elementD
 Gui::View3DInventor* view = nullptr;
     try {
         view = dynamic_cast<Gui::View3DInventor*>(this->getActiveView());
-    } catch (const Base::RuntimeError& e) {
+    } catch (const Base::RuntimeError&) {
         Base::Console().Log("ViewProviderMeasureBase::getTextDirection: Could not get active view\n");
     }
 
@@ -430,7 +430,7 @@ bool ViewProviderMeasureBase::isSubjectVisible()
     Gui::Document* guiDoc = nullptr;
     try {
         guiDoc = this->getDocument();
-    } catch (const Base::RuntimeError& e) {
+    } catch (const Base::RuntimeError&) {
         Base::Console().Log("ViewProviderMeasureBase::isSubjectVisible: Could not get document\n");
         return false;
     }
@@ -550,7 +550,7 @@ ViewProviderMeasure::ViewProviderMeasure()
     Gui::View3DInventor* view = nullptr;
     try {
         view = dynamic_cast<Gui::View3DInventor*>(this->getActiveView());
-    } catch (const Base::RuntimeError& e) {
+    } catch (const Base::RuntimeError& ) {
         Base::Console().Log("ViewProviderMeasure::ViewProviderMeasure: Could not get active view\n");
     }
 
@@ -581,7 +581,7 @@ void ViewProviderMeasure::positionAnno(const Measure::MeasureBase* measureObject
     Gui::View3DInventor* view = nullptr;
     try {
         view = dynamic_cast<Gui::View3DInventor*>(this->getActiveView());
-    } catch (const Base::RuntimeError& e) {
+    } catch (const Base::RuntimeError&) {
         Base::Console().Log("ViewProviderMeasure::positionAnno: Could not get active view\n");
     }
 

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -81,9 +81,9 @@ namespace TechDrawGui
 //internal helper functions
 TechDraw::LineFormat& _getActiveLineAttributes();
 Base::Vector3d _circleCenter(Base::Vector3d p1, Base::Vector3d p2, Base::Vector3d p3);
-void _createThreadCircle(const std::string Name, TechDraw::DrawViewPart* objFeat, float factor);
+void _createThreadCircle(const std::string Name, TechDraw::DrawViewPart* objFeat, double factor);
 void _createThreadLines(const std::vector<std::string>& SubNames, TechDraw::DrawViewPart* objFeat,
-                        float factor);
+                        double factor);
 void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge);
 void _setLineAttributes(TechDraw::CenterLine* cosEdge);
 void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge, int style, float weight, App::Color color);
@@ -2113,7 +2113,7 @@ Base::Vector3d _circleCenter(Base::Vector3d p1, Base::Vector3d p2, Base::Vector3
     return Base::Vector3d(center.x, center.y, 0.0);
 }
 
-void _createThreadCircle(const std::string Name, TechDraw::DrawViewPart* objFeat, float factor)
+void _createThreadCircle(const std::string Name, TechDraw::DrawViewPart* objFeat, double factor)
 {
     constexpr double ArcStartDegree{255.0};
     constexpr double ArcEndDegree{165.0};
@@ -2138,7 +2138,7 @@ void _createThreadCircle(const std::string Name, TechDraw::DrawViewPart* objFeat
 }
 
 void _createThreadLines(const std::vector<std::string>& SubNames, TechDraw::DrawViewPart* objFeat,
-                        float factor)
+                        double factor)
 {
     // create symbolizing lines of a thread from the side seen
     std::string GeoType0 = TechDraw::DrawUtil::getGeomTypeFromName(SubNames[0]);

--- a/tests/src/Mod/Material/App/TestMaterials.cpp
+++ b/tests/src/Mod/Material/App/TestMaterials.cpp
@@ -327,18 +327,18 @@ TEST_F(TestMaterial, TestCalculiXSteel)
 
     // These are the preferred method of access
     //
-    EXPECT_FLOAT_EQ(steel->getPhysicalQuantity(QString::fromStdString("Density")).getValue(), 7.9e-06);
-    EXPECT_FLOAT_EQ(steel->getPhysicalValue(QString::fromStdString("PoissonRatio")).toDouble(), 0.3);
-    EXPECT_FLOAT_EQ(steel->getPhysicalQuantity(QString::fromStdString("YoungsModulus")).getValue(), 210000000.0);
-    EXPECT_FLOAT_EQ(steel->getPhysicalQuantity(QString::fromStdString("SpecificHeat")).getValue(), 590000000.0);
-    EXPECT_FLOAT_EQ(steel->getPhysicalQuantity(QString::fromStdString("ThermalConductivity")).getValue(), 43000.0);
-    EXPECT_FLOAT_EQ(steel->getPhysicalQuantity(QString::fromStdString("ThermalExpansionCoefficient")).getValue(), 1.2e-05);
+    EXPECT_DOUBLE_EQ(steel->getPhysicalQuantity(QString::fromStdString("Density")).getValue(), 7.9e-06);
+    EXPECT_NEAR(steel->getPhysicalValue(QString::fromStdString("PoissonRatio")).toDouble(), 0.3, 1e-6);
+    EXPECT_DOUBLE_EQ(steel->getPhysicalQuantity(QString::fromStdString("YoungsModulus")).getValue(), 210000000.0);
+    EXPECT_DOUBLE_EQ(steel->getPhysicalQuantity(QString::fromStdString("SpecificHeat")).getValue(), 590000000.0);
+    EXPECT_DOUBLE_EQ(steel->getPhysicalQuantity(QString::fromStdString("ThermalConductivity")).getValue(), 43000.0);
+    EXPECT_DOUBLE_EQ(steel->getPhysicalQuantity(QString::fromStdString("ThermalExpansionCoefficient")).getValue(), 1.2e-05);
     EXPECT_EQ(steel->getAppearanceValue(QString::fromStdString("AmbientColor")), QString::fromStdString("(0.0020, 0.0020, 0.0020, 1.0)"));
     EXPECT_EQ(steel->getAppearanceValue(QString::fromStdString("DiffuseColor")), QString::fromStdString("(0.0000, 0.0000, 0.0000, 1.0)"));
     EXPECT_EQ(steel->getAppearanceValue(QString::fromStdString("EmissiveColor")), QString::fromStdString("(0.0000, 0.0000, 0.0000, 1.0)"));
-    EXPECT_FLOAT_EQ(steel->getAppearanceValue(QString::fromStdString("Shininess")).toDouble(), 0.06);
+    EXPECT_NEAR(steel->getAppearanceValue(QString::fromStdString("Shininess")).toDouble(), 0.06, 1e-6);
     EXPECT_EQ(steel->getAppearanceValue(QString::fromStdString("SpecularColor")), QString::fromStdString("(0.9800, 0.9800, 0.9800, 1.0)"));
-    EXPECT_FLOAT_EQ(steel->getAppearanceValue(QString::fromStdString("Transparency")).toDouble(), 0.0);
+    EXPECT_DOUBLE_EQ(steel->getAppearanceValue(QString::fromStdString("Transparency")).toDouble(), 0.0);
 
     EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("Density")).getUserString(), parseQuantity("7900.00 kg/m^3"));
     EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("YoungsModulus")).getUserString(), parseQuantity("210.00 GPa"));

--- a/tests/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/tests/src/Mod/Part/App/FeatureChamfer.cpp
@@ -101,7 +101,7 @@ TEST_F(FeatureChamferTest, testMost)
     _chamfer->execute();
     double chamferVolume = PartTestHelpers::getVolume(_chamfer->Shape.getValue());
     // Assert
-    EXPECT_FLOAT_EQ(chamferVolume, 121.46667);  // This is calculable, but painful.
+    EXPECT_NEAR(chamferVolume, 121.46667, 1e-5);  // This is calculable, but painful.
 }
 
 // Worth noting that FeaturePartCommon with insufficient parameters says MustExecute false,

--- a/tests/src/Mod/Part/App/FeatureFillet.cpp
+++ b/tests/src/Mod/Part/App/FeatureFillet.cpp
@@ -76,7 +76,7 @@ TEST_F(FeatureFilletTest, testOtherEdges)
     _fillet->execute();
     filletVolume = PartTestHelpers::getVolume(_fillet->Shape.getValue());
     // Assert
-    EXPECT_FLOAT_EQ(filletVolume, 125.57079);
+    EXPECT_NEAR(filletVolume, 125.57079, 1e-5);
 }
 
 TEST_F(FeatureFilletTest, testMostEdges)
@@ -93,7 +93,7 @@ TEST_F(FeatureFilletTest, testMostEdges)
     _fillet->execute();
     double filletVolume = PartTestHelpers::getVolume(_fillet->Shape.getValue());
     // Assert
-    EXPECT_FLOAT_EQ(filletVolume, 118.38763);
+    EXPECT_NEAR(filletVolume, 118.38763, 1e-5);
 }
 
 // Worth noting that FeaturePartCommon with insufficient parameters says MustExecute false,

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -577,7 +577,7 @@ TEST_F(TopoShapeExpansionTest, makeElementWiresCombinesWires)
     auto elements = elementMap((topoShape));
     Base::BoundBox3d bb = topoShape.getBoundBox();
     // Assert shape is correct
-    EXPECT_FLOAT_EQ(getLength(topoShape.getShape()), 4.4142137);
+    EXPECT_NEAR(getLength(topoShape.getShape()), 4.4142137, 1e-6);
     EXPECT_TRUE(PartTestHelpers::boxesMatch(bb, Base::BoundBox3d(0, 0, 0, 3, 2, 0)));
     // Assert map is correct
     EXPECT_TRUE(allElementsMatch(topoShape,
@@ -610,10 +610,10 @@ TEST_F(TopoShapeExpansionTest, makeElementFaceNull)
     double area3 = getArea(topoShape.getShape());
     // Assert
     EXPECT_FALSE(face1.IsEqual(newFace.getShape()));
-    EXPECT_FLOAT_EQ(area, Len * Wid + M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area1, Len * Wid + M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area2, Len * Wid - M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area3, Len * Wid + M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area, Len * Wid + M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area1, Len * Wid + M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area2, Len * Wid - M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area3, Len * Wid + M_PI * Rad * Rad);
     EXPECT_STREQ(newFace.shapeName().c_str(), "Face");
 }
 
@@ -634,10 +634,10 @@ TEST_F(TopoShapeExpansionTest, makeElementFaceSimple)
     // Assert
     EXPECT_TRUE(newFace.getShape().IsEqual(topoShape.getShape()));  // topoShape was altered
     EXPECT_FALSE(face1.IsEqual(newFace.getShape()));
-    EXPECT_FLOAT_EQ(area, Len * Wid + M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area1, Len * Wid + M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area2, Len * Wid);
-    EXPECT_FLOAT_EQ(area3, Len * Wid);
+    EXPECT_DOUBLE_EQ(area, Len * Wid + M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area1, Len * Wid + M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area2, Len * Wid);
+    EXPECT_DOUBLE_EQ(area3, Len * Wid);
     EXPECT_STREQ(newFace.shapeName().c_str(), "Face");
 }
 
@@ -658,10 +658,10 @@ TEST_F(TopoShapeExpansionTest, makeElementFaceParams)
     // Assert
     EXPECT_TRUE(newFace.getShape().IsEqual(topoShape.getShape()));  // topoShape was altered
     EXPECT_FALSE(face1.IsEqual(newFace.getShape()));
-    EXPECT_FLOAT_EQ(area, Len * Wid + M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area1, Len * Wid + M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area2, Len * Wid);
-    EXPECT_FLOAT_EQ(area3, Len * Wid);
+    EXPECT_DOUBLE_EQ(area, Len * Wid + M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area1, Len * Wid + M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area2, Len * Wid);
+    EXPECT_DOUBLE_EQ(area3, Len * Wid);
     EXPECT_STREQ(newFace.shapeName().c_str(), "Face");
 }
 
@@ -682,10 +682,10 @@ TEST_F(TopoShapeExpansionTest, makeElementFaceFromFace)
     // Assert
     EXPECT_TRUE(newFace.getShape().IsEqual(topoShape.getShape()));  // topoShape was altered
     EXPECT_FALSE(face1.IsEqual(newFace.getShape()));
-    EXPECT_FLOAT_EQ(area, Len * Wid + M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area1, Len * Wid + M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area2, Len * Wid - M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area3, Len * Wid - M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area, Len * Wid + M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area1, Len * Wid + M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area2, Len * Wid - M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area3, Len * Wid - M_PI * Rad * Rad);
     EXPECT_STREQ(newFace.shapeName().c_str(), "Face");
 }
 
@@ -707,10 +707,10 @@ TEST_F(TopoShapeExpansionTest, makeElementFaceOpenWire)
     // Assert
     EXPECT_TRUE(newFace.getShape().IsEqual(topoShape.getShape()));  // topoShape was altered
     EXPECT_FALSE(face1.IsEqual(newFace.getShape()));
-    EXPECT_FLOAT_EQ(area, Len * Wid + M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area1, 0);  // Len * Wid - M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area2, Len * Wid);
-    EXPECT_FLOAT_EQ(area3, Len * Wid);
+    EXPECT_DOUBLE_EQ(area, Len * Wid + M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area1, 0);  // Len * Wid - M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area2, Len * Wid);
+    EXPECT_DOUBLE_EQ(area3, Len * Wid);
     EXPECT_STREQ(newFace.shapeName().c_str(), "Face");
 }
 
@@ -732,10 +732,10 @@ TEST_F(TopoShapeExpansionTest, makeElementFaceClosedWire)
     // Assert
     EXPECT_TRUE(newFace.getShape().IsEqual(topoShape.getShape()));  // topoShape was altered
     EXPECT_FALSE(face1.IsEqual(newFace.getShape()));
-    EXPECT_FLOAT_EQ(area, Len * Wid + M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area1, 0);  // Len * Wid - M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area2, M_PI * Rad * Rad);
-    EXPECT_FLOAT_EQ(area3, M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area, Len * Wid + M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area1, 0);  // Len * Wid - M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area2, M_PI * Rad * Rad);
+    EXPECT_DOUBLE_EQ(area3, M_PI * Rad * Rad);
     EXPECT_STREQ(newFace.shapeName().c_str(), "Face");
 }
 
@@ -838,8 +838,8 @@ TEST_F(TopoShapeExpansionTest, splitWires)
     TopoShape wire = topoShape.splitWires(&inner, TopoShape::SplitWireReorient::ReorientReversed);
     // Assert
     EXPECT_EQ(inner.size(), 1);
-    EXPECT_FLOAT_EQ(getLength(wire.getShape()), 2 + 2 + 3 + 3);
-    EXPECT_FLOAT_EQ(getLength(inner.front().getShape()), M_PI * Rad * 2);
+    EXPECT_DOUBLE_EQ(getLength(wire.getShape()), 2 + 2 + 3 + 3);
+    EXPECT_DOUBLE_EQ(getLength(inner.front().getShape()), M_PI * Rad * 2);
     EXPECT_EQ(wire.getShape().Orientation(), TopAbs_REVERSED);
     for (TopoShape& shape : inner) {
         EXPECT_EQ(shape.getShape().Orientation(), TopAbs_FORWARD);
@@ -1703,7 +1703,7 @@ TEST_F(TopoShapeExpansionTest, makeElementRuledSurfaceWires)
     auto elements = elementMap(cube1TS);
     // Assert
     EXPECT_EQ(cube1TS.countSubElements("Wire"), 4);
-    EXPECT_FLOAT_EQ(getArea(cube1TS.getShape()), 2.023056);
+    EXPECT_NEAR(getArea(cube1TS.getShape()), 2.023056, 1e-6);
     // Assert that we're creating a correct element map
     EXPECT_TRUE(cube1TS.getMappedChildElements().empty());
     // TODO: Revisit these when resetElementMap() is fully worked through.  Suspect that last loop
@@ -1745,11 +1745,11 @@ TEST_F(TopoShapeExpansionTest, makeElementLoft)
     auto elements = elementMap((topoShape));
     // Assert that we haven't broken the basic Loft functionality
     EXPECT_EQ(topoShape.countSubElements("Wire"), 4);
-    EXPECT_FLOAT_EQ(getArea(topoShape.getShape()), 200);
-    EXPECT_FLOAT_EQ(getVolume(topoShape.getShape()), 166.66667);
-    EXPECT_FLOAT_EQ(getVolume(topoShape2.getShape()), 250);
-    EXPECT_FLOAT_EQ(getVolume(topoShape3.getShape()), 166.66667);
-    EXPECT_FLOAT_EQ(getVolume(topoShape4.getShape()), 250);
+    EXPECT_DOUBLE_EQ(getArea(topoShape.getShape()), 200);
+    EXPECT_NEAR(getVolume(topoShape.getShape()), 166.66667, 1e-5);
+    EXPECT_DOUBLE_EQ(getVolume(topoShape2.getShape()), 250);
+    EXPECT_NEAR(getVolume(topoShape3.getShape()), 166.66667, 1e-5);
+    EXPECT_DOUBLE_EQ(getVolume(topoShape4.getShape()), 250);
     EXPECT_NEAR(getVolume(topoShape5.getShape()), 0, 1e-07);
     // Assert that we're creating a correct element map
     EXPECT_TRUE(topoShape.getMappedChildElements().empty());
@@ -1784,8 +1784,8 @@ TEST_F(TopoShapeExpansionTest, makeElementPipeShell)
     auto elements = elementMap((topoShape));
     // Assert that we haven't broken the basic Loft functionality
     EXPECT_EQ(topoShape.countSubElements("Wire"), 4);
-    EXPECT_FLOAT_EQ(getArea(topoShape.getShape()), 160);
-    EXPECT_FLOAT_EQ(getVolume(topoShape.getShape()), 133.33334);
+    EXPECT_DOUBLE_EQ(getArea(topoShape.getShape()), 160);
+    EXPECT_NEAR(getVolume(topoShape.getShape()), 133.33334, 1e-5);
     // Assert that we're creating a correct element map
     EXPECT_TRUE(topoShape.getMappedChildElements().empty());
     EXPECT_EQ(elements.size(), 24);
@@ -1808,7 +1808,7 @@ TEST_F(TopoShapeExpansionTest, makeElementThickSolid)
     auto elements = elementMap(cube1TS);
     // Assert
     EXPECT_EQ(cube1TS.countSubElements("Wire"), 16);
-    EXPECT_FLOAT_EQ(getArea(cube1TS.getShape()), 9.4911509);
+    EXPECT_NEAR(getArea(cube1TS.getShape()), 9.4911509, 1e-6);
     // Assert that we're creating a correct element map
     EXPECT_TRUE(cube1TS.getMappedChildElements().empty());
     EXPECT_EQ(elements.size(), 74);
@@ -2108,7 +2108,7 @@ TEST_F(TopoShapeExpansionTest, makeElementChamfer)
     auto elements = elementMap(cube1TS);
     // Assert shape is correct
     EXPECT_EQ(cube1TS.countSubElements("Wire"), 26);
-    EXPECT_FLOAT_EQ(getArea(cube1TS.getShape()), 5.640996);
+    EXPECT_NEAR(getArea(cube1TS.getShape()), 5.640996, 1e-6);
     // Assert that we're creating a correct element map
     EXPECT_TRUE(cube1TS.getMappedChildElements().empty());
     EXPECT_TRUE(allElementsMatch(cube1TS,
@@ -2225,7 +2225,7 @@ TEST_F(TopoShapeExpansionTest, makeElementFillet)
     auto elements = elementMap(cube1TS);
     // Assert shape is correct
     EXPECT_EQ(cube1TS.countSubElements("Wire"), 26);
-    EXPECT_FLOAT_EQ(getArea(cube1TS.getShape()), 5.739646);
+    EXPECT_NEAR(getArea(cube1TS.getShape()), 5.739646, 1e-6);
     // Assert that we're creating a correct element map
     EXPECT_TRUE(cube1TS.getMappedChildElements().empty());
     EXPECT_TRUE(elementsMatch(cube1TS,
@@ -2751,7 +2751,7 @@ TEST_F(TopoShapeExpansionTest, makeElementRevolve)
     EXPECT_TRUE(PartTestHelpers::boxesMatch(
         bb,
         Base::BoundBox3d(0.0, 0.0, 0.0, 0.85090352453411933, 1.0, 1.0)));
-    EXPECT_FLOAT_EQ(getVolume(result.getShape()), 0.50885141);
+    EXPECT_NEAR(getVolume(result.getShape()), 0.50885141, 1e-6);
     // Assert elementMap is correct
     EXPECT_TRUE(
         elementsMatch(result,
@@ -2912,7 +2912,7 @@ TEST_F(TopoShapeExpansionTest, makeElementBSplineFace)
     EXPECT_TRUE(PartTestHelpers::boxesMatch(
         bb,
         Base::BoundBox3d(-10, -2.0597998470594132, 2, -4, 2.1254369627132599, 2)));
-    EXPECT_FLOAT_EQ(getArea(result.getShape()), 14.677052);
+    EXPECT_NEAR(getArea(result.getShape()), 14.677052, 1e-6);
     // Assert elementMap is correct
     EXPECT_TRUE(elementsMatch(result,
                               {
@@ -3171,7 +3171,7 @@ TEST_F(TopoShapeExpansionTest, makeElementOffset)
     // Assert shape is correct
     EXPECT_TRUE(
         PartTestHelpers::boxesMatch(bb, Base::BoundBox3d(-0.25, -0.25, -0.25, 1.25, 1.25, 1.25)));
-    EXPECT_FLOAT_EQ(getVolume(result.getShape()), 3.1544986);
+    EXPECT_NEAR(getVolume(result.getShape()), 3.1544986, 1e-6);
     // Assert elementMap is correct
     //    EXPECT_EQ(elements.size(), 98);
     //    EXPECT_EQ(elements.count(IndexedName("Face", 1)), 1);


### PR DESCRIPTION
* avoid redefines in Assembly
* explicit cast from size_t to int
* remove unused variables
* avoid implicit cast from double to float
* in test cases replace EXPECT_FLOAT_EQ with EXPECT_DOUBLE_EQ or EXPECT_NEAR when doubles are used