### PR TITLE
BIM: fix BIM_Setup unit system issue

### DIFF
--- a/src/Mod/BIM/bimcommands/BimSetup.py
+++ b/src/Mod/BIM/bimcommands/BimSetup.py
@@ -173,6 +173,18 @@ class BIM_Setup:
         FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").SetInt(
             "UserSchema", unit
         )
+        if FreeCAD.ActiveDocument is not None:
+            docs_dict = FreeCAD.listDocuments()
+            for doc in docs_dict.values():
+                doc.UnitSystem = unit
+            if len(docs_dict) == 1:
+                FreeCAD.Console.PrintWarning(
+                    translate("BIM", "Unit system updated for active document") + "\n"
+                )
+            else:
+                FreeCAD.Console.PrintWarning(
+                    translate("BIM", "Unit system updated for all opened documents") + "\n"
+                )
         if hasattr(FreeCAD.Units, "setSchema"):
             FreeCAD.Units.setSchema(unit)
         decimals = self.form.settingDecimals.value()
@@ -474,7 +486,7 @@ class BIM_Setup:
             unit = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt(
                 "UserSchema", 0
             )
-            unit = [0, 2, 3, 3, 1, 5, 0, 4][
+            unit = [0, 2, 3, 3, 1, 5, 0, 4, 0, 2][
                 unit
             ]  # less choices in our simplified dialog
             decimals = FreeCAD.ParamGet(
@@ -620,16 +632,16 @@ class BIM_Setup:
         g = ((color >> 16) & 0xFF) / 255.0
         b = ((color >> 8) & 0xFF) / 255.0
         from PySide import QtGui
-    
+
         return QtGui.QColor.fromRgbF(r, g, b)
-    
-    
+
+
     def getIfcOpenShell(self,force=False):
         """downloads and installs IfcOpenShell"""
-        
+
         # TODO WARNING the IfcOpenBot repo below is not actively kept updated.
         # We need to use PIP
-    
+
         ifcok = False
         if not force:
             try:
@@ -649,7 +661,7 @@ class BIM_Setup:
             from PySide import QtGui
             import zipfile
             from urllib import request
-    
+
             if not FreeCAD.GuiUp:
                 reply = QtGui.QMessageBox.Yes
             else:
@@ -706,11 +718,11 @@ class BIM_Setup:
                             if u:
                                 if sys.version_info.major < 3:
                                     import StringIO as io
-    
+
                                     _stringio = io.StringIO
                                 else:
                                     import io
-    
+
                                     _stringio = io.BytesIO
                                 zfile = _stringio()
                                 zfile.write(u.read())


### PR DESCRIPTION
Fixes #14675.

Note that I would prefer to use the FEM unit system (always mm). BIM_Setup does not support that, and this PR does not change that.
