### PR TITLE
Gui: Tree.cpp make some gui texts more consistent

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -404,8 +404,8 @@ class TreeWidgetItemDelegate: public QStyledItemDelegate {
     // Beware, big scary hack incoming!
     //
     // This is artificial QTreeWidget that is not rendered and its sole goal is to be the source
-    // of style information that can be manipulated using QSS. From Qt6.5 tree branches also 
-    // have rendered background using ::item sub-control. Whole row also gets background from 
+    // of style information that can be manipulated using QSS. From Qt6.5 tree branches also
+    // have rendered background using ::item sub-control. Whole row also gets background from
     // the same sub-control. Only way to prevent this is to disable background of ::item,
     // this however limits our ability to style tree items. As solution we create this widget
     // that will be for painter to read information and draw proper backgrounds only when asked.
@@ -447,9 +447,9 @@ QRect TreeWidgetItemDelegate::calculateItemRect(const QStyleOptionViewItem &opti
     QRect rect = option.rect;
 
     const int margin = style->pixelMetric(QStyle::PM_FocusFrameHMargin, &option, artificial) + 1;
-    
+
     // 2 margin for text, 2 margin for decoration (icon) = 4 times margin
-    int width = 4 * margin 
+    int width = 4 * margin
         + option.fontMetrics.boundingRect(option.text).width()
         + option.decorationSize.width()
         + TreeParams::getItemBackgroundPadding()
@@ -457,7 +457,7 @@ QRect TreeWidgetItemDelegate::calculateItemRect(const QStyleOptionViewItem &opti
 
     if (TreeParams::getCheckBoxesSelection()) {
         // another 2 margin for checkbox
-        width += 2 * margin 
+        width += 2 * margin
             + style->pixelMetric(QStyle::PM_IndicatorWidth)
             + style->pixelMetric(QStyle::PM_LayoutHorizontalSpacing);
     }
@@ -482,7 +482,7 @@ void TreeWidgetItemDelegate::paint(QPainter *painter,
     // rendering as transparent overlay.
 
     bool trimBG = TreeParams::getHideColumn() || TreeParams::getHideInternalNames();
-    
+
     if (index.column() == 0) {
         if (tree->testAttribute(Qt::WA_NoSystemBackground)
                 && (trimBG || (opt.backgroundBrush.style() == Qt::NoBrush
@@ -995,11 +995,11 @@ void TreeWidget::contextMenuEvent(QContextMenuEvent* e)
     if (this->contextItem && this->contextItem->type() == DocumentType) {
         auto docitem = static_cast<DocumentItem*>(this->contextItem);
         App::Document* doc = docitem->document()->getDocument();
-        
+
         // It's better to let user decide whether and how to activate
         // the current document, such as by double-clicking.
         // App::GetApplication().setActiveDocument(doc);
-        
+
         showHiddenAction->setChecked(docitem->showHidden());
         contextMenu.addAction(this->showHiddenAction);
         contextMenu.addAction(this->searchObjectsAction);
@@ -1108,9 +1108,9 @@ void TreeWidget::contextMenuEvent(QContextMenuEvent* e)
     contextMenu.addSeparator();
     contextMenu.addMenu(&settingsMenu);
 
-    QAction* action = new QAction(tr("Show description column"), this);
+    QAction* action = new QAction(tr("Show description"), this);
     QAction* internalNameAction = new QAction(tr("Show internal name"), this);
-    action->setStatusTip(tr("Show an extra tree view column for item description. The item's description can be set by pressing F2 (or your OS's edit button) or by editing the 'label2' property."));
+    action->setStatusTip(tr("Show a description column for items. An item's description can be set by pressing F2 (or your OS's edit button) or by editing the 'label2' property."));
     action->setCheckable(true);
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/TreeView");
@@ -2916,11 +2916,11 @@ struct UpdateDisabler {
         focus = widget.hasFocus();
         visible = widget.isVisible();
         if (visible) {
-            // setUpdatesEnabled(false) does not seem to speed up anything. 
-            // setVisible(false) on the other hand makes QTreeWidget::setData 
-            // (i.e. any change to QTreeWidgetItem) faster by 10+ times. 
-            // 
-            // widget.setUpdatesEnabled(false); 
+            // setUpdatesEnabled(false) does not seem to speed up anything.
+            // setVisible(false) on the other hand makes QTreeWidget::setData
+            // (i.e. any change to QTreeWidgetItem) faster by 10+ times.
+            //
+            // widget.setUpdatesEnabled(false);
 
             widget.setVisible(false);
         }


### PR DESCRIPTION
The gui texts for "Show description" and "Show internal name" were inconsistent.

"Show description column" -> "Show description"

"Show an extra tree view column for item description. -> "Show a description column for items."
