### PR TITLE
TechDraw: Update TD page templates with autofill and editable attributes

### DIFF
--- a/src/Mod/TechDraw/Templates/A3_Landscape_TD.svg
+++ b/src/Mod/TechDraw/Templates/A3_Landscape_TD.svg
@@ -5,37 +5,15 @@
    height="297mm"
    version="1.1"
    viewBox="0 0 420 297"
-   sodipodi:docname="A3_Landscape_TD.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="mm"
-     inkscape:zoom="0.91092262"
-     inkscape:cx="848.59019"
-     inkscape:cy="632.87483"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
   <!-- Working space 10 10 410 287 -->
   <!-- Title block 220 227 410 287 -->
   <metadata
@@ -46,7 +24,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -864,11 +841,11 @@
        fill-rule="evenodd"
        stroke="none" />
   </g>
-  <!-- DrawingContent -->
   <path
      id="path10-4"
      style="fill:#212529;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.700001;stroke-linecap:square"
-     d="m 376.00004,258.50003 -1.66666,1.66665 V 268.5 h 3.35448 c 0.1263,0 0.23845,-0.0817 0.27749,-0.20183 l 0.30112,-0.92772 c 0.0288,-0.0888 0.0984,-0.15833 0.18717,-0.18717 l 0.23193,-0.0757 c 0.0888,-0.0288 0.18651,-0.0126 0.26205,0.0415 l 0.78938,0.57373 c 0.10221,0.0744 0.2412,0.0744 0.34344,0 l 0.70717,-0.51432 c 0.10221,-0.0744 0.14488,-0.20615 0.10583,-0.32634 l -0.3011,-0.92855 c -0.0288,-0.0888 -0.0126,-0.18568 0.0415,-0.26123 l 0.14314,-0.19693 c 0.0548,-0.0756 0.14268,-0.12047 0.236,-0.12047 h 0.97575 c 0.1263,2e-5 0.23846,-0.0816 0.2775,-0.20181 l 0.27018,-0.83171 c 0.0391,-0.12016 -0.003,-0.25206 -0.10582,-0.32633 l -0.78938,-0.57373 c -0.0756,-0.0548 -0.12047,-0.14268 -0.12047,-0.236 v -0.24415 c 0,-0.0934 0.0448,-0.18113 0.12047,-0.236 l 0.90494,-0.65755 c 0.0756,-0.0548 0.12047,-0.14268 0.12047,-0.236 V 258.5 Z m 0,1.66665 h 4.99998 v 1.66668 h -3.33333 v 1.25 h 1.66668 v 1.66665 h -1.66668 v 2.08333 h -1.66665 z" />
+     d="m 375.82505,258.50003 -1.66666,1.66665 V 268.5 h 3.35448 c 0.1263,0 0.23845,-0.0817 0.27749,-0.20183 l 0.30112,-0.92772 c 0.0288,-0.0888 0.0984,-0.15833 0.18717,-0.18717 l 0.23193,-0.0757 c 0.0888,-0.0288 0.18651,-0.0126 0.26205,0.0415 l 0.78938,0.57373 c 0.10221,0.0744 0.2412,0.0744 0.34344,0 l 0.70717,-0.51432 c 0.10221,-0.0744 0.14488,-0.20615 0.10583,-0.32634 l -0.3011,-0.92855 c -0.0288,-0.0888 -0.0126,-0.18568 0.0415,-0.26123 l 0.14314,-0.19693 c 0.0548,-0.0756 0.14268,-0.12047 0.236,-0.12047 h 0.97575 c 0.1263,2e-5 0.23846,-0.0816 0.2775,-0.20181 l 0.27018,-0.83171 c 0.0391,-0.12016 -0.003,-0.25206 -0.10582,-0.32633 l -0.78938,-0.57373 c -0.0756,-0.0548 -0.12047,-0.14268 -0.12047,-0.236 v -0.24415 c 0,-0.0934 0.0448,-0.18113 0.12047,-0.236 l 0.90494,-0.65755 c 0.0756,-0.0548 0.12047,-0.14268 0.12047,-0.236 V 258.5 Z m 0,1.66665 h 4.99998 v 1.66668 h -3.33333 v 1.25 h 1.66668 v 1.66665 h -1.66668 v 2.08333 h -1.66665 z" />
+  <!-- DrawingContent -->
   <g
      id="titleblock-text-editable"
      font-family="osifont"
@@ -879,56 +856,60 @@
        x="220.9935"
        y="232.95425"
        style="line-height:0%"
-       index:editable="AuthorName"><tspan
+       freecad:editable="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
+       freecad:autofill="author"><tspan
          id="tspan181">AUTHOR NAME</tspan></text>
     <text
        id="text187"
        x="220.78677"
        y="240.50475"
        style="line-height:0%"
-       index:editable="CreationDate"><tspan
+       freecad:editable="CreationDate"
+       freecad:autofill="date"><tspan
          id="tspan185">CREATION DATE</tspan></text>
     <text
        id="text191"
        x="220.74191"
        y="247.9375"
        style="line-height:0%"
-       index:editable="SupervisorName"><tspan
+       freecad:editable="SupervisorName"><tspan
          id="tspan189">SUPERVISOR NAME</tspan></text>
     <text
        id="text195"
        x="220.69022"
        y="255.35406"
        style="line-height:0%"
-       index:editable="CheckDate"><tspan
+       freecad:editable="CheckDate"><tspan
          id="tspan193">CHECK DATE</tspan></text>
     <text
        id="text199"
        x="220.65581"
        y="278.57715"
        style="line-height:0%"
-       index:editable="FC-Scale"><tspan
+       freecad:editable="FC-Scale"
+       freecad:autofill="scale"><tspan
          id="tspan197">SCALE</tspan></text>
     <text
        id="text203"
        x="240.50963"
        y="278.57715"
        style="line-height:0%"
-       index:editable="Weight"><tspan
+       freecad:editable="Weight"><tspan
          id="tspan201">WEIGHT</tspan></text>
     <text
        id="text207"
        x="266.50964"
        y="278.57715"
        style="line-height:0%"
-       index:editable="DrawingNumber"><tspan
+       freecad:editable="DrawingNumber"><tspan
          id="tspan205">NUMBER</tspan></text>
     <text
        id="tspan3333-6-6-3-8-7"
        x="366.50964"
        y="278.57715"
        style="line-height:0%"
-       index:editable="SheetNumber"><tspan
+       freecad:editable="SheetNumber"
+       freecad:autofill="sheet"><tspan
          id="tspan209">SHEET</tspan></text>
     <text
        id="text214"
@@ -936,14 +917,15 @@
        y="241.26292"
        font-size="8px"
        style="line-height:0%"
-       index:editable="FC-Title"><tspan
+       freecad:editable="FC-Title"
+       freecad:autofill="title"><tspan
          id="tspan212">TITLE</tspan></text>
     <text
        id="tspan3333-5-6"
        x="270.19635"
        y="247.26292"
        style="line-height:0%"
-       index:editable="Subtitle"><tspan
+       freecad:editable="Subtitle"><tspan
          id="tspan216">SUBTITLE</tspan></text>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/A4_Landscape_TD.svg
+++ b/src/Mod/TechDraw/Templates/A4_Landscape_TD.svg
@@ -5,37 +5,15 @@
    height="210mm"
    version="1.1"
    viewBox="0 0 297 210"
-   sodipodi:docname="A4_Landscape_TD.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="mm"
-     inkscape:zoom="3.6435046"
-     inkscape:cx="902.42785"
-     inkscape:cy="618.49792"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="g4419" />
   <!-- Working space 10 10 287 200 -->
   <!-- Title block 147 153 287 200 -->
   <metadata
@@ -46,7 +24,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -905,8 +882,7 @@
     <path
        id="path10-4"
        style="fill:#212529;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.700001;stroke-linecap:square"
-       d="m 257.14003,171.50403 -1.66666,1.66665 v 8.33332 h 3.35448 c 0.1263,0 0.23845,-0.0817 0.27749,-0.20183 l 0.30112,-0.92772 c 0.0288,-0.0888 0.0984,-0.15833 0.18717,-0.18717 l 0.23193,-0.0757 c 0.0888,-0.0288 0.18651,-0.0126 0.26205,0.0415 l 0.78938,0.57373 c 0.10221,0.0744 0.2412,0.0744 0.34344,0 l 0.70717,-0.51432 c 0.10221,-0.0744 0.14488,-0.20615 0.10583,-0.32634 l -0.3011,-0.92855 c -0.0288,-0.0888 -0.0126,-0.18568 0.0415,-0.26123 l 0.14314,-0.19693 c 0.0548,-0.0756 0.14268,-0.12047 0.236,-0.12047 h 0.97575 c 0.1263,2e-5 0.23846,-0.0816 0.2775,-0.20181 l 0.27018,-0.83171 c 0.0391,-0.12016 -0.003,-0.25206 -0.10582,-0.32633 l -0.78938,-0.57373 c -0.0756,-0.0548 -0.12047,-0.14268 -0.12047,-0.236 v -0.24415 c 0,-0.0934 0.0448,-0.18113 0.12047,-0.236 l 0.90494,-0.65755 c 0.0756,-0.0548 0.12047,-0.14268 0.12047,-0.236 V 171.504 Z m 0,1.66665 h 4.99998 v 1.66668 h -3.33333 v 1.25 h 1.66668 v 1.66665 h -1.66668 v 2.08333 h -1.66665 z"
-       transform="translate(153.06,-0.054004)" />
+       d="m 410.20003,171.45004 -1.66666,1.66665 v 8.33332 h 3.35448 c 0.1263,0 0.23845,-0.0817 0.27749,-0.20183 l 0.30112,-0.92772 c 0.0288,-0.0888 0.0984,-0.15833 0.18717,-0.18717 l 0.23193,-0.0757 c 0.0888,-0.0288 0.18651,-0.0126 0.26205,0.0415 l 0.78938,0.57373 c 0.10221,0.0744 0.2412,0.0744 0.34344,0 l 0.70717,-0.51432 c 0.10221,-0.0744 0.14488,-0.20615 0.10583,-0.32634 l -0.3011,-0.92855 c -0.0288,-0.0888 -0.0126,-0.18568 0.0415,-0.26123 l 0.14314,-0.19693 c 0.0548,-0.0756 0.14268,-0.12047 0.236,-0.12047 h 0.97575 c 0.1263,2e-5 0.23846,-0.0816 0.2775,-0.20181 l 0.27018,-0.83171 c 0.0391,-0.12016 -0.003,-0.25206 -0.10582,-0.32633 l -0.78938,-0.57373 c -0.0756,-0.0548 -0.12047,-0.14268 -0.12047,-0.236 v -0.24415 c 0,-0.0934 0.0448,-0.18113 0.12047,-0.236 l 0.90494,-0.65755 c 0.0756,-0.0548 0.12047,-0.14268 0.12047,-0.236 v -3.33169 z m 0,1.66665 h 4.99998 v 1.66668 h -3.33333 v 1.25 h 1.66668 v 1.66665 h -1.66668 v 2.08333 h -1.66665 z" />
   </g>
   <g
      id="g3298"
@@ -919,8 +895,8 @@
        x="147.9312"
        y="160.67236"
        style="line-height:0%"
-       index:editable="Designed_by_Name"
-       index:autofill="author"><tspan
+       freecad:editable="Designed_by_Name"
+       freecad:autofill="author"><tspan
          id="tspan3268"
          x="147.9312"
          y="160.67236"
@@ -931,8 +907,8 @@
        x="147.93056"
        y="168.59135"
        style="line-height:0%"
-       index:editable="FC-Date"
-       index:autofill="date"><tspan
+       freecad:editable="FC-Date"
+       freecad:autofill="date"><tspan
          id="tspan3272"
          x="147.93056"
          y="168.59135"
@@ -945,8 +921,8 @@
        text-align="center"
        text-anchor="middle"
        style="line-height:0%"
-       index:editable="FC-SC"
-       index:autofill="scale"><tspan
+       freecad:editable="FC-SC"
+       freecad:autofill="scale"><tspan
          id="tspan3276"
          x="154.46243"
          y="191.45177"
@@ -959,7 +935,7 @@
        text-align="center"
        text-anchor="middle"
        style="line-height:0%"
-       index:editable="Weight"><tspan
+       freecad:editable="Weight"><tspan
          id="tspan3280"
          x="173.94231"
          y="191.44733"
@@ -970,8 +946,8 @@
        x="186.05237"
        y="158.72597"
        style="line-height:0%"
-       index:editable="FC-Title"
-       index:autofill="title"><tspan
+       freecad:editable="FC-Title"
+       freecad:autofill="title"><tspan
          id="tspan3284"
          x="186.05237"
          y="158.72597"
@@ -982,7 +958,7 @@
        x="185.99422"
        y="165.73558"
        style="line-height:0%"
-       index:editable="Subtitle"><tspan
+       freecad:editable="Subtitle"><tspan
          id="tspan3288"
          x="185.99422"
          y="165.73558"
@@ -993,7 +969,7 @@
        x="185.6927"
        y="191.31752"
        style="line-height:0%"
-       index:editable="Drawing_number"><tspan
+       freecad:editable="Drawing_number"><tspan
          id="tspan3292"
          x="185.6927"
          y="191.31752"
@@ -1004,8 +980,8 @@
        x="248.32477"
        y="191.45177"
        style="line-height:0%"
-       index:editable="FC-SH"
-       index:autofill="sheet"><tspan
+       freecad:editable="FC-SH"
+       freecad:autofill="sheet"><tspan
          id="tspan3296"
          x="248.32477"
          y="191.45177"

--- a/src/Mod/TechDraw/Templates/ANSIC_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/ANSIC_Portrait.svg
@@ -4,36 +4,16 @@
    width="432"
    height="559"
    version="1.1"
-   sodipodi:docname="ANSIC_Portrait.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index0="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace"
+   xmlns:index="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="2.9675716"
-     inkscape:cx="217.34943"
-     inkscape:cy="518.10039"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg7089" />
   <!-- Working space 11 11 421 549 -->
   <metadata
      id="metadata7094">
@@ -43,7 +23,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -874,7 +853,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="AUTHOR NAME"><tspan
+     freecad:editable="AUTHOR NAME"
+     freecad:autofill="author"><tspan
        id="tspan3333"
        x="268.18655"
        y="502.91241"
@@ -890,7 +870,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="CREATION DATE"><tspan
+     freecad:editable="CREATION DATE"
+     freecad:autofill="date"><tspan
        id="tspan3333-6"
        x="268.01437"
        y="509.20078"
@@ -906,7 +887,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SUPERVISOR NAME"><tspan
+     freecad:editable="SUPERVISOR NAME"><tspan
        id="tspan3333-6-9"
        x="267.97702"
        y="515.39111"
@@ -922,7 +903,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="CHECK DATE"><tspan
+     freecad:editable="CHECK DATE"><tspan
        id="tspan3333-6-1"
        x="267.93396"
        y="521.56787"
@@ -938,7 +919,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SCALE"><tspan
+     freecad:editable="SCALE"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6"
        x="267.9053"
        y="540.90906"
@@ -954,7 +936,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="WEIGHT"><tspan
+     freecad:editable="WEIGHT"><tspan
        id="tspan3333-6-6-3"
        x="284.4404"
        y="540.90906"
@@ -970,7 +952,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="NUMBER"><tspan
+     freecad:editable="NUMBER"><tspan
        id="tspan3333-6-6-3-8"
        x="306.0943"
        y="540.90906"
@@ -986,7 +968,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SHEET"><tspan
+     freecad:editable="SHEET"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7"
        x="387.37848"
        y="540.90906"
@@ -1002,7 +985,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="TITLE"><tspan
+     freecad:editable="TITLE"
+     freecad:autofill="title"><tspan
        id="tspan3333-5"
        x="305.16473"
        y="503.83221"
@@ -1019,24 +1003,25 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SUBTITLE"><tspan
+     index:editable="SUBTITLE"><tspan
        id="tspan3333-5-6"
        x="305.16473"
        y="508.82922"
        stroke-width=".10827">SUBTITLE</tspan></text>
   <text
      id="text5300"
-     x="253.43817"
-     y="560.69916"
+     x="267.82068"
+     y="529.92542"
      fill="#000000"
      font-family="Sans"
      font-size="3.3314px"
      letter-spacing="0px"
      word-spacing="0px"
-     style="line-height:125%"><tspan
+     style="line-height:125%"
+     freecad:editable="ANSI C"><tspan
        id="tspan5302"
-       x="253.43817"
-       y="560.69916">ANSI C</tspan></text>
+       x="267.82068"
+       y="529.92542">ANSI C</tspan></text>
   <g
      id="g7772"
      transform="matrix(.95 0 0 .95 135.02 441.57)"

--- a/src/Mod/TechDraw/Templates/ANSID_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/ANSID_Landscape.svg
@@ -4,36 +4,15 @@
    width="864"
    height="559"
    version="1.1"
-   sodipodi:docname="ANSID_Landscape.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index0="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="53.555555"
-     inkscape:cx="811.49378"
-     inkscape:cy="516.70643"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg6778" />
   <!-- Working space 21 20 843 539 -->
   <metadata
      id="metadata6783">
@@ -43,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -874,7 +852,8 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="AUTHOR NAME"><tspan
+     freecad:editable="AUTHOR NAME"
+     freecad:autofill="author"><tspan
        id="tspan3333"
        x="690.42792"
        y="495.25952"
@@ -890,7 +869,8 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="CREATION DATE"><tspan
+     freecad:editable="CREATION DATE"
+     freecad:autofill="date"><tspan
        id="tspan3333-6"
        x="690.25861"
        y="501.44135"
@@ -906,7 +886,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SUPERVISOR NAME"><tspan
+     freecad:editable="SUPERVISOR NAME"><tspan
        id="tspan3333-6-9"
        x="690.22192"
        y="507.52676"
@@ -922,7 +902,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="CHECK DATE"><tspan
+     freecad:editable="CHECK DATE"><tspan
        id="tspan3333-6-1"
        x="690.17957"
        y="513.59888"
@@ -938,7 +918,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SCALE"><tspan
+     freecad:editable="SCALE"><tspan
        id="tspan3333-6-6"
        x="692.15143"
        y="532.6123"
@@ -954,7 +934,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="WEIGHT"><tspan
+     freecad:editable="WEIGHT"><tspan
        id="tspan3333-6-6-3"
        x="708.40631"
        y="532.6123"
@@ -970,7 +950,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="NUMBER"><tspan
+     freecad:editable="NUMBER"><tspan
        id="tspan3333-6-6-3-8"
        x="729.6933"
        y="532.6123"
@@ -986,7 +966,8 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SHEET"><tspan
+     freecad:editable="SHEET"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7"
        x="807.56622"
        y="532.6123"
@@ -1002,7 +983,8 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="TITLE"><tspan
+     freecad:editable="TITLE"
+     freecad:autofill="title"><tspan
        id="tspan3333-5"
        x="729.14453"
        y="497.34311"
@@ -1019,7 +1001,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SUBTITLE"><tspan
+     freecad:editable="SUBTITLE"><tspan
        id="tspan3333-5-6"
        x="730.07397"
        y="502.98151"
@@ -1034,7 +1016,8 @@
      font-size="3.2749px"
      letter-spacing="0px"
      word-spacing="0px"
-     style="line-height:125%"><tspan
+     style="line-height:125%"
+     freecad:editable="ANSI D"><tspan
        id="tspan5302"
        x="648.71741"
        y="556.26562">ANSI D</tspan></text>

--- a/src/Mod/TechDraw/Templates/ANSID_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/ANSID_Portrait.svg
@@ -4,36 +4,15 @@
    width="559"
    height="864"
    version="1.1"
-   sodipodi:docname="ANSID_Portrait.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index0="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="43.444444"
-     inkscape:cx="515.80819"
-     inkscape:cy="823.33888"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg8116" />
   <!-- Working space 15 16 544 849 -->
   <metadata
      id="metadata8121">
@@ -43,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -874,7 +852,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="AUTHOR NAME"><tspan
+     freecad:editable="AUTHOR NAME"
+     freecad:autofill="author"><tspan
        id="tspan3333"
        x="392.41803"
        y="802.45728"
@@ -890,7 +869,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="CREATION DATE"><tspan
+     freecad:editable="CREATION DATE"
+     freecad:autofill="date"><tspan
        id="tspan3333-6"
        x="392.24588"
        y="808.74567"
@@ -906,7 +886,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SUPERVISOR NAME"><tspan
+     freecad:editable="SUPERVISOR NAME"><tspan
        id="tspan3333-6-9"
        x="392.2085"
        y="814.93597"
@@ -922,7 +902,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="CHECK DATE"><tspan
+     freecad:editable="CHECK DATE"><tspan
        id="tspan3333-6-1"
        x="392.16544"
        y="821.11279"
@@ -938,7 +918,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SCALE"><tspan
+     freecad:editable="SCALE"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6"
        x="392.13678"
        y="840.45392"
@@ -954,7 +935,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="WEIGHT"><tspan
+     freecad:editable="WEIGHT"><tspan
        id="tspan3333-6-6-3"
        x="408.67188"
        y="840.45392"
@@ -970,7 +951,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="NUMBER"><tspan
+     freecad:editable="NUMBER"><tspan
        id="tspan3333-6-6-3-8"
        x="430.32578"
        y="840.45392"
@@ -986,7 +967,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SHEET"><tspan
+     freecad:editable="SHEET"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7"
        x="509.60999"
        y="840.45392"
@@ -1002,7 +984,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="TITLE"><tspan
+     freecad:editable="TITLE"
+     freecad:autofill="title"><tspan
        id="tspan3333-5"
        x="433.39624"
        y="809.37708"
@@ -1019,7 +1002,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SUBTITLE"><tspan
+     freecad:editable="SUBTITLE"><tspan
        id="tspan3333-5-6"
        x="433.39624"
        y="814.37415"
@@ -1034,7 +1017,8 @@
      font-size="3.3314px"
      letter-spacing="0px"
      word-spacing="0px"
-     style="line-height:125%"><tspan
+     style="line-height:125%"
+     freecad:editable="ANSI D"><tspan
        id="tspan5302"
        x="370.50534"
        y="877.22357">ANSI D</tspan></text>

--- a/src/Mod/TechDraw/Templates/ANSIE_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/ANSIE_Landscape.svg
@@ -4,36 +4,16 @@
    width="1118"
    height="864"
    version="1.1"
-   sodipodi:docname="ANSIE_Landscape.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index0="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace"
+   xmlns:index="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="58.531744"
-     inkscape:cx="1061.3728"
-     inkscape:cy="810.81644"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg7700" />
   <!-- Working space 28 30 1090 834 -->
   <metadata
      id="metadata7705">
@@ -43,7 +23,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -822,7 +801,8 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="AUTHOR NAME"><tspan
+     freecad:autofill="author"
+     freecad:editable="AUTHOR NAME"><tspan
        id="tspan3333"
        x="938.71722"
        y="788.95203"
@@ -838,7 +818,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="CREATION DATE"><tspan
+     freecad:editable="CREATION DATE"><tspan
        id="tspan3333-6"
        x="938.54797"
        y="795.13385"
@@ -854,7 +834,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SUPERVISOR NAME"><tspan
+     freecad:editable="SUPERVISOR NAME"><tspan
        id="tspan3333-6-9"
        x="938.51123"
        y="801.21924"
@@ -870,7 +850,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="CHECK DATE"><tspan
+     freecad:editable="CHECK DATE"><tspan
        id="tspan3333-6-1"
        x="938.46893"
        y="807.29144"
@@ -886,7 +866,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SCALE"><tspan
+     index:editable="SCALE"><tspan
        id="tspan3333-6-6"
        x="938.44073"
        y="826.30487"
@@ -902,7 +882,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="WEIGHT"><tspan
+     freecad:editable="WEIGHT"><tspan
        id="tspan3333-6-6-3"
        x="954.69568"
        y="826.30487"
@@ -918,7 +898,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="NUMBER"><tspan
+     freecad:editable="NUMBER"><tspan
        id="tspan3333-6-6-3-8"
        x="975.98267"
        y="826.30487"
@@ -934,7 +914,8 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SHEET"><tspan
+     freecad:editable="SHEET"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7"
        x="1057.8556"
        y="826.30487"
@@ -950,7 +931,8 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="TITLE"><tspan
+     freecad:editable="TITLE"
+     freecad:autofill="title"><tspan
        id="tspan3333-5"
        x="979.00104"
        y="795.75458"
@@ -967,7 +949,7 @@
      stroke-width=".10643"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SUBTITLE"><tspan
+     freecad:editable="SUBTITLE"><tspan
        id="tspan3333-5-6"
        x="979.00104"
        y="800.66699"
@@ -983,7 +965,8 @@
      letter-spacing="0px"
      stroke-width="1.0132"
      word-spacing="0px"
-     style="line-height:125%"><tspan
+     style="line-height:125%"
+     freecad:editable="ANSI E"><tspan
        id="tspan5302"
        x="881.18439"
        y="869.64899"

--- a/src/Mod/TechDraw/Templates/ANSIE_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/ANSIE_Portrait.svg
@@ -4,36 +4,16 @@
    width="864"
    height="1118"
    version="1.1"
-   sodipodi:docname="ANSIE_Portrait.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index0="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace"
+   xmlns:index="https://www.freecadweb.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="47.481145"
-     inkscape:cx="813.20701"
-     inkscape:cy="1076.3746"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg8939" />
   <!-- Working space 22 21 842 1099 -->
   <metadata
      id="metadata8944">
@@ -43,7 +23,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -874,7 +853,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="AUTHOR NAME"><tspan
+     freecad:editable="AUTHOR NAME"
+     freecad:autofill="author"><tspan
        id="tspan3333"
        x="688.3717"
        y="1052.0906"
@@ -890,7 +870,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="CREATION DATE"><tspan
+     freecad:editable="CREATION DATE"
+     freecad:autofill="date"><tspan
        id="tspan3333-6"
        x="688.19958"
        y="1058.379"
@@ -906,7 +887,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SUPERVISOR NAME"><tspan
+     freecad:editable="SUPERVISOR NAME"><tspan
        id="tspan3333-6-9"
        x="688.16223"
        y="1064.5693"
@@ -922,7 +903,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="CHECK DATE"><tspan
+     freecad:editable="CHECK DATE"><tspan
        id="tspan3333-6-1"
        x="688.11914"
        y="1070.7461"
@@ -938,7 +919,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SCALE"><tspan
+     freecad:editable="SCALE"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6"
        x="688.09052"
        y="1090.0873"
@@ -954,7 +936,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="WEIGHT"><tspan
+     freecad:editable="WEIGHT"><tspan
        id="tspan3333-6-6-3"
        x="704.62561"
        y="1090.0873"
@@ -970,7 +952,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="NUMBER"><tspan
+     freecad:editable="NUMBER"><tspan
        id="tspan3333-6-6-3-8"
        x="726.27948"
        y="1090.0873"
@@ -986,7 +968,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SHEET"><tspan
+     index:editable="SHEET"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7"
        x="807.56366"
        y="1090.0873"
@@ -1002,7 +985,8 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="TITLE"><tspan
+     index:editable="TITLE"
+     freecad:autofill="title"><tspan
        id="tspan3333-5"
        x="729.34991"
        y="1059.0105"
@@ -1019,7 +1003,7 @@
      stroke-width=".10827"
      word-spacing="0px"
      style="line-height:125%"
-     index0:editable="SUBTITLE"><tspan
+     freecad:editable="SUBTITLE"><tspan
        id="tspan3333-5-6"
        x="729.34991"
        y="1064.0074"
@@ -1034,7 +1018,8 @@
      font-size="3.3314px"
      letter-spacing="0px"
      word-spacing="0px"
-     style="line-height:125%"><tspan
+     style="line-height:125%"
+     freecad:editable="ANSI E"><tspan
        id="tspan5302"
        x="651.74182"
        y="1140.7695">ANSI E</tspan></text>

--- a/src/Mod/TechDraw/Templates/Arch_A_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/Arch_A_Landscape.svg
@@ -5,37 +5,15 @@
    height="9in"
    version="1.1"
    viewBox="0 0 304.8 228.6"
-   sodipodi:docname="Arch_A_Landscape.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="1.2552083"
-     inkscape:cx="701.87552"
-     inkscape:cy="720.59751"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-2"
        x="283.0657"
        y="175.03815"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-68"
        x="144.35803"
        y="176.24402"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-91"
        x="144.19897"
        y="182.16211"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-8"
        x="144.16687"
        y="188.71411"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-4"
        x="144.19897"
        y="194.81433"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch A"><tspan
        id="tspan3316-5"
        x="144.22839"
        y="203.72925"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-5"
        x="144.38055"
        y="213.91559"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-9"
        x="160.40979"
        y="213.91559"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-4"
        x="180.55609"
        y="213.89391"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-8"
        x="261.83624"
        y="213.91559"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-8"
        x="228.70593"
        y="181.586"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-5"
        x="228.62775"
        y="189.89587"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-4"
        x="180.69427"
        y="202.54376"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-2"
        x="144.03998"
        y="220.16803"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-6"
        x="282.92398"
        y="219.41907"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-0"
        x="282.92398"
        y="213.96117"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-1"
        x="282.92398"
        y="208.44861"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-1"
        x="282.86539"
        y="202.97949"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-5"
        x="282.80679"
        y="197.00684"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-2"
        x="282.86539"
        y="191.49432"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-8"
        x="282.92398"
        y="186.00787"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-0"
        x="282.80679"
        y="180.54956"

--- a/src/Mod/TechDraw/Templates/Arch_A_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/Arch_A_Portrait.svg
@@ -5,37 +5,15 @@
    height="12in"
    version="1.1"
    viewBox="0 0 228.6 304.8"
-   sodipodi:docname="Arch_A_Portrait.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="16.291667"
-     inkscape:cx="728.04092"
-     inkscape:cy="1060.4501"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg13637" />
   <metadata
      id="metadata13642">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-0"
        x="208.51097"
        y="253.57515"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-50"
        x="69.803276"
        y="254.78102"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-11"
        x="69.644218"
        y="260.69913"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-4"
        x="69.612114"
        y="267.25113"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-5"
        x="69.644218"
        y="273.35135"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch A"><tspan
        id="tspan3316-6"
        x="69.673637"
        y="282.26627"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-5"
        x="69.825798"
        y="292.45261"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-5"
        x="85.855034"
        y="292.45261"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-0"
        x="106.00134"
        y="292.43094"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-2"
        x="187.28148"
        y="292.45261"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-5"
        x="154.15118"
        y="260.12302"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-0"
        x="154.07298"
        y="268.43289"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-0"
        x="106.13952"
        y="281.08078"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-5"
        x="69.485222"
        y="298.70505"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-4"
        x="208.36925"
        y="297.95609"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-1"
        x="208.36925"
        y="292.4982"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-7"
        x="208.36925"
        y="286.98563"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-0"
        x="208.31065"
        y="281.51651"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-3"
        x="208.25206"
        y="275.54385"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-2"
        x="208.31065"
        y="270.03134"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-0"
        x="208.36925"
        y="264.54489"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-6"
        x="208.25206"
        y="259.08658"

--- a/src/Mod/TechDraw/Templates/Arch_B_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/Arch_B_Landscape.svg
@@ -5,37 +5,15 @@
    height="12in"
    version="1.1"
    viewBox="0 0 457.2 304.8"
-   sodipodi:docname="Arch_B_Landscape.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="0.59171088"
-     inkscape:cx="723.32623"
-     inkscape:cy="796.84186"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4236" />
   <metadata
      id="metadata4241">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-0"
        x="431.83713"
        y="248.67249"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-2"
        x="293.12946"
        y="249.87836"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-90"
        x="292.9704"
        y="255.79645"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-5"
        x="292.93829"
        y="262.34845"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-8"
        x="292.9704"
        y="268.44867"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch B"><tspan
        id="tspan3316-3"
        x="292.99982"
        y="277.36359"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-5"
        x="293.15198"
        y="287.54993"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-1"
        x="309.18121"
        y="287.54993"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-3"
        x="329.32751"
        y="287.52826"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-1"
        x="410.60767"
        y="287.54993"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-4"
        x="377.47736"
        y="255.22034"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-3"
        x="377.39917"
        y="263.53021"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-9"
        x="329.4657"
        y="276.1781"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-4"
        x="292.8114"
        y="293.80237"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-4"
        x="431.6954"
        y="293.05341"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-2"
        x="431.6954"
        y="287.59552"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-9"
        x="431.6954"
        y="282.08295"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-9"
        x="431.63681"
        y="276.61383"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-7"
        x="431.57822"
        y="270.64117"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-0"
        x="431.63681"
        y="265.12866"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-9"
        x="431.6954"
        y="259.64221"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-1"
        x="431.57822"
        y="254.1839"

--- a/src/Mod/TechDraw/Templates/Arch_B_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/Arch_B_Portrait.svg
@@ -5,37 +5,15 @@
    height="18in"
    version="1.1"
    viewBox="0 0 304.8 457.2"
-   sodipodi:docname="Arch_B_Portrait.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="10.861111"
-     inkscape:cx="1010.3018"
-     inkscape:cy="1623.6368"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg14912" />
   <metadata
      id="metadata14917">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-2"
        x="282.84033"
        y="403.29523"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-0"
        x="144.13264"
        y="404.5011"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-2"
        x="143.97359"
        y="410.41919"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-9"
        x="143.94148"
        y="416.97119"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-5"
        x="143.97359"
        y="423.07141"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch B"><tspan
        id="tspan3316-6"
        x="144.00301"
        y="431.98633"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-0"
        x="144.15517"
        y="442.17267"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-7"
        x="160.1844"
        y="442.17267"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-8"
        x="180.3307"
        y="442.151"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-6"
        x="261.61084"
        y="442.17267"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-7"
        x="228.48055"
        y="409.84308"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-4"
        x="228.40236"
        y="418.15295"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-5"
        x="180.46889"
        y="430.80084"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-2"
        x="143.81459"
        y="448.42511"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-0"
        x="282.69861"
        y="447.67615"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-4"
        x="282.69861"
        y="442.21826"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-4"
        x="282.69861"
        y="436.70569"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-9"
        x="282.64001"
        y="431.23657"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-3"
        x="282.58142"
        y="425.26392"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-0"
        x="282.64001"
        y="419.7514"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-5"
        x="282.69861"
        y="414.26495"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-9"
        x="282.58142"
        y="408.80664"

--- a/src/Mod/TechDraw/Templates/Arch_C_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/Arch_C_Landscape.svg
@@ -5,37 +5,15 @@
    height="18in"
    version="1.1"
    viewBox="0 0 609.6 457.2"
-   sodipodi:docname="Arch_C_Landscape.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="1.2552083"
-     inkscape:cx="1712.8631"
-     inkscape:cy="1643.1535"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5181" />
   <metadata
      id="metadata5186">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-3"
        x="580.60858"
        y="395.94116"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-7"
        x="441.90091"
        y="397.14703"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-3"
        x="441.74185"
        y="403.06512"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-6"
        x="441.70975"
        y="409.61713"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-7"
        x="441.74185"
        y="415.71735"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch C"><tspan
        id="tspan3316-9"
        x="441.77127"
        y="424.63226"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-7"
        x="441.92343"
        y="434.8186"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-7"
        x="457.95267"
        y="434.8186"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-6"
        x="478.09897"
        y="434.79694"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-4"
        x="559.37909"
        y="434.8186"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-2"
        x="526.24878"
        y="402.48901"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-3"
        x="526.17059"
        y="410.79889"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-1"
        x="478.23715"
        y="423.44678"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-7"
        x="441.58286"
        y="441.07104"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-1"
        x="580.46686"
        y="440.32208"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-6"
        x="580.46686"
        y="434.8642"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-6"
        x="580.46686"
        y="429.35162"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-8"
        x="580.40826"
        y="423.88251"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-3"
        x="580.34967"
        y="417.90985"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-5"
        x="580.40826"
        y="412.39734"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-1"
        x="580.46686"
        y="406.91089"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-7"
        x="580.34967"
        y="401.45258"

--- a/src/Mod/TechDraw/Templates/Arch_C_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/Arch_C_Portrait.svg
@@ -5,37 +5,15 @@
    height="24in"
    version="1.1"
    viewBox="0 0 457.2 609.6"
-   sodipodi:docname="Arch_C_Portrait.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="11.519948"
-     inkscape:cx="1582.212"
-     inkscape:cy="2170.5393"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg16469" />
   <metadata
      id="metadata16474">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-2"
        x="431.49911"
        y="553.01501"
@@ -1148,7 +1125,8 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-51"
        x="292.79144"
        y="554.22089"
@@ -1164,7 +1142,8 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-2"
        x="292.63239"
        y="560.13898"
@@ -1180,7 +1159,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-2"
        x="292.60028"
        y="566.69104"
@@ -1196,7 +1175,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-3"
        x="292.63239"
        y="572.7912"
@@ -1212,7 +1191,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch C"><tspan
        id="tspan3316-5"
        x="292.6618"
        y="581.70612"
@@ -1228,7 +1207,8 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-6"
        x="292.81393"
        y="591.89246"
@@ -1244,7 +1224,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-1"
        x="308.84317"
        y="591.89246"
@@ -1260,7 +1240,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-3"
        x="328.9895"
        y="591.87079"
@@ -1276,7 +1256,8 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-9"
        x="410.26965"
        y="591.89246"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-7"
        x="377.13931"
        y="559.56287"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-5"
        x="377.06113"
        y="567.87274"
@@ -1337,7 +1319,8 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-5"
        x="329.12769"
        y="580.52063"
@@ -1353,7 +1336,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-4"
        x="292.47336"
        y="598.1449"
@@ -1369,7 +1352,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-3"
        x="431.35739"
        y="597.39594"
@@ -1385,7 +1368,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-1"
        x="431.35739"
        y="591.93805"
@@ -1401,7 +1384,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-8"
        x="431.35739"
        y="586.42548"
@@ -1417,7 +1400,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-0"
        x="431.2988"
        y="580.95636"
@@ -1433,7 +1416,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-7"
        x="431.2402"
        y="574.9837"
@@ -1449,7 +1432,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-8"
        x="431.2988"
        y="569.47119"
@@ -1465,7 +1448,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-9"
        x="431.35739"
        y="563.98474"
@@ -1481,7 +1464,7 @@
      stroke-width=".07327"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-5"
        x="431.2402"
        y="558.52643"

--- a/src/Mod/TechDraw/Templates/Arch_D_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/Arch_D_Landscape.svg
@@ -5,37 +5,15 @@
    height="24in"
    version="1.1"
    viewBox="0 0 914.4 609.6"
-   sodipodi:docname="Arch_D_Landscape.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="9.4673741"
-     inkscape:cx="3249.898"
-     inkscape:cy="2142.78"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg7113" />
   <metadata
      id="metadata7118">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-8"
        x="878.15149"
        y="543.2099"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-63"
        x="739.44379"
        y="544.41577"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-0"
        x="739.28473"
        y="550.33386"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-3"
        x="739.25262"
        y="556.88586"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-6"
        x="739.28473"
        y="562.98608"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch D"><tspan
        id="tspan3316-6"
        x="739.31415"
        y="571.901"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-7"
        x="739.46631"
        y="582.08734"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-0"
        x="755.49554"
        y="582.08734"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-5"
        x="775.64185"
        y="582.06567"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-5"
        x="856.922"
        y="582.08734"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-2"
        x="823.79169"
        y="549.75775"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-5"
        x="823.7135"
        y="558.06763"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-0"
        x="775.78003"
        y="570.71552"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-6"
        x="739.12573"
        y="588.33978"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-2"
        x="878.00977"
        y="587.59082"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-4"
        x="878.00977"
        y="582.13293"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-3"
        x="878.00977"
        y="576.62036"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-7"
        x="877.95117"
        y="571.15125"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-5"
        x="877.89258"
        y="565.17859"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-0"
        x="877.95117"
        y="559.66608"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-1"
        x="878.00977"
        y="554.17963"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-6"
        x="877.89258"
        y="548.72131"

--- a/src/Mod/TechDraw/Templates/Arch_D_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/Arch_D_Portrait.svg
@@ -5,37 +5,15 @@
    height="36in"
    version="1.1"
    viewBox="0 0 609.6 914.4"
-   sodipodi:docname="Arch_D_Portrait.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="15.359931"
-     inkscape:cx="2136.8586"
-     inkscape:cy="3325.4382"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg17716" />
   <metadata
      id="metadata17721">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-1"
        x="580.15784"
        y="852.45526"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-2"
        x="441.45013"
        y="853.66113"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-5"
        x="441.29108"
        y="859.57922"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-0"
        x="441.25897"
        y="866.13123"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-1"
        x="441.29108"
        y="872.23145"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch D"><tspan
        id="tspan3316-2"
        x="441.3205"
        y="881.14636"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-8"
        x="441.47266"
        y="891.3327"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-7"
        x="457.50189"
        y="891.3327"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-4"
        x="477.64819"
        y="891.31104"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-9"
        x="558.92834"
        y="891.3327"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-2"
        x="525.79803"
        y="859.00311"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-0"
        x="525.71985"
        y="867.31299"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-7"
        x="477.78638"
        y="879.96088"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-8"
        x="441.13208"
        y="897.58514"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-0"
        x="580.01611"
        y="896.83618"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-0"
        x="580.01611"
        y="891.3783"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-9"
        x="580.01611"
        y="885.86572"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-3"
        x="579.95752"
        y="880.39661"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-3"
        x="579.89893"
        y="874.42395"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-2"
        x="579.95752"
        y="868.91144"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-6"
        x="580.01611"
        y="863.42499"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-3"
        x="579.89893"
        y="857.96667"

--- a/src/Mod/TechDraw/Templates/Arch_E1_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/Arch_E1_Landscape.svg
@@ -5,37 +5,15 @@
    height="30in"
    version="1.1"
    viewBox="0 0 1066.8 762"
-   sodipodi:docname="Arch_E1_Landscape.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="22.952381"
-     inkscape:cx="3830.3216"
-     inkscape:cy="2716.6463"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg9824" />
   <metadata
      id="metadata9829">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-2"
        x="1026.9229"
        y="690.47858"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-3"
        x="888.21515"
        y="691.68445"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-18"
        x="888.05609"
        y="697.60254"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-9"
        x="888.02399"
        y="704.15454"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-2"
        x="888.05609"
        y="710.25476"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch E1"><tspan
        id="tspan3316-3"
        x="888.08551"
        y="719.16968"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-2"
        x="888.23767"
        y="729.35602"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-1"
        x="904.26691"
        y="729.35602"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-0"
        x="924.41321"
        y="729.33435"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-8"
        x="1005.6934"
        y="729.35602"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-3"
        x="972.56305"
        y="697.02643"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-0"
        x="972.48486"
        y="705.3363"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-8"
        x="924.55139"
        y="717.98419"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-4"
        x="887.89709"
        y="735.60846"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-3"
        x="1026.7811"
        y="734.8595"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-4"
        x="1026.7811"
        y="729.40161"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-0"
        x="1026.7811"
        y="723.88904"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-6"
        x="1026.7225"
        y="718.41992"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-5"
        x="1026.6639"
        y="712.44727"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-1"
        x="1026.7225"
        y="706.93475"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-0"
        x="1026.7811"
        y="701.4483"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-3"
        x="1026.6639"
        y="695.98999"

--- a/src/Mod/TechDraw/Templates/Arch_E1_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/Arch_E1_Portrait.svg
@@ -5,37 +5,15 @@
    height="42in"
    version="1.1"
    viewBox="0 0 762 1066.8"
-   sodipodi:docname="Arch_E1_Portrait.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="13.165655"
-     inkscape:cx="2691.0929"
-     inkscape:cy="3890.4635"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg20210" />
   <metadata
      id="metadata20215">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-4"
        x="728.88446"
        y="1002.3718"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-7"
        x="590.17676"
        y="1003.5776"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-95"
        x="590.0177"
        y="1009.4957"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-4"
        x="589.9856"
        y="1016.0477"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-6"
        x="590.0177"
        y="1022.1479"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch E1"><tspan
        id="tspan3316-5"
        x="590.04712"
        y="1031.0629"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-5"
        x="590.19928"
        y="1041.2491"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-5"
        x="606.22852"
        y="1041.2491"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-8"
        x="626.37482"
        y="1041.2275"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-1"
        x="707.65497"
        y="1041.2491"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-0"
        x="674.52466"
        y="1008.9196"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-2"
        x="674.44647"
        y="1017.2295"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-2"
        x="626.513"
        y="1029.8773"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-5"
        x="589.8587"
        y="1047.5016"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-3"
        x="728.74274"
        y="1046.7527"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-5"
        x="728.74274"
        y="1041.2948"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-1"
        x="728.74274"
        y="1035.7822"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-6"
        x="728.68414"
        y="1030.3131"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-2"
        x="728.62555"
        y="1024.3405"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-3"
        x="728.68414"
        y="1018.8279"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-1"
        x="728.74274"
        y="1013.3415"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-6"
        x="728.62555"
        y="1007.8832"

--- a/src/Mod/TechDraw/Templates/Arch_E2_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/Arch_E2_Landscape.svg
@@ -5,37 +5,15 @@
    height="26in"
    version="1.1"
    viewBox="0 0 965.2 660.4"
-   sodipodi:docname="Arch_E2_Landscape.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="12.68421"
-     inkscape:cx="3455.8714"
-     inkscape:cy="2328.5249"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg11066" />
   <metadata
      id="metadata11071">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308"
        x="927.74194"
        y="592.29944"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333"
        x="789.03424"
        y="593.50531"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6"
        x="788.87518"
        y="599.4234"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9"
        x="788.84308"
        y="605.9754"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1"
        x="788.87518"
        y="612.07562"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch E2"><tspan
        id="tspan3316"
        x="788.9046"
        y="620.99054"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6"
        x="789.05676"
        y="631.17688"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3"
        x="805.086"
        y="631.17688"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8"
        x="825.2323"
        y="631.15521"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7"
        x="906.51245"
        y="631.17688"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5"
        x="873.38214"
        y="598.84729"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6"
        x="873.30396"
        y="607.15717"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243"
        x="825.37048"
        y="619.80505"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289"
        x="788.71619"
        y="637.42932"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0"
        x="927.60022"
        y="636.68036"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280"
        x="927.60022"
        y="631.22247"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284"
        x="927.60022"
        y="625.7099"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288"
        x="927.54163"
        y="620.24078"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292"
        x="927.48303"
        y="614.26813"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296"
        x="927.54163"
        y="608.75562"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300"
        x="927.60022"
        y="603.26917"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304"
        x="927.48303"
        y="597.81085"

--- a/src/Mod/TechDraw/Templates/Arch_E2_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/Arch_E2_Portrait.svg
@@ -5,37 +5,15 @@
    height="38in"
    version="1.1"
    viewBox="0 0 660.4 965.2"
-   sodipodi:docname="Arch_E2_Portrait.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="20.578947"
-     inkscape:cx="2331.266"
-     inkscape:cy="3513.7123"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg21457" />
   <metadata
      id="metadata21462">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308"
        x="629.71075"
        y="902.36188"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333"
        x="491.00302"
        y="903.56775"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6"
        x="490.84396"
        y="909.48584"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9"
        x="490.81186"
        y="916.03784"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1"
        x="490.84396"
        y="922.13806"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch E2"><tspan
        id="tspan3316"
        x="490.87338"
        y="931.05298"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6"
        x="491.02554"
        y="941.23932"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3"
        x="507.05478"
        y="941.23932"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8"
        x="527.20111"
        y="941.21765"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7"
        x="608.48126"
        y="941.23932"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5"
        x="575.35095"
        y="908.90973"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6"
        x="575.27277"
        y="917.2196"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243"
        x="527.33929"
        y="929.86749"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289"
        x="490.68497"
        y="947.49176"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0"
        x="629.56903"
        y="946.7428"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280"
        x="629.56903"
        y="941.28491"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284"
        x="629.56903"
        y="935.77234"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288"
        x="629.51044"
        y="930.30322"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292"
        x="629.45184"
        y="924.33057"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296"
        x="629.51044"
        y="918.81805"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300"
        x="629.56903"
        y="913.3316"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304"
        x="629.45184"
        y="907.87329"

--- a/src/Mod/TechDraw/Templates/Arch_E3_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/Arch_E3_Landscape.svg
@@ -5,37 +5,15 @@
    height="27in"
    version="1.1"
    viewBox="0 0 990.6 685.8"
-   sodipodi:docname="Arch_E3_Landscape.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="12.358974"
-     inkscape:cx="3545.0353"
-     inkscape:cy="2416.0986"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg12339" />
   <text
      id="text306"
      x="952.26117"
@@ -47,7 +25,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308"
        x="952.26117"
        y="616.58539"
@@ -60,7 +38,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333"
        x="813.55347"
        y="617.79126"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6"
        x="813.39441"
        y="623.70935"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9"
        x="813.3623"
        y="630.26135"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1"
        x="813.39441"
        y="636.36157"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch E3"><tspan
        id="tspan3316"
        x="813.42383"
        y="645.27649"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6"
        x="813.57599"
        y="655.46283"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3"
        x="829.60522"
        y="655.46283"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8"
        x="849.75153"
        y="655.44116"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7"
        x="931.03168"
        y="655.46283"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5"
        x="897.90137"
        y="623.13324"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6"
        x="897.82318"
        y="631.44312"
@@ -1337,7 +1319,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"><tspan
        id="tspan243"
        x="849.88971"
        y="644.091"
@@ -1353,7 +1335,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289"
        x="813.23541"
        y="661.71527"
@@ -1369,7 +1351,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0"
        x="952.11945"
        y="660.96631"
@@ -1385,7 +1367,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280"
        x="952.11945"
        y="655.50842"
@@ -1401,7 +1383,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284"
        x="952.11945"
        y="649.99585"
@@ -1417,7 +1399,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288"
        x="952.06085"
        y="644.52673"
@@ -1433,7 +1415,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292"
        x="952.00226"
        y="638.55408"
@@ -1449,7 +1431,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296"
        x="952.06085"
        y="633.04156"
@@ -1465,7 +1447,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300"
        x="952.11945"
        y="627.55511"
@@ -1481,7 +1463,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304"
        x="952.00226"
        y="622.0968"

--- a/src/Mod/TechDraw/Templates/Arch_E3_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/Arch_E3_Portrait.svg
@@ -5,37 +5,15 @@
    height="39in"
    version="1.1"
    viewBox="0 0 685.8 990.6"
-   sodipodi:docname="Arch_E3_Portrait.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="14.178397"
-     inkscape:cx="2417.1984"
-     inkscape:cy="3600.6537"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg22704" />
   <g
      id="g7772"
      transform="matrix(.9504 0 0 .95085 383.98 866.17)"
@@ -417,7 +395,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -433,7 +410,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333"
        x="515.75122"
        y="928.52112"
@@ -449,7 +427,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6"
        x="515.59216"
        y="934.43921"
@@ -465,7 +444,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9"
        x="515.56006"
        y="940.99121"
@@ -481,7 +460,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1"
        x="515.59216"
        y="947.09149"
@@ -497,7 +476,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch E3"><tspan
        id="tspan3316"
        x="515.62158"
        y="956.00635"
@@ -513,7 +492,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6"
        x="515.77374"
        y="966.19275"
@@ -529,7 +509,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3"
        x="531.80298"
        y="966.19275"
@@ -545,7 +525,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8"
        x="551.94928"
        y="966.17102"
@@ -561,7 +541,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7"
        x="633.12579"
        y="966.19275"
@@ -580,7 +561,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5"
        x="600.09918"
        y="934.57281"
@@ -604,7 +586,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6"
        x="600.021"
        y="942.88269"
@@ -622,7 +604,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243"
        x="552.08746"
        y="954.82092"
@@ -638,7 +621,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289"
        x="515.43317"
        y="972.44519"
@@ -654,7 +637,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0"
        x="654.3172"
        y="971.69617"
@@ -670,7 +653,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280"
        x="654.3172"
        y="966.23828"
@@ -686,7 +669,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284"
        x="654.3172"
        y="960.72571"
@@ -702,7 +685,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288"
        x="654.25861"
        y="955.25659"
@@ -718,7 +701,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292"
        x="654.20001"
        y="949.28394"
@@ -734,7 +717,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296"
        x="654.25861"
        y="943.77142"
@@ -750,7 +733,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300"
        x="654.3172"
        y="938.28503"
@@ -766,7 +749,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304"
        x="654.20001"
        y="932.82672"
@@ -1173,7 +1156,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308"
        x="654.45892"
        y="927.31525"

--- a/src/Mod/TechDraw/Templates/Arch_E_Landscape.svg
+++ b/src/Mod/TechDraw/Templates/Arch_E_Landscape.svg
@@ -5,37 +5,15 @@
    height="36in"
    version="1.1"
    viewBox="0 0 1219.2 914.4"
-   sodipodi:docname="Arch_E_Landscape.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="20.083333"
-     inkscape:cx="4395.7345"
-     inkscape:cy="3271.3942"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg8386" />
   <metadata
      id="metadata8391">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-3"
        x="1175.6943"
        y="837.74719"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-9"
        x="1036.9866"
        y="838.95306"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-3"
        x="1036.8275"
        y="844.87115"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-7"
        x="1036.7954"
        y="851.42316"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-9"
        x="1036.8275"
        y="857.52338"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch E"><tspan
        id="tspan3316-9"
        x="1036.8569"
        y="866.43829"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-8"
        x="1037.0092"
        y="876.62463"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-5"
        x="1053.0383"
        y="876.62463"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-0"
        x="1073.1847"
        y="876.60297"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-0"
        x="1154.4648"
        y="876.62463"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-3"
        x="1121.3345"
        y="844.29504"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-8"
        x="1121.2563"
        y="852.60492"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-1"
        x="1073.3229"
        y="865.25281"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-6"
        x="1036.6686"
        y="882.87708"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-1"
        x="1175.5526"
        y="882.12811"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-3"
        x="1175.5526"
        y="876.67023"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-2"
        x="1175.5526"
        y="871.15765"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-4"
        x="1175.494"
        y="865.68854"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-2"
        x="1175.4354"
        y="859.71588"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-8"
        x="1175.494"
        y="854.20337"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-0"
        x="1175.5526"
        y="848.71692"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-2"
        x="1175.4354"
        y="843.25861"

--- a/src/Mod/TechDraw/Templates/Arch_E_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/Arch_E_Portrait.svg
@@ -5,37 +5,15 @@
    height="48in"
    version="1.1"
    viewBox="0 0 914.4 1219.2"
-   sodipodi:docname="Arch_E_Portrait.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:freecad="http://freecadweb.org/wiki/index.php?title=Svg_Namespace"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:index="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
   <defs
      id="defs1" />
-  <sodipodi:namedview
-     id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:document-units="in"
-     inkscape:zoom="8.1458333"
-     inkscape:cx="3258.9668"
-     inkscape:cy="4421.2174"
-     inkscape:window-width="2560"
-     inkscape:window-height="1369"
-     inkscape:window-x="2728"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg18963" />
   <metadata
      id="metadata18968">
     <rdf:RDF>
@@ -44,7 +22,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -451,7 +428,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="A__"><tspan
+     freecad:editable="A__"><tspan
        id="tspan308-2"
        x="877.47534"
        y="1151.8953"
@@ -1148,7 +1125,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="AuthorName"><tspan
+     freecad:editable="AuthorName"
+     freecad:autofill="author"><tspan
        id="tspan3333-4"
        x="738.76764"
        y="1153.1012"
@@ -1164,7 +1142,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CreationDate"><tspan
+     freecad:editable="CreationDate"
+     freecad:autofill="date"><tspan
        id="tspan3333-6-2"
        x="738.60858"
        y="1159.0193"
@@ -1180,7 +1159,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SupervisorName"><tspan
+     freecad:editable="SupervisorName"><tspan
        id="tspan3333-6-9-7"
        x="738.57648"
        y="1165.5713"
@@ -1196,7 +1175,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="CheckDate"><tspan
+     freecad:editable="CheckDate"><tspan
        id="tspan3333-6-1-6"
        x="738.60858"
        y="1171.6715"
@@ -1212,7 +1191,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Size"><tspan
+     freecad:editable="Arch E"><tspan
        id="tspan3316-5"
        x="738.638"
        y="1180.5864"
@@ -1228,7 +1207,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Scale"><tspan
+     freecad:editable="Scale"
+     freecad:autofill="scale"><tspan
        id="tspan3333-6-6-8"
        x="738.79016"
        y="1190.7727"
@@ -1244,7 +1224,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Weight"><tspan
+     freecad:editable="Weight"><tspan
        id="tspan3333-6-6-3-5"
        x="754.8194"
        y="1190.7727"
@@ -1260,7 +1240,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="DrawingNumber"><tspan
+     freecad:editable="DrawingNumber"><tspan
        id="tspan3333-6-6-3-8-75"
        x="774.9657"
        y="1190.7511"
@@ -1276,7 +1256,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="SheetNumber"><tspan
+     freecad:editable="SheetNumber"
+     freecad:autofill="sheet"><tspan
        id="tspan3333-6-6-3-8-7-9"
        x="856.24585"
        y="1190.7727"
@@ -1295,7 +1276,8 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Title"><tspan
+     freecad:editable="Title"
+     freecad:autofill="title"><tspan
        id="tspan3333-5-1"
        x="823.11554"
        y="1158.4431"
@@ -1319,7 +1301,7 @@
      text-anchor="middle"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Subtitle"><tspan
+     freecad:editable="Subtitle"><tspan
        id="tspan3333-5-6-8"
        x="823.03735"
        y="1166.7531"
@@ -1337,7 +1319,8 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="Company_name"><tspan
+     freecad:editable="Company_name"
+     freecad:autofill="organization"><tspan
        id="tspan243-3"
        x="775.10388"
        y="1179.4009"
@@ -1353,7 +1336,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="COPYRIGHT"><tspan
+     freecad:editable="COPYRIGHT"><tspan
        id="tspan289-7"
        x="738.44958"
        y="1197.0251"
@@ -1369,7 +1352,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="I__"><tspan
+     freecad:editable="I__"><tspan
        id="tspan3245-0-3"
        x="877.33362"
        y="1196.2762"
@@ -1385,7 +1368,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="H__"><tspan
+     freecad:editable="H__"><tspan
        id="tspan280-8"
        x="877.33362"
        y="1190.8184"
@@ -1401,7 +1384,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="G__"><tspan
+     freecad:editable="G__"><tspan
        id="tspan284-0"
        x="877.33362"
        y="1185.3058"
@@ -1417,7 +1400,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="F__"><tspan
+     freecad:editable="F__"><tspan
        id="tspan288-4"
        x="877.27502"
        y="1179.8367"
@@ -1433,7 +1416,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="E__"><tspan
+     freecad:editable="E__"><tspan
        id="tspan292-1"
        x="877.21643"
        y="1173.864"
@@ -1449,7 +1432,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="D__"><tspan
+     freecad:editable="D__"><tspan
        id="tspan296-4"
        x="877.27502"
        y="1168.3514"
@@ -1465,7 +1448,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="C__"><tspan
+     freecad:editable="C__"><tspan
        id="tspan300-6"
        x="877.33362"
        y="1162.865"
@@ -1481,7 +1464,7 @@
      stroke-width=".054953"
      word-spacing="0px"
      style="line-height:125%"
-     index:editable="B__"><tspan
+     freecad:editable="B__"><tspan
        id="tspan304-8"
        x="877.21643"
        y="1157.4067"

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_1_minimal.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_1_minimal.svg
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
 <svg
    width="180mm"
    height="36mm"
@@ -11,12 +10,19 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
-  <title id="title">Title block ISO 7200 - Minimal</title>
-  <metadata id="metadata">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace"
+   xmlns:index0="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+  <defs
+     id="defs16" />
+  <title
+     id="title">Title block ISO 7200 - Minimal</title>
+  <metadata
+     id="metadata">
     <rdf:RDF>
-      <cc:Work rdf:about="">
-        <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+      <cc:Work
+         rdf:about="">
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
         <dc:title>Title block ISO 7200 - Minimal</dc:title>
         <dc:creator>
           <cc:Agent>
@@ -24,66 +30,285 @@
           </cc:Agent>
         </dc:creator>
       </cc:Work>
-      <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
       </cc:License>
     </rdf:RDF>
   </metadata>
-  <g id="title_block_borders" style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:round;stroke-linejoin:round">
-    <rect id="title_block_frame" x="0" y="0" width="180" height="36" style="stroke-width:0.7" />
-    <rect id="legal_owner_border" x="140" y="0" width="40" height="24" />
-    <rect id="identification_number_border" x="0" y="24" width="80" height="12" />
-    <rect id="revision_index_border" x="140" y="24" width="20" height="12" />
-    <rect id="date_of_issue_border" x="100" y="24" width="40" height="12" />
-    <rect id="sheet_number_border" x="160" y="24" width="20" height="12" />
-    <rect id="language_code_border" x="80" y="24" width="20" height="12" />
-    <rect id="title_border" x="0" y="0" width="80" height="12" />
-    <rect id="approval_person_border" x="80" y="12" width="60" height="12" />
-    <rect id="creator_border" x="80" y="0" width="60" height="12" />
-    <rect id="document_type_border" x="0" y="12" width="80" height="12" />
+  <g
+     id="title_block_borders"
+     style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:round;stroke-linejoin:round">
+    <rect
+       id="title_block_frame"
+       x="0"
+       y="0"
+       width="180"
+       height="36"
+       style="stroke-width:0.7" />
+    <rect
+       id="legal_owner_border"
+       x="140"
+       y="0"
+       width="40"
+       height="24" />
+    <rect
+       id="identification_number_border"
+       x="0"
+       y="24"
+       width="80"
+       height="12" />
+    <rect
+       id="revision_index_border"
+       x="140"
+       y="24"
+       width="20"
+       height="12" />
+    <rect
+       id="date_of_issue_border"
+       x="100"
+       y="24"
+       width="40"
+       height="12" />
+    <rect
+       id="sheet_number_border"
+       x="160"
+       y="24"
+       width="20"
+       height="12" />
+    <rect
+       id="language_code_border"
+       x="80"
+       y="24"
+       width="20"
+       height="12" />
+    <rect
+       id="title_border"
+       x="0"
+       y="0"
+       width="80"
+       height="12" />
+    <rect
+       id="approval_person_border"
+       x="80"
+       y="12"
+       width="60"
+       height="12" />
+    <rect
+       id="creator_border"
+       x="80"
+       y="0"
+       width="60"
+       height="12" />
+    <rect
+       id="document_type_border"
+       x="0"
+       y="12"
+       width="80"
+       height="12" />
   </g>
-  <g id="title_block_labels" style="font-size:3.5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
-    <text id="legal_owner label" x="140.5" y="3.6">Owner:</text>
-    <text id="identification_number_label" x="0.5" y="27.6">Drawing number:</text>
-    <text id="revision_index_label" x="140.5" y="27.6">Revision:</text>
-    <text id="date_of_issue_label" x="100.5" y="27.6">Issue date:</text>
-    <text id="sheet_number_label" x="160.5" y="27.6">Sheet:</text>
-    <text id="language_code_label" x="80.5" y="27.6">Language:</text>
-    <text id="title_label" x="0.5" y="3.6">Title:</text>
-    <text id="approval_person_label" x="80.5" y="15.6">Approved by:</text>
-    <text id="creator_label" x="80.5" y="3.6">Created by:</text>
-    <text id="document_type_label" x="0.5" y="15.6">Document type:</text>
-    <text id="sheet_scale_label" x="120.5" y="-8.4">Scale:</text>
-    <text id="general_tolerances_label" x="80.5" y="-8.4">General tolerances:</text>
-    <text id="part_material_label" x="0.5" y="-8.4">Part Material:</text>
+  <g
+     id="title_block_labels"
+     style="font-size:3.5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
+    <text
+       id="legal_owner label"
+       x="140.5"
+       y="3.6">Owner:</text>
+    <text
+       id="identification_number_label"
+       x="0.5"
+       y="27.6">Drawing number:</text>
+    <text
+       id="revision_index_label"
+       x="140.5"
+       y="27.6">Revision:</text>
+    <text
+       id="date_of_issue_label"
+       x="100.5"
+       y="27.6">Issue date:</text>
+    <text
+       id="sheet_number_label"
+       x="160.5"
+       y="27.6">Sheet:</text>
+    <text
+       id="language_code_label"
+       x="80.5"
+       y="27.6">Language:</text>
+    <text
+       id="title_label"
+       x="0.5"
+       y="3.6">Title:</text>
+    <text
+       id="approval_person_label"
+       x="80.5"
+       y="15.6">Approved by:</text>
+    <text
+       id="creator_label"
+       x="80.5"
+       y="3.6">Created by:</text>
+    <text
+       id="document_type_label"
+       x="0.5"
+       y="15.6">Document type:</text>
+    <text
+       id="sheet_scale_label"
+       x="120.5"
+       y="-8.4">Scale:</text>
+    <text
+       id="general_tolerances_label"
+       x="80.5"
+       y="-8.4">General tolerances:</text>
+    <text
+       id="part_material_label"
+       x="0.5"
+       y="-8.4">Part Material:</text>
   </g>
-  <g id="title_block_data_fields" style="font-size:5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
-    <text id="legal_owner_1_data_field" x="160" y="9.1" freecad:editable="legal_owner_1" freecad:autofill="organization" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_2_data_field" x="160" y="13.1" freecad:editable="legal_owner_2" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_3_data_field" x="160" y="17.1" freecad:editable="legal_owner_3" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_4_data_field" x="160" y="21.1" freecad:editable="legal_owner_4" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="identification_number_data_field" x="1" y="33.2" freecad:editable="identification_number"><tspan>DN</tspan></text>
-    <text id="revision_index_data_field" x="150" y="33.2" freecad:editable="revision_index" style="text-align:center;text-anchor:middle"><tspan>AAA</tspan></text>
-    <text id="date_of_issue_data_field" x="101" y="33.2" freecad:editable="date_of_issue" freecad:autofill="date"><tspan>YYYY-MM-DD</tspan></text>
-    <text id="sheet_number_data_field" x="170" y="33.2" freecad:editable="sheet_number" freecad:autofill="sheet" style="text-align:center;text-anchor:middle"><tspan>X / Y</tspan></text>
-    <text id="language_code_data_field" x="90" y="33.2" freecad:editable="language_code" style="text-align:center;text-anchor:middle"><tspan>EN</tspan></text>
-    <text id="title_data_field" x="1" y="9.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 5457 template</tspan></text>
-    <text id="approval_person_data_field" x="81" y="21.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
-    <text id="creator_data_field" x="81" y="9.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1" y="21.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
-    <text id="sheet_scale_data_field" x="130" y="-2.8" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
-    <text id="general_tolerances_data_field" x="81" y="-2.8" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>
-    <text id="part_material_data_field" x="1" y="-2.8" freecad:editable="part_material"><tspan>Stainless steel Mat.No. 1.4301</tspan></text>
+  <g
+     id="title_block_data_fields"
+     style="font-size:5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
+    <text
+       id="legal_owner_1_data_field"
+       x="160"
+       y="9.1"
+       index0:editable="legal_owner_1"
+       index0:autofill="organization"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan1" /></text>
+    <text
+       id="legal_owner_2_data_field"
+       x="160"
+       y="13.1"
+       index0:editable="legal_owner_2"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan2" /></text>
+    <text
+       id="legal_owner_3_data_field"
+       x="160"
+       y="17.1"
+       index0:editable="legal_owner_3"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan3" /></text>
+    <text
+       id="legal_owner_4_data_field"
+       x="160"
+       y="21.1"
+       index0:editable="legal_owner_4"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan4" /></text>
+    <text
+       id="identification_number_data_field"
+       x="1"
+       y="33.2"
+       freecad:editable="identification_number"><tspan
+         id="tspan5">DN</tspan></text>
+    <text
+       id="revision_index_data_field"
+       x="150"
+       y="33.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="revision_index"><tspan
+         id="tspan6">AAA</tspan></text>
+    <text
+       id="date_of_issue_data_field"
+       x="101"
+       y="33.2"
+       freecad:autofill="date"
+       freecad:editable="date_of_issue"><tspan
+         id="tspan7">YYYY-MM-DD</tspan></text>
+    <text
+       id="sheet_number_data_field"
+       x="170"
+       y="33.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:autofill="sheet"
+       freecad:editable="sheet_number"><tspan
+         id="tspan8">X / Y</tspan></text>
+    <text
+       id="language_code_data_field"
+       x="90"
+       y="33.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="language_code"><tspan
+         id="tspan9">EN</tspan></text>
+    <text
+       id="title_data_field"
+       x="1"
+       y="9.2"
+       freecad:autofill="title"
+       freecad:editable="title"><tspan
+         id="tspan10">ISO 5457 template</tspan></text>
+    <text
+       id="approval_person_data_field"
+       x="81"
+       y="21.2"
+       freecad:editable="approval_person"><tspan
+         id="tspan11">B. Hecate</tspan></text>
+    <text
+       id="creator_data_field"
+       x="81"
+       y="9.2"
+       freecad:autofill="author"
+       freecad:editable="creator"><tspan
+         id="tspan12">A. Nemesis</tspan></text>
+    <text
+       id="document_type_data_field"
+       x="1"
+       y="21.2"
+       freecad:editable="document_type"><tspan
+         id="tspan13">Assembly Drawing</tspan></text>
+    <text
+       id="sheet_scale_data_field"
+       x="130"
+       y="-2.8"
+       style="text-align:center;text-anchor:middle"
+       freecad:autofill="scale"
+       freecad:editable="sheet_scale"><tspan
+         id="tspan14">1 : 1</tspan></text>
+    <text
+       id="general_tolerances_data_field"
+       x="81"
+       y="-2.8"
+       freecad:editable="general_tolerances"><tspan
+         id="tspan15">ISO 2768-m</tspan></text>
+    <text
+       id="part_material_data_field"
+       x="1"
+       y="-2.8"
+       freecad:editable="part_material"><tspan
+         id="tspan16">Stainless steel Mat.No. 1.4301</tspan></text>
   </g>
-  <g id="extras_outlines" style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round">
-    <path id="first_angle_trapezoid" d="m 159,-17 -10,2.5 v 5 l 10,2.5 z" />
-    <circle id="first_angle_inner circle" cx="166" cy="-12" r="2.5" />
-    <circle id="first_angle_outer circle" cx="166" cy="-12" r="5" />
+  <g
+     id="extras_outlines"
+     style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round">
+    <path
+       id="first_angle_trapezoid"
+       d="m 159,-17 -10,2.5 v 5 l 10,2.5 z" />
+    <circle
+       id="first_angle_inner circle"
+       cx="166"
+       cy="-12"
+       r="2.5" />
+    <circle
+       id="first_angle_outer circle"
+       cx="166"
+       cy="-12"
+       r="5" />
   </g>
-  <g id="extras_centre_lines" style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:6, 0.75, 0.125, 0.75" >
-    <path id="first_angle_horizontal" d="m 148,-12 h 24" style="stroke-dashoffset:0.25" />
-    <path id="first_angle_vertical" d="m 166,-6 v -12" style="stroke-dashoffset:4.625" />
+  <g
+     id="extras_centre_lines"
+     style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:6, 0.75, 0.125, 0.75">
+    <path
+       id="first_angle_horizontal"
+       d="m 148,-12 h 24"
+       style="stroke-dashoffset:0.25" />
+    <path
+       id="first_angle_vertical"
+       d="m 166,-6 v -12"
+       style="stroke-dashoffset:4.625" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_2.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_2.svg
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
 <svg
    width="180mm"
    height="36mm"
@@ -11,12 +10,19 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
-  <title id="title">Title block ISO 7200</title>
-  <metadata id="metadata">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace"
+   xmlns:index0="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+  <defs
+     id="defs13" />
+  <title
+     id="title">Title block ISO 7200</title>
+  <metadata
+     id="metadata">
     <rdf:RDF>
-      <cc:Work rdf:about="">
-        <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+      <cc:Work
+         rdf:about="">
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
         <dc:title>Title block ISO 7200</dc:title>
         <dc:creator>
           <cc:Agent>
@@ -24,51 +30,223 @@
           </cc:Agent>
         </dc:creator>
       </cc:Work>
-      <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
       </cc:License>
     </rdf:RDF>
   </metadata>
-  <g id="title_block_borders" style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:round;stroke-linejoin:round">
-    <rect id="title_block_frame" x="0" y="0" width="180" height="36" style="stroke-width:0.7" />
-    <rect id="legal_owner_border" x="140" y="0" width="40" height="24" />
-    <rect id="identification_number_border" x="0" y="24" width="60" height="12" />
-    <rect id="revision_index_border" x="100" y="24" width="20" height="12" />
-    <rect id="date_of_issue_border" x="60" y="24" width="40" height="12" />
-    <rect id="sheet_number_border" x="120" y="24" width="20" height="12" />
-    <rect id="title_border" x="0" y="0" width="80" height="12" />
-    <rect id="responsible_department_border" x="140" y="24" width="40" height="12" />
-    <rect id="approval_person_border" x="80" y="12" width="60" height="12" />
-    <rect id="creator_border" x="80" y="0" width="60" height="12" />
-    <rect id="document_type_border" x="0" y="12" width="80" height="12" />
+  <g
+     id="title_block_borders"
+     style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:round;stroke-linejoin:round">
+    <rect
+       id="title_block_frame"
+       x="0"
+       y="0"
+       width="180"
+       height="36"
+       style="stroke-width:0.7" />
+    <rect
+       id="legal_owner_border"
+       x="140"
+       y="0"
+       width="40"
+       height="24" />
+    <rect
+       id="identification_number_border"
+       x="0"
+       y="24"
+       width="60"
+       height="12" />
+    <rect
+       id="revision_index_border"
+       x="100"
+       y="24"
+       width="20"
+       height="12" />
+    <rect
+       id="date_of_issue_border"
+       x="60"
+       y="24"
+       width="40"
+       height="12" />
+    <rect
+       id="sheet_number_border"
+       x="120"
+       y="24"
+       width="20"
+       height="12" />
+    <rect
+       id="title_border"
+       x="0"
+       y="0"
+       width="80"
+       height="12" />
+    <rect
+       id="responsible_department_border"
+       x="140"
+       y="24"
+       width="40"
+       height="12" />
+    <rect
+       id="approval_person_border"
+       x="80"
+       y="12"
+       width="60"
+       height="12" />
+    <rect
+       id="creator_border"
+       x="80"
+       y="0"
+       width="60"
+       height="12" />
+    <rect
+       id="document_type_border"
+       x="0"
+       y="12"
+       width="80"
+       height="12" />
   </g>
-  <g id="title_block_labels" style="font-size:3.5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
-    <text id="legal_owner label" x="140.5" y="3.6">Owner:</text>
-    <text id="identification_number_label" x="0.5" y="27.6">Drawing number:</text>
-    <text id="revision_index_label" x="100.5" y="27.6">Revision:</text>
-    <text id="date_of_issue_label" x="60.5" y="27.6">Issue date:</text>
-    <text id="sheet_number_label" x="120.5" y="27.6">Sheet:</text>
-    <text id="title_label" x="0.5" y="3.6">Title:</text>
-    <text id="responsible_department_label" x="140.5" y="27.6">Responsible department:</text>
-    <text id="approval_person_label" x="80.5" y="15.6">Approved by:</text>
-    <text id="creator_label" x="80.5" y="3.6">Created by:</text>
-    <text id="document_type_label" x="0.5" y="15.6">Document type:</text>
+  <g
+     id="title_block_labels"
+     style="font-size:3.5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
+    <text
+       id="legal_owner label"
+       x="140.5"
+       y="3.6">Owner:</text>
+    <text
+       id="identification_number_label"
+       x="0.5"
+       y="27.6">Drawing number:</text>
+    <text
+       id="revision_index_label"
+       x="100.5"
+       y="27.6">Revision:</text>
+    <text
+       id="date_of_issue_label"
+       x="60.5"
+       y="27.6">Issue date:</text>
+    <text
+       id="sheet_number_label"
+       x="120.5"
+       y="27.6">Sheet:</text>
+    <text
+       id="title_label"
+       x="0.5"
+       y="3.6">Title:</text>
+    <text
+       id="responsible_department_label"
+       x="140.5"
+       y="27.6">Responsible department:</text>
+    <text
+       id="approval_person_label"
+       x="80.5"
+       y="15.6">Approved by:</text>
+    <text
+       id="creator_label"
+       x="80.5"
+       y="3.6">Created by:</text>
+    <text
+       id="document_type_label"
+       x="0.5"
+       y="15.6">Document type:</text>
   </g>
-  <g id="title_block_data_fields" style="font-size:5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
-    <text id="owner_1_data_field" x="160" y="9.1" freecad:editable="legal_owner_1" freecad:autofill="organization" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="owner_2_data_field" x="160" y="13.1" freecad:editable="legal_owner_2" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="owner_3_data_field" x="160" y="17.1" freecad:editable="legal_owner_3" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="owner_4_data_field" x="160" y="21.1" freecad:editable="legal_owner_4" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="identification_number_data_field" y="33.2" x="1" freecad:editable="identification_number"><tspan>DN</tspan></text>
-    <text id="revision_index_data_field" x="110" y="33.2" freecad:editable="revision_index" style="text-align:center;text-anchor:middle"><tspan>AAA</tspan></text>
-    <text id="date_of_issue_data_field" x="61" y="33.2" freecad:editable="date_of_issue" freecad:autofill="date"><tspan>YYYY-MM-DD</tspan></text>
-    <text id="sheet_number_data_field" x="130" y="33.2" freecad:editable="sheet_number" freecad:autofill="sheet" style="text-align:center;text-anchor:middle"><tspan>X / Y</tspan></text>
-    <text id="title_data_field" x="1" y="9.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 5457 template</tspan></text>
-    <text id="responsible_department_data_field" x="141" y="33.2" freecad:editable="responsible_department"><tspan>RD</tspan></text>
-    <text id="approval_person_data_field" x="81" y="21.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
-    <text id="creator_data_field" x="81" y="9.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1" y="21.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
+  <g
+     id="title_block_data_fields"
+     style="font-size:5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
+    <text
+       id="owner_1_data_field"
+       x="160"
+       y="9.1"
+       index0:editable="legal_owner_1"
+       index0:autofill="organization"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan1" /></text>
+    <text
+       id="owner_2_data_field"
+       x="160"
+       y="13.1"
+       index0:editable="legal_owner_2"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan2" /></text>
+    <text
+       id="owner_3_data_field"
+       x="160"
+       y="17.1"
+       index0:editable="legal_owner_3"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan3" /></text>
+    <text
+       id="owner_4_data_field"
+       x="160"
+       y="21.1"
+       index0:editable="legal_owner_4"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan4" /></text>
+    <text
+       id="identification_number_data_field"
+       y="33.2"
+       x="1"
+       freecad:editable="identification_number"><tspan
+         id="tspan5">DN</tspan></text>
+    <text
+       id="revision_index_data_field"
+       x="110"
+       y="33.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="revision_index"><tspan
+         id="tspan6">AAA</tspan></text>
+    <text
+       id="date_of_issue_data_field"
+       x="61"
+       y="33.2"
+       freecad:autofill="date"
+       freecad:editable="date_of_issue"><tspan
+         id="tspan7">YYYY-MM-DD</tspan></text>
+    <text
+       id="sheet_number_data_field"
+       x="130"
+       y="33.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:autofill="sheet"
+       freecad:editable="sheet_number"><tspan
+         id="tspan8">X / Y</tspan></text>
+    <text
+       id="title_data_field"
+       x="1"
+       y="9.2"
+       freecad:autofill="title"
+       freecad:editable="title"><tspan
+         id="tspan9">ISO 5457 template</tspan></text>
+    <text
+       id="responsible_department_data_field"
+       x="141"
+       y="33.2"
+       freecad:editable="responsible_department"><tspan
+         id="tspan10">RD</tspan></text>
+    <text
+       id="approval_person_data_field"
+       x="81"
+       y="21.2"
+       freecad:editable="approval_person"><tspan
+         id="tspan11">B. Hecate</tspan></text>
+    <text
+       id="creator_data_field"
+       x="81"
+       y="9.2"
+       freecad:autofill="author"
+       freecad:editable="creator"><tspan
+         id="tspan12">A. Nemesis</tspan></text>
+    <text
+       id="document_type_data_field"
+       x="1"
+       y="21.2"
+       freecad:editable="document_type"><tspan
+         id="tspan13">Assembly Drawing</tspan></text>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_3_advanced.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_3_advanced.svg
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
 <svg
    width="180mm"
    height="48mm"
@@ -11,12 +10,19 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
-  <title id="title">Title block ISO 7200 - Advanced</title>
-  <metadata id="metadata">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace"
+   xmlns:index0="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+  <defs
+     id="defs20" />
+  <title
+     id="title">Title block ISO 7200 - Advanced</title>
+  <metadata
+     id="metadata">
     <rdf:RDF>
-      <cc:Work rdf:about="">
-        <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+      <cc:Work
+         rdf:about="">
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
         <dc:title>Title block ISO 7200 - Advanced</dc:title>
         <dc:creator>
           <cc:Agent>
@@ -24,74 +30,329 @@
           </cc:Agent>
         </dc:creator>
       </cc:Work>
-      <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
       </cc:License>
     </rdf:RDF>
   </metadata>
-  <g id="title_block_borders" style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:round;stroke-linejoin:round">
-    <rect id="title_block_frame" x="0" y="0" width="180" height="48" style="stroke-width:0.7" />
-    <rect id="legal_owner_border" x="140" y="0" width="40" height="24" />
-    <rect id="identification_number_border" x="80" y="24" width="60" height="12" />
-    <rect id="revision_index_border" x="140" y="36" width="20" height="12" />
-    <rect id="date_of_issue_border" x="100" y="36" width="40" height="12" />
-    <rect id="sheet_number_border" x="160" y="36" width="20" height="12" />
-    <rect id="language_code_border" x="80" y="36" width="20" height="12" />
-    <rect id="title_border" x="0" y="0" width="80" height="24" />
-    <rect id="responsible_department_border" x="140" y="24" width="40" height="12" />
-    <rect id="approval_person_border" x="80" y="12" width="60" height="12" />
-    <rect id="creator_border" x="80" y="0" width="60" height="12" />
-    <rect id="document_type_border" x="0" y="24" width="80" height="12" />
-    <rect id="document_status_border" x="0" y="36" width="80" height="12" />
+  <g
+     id="title_block_borders"
+     style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:round;stroke-linejoin:round">
+    <rect
+       id="title_block_frame"
+       x="0"
+       y="0"
+       width="180"
+       height="48"
+       style="stroke-width:0.7" />
+    <rect
+       id="legal_owner_border"
+       x="140"
+       y="0"
+       width="40"
+       height="24" />
+    <rect
+       id="identification_number_border"
+       x="80"
+       y="24"
+       width="60"
+       height="12" />
+    <rect
+       id="revision_index_border"
+       x="140"
+       y="36"
+       width="20"
+       height="12" />
+    <rect
+       id="date_of_issue_border"
+       x="100"
+       y="36"
+       width="40"
+       height="12" />
+    <rect
+       id="sheet_number_border"
+       x="160"
+       y="36"
+       width="20"
+       height="12" />
+    <rect
+       id="language_code_border"
+       x="80"
+       y="36"
+       width="20"
+       height="12" />
+    <rect
+       id="title_border"
+       x="0"
+       y="0"
+       width="80"
+       height="24" />
+    <rect
+       id="responsible_department_border"
+       x="140"
+       y="24"
+       width="40"
+       height="12" />
+    <rect
+       id="approval_person_border"
+       x="80"
+       y="12"
+       width="60"
+       height="12" />
+    <rect
+       id="creator_border"
+       x="80"
+       y="0"
+       width="60"
+       height="12" />
+    <rect
+       id="document_type_border"
+       x="0"
+       y="24"
+       width="80"
+       height="12" />
+    <rect
+       id="document_status_border"
+       x="0"
+       y="36"
+       width="80"
+       height="12" />
   </g>
-  <g id="title_block_labels" style="font-size:3.5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
-    <text id="legal_owner_label" x="140.5" y="3.6">Owner:</text>
-    <text id="identification_number_label" x="80.5" y="27.6">Drawing number:</text>
-    <text id="revision_index_label" x="140.5" y="39.6">Revision:</text>
-    <text id="date_of_issue_label" x="100.5" y="39.6">Issue date:</text>
-    <text id="sheet_number_label" x="160.5" y="39.6">Sheet:</text>
-    <text id="language_code_label" x="80.5" y="39.6">Language:</text>
-    <text id="title_label" x="0.5" y="3.6">Title, supplementary title:</text>
-    <text id="responsible_department_label" x="140.5" y="27.6">Responsible department:</text>
-    <text id="approval_person_label" x="80.5" y="15.6">Approved by:</text>
-    <text id="creator_label" x="80.5" y="3.6">Created by:</text>
-    <text id="document_type label" x="0.5" y="27.6">Document type:</text>
-    <text id="document_status_label" x="0.5" y="39.6">Document status:</text>
-    <text id="sheet_scale_label" x="120.5" y="-8.4">Scale:</text>
-    <text id="general_tolerances_label" x="80.5" y="-8.4">General tolerances:</text>
-    <text id="part_material_label" x="0.5" y="-8.4">Part Material:</text>
+  <g
+     id="title_block_labels"
+     style="font-size:3.5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
+    <text
+       id="legal_owner_label"
+       x="140.5"
+       y="3.6">Owner:</text>
+    <text
+       id="identification_number_label"
+       x="80.5"
+       y="27.6">Drawing number:</text>
+    <text
+       id="revision_index_label"
+       x="140.5"
+       y="39.6">Revision:</text>
+    <text
+       id="date_of_issue_label"
+       x="100.5"
+       y="39.6">Issue date:</text>
+    <text
+       id="sheet_number_label"
+       x="160.5"
+       y="39.6">Sheet:</text>
+    <text
+       id="language_code_label"
+       x="80.5"
+       y="39.6">Language:</text>
+    <text
+       id="title_label"
+       x="0.5"
+       y="3.6">Title, supplementary title:</text>
+    <text
+       id="responsible_department_label"
+       x="140.5"
+       y="27.6">Responsible department:</text>
+    <text
+       id="approval_person_label"
+       x="80.5"
+       y="15.6">Approved by:</text>
+    <text
+       id="creator_label"
+       x="80.5"
+       y="3.6">Created by:</text>
+    <text
+       id="document_type label"
+       x="0.5"
+       y="27.6">Document type:</text>
+    <text
+       id="document_status_label"
+       x="0.5"
+       y="39.6">Document status:</text>
+    <text
+       id="sheet_scale_label"
+       x="120.5"
+       y="-8.4">Scale:</text>
+    <text
+       id="general_tolerances_label"
+       x="80.5"
+       y="-8.4">General tolerances:</text>
+    <text
+       id="part_material_label"
+       x="0.5"
+       y="-8.4">Part Material:</text>
   </g>
-  <g id="title_block_data_fields" style="font-size:5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
-    <text id="legal_owner_1_data_field" x="160" y="9.1" freecad:editable="legal_owner_1" freecad:autofill="organization" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_2_data_field" x="160" y="13.1" freecad:editable="legal_owner_2" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_3_data_field" x="160" y="17.1" freecad:editable="legal_owner_3" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_4_data_field" x="160" y="21.1" freecad:editable="legal_owner_4" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="identification_number_data_field" x="81" y="33.2" freecad:editable="drawing_number"><tspan>DN</tspan></text>
-    <text id="revision_index_data_field" x="150" y="45.2" freecad:editable="revision_index" style="text-align:center;text-anchor:middle"><tspan>AAA</tspan></text>
-    <text id="date_of_issue_data_field" x="101" y="45.2" freecad:editable="date_of_issue" freecad:autofill="date"><tspan>YYYY-MM-DD</tspan></text>
-    <text id="sheet_number_data_field" x="170" y="45.2" freecad:editable="sheet_number" freecad:autofill="sheet" style="text-align:center;text-anchor:middle"><tspan>X / Y</tspan></text>
-    <text id="language_data_field" x="90" y="45.2" freecad:editable="language_code" style="text-align:center;text-anchor:middle"><tspan>EN</tspan></text>
-    <text id="title_data_field" x="1" y="9.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 7200 titleblock</tspan></text>
-    <text id="supplementary_title_1_data_field" x="1" y="15.2" freecad:editable="supplementary_title_1"><tspan>ST1</tspan></text>
-    <text id="supplementary_title_2_data_field" x="1" y="21.2" freecad:editable="supplementary_title_2"><tspan>ST2</tspan></text>
-    <text id="responsible_department_data_field" x="141" y="33.2" freecad:editable="responsible_department"><tspan>RD</tspan></text>
-    <text id="approval_person_data_field" x="81" y="21.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
-    <text id="creator_data_field" x="81" y="9.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1" y="33.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
-    <text id="document_status_data_field" x="1" y="45.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
-    <text id="sheet_scale_data_field" x="130" y="-2.8" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
-    <text id="general_tolerances_data_field" x="81" y="-2.8" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>
-    <text id="part_material_data_field" x="1" y="-2.8" freecad:editable="part_material"><tspan>Stainless steel Mat.No. 1.4301</tspan></text>
+  <g
+     id="title_block_data_fields"
+     style="font-size:5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
+    <text
+       id="legal_owner_1_data_field"
+       x="160"
+       y="9.1"
+       index0:editable="legal_owner_1"
+       index0:autofill="organization"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan1" /></text>
+    <text
+       id="legal_owner_2_data_field"
+       x="160"
+       y="13.1"
+       index0:editable="legal_owner_2"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan2" /></text>
+    <text
+       id="legal_owner_3_data_field"
+       x="160"
+       y="17.1"
+       index0:editable="legal_owner_3"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan3" /></text>
+    <text
+       id="legal_owner_4_data_field"
+       x="160"
+       y="21.1"
+       index0:editable="legal_owner_4"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan4" /></text>
+    <text
+       id="identification_number_data_field"
+       x="81"
+       y="33.2"
+       index0:editable="drawing_number"><tspan
+         id="tspan5">DN</tspan></text>
+    <text
+       id="revision_index_data_field"
+       x="150"
+       y="45.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="revision_index"><tspan
+         id="tspan6">AAA</tspan></text>
+    <text
+       id="date_of_issue_data_field"
+       x="101"
+       y="45.2"
+       freecad:autofill="date"
+       freecad:editable="date_of_issue"><tspan
+         id="tspan7">YYYY-MM-DD</tspan></text>
+    <text
+       id="sheet_number_data_field"
+       x="170"
+       y="45.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:autofill="sheet"
+       freecad:editable="sheet_number"><tspan
+         id="tspan8">X / Y</tspan></text>
+    <text
+       id="language_data_field"
+       x="90"
+       y="45.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="language_code"><tspan
+         id="tspan9">EN</tspan></text>
+    <text
+       id="title_data_field"
+       x="1"
+       y="9.2"
+       freecad:autofill="title"
+       freecad:editable="title"><tspan
+         id="tspan10">ISO 7200 titleblock</tspan></text>
+    <text
+       id="supplementary_title_1_data_field"
+       x="1"
+       y="15.2"
+       freecad:editable="supplementary_title_1"><tspan
+         id="tspan11">ST1</tspan></text>
+    <text
+       id="supplementary_title_2_data_field"
+       x="1"
+       y="21.2"
+       freecad:editable="supplementary_title_2"><tspan
+         id="tspan12">ST2</tspan></text>
+    <text
+       id="responsible_department_data_field"
+       x="141"
+       y="33.2"
+       freecad:editable="responsible_department"><tspan
+         id="tspan13">RD</tspan></text>
+    <text
+       id="approval_person_data_field"
+       x="81"
+       y="21.2"
+       freecad:editable="approval_person"><tspan
+         id="tspan14">B. Hecate</tspan></text>
+    <text
+       id="creator_data_field"
+       x="81"
+       y="9.2"
+       freecad:autofill="author"
+       freecad:editable="creator"><tspan
+         id="tspan15">A. Nemesis</tspan></text>
+    <text
+       id="document_type_data_field"
+       x="1"
+       y="33.2"
+       freecad:editable="document_type"><tspan
+         id="tspan16">Assembly Drawing</tspan></text>
+    <text
+       id="document_status_data_field"
+       x="1"
+       y="45.2"
+       freecad:editable="document_status"><tspan
+         id="tspan17">In preparation</tspan></text>
+    <text
+       id="sheet_scale_data_field"
+       x="130"
+       y="-2.8"
+       style="text-align:center;text-anchor:middle"
+       freecad:autofill="scale"
+       freecad:editable="sheet_scale"><tspan
+         id="tspan18">1 : 1</tspan></text>
+    <text
+       id="general_tolerances_data_field"
+       x="81"
+       y="-2.8"
+       freecad:editable="general_tolerances"><tspan
+         id="tspan19">ISO 2768-m</tspan></text>
+    <text
+       id="part_material_data_field"
+       x="1"
+       y="-2.8"
+       freecad:editable="part_material"><tspan
+         id="tspan20">Stainless steel Mat.No. 1.4301</tspan></text>
   </g>
-  <g id="extras_outlines" style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round">
-    <path id="first_angle_trapezoid" d="m 159,-17 -10,2.5 v 5 l 10,2.5 z" />
-    <circle id="first_angle_inner circle" cx="166" cy="-12" r="2.5" />
-    <circle id="first_angle_outer circle" cx="166" cy="-12" r="5" />
+  <g
+     id="extras_outlines"
+     style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round">
+    <path
+       id="first_angle_trapezoid"
+       d="m 159,-17 -10,2.5 v 5 l 10,2.5 z" />
+    <circle
+       id="first_angle_inner circle"
+       cx="166"
+       cy="-12"
+       r="2.5" />
+    <circle
+       id="first_angle_outer circle"
+       cx="166"
+       cy="-12"
+       r="5" />
   </g>
-  <g id="extras_centre_lines" style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:6, 0.75, 0.125, 0.75" >
-    <path id="first_angle_horizontal" d="m 148,-12 h 24" style="stroke-dashoffset:0.25" />
-    <path id="first_angle_vertical" d="m 166,-6 v -12" style="stroke-dashoffset:4.625" />
+  <g
+     id="extras_centre_lines"
+     style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:6, 0.75, 0.125, 0.75">
+    <path
+       id="first_angle_horizontal"
+       d="m 148,-12 h 24"
+       style="stroke-dashoffset:0.25" />
+    <path
+       id="first_angle_vertical"
+       d="m 166,-6 v -12"
+       style="stroke-dashoffset:4.625" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_4.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_4.svg
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
 <svg
    width="180mm"
    height="48mm"
@@ -11,12 +10,19 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
-  <title id="title">Title block ISO 7200</title>
-  <metadata id="metadata">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace"
+   xmlns:index0="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+  <defs
+     id="defs17" />
+  <title
+     id="title">Title block ISO 7200</title>
+  <metadata
+     id="metadata">
     <rdf:RDF>
-      <cc:Work rdf:about="">
-        <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+      <cc:Work
+         rdf:about="">
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
         <dc:title>Title block ISO 7200</dc:title>
         <dc:creator>
           <cc:Agent>
@@ -24,62 +30,284 @@
           </cc:Agent>
         </dc:creator>
       </cc:Work>
-      <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
       </cc:License>
     </rdf:RDF>
   </metadata>
-  <g id="title_block_borders" style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:round;stroke-linejoin:round">
-    <rect id="title_block_frame" width="180" x="0" height="48" y="0" style="stroke-width:0.7" />
-    <rect id="legal_owner_border" width="40" x="140" height="24" y="0" />
-    <rect id="identification_number_border" width="60" x="80" height="12" y="24" />
-    <rect id="revision_index_border" width="20" x="140" height="12" y="36" />
-    <rect id="date_of_issue_border" width="40" x="100" height="12" y="36" />
-    <rect id="Sheet number border" width="20" x="160" height="12" y="36" />
-    <rect id="language_code_border" width="20" x="60" height="12" y="36" />
-    <rect id="title_border" width="80" x="0" height="24" y="0" />
-    <rect id="responsible_department_border" width="40" x="140" height="12" y="24" />
-    <rect id="approval_person_border" width="60" x="80" height="12" y="12" />
-    <rect id="creator_border" width="60" x="80" height="12" y="0" />
-    <rect id="document_type_border" width="80" x="0" height="12" y="24" />
-    <rect id="document_status_border" width="60" x="0" height="12" y="36" />
-    <rect id="paper_size_border" width="20" x="80" height="12" y="36" />
+  <g
+     id="title_block_borders"
+     style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:round;stroke-linejoin:round">
+    <rect
+       id="title_block_frame"
+       width="180"
+       x="0"
+       height="48"
+       y="0"
+       style="stroke-width:0.7" />
+    <rect
+       id="legal_owner_border"
+       width="40"
+       x="140"
+       height="24"
+       y="0" />
+    <rect
+       id="identification_number_border"
+       width="60"
+       x="80"
+       height="12"
+       y="24" />
+    <rect
+       id="revision_index_border"
+       width="20"
+       x="140"
+       height="12"
+       y="36" />
+    <rect
+       id="date_of_issue_border"
+       width="40"
+       x="100"
+       height="12"
+       y="36" />
+    <rect
+       id="Sheet number border"
+       width="20"
+       x="160"
+       height="12"
+       y="36" />
+    <rect
+       id="language_code_border"
+       width="20"
+       x="60"
+       height="12"
+       y="36" />
+    <rect
+       id="title_border"
+       width="80"
+       x="0"
+       height="24"
+       y="0" />
+    <rect
+       id="responsible_department_border"
+       width="40"
+       x="140"
+       height="12"
+       y="24" />
+    <rect
+       id="approval_person_border"
+       width="60"
+       x="80"
+       height="12"
+       y="12" />
+    <rect
+       id="creator_border"
+       width="60"
+       x="80"
+       height="12"
+       y="0" />
+    <rect
+       id="document_type_border"
+       width="80"
+       x="0"
+       height="12"
+       y="24" />
+    <rect
+       id="document_status_border"
+       width="60"
+       x="0"
+       height="12"
+       y="36" />
+    <rect
+       id="paper_size_border"
+       width="20"
+       x="80"
+       height="12"
+       y="36" />
   </g>
-  <g id="title_block_labels" style="font-size:3.5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
-    <text id="legal_owner_label" x="140.5" y="3.6">Owner:</text>
-    <text id="identification_number_label" x="80.5" y="27.6">Drawing number:</text>
-    <text id="revision_index_label" x="140.5" y="39.6">Revision:</text>
-    <text id="date_of_issue_label" x="100.5" y="39.6">Issue date:</text>
-    <text id="sheet_number_label" x="160.5" y="39.6">Sheet:</text>
-    <text id="language_code_label" x="60.5" y="39.6">Language:</text>
-    <text id="title_label" x="0.5" y="3.6">Title, supplementary title:</text>
-    <text id="responsible_department_label" x="140.5" y="27.6">Responsible department:</text>
-    <text id="approval_person_label" x="80.5" y="15.6">Approved by:</text>
-    <text id="creator_label" x="80.5" y="3.6">Created by:</text>
-    <text id="document_type_label" x="0.5" y="27.6">Document type:</text>
-    <text id="document_status_label" x="0.5" y="39.6">Document status:</text>
-    <text id="paper_size_label" x="80.5" y="39.6">Paper size:</text>
+  <g
+     id="title_block_labels"
+     style="font-size:3.5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
+    <text
+       id="legal_owner_label"
+       x="140.5"
+       y="3.6">Owner:</text>
+    <text
+       id="identification_number_label"
+       x="80.5"
+       y="27.6">Drawing number:</text>
+    <text
+       id="revision_index_label"
+       x="140.5"
+       y="39.6">Revision:</text>
+    <text
+       id="date_of_issue_label"
+       x="100.5"
+       y="39.6">Issue date:</text>
+    <text
+       id="sheet_number_label"
+       x="160.5"
+       y="39.6">Sheet:</text>
+    <text
+       id="language_code_label"
+       x="60.5"
+       y="39.6">Language:</text>
+    <text
+       id="title_label"
+       x="0.5"
+       y="3.6">Title, supplementary title:</text>
+    <text
+       id="responsible_department_label"
+       x="140.5"
+       y="27.6">Responsible department:</text>
+    <text
+       id="approval_person_label"
+       x="80.5"
+       y="15.6">Approved by:</text>
+    <text
+       id="creator_label"
+       x="80.5"
+       y="3.6">Created by:</text>
+    <text
+       id="document_type_label"
+       x="0.5"
+       y="27.6">Document type:</text>
+    <text
+       id="document_status_label"
+       x="0.5"
+       y="39.6">Document status:</text>
+    <text
+       id="paper_size_label"
+       x="80.5"
+       y="39.6">Paper size:</text>
   </g>
-  <g id="title_block_data_fields" style="font-size:5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
-    <text id="legal_owner_1_data_field" x="160" y="9.1" freecad:editable="legal_owner_1" freecad:autofill="organization" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_2_data_field" x="160" y="13.1" freecad:editable="legal_owner_2" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_3_data_field" x="160" y="17.1" freecad:editable="legal_owner_3" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_4_data_field" x="160" y="21.1" freecad:editable="legal_owner_4" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="identification_number_data_field" x="81" y="33.2" freecad:editable="identification_number"><tspan>DN</tspan></text>
-    <text id="revision_index_data_field" x="150" y="45.2" freecad:editable="revision_index" style="text-align:center;text-anchor:middle"><tspan>AAA</tspan></text>
-    <text id="date_of_issue_data_field" x="101" y="45.2" freecad:editable="date_of_issue" freecad:autofill="date"><tspan>YYYY-MM-DD</tspan></text>
-    <text id="sheet_number_data_field" x="170" y="45.2" freecad:editable="sheet_number" freecad:autofill="sheet" style="text-align:center;text-anchor:middle"><tspan>X / Y</tspan></text>
-    <text id="language_code_data_field" x="70" y="45.2" freecad:editable="language_code" style="text-align:center;text-anchor:middle"><tspan>EN</tspan></text>
-    <text id="title_data_field" x="1" y="9.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 7200 titleblock</tspan></text>
-    <text id="Supplementary title 1 data field" x="1" y="15.2" freecad:editable="supplementary_title_1"><tspan>ST1</tspan></text>
-    <text id="Supplementary title 2 data field" x="1" y="21.2" freecad:editable="supplementary_title_2"><tspan>ST2</tspan></text>
-    <text id="responsible_department_data_field" x="141" y="33" freecad:editable="responsible_department"><tspan>RD</tspan></text>
-    <text id="approval_person_data_field" x="81" y="21.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
-    <text id="creator_data_field" x="81" y="9.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1" y="33.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
-    <text id="document_status_data_field" x="1" y="45.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
-    <text id="paper_size_data_field" x="90" y="45.2" style="text-align:center;text-anchor:middle">A3</text>
+  <g
+     id="title_block_data_fields"
+     style="font-size:5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
+    <text
+       id="legal_owner_1_data_field"
+       x="160"
+       y="9.1"
+       index0:editable="legal_owner_1"
+       index0:autofill="organization"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan1" /></text>
+    <text
+       id="legal_owner_2_data_field"
+       x="160"
+       y="13.1"
+       index0:editable="legal_owner_2"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan2" /></text>
+    <text
+       id="legal_owner_3_data_field"
+       x="160"
+       y="17.1"
+       index0:editable="legal_owner_3"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan3" /></text>
+    <text
+       id="legal_owner_4_data_field"
+       x="160"
+       y="21.1"
+       index0:editable="legal_owner_4"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan4" /></text>
+    <text
+       id="identification_number_data_field"
+       x="81"
+       y="33.2"
+       freecad:editable="identification_number"><tspan
+         id="tspan5">DN</tspan></text>
+    <text
+       id="revision_index_data_field"
+       x="150"
+       y="45.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="revision_index"><tspan
+         id="tspan6">AAA</tspan></text>
+    <text
+       id="date_of_issue_data_field"
+       x="101"
+       y="45.2"
+       freecad:autofill="date"
+       freecad:editable="date_of_issue"><tspan
+         id="tspan7">YYYY-MM-DD</tspan></text>
+    <text
+       id="sheet_number_data_field"
+       x="170"
+       y="45.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:autofill="sheet"
+       freecad:editable="sheet_number"><tspan
+         id="tspan8">X / Y</tspan></text>
+    <text
+       id="language_code_data_field"
+       x="70"
+       y="45.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="language_code"><tspan
+         id="tspan9">EN</tspan></text>
+    <text
+       id="title_data_field"
+       x="1"
+       y="9.2"
+       freecad:autofill="title"
+       freecad:editable="title"><tspan
+         id="tspan10">ISO 7200 titleblock</tspan></text>
+    <text
+       id="Supplementary title 1 data field"
+       x="1"
+       y="15.2"
+       freecad:editable="supplementary_title_1"><tspan
+         id="tspan11">ST1</tspan></text>
+    <text
+       id="Supplementary title 2 data field"
+       x="1"
+       y="21.2"
+       freecad:editable="supplementary_title_2"><tspan
+         id="tspan12">ST2</tspan></text>
+    <text
+       id="responsible_department_data_field"
+       x="141"
+       y="33"
+       freecad:editable="responsible_department"><tspan
+         id="tspan13">RD</tspan></text>
+    <text
+       id="approval_person_data_field"
+       x="81"
+       y="21.2"
+       freecad:editable="approval_person"><tspan
+         id="tspan14">B. Hecate</tspan></text>
+    <text
+       id="creator_data_field"
+       x="81"
+       y="9.2"
+       freecad:autofill="author"
+       freecad:editable="creator"><tspan
+         id="tspan15">A. Nemesis</tspan></text>
+    <text
+       id="document_type_data_field"
+       x="1"
+       y="33.2"
+       freecad:editable="document_type"><tspan
+         id="tspan16">Assembly Drawing</tspan></text>
+    <text
+       id="document_status_data_field"
+       x="1"
+       y="45.2"
+       freecad:editable="document_status"><tspan
+         id="tspan17">In preparation</tspan></text>
+    <text
+       id="paper_size_data_field"
+       x="90"
+       y="45.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="paper_size">A3</text>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_5_maximal.svg
+++ b/src/Mod/TechDraw/Templates/ISO 5457/ISO7200_titleblock_5_maximal.svg
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
 <svg
    width="180mm"
    height="60mm"
@@ -11,12 +10,19 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:freecad="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
-  <title id="title">Title block ISO 7200 - Maximal</title>
-  <metadata id="metadata">
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace"
+   xmlns:index0="http://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+  <defs
+     id="defs23" />
+  <title
+     id="title">Title block ISO 7200 - Maximal</title>
+  <metadata
+     id="metadata">
     <rdf:RDF>
-      <cc:Work rdf:about="">
-        <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+      <cc:Work
+         rdf:about="">
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
         <dc:title>Title block ISO 7200 - Maximal</dc:title>
         <dc:creator>
           <cc:Agent>
@@ -24,88 +30,394 @@
           </cc:Agent>
         </dc:creator>
       </cc:Work>
-      <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
       </cc:License>
     </rdf:RDF>
   </metadata>
-  <g id="title_block_borders" style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:round;stroke-linejoin:round">
-    <rect id="title_block_frame" x="0" y="0" width="180" height="60" style="stroke-width:0.7" />
-    <rect id="legal_owner_border" x="140" y="0" width="40" height="24" />
-    <rect id="identification_number_border" x="100" y="36" width="60" height="12" />
-    <rect id="revision_index_border" x="140" y="48" width="20" height="12" />
-    <rect id="date_of_issue_border" x="100" y="48" width="40" height="12" />
-    <rect id="sheet_number_border" x="160" y="48" width="20" height="12" />
-    <rect id="language_code_border" x="60" y="48" width="20" height="12" />
-    <rect id="title_border" x="0" y="0" width="80" height="24" />
-    <rect id="responsible_department_border" x="140" y="24" width="40" height="12" />
-    <rect id="technical_reference_border" x="80" y="24" width="60" height="12" />
-    <rect id="approval_person_border" x="80" y="12" width="60" height="12" />
-    <rect id="creator_border" x="80" y="0" width="60" height="12" />
-    <rect id="document_type_border" x="0" y="24" width="80" height="12" />
-    <rect id="key_words_border" x="0" y="36" width="100" height="12" />
-    <rect id="document_status_border" x="0" y="48" width="60" height="12" />
-    <rect id="page_number_border" x="160" y="36" width="20" height="12" />
-    <rect id="paper_size_border" x="80" y="48" width="20" height="12" />
+  <g
+     id="title_block_borders"
+     style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:round;stroke-linejoin:round">
+    <rect
+       id="title_block_frame"
+       x="0"
+       y="0"
+       width="180"
+       height="60"
+       style="stroke-width:0.7" />
+    <rect
+       id="legal_owner_border"
+       x="140"
+       y="0"
+       width="40"
+       height="24" />
+    <rect
+       id="identification_number_border"
+       x="100"
+       y="36"
+       width="60"
+       height="12" />
+    <rect
+       id="revision_index_border"
+       x="140"
+       y="48"
+       width="20"
+       height="12" />
+    <rect
+       id="date_of_issue_border"
+       x="100"
+       y="48"
+       width="40"
+       height="12" />
+    <rect
+       id="sheet_number_border"
+       x="160"
+       y="48"
+       width="20"
+       height="12" />
+    <rect
+       id="language_code_border"
+       x="60"
+       y="48"
+       width="20"
+       height="12" />
+    <rect
+       id="title_border"
+       x="0"
+       y="0"
+       width="80"
+       height="24" />
+    <rect
+       id="responsible_department_border"
+       x="140"
+       y="24"
+       width="40"
+       height="12" />
+    <rect
+       id="technical_reference_border"
+       x="80"
+       y="24"
+       width="60"
+       height="12" />
+    <rect
+       id="approval_person_border"
+       x="80"
+       y="12"
+       width="60"
+       height="12" />
+    <rect
+       id="creator_border"
+       x="80"
+       y="0"
+       width="60"
+       height="12" />
+    <rect
+       id="document_type_border"
+       x="0"
+       y="24"
+       width="80"
+       height="12" />
+    <rect
+       id="key_words_border"
+       x="0"
+       y="36"
+       width="100"
+       height="12" />
+    <rect
+       id="document_status_border"
+       x="0"
+       y="48"
+       width="60"
+       height="12" />
+    <rect
+       id="page_number_border"
+       x="160"
+       y="36"
+       width="20"
+       height="12" />
+    <rect
+       id="paper_size_border"
+       x="80"
+       y="48"
+       width="20"
+       height="12" />
   </g>
-  <g id="title_block_labels"
+  <g
+     id="title_block_labels"
      style="font-size:3.5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
-    <text id="legal_owner_label" x="140.5" y="3.6">Owner:</text>
-    <text id="identification_number_label" x="100.5" y="39.6">Drawing number:</text>
-    <text id="revision_index_label" x="140.5" y="51.6">Revision:</text>
-    <text id="date_of_issue_label" x="100.5" y="51.6">Issue date:</text>
-    <text id="sheet_number_label" x="160.5" y="51.6">Sheet:</text>
-    <text id="language_code_label" x="60.5" y="51.6">Language:</text>
-    <text id="title_label" x="0.5" y="3.6">Title, supplementary title:</text>
-    <text id="responsible_department_label" x="140.5" y="27.6">Responsible department:</text>
-    <text id="technical_reference_label" x="80.5" y="27.6">Technical reference:</text>
-    <text id="approval_person_label" x="80.5" y="15.6">Approved by:</text>
-    <text id="creator_label" x="80.5" y="3.6">Created by:</text>
-    <text id="document_type_label" x="0.5" y="27.6">Document type:</text>
-    <text id="key_words_label" x="0.5" y="39.6">Key words:</text>
-    <text id="document_status_label" x="0.5" y="51.6">Document status:</text>
-    <text id="page_number_label" x="160.5" y="39.6">Page:</text>
-    <text id="paper_size_label" x="80.5" y="51.6">Paper size:</text>
-    <text id="sheet_scale_label" x="120.5" y="-8.4">Scale:</text>
-    <text id="general_tolerances_label" x="80.5" y="-8.4">General tolerances:</text>
-    <text id="part_material_label" x="0.5" y="-8.4">Part Material:</text>
+    <text
+       id="legal_owner_label"
+       x="140.5"
+       y="3.6">Owner:</text>
+    <text
+       id="identification_number_label"
+       x="100.5"
+       y="39.6">Drawing number:</text>
+    <text
+       id="revision_index_label"
+       x="140.5"
+       y="51.6">Revision:</text>
+    <text
+       id="date_of_issue_label"
+       x="100.5"
+       y="51.6">Issue date:</text>
+    <text
+       id="sheet_number_label"
+       x="160.5"
+       y="51.6">Sheet:</text>
+    <text
+       id="language_code_label"
+       x="60.5"
+       y="51.6">Language:</text>
+    <text
+       id="title_label"
+       x="0.5"
+       y="3.6">Title, supplementary title:</text>
+    <text
+       id="responsible_department_label"
+       x="140.5"
+       y="27.6">Responsible department:</text>
+    <text
+       id="technical_reference_label"
+       x="80.5"
+       y="27.6">Technical reference:</text>
+    <text
+       id="approval_person_label"
+       x="80.5"
+       y="15.6">Approved by:</text>
+    <text
+       id="creator_label"
+       x="80.5"
+       y="3.6">Created by:</text>
+    <text
+       id="document_type_label"
+       x="0.5"
+       y="27.6">Document type:</text>
+    <text
+       id="key_words_label"
+       x="0.5"
+       y="39.6">Key words:</text>
+    <text
+       id="document_status_label"
+       x="0.5"
+       y="51.6">Document status:</text>
+    <text
+       id="page_number_label"
+       x="160.5"
+       y="39.6">Page:</text>
+    <text
+       id="paper_size_label"
+       x="80.5"
+       y="51.6">Paper size:</text>
+    <text
+       id="sheet_scale_label"
+       x="120.5"
+       y="-8.4">Scale:</text>
+    <text
+       id="general_tolerances_label"
+       x="80.5"
+       y="-8.4">General tolerances:</text>
+    <text
+       id="part_material_label"
+       x="0.5"
+       y="-8.4">Part Material:</text>
   </g>
-  <g id="title_block_data_fields"
+  <g
+     id="title_block_data_fields"
      style="font-size:5px;font-family:osifont;text-anchor:start;fill:#000000;stroke:none">
-    <text id="legal_owner_1_data_field" x="160" y="9.1" freecad:editable="legal_owner_1" freecad:autofill="organization" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_2_data_field" x="160" y="13.1" freecad:editable="legal_owner_2" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_3_data_field" x="160" y="17.1" freecad:editable="legal_owner_3" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="legal_owner_4_data_field" x="160" y="21.1" freecad:editable="legal_owner_4" style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan> </tspan></text>
-    <text id="identification_number_data_field" x="101" y="45.2" freecad:editable="identification_number"><tspan>DN</tspan></text>
-    <text id="revision_index_data_field" x="150" y="57.2" freecad:editable="revision_index" style="text-align:center;text-anchor:middle"><tspan>AAA</tspan></text>
-    <text id="date_of_issue_data_field" x="101" y="57.2" freecad:editable="date_of_issue" freecad:autofill="date"><tspan>YYYY-MM-DD</tspan></text>
-    <text id="sheet_number_data_field" x="170" y="57.2" freecad:editable="sheet_number" freecad:autofill="sheet" style="text-align:center;text-anchor:middle"><tspan>X / Y</tspan></text>
-    <text id="language_code_data_field" x="70" y="57.2" freecad:editable="language_code" style="text-align:center;text-anchor:middle"><tspan>EN</tspan></text>
-    <text id="title_data_field" x="1" y="9.2" freecad:editable="title" freecad:autofill="title"><tspan>ISO 7200 titleblock</tspan></text>
-    <text id="Supplementary title 1 data_field" x="1" y="15.2" freecad:editable="supplementary_title_1"><tspan>ST1</tspan></text>
-    <text id="Supplementary title 2 data_field" x="1" y="21.2" freecad:editable="supplementary_title_2"><tspan>ST2</tspan></text>
-    <text id="responsible_department_data_field" x="141" y="33.2" freecad:editable="responsible_department"><tspan>RD</tspan></text>
-    <text id="technical_reference_data_field" x="81" y="33.2" freecad:editable="technical_reference"><tspan>C. Kali</tspan></text>
-    <text id="approval_person_data_field" x="81" y="21.2" freecad:editable="approval_person"><tspan>B. Hecate</tspan></text>
-    <text id="creator_data_field" x="81" y="9.2" freecad:editable="creator" freecad:autofill="author"><tspan>A. Nemesis</tspan></text>
-    <text id="document_type_data_field" x="1" y="33.2" freecad:editable="document_type"><tspan>Assembly Drawing</tspan></text>
-    <text id="key_words_data_field" x="1" y="45.2" freecad:editable="key_words"><tspan>KW</tspan></text>
-    <text id="document_status_data_field" x="1" y="57.2" freecad:editable="document_status"><tspan>In preparation</tspan></text>
-    <text id="page_number_data_field" x="170" y="45.2" freecad:editable="page_number" style="text-align:center;text-anchor:middle"><tspan>X / Y</tspan></text>
-    <text id="paper_size_data_field" x="90" y="57.2" style="text-align:center;text-anchor:middle">A3</text>
-    <text id="sheet_scale_data_field" x="130" y="-2.8" freecad:editable="sheet_scale" freecad:autofill="scale" style="text-align:center;text-anchor:middle"><tspan>1 : 1</tspan></text>
-    <text id="general_tolerances_data_field" x="81" y="-2.8" freecad:editable="general_tolerances"><tspan>ISO 2768-m</tspan></text>
-    <text id="part_material_data_field" x="1" y="-2.8" freecad:editable="part_material"><tspan>Stainless steel Mat.No. 1.4301</tspan></text>
+    <text
+       id="legal_owner_1_data_field"
+       x="160"
+       y="9.1"
+       index0:editable="legal_owner_1"
+       index0:autofill="organization"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan1" /></text>
+    <text
+       id="legal_owner_2_data_field"
+       x="160"
+       y="13.1"
+       index0:editable="legal_owner_2"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan2" /></text>
+    <text
+       id="legal_owner_3_data_field"
+       x="160"
+       y="17.1"
+       index0:editable="legal_owner_3"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan3" /></text>
+    <text
+       id="legal_owner_4_data_field"
+       x="160"
+       y="21.1"
+       index0:editable="legal_owner_4"
+       style="font-size:3.5px;text-align:center;text-anchor:middle"><tspan
+         id="tspan4" /></text>
+    <text
+       id="identification_number_data_field"
+       x="101"
+       y="45.2"
+       freecad:editable="identification_number"><tspan
+         id="tspan5">DN</tspan></text>
+    <text
+       id="revision_index_data_field"
+       x="150"
+       y="57.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="revision_index"><tspan
+         id="tspan6">AAA</tspan></text>
+    <text
+       id="date_of_issue_data_field"
+       x="101"
+       y="57.2"
+       freecad:autofill="date"
+       freecad:editable="date_of_issue"><tspan
+         id="tspan7">YYYY-MM-DD</tspan></text>
+    <text
+       id="sheet_number_data_field"
+       x="170"
+       y="57.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:autofill="sheet"
+       freecad:editable="sheet_number"><tspan
+         id="tspan8">X / Y</tspan></text>
+    <text
+       id="language_code_data_field"
+       x="70"
+       y="57.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="language_code"><tspan
+         id="tspan9">EN</tspan></text>
+    <text
+       id="title_data_field"
+       x="1"
+       y="9.2"
+       freecad:autofill="title"
+       freecad:editable="title"><tspan
+         id="tspan10">ISO 7200 titleblock</tspan></text>
+    <text
+       id="Supplementary title 1 data_field"
+       x="1"
+       y="15.2"
+       freecad:editable="supplementary_title_1"><tspan
+         id="tspan11">ST1</tspan></text>
+    <text
+       id="Supplementary title 2 data_field"
+       x="1"
+       y="21.2"
+       freecad:editable="supplementary_title_2"><tspan
+         id="tspan12">ST2</tspan></text>
+    <text
+       id="responsible_department_data_field"
+       x="141"
+       y="33.2"
+       freecad:editable="responsible_department"><tspan
+         id="tspan13">RD</tspan></text>
+    <text
+       id="technical_reference_data_field"
+       x="81"
+       y="33.2"
+       freecad:editable="technical_reference"><tspan
+         id="tspan14">C. Kali</tspan></text>
+    <text
+       id="approval_person_data_field"
+       x="81"
+       y="21.2"
+       freecad:editable="approval_person"><tspan
+         id="tspan15">B. Hecate</tspan></text>
+    <text
+       id="creator_data_field"
+       x="81"
+       y="9.2"
+       freecad:autofill="author"
+       freecad:editable="creator"><tspan
+         id="tspan16">A. Nemesis</tspan></text>
+    <text
+       id="document_type_data_field"
+       x="1"
+       y="33.2"
+       freecad:editable="document_type"><tspan
+         id="tspan17">Assembly Drawing</tspan></text>
+    <text
+       id="key_words_data_field"
+       x="1"
+       y="45.2"
+       freecad:editable="key_words"><tspan
+         id="tspan18">KW</tspan></text>
+    <text
+       id="document_status_data_field"
+       x="1"
+       y="57.2"
+       freecad:editable="document_status"><tspan
+         id="tspan19">In preparation</tspan></text>
+    <text
+       id="page_number_data_field"
+       x="170"
+       y="45.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="page_number"><tspan
+         id="tspan20">X / Y</tspan></text>
+    <text
+       id="paper_size_data_field"
+       x="90"
+       y="57.2"
+       style="text-align:center;text-anchor:middle"
+       freecad:editable="paper_size">A3</text>
+    <text
+       id="sheet_scale_data_field"
+       x="130"
+       y="-2.8"
+       style="text-align:center;text-anchor:middle"
+       freecad:autofill="scale"
+       freecad:editable="sheet_scale"><tspan
+         id="tspan21">1 : 1</tspan></text>
+    <text
+       id="general_tolerances_data_field"
+       x="81"
+       y="-2.8"
+       freecad:editable="general_tolerances"><tspan
+         id="tspan22">ISO 2768-m</tspan></text>
+    <text
+       id="part_material_data_field"
+       x="1"
+       y="-2.8"
+       freecad:editable="part_material"><tspan
+         id="tspan23">Stainless steel Mat.No. 1.4301</tspan></text>
   </g>
-  <g id="extras_outlines" style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round">
-    <path id="first_angle_trapezoid" d="m 159,-17 -10,2.5 v 5 l 10,2.5 z" />
-    <circle id="first_angle_inner circle" cx="166" cy="-12" r="2.5" />
-    <circle id="first_angle_outer circle" cx="166" cy="-12" r="5" />
+  <g
+     id="extras_outlines"
+     style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round">
+    <path
+       id="first_angle_trapezoid"
+       d="m 159,-17 -10,2.5 v 5 l 10,2.5 z" />
+    <circle
+       id="first_angle_inner circle"
+       cx="166"
+       cy="-12"
+       r="2.5" />
+    <circle
+       id="first_angle_outer circle"
+       cx="166"
+       cy="-12"
+       r="5" />
   </g>
-  <g id="extras_centre_lines" style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:6, 0.75, 0.125, 0.75" >
-    <path id="first_angle_horizontal" d="m 148,-12 h 24" style="stroke-dashoffset:0.25" />
-    <path id="first_angle_vertical" d="m 166,-6 v -12" style="stroke-dashoffset:4.625" />
+  <g
+     id="extras_centre_lines"
+     style="fill:none;stroke:#000000;stroke-width:0.25;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:6, 0.75, 0.125, 0.75">
+    <path
+       id="first_angle_horizontal"
+       d="m 148,-12 h 24"
+       style="stroke-dashoffset:0.25" />
+    <path
+       id="first_angle_vertical"
+       d="m 166,-6 v -12"
+       style="stroke-dashoffset:4.625" />
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/locale/de/A0_Landscape_ISO7200_DE.svg
+++ b/src/Mod/TechDraw/Templates/locale/de/A0_Landscape_ISO7200_DE.svg
@@ -1,258 +1,1016 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-  width="1189mm"
-  height="841mm"
-  viewBox="0 0 1189 841"
-  id="template"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:svg="http://www.w3.org/2000/svg"
-  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-  xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
-
-  <sodipodi:namedview
-     id="namedview3"
-     pagecolor="#ffffff" />
-
-  <g id="frame"
+   width="1189mm"
+   height="841mm"
+   viewBox="0 0 1189 841"
+   id="template"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+  <defs
+     id="defs156" />
+  <g
+     id="frame"
      style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-    <rect style="stroke-width:0.7" width="1159" height="821" x="20" y="10" />
-    <rect width="1169" height="831" x="15" y="5" />
-    <path d="m 68.29,5.00 v 5" />
-    <path d="m 68.29,831.00 v 5" />
-    <path d="m 116.58,5.00 v 5" />
-    <path d="m 116.58,831.00 v 5" />
-    <path d="m 164.88,5.00 v 5" />
-    <path d="m 164.88,831.00 v 5" />
-    <path d="m 213.17,5.00 v 5" />
-    <path d="m 213.17,831.00 v 5" />
-    <path d="m 261.46,5.00 v 5" />
-    <path d="m 261.46,831.00 v 5" />
-    <path d="m 309.75,5.00 v 5" />
-    <path d="m 309.75,831.00 v 5" />
-    <path d="m 358.04,5.00 v 5" />
-    <path d="m 358.04,831.00 v 5" />
-    <path d="m 406.33,5.00 v 5" />
-    <path d="m 406.33,831.00 v 5" />
-    <path d="m 454.62,5.00 v 5" />
-    <path d="m 454.62,831.00 v 5" />
-    <path d="m 502.92,5.00 v 5" />
-    <path d="m 502.92,831.00 v 5" />
-    <path d="m 551.21,5.00 v 5" />
-    <path d="m 551.21,831.00 v 5" />
-    <path d="m 599.50,5.00 v 5" />
-    <path d="m 599.50,831.00 v 5" />
-    <path d="m 647.79,5.00 v 5" />
-    <path d="m 647.79,831.00 v 5" />
-    <path d="m 696.08,5.00 v 5" />
-    <path d="m 696.08,831.00 v 5" />
-    <path d="m 744.38,5.00 v 5" />
-    <path d="m 744.38,831.00 v 5" />
-    <path d="m 792.67,5.00 v 5" />
-    <path d="m 792.67,831.00 v 5" />
-    <path d="m 840.96,5.00 v 5" />
-    <path d="m 840.96,831.00 v 5" />
-    <path d="m 889.25,5.00 v 5" />
-    <path d="m 889.25,831.00 v 5" />
-    <path d="m 937.54,5.00 v 5" />
-    <path d="m 937.54,831.00 v 5" />
-    <path d="m 985.83,5.00 v 5" />
-    <path d="m 985.83,831.00 v 5" />
-    <path d="m 1034.12,5.00 v 5" />
-    <path d="m 1034.12,831.00 v 5" />
-    <path d="m 1082.42,5.00 v 5" />
-    <path d="m 1082.42,831.00 v 5" />
-    <path d="m 1130.71,5.00 v 5" />
-    <path d="m 1130.71,831.00 v 5" />
-    <path d="m 15.00,61.31 h 5" />
-    <path d="m 1179.00,61.31 h 5" />
-    <path d="m 15.00,112.62 h 5" />
-    <path d="m 1179.00,112.62 h 5" />
-    <path d="m 15.00,163.94 h 5" />
-    <path d="m 1179.00,163.94 h 5" />
-    <path d="m 15.00,215.25 h 5" />
-    <path d="m 1179.00,215.25 h 5" />
-    <path d="m 15.00,266.56 h 5" />
-    <path d="m 1179.00,266.56 h 5" />
-    <path d="m 15.00,317.88 h 5" />
-    <path d="m 1179.00,317.88 h 5" />
-    <path d="m 15.00,369.19 h 5" />
-    <path d="m 1179.00,369.19 h 5" />
-    <path d="m 15.00,420.50 h 5" />
-    <path d="m 1179.00,420.50 h 5" />
-    <path d="m 15.00,471.81 h 5" />
-    <path d="m 1179.00,471.81 h 5" />
-    <path d="m 15.00,523.12 h 5" />
-    <path d="m 1179.00,523.12 h 5" />
-    <path d="m 15.00,574.44 h 5" />
-    <path d="m 1179.00,574.44 h 5" />
-    <path d="m 15.00,625.75 h 5" />
-    <path d="m 1179.00,625.75 h 5" />
-    <path d="m 15.00,677.06 h 5" />
-    <path d="m 1179.00,677.06 h 5" />
-    <path d="m 15.00,728.38 h 5" />
-    <path d="m 1179.00,728.38 h 5" />
-    <path d="m 15.00,779.69 h 5" />
-    <path d="m 1179.00,779.69 h 5" />
+    <rect
+       style="stroke-width:0.7"
+       width="1159"
+       height="821"
+       x="20"
+       y="10"
+       id="rect1" />
+    <rect
+       width="1169"
+       height="831"
+       x="15"
+       y="5"
+       id="rect2" />
+    <path
+       d="m 68.29,5.00 v 5"
+       id="path2" />
+    <path
+       d="m 68.29,831.00 v 5"
+       id="path3" />
+    <path
+       d="m 116.58,5.00 v 5"
+       id="path4" />
+    <path
+       d="m 116.58,831.00 v 5"
+       id="path5" />
+    <path
+       d="m 164.88,5.00 v 5"
+       id="path6" />
+    <path
+       d="m 164.88,831.00 v 5"
+       id="path7" />
+    <path
+       d="m 213.17,5.00 v 5"
+       id="path8" />
+    <path
+       d="m 213.17,831.00 v 5"
+       id="path9" />
+    <path
+       d="m 261.46,5.00 v 5"
+       id="path10" />
+    <path
+       d="m 261.46,831.00 v 5"
+       id="path11" />
+    <path
+       d="m 309.75,5.00 v 5"
+       id="path12" />
+    <path
+       d="m 309.75,831.00 v 5"
+       id="path13" />
+    <path
+       d="m 358.04,5.00 v 5"
+       id="path14" />
+    <path
+       d="m 358.04,831.00 v 5"
+       id="path15" />
+    <path
+       d="m 406.33,5.00 v 5"
+       id="path16" />
+    <path
+       d="m 406.33,831.00 v 5"
+       id="path17" />
+    <path
+       d="m 454.62,5.00 v 5"
+       id="path18" />
+    <path
+       d="m 454.62,831.00 v 5"
+       id="path19" />
+    <path
+       d="m 502.92,5.00 v 5"
+       id="path20" />
+    <path
+       d="m 502.92,831.00 v 5"
+       id="path21" />
+    <path
+       d="m 551.21,5.00 v 5"
+       id="path22" />
+    <path
+       d="m 551.21,831.00 v 5"
+       id="path23" />
+    <path
+       d="m 599.50,5.00 v 5"
+       id="path24" />
+    <path
+       d="m 599.50,831.00 v 5"
+       id="path25" />
+    <path
+       d="m 647.79,5.00 v 5"
+       id="path26" />
+    <path
+       d="m 647.79,831.00 v 5"
+       id="path27" />
+    <path
+       d="m 696.08,5.00 v 5"
+       id="path28" />
+    <path
+       d="m 696.08,831.00 v 5"
+       id="path29" />
+    <path
+       d="m 744.38,5.00 v 5"
+       id="path30" />
+    <path
+       d="m 744.38,831.00 v 5"
+       id="path31" />
+    <path
+       d="m 792.67,5.00 v 5"
+       id="path32" />
+    <path
+       d="m 792.67,831.00 v 5"
+       id="path33" />
+    <path
+       d="m 840.96,5.00 v 5"
+       id="path34" />
+    <path
+       d="m 840.96,831.00 v 5"
+       id="path35" />
+    <path
+       d="m 889.25,5.00 v 5"
+       id="path36" />
+    <path
+       d="m 889.25,831.00 v 5"
+       id="path37" />
+    <path
+       d="m 937.54,5.00 v 5"
+       id="path38" />
+    <path
+       d="m 937.54,831.00 v 5"
+       id="path39" />
+    <path
+       d="m 985.83,5.00 v 5"
+       id="path40" />
+    <path
+       d="m 985.83,831.00 v 5"
+       id="path41" />
+    <path
+       d="m 1034.12,5.00 v 5"
+       id="path42" />
+    <path
+       d="m 1034.12,831.00 v 5"
+       id="path43" />
+    <path
+       d="m 1082.42,5.00 v 5"
+       id="path44" />
+    <path
+       d="m 1082.42,831.00 v 5"
+       id="path45" />
+    <path
+       d="m 1130.71,5.00 v 5"
+       id="path46" />
+    <path
+       d="m 1130.71,831.00 v 5"
+       id="path47" />
+    <path
+       d="m 15.00,61.31 h 5"
+       id="path48" />
+    <path
+       d="m 1179.00,61.31 h 5"
+       id="path49" />
+    <path
+       d="m 15.00,112.62 h 5"
+       id="path50" />
+    <path
+       d="m 1179.00,112.62 h 5"
+       id="path51" />
+    <path
+       d="m 15.00,163.94 h 5"
+       id="path52" />
+    <path
+       d="m 1179.00,163.94 h 5"
+       id="path53" />
+    <path
+       d="m 15.00,215.25 h 5"
+       id="path54" />
+    <path
+       d="m 1179.00,215.25 h 5"
+       id="path55" />
+    <path
+       d="m 15.00,266.56 h 5"
+       id="path56" />
+    <path
+       d="m 1179.00,266.56 h 5"
+       id="path57" />
+    <path
+       d="m 15.00,317.88 h 5"
+       id="path58" />
+    <path
+       d="m 1179.00,317.88 h 5"
+       id="path59" />
+    <path
+       d="m 15.00,369.19 h 5"
+       id="path60" />
+    <path
+       d="m 1179.00,369.19 h 5"
+       id="path61" />
+    <path
+       d="m 15.00,420.50 h 5"
+       id="path62" />
+    <path
+       d="m 1179.00,420.50 h 5"
+       id="path63" />
+    <path
+       d="m 15.00,471.81 h 5"
+       id="path64" />
+    <path
+       d="m 1179.00,471.81 h 5"
+       id="path65" />
+    <path
+       d="m 15.00,523.12 h 5"
+       id="path66" />
+    <path
+       d="m 1179.00,523.12 h 5"
+       id="path67" />
+    <path
+       d="m 15.00,574.44 h 5"
+       id="path68" />
+    <path
+       d="m 1179.00,574.44 h 5"
+       id="path69" />
+    <path
+       d="m 15.00,625.75 h 5"
+       id="path70" />
+    <path
+       d="m 1179.00,625.75 h 5"
+       id="path71" />
+    <path
+       d="m 15.00,677.06 h 5"
+       id="path72" />
+    <path
+       d="m 1179.00,677.06 h 5"
+       id="path73" />
+    <path
+       d="m 15.00,728.38 h 5"
+       id="path74" />
+    <path
+       d="m 1179.00,728.38 h 5"
+       id="path75" />
+    <path
+       d="m 15.00,779.69 h 5"
+       id="path76" />
+    <path
+       d="m 1179.00,779.69 h 5"
+       id="path77" />
   </g>
-  <g id="coords"
+  <g
+     id="coords"
      style="font-size:3.52778px;font-family:Open Sans;font-weight:bold;text-anchor:middle">
-    <text x="44.15" y="9.00">1</text>
-    <text x="44.15" y="835.00">1</text>
-    <text x="92.44" y="9.00">2</text>
-    <text x="92.44" y="835.00">2</text>
-    <text x="140.73" y="9.00">3</text>
-    <text x="140.73" y="835.00">3</text>
-    <text x="189.02" y="9.00">4</text>
-    <text x="189.02" y="835.00">4</text>
-    <text x="237.31" y="9.00">5</text>
-    <text x="237.31" y="835.00">5</text>
-    <text x="285.60" y="9.00">6</text>
-    <text x="285.60" y="835.00">6</text>
-    <text x="333.90" y="9.00">7</text>
-    <text x="333.90" y="835.00">7</text>
-    <text x="382.19" y="9.00">8</text>
-    <text x="382.19" y="835.00">8</text>
-    <text x="430.48" y="9.00">9</text>
-    <text x="430.48" y="835.00">9</text>
-    <text x="478.77" y="9.00">10</text>
-    <text x="478.77" y="835.00">10</text>
-    <text x="527.06" y="9.00">11</text>
-    <text x="527.06" y="835.00">11</text>
-    <text x="575.35" y="9.00">12</text>
-    <text x="575.35" y="835.00">12</text>
-    <text x="623.65" y="9.00">13</text>
-    <text x="623.65" y="835.00">13</text>
-    <text x="671.94" y="9.00">14</text>
-    <text x="671.94" y="835.00">14</text>
-    <text x="720.23" y="9.00">15</text>
-    <text x="720.23" y="835.00">15</text>
-    <text x="768.52" y="9.00">16</text>
-    <text x="768.52" y="835.00">16</text>
-    <text x="816.81" y="9.00">17</text>
-    <text x="816.81" y="835.00">17</text>
-    <text x="865.10" y="9.00">18</text>
-    <text x="865.10" y="835.00">18</text>
-    <text x="913.40" y="9.00">19</text>
-    <text x="913.40" y="835.00">19</text>
-    <text x="961.69" y="9.00">20</text>
-    <text x="961.69" y="835.00">20</text>
-    <text x="1009.98" y="9.00">21</text>
-    <text x="1009.98" y="835.00">21</text>
-    <text x="1058.27" y="9.00">22</text>
-    <text x="1058.27" y="835.00">22</text>
-    <text x="1106.56" y="9.00">23</text>
-    <text x="1106.56" y="835.00">23</text>
-    <text x="1154.85" y="9.00">24</text>
-    <text x="1154.85" y="835.00">24</text>
-    <text x="17.50" y="35.66">A</text>
-    <text x="1181.50" y="35.66">A</text>
-    <text x="17.50" y="86.97">B</text>
-    <text x="1181.50" y="86.97">B</text>
-    <text x="17.50" y="138.28">C</text>
-    <text x="1181.50" y="138.28">C</text>
-    <text x="17.50" y="189.59">D</text>
-    <text x="1181.50" y="189.59">D</text>
-    <text x="17.50" y="240.91">E</text>
-    <text x="1181.50" y="240.91">E</text>
-    <text x="17.50" y="292.22">F</text>
-    <text x="1181.50" y="292.22">F</text>
-    <text x="17.50" y="343.53">G</text>
-    <text x="1181.50" y="343.53">G</text>
-    <text x="17.50" y="394.84">H</text>
-    <text x="1181.50" y="394.84">H</text>
-    <text x="17.50" y="446.16">I</text>
-    <text x="1181.50" y="446.16">I</text>
-    <text x="17.50" y="497.47">J</text>
-    <text x="1181.50" y="497.47">J</text>
-    <text x="17.50" y="548.78">K</text>
-    <text x="1181.50" y="548.78">K</text>
-    <text x="17.50" y="600.09">L</text>
-    <text x="1181.50" y="600.09">L</text>
-    <text x="17.50" y="651.41">M</text>
-    <text x="1181.50" y="651.41">M</text>
-    <text x="17.50" y="702.72">N</text>
-    <text x="1181.50" y="702.72">N</text>
-    <text x="17.50" y="754.03">O</text>
-    <text x="1181.50" y="754.03">O</text>
-    <text x="17.50" y="805.34">P</text>
-    <text x="1181.50" y="805.34">P</text>
+    <text
+       x="44.15"
+       y="9.00"
+       id="text77">1</text>
+    <text
+       x="44.15"
+       y="835.00"
+       id="text78">1</text>
+    <text
+       x="92.44"
+       y="9.00"
+       id="text79">2</text>
+    <text
+       x="92.44"
+       y="835.00"
+       id="text80">2</text>
+    <text
+       x="140.73"
+       y="9.00"
+       id="text81">3</text>
+    <text
+       x="140.73"
+       y="835.00"
+       id="text82">3</text>
+    <text
+       x="189.02"
+       y="9.00"
+       id="text83">4</text>
+    <text
+       x="189.02"
+       y="835.00"
+       id="text84">4</text>
+    <text
+       x="237.31"
+       y="9.00"
+       id="text85">5</text>
+    <text
+       x="237.31"
+       y="835.00"
+       id="text86">5</text>
+    <text
+       x="285.60"
+       y="9.00"
+       id="text87">6</text>
+    <text
+       x="285.60"
+       y="835.00"
+       id="text88">6</text>
+    <text
+       x="333.90"
+       y="9.00"
+       id="text89">7</text>
+    <text
+       x="333.90"
+       y="835.00"
+       id="text90">7</text>
+    <text
+       x="382.19"
+       y="9.00"
+       id="text91">8</text>
+    <text
+       x="382.19"
+       y="835.00"
+       id="text92">8</text>
+    <text
+       x="430.48"
+       y="9.00"
+       id="text93">9</text>
+    <text
+       x="430.48"
+       y="835.00"
+       id="text94">9</text>
+    <text
+       x="478.77"
+       y="9.00"
+       id="text95">10</text>
+    <text
+       x="478.77"
+       y="835.00"
+       id="text96">10</text>
+    <text
+       x="527.06"
+       y="9.00"
+       id="text97">11</text>
+    <text
+       x="527.06"
+       y="835.00"
+       id="text98">11</text>
+    <text
+       x="575.35"
+       y="9.00"
+       id="text99">12</text>
+    <text
+       x="575.35"
+       y="835.00"
+       id="text100">12</text>
+    <text
+       x="623.65"
+       y="9.00"
+       id="text101">13</text>
+    <text
+       x="623.65"
+       y="835.00"
+       id="text102">13</text>
+    <text
+       x="671.94"
+       y="9.00"
+       id="text103">14</text>
+    <text
+       x="671.94"
+       y="835.00"
+       id="text104">14</text>
+    <text
+       x="720.23"
+       y="9.00"
+       id="text105">15</text>
+    <text
+       x="720.23"
+       y="835.00"
+       id="text106">15</text>
+    <text
+       x="768.52"
+       y="9.00"
+       id="text107">16</text>
+    <text
+       x="768.52"
+       y="835.00"
+       id="text108">16</text>
+    <text
+       x="816.81"
+       y="9.00"
+       id="text109">17</text>
+    <text
+       x="816.81"
+       y="835.00"
+       id="text110">17</text>
+    <text
+       x="865.10"
+       y="9.00"
+       id="text111">18</text>
+    <text
+       x="865.10"
+       y="835.00"
+       id="text112">18</text>
+    <text
+       x="913.40"
+       y="9.00"
+       id="text113">19</text>
+    <text
+       x="913.40"
+       y="835.00"
+       id="text114">19</text>
+    <text
+       x="961.69"
+       y="9.00"
+       id="text115">20</text>
+    <text
+       x="961.69"
+       y="835.00"
+       id="text116">20</text>
+    <text
+       x="1009.98"
+       y="9.00"
+       id="text117">21</text>
+    <text
+       x="1009.98"
+       y="835.00"
+       id="text118">21</text>
+    <text
+       x="1058.27"
+       y="9.00"
+       id="text119">22</text>
+    <text
+       x="1058.27"
+       y="835.00"
+       id="text120">22</text>
+    <text
+       x="1106.56"
+       y="9.00"
+       id="text121">23</text>
+    <text
+       x="1106.56"
+       y="835.00"
+       id="text122">23</text>
+    <text
+       x="1154.85"
+       y="9.00"
+       id="text123">24</text>
+    <text
+       x="1154.85"
+       y="835.00"
+       id="text124">24</text>
+    <text
+       x="17.50"
+       y="35.66"
+       id="text125">A</text>
+    <text
+       x="1181.50"
+       y="35.66"
+       id="text126">A</text>
+    <text
+       x="17.50"
+       y="86.97"
+       id="text127">B</text>
+    <text
+       x="1181.50"
+       y="86.97"
+       id="text128">B</text>
+    <text
+       x="17.50"
+       y="138.28"
+       id="text129">C</text>
+    <text
+       x="1181.50"
+       y="138.28"
+       id="text130">C</text>
+    <text
+       x="17.50"
+       y="189.59"
+       id="text131">D</text>
+    <text
+       x="1181.50"
+       y="189.59"
+       id="text132">D</text>
+    <text
+       x="17.50"
+       y="240.91"
+       id="text133">E</text>
+    <text
+       x="1181.50"
+       y="240.91"
+       id="text134">E</text>
+    <text
+       x="17.50"
+       y="292.22"
+       id="text135">F</text>
+    <text
+       x="1181.50"
+       y="292.22"
+       id="text136">F</text>
+    <text
+       x="17.50"
+       y="343.53"
+       id="text137">G</text>
+    <text
+       x="1181.50"
+       y="343.53"
+       id="text138">G</text>
+    <text
+       x="17.50"
+       y="394.84"
+       id="text139">H</text>
+    <text
+       x="1181.50"
+       y="394.84"
+       id="text140">H</text>
+    <text
+       x="17.50"
+       y="446.16"
+       id="text141">I</text>
+    <text
+       x="1181.50"
+       y="446.16"
+       id="text142">I</text>
+    <text
+       x="17.50"
+       y="497.47"
+       id="text143">J</text>
+    <text
+       x="1181.50"
+       y="497.47"
+       id="text144">J</text>
+    <text
+       x="17.50"
+       y="548.78"
+       id="text145">K</text>
+    <text
+       x="1181.50"
+       y="548.78"
+       id="text146">K</text>
+    <text
+       x="17.50"
+       y="600.09"
+       id="text147">L</text>
+    <text
+       x="1181.50"
+       y="600.09"
+       id="text148">L</text>
+    <text
+       x="17.50"
+       y="651.41"
+       id="text149">M</text>
+    <text
+       x="1181.50"
+       y="651.41"
+       id="text150">M</text>
+    <text
+       x="17.50"
+       y="702.72"
+       id="text151">N</text>
+    <text
+       x="1181.50"
+       y="702.72"
+       id="text152">N</text>
+    <text
+       x="17.50"
+       y="754.03"
+       id="text153">O</text>
+    <text
+       x="1181.50"
+       y="754.03"
+       id="text154">O</text>
+    <text
+       x="17.50"
+       y="805.34"
+       id="text155">P</text>
+    <text
+       x="1181.50"
+       y="805.34"
+       id="text156">P</text>
   </g>
-  <g id="fieldframes" transform="translate(1179, 831)">
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-3e-5 V -40" id="path1277"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70.00001,-3e-5 -70,-30" id="path1279"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-10 H 0" id="path1279-7"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-20 H 0" id="path2330"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-30 H 0" id="path1279-7-6"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -12.00001,-3e-5 -12,-10" id="path1390"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -20,-30 V -40" id="path1390-4"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -27,-3e-5 V -10" id="path1392"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -56,0 1e-5,-10" id="path1279-3"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -95,-30 v -9.99998" id="path1279-3-8"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -55,-30.00002 V -40" id="path1279-3-8-3"/>
-    <rect style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" id="rect5692" width="180" height="40" x="-180" y="-40"/>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-11" y="-7" id="text1398"><tspan id="tspan1396" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-11" y="-7">Blatt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-25" y="-2" id="text1398-4-4"><tspan id="tspan1396-7-5" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-25" y="-2">A0</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-26" y="-7" id="text1571"><tspan id="tspan1569" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-26" y="-7">Blattgröße</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-55" y="-7" id="text1575"><tspan id="tspan1573" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-55" y="-7">Ausgabedatum</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7" id="text1398-9"><tspan id="tspan1396-3" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7">Maßstab</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-17" id="text2403"><tspan id="tspan2401" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-17">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-27" id="text1398-9-3"><tspan id="tspan1396-3-1" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-27">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-27" id="text2602"><tspan id="tspan2600" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-27">Titel</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-179" y="-37" id="text2602-5"><tspan id="tspan2600-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-179" y="-37">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-37" id="text1398-9-3-6"><tspan id="tspan1396-3-1-2" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-37">Erstellt durch</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-94" y="-37" id="text1398-9-3-6-1"><tspan id="tspan1396-3-1-2-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-94" y="-37">Genehmigt von</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-54" y="-37" id="text1398-9-3-5"><tspan id="tspan1396-3-1-9" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-54" y="-37">Dokumentenart</tspan></text>
-    <text style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583" x="163.99998" y="285" id="text1915"><tspan id="tspan1913" style="stroke-width:0.264583" x="163.99998" y="285"/></text>
-    <g style="fill:none;stroke-linecap:round;stroke-linejoin:round" id="g2904" transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
-      <g id="g2882">
+  <g
+     id="fieldframes"
+     transform="translate(1179, 831)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-3e-5 V -40"
+       id="path1277" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70.00001,-3e-5 -70,-30"
+       id="path1279" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-10 H 0"
+       id="path1279-7" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-20 H 0"
+       id="path2330" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-30 H 0"
+       id="path1279-7-6" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -12.00001,-3e-5 -12,-10"
+       id="path1390" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -20,-30 V -40"
+       id="path1390-4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -27,-3e-5 V -10"
+       id="path1392" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -56,0 1e-5,-10"
+       id="path1279-3" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -95,-30 v -9.99998"
+       id="path1279-3-8" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -55,-30.00002 V -40"
+       id="path1279-3-8-3" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5692"
+       width="180"
+       height="40"
+       x="-180"
+       y="-40" />
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-11"
+       y="-7"
+       id="text1398"><tspan
+         id="tspan1396"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-11"
+         y="-7">Blatt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-25"
+       y="-2"
+       id="text1398-4-4"><tspan
+         id="tspan1396-7-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-25"
+         y="-2">A0</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-26"
+       y="-7"
+       id="text1571"><tspan
+         id="tspan1569"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-26"
+         y="-7">Blattgröße</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-55"
+       y="-7"
+       id="text1575"><tspan
+         id="tspan1573"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-55"
+         y="-7">Ausgabedatum</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69.000015"
+       y="-7"
+       id="text1398-9"><tspan
+         id="tspan1396-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69.000015"
+         y="-7">Maßstab</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-17"
+       id="text2403"><tspan
+         id="tspan2401"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-17">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-27"
+       id="text1398-9-3"><tspan
+         id="tspan1396-3-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-27">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-27"
+       id="text2602"><tspan
+         id="tspan2600"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-27">Titel</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-179"
+       y="-37"
+       id="text2602-5"><tspan
+         id="tspan2600-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-179"
+         y="-37">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-37"
+       id="text1398-9-3-6"><tspan
+         id="tspan1396-3-1-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-37">Erstellt durch</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-94"
+       y="-37"
+       id="text1398-9-3-6-1"><tspan
+         id="tspan1396-3-1-2-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-94"
+         y="-37">Genehmigt von</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-54"
+       y="-37"
+       id="text1398-9-3-5"><tspan
+         id="tspan1396-3-1-9"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-54"
+         y="-37">Dokumentenart</tspan></text>
+    <text
+       style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583"
+       x="163.99998"
+       y="285"
+       id="text1915"><tspan
+         id="tspan1913"
+         style="stroke-width:0.264583"
+         x="163.99998"
+         y="285" /></text>
+    <g
+       style="fill:none;stroke-linecap:round;stroke-linejoin:round"
+       id="g2904"
+       transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
+      <g
+         id="g2882">
         <!-- Circle -->
-        <circle cx="0" cy="0" r="5" style="stroke:#000000;stroke-width:0.3" id="circle2856"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2856" />
         <!-- Line -->
-        <path d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338" style="stroke:#000000;stroke-width:0.18" id="path2858"/>
+        <path
+           d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2858" />
         <!-- Line -->
-        <path d="M -12.5,5 V -5" style="stroke:#000000;stroke-width:0.3" id="path2860"/>
+        <path
+           d="M -12.5,5 V -5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2860" />
         <!-- Line -->
-        <path d="m -22.5,2.3205 v -4.641" style="stroke:#000000;stroke-width:0.3" id="path2862"/>
+        <path
+           d="m -22.5,2.3205 v -4.641"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2862" />
         <!-- Line -->
-        <path d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6" style="stroke:#000000;stroke-width:0.18" id="path2864"/>
+        <path
+           d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2864" />
         <!-- Line -->
-        <path d="m -12.5,5 -10,-2.6795" style="stroke:#000000;stroke-width:0.3" id="path2866"/>
+        <path
+           d="m -12.5,5 -10,-2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2866" />
         <!-- Line -->
-        <path d="m -12.5,-5 -10,2.6795" style="stroke:#000000;stroke-width:0.3" id="path2868"/>
+        <path
+           d="m -12.5,-5 -10,2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2868" />
         <!-- Line -->
-        <path d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338" style="stroke:#000000;stroke-width:0.18" id="path2870"/>
+        <path
+           d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2870" />
         <!-- Circle -->
-        <circle cx="0" cy="0" r="2.320508" style="stroke:#000000;stroke-width:0.3" id="circle2872"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="2.320508"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2872" />
         <!-- Line -->
-        <path d="m -15.9438,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2874"/>
+        <path
+           d="m -15.9438,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2874" />
         <!-- Line -->
-        <path d="m -12.6961,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2876"/>
+        <path
+           d="m -12.6961,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2876" />
         <!-- Line -->
-        <path d="m -19.1721,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2878"/>
+        <path
+           d="m -19.1721,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2878" />
         <!-- Line -->
-        <path d="m -22.4247,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2880"/>
+        <path
+           d="m -22.4247,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2880" />
       </g>
     </g>
-    
   </g>
-  <g id="editables">
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1169.0" y="829.0" id="text1398-4" freecad:editable="page_number"><tspan id="tspan1396-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="1169.0" y="829.0">1/1</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1125.0" y="829.0" id="text1398-4-4-9" freecad:editable="fc-date"><tspan id="tspan1396-7-5-8" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="1125.0" y="829.0">2023-12-22</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1111.0" y="819.0" id="text2977" freecad:editable="Sachnummer"><tspan id="tspan2975" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="1111.0" y="819.0">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1111.0" y="809.0" id="text2981" freecad:editable="projekt"><tspan id="tspan2979" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="1111.0" y="809.0">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1126.0" y="799.0" id="text2985" freecad:editable="document_type"><tspan id="tspan2983" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="1126.0" y="799.0">Dokumentenart</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1086.0" y="799.0" id="text2989" freecad:editable="Genehmiger"><tspan id="tspan2987" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="1086.0" y="799.0">Genehmiger</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1046.0" y="799.0" id="text2993" freecad:editable="author_name"><tspan id="tspan2991" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="1046.0" y="799.0">Ersteller</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1001.0" y="802.0" id="text2993-7" freecad:editable="owner_1"><tspan id="tspan2991-6" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="1001.0" y="802.0">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1001.0" y="808.0" id="text3985" freecad:editable="owner_2"><tspan id="tspan939" x="1001.0" y="808.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1001.0" y="814.0" id="text3989" freecad:editable="owner_3"><tspan id="tspan937" x="1001.0" y="814.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1001.0" y="820.0" id="text3993" freecad:editable="owner_4"><tspan id="tspan935" x="1001.0" y="820.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1001.0" y="826.0" id="text3997" freecad:editable="owner5"><tspan id="tspan933" x="1001.0" y="826.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1046.0" y="809.0" id="text1398-4-4-9-0-1" freecad:editable="drawing_title"><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="1046.0" y="809.0" id="tspan3120">Titel</tspan><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-133" y="-15.826385" id="tspan3118"/></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1046.0" y="815.0" id="text1398-4-4-9-0-1-7" freecad:editable="drawing_title_2"><tspan id="tspan941" x="1046.0" y="815.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1046.0" y="820.0" id="text1398-4-4-9-0-1-5" freecad:editable="drawing_subtitle"><tspan id="tspan943" x="1046.0" y="820.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1046.0" y="824.0" id="text1398-4-4-9-0-1-5-1" freecad:editable="drawing_subtitle_2"><tspan id="tspan945" x="1046.0" y="824.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1046.0" y="828.0" id="text1398-4-4-9-0-1-5-5" freecad:editable="drawing_subtitle_3"><tspan id="tspan947" x="1046.0" y="828.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="1110.999985" y="829.0" id="text1398-4-4-9-4" freecad:editable="fc-sc"><tspan id="tspan1396-7-5-8-44" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="1110.999985" y="829.0">1:1</tspan></text>
+  <g
+     id="editables">
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1169.0"
+       y="829.0"
+       id="text1398-4"
+       freecad:editable="page_number"
+       freecad:autofill="sheet"><tspan
+         id="tspan1396-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="1169.0"
+         y="829.0">1/1</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1125.0"
+       y="829.0"
+       id="text1398-4-4-9"
+       freecad:editable="fc-date"
+       freecad:autofill="date"><tspan
+         id="tspan1396-7-5-8"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="1125.0"
+         y="829.0">2023-12-22</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1111.0"
+       y="819.0"
+       id="text2977"
+       freecad:editable="Sachnummer"><tspan
+         id="tspan2975"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="1111.0"
+         y="819.0">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1111.0"
+       y="809.0"
+       id="text2981"
+       freecad:editable="projekt"><tspan
+         id="tspan2979"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="1111.0"
+         y="809.0">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1126.0"
+       y="799.0"
+       id="text2985"
+       freecad:editable="document_type"><tspan
+         id="tspan2983"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="1126.0"
+         y="799.0">Dokumentenart</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1086.0"
+       y="799.0"
+       id="text2989"
+       freecad:editable="Genehmiger"><tspan
+         id="tspan2987"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="1086.0"
+         y="799.0">Genehmiger</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1046.0"
+       y="799.0"
+       id="text2993"
+       freecad:editable="author_name"
+       freecad:autofill="author"><tspan
+         id="tspan2991"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="1046.0"
+         y="799.0">Ersteller</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1001.0"
+       y="802.0"
+       id="text2993-7"
+       freecad:editable="owner_1"
+       freecad:autofill="organization"><tspan
+         id="tspan2991-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="1001.0"
+         y="802.0">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1001.0"
+       y="808.0"
+       id="text3985"
+       freecad:editable="owner_2"><tspan
+         id="tspan939"
+         x="1001.0"
+         y="808.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1001.0"
+       y="814.0"
+       id="text3989"
+       freecad:editable="owner_3"><tspan
+         id="tspan937"
+         x="1001.0"
+         y="814.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1001.0"
+       y="820.0"
+       id="text3993"
+       freecad:editable="owner_4"><tspan
+         id="tspan935"
+         x="1001.0"
+         y="820.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1001.0"
+       y="826.0"
+       id="text3997"
+       freecad:editable="owner5"><tspan
+         id="tspan933"
+         x="1001.0"
+         y="826.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1046.0"
+       y="809.0"
+       id="text1398-4-4-9-0-1"
+       freecad:editable="drawing_title"
+       freecad:autofill="title"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="1046.0"
+         y="809.0"
+         id="tspan3120">Titel</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-133"
+         y="-15.826385"
+         id="tspan3118" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1046.0"
+       y="815.0"
+       id="text1398-4-4-9-0-1-7"
+       freecad:editable="drawing_title_2"><tspan
+         id="tspan941"
+         x="1046.0"
+         y="815.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1046.0"
+       y="820.0"
+       id="text1398-4-4-9-0-1-5"
+       freecad:editable="drawing_subtitle"><tspan
+         id="tspan943"
+         x="1046.0"
+         y="820.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1046.0"
+       y="824.0"
+       id="text1398-4-4-9-0-1-5-1"
+       freecad:editable="drawing_subtitle_2"><tspan
+         id="tspan945"
+         x="1046.0"
+         y="824.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1046.0"
+       y="828.0"
+       id="text1398-4-4-9-0-1-5-5"
+       freecad:editable="drawing_subtitle_3"><tspan
+         id="tspan947"
+         x="1046.0"
+         y="828.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="1110.999985"
+       y="829.0"
+       id="text1398-4-4-9-4"
+       freecad:editable="fc-sc"
+       freecad:autofill="scale"><tspan
+         id="tspan1396-7-5-8-44"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="1110.999985"
+         y="829.0">1:1</tspan></text>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/locale/de/A1_Landscape_ISO7200_DE.svg
+++ b/src/Mod/TechDraw/Templates/locale/de/A1_Landscape_ISO7200_DE.svg
@@ -1,210 +1,848 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-  width="841mm"
-  height="594mm"
-  viewBox="0 0 841 594"
-  id="template"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:svg="http://www.w3.org/2000/svg"
-  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-  xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
-
-  <sodipodi:namedview
-     id="namedview3"
-     pagecolor="#ffffff" />
-
-  <g id="frame"
+   width="841mm"
+   height="594mm"
+   viewBox="0 0 841 594"
+   id="template"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+  <defs
+     id="defs108" />
+  <g
+     id="frame"
      style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-    <rect style="stroke-width:0.7" width="811" height="574" x="20" y="10" />
-    <rect width="821" height="584" x="15" y="5" />
-    <path d="m 70.69,5.00 v 5" />
-    <path d="m 70.69,584.00 v 5" />
-    <path d="m 121.38,5.00 v 5" />
-    <path d="m 121.38,584.00 v 5" />
-    <path d="m 172.06,5.00 v 5" />
-    <path d="m 172.06,584.00 v 5" />
-    <path d="m 222.75,5.00 v 5" />
-    <path d="m 222.75,584.00 v 5" />
-    <path d="m 273.44,5.00 v 5" />
-    <path d="m 273.44,584.00 v 5" />
-    <path d="m 324.12,5.00 v 5" />
-    <path d="m 324.12,584.00 v 5" />
-    <path d="m 374.81,5.00 v 5" />
-    <path d="m 374.81,584.00 v 5" />
-    <path d="m 425.50,5.00 v 5" />
-    <path d="m 425.50,584.00 v 5" />
-    <path d="m 476.19,5.00 v 5" />
-    <path d="m 476.19,584.00 v 5" />
-    <path d="m 526.88,5.00 v 5" />
-    <path d="m 526.88,584.00 v 5" />
-    <path d="m 577.56,5.00 v 5" />
-    <path d="m 577.56,584.00 v 5" />
-    <path d="m 628.25,5.00 v 5" />
-    <path d="m 628.25,584.00 v 5" />
-    <path d="m 678.94,5.00 v 5" />
-    <path d="m 678.94,584.00 v 5" />
-    <path d="m 729.62,5.00 v 5" />
-    <path d="m 729.62,584.00 v 5" />
-    <path d="m 780.31,5.00 v 5" />
-    <path d="m 780.31,584.00 v 5" />
-    <path d="m 15.00,57.83 h 5" />
-    <path d="m 831.00,57.83 h 5" />
-    <path d="m 15.00,105.67 h 5" />
-    <path d="m 831.00,105.67 h 5" />
-    <path d="m 15.00,153.50 h 5" />
-    <path d="m 831.00,153.50 h 5" />
-    <path d="m 15.00,201.33 h 5" />
-    <path d="m 831.00,201.33 h 5" />
-    <path d="m 15.00,249.17 h 5" />
-    <path d="m 831.00,249.17 h 5" />
-    <path d="m 15.00,297.00 h 5" />
-    <path d="m 831.00,297.00 h 5" />
-    <path d="m 15.00,344.83 h 5" />
-    <path d="m 831.00,344.83 h 5" />
-    <path d="m 15.00,392.67 h 5" />
-    <path d="m 831.00,392.67 h 5" />
-    <path d="m 15.00,440.50 h 5" />
-    <path d="m 831.00,440.50 h 5" />
-    <path d="m 15.00,488.33 h 5" />
-    <path d="m 831.00,488.33 h 5" />
-    <path d="m 15.00,536.17 h 5" />
-    <path d="m 831.00,536.17 h 5" />
+    <rect
+       style="stroke-width:0.7"
+       width="811"
+       height="574"
+       x="20"
+       y="10"
+       id="rect1" />
+    <rect
+       width="821"
+       height="584"
+       x="15"
+       y="5"
+       id="rect2" />
+    <path
+       d="m 70.69,5.00 v 5"
+       id="path2" />
+    <path
+       d="m 70.69,584.00 v 5"
+       id="path3" />
+    <path
+       d="m 121.38,5.00 v 5"
+       id="path4" />
+    <path
+       d="m 121.38,584.00 v 5"
+       id="path5" />
+    <path
+       d="m 172.06,5.00 v 5"
+       id="path6" />
+    <path
+       d="m 172.06,584.00 v 5"
+       id="path7" />
+    <path
+       d="m 222.75,5.00 v 5"
+       id="path8" />
+    <path
+       d="m 222.75,584.00 v 5"
+       id="path9" />
+    <path
+       d="m 273.44,5.00 v 5"
+       id="path10" />
+    <path
+       d="m 273.44,584.00 v 5"
+       id="path11" />
+    <path
+       d="m 324.12,5.00 v 5"
+       id="path12" />
+    <path
+       d="m 324.12,584.00 v 5"
+       id="path13" />
+    <path
+       d="m 374.81,5.00 v 5"
+       id="path14" />
+    <path
+       d="m 374.81,584.00 v 5"
+       id="path15" />
+    <path
+       d="m 425.50,5.00 v 5"
+       id="path16" />
+    <path
+       d="m 425.50,584.00 v 5"
+       id="path17" />
+    <path
+       d="m 476.19,5.00 v 5"
+       id="path18" />
+    <path
+       d="m 476.19,584.00 v 5"
+       id="path19" />
+    <path
+       d="m 526.88,5.00 v 5"
+       id="path20" />
+    <path
+       d="m 526.88,584.00 v 5"
+       id="path21" />
+    <path
+       d="m 577.56,5.00 v 5"
+       id="path22" />
+    <path
+       d="m 577.56,584.00 v 5"
+       id="path23" />
+    <path
+       d="m 628.25,5.00 v 5"
+       id="path24" />
+    <path
+       d="m 628.25,584.00 v 5"
+       id="path25" />
+    <path
+       d="m 678.94,5.00 v 5"
+       id="path26" />
+    <path
+       d="m 678.94,584.00 v 5"
+       id="path27" />
+    <path
+       d="m 729.62,5.00 v 5"
+       id="path28" />
+    <path
+       d="m 729.62,584.00 v 5"
+       id="path29" />
+    <path
+       d="m 780.31,5.00 v 5"
+       id="path30" />
+    <path
+       d="m 780.31,584.00 v 5"
+       id="path31" />
+    <path
+       d="m 15.00,57.83 h 5"
+       id="path32" />
+    <path
+       d="m 831.00,57.83 h 5"
+       id="path33" />
+    <path
+       d="m 15.00,105.67 h 5"
+       id="path34" />
+    <path
+       d="m 831.00,105.67 h 5"
+       id="path35" />
+    <path
+       d="m 15.00,153.50 h 5"
+       id="path36" />
+    <path
+       d="m 831.00,153.50 h 5"
+       id="path37" />
+    <path
+       d="m 15.00,201.33 h 5"
+       id="path38" />
+    <path
+       d="m 831.00,201.33 h 5"
+       id="path39" />
+    <path
+       d="m 15.00,249.17 h 5"
+       id="path40" />
+    <path
+       d="m 831.00,249.17 h 5"
+       id="path41" />
+    <path
+       d="m 15.00,297.00 h 5"
+       id="path42" />
+    <path
+       d="m 831.00,297.00 h 5"
+       id="path43" />
+    <path
+       d="m 15.00,344.83 h 5"
+       id="path44" />
+    <path
+       d="m 831.00,344.83 h 5"
+       id="path45" />
+    <path
+       d="m 15.00,392.67 h 5"
+       id="path46" />
+    <path
+       d="m 831.00,392.67 h 5"
+       id="path47" />
+    <path
+       d="m 15.00,440.50 h 5"
+       id="path48" />
+    <path
+       d="m 831.00,440.50 h 5"
+       id="path49" />
+    <path
+       d="m 15.00,488.33 h 5"
+       id="path50" />
+    <path
+       d="m 831.00,488.33 h 5"
+       id="path51" />
+    <path
+       d="m 15.00,536.17 h 5"
+       id="path52" />
+    <path
+       d="m 831.00,536.17 h 5"
+       id="path53" />
   </g>
-  <g id="coords"
+  <g
+     id="coords"
      style="font-size:3.52778px;font-family:Open Sans;font-weight:bold;text-anchor:middle">
-    <text x="45.34" y="9.00">1</text>
-    <text x="45.34" y="588.00">1</text>
-    <text x="96.03" y="9.00">2</text>
-    <text x="96.03" y="588.00">2</text>
-    <text x="146.72" y="9.00">3</text>
-    <text x="146.72" y="588.00">3</text>
-    <text x="197.41" y="9.00">4</text>
-    <text x="197.41" y="588.00">4</text>
-    <text x="248.09" y="9.00">5</text>
-    <text x="248.09" y="588.00">5</text>
-    <text x="298.78" y="9.00">6</text>
-    <text x="298.78" y="588.00">6</text>
-    <text x="349.47" y="9.00">7</text>
-    <text x="349.47" y="588.00">7</text>
-    <text x="400.16" y="9.00">8</text>
-    <text x="400.16" y="588.00">8</text>
-    <text x="450.84" y="9.00">9</text>
-    <text x="450.84" y="588.00">9</text>
-    <text x="501.53" y="9.00">10</text>
-    <text x="501.53" y="588.00">10</text>
-    <text x="552.22" y="9.00">11</text>
-    <text x="552.22" y="588.00">11</text>
-    <text x="602.91" y="9.00">12</text>
-    <text x="602.91" y="588.00">12</text>
-    <text x="653.59" y="9.00">13</text>
-    <text x="653.59" y="588.00">13</text>
-    <text x="704.28" y="9.00">14</text>
-    <text x="704.28" y="588.00">14</text>
-    <text x="754.97" y="9.00">15</text>
-    <text x="754.97" y="588.00">15</text>
-    <text x="805.66" y="9.00">16</text>
-    <text x="805.66" y="588.00">16</text>
-    <text x="17.50" y="33.92">A</text>
-    <text x="833.50" y="33.92">A</text>
-    <text x="17.50" y="81.75">B</text>
-    <text x="833.50" y="81.75">B</text>
-    <text x="17.50" y="129.58">C</text>
-    <text x="833.50" y="129.58">C</text>
-    <text x="17.50" y="177.42">D</text>
-    <text x="833.50" y="177.42">D</text>
-    <text x="17.50" y="225.25">E</text>
-    <text x="833.50" y="225.25">E</text>
-    <text x="17.50" y="273.08">F</text>
-    <text x="833.50" y="273.08">F</text>
-    <text x="17.50" y="320.92">G</text>
-    <text x="833.50" y="320.92">G</text>
-    <text x="17.50" y="368.75">H</text>
-    <text x="833.50" y="368.75">H</text>
-    <text x="17.50" y="416.58">I</text>
-    <text x="833.50" y="416.58">I</text>
-    <text x="17.50" y="464.42">J</text>
-    <text x="833.50" y="464.42">J</text>
-    <text x="17.50" y="512.25">K</text>
-    <text x="833.50" y="512.25">K</text>
-    <text x="17.50" y="560.08">L</text>
-    <text x="833.50" y="560.08">L</text>
+    <text
+       x="45.34"
+       y="9.00"
+       id="text53">1</text>
+    <text
+       x="45.34"
+       y="588.00"
+       id="text54">1</text>
+    <text
+       x="96.03"
+       y="9.00"
+       id="text55">2</text>
+    <text
+       x="96.03"
+       y="588.00"
+       id="text56">2</text>
+    <text
+       x="146.72"
+       y="9.00"
+       id="text57">3</text>
+    <text
+       x="146.72"
+       y="588.00"
+       id="text58">3</text>
+    <text
+       x="197.41"
+       y="9.00"
+       id="text59">4</text>
+    <text
+       x="197.41"
+       y="588.00"
+       id="text60">4</text>
+    <text
+       x="248.09"
+       y="9.00"
+       id="text61">5</text>
+    <text
+       x="248.09"
+       y="588.00"
+       id="text62">5</text>
+    <text
+       x="298.78"
+       y="9.00"
+       id="text63">6</text>
+    <text
+       x="298.78"
+       y="588.00"
+       id="text64">6</text>
+    <text
+       x="349.47"
+       y="9.00"
+       id="text65">7</text>
+    <text
+       x="349.47"
+       y="588.00"
+       id="text66">7</text>
+    <text
+       x="400.16"
+       y="9.00"
+       id="text67">8</text>
+    <text
+       x="400.16"
+       y="588.00"
+       id="text68">8</text>
+    <text
+       x="450.84"
+       y="9.00"
+       id="text69">9</text>
+    <text
+       x="450.84"
+       y="588.00"
+       id="text70">9</text>
+    <text
+       x="501.53"
+       y="9.00"
+       id="text71">10</text>
+    <text
+       x="501.53"
+       y="588.00"
+       id="text72">10</text>
+    <text
+       x="552.22"
+       y="9.00"
+       id="text73">11</text>
+    <text
+       x="552.22"
+       y="588.00"
+       id="text74">11</text>
+    <text
+       x="602.91"
+       y="9.00"
+       id="text75">12</text>
+    <text
+       x="602.91"
+       y="588.00"
+       id="text76">12</text>
+    <text
+       x="653.59"
+       y="9.00"
+       id="text77">13</text>
+    <text
+       x="653.59"
+       y="588.00"
+       id="text78">13</text>
+    <text
+       x="704.28"
+       y="9.00"
+       id="text79">14</text>
+    <text
+       x="704.28"
+       y="588.00"
+       id="text80">14</text>
+    <text
+       x="754.97"
+       y="9.00"
+       id="text81">15</text>
+    <text
+       x="754.97"
+       y="588.00"
+       id="text82">15</text>
+    <text
+       x="805.66"
+       y="9.00"
+       id="text83">16</text>
+    <text
+       x="805.66"
+       y="588.00"
+       id="text84">16</text>
+    <text
+       x="17.50"
+       y="33.92"
+       id="text85">A</text>
+    <text
+       x="833.50"
+       y="33.92"
+       id="text86">A</text>
+    <text
+       x="17.50"
+       y="81.75"
+       id="text87">B</text>
+    <text
+       x="833.50"
+       y="81.75"
+       id="text88">B</text>
+    <text
+       x="17.50"
+       y="129.58"
+       id="text89">C</text>
+    <text
+       x="833.50"
+       y="129.58"
+       id="text90">C</text>
+    <text
+       x="17.50"
+       y="177.42"
+       id="text91">D</text>
+    <text
+       x="833.50"
+       y="177.42"
+       id="text92">D</text>
+    <text
+       x="17.50"
+       y="225.25"
+       id="text93">E</text>
+    <text
+       x="833.50"
+       y="225.25"
+       id="text94">E</text>
+    <text
+       x="17.50"
+       y="273.08"
+       id="text95">F</text>
+    <text
+       x="833.50"
+       y="273.08"
+       id="text96">F</text>
+    <text
+       x="17.50"
+       y="320.92"
+       id="text97">G</text>
+    <text
+       x="833.50"
+       y="320.92"
+       id="text98">G</text>
+    <text
+       x="17.50"
+       y="368.75"
+       id="text99">H</text>
+    <text
+       x="833.50"
+       y="368.75"
+       id="text100">H</text>
+    <text
+       x="17.50"
+       y="416.58"
+       id="text101">I</text>
+    <text
+       x="833.50"
+       y="416.58"
+       id="text102">I</text>
+    <text
+       x="17.50"
+       y="464.42"
+       id="text103">J</text>
+    <text
+       x="833.50"
+       y="464.42"
+       id="text104">J</text>
+    <text
+       x="17.50"
+       y="512.25"
+       id="text105">K</text>
+    <text
+       x="833.50"
+       y="512.25"
+       id="text106">K</text>
+    <text
+       x="17.50"
+       y="560.08"
+       id="text107">L</text>
+    <text
+       x="833.50"
+       y="560.08"
+       id="text108">L</text>
   </g>
-  <g id="fieldframes" transform="translate(831, 584)">
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-3e-5 V -40" id="path1277"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70.00001,-3e-5 -70,-30" id="path1279"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-10 H 0" id="path1279-7"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-20 H 0" id="path2330"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-30 H 0" id="path1279-7-6"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -12.00001,-3e-5 -12,-10" id="path1390"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -20,-30 V -40" id="path1390-4"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -27,-3e-5 V -10" id="path1392"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -56,0 1e-5,-10" id="path1279-3"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -95,-30 v -9.99998" id="path1279-3-8"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -55,-30.00002 V -40" id="path1279-3-8-3"/>
-    <rect style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" id="rect5692" width="180" height="40" x="-180" y="-40"/>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-11" y="-7" id="text1398"><tspan id="tspan1396" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-11" y="-7">Blatt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-25" y="-2" id="text1398-4-4"><tspan id="tspan1396-7-5" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-25" y="-2">A1</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-26" y="-7" id="text1571"><tspan id="tspan1569" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-26" y="-7">Blattgröße</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-55" y="-7" id="text1575"><tspan id="tspan1573" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-55" y="-7">Ausgabedatum</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7" id="text1398-9"><tspan id="tspan1396-3" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7">Maßstab</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-17" id="text2403"><tspan id="tspan2401" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-17">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-27" id="text1398-9-3"><tspan id="tspan1396-3-1" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-27">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-27" id="text2602"><tspan id="tspan2600" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-27">Titel</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-179" y="-37" id="text2602-5"><tspan id="tspan2600-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-179" y="-37">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-37" id="text1398-9-3-6"><tspan id="tspan1396-3-1-2" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-37">Erstellt durch</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-94" y="-37" id="text1398-9-3-6-1"><tspan id="tspan1396-3-1-2-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-94" y="-37">Genehmigt von</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-54" y="-37" id="text1398-9-3-5"><tspan id="tspan1396-3-1-9" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-54" y="-37">Dokumentenart</tspan></text>
-    <text style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583" x="163.99998" y="285" id="text1915"><tspan id="tspan1913" style="stroke-width:0.264583" x="163.99998" y="285"/></text>
-    <g style="fill:none;stroke-linecap:round;stroke-linejoin:round" id="g2904" transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
-      <g id="g2882">
+  <g
+     id="fieldframes"
+     transform="translate(831, 584)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-3e-5 V -40"
+       id="path1277" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70.00001,-3e-5 -70,-30"
+       id="path1279" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-10 H 0"
+       id="path1279-7" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-20 H 0"
+       id="path2330" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-30 H 0"
+       id="path1279-7-6" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -12.00001,-3e-5 -12,-10"
+       id="path1390" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -20,-30 V -40"
+       id="path1390-4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -27,-3e-5 V -10"
+       id="path1392" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -56,0 1e-5,-10"
+       id="path1279-3" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -95,-30 v -9.99998"
+       id="path1279-3-8" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -55,-30.00002 V -40"
+       id="path1279-3-8-3" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5692"
+       width="180"
+       height="40"
+       x="-180"
+       y="-40" />
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-11"
+       y="-7"
+       id="text1398"><tspan
+         id="tspan1396"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-11"
+         y="-7">Blatt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-25"
+       y="-2"
+       id="text1398-4-4"><tspan
+         id="tspan1396-7-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-25"
+         y="-2">A1</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-26"
+       y="-7"
+       id="text1571"><tspan
+         id="tspan1569"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-26"
+         y="-7">Blattgröße</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-55"
+       y="-7"
+       id="text1575"><tspan
+         id="tspan1573"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-55"
+         y="-7">Ausgabedatum</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69.000015"
+       y="-7"
+       id="text1398-9"><tspan
+         id="tspan1396-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69.000015"
+         y="-7">Maßstab</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-17"
+       id="text2403"><tspan
+         id="tspan2401"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-17">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-27"
+       id="text1398-9-3"><tspan
+         id="tspan1396-3-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-27">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-27"
+       id="text2602"><tspan
+         id="tspan2600"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-27">Titel</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-179"
+       y="-37"
+       id="text2602-5"><tspan
+         id="tspan2600-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-179"
+         y="-37">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-37"
+       id="text1398-9-3-6"><tspan
+         id="tspan1396-3-1-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-37">Erstellt durch</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-94"
+       y="-37"
+       id="text1398-9-3-6-1"><tspan
+         id="tspan1396-3-1-2-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-94"
+         y="-37">Genehmigt von</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-54"
+       y="-37"
+       id="text1398-9-3-5"><tspan
+         id="tspan1396-3-1-9"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-54"
+         y="-37">Dokumentenart</tspan></text>
+    <text
+       style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583"
+       x="163.99998"
+       y="285"
+       id="text1915"><tspan
+         id="tspan1913"
+         style="stroke-width:0.264583"
+         x="163.99998"
+         y="285" /></text>
+    <g
+       style="fill:none;stroke-linecap:round;stroke-linejoin:round"
+       id="g2904"
+       transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
+      <g
+         id="g2882">
         <!-- Circle -->
-        <circle cx="0" cy="0" r="5" style="stroke:#000000;stroke-width:0.3" id="circle2856"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2856" />
         <!-- Line -->
-        <path d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338" style="stroke:#000000;stroke-width:0.18" id="path2858"/>
+        <path
+           d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2858" />
         <!-- Line -->
-        <path d="M -12.5,5 V -5" style="stroke:#000000;stroke-width:0.3" id="path2860"/>
+        <path
+           d="M -12.5,5 V -5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2860" />
         <!-- Line -->
-        <path d="m -22.5,2.3205 v -4.641" style="stroke:#000000;stroke-width:0.3" id="path2862"/>
+        <path
+           d="m -22.5,2.3205 v -4.641"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2862" />
         <!-- Line -->
-        <path d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6" style="stroke:#000000;stroke-width:0.18" id="path2864"/>
+        <path
+           d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2864" />
         <!-- Line -->
-        <path d="m -12.5,5 -10,-2.6795" style="stroke:#000000;stroke-width:0.3" id="path2866"/>
+        <path
+           d="m -12.5,5 -10,-2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2866" />
         <!-- Line -->
-        <path d="m -12.5,-5 -10,2.6795" style="stroke:#000000;stroke-width:0.3" id="path2868"/>
+        <path
+           d="m -12.5,-5 -10,2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2868" />
         <!-- Line -->
-        <path d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338" style="stroke:#000000;stroke-width:0.18" id="path2870"/>
+        <path
+           d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2870" />
         <!-- Circle -->
-        <circle cx="0" cy="0" r="2.320508" style="stroke:#000000;stroke-width:0.3" id="circle2872"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="2.320508"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2872" />
         <!-- Line -->
-        <path d="m -15.9438,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2874"/>
+        <path
+           d="m -15.9438,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2874" />
         <!-- Line -->
-        <path d="m -12.6961,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2876"/>
+        <path
+           d="m -12.6961,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2876" />
         <!-- Line -->
-        <path d="m -19.1721,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2878"/>
+        <path
+           d="m -19.1721,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2878" />
         <!-- Line -->
-        <path d="m -22.4247,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2880"/>
+        <path
+           d="m -22.4247,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2880" />
       </g>
     </g>
-    
   </g>
-  <g id="editables">
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="821.0" y="582.0" id="text1398-4" freecad:editable="page_number"><tspan id="tspan1396-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="821.0" y="582.0">1/1</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="777.0" y="582.0" id="text1398-4-4-9" freecad:editable="fc-date"><tspan id="tspan1396-7-5-8" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="777.0" y="582.0">2023-12-22</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="763.0" y="572.0" id="text2977" freecad:editable="Sachnummer"><tspan id="tspan2975" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="763.0" y="572.0">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="763.0" y="562.0" id="text2981" freecad:editable="projekt"><tspan id="tspan2979" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="763.0" y="562.0">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="778.0" y="552.0" id="text2985" freecad:editable="document_type"><tspan id="tspan2983" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="778.0" y="552.0">Dokumentenart</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="738.0" y="552.0" id="text2989" freecad:editable="Genehmiger"><tspan id="tspan2987" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="738.0" y="552.0">Genehmiger</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="698.0" y="552.0" id="text2993" freecad:editable="author_name"><tspan id="tspan2991" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="698.0" y="552.0">Ersteller</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="653.0" y="555.0" id="text2993-7" freecad:editable="owner_1"><tspan id="tspan2991-6" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="653.0" y="555.0">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="653.0" y="561.0" id="text3985" freecad:editable="owner_2"><tspan id="tspan939" x="653.0" y="561.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="653.0" y="567.0" id="text3989" freecad:editable="owner_3"><tspan id="tspan937" x="653.0" y="567.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="653.0" y="573.0" id="text3993" freecad:editable="owner_4"><tspan id="tspan935" x="653.0" y="573.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="653.0" y="579.0" id="text3997" freecad:editable="owner5"><tspan id="tspan933" x="653.0" y="579.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="698.0" y="562.0" id="text1398-4-4-9-0-1" freecad:editable="drawing_title"><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="698.0" y="562.0" id="tspan3120">Titel</tspan><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-133" y="-15.826385" id="tspan3118"/></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="698.0" y="568.0" id="text1398-4-4-9-0-1-7" freecad:editable="drawing_title_2"><tspan id="tspan941" x="698.0" y="568.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="698.0" y="573.0" id="text1398-4-4-9-0-1-5" freecad:editable="drawing_subtitle"><tspan id="tspan943" x="698.0" y="573.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="698.0" y="577.0" id="text1398-4-4-9-0-1-5-1" freecad:editable="drawing_subtitle_2"><tspan id="tspan945" x="698.0" y="577.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="698.0" y="581.0" id="text1398-4-4-9-0-1-5-5" freecad:editable="drawing_subtitle_3"><tspan id="tspan947" x="698.0" y="581.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="762.999985" y="582.0" id="text1398-4-4-9-4" freecad:editable="fc-sc"><tspan id="tspan1396-7-5-8-44" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="762.999985" y="582.0">1:1</tspan></text>
+  <g
+     id="editables">
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="821.0"
+       y="582.0"
+       id="text1398-4"
+       freecad:editable="page_number"
+       freecad:autofill="sheet"><tspan
+         id="tspan1396-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="821.0"
+         y="582.0">1/1</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="777.0"
+       y="582.0"
+       id="text1398-4-4-9"
+       freecad:editable="fc-date"
+       freecad:autofill="date"><tspan
+         id="tspan1396-7-5-8"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="777.0"
+         y="582.0">2023-12-22</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="763.0"
+       y="572.0"
+       id="text2977"
+       freecad:editable="Sachnummer"><tspan
+         id="tspan2975"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="763.0"
+         y="572.0">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="763.0"
+       y="562.0"
+       id="text2981"
+       freecad:editable="projekt"><tspan
+         id="tspan2979"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="763.0"
+         y="562.0">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="778.0"
+       y="552.0"
+       id="text2985"
+       freecad:editable="document_type"><tspan
+         id="tspan2983"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="778.0"
+         y="552.0">Dokumentenart</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="738.0"
+       y="552.0"
+       id="text2989"
+       freecad:editable="Genehmiger"><tspan
+         id="tspan2987"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="738.0"
+         y="552.0">Genehmiger</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="698.0"
+       y="552.0"
+       id="text2993"
+       freecad:editable="author_name"
+       freecad:autofill="author"><tspan
+         id="tspan2991"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="698.0"
+         y="552.0">Ersteller</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="653.0"
+       y="555.0"
+       id="text2993-7"
+       freecad:editable="owner_1"
+       freecad:autofill="organization"><tspan
+         id="tspan2991-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="653.0"
+         y="555.0">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="653.0"
+       y="561.0"
+       id="text3985"
+       freecad:editable="owner_2"><tspan
+         id="tspan939"
+         x="653.0"
+         y="561.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="653.0"
+       y="567.0"
+       id="text3989"
+       freecad:editable="owner_3"><tspan
+         id="tspan937"
+         x="653.0"
+         y="567.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="653.0"
+       y="573.0"
+       id="text3993"
+       freecad:editable="owner_4"><tspan
+         id="tspan935"
+         x="653.0"
+         y="573.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="653.0"
+       y="579.0"
+       id="text3997"
+       freecad:editable="owner5"><tspan
+         id="tspan933"
+         x="653.0"
+         y="579.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="698.0"
+       y="562.0"
+       id="text1398-4-4-9-0-1"
+       freecad:editable="drawing_title"
+       freecad:autofill="title"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="698.0"
+         y="562.0"
+         id="tspan3120">Titel</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-133"
+         y="-15.826385"
+         id="tspan3118" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="698.0"
+       y="568.0"
+       id="text1398-4-4-9-0-1-7"
+       freecad:editable="drawing_title_2"><tspan
+         id="tspan941"
+         x="698.0"
+         y="568.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="698.0"
+       y="573.0"
+       id="text1398-4-4-9-0-1-5"
+       freecad:editable="drawing_subtitle"><tspan
+         id="tspan943"
+         x="698.0"
+         y="573.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="698.0"
+       y="577.0"
+       id="text1398-4-4-9-0-1-5-1"
+       freecad:editable="drawing_subtitle_2"><tspan
+         id="tspan945"
+         x="698.0"
+         y="577.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="698.0"
+       y="581.0"
+       id="text1398-4-4-9-0-1-5-5"
+       freecad:editable="drawing_subtitle_3"><tspan
+         id="tspan947"
+         x="698.0"
+         y="581.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="762.999985"
+       y="582.0"
+       id="text1398-4-4-9-4"
+       freecad:editable="fc-sc"
+       freecad:autofill="scale"><tspan
+         id="tspan1396-7-5-8-44"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="762.999985"
+         y="582.0">1:1</tspan></text>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/locale/de/A2_Landscape_ISO7200_DE.svg
+++ b/src/Mod/TechDraw/Templates/locale/de/A2_Landscape_ISO7200_DE.svg
@@ -1,178 +1,736 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-  width="594mm"
-  height="420mm"
-  viewBox="0 0 594 420"
-  id="template"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:svg="http://www.w3.org/2000/svg"
-  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-  xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
-
-  <sodipodi:namedview
-     id="namedview3"
-     pagecolor="#ffffff" />
-
-  <g id="frame"
+   width="594mm"
+   height="420mm"
+   viewBox="0 0 594 420"
+   id="template"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+  <defs
+     id="defs76" />
+  <g
+     id="frame"
      style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-    <rect style="stroke-width:0.7" width="564" height="400" x="20" y="10" />
-    <rect width="574" height="410" x="15" y="5" />
-    <path d="m 67.00,5.00 v 5" />
-    <path d="m 67.00,410.00 v 5" />
-    <path d="m 114.00,5.00 v 5" />
-    <path d="m 114.00,410.00 v 5" />
-    <path d="m 161.00,5.00 v 5" />
-    <path d="m 161.00,410.00 v 5" />
-    <path d="m 208.00,5.00 v 5" />
-    <path d="m 208.00,410.00 v 5" />
-    <path d="m 255.00,5.00 v 5" />
-    <path d="m 255.00,410.00 v 5" />
-    <path d="m 302.00,5.00 v 5" />
-    <path d="m 302.00,410.00 v 5" />
-    <path d="m 349.00,5.00 v 5" />
-    <path d="m 349.00,410.00 v 5" />
-    <path d="m 396.00,5.00 v 5" />
-    <path d="m 396.00,410.00 v 5" />
-    <path d="m 443.00,5.00 v 5" />
-    <path d="m 443.00,410.00 v 5" />
-    <path d="m 490.00,5.00 v 5" />
-    <path d="m 490.00,410.00 v 5" />
-    <path d="m 537.00,5.00 v 5" />
-    <path d="m 537.00,410.00 v 5" />
-    <path d="m 15.00,60.00 h 5" />
-    <path d="m 584.00,60.00 h 5" />
-    <path d="m 15.00,110.00 h 5" />
-    <path d="m 584.00,110.00 h 5" />
-    <path d="m 15.00,160.00 h 5" />
-    <path d="m 584.00,160.00 h 5" />
-    <path d="m 15.00,210.00 h 5" />
-    <path d="m 584.00,210.00 h 5" />
-    <path d="m 15.00,260.00 h 5" />
-    <path d="m 584.00,260.00 h 5" />
-    <path d="m 15.00,310.00 h 5" />
-    <path d="m 584.00,310.00 h 5" />
-    <path d="m 15.00,360.00 h 5" />
-    <path d="m 584.00,360.00 h 5" />
+    <rect
+       style="stroke-width:0.7"
+       width="564"
+       height="400"
+       x="20"
+       y="10"
+       id="rect1" />
+    <rect
+       width="574"
+       height="410"
+       x="15"
+       y="5"
+       id="rect2" />
+    <path
+       d="m 67.00,5.00 v 5"
+       id="path2" />
+    <path
+       d="m 67.00,410.00 v 5"
+       id="path3" />
+    <path
+       d="m 114.00,5.00 v 5"
+       id="path4" />
+    <path
+       d="m 114.00,410.00 v 5"
+       id="path5" />
+    <path
+       d="m 161.00,5.00 v 5"
+       id="path6" />
+    <path
+       d="m 161.00,410.00 v 5"
+       id="path7" />
+    <path
+       d="m 208.00,5.00 v 5"
+       id="path8" />
+    <path
+       d="m 208.00,410.00 v 5"
+       id="path9" />
+    <path
+       d="m 255.00,5.00 v 5"
+       id="path10" />
+    <path
+       d="m 255.00,410.00 v 5"
+       id="path11" />
+    <path
+       d="m 302.00,5.00 v 5"
+       id="path12" />
+    <path
+       d="m 302.00,410.00 v 5"
+       id="path13" />
+    <path
+       d="m 349.00,5.00 v 5"
+       id="path14" />
+    <path
+       d="m 349.00,410.00 v 5"
+       id="path15" />
+    <path
+       d="m 396.00,5.00 v 5"
+       id="path16" />
+    <path
+       d="m 396.00,410.00 v 5"
+       id="path17" />
+    <path
+       d="m 443.00,5.00 v 5"
+       id="path18" />
+    <path
+       d="m 443.00,410.00 v 5"
+       id="path19" />
+    <path
+       d="m 490.00,5.00 v 5"
+       id="path20" />
+    <path
+       d="m 490.00,410.00 v 5"
+       id="path21" />
+    <path
+       d="m 537.00,5.00 v 5"
+       id="path22" />
+    <path
+       d="m 537.00,410.00 v 5"
+       id="path23" />
+    <path
+       d="m 15.00,60.00 h 5"
+       id="path24" />
+    <path
+       d="m 584.00,60.00 h 5"
+       id="path25" />
+    <path
+       d="m 15.00,110.00 h 5"
+       id="path26" />
+    <path
+       d="m 584.00,110.00 h 5"
+       id="path27" />
+    <path
+       d="m 15.00,160.00 h 5"
+       id="path28" />
+    <path
+       d="m 584.00,160.00 h 5"
+       id="path29" />
+    <path
+       d="m 15.00,210.00 h 5"
+       id="path30" />
+    <path
+       d="m 584.00,210.00 h 5"
+       id="path31" />
+    <path
+       d="m 15.00,260.00 h 5"
+       id="path32" />
+    <path
+       d="m 584.00,260.00 h 5"
+       id="path33" />
+    <path
+       d="m 15.00,310.00 h 5"
+       id="path34" />
+    <path
+       d="m 584.00,310.00 h 5"
+       id="path35" />
+    <path
+       d="m 15.00,360.00 h 5"
+       id="path36" />
+    <path
+       d="m 584.00,360.00 h 5"
+       id="path37" />
   </g>
-  <g id="coords"
+  <g
+     id="coords"
      style="font-size:3.52778px;font-family:Open Sans;font-weight:bold;text-anchor:middle">
-    <text x="43.50" y="9.00">1</text>
-    <text x="43.50" y="414.00">1</text>
-    <text x="90.50" y="9.00">2</text>
-    <text x="90.50" y="414.00">2</text>
-    <text x="137.50" y="9.00">3</text>
-    <text x="137.50" y="414.00">3</text>
-    <text x="184.50" y="9.00">4</text>
-    <text x="184.50" y="414.00">4</text>
-    <text x="231.50" y="9.00">5</text>
-    <text x="231.50" y="414.00">5</text>
-    <text x="278.50" y="9.00">6</text>
-    <text x="278.50" y="414.00">6</text>
-    <text x="325.50" y="9.00">7</text>
-    <text x="325.50" y="414.00">7</text>
-    <text x="372.50" y="9.00">8</text>
-    <text x="372.50" y="414.00">8</text>
-    <text x="419.50" y="9.00">9</text>
-    <text x="419.50" y="414.00">9</text>
-    <text x="466.50" y="9.00">10</text>
-    <text x="466.50" y="414.00">10</text>
-    <text x="513.50" y="9.00">11</text>
-    <text x="513.50" y="414.00">11</text>
-    <text x="560.50" y="9.00">12</text>
-    <text x="560.50" y="414.00">12</text>
-    <text x="17.50" y="35.00">A</text>
-    <text x="586.50" y="35.00">A</text>
-    <text x="17.50" y="85.00">B</text>
-    <text x="586.50" y="85.00">B</text>
-    <text x="17.50" y="135.00">C</text>
-    <text x="586.50" y="135.00">C</text>
-    <text x="17.50" y="185.00">D</text>
-    <text x="586.50" y="185.00">D</text>
-    <text x="17.50" y="235.00">E</text>
-    <text x="586.50" y="235.00">E</text>
-    <text x="17.50" y="285.00">F</text>
-    <text x="586.50" y="285.00">F</text>
-    <text x="17.50" y="335.00">G</text>
-    <text x="586.50" y="335.00">G</text>
-    <text x="17.50" y="385.00">H</text>
-    <text x="586.50" y="385.00">H</text>
+    <text
+       x="43.50"
+       y="9.00"
+       id="text37">1</text>
+    <text
+       x="43.50"
+       y="414.00"
+       id="text38">1</text>
+    <text
+       x="90.50"
+       y="9.00"
+       id="text39">2</text>
+    <text
+       x="90.50"
+       y="414.00"
+       id="text40">2</text>
+    <text
+       x="137.50"
+       y="9.00"
+       id="text41">3</text>
+    <text
+       x="137.50"
+       y="414.00"
+       id="text42">3</text>
+    <text
+       x="184.50"
+       y="9.00"
+       id="text43">4</text>
+    <text
+       x="184.50"
+       y="414.00"
+       id="text44">4</text>
+    <text
+       x="231.50"
+       y="9.00"
+       id="text45">5</text>
+    <text
+       x="231.50"
+       y="414.00"
+       id="text46">5</text>
+    <text
+       x="278.50"
+       y="9.00"
+       id="text47">6</text>
+    <text
+       x="278.50"
+       y="414.00"
+       id="text48">6</text>
+    <text
+       x="325.50"
+       y="9.00"
+       id="text49">7</text>
+    <text
+       x="325.50"
+       y="414.00"
+       id="text50">7</text>
+    <text
+       x="372.50"
+       y="9.00"
+       id="text51">8</text>
+    <text
+       x="372.50"
+       y="414.00"
+       id="text52">8</text>
+    <text
+       x="419.50"
+       y="9.00"
+       id="text53">9</text>
+    <text
+       x="419.50"
+       y="414.00"
+       id="text54">9</text>
+    <text
+       x="466.50"
+       y="9.00"
+       id="text55">10</text>
+    <text
+       x="466.50"
+       y="414.00"
+       id="text56">10</text>
+    <text
+       x="513.50"
+       y="9.00"
+       id="text57">11</text>
+    <text
+       x="513.50"
+       y="414.00"
+       id="text58">11</text>
+    <text
+       x="560.50"
+       y="9.00"
+       id="text59">12</text>
+    <text
+       x="560.50"
+       y="414.00"
+       id="text60">12</text>
+    <text
+       x="17.50"
+       y="35.00"
+       id="text61">A</text>
+    <text
+       x="586.50"
+       y="35.00"
+       id="text62">A</text>
+    <text
+       x="17.50"
+       y="85.00"
+       id="text63">B</text>
+    <text
+       x="586.50"
+       y="85.00"
+       id="text64">B</text>
+    <text
+       x="17.50"
+       y="135.00"
+       id="text65">C</text>
+    <text
+       x="586.50"
+       y="135.00"
+       id="text66">C</text>
+    <text
+       x="17.50"
+       y="185.00"
+       id="text67">D</text>
+    <text
+       x="586.50"
+       y="185.00"
+       id="text68">D</text>
+    <text
+       x="17.50"
+       y="235.00"
+       id="text69">E</text>
+    <text
+       x="586.50"
+       y="235.00"
+       id="text70">E</text>
+    <text
+       x="17.50"
+       y="285.00"
+       id="text71">F</text>
+    <text
+       x="586.50"
+       y="285.00"
+       id="text72">F</text>
+    <text
+       x="17.50"
+       y="335.00"
+       id="text73">G</text>
+    <text
+       x="586.50"
+       y="335.00"
+       id="text74">G</text>
+    <text
+       x="17.50"
+       y="385.00"
+       id="text75">H</text>
+    <text
+       x="586.50"
+       y="385.00"
+       id="text76">H</text>
   </g>
-  <g id="fieldframes" transform="translate(584, 410)">
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-3e-5 V -40" id="path1277"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70.00001,-3e-5 -70,-30" id="path1279"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-10 H 0" id="path1279-7"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-20 H 0" id="path2330"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-30 H 0" id="path1279-7-6"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -12.00001,-3e-5 -12,-10" id="path1390"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -20,-30 V -40" id="path1390-4"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -27,-3e-5 V -10" id="path1392"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -56,0 1e-5,-10" id="path1279-3"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -95,-30 v -9.99998" id="path1279-3-8"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -55,-30.00002 V -40" id="path1279-3-8-3"/>
-    <rect style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" id="rect5692" width="180" height="40" x="-180" y="-40"/>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-11" y="-7" id="text1398"><tspan id="tspan1396" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-11" y="-7">Blatt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-25" y="-2" id="text1398-4-4"><tspan id="tspan1396-7-5" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-25" y="-2">A2</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-26" y="-7" id="text1571"><tspan id="tspan1569" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-26" y="-7">Blattgröße</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-55" y="-7" id="text1575"><tspan id="tspan1573" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-55" y="-7">Ausgabedatum</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7" id="text1398-9"><tspan id="tspan1396-3" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7">Maßstab</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-17" id="text2403"><tspan id="tspan2401" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-17">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-27" id="text1398-9-3"><tspan id="tspan1396-3-1" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-27">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-27" id="text2602"><tspan id="tspan2600" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-27">Titel</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-179" y="-37" id="text2602-5"><tspan id="tspan2600-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-179" y="-37">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-37" id="text1398-9-3-6"><tspan id="tspan1396-3-1-2" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-37">Erstellt durch</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-94" y="-37" id="text1398-9-3-6-1"><tspan id="tspan1396-3-1-2-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-94" y="-37">Genehmigt von</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-54" y="-37" id="text1398-9-3-5"><tspan id="tspan1396-3-1-9" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-54" y="-37">Dokumentenart</tspan></text>
-    <text style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583" x="163.99998" y="285" id="text1915"><tspan id="tspan1913" style="stroke-width:0.264583" x="163.99998" y="285"/></text>
-    <g style="fill:none;stroke-linecap:round;stroke-linejoin:round" id="g2904" transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
-      <g id="g2882">
+  <g
+     id="fieldframes"
+     transform="translate(584, 410)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-3e-5 V -40"
+       id="path1277" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70.00001,-3e-5 -70,-30"
+       id="path1279" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-10 H 0"
+       id="path1279-7" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-20 H 0"
+       id="path2330" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-30 H 0"
+       id="path1279-7-6" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -12.00001,-3e-5 -12,-10"
+       id="path1390" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -20,-30 V -40"
+       id="path1390-4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -27,-3e-5 V -10"
+       id="path1392" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -56,0 1e-5,-10"
+       id="path1279-3" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -95,-30 v -9.99998"
+       id="path1279-3-8" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -55,-30.00002 V -40"
+       id="path1279-3-8-3" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5692"
+       width="180"
+       height="40"
+       x="-180"
+       y="-40" />
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-11"
+       y="-7"
+       id="text1398"><tspan
+         id="tspan1396"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-11"
+         y="-7">Blatt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-25"
+       y="-2"
+       id="text1398-4-4"><tspan
+         id="tspan1396-7-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-25"
+         y="-2">A2</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-26"
+       y="-7"
+       id="text1571"><tspan
+         id="tspan1569"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-26"
+         y="-7">Blattgröße</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-55"
+       y="-7"
+       id="text1575"><tspan
+         id="tspan1573"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-55"
+         y="-7">Ausgabedatum</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69.000015"
+       y="-7"
+       id="text1398-9"><tspan
+         id="tspan1396-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69.000015"
+         y="-7">Maßstab</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-17"
+       id="text2403"><tspan
+         id="tspan2401"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-17">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-27"
+       id="text1398-9-3"><tspan
+         id="tspan1396-3-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-27">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-27"
+       id="text2602"><tspan
+         id="tspan2600"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-27">Titel</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-179"
+       y="-37"
+       id="text2602-5"><tspan
+         id="tspan2600-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-179"
+         y="-37">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-37"
+       id="text1398-9-3-6"><tspan
+         id="tspan1396-3-1-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-37">Erstellt durch</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-94"
+       y="-37"
+       id="text1398-9-3-6-1"><tspan
+         id="tspan1396-3-1-2-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-94"
+         y="-37">Genehmigt von</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-54"
+       y="-37"
+       id="text1398-9-3-5"><tspan
+         id="tspan1396-3-1-9"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-54"
+         y="-37">Dokumentenart</tspan></text>
+    <text
+       style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583"
+       x="163.99998"
+       y="285"
+       id="text1915"><tspan
+         id="tspan1913"
+         style="stroke-width:0.264583"
+         x="163.99998"
+         y="285" /></text>
+    <g
+       style="fill:none;stroke-linecap:round;stroke-linejoin:round"
+       id="g2904"
+       transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
+      <g
+         id="g2882">
         <!-- Circle -->
-        <circle cx="0" cy="0" r="5" style="stroke:#000000;stroke-width:0.3" id="circle2856"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2856" />
         <!-- Line -->
-        <path d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338" style="stroke:#000000;stroke-width:0.18" id="path2858"/>
+        <path
+           d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2858" />
         <!-- Line -->
-        <path d="M -12.5,5 V -5" style="stroke:#000000;stroke-width:0.3" id="path2860"/>
+        <path
+           d="M -12.5,5 V -5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2860" />
         <!-- Line -->
-        <path d="m -22.5,2.3205 v -4.641" style="stroke:#000000;stroke-width:0.3" id="path2862"/>
+        <path
+           d="m -22.5,2.3205 v -4.641"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2862" />
         <!-- Line -->
-        <path d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6" style="stroke:#000000;stroke-width:0.18" id="path2864"/>
+        <path
+           d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2864" />
         <!-- Line -->
-        <path d="m -12.5,5 -10,-2.6795" style="stroke:#000000;stroke-width:0.3" id="path2866"/>
+        <path
+           d="m -12.5,5 -10,-2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2866" />
         <!-- Line -->
-        <path d="m -12.5,-5 -10,2.6795" style="stroke:#000000;stroke-width:0.3" id="path2868"/>
+        <path
+           d="m -12.5,-5 -10,2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2868" />
         <!-- Line -->
-        <path d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338" style="stroke:#000000;stroke-width:0.18" id="path2870"/>
+        <path
+           d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2870" />
         <!-- Circle -->
-        <circle cx="0" cy="0" r="2.320508" style="stroke:#000000;stroke-width:0.3" id="circle2872"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="2.320508"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2872" />
         <!-- Line -->
-        <path d="m -15.9438,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2874"/>
+        <path
+           d="m -15.9438,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2874" />
         <!-- Line -->
-        <path d="m -12.6961,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2876"/>
+        <path
+           d="m -12.6961,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2876" />
         <!-- Line -->
-        <path d="m -19.1721,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2878"/>
+        <path
+           d="m -19.1721,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2878" />
         <!-- Line -->
-        <path d="m -22.4247,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2880"/>
+        <path
+           d="m -22.4247,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2880" />
       </g>
     </g>
-    
   </g>
-  <g id="editables">
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="574.0" y="408.0" id="text1398-4" freecad:editable="page_number"><tspan id="tspan1396-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="574.0" y="408.0">1/1</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="530.0" y="408.0" id="text1398-4-4-9" freecad:editable="fc-date"><tspan id="tspan1396-7-5-8" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="530.0" y="408.0">2023-12-22</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="516.0" y="398.0" id="text2977" freecad:editable="Sachnummer"><tspan id="tspan2975" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="516.0" y="398.0">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="516.0" y="388.0" id="text2981" freecad:editable="projekt"><tspan id="tspan2979" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="516.0" y="388.0">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="531.0" y="378.0" id="text2985" freecad:editable="document_type"><tspan id="tspan2983" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="531.0" y="378.0">Dokumentenart</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="491.0" y="378.0" id="text2989" freecad:editable="Genehmiger"><tspan id="tspan2987" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="491.0" y="378.0">Genehmiger</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="451.0" y="378.0" id="text2993" freecad:editable="author_name"><tspan id="tspan2991" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="451.0" y="378.0">Ersteller</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="406.0" y="381.0" id="text2993-7" freecad:editable="owner_1"><tspan id="tspan2991-6" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="406.0" y="381.0">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="406.0" y="387.0" id="text3985" freecad:editable="owner_2"><tspan id="tspan939" x="406.0" y="387.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="406.0" y="393.0" id="text3989" freecad:editable="owner_3"><tspan id="tspan937" x="406.0" y="393.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="406.0" y="399.0" id="text3993" freecad:editable="owner_4"><tspan id="tspan935" x="406.0" y="399.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="406.0" y="405.0" id="text3997" freecad:editable="owner5"><tspan id="tspan933" x="406.0" y="405.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="451.0" y="388.0" id="text1398-4-4-9-0-1" freecad:editable="drawing_title"><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="451.0" y="388.0" id="tspan3120">Titel</tspan><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-133" y="-15.826385" id="tspan3118"/></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="451.0" y="394.0" id="text1398-4-4-9-0-1-7" freecad:editable="drawing_title_2"><tspan id="tspan941" x="451.0" y="394.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="451.0" y="399.0" id="text1398-4-4-9-0-1-5" freecad:editable="drawing_subtitle"><tspan id="tspan943" x="451.0" y="399.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="451.0" y="403.0" id="text1398-4-4-9-0-1-5-1" freecad:editable="drawing_subtitle_2"><tspan id="tspan945" x="451.0" y="403.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="451.0" y="407.0" id="text1398-4-4-9-0-1-5-5" freecad:editable="drawing_subtitle_3"><tspan id="tspan947" x="451.0" y="407.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="515.999985" y="408.0" id="text1398-4-4-9-4" freecad:editable="fc-sc"><tspan id="tspan1396-7-5-8-44" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="515.999985" y="408.0">1:1</tspan></text>
+  <g
+     id="editables">
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="574.0"
+       y="408.0"
+       id="text1398-4"
+       freecad:editable="page_number"
+       freecad:autofill="sheet"><tspan
+         id="tspan1396-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="574.0"
+         y="408.0">1/1</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="530.0"
+       y="408.0"
+       id="text1398-4-4-9"
+       freecad:editable="fc-date"
+       freecad:autofill="date"><tspan
+         id="tspan1396-7-5-8"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="530.0"
+         y="408.0">2023-12-22</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="516.0"
+       y="398.0"
+       id="text2977"
+       freecad:editable="Sachnummer"><tspan
+         id="tspan2975"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="516.0"
+         y="398.0">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="516.0"
+       y="388.0"
+       id="text2981"
+       freecad:editable="projekt"><tspan
+         id="tspan2979"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="516.0"
+         y="388.0">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="531.0"
+       y="378.0"
+       id="text2985"
+       freecad:editable="document_type"><tspan
+         id="tspan2983"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="531.0"
+         y="378.0">Dokumentenart</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="491.0"
+       y="378.0"
+       id="text2989"
+       freecad:editable="Genehmiger"><tspan
+         id="tspan2987"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="491.0"
+         y="378.0">Genehmiger</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="451.0"
+       y="378.0"
+       id="text2993"
+       freecad:editable="author_name"
+       freecad:autofill="author"><tspan
+         id="tspan2991"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="451.0"
+         y="378.0">Ersteller</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="406.0"
+       y="381.0"
+       id="text2993-7"
+       freecad:editable="owner_1"
+       freecad:autofill="organization"><tspan
+         id="tspan2991-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="406.0"
+         y="381.0">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="406.0"
+       y="387.0"
+       id="text3985"
+       freecad:editable="owner_2"><tspan
+         id="tspan939"
+         x="406.0"
+         y="387.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="406.0"
+       y="393.0"
+       id="text3989"
+       freecad:editable="owner_3"><tspan
+         id="tspan937"
+         x="406.0"
+         y="393.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="406.0"
+       y="399.0"
+       id="text3993"
+       freecad:editable="owner_4"><tspan
+         id="tspan935"
+         x="406.0"
+         y="399.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="406.0"
+       y="405.0"
+       id="text3997"
+       freecad:editable="owner5"><tspan
+         id="tspan933"
+         x="406.0"
+         y="405.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="451.0"
+       y="388.0"
+       id="text1398-4-4-9-0-1"
+       freecad:editable="drawing_title"
+       freecad:autofill="title"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="451.0"
+         y="388.0"
+         id="tspan3120">Titel</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-133"
+         y="-15.826385"
+         id="tspan3118" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="451.0"
+       y="394.0"
+       id="text1398-4-4-9-0-1-7"
+       freecad:editable="drawing_title_2"><tspan
+         id="tspan941"
+         x="451.0"
+         y="394.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="451.0"
+       y="399.0"
+       id="text1398-4-4-9-0-1-5"
+       freecad:editable="drawing_subtitle"><tspan
+         id="tspan943"
+         x="451.0"
+         y="399.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="451.0"
+       y="403.0"
+       id="text1398-4-4-9-0-1-5-1"
+       freecad:editable="drawing_subtitle_2"><tspan
+         id="tspan945"
+         x="451.0"
+         y="403.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="451.0"
+       y="407.0"
+       id="text1398-4-4-9-0-1-5-5"
+       freecad:editable="drawing_subtitle_3"><tspan
+         id="tspan947"
+         x="451.0"
+         y="407.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="515.999985"
+       y="408.0"
+       id="text1398-4-4-9-4"
+       freecad:editable="fc-sc"
+       freecad:autofill="scale"><tspan
+         id="tspan1396-7-5-8-44"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="515.999985"
+         y="408.0">1:1</tspan></text>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/locale/de/A3_Landscape_ISO7200_DE.svg
+++ b/src/Mod/TechDraw/Templates/locale/de/A3_Landscape_ISO7200_DE.svg
@@ -1,154 +1,652 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-  width="420mm"
-  height="297mm"
-  viewBox="0 0 420 297"
-  id="template"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:svg="http://www.w3.org/2000/svg"
-  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-  xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
-
-  <sodipodi:namedview
-     id="namedview3"
-     pagecolor="#ffffff" />
-
-  <g id="frame"
+   width="420mm"
+   height="297mm"
+   viewBox="0 0 420 297"
+   id="template"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+  <defs
+     id="defs52" />
+  <g
+     id="frame"
      style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-    <rect style="stroke-width:0.7" width="390" height="277" x="20" y="10" />
-    <rect width="400" height="287" x="15" y="5" />
-    <path d="m 68.75,5.00 v 5" />
-    <path d="m 68.75,287.00 v 5" />
-    <path d="m 117.50,5.00 v 5" />
-    <path d="m 117.50,287.00 v 5" />
-    <path d="m 166.25,5.00 v 5" />
-    <path d="m 166.25,287.00 v 5" />
-    <path d="m 215.00,5.00 v 5" />
-    <path d="m 215.00,287.00 v 5" />
-    <path d="m 263.75,5.00 v 5" />
-    <path d="m 263.75,287.00 v 5" />
-    <path d="m 312.50,5.00 v 5" />
-    <path d="m 312.50,287.00 v 5" />
-    <path d="m 361.25,5.00 v 5" />
-    <path d="m 361.25,287.00 v 5" />
-    <path d="m 15.00,56.17 h 5" />
-    <path d="m 410.00,56.17 h 5" />
-    <path d="m 15.00,102.33 h 5" />
-    <path d="m 410.00,102.33 h 5" />
-    <path d="m 15.00,148.50 h 5" />
-    <path d="m 410.00,148.50 h 5" />
-    <path d="m 15.00,194.67 h 5" />
-    <path d="m 410.00,194.67 h 5" />
-    <path d="m 15.00,240.83 h 5" />
-    <path d="m 410.00,240.83 h 5" />
+    <rect
+       style="stroke-width:0.7"
+       width="390"
+       height="277"
+       x="20"
+       y="10"
+       id="rect1" />
+    <rect
+       width="400"
+       height="287"
+       x="15"
+       y="5"
+       id="rect2" />
+    <path
+       d="m 68.75,5.00 v 5"
+       id="path2" />
+    <path
+       d="m 68.75,287.00 v 5"
+       id="path3" />
+    <path
+       d="m 117.50,5.00 v 5"
+       id="path4" />
+    <path
+       d="m 117.50,287.00 v 5"
+       id="path5" />
+    <path
+       d="m 166.25,5.00 v 5"
+       id="path6" />
+    <path
+       d="m 166.25,287.00 v 5"
+       id="path7" />
+    <path
+       d="m 215.00,5.00 v 5"
+       id="path8" />
+    <path
+       d="m 215.00,287.00 v 5"
+       id="path9" />
+    <path
+       d="m 263.75,5.00 v 5"
+       id="path10" />
+    <path
+       d="m 263.75,287.00 v 5"
+       id="path11" />
+    <path
+       d="m 312.50,5.00 v 5"
+       id="path12" />
+    <path
+       d="m 312.50,287.00 v 5"
+       id="path13" />
+    <path
+       d="m 361.25,5.00 v 5"
+       id="path14" />
+    <path
+       d="m 361.25,287.00 v 5"
+       id="path15" />
+    <path
+       d="m 15.00,56.17 h 5"
+       id="path16" />
+    <path
+       d="m 410.00,56.17 h 5"
+       id="path17" />
+    <path
+       d="m 15.00,102.33 h 5"
+       id="path18" />
+    <path
+       d="m 410.00,102.33 h 5"
+       id="path19" />
+    <path
+       d="m 15.00,148.50 h 5"
+       id="path20" />
+    <path
+       d="m 410.00,148.50 h 5"
+       id="path21" />
+    <path
+       d="m 15.00,194.67 h 5"
+       id="path22" />
+    <path
+       d="m 410.00,194.67 h 5"
+       id="path23" />
+    <path
+       d="m 15.00,240.83 h 5"
+       id="path24" />
+    <path
+       d="m 410.00,240.83 h 5"
+       id="path25" />
   </g>
-  <g id="coords"
+  <g
+     id="coords"
      style="font-size:3.52778px;font-family:Open Sans;font-weight:bold;text-anchor:middle">
-    <text x="44.38" y="9.00">1</text>
-    <text x="44.38" y="291.00">1</text>
-    <text x="93.12" y="9.00">2</text>
-    <text x="93.12" y="291.00">2</text>
-    <text x="141.88" y="9.00">3</text>
-    <text x="141.88" y="291.00">3</text>
-    <text x="190.62" y="9.00">4</text>
-    <text x="190.62" y="291.00">4</text>
-    <text x="239.38" y="9.00">5</text>
-    <text x="239.38" y="291.00">5</text>
-    <text x="288.12" y="9.00">6</text>
-    <text x="288.12" y="291.00">6</text>
-    <text x="336.88" y="9.00">7</text>
-    <text x="336.88" y="291.00">7</text>
-    <text x="385.62" y="9.00">8</text>
-    <text x="385.62" y="291.00">8</text>
-    <text x="17.50" y="33.08">A</text>
-    <text x="412.50" y="33.08">A</text>
-    <text x="17.50" y="79.25">B</text>
-    <text x="412.50" y="79.25">B</text>
-    <text x="17.50" y="125.42">C</text>
-    <text x="412.50" y="125.42">C</text>
-    <text x="17.50" y="171.58">D</text>
-    <text x="412.50" y="171.58">D</text>
-    <text x="17.50" y="217.75">E</text>
-    <text x="412.50" y="217.75">E</text>
-    <text x="17.50" y="263.92">F</text>
-    <text x="412.50" y="263.92">F</text>
+    <text
+       x="44.38"
+       y="9.00"
+       id="text25">1</text>
+    <text
+       x="44.38"
+       y="291.00"
+       id="text26">1</text>
+    <text
+       x="93.12"
+       y="9.00"
+       id="text27">2</text>
+    <text
+       x="93.12"
+       y="291.00"
+       id="text28">2</text>
+    <text
+       x="141.88"
+       y="9.00"
+       id="text29">3</text>
+    <text
+       x="141.88"
+       y="291.00"
+       id="text30">3</text>
+    <text
+       x="190.62"
+       y="9.00"
+       id="text31">4</text>
+    <text
+       x="190.62"
+       y="291.00"
+       id="text32">4</text>
+    <text
+       x="239.38"
+       y="9.00"
+       id="text33">5</text>
+    <text
+       x="239.38"
+       y="291.00"
+       id="text34">5</text>
+    <text
+       x="288.12"
+       y="9.00"
+       id="text35">6</text>
+    <text
+       x="288.12"
+       y="291.00"
+       id="text36">6</text>
+    <text
+       x="336.88"
+       y="9.00"
+       id="text37">7</text>
+    <text
+       x="336.88"
+       y="291.00"
+       id="text38">7</text>
+    <text
+       x="385.62"
+       y="9.00"
+       id="text39">8</text>
+    <text
+       x="385.62"
+       y="291.00"
+       id="text40">8</text>
+    <text
+       x="17.50"
+       y="33.08"
+       id="text41">A</text>
+    <text
+       x="412.50"
+       y="33.08"
+       id="text42">A</text>
+    <text
+       x="17.50"
+       y="79.25"
+       id="text43">B</text>
+    <text
+       x="412.50"
+       y="79.25"
+       id="text44">B</text>
+    <text
+       x="17.50"
+       y="125.42"
+       id="text45">C</text>
+    <text
+       x="412.50"
+       y="125.42"
+       id="text46">C</text>
+    <text
+       x="17.50"
+       y="171.58"
+       id="text47">D</text>
+    <text
+       x="412.50"
+       y="171.58"
+       id="text48">D</text>
+    <text
+       x="17.50"
+       y="217.75"
+       id="text49">E</text>
+    <text
+       x="412.50"
+       y="217.75"
+       id="text50">E</text>
+    <text
+       x="17.50"
+       y="263.92"
+       id="text51">F</text>
+    <text
+       x="412.50"
+       y="263.92"
+       id="text52">F</text>
   </g>
-  <g id="fieldframes" transform="translate(410, 287)">
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-3e-5 V -40" id="path1277"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70.00001,-3e-5 -70,-30" id="path1279"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-10 H 0" id="path1279-7"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-20 H 0" id="path2330"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-30 H 0" id="path1279-7-6"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -12.00001,-3e-5 -12,-10" id="path1390"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -20,-30 V -40" id="path1390-4"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -27,-3e-5 V -10" id="path1392"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -56,0 1e-5,-10" id="path1279-3"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -95,-30 v -9.99998" id="path1279-3-8"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -55,-30.00002 V -40" id="path1279-3-8-3"/>
-    <rect style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" id="rect5692" width="180" height="40" x="-180" y="-40"/>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-11" y="-7" id="text1398"><tspan id="tspan1396" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-11" y="-7">Blatt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-25" y="-2" id="text1398-4-4"><tspan id="tspan1396-7-5" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-25" y="-2">A3</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-26" y="-7" id="text1571"><tspan id="tspan1569" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-26" y="-7">Blattgröße</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-55" y="-7" id="text1575"><tspan id="tspan1573" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-55" y="-7">Ausgabedatum</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7" id="text1398-9"><tspan id="tspan1396-3" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7">Maßstab</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-17" id="text2403"><tspan id="tspan2401" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-17">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-27" id="text1398-9-3"><tspan id="tspan1396-3-1" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-27">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-27" id="text2602"><tspan id="tspan2600" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-27">Titel</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-179" y="-37" id="text2602-5"><tspan id="tspan2600-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-179" y="-37">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-37" id="text1398-9-3-6"><tspan id="tspan1396-3-1-2" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-37">Erstellt durch</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-94" y="-37" id="text1398-9-3-6-1"><tspan id="tspan1396-3-1-2-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-94" y="-37">Genehmigt von</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-54" y="-37" id="text1398-9-3-5"><tspan id="tspan1396-3-1-9" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-54" y="-37">Dokumentenart</tspan></text>
-    <text style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583" x="163.99998" y="285" id="text1915"><tspan id="tspan1913" style="stroke-width:0.264583" x="163.99998" y="285"/></text>
-    <g style="fill:none;stroke-linecap:round;stroke-linejoin:round" id="g2904" transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
-      <g id="g2882">
+  <g
+     id="fieldframes"
+     transform="translate(410, 287)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-3e-5 V -40"
+       id="path1277" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70.00001,-3e-5 -70,-30"
+       id="path1279" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-10 H 0"
+       id="path1279-7" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-20 H 0"
+       id="path2330" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-30 H 0"
+       id="path1279-7-6" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -12.00001,-3e-5 -12,-10"
+       id="path1390" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -20,-30 V -40"
+       id="path1390-4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -27,-3e-5 V -10"
+       id="path1392" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -56,0 1e-5,-10"
+       id="path1279-3" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -95,-30 v -9.99998"
+       id="path1279-3-8" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -55,-30.00002 V -40"
+       id="path1279-3-8-3" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5692"
+       width="180"
+       height="40"
+       x="-180"
+       y="-40" />
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-11"
+       y="-7"
+       id="text1398"><tspan
+         id="tspan1396"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-11"
+         y="-7">Blatt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-25"
+       y="-2"
+       id="text1398-4-4"><tspan
+         id="tspan1396-7-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-25"
+         y="-2">A3</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-26"
+       y="-7"
+       id="text1571"><tspan
+         id="tspan1569"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-26"
+         y="-7">Blattgröße</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-55"
+       y="-7"
+       id="text1575"><tspan
+         id="tspan1573"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-55"
+         y="-7">Ausgabedatum</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69.000015"
+       y="-7"
+       id="text1398-9"><tspan
+         id="tspan1396-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69.000015"
+         y="-7">Maßstab</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-17"
+       id="text2403"><tspan
+         id="tspan2401"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-17">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-27"
+       id="text1398-9-3"><tspan
+         id="tspan1396-3-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-27">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-27"
+       id="text2602"><tspan
+         id="tspan2600"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-27">Titel</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-179"
+       y="-37"
+       id="text2602-5"><tspan
+         id="tspan2600-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-179"
+         y="-37">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-37"
+       id="text1398-9-3-6"><tspan
+         id="tspan1396-3-1-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-37">Erstellt durch</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-94"
+       y="-37"
+       id="text1398-9-3-6-1"><tspan
+         id="tspan1396-3-1-2-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-94"
+         y="-37">Genehmigt von</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-54"
+       y="-37"
+       id="text1398-9-3-5"><tspan
+         id="tspan1396-3-1-9"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-54"
+         y="-37">Dokumentenart</tspan></text>
+    <text
+       style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583"
+       x="163.99998"
+       y="285"
+       id="text1915"><tspan
+         id="tspan1913"
+         style="stroke-width:0.264583"
+         x="163.99998"
+         y="285" /></text>
+    <g
+       style="fill:none;stroke-linecap:round;stroke-linejoin:round"
+       id="g2904"
+       transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
+      <g
+         id="g2882">
         <!-- Circle -->
-        <circle cx="0" cy="0" r="5" style="stroke:#000000;stroke-width:0.3" id="circle2856"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2856" />
         <!-- Line -->
-        <path d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338" style="stroke:#000000;stroke-width:0.18" id="path2858"/>
+        <path
+           d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2858" />
         <!-- Line -->
-        <path d="M -12.5,5 V -5" style="stroke:#000000;stroke-width:0.3" id="path2860"/>
+        <path
+           d="M -12.5,5 V -5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2860" />
         <!-- Line -->
-        <path d="m -22.5,2.3205 v -4.641" style="stroke:#000000;stroke-width:0.3" id="path2862"/>
+        <path
+           d="m -22.5,2.3205 v -4.641"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2862" />
         <!-- Line -->
-        <path d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6" style="stroke:#000000;stroke-width:0.18" id="path2864"/>
+        <path
+           d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2864" />
         <!-- Line -->
-        <path d="m -12.5,5 -10,-2.6795" style="stroke:#000000;stroke-width:0.3" id="path2866"/>
+        <path
+           d="m -12.5,5 -10,-2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2866" />
         <!-- Line -->
-        <path d="m -12.5,-5 -10,2.6795" style="stroke:#000000;stroke-width:0.3" id="path2868"/>
+        <path
+           d="m -12.5,-5 -10,2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2868" />
         <!-- Line -->
-        <path d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338" style="stroke:#000000;stroke-width:0.18" id="path2870"/>
+        <path
+           d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2870" />
         <!-- Circle -->
-        <circle cx="0" cy="0" r="2.320508" style="stroke:#000000;stroke-width:0.3" id="circle2872"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="2.320508"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2872" />
         <!-- Line -->
-        <path d="m -15.9438,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2874"/>
+        <path
+           d="m -15.9438,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2874" />
         <!-- Line -->
-        <path d="m -12.6961,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2876"/>
+        <path
+           d="m -12.6961,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2876" />
         <!-- Line -->
-        <path d="m -19.1721,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2878"/>
+        <path
+           d="m -19.1721,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2878" />
         <!-- Line -->
-        <path d="m -22.4247,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2880"/>
+        <path
+           d="m -22.4247,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2880" />
       </g>
     </g>
-    
   </g>
-  <g id="editables">
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="400.0" y="285.0" id="text1398-4" freecad:editable="page_number"><tspan id="tspan1396-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="400.0" y="285.0">1/1</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="356.0" y="285.0" id="text1398-4-4-9" freecad:editable="fc-date"><tspan id="tspan1396-7-5-8" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="356.0" y="285.0">2023-12-22</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="342.0" y="275.0" id="text2977" freecad:editable="Sachnummer"><tspan id="tspan2975" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="342.0" y="275.0">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="342.0" y="265.0" id="text2981" freecad:editable="projekt"><tspan id="tspan2979" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="342.0" y="265.0">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="357.0" y="255.0" id="text2985" freecad:editable="document_type"><tspan id="tspan2983" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="357.0" y="255.0">Dokumentenart</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="317.0" y="255.0" id="text2989" freecad:editable="Genehmiger"><tspan id="tspan2987" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="317.0" y="255.0">Genehmiger</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="277.0" y="255.0" id="text2993" freecad:editable="author_name"><tspan id="tspan2991" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="277.0" y="255.0">Ersteller</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="232.0" y="258.0" id="text2993-7" freecad:editable="owner_1"><tspan id="tspan2991-6" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="232.0" y="258.0">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="232.0" y="264.0" id="text3985" freecad:editable="owner_2"><tspan id="tspan939" x="232.0" y="264.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="232.0" y="270.0" id="text3989" freecad:editable="owner_3"><tspan id="tspan937" x="232.0" y="270.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="232.0" y="276.0" id="text3993" freecad:editable="owner_4"><tspan id="tspan935" x="232.0" y="276.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="232.0" y="282.0" id="text3997" freecad:editable="owner5"><tspan id="tspan933" x="232.0" y="282.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="277.0" y="265.0" id="text1398-4-4-9-0-1" freecad:editable="drawing_title"><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="277.0" y="265.0" id="tspan3120">Titel</tspan><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-133" y="-15.826385" id="tspan3118"/></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="277.0" y="271.0" id="text1398-4-4-9-0-1-7" freecad:editable="drawing_title_2"><tspan id="tspan941" x="277.0" y="271.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="277.0" y="276.0" id="text1398-4-4-9-0-1-5" freecad:editable="drawing_subtitle"><tspan id="tspan943" x="277.0" y="276.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="277.0" y="280.0" id="text1398-4-4-9-0-1-5-1" freecad:editable="drawing_subtitle_2"><tspan id="tspan945" x="277.0" y="280.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="277.0" y="284.0" id="text1398-4-4-9-0-1-5-5" freecad:editable="drawing_subtitle_3"><tspan id="tspan947" x="277.0" y="284.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="341.999985" y="285.0" id="text1398-4-4-9-4" freecad:editable="fc-sc"><tspan id="tspan1396-7-5-8-44" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="341.999985" y="285.0">1:1</tspan></text>
+  <g
+     id="editables">
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="400.0"
+       y="285.0"
+       id="text1398-4"
+       freecad:editable="page_number"
+       freecad:autofill="sheet"><tspan
+         id="tspan1396-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="400.0"
+         y="285.0">1/1</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="356.0"
+       y="285.0"
+       id="text1398-4-4-9"
+       freecad:editable="fc-date"
+       freecad:autofill="date"><tspan
+         id="tspan1396-7-5-8"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="356.0"
+         y="285.0">2023-12-22</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="342.0"
+       y="275.0"
+       id="text2977"
+       freecad:editable="Sachnummer"><tspan
+         id="tspan2975"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="342.0"
+         y="275.0">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="342.0"
+       y="265.0"
+       id="text2981"
+       freecad:editable="projekt"><tspan
+         id="tspan2979"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="342.0"
+         y="265.0">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="357.0"
+       y="255.0"
+       id="text2985"
+       freecad:editable="document_type"><tspan
+         id="tspan2983"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="357.0"
+         y="255.0">Dokumentenart</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="317.0"
+       y="255.0"
+       id="text2989"
+       freecad:editable="Genehmiger"><tspan
+         id="tspan2987"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="317.0"
+         y="255.0">Genehmiger</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="277.0"
+       y="255.0"
+       id="text2993"
+       freecad:editable="author_name"
+       freecad:autofill="author"><tspan
+         id="tspan2991"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="277.0"
+         y="255.0">Ersteller</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="232.0"
+       y="258.0"
+       id="text2993-7"
+       freecad:editable="owner_1"
+       freecad:autofill="organization"><tspan
+         id="tspan2991-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="232.0"
+         y="258.0">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="232.0"
+       y="264.0"
+       id="text3985"
+       freecad:editable="owner_2"><tspan
+         id="tspan939"
+         x="232.0"
+         y="264.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="232.0"
+       y="270.0"
+       id="text3989"
+       freecad:editable="owner_3"><tspan
+         id="tspan937"
+         x="232.0"
+         y="270.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="232.0"
+       y="276.0"
+       id="text3993"
+       freecad:editable="owner_4"><tspan
+         id="tspan935"
+         x="232.0"
+         y="276.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="232.0"
+       y="282.0"
+       id="text3997"
+       freecad:editable="owner5"><tspan
+         id="tspan933"
+         x="232.0"
+         y="282.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="277.0"
+       y="265.0"
+       id="text1398-4-4-9-0-1"
+       freecad:editable="drawing_title"
+       freecad:autofill="title"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="277.0"
+         y="265.0"
+         id="tspan3120">Titel</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-133"
+         y="-15.826385"
+         id="tspan3118" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="277.0"
+       y="271.0"
+       id="text1398-4-4-9-0-1-7"
+       freecad:editable="drawing_title_2"><tspan
+         id="tspan941"
+         x="277.0"
+         y="271.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="277.0"
+       y="276.0"
+       id="text1398-4-4-9-0-1-5"
+       freecad:editable="drawing_subtitle"><tspan
+         id="tspan943"
+         x="277.0"
+         y="276.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="277.0"
+       y="280.0"
+       id="text1398-4-4-9-0-1-5-1"
+       freecad:editable="drawing_subtitle_2"><tspan
+         id="tspan945"
+         x="277.0"
+         y="280.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="277.0"
+       y="284.0"
+       id="text1398-4-4-9-0-1-5-5"
+       freecad:editable="drawing_subtitle_3"><tspan
+         id="tspan947"
+         x="277.0"
+         y="284.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="341.999985"
+       y="285.0"
+       id="text1398-4-4-9-4"
+       freecad:editable="fc-sc"
+       freecad:autofill="scale"><tspan
+         id="tspan1396-7-5-8-44"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="341.999985"
+         y="285.0">1:1</tspan></text>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/locale/de/A4_Landscape_ISO7200_DE.svg
+++ b/src/Mod/TechDraw/Templates/locale/de/A4_Landscape_ISO7200_DE.svg
@@ -1,138 +1,596 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-  width="297mm"
-  height="210mm"
-  viewBox="0 0 297 210"
-  id="template"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:svg="http://www.w3.org/2000/svg"
-  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-  xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
-
-  <sodipodi:namedview
-     id="namedview3"
-     pagecolor="#ffffff" />
-
-  <g id="frame"
+   width="297mm"
+   height="210mm"
+   viewBox="0 0 297 210"
+   id="template"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+  <defs
+     id="defs36" />
+  <g
+     id="frame"
      style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-    <rect style="stroke-width:0.7" width="267" height="190" x="20" y="10" />
-    <rect width="277" height="200" x="15" y="5" />
-    <path d="m 64.50,5.00 v 5" />
-    <path d="m 64.50,200.00 v 5" />
-    <path d="m 109.00,5.00 v 5" />
-    <path d="m 109.00,200.00 v 5" />
-    <path d="m 153.50,5.00 v 5" />
-    <path d="m 153.50,200.00 v 5" />
-    <path d="m 198.00,5.00 v 5" />
-    <path d="m 198.00,200.00 v 5" />
-    <path d="m 242.50,5.00 v 5" />
-    <path d="m 242.50,200.00 v 5" />
-    <path d="m 15.00,57.50 h 5" />
-    <path d="m 287.00,57.50 h 5" />
-    <path d="m 15.00,105.00 h 5" />
-    <path d="m 287.00,105.00 h 5" />
-    <path d="m 15.00,152.50 h 5" />
-    <path d="m 287.00,152.50 h 5" />
+    <rect
+       style="stroke-width:0.7"
+       width="267"
+       height="190"
+       x="20"
+       y="10"
+       id="rect1" />
+    <rect
+       width="277"
+       height="200"
+       x="15"
+       y="5"
+       id="rect2" />
+    <path
+       d="m 64.50,5.00 v 5"
+       id="path2" />
+    <path
+       d="m 64.50,200.00 v 5"
+       id="path3" />
+    <path
+       d="m 109.00,5.00 v 5"
+       id="path4" />
+    <path
+       d="m 109.00,200.00 v 5"
+       id="path5" />
+    <path
+       d="m 153.50,5.00 v 5"
+       id="path6" />
+    <path
+       d="m 153.50,200.00 v 5"
+       id="path7" />
+    <path
+       d="m 198.00,5.00 v 5"
+       id="path8" />
+    <path
+       d="m 198.00,200.00 v 5"
+       id="path9" />
+    <path
+       d="m 242.50,5.00 v 5"
+       id="path10" />
+    <path
+       d="m 242.50,200.00 v 5"
+       id="path11" />
+    <path
+       d="m 15.00,57.50 h 5"
+       id="path12" />
+    <path
+       d="m 287.00,57.50 h 5"
+       id="path13" />
+    <path
+       d="m 15.00,105.00 h 5"
+       id="path14" />
+    <path
+       d="m 287.00,105.00 h 5"
+       id="path15" />
+    <path
+       d="m 15.00,152.50 h 5"
+       id="path16" />
+    <path
+       d="m 287.00,152.50 h 5"
+       id="path17" />
   </g>
-  <g id="coords"
+  <g
+     id="coords"
      style="font-size:3.52778px;font-family:Open Sans;font-weight:bold;text-anchor:middle">
-    <text x="42.25" y="9.00">1</text>
-    <text x="42.25" y="204.00">1</text>
-    <text x="86.75" y="9.00">2</text>
-    <text x="86.75" y="204.00">2</text>
-    <text x="131.25" y="9.00">3</text>
-    <text x="131.25" y="204.00">3</text>
-    <text x="175.75" y="9.00">4</text>
-    <text x="175.75" y="204.00">4</text>
-    <text x="220.25" y="9.00">5</text>
-    <text x="220.25" y="204.00">5</text>
-    <text x="264.75" y="9.00">6</text>
-    <text x="264.75" y="204.00">6</text>
-    <text x="17.50" y="33.75">A</text>
-    <text x="289.50" y="33.75">A</text>
-    <text x="17.50" y="81.25">B</text>
-    <text x="289.50" y="81.25">B</text>
-    <text x="17.50" y="128.75">C</text>
-    <text x="289.50" y="128.75">C</text>
-    <text x="17.50" y="176.25">D</text>
-    <text x="289.50" y="176.25">D</text>
+    <text
+       x="42.25"
+       y="9.00"
+       id="text17">1</text>
+    <text
+       x="42.25"
+       y="204.00"
+       id="text18">1</text>
+    <text
+       x="86.75"
+       y="9.00"
+       id="text19">2</text>
+    <text
+       x="86.75"
+       y="204.00"
+       id="text20">2</text>
+    <text
+       x="131.25"
+       y="9.00"
+       id="text21">3</text>
+    <text
+       x="131.25"
+       y="204.00"
+       id="text22">3</text>
+    <text
+       x="175.75"
+       y="9.00"
+       id="text23">4</text>
+    <text
+       x="175.75"
+       y="204.00"
+       id="text24">4</text>
+    <text
+       x="220.25"
+       y="9.00"
+       id="text25">5</text>
+    <text
+       x="220.25"
+       y="204.00"
+       id="text26">5</text>
+    <text
+       x="264.75"
+       y="9.00"
+       id="text27">6</text>
+    <text
+       x="264.75"
+       y="204.00"
+       id="text28">6</text>
+    <text
+       x="17.50"
+       y="33.75"
+       id="text29">A</text>
+    <text
+       x="289.50"
+       y="33.75"
+       id="text30">A</text>
+    <text
+       x="17.50"
+       y="81.25"
+       id="text31">B</text>
+    <text
+       x="289.50"
+       y="81.25"
+       id="text32">B</text>
+    <text
+       x="17.50"
+       y="128.75"
+       id="text33">C</text>
+    <text
+       x="289.50"
+       y="128.75"
+       id="text34">C</text>
+    <text
+       x="17.50"
+       y="176.25"
+       id="text35">D</text>
+    <text
+       x="289.50"
+       y="176.25"
+       id="text36">D</text>
   </g>
-  <g id="fieldframes" transform="translate(287, 200)">
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-3e-5 V -40" id="path1277"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70.00001,-3e-5 -70,-30" id="path1279"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-10 H 0" id="path1279-7"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-20 H 0" id="path2330"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-30 H 0" id="path1279-7-6"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -12.00001,-3e-5 -12,-10" id="path1390"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -20,-30 V -40" id="path1390-4"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -27,-3e-5 V -10" id="path1392"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -56,0 1e-5,-10" id="path1279-3"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -95,-30 v -9.99998" id="path1279-3-8"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -55,-30.00002 V -40" id="path1279-3-8-3"/>
-    <rect style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" id="rect5692" width="180" height="40" x="-180" y="-40"/>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-11" y="-7" id="text1398"><tspan id="tspan1396" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-11" y="-7">Blatt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-25" y="-2" id="text1398-4-4"><tspan id="tspan1396-7-5" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-25" y="-2">A4</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-26" y="-7" id="text1571"><tspan id="tspan1569" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-26" y="-7">Blattgröße</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-55" y="-7" id="text1575"><tspan id="tspan1573" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-55" y="-7">Ausgabedatum</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7" id="text1398-9"><tspan id="tspan1396-3" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7">Maßstab</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-17" id="text2403"><tspan id="tspan2401" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-17">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-27" id="text1398-9-3"><tspan id="tspan1396-3-1" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-27">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-27" id="text2602"><tspan id="tspan2600" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-27">Titel</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-179" y="-37" id="text2602-5"><tspan id="tspan2600-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-179" y="-37">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-37" id="text1398-9-3-6"><tspan id="tspan1396-3-1-2" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-37">Erstellt durch</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-94" y="-37" id="text1398-9-3-6-1"><tspan id="tspan1396-3-1-2-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-94" y="-37">Genehmigt von</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-54" y="-37" id="text1398-9-3-5"><tspan id="tspan1396-3-1-9" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-54" y="-37">Dokumentenart</tspan></text>
-    <text style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583" x="163.99998" y="285" id="text1915"><tspan id="tspan1913" style="stroke-width:0.264583" x="163.99998" y="285"/></text>
-    <g style="fill:none;stroke-linecap:round;stroke-linejoin:round" id="g2904" transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
-      <g id="g2882">
+  <g
+     id="fieldframes"
+     transform="translate(287, 200)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-3e-5 V -40"
+       id="path1277" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70.00001,-3e-5 -70,-30"
+       id="path1279" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-10 H 0"
+       id="path1279-7" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-20 H 0"
+       id="path2330" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-30 H 0"
+       id="path1279-7-6" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -12.00001,-3e-5 -12,-10"
+       id="path1390" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -20,-30 V -40"
+       id="path1390-4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -27,-3e-5 V -10"
+       id="path1392" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -56,0 1e-5,-10"
+       id="path1279-3" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -95,-30 v -9.99998"
+       id="path1279-3-8" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -55,-30.00002 V -40"
+       id="path1279-3-8-3" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5692"
+       width="180"
+       height="40"
+       x="-180"
+       y="-40" />
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-11"
+       y="-7"
+       id="text1398"><tspan
+         id="tspan1396"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-11"
+         y="-7">Blatt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-25"
+       y="-2"
+       id="text1398-4-4"><tspan
+         id="tspan1396-7-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-25"
+         y="-2">A4</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-26"
+       y="-7"
+       id="text1571"><tspan
+         id="tspan1569"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-26"
+         y="-7">Blattgröße</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-55"
+       y="-7"
+       id="text1575"><tspan
+         id="tspan1573"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-55"
+         y="-7">Ausgabedatum</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69.000015"
+       y="-7"
+       id="text1398-9"><tspan
+         id="tspan1396-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69.000015"
+         y="-7">Maßstab</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-17"
+       id="text2403"><tspan
+         id="tspan2401"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-17">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-27"
+       id="text1398-9-3"><tspan
+         id="tspan1396-3-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-27">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-27"
+       id="text2602"><tspan
+         id="tspan2600"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-27">Titel</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-179"
+       y="-37"
+       id="text2602-5"><tspan
+         id="tspan2600-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-179"
+         y="-37">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-37"
+       id="text1398-9-3-6"><tspan
+         id="tspan1396-3-1-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-37">Erstellt durch</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-94"
+       y="-37"
+       id="text1398-9-3-6-1"><tspan
+         id="tspan1396-3-1-2-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-94"
+         y="-37">Genehmigt von</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-54"
+       y="-37"
+       id="text1398-9-3-5"><tspan
+         id="tspan1396-3-1-9"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-54"
+         y="-37">Dokumentenart</tspan></text>
+    <text
+       style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583"
+       x="163.99998"
+       y="285"
+       id="text1915"><tspan
+         id="tspan1913"
+         style="stroke-width:0.264583"
+         x="163.99998"
+         y="285" /></text>
+    <g
+       style="fill:none;stroke-linecap:round;stroke-linejoin:round"
+       id="g2904"
+       transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
+      <g
+         id="g2882">
         <!-- Circle -->
-        <circle cx="0" cy="0" r="5" style="stroke:#000000;stroke-width:0.3" id="circle2856"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2856" />
         <!-- Line -->
-        <path d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338" style="stroke:#000000;stroke-width:0.18" id="path2858"/>
+        <path
+           d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2858" />
         <!-- Line -->
-        <path d="M -12.5,5 V -5" style="stroke:#000000;stroke-width:0.3" id="path2860"/>
+        <path
+           d="M -12.5,5 V -5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2860" />
         <!-- Line -->
-        <path d="m -22.5,2.3205 v -4.641" style="stroke:#000000;stroke-width:0.3" id="path2862"/>
+        <path
+           d="m -22.5,2.3205 v -4.641"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2862" />
         <!-- Line -->
-        <path d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6" style="stroke:#000000;stroke-width:0.18" id="path2864"/>
+        <path
+           d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2864" />
         <!-- Line -->
-        <path d="m -12.5,5 -10,-2.6795" style="stroke:#000000;stroke-width:0.3" id="path2866"/>
+        <path
+           d="m -12.5,5 -10,-2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2866" />
         <!-- Line -->
-        <path d="m -12.5,-5 -10,2.6795" style="stroke:#000000;stroke-width:0.3" id="path2868"/>
+        <path
+           d="m -12.5,-5 -10,2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2868" />
         <!-- Line -->
-        <path d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338" style="stroke:#000000;stroke-width:0.18" id="path2870"/>
+        <path
+           d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2870" />
         <!-- Circle -->
-        <circle cx="0" cy="0" r="2.320508" style="stroke:#000000;stroke-width:0.3" id="circle2872"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="2.320508"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2872" />
         <!-- Line -->
-        <path d="m -15.9438,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2874"/>
+        <path
+           d="m -15.9438,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2874" />
         <!-- Line -->
-        <path d="m -12.6961,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2876"/>
+        <path
+           d="m -12.6961,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2876" />
         <!-- Line -->
-        <path d="m -19.1721,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2878"/>
+        <path
+           d="m -19.1721,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2878" />
         <!-- Line -->
-        <path d="m -22.4247,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2880"/>
+        <path
+           d="m -22.4247,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2880" />
       </g>
     </g>
-    
   </g>
-  <g id="editables">
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="277.0" y="198.0" id="text1398-4" freecad:editable="page_number"><tspan id="tspan1396-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="277.0" y="198.0">1/1</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="233.0" y="198.0" id="text1398-4-4-9" freecad:editable="fc-date"><tspan id="tspan1396-7-5-8" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="233.0" y="198.0">2023-12-22</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="219.0" y="188.0" id="text2977" freecad:editable="Sachnummer"><tspan id="tspan2975" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="219.0" y="188.0">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="219.0" y="178.0" id="text2981" freecad:editable="projekt"><tspan id="tspan2979" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="219.0" y="178.0">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="234.0" y="168.0" id="text2985" freecad:editable="document_type"><tspan id="tspan2983" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="234.0" y="168.0">Dokumentenart</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="194.0" y="168.0" id="text2989" freecad:editable="Genehmiger"><tspan id="tspan2987" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="194.0" y="168.0">Genehmiger</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="154.0" y="168.0" id="text2993" freecad:editable="author_name"><tspan id="tspan2991" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="154.0" y="168.0">Ersteller</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="109.0" y="171.0" id="text2993-7" freecad:editable="owner_1"><tspan id="tspan2991-6" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="109.0" y="171.0">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="109.0" y="177.0" id="text3985" freecad:editable="owner_2"><tspan id="tspan939" x="109.0" y="177.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="109.0" y="183.0" id="text3989" freecad:editable="owner_3"><tspan id="tspan937" x="109.0" y="183.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="109.0" y="189.0" id="text3993" freecad:editable="owner_4"><tspan id="tspan935" x="109.0" y="189.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="109.0" y="195.0" id="text3997" freecad:editable="owner5"><tspan id="tspan933" x="109.0" y="195.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="154.0" y="178.0" id="text1398-4-4-9-0-1" freecad:editable="drawing_title"><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="154.0" y="178.0" id="tspan3120">Titel</tspan><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-133" y="-15.826385" id="tspan3118"/></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="154.0" y="184.0" id="text1398-4-4-9-0-1-7" freecad:editable="drawing_title_2"><tspan id="tspan941" x="154.0" y="184.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="154.0" y="189.0" id="text1398-4-4-9-0-1-5" freecad:editable="drawing_subtitle"><tspan id="tspan943" x="154.0" y="189.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="154.0" y="193.0" id="text1398-4-4-9-0-1-5-1" freecad:editable="drawing_subtitle_2"><tspan id="tspan945" x="154.0" y="193.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="154.0" y="197.0" id="text1398-4-4-9-0-1-5-5" freecad:editable="drawing_subtitle_3"><tspan id="tspan947" x="154.0" y="197.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="218.99998499999998" y="198.0" id="text1398-4-4-9-4" freecad:editable="fc-sc"><tspan id="tspan1396-7-5-8-44" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="218.99998499999998" y="198.0">1:1</tspan></text>
+  <g
+     id="editables">
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="277.0"
+       y="198.0"
+       id="text1398-4"
+       freecad:editable="page_number"
+       freecad:autofill="sheet"><tspan
+         id="tspan1396-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="277.0"
+         y="198.0">1/1</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="233.0"
+       y="198.0"
+       id="text1398-4-4-9"
+       freecad:editable="fc-date"
+       freecad:autofill="date"><tspan
+         id="tspan1396-7-5-8"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="233.0"
+         y="198.0">2023-12-22</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="219.0"
+       y="188.0"
+       id="text2977"
+       freecad:editable="Sachnummer"><tspan
+         id="tspan2975"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="219.0"
+         y="188.0">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="219.0"
+       y="178.0"
+       id="text2981"
+       freecad:editable="projekt"><tspan
+         id="tspan2979"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="219.0"
+         y="178.0">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="234.0"
+       y="168.0"
+       id="text2985"
+       freecad:editable="document_type"><tspan
+         id="tspan2983"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="234.0"
+         y="168.0">Dokumentenart</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="194.0"
+       y="168.0"
+       id="text2989"
+       freecad:editable="Genehmiger"><tspan
+         id="tspan2987"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="194.0"
+         y="168.0">Genehmiger</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="154.0"
+       y="168.0"
+       id="text2993"
+       freecad:editable="author_name"
+       freecad:autofill="author"><tspan
+         id="tspan2991"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="154.0"
+         y="168.0">Ersteller</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="109.0"
+       y="171.0"
+       id="text2993-7"
+       freecad:editable="owner_1"
+       freecad:autofill="organization"><tspan
+         id="tspan2991-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="109.0"
+         y="171.0">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="109.0"
+       y="177.0"
+       id="text3985"
+       freecad:editable="owner_2"><tspan
+         id="tspan939"
+         x="109.0"
+         y="177.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="109.0"
+       y="183.0"
+       id="text3989"
+       freecad:editable="owner_3"><tspan
+         id="tspan937"
+         x="109.0"
+         y="183.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="109.0"
+       y="189.0"
+       id="text3993"
+       freecad:editable="owner_4"><tspan
+         id="tspan935"
+         x="109.0"
+         y="189.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="109.0"
+       y="195.0"
+       id="text3997"
+       freecad:editable="owner5"><tspan
+         id="tspan933"
+         x="109.0"
+         y="195.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="154.0"
+       y="178.0"
+       id="text1398-4-4-9-0-1"
+       freecad:editable="drawing_title"
+       freecad:autofill="title"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="154.0"
+         y="178.0"
+         id="tspan3120">Titel</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-133"
+         y="-15.826385"
+         id="tspan3118" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="154.0"
+       y="184.0"
+       id="text1398-4-4-9-0-1-7"
+       freecad:editable="drawing_title_2"><tspan
+         id="tspan941"
+         x="154.0"
+         y="184.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="154.0"
+       y="189.0"
+       id="text1398-4-4-9-0-1-5"
+       freecad:editable="drawing_subtitle"><tspan
+         id="tspan943"
+         x="154.0"
+         y="189.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="154.0"
+       y="193.0"
+       id="text1398-4-4-9-0-1-5-1"
+       freecad:editable="drawing_subtitle_2"><tspan
+         id="tspan945"
+         x="154.0"
+         y="193.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="154.0"
+       y="197.0"
+       id="text1398-4-4-9-0-1-5-5"
+       freecad:editable="drawing_subtitle_3"><tspan
+         id="tspan947"
+         x="154.0"
+         y="197.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="218.99998499999998"
+       y="198.0"
+       id="text1398-4-4-9-4"
+       freecad:editable="fc-sc"
+       freecad:autofill="scale"><tspan
+         id="tspan1396-7-5-8-44"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="218.99998499999998"
+         y="198.0">1:1</tspan></text>
   </g>
 </svg>

--- a/src/Mod/TechDraw/Templates/locale/de/A4_Portrait_ISO7200_DE.svg
+++ b/src/Mod/TechDraw/Templates/locale/de/A4_Portrait_ISO7200_DE.svg
@@ -1,138 +1,596 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-  width="210mm"
-  height="297mm"
-  viewBox="0 0 210 297"
-  id="template"
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:svg="http://www.w3.org/2000/svg"
-  xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-  xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
-
-  <sodipodi:namedview
-     id="namedview3"
-     pagecolor="#ffffff" />
-
-  <g id="frame"
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   id="template"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:freecad="https://www.freecad.org/wiki/index.php?title=Svg_Namespace">
+  <defs
+     id="defs36" />
+  <g
+     id="frame"
      style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
-    <rect style="stroke-width:0.7" width="180" height="277" x="20" y="10" />
-    <rect width="190" height="287" x="15" y="5" />
-    <path d="m 65.00,5.00 v 5" />
-    <path d="m 65.00,287.00 v 5" />
-    <path d="m 110.00,5.00 v 5" />
-    <path d="m 110.00,287.00 v 5" />
-    <path d="m 155.00,5.00 v 5" />
-    <path d="m 155.00,287.00 v 5" />
-    <path d="m 15.00,56.17 h 5" />
-    <path d="m 200.00,56.17 h 5" />
-    <path d="m 15.00,102.33 h 5" />
-    <path d="m 200.00,102.33 h 5" />
-    <path d="m 15.00,148.50 h 5" />
-    <path d="m 200.00,148.50 h 5" />
-    <path d="m 15.00,194.67 h 5" />
-    <path d="m 200.00,194.67 h 5" />
-    <path d="m 15.00,240.83 h 5" />
-    <path d="m 200.00,240.83 h 5" />
+    <rect
+       style="stroke-width:0.7"
+       width="180"
+       height="277"
+       x="20"
+       y="10"
+       id="rect1" />
+    <rect
+       width="190"
+       height="287"
+       x="15"
+       y="5"
+       id="rect2" />
+    <path
+       d="m 65.00,5.00 v 5"
+       id="path2" />
+    <path
+       d="m 65.00,287.00 v 5"
+       id="path3" />
+    <path
+       d="m 110.00,5.00 v 5"
+       id="path4" />
+    <path
+       d="m 110.00,287.00 v 5"
+       id="path5" />
+    <path
+       d="m 155.00,5.00 v 5"
+       id="path6" />
+    <path
+       d="m 155.00,287.00 v 5"
+       id="path7" />
+    <path
+       d="m 15.00,56.17 h 5"
+       id="path8" />
+    <path
+       d="m 200.00,56.17 h 5"
+       id="path9" />
+    <path
+       d="m 15.00,102.33 h 5"
+       id="path10" />
+    <path
+       d="m 200.00,102.33 h 5"
+       id="path11" />
+    <path
+       d="m 15.00,148.50 h 5"
+       id="path12" />
+    <path
+       d="m 200.00,148.50 h 5"
+       id="path13" />
+    <path
+       d="m 15.00,194.67 h 5"
+       id="path14" />
+    <path
+       d="m 200.00,194.67 h 5"
+       id="path15" />
+    <path
+       d="m 15.00,240.83 h 5"
+       id="path16" />
+    <path
+       d="m 200.00,240.83 h 5"
+       id="path17" />
   </g>
-  <g id="coords"
+  <g
+     id="coords"
      style="font-size:3.52778px;font-family:Open Sans;font-weight:bold;text-anchor:middle">
-    <text x="42.50" y="9.00">1</text>
-    <text x="42.50" y="291.00">1</text>
-    <text x="87.50" y="9.00">2</text>
-    <text x="87.50" y="291.00">2</text>
-    <text x="132.50" y="9.00">3</text>
-    <text x="132.50" y="291.00">3</text>
-    <text x="177.50" y="9.00">4</text>
-    <text x="177.50" y="291.00">4</text>
-    <text x="17.50" y="33.08">A</text>
-    <text x="202.50" y="33.08">A</text>
-    <text x="17.50" y="79.25">B</text>
-    <text x="202.50" y="79.25">B</text>
-    <text x="17.50" y="125.42">C</text>
-    <text x="202.50" y="125.42">C</text>
-    <text x="17.50" y="171.58">D</text>
-    <text x="202.50" y="171.58">D</text>
-    <text x="17.50" y="217.75">E</text>
-    <text x="202.50" y="217.75">E</text>
-    <text x="17.50" y="263.92">F</text>
-    <text x="202.50" y="263.92">F</text>
+    <text
+       x="42.50"
+       y="9.00"
+       id="text17">1</text>
+    <text
+       x="42.50"
+       y="291.00"
+       id="text18">1</text>
+    <text
+       x="87.50"
+       y="9.00"
+       id="text19">2</text>
+    <text
+       x="87.50"
+       y="291.00"
+       id="text20">2</text>
+    <text
+       x="132.50"
+       y="9.00"
+       id="text21">3</text>
+    <text
+       x="132.50"
+       y="291.00"
+       id="text22">3</text>
+    <text
+       x="177.50"
+       y="9.00"
+       id="text23">4</text>
+    <text
+       x="177.50"
+       y="291.00"
+       id="text24">4</text>
+    <text
+       x="17.50"
+       y="33.08"
+       id="text25">A</text>
+    <text
+       x="202.50"
+       y="33.08"
+       id="text26">A</text>
+    <text
+       x="17.50"
+       y="79.25"
+       id="text27">B</text>
+    <text
+       x="202.50"
+       y="79.25"
+       id="text28">B</text>
+    <text
+       x="17.50"
+       y="125.42"
+       id="text29">C</text>
+    <text
+       x="202.50"
+       y="125.42"
+       id="text30">C</text>
+    <text
+       x="17.50"
+       y="171.58"
+       id="text31">D</text>
+    <text
+       x="202.50"
+       y="171.58"
+       id="text32">D</text>
+    <text
+       x="17.50"
+       y="217.75"
+       id="text33">E</text>
+    <text
+       x="202.50"
+       y="217.75"
+       id="text34">E</text>
+    <text
+       x="17.50"
+       y="263.92"
+       id="text35">F</text>
+    <text
+       x="202.50"
+       y="263.92"
+       id="text36">F</text>
   </g>
-  <g id="fieldframes" transform="translate(200, 287)">
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-3e-5 V -40" id="path1277"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70.00001,-3e-5 -70,-30" id="path1279"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-10 H 0" id="path1279-7"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -70,-20 H 0" id="path2330"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -135,-30 H 0" id="path1279-7-6"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -12.00001,-3e-5 -12,-10" id="path1390"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -20,-30 V -40" id="path1390-4"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -27,-3e-5 V -10" id="path1392"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -56,0 1e-5,-10" id="path1279-3"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="m -95,-30 v -9.99998" id="path1279-3-8"/>
-    <path style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" d="M -55,-30.00002 V -40" id="path1279-3-8-3"/>
-    <rect style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1" id="rect5692" width="180" height="40" x="-180" y="-40"/>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-11" y="-7" id="text1398"><tspan id="tspan1396" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-11" y="-7">Blatt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-25" y="-2" id="text1398-4-4"><tspan id="tspan1396-7-5" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-25" y="-2">A4</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-26" y="-7" id="text1571"><tspan id="tspan1569" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-26" y="-7">Blattgröße</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-55" y="-7" id="text1575"><tspan id="tspan1573" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-55" y="-7">Ausgabedatum</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7" id="text1398-9"><tspan id="tspan1396-3" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69.000015" y="-7">Maßstab</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-17" id="text2403"><tspan id="tspan2401" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-17">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-69" y="-27" id="text1398-9-3"><tspan id="tspan1396-3-1" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-69" y="-27">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-27" id="text2602"><tspan id="tspan2600" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-27">Titel</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-179" y="-37" id="text2602-5"><tspan id="tspan2600-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-179" y="-37">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-134" y="-37" id="text1398-9-3-6"><tspan id="tspan1396-3-1-2" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-134" y="-37">Erstellt durch</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-94" y="-37" id="text1398-9-3-6-1"><tspan id="tspan1396-3-1-2-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-94" y="-37">Genehmigt von</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="-54" y="-37" id="text1398-9-3-5"><tspan id="tspan1396-3-1-9" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-54" y="-37">Dokumentenart</tspan></text>
-    <text style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583" x="163.99998" y="285" id="text1915"><tspan id="tspan1913" style="stroke-width:0.264583" x="163.99998" y="285"/></text>
-    <g style="fill:none;stroke-linecap:round;stroke-linejoin:round" id="g2904" transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
-      <g id="g2882">
+  <g
+     id="fieldframes"
+     transform="translate(200, 287)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-3e-5 V -40"
+       id="path1277" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70.00001,-3e-5 -70,-30"
+       id="path1279" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-10 H 0"
+       id="path1279-7" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -70,-20 H 0"
+       id="path2330" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -135,-30 H 0"
+       id="path1279-7-6" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -12.00001,-3e-5 -12,-10"
+       id="path1390" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -20,-30 V -40"
+       id="path1390-4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -27,-3e-5 V -10"
+       id="path1392" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -56,0 1e-5,-10"
+       id="path1279-3" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m -95,-30 v -9.99998"
+       id="path1279-3-8" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M -55,-30.00002 V -40"
+       id="path1279-3-8-3" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.699567;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5692"
+       width="180"
+       height="40"
+       x="-180"
+       y="-40" />
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-11"
+       y="-7"
+       id="text1398"><tspan
+         id="tspan1396"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-11"
+         y="-7">Blatt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-25"
+       y="-2"
+       id="text1398-4-4"><tspan
+         id="tspan1396-7-5"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-25"
+         y="-2">A4</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-26"
+       y="-7"
+       id="text1571"><tspan
+         id="tspan1569"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-26"
+         y="-7">Blattgröße</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-55"
+       y="-7"
+       id="text1575"><tspan
+         id="tspan1573"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-55"
+         y="-7">Ausgabedatum</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69.000015"
+       y="-7"
+       id="text1398-9"><tspan
+         id="tspan1396-3"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69.000015"
+         y="-7">Maßstab</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-17"
+       id="text2403"><tspan
+         id="tspan2401"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-17">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-69"
+       y="-27"
+       id="text1398-9-3"><tspan
+         id="tspan1396-3-1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-69"
+         y="-27">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-27"
+       id="text2602"><tspan
+         id="tspan2600"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-27">Titel</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-179"
+       y="-37"
+       id="text2602-5"><tspan
+         id="tspan2600-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-179"
+         y="-37">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-134"
+       y="-37"
+       id="text1398-9-3-6"><tspan
+         id="tspan1396-3-1-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-134"
+         y="-37">Erstellt durch</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-94"
+       y="-37"
+       id="text1398-9-3-6-1"><tspan
+         id="tspan1396-3-1-2-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-94"
+         y="-37">Genehmigt von</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="-54"
+       y="-37"
+       id="text1398-9-3-5"><tspan
+         id="tspan1396-3-1-9"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.46944px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-54"
+         y="-37">Dokumentenart</tspan></text>
+    <text
+       style="font-size:4.23333px;line-height:1.25;font-family:'Latin Modern Mono';-inkscape-font-specification:'Latin Modern Mono';text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.264583"
+       x="163.99998"
+       y="285"
+       id="text1915"><tspan
+         id="tspan1913"
+         style="stroke-width:0.264583"
+         x="163.99998"
+         y="285" /></text>
+    <g
+       style="fill:none;stroke-linecap:round;stroke-linejoin:round"
+       id="g2904"
+       transform="matrix(0.56375738,0,0,0.56375738,-4.99981,-35)">
+      <g
+         id="g2882">
         <!-- Circle -->
-        <circle cx="0" cy="0" r="5" style="stroke:#000000;stroke-width:0.3" id="circle2856"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2856" />
         <!-- Line -->
-        <path d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338" style="stroke:#000000;stroke-width:0.18" id="path2858"/>
+        <path
+           d="M 0,5.7483 V 1.7145 m 0,-1.143 v -1.143 m 0,-1.143 v -4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2858" />
         <!-- Line -->
-        <path d="M -12.5,5 V -5" style="stroke:#000000;stroke-width:0.3" id="path2860"/>
+        <path
+           d="M -12.5,5 V -5"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2860" />
         <!-- Line -->
-        <path d="m -22.5,2.3205 v -4.641" style="stroke:#000000;stroke-width:0.3" id="path2862"/>
+        <path
+           d="m -22.5,2.3205 v -4.641"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2862" />
         <!-- Line -->
-        <path d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6" style="stroke:#000000;stroke-width:0.18" id="path2864"/>
+        <path
+           d="m -23.5,0 h 0.6 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 2.16 m 0.54,0 v 0 m 0.54,0 h 0.6"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2864" />
         <!-- Line -->
-        <path d="m -12.5,5 -10,-2.6795" style="stroke:#000000;stroke-width:0.3" id="path2866"/>
+        <path
+           d="m -12.5,5 -10,-2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2866" />
         <!-- Line -->
-        <path d="m -12.5,-5 -10,2.6795" style="stroke:#000000;stroke-width:0.3" id="path2868"/>
+        <path
+           d="m -12.5,-5 -10,2.6795"
+           style="stroke:#000000;stroke-width:0.3"
+           id="path2868" />
         <!-- Line -->
-        <path d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338" style="stroke:#000000;stroke-width:0.18" id="path2870"/>
+        <path
+           d="m -5.7483,0 h 4.0338 m 1.143,0 h 1.143 m 1.143,0 h 4.0338"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2870" />
         <!-- Circle -->
-        <circle cx="0" cy="0" r="2.320508" style="stroke:#000000;stroke-width:0.3" id="circle2872"/>
+        <circle
+           cx="0"
+           cy="0"
+           r="2.320508"
+           style="stroke:#000000;stroke-width:0.3"
+           id="circle2872" />
         <!-- Line -->
-        <path d="m -15.9438,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2874"/>
+        <path
+           d="m -15.9438,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2874" />
         <!-- Line -->
-        <path d="m -12.6961,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2876"/>
+        <path
+           d="m -12.6961,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2876" />
         <!-- Line -->
-        <path d="m -19.1721,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2878"/>
+        <path
+           d="m -19.1721,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2878" />
         <!-- Line -->
-        <path d="m -22.4247,0 h 0.1091" style="stroke:#000000;stroke-width:0.18" id="path2880"/>
+        <path
+           d="m -22.4247,0 h 0.1091"
+           style="stroke:#000000;stroke-width:0.18"
+           id="path2880" />
       </g>
     </g>
-    
   </g>
-  <g id="editables">
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="190.0" y="285.0" id="text1398-4" freecad:editable="page_number"><tspan id="tspan1396-7" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="190.0" y="285.0">1/1</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="146.0" y="285.0" id="text1398-4-4-9" freecad:editable="fc-date"><tspan id="tspan1396-7-5-8" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="146.0" y="285.0">2023-12-22</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="132.0" y="275.0" id="text2977" freecad:editable="Sachnummer"><tspan id="tspan2975" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="132.0" y="275.0">Sachnummer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="132.0" y="265.0" id="text2981" freecad:editable="projekt"><tspan id="tspan2979" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="132.0" y="265.0">Projekt</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="147.0" y="255.0" id="text2985" freecad:editable="document_type"><tspan id="tspan2983" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="147.0" y="255.0">Dokumentenart</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="107.0" y="255.0" id="text2989" freecad:editable="Genehmiger"><tspan id="tspan2987" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="107.0" y="255.0">Genehmiger</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="67.0" y="255.0" id="text2993" freecad:editable="author_name"><tspan id="tspan2991" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="67.0" y="255.0">Ersteller</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="22.0" y="258.0" id="text2993-7" freecad:editable="owner_1"><tspan id="tspan2991-6" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="22.0" y="258.0">Eigentümer</tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="22.0" y="264.0" id="text3985" freecad:editable="owner_2"><tspan id="tspan939" x="22.0" y="264.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="22.0" y="270.0" id="text3989" freecad:editable="owner_3"><tspan id="tspan937" x="22.0" y="270.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="22.0" y="276.0" id="text3993" freecad:editable="owner_4"><tspan id="tspan935" x="22.0" y="276.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="22.0" y="282.0" id="text3997" freecad:editable="owner5"><tspan id="tspan933" x="22.0" y="282.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="67.0" y="265.0" id="text1398-4-4-9-0-1" freecad:editable="drawing_title"><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="67.0" y="265.0" id="tspan3120">Titel</tspan><tspan style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="-133" y="-15.826385" id="tspan3118"/></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="67.0" y="271.0" id="text1398-4-4-9-0-1-7" freecad:editable="drawing_title_2"><tspan id="tspan941" x="67.0" y="271.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="67.0" y="276.0" id="text1398-4-4-9-0-1-5" freecad:editable="drawing_subtitle"><tspan id="tspan943" x="67.0" y="276.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="67.0" y="280.0" id="text1398-4-4-9-0-1-5-1" freecad:editable="drawing_subtitle_2"><tspan id="tspan945" x="67.0" y="280.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="67.0" y="284.0" id="text1398-4-4-9-0-1-5-5" freecad:editable="drawing_subtitle_3"><tspan id="tspan947" x="67.0" y="284.0"></tspan></text>
-    <text style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583" x="131.99998499999998" y="285.0" id="text1398-4-4-9-4" freecad:editable="fc-sc"><tspan id="tspan1396-7-5-8-44" style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583" x="131.99998499999998" y="285.0">1:1</tspan></text>
+  <g
+     id="editables">
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="190.0"
+       y="285.0"
+       id="text1398-4"
+       freecad:editable="page_number"
+       freecad:autofill="sheet"><tspan
+         id="tspan1396-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="190.0"
+         y="285.0">1/1</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="146.0"
+       y="285.0"
+       id="text1398-4-4-9"
+       freecad:editable="fc-date"
+       freecad:autofill="date"><tspan
+         id="tspan1396-7-5-8"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="146.0"
+         y="285.0">2023-12-22</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="132.0"
+       y="275.0"
+       id="text2977"
+       freecad:editable="Sachnummer"><tspan
+         id="tspan2975"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="132.0"
+         y="275.0">Sachnummer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="132.0"
+       y="265.0"
+       id="text2981"
+       freecad:editable="projekt"><tspan
+         id="tspan2979"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="132.0"
+         y="265.0">Projekt</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="147.0"
+       y="255.0"
+       id="text2985"
+       freecad:editable="document_type"><tspan
+         id="tspan2983"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="147.0"
+         y="255.0">Dokumentenart</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="107.0"
+       y="255.0"
+       id="text2989"
+       freecad:editable="Genehmiger"><tspan
+         id="tspan2987"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="107.0"
+         y="255.0">Genehmiger</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="67.0"
+       y="255.0"
+       id="text2993"
+       freecad:editable="author_name"
+       freecad:autofill="author"><tspan
+         id="tspan2991"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="67.0"
+         y="255.0">Ersteller</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="22.0"
+       y="258.0"
+       id="text2993-7"
+       freecad:editable="owner_1"
+       freecad:autofill="organization"><tspan
+         id="tspan2991-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="22.0"
+         y="258.0">Eigentümer</tspan></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="22.0"
+       y="264.0"
+       id="text3985"
+       freecad:editable="owner_2"><tspan
+         id="tspan939"
+         x="22.0"
+         y="264.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="22.0"
+       y="270.0"
+       id="text3989"
+       freecad:editable="owner_3"><tspan
+         id="tspan937"
+         x="22.0"
+         y="270.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="22.0"
+       y="276.0"
+       id="text3993"
+       freecad:editable="owner_4"><tspan
+         id="tspan935"
+         x="22.0"
+         y="276.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="22.0"
+       y="282.0"
+       id="text3997"
+       freecad:editable="owner5"><tspan
+         id="tspan933"
+         x="22.0"
+         y="282.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="67.0"
+       y="265.0"
+       id="text1398-4-4-9-0-1"
+       freecad:editable="drawing_title"
+       freecad:autofill="title"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="67.0"
+         y="265.0"
+         id="tspan3120">Titel</tspan><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="-133"
+         y="-15.826385"
+         id="tspan3118" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="67.0"
+       y="271.0"
+       id="text1398-4-4-9-0-1-7"
+       freecad:editable="drawing_title_2"><tspan
+         id="tspan941"
+         x="67.0"
+         y="271.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="67.0"
+       y="276.0"
+       id="text1398-4-4-9-0-1-5"
+       freecad:editable="drawing_subtitle"><tspan
+         id="tspan943"
+         x="67.0"
+         y="276.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="67.0"
+       y="280.0"
+       id="text1398-4-4-9-0-1-5-1"
+       freecad:editable="drawing_subtitle_2"><tspan
+         id="tspan945"
+         x="67.0"
+         y="280.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.52778px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="67.0"
+       y="284.0"
+       id="text1398-4-4-9-0-1-5-5"
+       freecad:editable="drawing_subtitle_3"><tspan
+         id="tspan947"
+         x="67.0"
+         y="284.0" /></text>
+    <text
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;line-height:1.25;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;stroke-width:0.264583"
+       x="131.99998499999998"
+       y="285.0"
+       id="text1398-4-4-9-4"
+       freecad:editable="fc-sc"
+       freecad:autofill="scale"><tspan
+         id="tspan1396-7-5-8-44"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:osifont;-inkscape-font-specification:'osifont, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;stroke-width:0.264583"
+         x="131.99998499999998"
+         y="285.0">1:1</tspan></text>
   </g>
 </svg>


### PR DESCRIPTION
fixes https://github.com/FreeCAD/FreeCAD/pull/14289#issuecomment-2180324123

Fixed the `index0:editable` from the past PR and also from other files which were not touched by the PR but did not work either. Added `freecad:autofill` attributes too.

@Roy-043 @WandererFan FYI