### PR TITLE
Gui: Remove unused ref to GL context

### DIFF
--- a/src/Gui/Quarter/QuarterWidget.cpp
+++ b/src/Gui/Quarter/QuarterWidget.cpp
@@ -168,8 +168,8 @@ public:
 
     void initializeGL() override
     {
-        QOpenGLContext *context = QOpenGLContext::currentContext();
 #if defined (_DEBUG) && 0
+        QOpenGLContext *context = QOpenGLContext::currentContext();
         if (context && context->hasExtension(QByteArrayLiteral("GL_KHR_debug"))) {
             QOpenGLDebugLogger *logger = new QOpenGLDebugLogger(this);
             connect(logger, &QOpenGLDebugLogger::messageLogged, this, &CustomGLWidget::handleLoggedMessage);


### PR DESCRIPTION
Move this variable inside the (no-longer-used?) debug block.