### PR TITLE
Draft: Remove Draft_Fillet chamfer recalculation

### DIFF
--- a/src/Mod/Draft/draftgeoutils/fillets.py
+++ b/src/Mod/Draft/draftgeoutils/fillets.py
@@ -91,11 +91,6 @@ def fillet(lEdges, r, chamfer=False):
 
         alpha = U1.getAngle(U2)
 
-        if chamfer:
-            # correcting r value so the size of the chamfer = r
-            beta = math.pi - alpha/2
-            r = (r/2)/math.cos(beta)
-
         # Edges have same direction
         if (round(alpha, precision()) == 0
                 or round(alpha - math.pi, precision()) == 0):


### PR DESCRIPTION
If two straight edges were selected the chamfer distance would be recalculated so that the length of the straight segment would be equal to `r` (the radius entered by the user). But this was, and is, not done if one or both edges are arcs.

By removing the recalculation code the endpoints of the straight chamfer edge now always match the endpoints of the fillet arc that would be created for the same radius. This also matches the fillet/chamfer behavior of a Draft_Wire and Draft_Rectangle and also the behavior we see in for example Part and Sketcher.
