### PR TITLE
Measure: Fix measure issues in assemblies

### DIFF
--- a/src/App/MeasureManager.cpp
+++ b/src/App/MeasureManager.cpp
@@ -62,6 +62,27 @@ namespace App {
         return empty;
     }
 
+    MeasureHandler MeasureManager::getMeasureHandler(const App::MeasureSelectionItem& selectionItem) {
+        auto objT = selectionItem.object;
+
+        App::DocumentObject* sub = objT.getSubObject();
+
+        const char* className = sub->getTypeId().getName();
+        std::string mod = Base::Type::getModuleName(className);
+
+        return getMeasureHandler(mod.c_str());
+    }
+
+    MeasureElementType MeasureManager::getMeasureElementType(const App::MeasureSelectionItem& selectionItem) {
+        auto handler = getMeasureHandler(selectionItem);
+        if (handler.module.empty()) {
+            return App::MeasureElementType::INVALID;
+        }
+
+        auto objT = selectionItem.object;
+        return handler.typeCb(objT.getObject(), objT.getSubName().c_str());
+    }
+
     void MeasureManager::addMeasureType(MeasureType* measureType) {
         _mMeasureTypes.push_back(measureType);
     }

--- a/src/App/MeasureManager.cpp
+++ b/src/App/MeasureManager.cpp
@@ -24,6 +24,7 @@
 #include <Base/Interpreter.h>
 #include <Base/VectorPy.h>
 #include <App/Document.h>
+#include <App/Link.h>
 
 #include "MeasureManager.h"
 
@@ -65,7 +66,12 @@ namespace App {
     MeasureHandler MeasureManager::getMeasureHandler(const App::MeasureSelectionItem& selectionItem) {
         auto objT = selectionItem.object;
 
+        // Resolve App::Link
         App::DocumentObject* sub = objT.getSubObject();
+        if (sub->isDerivedFrom<App::Link>()) {
+            auto link = static_cast<App::Link*>(sub);
+            sub = link->getLinkedObject(true);
+        }
 
         const char* className = sub->getTypeId().getName();
         std::string mod = Base::Type::getModuleName(className);

--- a/src/App/MeasureManager.h
+++ b/src/App/MeasureManager.h
@@ -93,6 +93,8 @@ public:
     static void addMeasureHandler(const char* module, MeasureTypeMethod typeCb);
     static bool hasMeasureHandler(const char* module);
     static MeasureHandler getMeasureHandler(const char* module);
+    static MeasureHandler getMeasureHandler(const App::MeasureSelectionItem& selectionItem);
+    static MeasureElementType getMeasureElementType(const App::MeasureSelectionItem& selectionItem);
     static void addMeasureType(MeasureType* measureType);
     static void addMeasureType(std::string id, std::string label, std::string measureObj, MeasureValidateMethod validatorCb, MeasurePrioritizeMethod prioritizeCb);
     static void addMeasureType(const char* id, const char* label, const char* measureObj, MeasureValidateMethod validatorCb, MeasurePrioritizeMethod prioritizeCb);

--- a/src/Mod/Measure/App/MeasureBase.h
+++ b/src/Mod/Measure/App/MeasureBase.h
@@ -34,6 +34,7 @@
 #include <App/PropertyStandard.h>
 #include <App/PropertyUnits.h>
 #include <App/FeaturePython.h>
+#include <App/Link.h>
 #include <Base/Quantity.h>
 #include <Base/Placement.h>
 #include <Base/Interpreter.h>
@@ -108,7 +109,12 @@ public:
 
     static Part::MeasureInfoPtr getMeasureInfo(App::SubObjectT& subObjT) {
 
+        // Resolve App::Link
         App::DocumentObject* sub = subObjT.getSubObject();
+        if (sub->isDerivedFrom<App::Link>()) {
+            auto link = static_cast<App::Link*>(sub);
+            sub = link->getLinkedObject(true);
+        }
 
         // Get the Geometry handler based on the module
         const char* className = sub->getTypeId().getName();

--- a/src/Mod/Measure/App/MeasureBase.h
+++ b/src/Mod/Measure/App/MeasureBase.h
@@ -106,6 +106,23 @@ public:
         return _mGeometryHandlers[module];
     }
 
+    static Part::MeasureInfoPtr getMeasureInfo(App::SubObjectT& subObjT) {
+
+        App::DocumentObject* sub = subObjT.getSubObject();
+
+        // Get the Geometry handler based on the module
+        const char* className = sub->getTypeId().getName();
+        std::string mod = Base::Type::getModuleName(className);
+                
+        auto handler = getGeometryHandler(mod);
+        if (!handler) {
+            Base::Console().Log("MeasureBaseExtendable::getMeasureInfo: No geometry handler available for submitted element type");
+            return nullptr;
+        }
+
+        return handler(subObjT);
+    }
+
     static void addGeometryHandlers(const std::vector<std::string>& modules, GeometryHandler callback){
         // TODO: this will replace a callback with a later one.  Should we check that there isn't already a
         // handler defined for this module?

--- a/src/Mod/Measure/App/MeasureDistance.cpp
+++ b/src/Mod/Measure/App/MeasureDistance.cpp
@@ -76,20 +76,7 @@ bool MeasureDistance::isValidSelection(const App::MeasureSelection& selection){
     }
 
     for (auto element : selection) {
-
-        auto objT = element.object;
-        
-        App::DocumentObject* ob = objT.getObject();
-        const std::string& subName = objT.getSubName();
-        const char* className = objT.getSubObject()->getTypeId().getName();
-        std::string mod = Base::Type::getModuleName(className);
-
-        if (!hasGeometryHandler(mod)) {
-            return false;
-        }
-
-        App::MeasureHandler handler = App::MeasureManager::getMeasureHandler(mod.c_str());
-        App::MeasureElementType type = handler.typeCb(ob, subName.c_str());
+        auto type = App::MeasureManager::getMeasureElementType(element);
 
         if (type == App::MeasureElementType::INVALID) {
             return false;
@@ -152,17 +139,11 @@ bool MeasureDistance::getShape(App::PropertyLinkSub* prop, TopoDS_Shape& rShape)
     }
 
     std::string subName = subs.at(0);
-    const char* className = ob->getSubObject(subName.c_str())->getTypeId().getName();
-    std::string mod = Base::Type::getModuleName(className);
-
-    if (!hasGeometryHandler(mod)) {
-        return false;
-    }
-
-    auto handler = getGeometryHandler(mod);
     App::SubObjectT subject{ob, subName.c_str()};
-    auto info = handler(subject);
-    if (!info->valid) {
+
+    auto info = getMeasureInfo(subject);
+    
+    if (!info || !info->valid) {
         return false;
     }
     auto distanceInfo = std::dynamic_pointer_cast<Part::MeasureDistanceInfo>(info);

--- a/src/Mod/Measure/App/MeasureLength.cpp
+++ b/src/Mod/Measure/App/MeasureLength.cpp
@@ -58,19 +58,7 @@ bool MeasureLength::isValidSelection(const App::MeasureSelection& selection){
     }
 
     for (auto element : selection) {
-        auto objT = element.object;
-        
-        App::DocumentObject* ob = objT.getObject();
-        const std::string& subName = objT.getSubName();
-        const char* className = objT.getSubObject()->getTypeId().getName();
-        std::string mod = Base::Type::getModuleName(className);
-
-        if (!hasGeometryHandler(mod)) {
-            return false;
-        }
-
-        App::MeasureHandler handler = App::MeasureManager::getMeasureHandler(mod.c_str());
-        App::MeasureElementType type = handler.typeCb(ob, subName.c_str());
+        auto type = App::MeasureManager::getMeasureElementType(element);
 
         if (type == App::MeasureElementType::INVALID) {
             return false;
@@ -91,7 +79,7 @@ void MeasureLength::parseSelection(const App::MeasureSelection& selection) {
     std::vector<std::string> subElements;
 
     for (auto element : selection) {
-        auto objT = element.object;        
+        auto objT = element.object;
 
         objects.push_back(objT.getObject());
         subElements.push_back(objT.getSubName());
@@ -116,19 +104,13 @@ void MeasureLength::recalculateLength()
 
     // Loop through Elements and call the valid geometry handler
     for (std::vector<App::DocumentObject*>::size_type i=0; i<objects.size(); i++) {
-        App::DocumentObject *object = objects.at(i);
-        std::string subElement = subElements.at(i);
 
-        // Get the Geometry handler based on the module
-        const char* className = object->getSubObject(subElement.c_str())->getTypeId().getName();
-        const std::string& mod = Base::Type::getModuleName(className);
-        auto handler = getGeometryHandler(mod);
-        if (!handler) {
-            throw Base::RuntimeError("No geometry handler available for submitted element type");
+        App::SubObjectT subject{objects.at(i), subElements.at(i).c_str()};
+        auto info = getMeasureInfo(subject);
+        if (!info || !info->valid) {
+            continue;
         }
 
-        App::SubObjectT subject{object, subElement.c_str()};
-        auto info = handler(subject);
         auto lengthInfo = std::dynamic_pointer_cast<Part::MeasureLengthInfo>(info);
         result += lengthInfo->length;
     }
@@ -158,18 +140,12 @@ Base::Placement MeasureLength::getPlacement() {
         return Base::Placement();
     }
 
-    App::DocumentObject* object = objects.front();
-    std::string subElement = subElements.front();
-    const char* className = object->getSubObject(subElement.c_str())->getTypeId().getName();
-    const std::string& mod = Base::Type::getModuleName(className);
-
-    auto handler = getGeometryHandler(mod);
-    if (!handler) {
-        throw Base::RuntimeError("No geometry handler available for submitted element type");
+    App::SubObjectT subject{objects.front(), subElements.front().c_str()};
+    auto info = getMeasureInfo(subject);
+    
+    if (!info || !info->valid) {
+        return {};
     }
-
-    App::SubObjectT subject{object, subElement.c_str()};
-    auto info = handler(subject);
     auto lengthInfo = std::dynamic_pointer_cast<Part::MeasureLengthInfo>(info);
     return lengthInfo->placement;
 }

--- a/src/Mod/Measure/App/MeasurePosition.cpp
+++ b/src/Mod/Measure/App/MeasurePosition.cpp
@@ -58,19 +58,7 @@ bool MeasurePosition::isValidSelection(const App::MeasureSelection& selection){
     }
 
     for (auto element : selection) {
-        auto objT = element.object;
-        
-        App::DocumentObject* ob = objT.getObject();
-        const std::string& subName = objT.getSubName();
-        const char* className = objT.getSubObject()->getTypeId().getName();
-        std::string mod = Base::Type::getModuleName(className);
-
-        if (!hasGeometryHandler(mod)) {
-            return false;
-        }
-
-        App::MeasureHandler handler = App::MeasureManager::getMeasureHandler(mod.c_str());
-        App::MeasureElementType type = handler.typeCb(ob, subName.c_str());
+        auto type = App::MeasureManager::getMeasureElementType(element);
 
         if (type == App::MeasureElementType::INVALID) {
             return false;
@@ -107,19 +95,13 @@ void MeasurePosition::recalculatePosition()
     const App::DocumentObject* object = Element.getValue();
     const std::vector<std::string>& subElements = Element.getSubValues();
 
-    // Get the position of the first point
-    std::string subElement = subElements.front();
-
-    // Get the Geometry handler based on the module
-    const char* className = object->getSubObject(subElement.c_str())->getTypeId().getName();
-    const std::string& mod = Base::Type::getModuleName(className);
-    auto handler = getGeometryHandler(mod);
-    if (!handler) {
-        throw Base::RuntimeError("No geometry handler available for submitted element type");
+    App::SubObjectT subject{object, subElements.front().c_str()};
+    auto info = getMeasureInfo(subject);
+    
+    if (!info || !info->valid) {
+        return;
     }
 
-    App::SubObjectT subject{object, subElement.c_str()};
-    auto info = handler(subject);
     auto positionInfo = std::dynamic_pointer_cast<Part::MeasurePositionInfo>(info);
     Position.setValue(positionInfo->position);
 }

--- a/src/Mod/Measure/App/MeasureRadius.cpp
+++ b/src/Mod/Measure/App/MeasureRadius.cpp
@@ -68,19 +68,7 @@ bool MeasureRadius::isValidSelection(const App::MeasureSelection& selection){
     }
 
     auto element = selection.front();
-    auto objT = element.object;
-    
-    App::DocumentObject* ob = objT.getObject();
-    const std::string& subName = objT.getSubName();
-    const char* className = objT.getSubObject()->getTypeId().getName();
-    std::string mod = Base::Type::getModuleName(className);
-
-    if (!hasGeometryHandler(mod)) {
-        return false;
-    }
-
-    App::MeasureHandler handler = App::MeasureManager::getMeasureHandler(mod.c_str());
-    App::MeasureElementType type = handler.typeCb(ob, subName.c_str());
+    auto type = App::MeasureManager::getMeasureElementType(element);
 
     if (type == App::MeasureElementType::INVALID) {
         return false;
@@ -102,19 +90,7 @@ bool MeasureRadius::isPrioritizedSelection(const App::MeasureSelection& selectio
     }
 
     auto element = selection.front();
-    auto objT = element.object;
-    
-    App::DocumentObject* ob = objT.getObject();
-    const std::string& subName = objT.getSubName();
-    const char* className = objT.getSubObject()->getTypeId().getName();
-    std::string mod = Base::Type::getModuleName(className);
-
-    if (!hasGeometryHandler(mod)) {
-        return false;
-    }
-
-    App::MeasureHandler handler = App::MeasureManager::getMeasureHandler(mod.c_str());
-    App::MeasureElementType type = handler.typeCb(ob, subName.c_str());
+    auto type = App::MeasureManager::getMeasureElementType(element);
 
     if (type == App::MeasureElementType::CIRCLE
         || type == App::MeasureElementType::ARC) {
@@ -179,7 +155,7 @@ Base::Vector3d MeasureRadius::getPointOnCurve() const
 //! get the handler's result for the first element
 Part::MeasureRadiusInfoPtr MeasureRadius::getMeasureInfoFirst() const
 {
-   const App::DocumentObject* object = Element.getValue();
+    const App::DocumentObject* object = Element.getValue();
     const std::vector<std::string>& subElements = Element.getSubValues();
 
     if (!object || subElements.empty()) {
@@ -187,18 +163,13 @@ Part::MeasureRadiusInfoPtr MeasureRadius::getMeasureInfoFirst() const
         return std::make_shared<Part::MeasureRadiusInfo>();
     }
 
-    std::string subElement = subElements.front();
-    const char* className = object->getSubObject(subElement.c_str())->getTypeId().getName();
-    const std::string& mod = Base::Type::getModuleName(className);
-
-    auto handler = getGeometryHandler(mod);
-    if (!handler) {
-        throw Base::RuntimeError("No geometry handler available for submitted element type");
+    App::SubObjectT subject{object, subElements.front().c_str()};
+    auto info = getMeasureInfo(subject);
+    if (!info || !info->valid) {
+// NOLINTNEXTLINE(modernize-return-braced-init-list)
+        return std::make_shared<Part::MeasureRadiusInfo>();
     }
 
-    std::string obName = object->getNameInDocument();
-    App::SubObjectT subject{object, subElement.c_str()};
-    auto info = handler(subject);
     auto radiusInfo = std::dynamic_pointer_cast<Part::MeasureRadiusInfo>(info);
     return radiusInfo;
 }

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -32,6 +32,7 @@
 
 #include <App/Document.h>
 #include <App/DocumentObjectGroup.h>
+#include <App/Link.h>
 #include <Gui/MainWindow.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
@@ -156,8 +157,14 @@ void TaskMeasure::update() {
     for(auto sel : Gui::Selection().getSelection()) {
         App::DocumentObject* ob = sel.pObject;
         App::DocumentObject* sub = ob->getSubObject(sel.SubName);
-        std::string mod = Base::Type::getModuleName(sub->getTypeId().getName());
 
+        // Resolve App::Link
+        if (sub->isDerivedFrom<App::Link>()) {
+            auto link = static_cast<App::Link*>(sub);
+            sub = link->getLinkedObject(true);
+        }
+
+        std::string mod = Base::Type::getModuleName(sub->getTypeId().getName());
         if (!App::MeasureManager::hasMeasureHandler(mod.c_str())) {
             Base::Console().Message("No measure handler available for geometry of module: %s\n", mod);
             clearSelection();

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -185,13 +185,12 @@ void TaskMeasure::update() {
     if (measureTypes.size() > 0) {
         measureType = measureTypes.front();
     }
-    
 
     if (!measureType) {
 
         // Note: If there's no valid measure type we might just restart the selection,
         // however this requires enough coverage of measuretypes that we can access all of them
-        
+
         // std::tuple<std::string, std::string> sel = selection.back();
         // clearSelection();
         // addElement(measureModule.c_str(), get<0>(sel).c_str(), get<1>(sel).c_str());
@@ -215,7 +214,7 @@ void TaskMeasure::update() {
         if (measureType->isPython) {
             Base::PyGILStateLocker lock;
             auto pyMeasureClass = measureType->pythonClass;
-            
+
             // Create a MeasurePython instance
             auto featurePython = doc->addObject("Measure::MeasurePython", measureType->label.c_str());
             setMeasureObject((Measure::MeasureBase*)featurePython);
@@ -297,7 +296,7 @@ void TaskMeasure::reset() {
     // Reset tool state
     this->clearSelection();
 
-    // Should the explicit mode also be reset? 
+    // Should the explicit mode also be reset?
     // setModeSilent(nullptr);
     // explicitMode = false;
 
@@ -368,7 +367,7 @@ void TaskMeasure::onModeChanged(int index) {
 
 void TaskMeasure::setModeSilent(App::MeasureType* mode) {
     modeSwitch->blockSignals(true);
-    
+
     if (mode == nullptr) {
         modeSwitch->setCurrentIndex(0);
     }

--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -89,20 +89,17 @@ static float getRadius(TopoDS_Shape& edge){
     return 0.0;
 }
 
-TopoDS_Shape getLocatedShape(const App::SubObjectT& subject)
+TopoDS_Shape getLocatedShape(const App::SubObjectT& subject, Base::Matrix4D* mat = nullptr)
 {
     App::DocumentObject* obj = subject.getSubObjectList().back();
     if (!obj) {
         return {};
     }
 
-    Part::TopoShape shape = Part::Feature::getTopoShape(obj, subject.getElementName());
+    Part::TopoShape shape = Part::Feature::getTopoShape(obj, subject.getElementName(), false, mat, nullptr, true);
     if (shape.isNull()) {
+        Base::Console().Log("Part::MeasureClient::getLocatedShape: Did not retrieve shape for %s, %s\n", obj->getNameInDocument(), subject.getElementName());
         return {};
-    }
-    auto geoFeat = dynamic_cast<App::GeoFeature*>(obj);
-    if (geoFeat) {
-        shape.setPlacement(geoFeat->globalPlacement());
     }
 
     // Don't get the subShape from datum elements
@@ -181,31 +178,22 @@ bool getShapeFromStrings(TopoDS_Shape &shapeOut, const App::SubObjectT& subject,
 }
 
 
-
 Part::VectorAdapter buildAdapter(const App::SubObjectT& subject)
 {
-    if (!subject.getObject()) {
-        return Part::VectorAdapter();
-    }
     Base::Matrix4D mat;
-    TopoDS_Shape shape = Part::Feature::getShape(subject.getObject(), subject.getElementName(), true);
+    TopoDS_Shape shape = getLocatedShape(subject, &mat);
+
     if (shape.IsNull()) {
         // failure here on loading document with existing measurement.
         Base::Console().Message("Part::buildAdapter did not retrieve shape for %s, %s\n",
                                 subject.getObjectName(), subject.getElementName());
         return Part::VectorAdapter();
     }
-
     TopAbs_ShapeEnum shapeType = shape.ShapeType();
-
 
     if (shapeType == TopAbs_EDGE)
     {
-      TopoDS_Shape edgeShape;
-      if (!getShapeFromStrings(edgeShape, subject, &mat)) {
-        return {};
-      }
-      TopoDS_Edge edge = TopoDS::Edge(edgeShape);
+      TopoDS_Edge edge = TopoDS::Edge(shape);
       // make edge orientation so that end of edge closest to pick is head of vector.
       TopoDS_Vertex firstVertex = TopExp::FirstVertex(edge, Standard_True);
       TopoDS_Vertex lastVertex = TopExp::LastVertex(edge, Standard_True);
@@ -232,12 +220,7 @@ Part::VectorAdapter buildAdapter(const App::SubObjectT& subject)
     }
     if (shapeType == TopAbs_FACE)
     {
-      TopoDS_Shape faceShape;
-      if (!getShapeFromStrings(faceShape, subject, &mat)) {
-        return {};
-      }
-
-      TopoDS_Face face = TopoDS::Face(faceShape);
+      TopoDS_Face face = TopoDS::Face(shape);
       Base::Vector3d vTemp(0.0, 0.0, 0.0); //v(current.x, current.y, current.z);
       vTemp = mat*vTemp;
       gp_Vec pickPoint(vTemp.x, vTemp.y, vTemp.z);


### PR DESCRIPTION
As described in #14559 measurements don't properly work with the integrated assembly workbench. This PR adds checks for App::Link types and resolves them to get the responsible module and fixes the retrieval of the located shapes.

Closes #14559