### PR TITLE
FEM: Remove unused members

### DIFF
--- a/src/Mod/Fem/Gui/TaskFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraint.cpp
@@ -60,9 +60,6 @@ TaskFemConstraint::TaskFemConstraint(ViewProviderFemConstraint* ConstraintView,
     , proxy(nullptr)
     , deleteAction(nullptr)
     , ConstraintView(ConstraintView)
-    , buttonBox(nullptr)
-    , okButton(nullptr)
-    , cancelButton(nullptr)
 {
     selectionMode = selref;
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraint.h
+++ b/src/Mod/Fem/Gui/TaskFemConstraint.h
@@ -86,13 +86,6 @@ protected:
         selloc,
         selnone
     } selectionMode;
-
-private:
-    // This seems to be the only way to access the widgets again in order to remove them from the
-    // dialog
-    QDialogButtonBox* buttonBox;
-    QPushButton* okButton;
-    QPushButton* cancelButton;
 };
 
 /// simulation dialog for the TaskView


### PR DESCRIPTION
It's not clear what the comment on these meant, but the compiler marks them as unused. Maybe vestigial?