### PR TITLE
[TechDraw] Make template autofilled fields read only

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -118,6 +118,7 @@ void execInsertPrefixChar(Gui::Command* cmd, std::string prefixFormat, const QAc
 
         if (action) {
             if (action->objectName() == QString::fromUtf8("TechDraw_ExtensionInsertRepetition")) {
+                ui.setWindowTitle(QApplication::translate("TechDraw_ExtensionDims", "Enter Text Value"));
                 ui.setFieldName(QT_TR_NOOP("Repeat Count"));
             }
         }

--- a/src/Mod/TechDraw/Gui/DlgTemplateField.cpp
+++ b/src/Mod/TechDraw/Gui/DlgTemplateField.cpp
@@ -67,6 +67,11 @@ QString DlgTemplateField::getFieldContent()
     return ui->leInput->text();
 }
 
+void DlgTemplateField::setFieldReadOnly(bool readOnly)
+{
+    ui->leInput->setReadOnly(readOnly);
+}
+
 void DlgTemplateField::accept()
 {
     QDialog::accept();

--- a/src/Mod/TechDraw/Gui/DlgTemplateField.h
+++ b/src/Mod/TechDraw/Gui/DlgTemplateField.h
@@ -45,6 +45,7 @@ public:
     void setFieldLength(int length);
     void setFieldContent(std::string content);
     QString getFieldContent();
+    void setFieldReadOnly(bool readOnly);
 
 public Q_SLOTS:
     void accept() override;

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -215,7 +215,8 @@ void QGISVGTemplate::createClickHandles()
         }
         double textLength = itemText.length() * charWidth;
         textLength = std::max(charWidth, textLength);
-        auto item(new TemplateTextField(this, svgTemplate, name.toStdString()));
+        auto item(new TemplateTextField(this, svgTemplate, name.toStdString(),
+                                        textElement.hasAttribute(QString::fromUtf8(FREECAD_ATTR_AUTOFILL))));
 
         double pad = 1.0;
         double top = Rez::guiX(-svgTemplate->getHeight()) + y - textHeight - pad;

--- a/src/Mod/TechDraw/Gui/TemplateTextField.cpp
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.cpp
@@ -23,6 +23,7 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
+  #include <QApplication>
   #include <QGraphicsSceneMouseEvent>
   #include <QInputDialog>
   #include <QLineEdit>
@@ -39,10 +40,12 @@ using namespace TechDrawGui;
 
 TemplateTextField::TemplateTextField(QGraphicsItem *parent,
                                      TechDraw::DrawTemplate *myTmplte,
-                                     const std::string &myFieldName)
+                                     const std::string &myFieldName,
+                                     bool isAutofilled)
     : QGraphicsItemGroup(parent),
       tmplte(myTmplte),
-      fieldNameStr(myFieldName)
+      fieldNameStr(myFieldName),
+      autofilled(isAutofilled)
 {
     setToolTip(QObject::tr("Click to update text"));
     m_rect = new QGraphicsRectItem();
@@ -74,6 +77,11 @@ void TemplateTextField::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 
         ui.setFieldName(fieldNameStr);
         ui.setFieldContent(tmplte->EditableTexts[fieldNameStr]);
+
+        if (autofilled) {
+            ui.setWindowTitle(QApplication::translate("TechDraw_Template", "Inspect Autofilled Field"));
+            ui.setFieldReadOnly(true);
+        }
 
         if (ui.exec() == QDialog::Accepted) {
         //WF: why is this escaped?

--- a/src/Mod/TechDraw/Gui/TemplateTextField.h
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.h
@@ -45,7 +45,8 @@ class TechDrawGuiExport TemplateTextField : public QGraphicsItemGroup
     public:
         TemplateTextField(QGraphicsItem *parent,
                           TechDraw::DrawTemplate *myTmplte,
-                          const std::string &myFieldName);
+                          const std::string &myFieldName,
+                          bool isAutofilled = false);
 
         ~TemplateTextField() override = default;
 
@@ -62,6 +63,7 @@ class TechDrawGuiExport TemplateTextField : public QGraphicsItemGroup
     protected:
         TechDraw::DrawTemplate *tmplte;
         std::string fieldNameStr;
+        bool autofilled;
 
         /// Need this to properly handle mouse release
         void mousePressEvent(QGraphicsSceneMouseEvent *event) override;


### PR DESCRIPTION
In current implementation the content of the template autofilled fields is always filled in by the application. Even though the user enters a different value and it is saved, it is not reflected in the document. I believe this can lead to complaints and error reports.
This pull request makes the editable field in the Template Field Dialog read only in case of autofilled text fields and changes the dialog title from "Change Editable Field" to "Inspect Autofilled Field". I believe this should make the behavior more evident.