### PR TITLE
[PartDesign] Fix Hole parameters, thread depth level not enabled unless clicked 3 times...

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -269,6 +269,9 @@ void TaskHoleParameters::threadedChanged()
 
     ui->ModelThread->setEnabled(isChecked);
     ui->ThreadDepthType->setEnabled(isChecked);
+    ui->ThreadDepth->setEnabled(
+        ui->Threaded->isChecked() && ui->ModelThread->isChecked() &&
+        std::string(pcHole->ThreadDepthType.getValueAsString()) == "Dimension");
 
     // conditional enabling of thread modeling options
     ui->UseCustomThreadClearance->setEnabled(ui->Threaded->isChecked() && ui->ModelThread->isChecked());


### PR DESCRIPTION
...when opening an existing hole feature

See forum discussion: https://forum.freecad.org/viewtopic.php?t=88611
