### PR TITLE
Toponaming: Fix save and restore of elementmaps

### DIFF
--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -457,7 +457,7 @@ void ComplexGeoData::Restore(Base::XMLReader& reader)
 
     const char* file = "";
     if (reader.hasAttribute("file")) {
-        reader.getAttribute("file");
+        file = reader.getAttribute("file");
     }
     if (*file != 0) {
         reader.addFile(file, this);

--- a/src/App/Property.cpp
+++ b/src/App/Property.cpp
@@ -88,6 +88,31 @@ std::string Property::getFullName() const {
     return name;
 }
 
+std::string Property::getFileName(const char* postfix, const char* prefix) const
+{
+    std::ostringstream ss;
+    if (prefix) {
+        ss << prefix;
+    }
+    if (!myName) {
+        ss << "Property";
+    }
+    else {
+        std::string name = getFullName();
+        auto pos = name.find('#');
+        if (pos == std::string::npos) {
+            ss << name;
+        }
+        else {
+            ss << (name.c_str() + pos + 1);
+        }
+    }
+    if (postfix) {
+        ss << postfix;
+    }
+    return ss.str();
+}
+
 short Property::getType() const
 {
     short type = 0;

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -288,6 +288,9 @@ protected:
     /// Verify a path for the current property
     virtual void verifyPath(const App::ObjectIdentifier & p) const;
 
+    /// Return a file name suitable for saving this property
+    std::string getFileName(const char *postfix=0, const char *prefix=0) const;
+
 public:
     // forbidden
     Property(const Property&) = delete;

--- a/src/Base/Reader.cpp
+++ b/src/Base/Reader.cpp
@@ -264,8 +264,8 @@ bool Base::XMLReader::isEndOfDocument() const
 void Base::XMLReader::readEndElement(const char* ElementName, int level)
 {
     // if we are already at the end of the current element
-    if ( (ReadType == EndElement || ReadType == StartEndElement) && ElementName && LocalName == ElementName
-        && (level < 0 || level == Level)) {
+    if ((ReadType == EndElement || ReadType == StartEndElement) && ElementName
+        && LocalName == ElementName && (level < 0 || level == Level)) {
         return;
     }
     if (ReadType == EndDocument) {

--- a/src/Base/Reader.cpp
+++ b/src/Base/Reader.cpp
@@ -264,7 +264,7 @@ bool Base::XMLReader::isEndOfDocument() const
 void Base::XMLReader::readEndElement(const char* ElementName, int level)
 {
     // if we are already at the end of the current element
-    if (ReadType == EndElement && ElementName && LocalName == ElementName
+    if ( (ReadType == EndElement || ReadType == StartEndElement) && ElementName && LocalName == ElementName
         && (level < 0 || level == Level)) {
         return;
     }

--- a/src/Base/Writer.cpp
+++ b/src/Base/Writer.cpp
@@ -320,6 +320,10 @@ void Writer::decInd()
     indBuf[indent] = '\0';
 }
 
+void Writer::putNextEntry(const char *file, const char *obj) {
+    ObjectName = obj?obj:file;
+}
+
 // ----------------------------------------------------------------------------
 
 ZipWriter::ZipWriter(const char* FileName)
@@ -346,6 +350,12 @@ ZipWriter::ZipWriter(std::ostream& os)
     ZipStream.setf(ios::fixed, ios::floatfield);
 }
 
+void ZipWriter::putNextEntry(const char *file, const char *obj) {
+    Writer::putNextEntry(file,obj);
+
+    ZipStream.putNextEntry(file);
+}
+
 void ZipWriter::writeFiles()
 {
     // use a while loop because it is possible that while
@@ -353,7 +363,9 @@ void ZipWriter::writeFiles()
     size_t index = 0;
     while (index < FileList.size()) {
         FileEntry entry = FileList[index];
-        ZipStream.putNextEntry(entry.FileName);
+        putNextEntry(entry.FileName.c_str());
+        indent = 0;
+        indBuf[0] = 0;
         entry.Object->SaveDocFile(*this);
         index++;
     }
@@ -372,8 +384,10 @@ FileWriter::FileWriter(const char* DirName)
 
 FileWriter::~FileWriter() = default;
 
-void FileWriter::putNextEntry(const char* file)
+void FileWriter::putNextEntry(const char* file, const char *obj)
 {
+    Writer::putNextEntry(file,obj);
+
     std::string fileName = DirName + "/" + file;
     this->FileStream.open(fileName.c_str(), std::ios::out | std::ios::binary);
 }
@@ -402,8 +416,9 @@ void FileWriter::writeFiles()
                 fi.createDirectory();
             }
 
-            std::string fileName = DirName + "/" + entry.FileName;
-            this->FileStream.open(fileName.c_str(), std::ios::out | std::ios::binary);
+            putNextEntry(entry.FileName.c_str());
+            indent = 0;
+            indBuf[0] = 0;
             entry.Object->SaveDocFile(*this);
             this->FileStream.close();
         }

--- a/src/Base/Writer.cpp
+++ b/src/Base/Writer.cpp
@@ -320,8 +320,9 @@ void Writer::decInd()
     indBuf[indent] = '\0';
 }
 
-void Writer::putNextEntry(const char *file, const char *obj) {
-    ObjectName = obj?obj:file;
+void Writer::putNextEntry(const char* file, const char* obj)
+{
+    ObjectName = obj ? obj : file;
 }
 
 // ----------------------------------------------------------------------------
@@ -350,8 +351,9 @@ ZipWriter::ZipWriter(std::ostream& os)
     ZipStream.setf(ios::fixed, ios::floatfield);
 }
 
-void ZipWriter::putNextEntry(const char *file, const char *obj) {
-    Writer::putNextEntry(file,obj);
+void ZipWriter::putNextEntry(const char* file, const char* obj)
+{
+    Writer::putNextEntry(file, obj);
 
     ZipStream.putNextEntry(file);
 }
@@ -384,9 +386,9 @@ FileWriter::FileWriter(const char* DirName)
 
 FileWriter::~FileWriter() = default;
 
-void FileWriter::putNextEntry(const char* file, const char *obj)
+void FileWriter::putNextEntry(const char* file, const char* obj)
 {
-    Writer::putNextEntry(file,obj);
+    Writer::putNextEntry(file, obj);
 
     std::string fileName = DirName + "/" + file;
     this->FileStream.open(fileName.c_str(), std::ios::out | std::ios::binary);

--- a/src/Base/Writer.h
+++ b/src/Base/Writer.h
@@ -68,6 +68,9 @@ public:
     void setFileVersion(int);
     int getFileVersion() const;
 
+    /// put the next entry with a give name
+    virtual void putNextEntry(const char *filename, const char *objName=nullptr);
+
     /// insert a file as CDATA section in the XML file
     void insertAsciiFile(const char* FileName);
     /// insert a binary file BASE64 coded as CDATA section in the XML file
@@ -206,10 +209,7 @@ public:
     {
         ZipStream.setLevel(level);
     }
-    void putNextEntry(const char* str)
-    {
-        ZipStream.putNextEntry(str);
-    }
+    void putNextEntry(const char *filename, const char *objName=nullptr) override;
 
     ZipWriter(const ZipWriter&) = delete;
     ZipWriter(ZipWriter&&) = delete;
@@ -256,7 +256,7 @@ public:
     explicit FileWriter(const char* DirName);
     ~FileWriter() override;
 
-    void putNextEntry(const char* file);
+    void putNextEntry(const char *filename, const char *objName=nullptr) override;
     void writeFiles() override;
 
     std::ostream& Stream() override

--- a/src/Base/Writer.h
+++ b/src/Base/Writer.h
@@ -69,7 +69,7 @@ public:
     int getFileVersion() const;
 
     /// put the next entry with a give name
-    virtual void putNextEntry(const char *filename, const char *objName=nullptr);
+    virtual void putNextEntry(const char* filename, const char* objName = nullptr);
 
     /// insert a file as CDATA section in the XML file
     void insertAsciiFile(const char* FileName);
@@ -209,7 +209,7 @@ public:
     {
         ZipStream.setLevel(level);
     }
-    void putNextEntry(const char *filename, const char *objName=nullptr) override;
+    void putNextEntry(const char* filename, const char* objName = nullptr) override;
 
     ZipWriter(const ZipWriter&) = delete;
     ZipWriter(ZipWriter&&) = delete;
@@ -256,7 +256,7 @@ public:
     explicit FileWriter(const char* DirName);
     ~FileWriter() override;
 
-    void putNextEntry(const char *filename, const char *objName=nullptr) override;
+    void putNextEntry(const char* filename, const char* objName = nullptr) override;
     void writeFiles() override;
 
     std::ostream& Stream() override

--- a/src/Mod/Part/App/PropertyTopoShapeList.h
+++ b/src/Mod/Part/App/PropertyTopoShapeList.h
@@ -84,6 +84,9 @@ public:
     void Save(Base::Writer &writer) const override;
     void Restore(Base::XMLReader &reader) override;
 
+    void SaveDocFile (Base::Writer &writer) const override;
+    void RestoreDocFile(Base::Reader &reader) override;
+
     App::Property *Copy() const override;
     void Paste(const App::Property &from) override;
 

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -1199,7 +1199,29 @@ bool TopoShape::getCenterOfGravity(Base::Vector3d& center) const
 
     return false;
 }
+#ifdef FC_USE_TNP_FIX
+void TopoShape::Save (Base::Writer &writer ) const
+{
+    Data::ComplexGeoData::Save(writer);
+}
 
+void TopoShape::Restore(Base::XMLReader &reader)
+{
+    Data::ComplexGeoData::Restore(reader);
+}
+
+void TopoShape::SaveDocFile (Base::Writer &writer) const
+{
+    Data::ComplexGeoData::SaveDocFile(writer);
+}
+
+void TopoShape::RestoreDocFile(Base::Reader &reader)
+{
+    Data::ComplexGeoData::RestoreDocFile(reader);
+}
+
+
+#else
 void TopoShape::Save (Base::Writer& writer) const
 {
     if(!writer.isForceXML()) {
@@ -1252,7 +1274,7 @@ void TopoShape::RestoreDocFile(Base::Reader& reader)
         importBrep(reader);
     }
 }
-
+#endif
 unsigned int TopoShape_RefCountShapes(const TopoDS_Shape& aShape)
 {
     unsigned int size = 1; // this shape

--- a/src/Mod/Part/parttests/TopoShapeTest.py
+++ b/src/Mod/Part/parttests/TopoShapeTest.py
@@ -90,10 +90,10 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
             ["CenterOfMass", App.Vector(1, 0.5, 1)],
             ["CompSolids", []],
             ["Compounds", []],
-            ["Content", ""],
+            ["Content", "<ElementMap/>\n"], # Our element map is empty, or there would be more here.
             ["ElementMap", {}],
             ["ElementReverseMap", {}],
-            # ['Hasher', {}],    # Todo:  Should this exist?  Different implementation?
+            ['Hasher', None],
             [
                 "MatrixOfInertia",
                 App.Matrix(

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -1463,6 +1463,17 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         else:
             self.assertEqual(App.Gui.Selection.getSelectionEx("", 0)[0].SubElementNames[0][-8:],",F.Face2")
 
+    def testFileSaveRestore(self):
+        self.Body = self.Doc.addObject('PartDesign::Body', 'Body')
+        self.create_t_sketch()
+        self.assertEqual(self.Doc.Sketch.Shape.ElementMapSize, 18)
+        filename = self.Doc.Name
+        self.Doc.saveAs(filename)
+        App.closeDocument(filename)
+        self.Doc = App.openDocument(filename+".FCStd")
+        self.Doc.recompute()
+        self.assertEqual(self.Doc.Sketch.Shape.ElementMapSize, 18)
+
     def create_t_sketch(self):
         self.Doc.getObject('Body').newObject('Sketcher::SketchObject', 'Sketch')
         geo_list = [
@@ -1492,4 +1503,4 @@ class TestTopologicalNamingProblem(unittest.TestCase):
 
     def tearDown(self):
         """ Close our test document """
-        App.closeDocument("PartDesignTestTNP")
+        App.closeDocument(self.Doc.Name)


### PR DESCRIPTION
Add a test to prove that elementmaps in a sketch last past a save and restore.  Correct the shape and property code at various levels to work correctly.