### PR TITLE
Assembly: Insert Component: Fix assembly not appearing

### DIFF
--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -882,10 +882,26 @@ std::vector< App::DocumentObject* > ViewProvider::claimChildren() const
     auto vector = getExtensionsDerivedFromType<Gui::ViewProviderExtension>();
     for (Gui::ViewProviderExtension* ext : vector) {
         std::vector< App::DocumentObject* > nvec = ext->extensionClaimChildren();
-        if (!nvec.empty())
+        if (!nvec.empty()){
             vec.insert(std::end(vec), std::begin(nvec), std::end(nvec));
+        }
     }
     return vec;
+}
+
+std::vector< App::DocumentObject* > ViewProvider::claimChildrenRecursive() const
+{
+    std::vector<App::DocumentObject*> children = claimChildren();
+    for (auto* child : claimChildren()) {
+        auto* vp = Application::Instance->getViewProvider(child);
+        if (!vp) { continue; }
+
+        std::vector<App::DocumentObject*> nvec = vp->claimChildrenRecursive();
+        if (!nvec.empty()){
+            children.insert(std::end(children), std::begin(nvec), std::end(nvec));
+        }
+    }
+    return children;
 }
 
 std::vector< App::DocumentObject* > ViewProvider::claimChildren3D() const

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -264,6 +264,11 @@ public:
     virtual std::vector<App::DocumentObject*> claimChildren() const;
     //@}
 
+    /** deliver the children belonging to this object recursively.
+      */
+    virtual std::vector<App::DocumentObject*> claimChildrenRecursive() const;
+    //@}
+
     /** @name Drag and drop
      * To enable drag and drop you have to re-implement \ref canDragObjects() and
      * \ref canDropObjects() to return true. For finer control you can also re-implement

--- a/src/Gui/ViewProviderPy.xml
+++ b/src/Gui/ViewProviderPy.xml
@@ -201,6 +201,13 @@ trans : Base.Placement, Base.Matrix</UserDocu>
 Returns list of objects that are to be grouped in tree under this object.</UserDocu>
             </Documentation>
         </Methode>
+        <Methode Name="claimChildrenRecursive" Const="true">
+            <Documentation>
+                <UserDocu>claimChildrenRecursive() -> list
+
+Returns list of objects that are to be grouped in tree under this object recursively.</UserDocu>
+            </Documentation>
+        </Methode>
         <Methode Name="partialRender">
             <Documentation>
                 <UserDocu>partialRender(sub=None, clear=False) -> int

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -393,7 +393,7 @@ PyObject* ViewProviderPy::claimChildren(PyObject* args)
 
     std::vector<App::DocumentObject*> children = this->getViewProviderPtr()->claimChildren();
     Py::List ret;
-    for(auto* child: children){
+    for(auto* child : children){
         if (child)
             ret.append(Py::asObject(child->getPyObject()));
         else
@@ -409,7 +409,7 @@ PyObject* ViewProviderPy::claimChildrenRecursive(PyObject* args)
 
     std::vector<App::DocumentObject*> children = this->getViewProviderPtr()->claimChildrenRecursive();
     Py::List ret;
-    for(auto* child: children){
+    for(auto* child : children){
         if (child)
             ret.append(Py::asObject(child->getPyObject()));
         else

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -393,7 +393,23 @@ PyObject* ViewProviderPy::claimChildren(PyObject* args)
 
     std::vector<App::DocumentObject*> children = this->getViewProviderPtr()->claimChildren();
     Py::List ret;
-    for(App::DocumentObject* child: children){
+    for(auto* child: children){
+        if (child)
+            ret.append(Py::asObject(child->getPyObject()));
+        else
+            ret.append(Py::None());
+    }
+    return Py::new_reference_to(ret);
+}
+
+PyObject* ViewProviderPy::claimChildrenRecursive(PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, ""))
+        return nullptr;
+
+    std::vector<App::DocumentObject*> children = this->getViewProviderPtr()->claimChildrenRecursive();
+    Py::List ret;
+    for(auto* child: children){
         if (child)
             ret.append(Py::asObject(child->getPyObject()));
         else

--- a/src/Mod/Assembly/CommandInsertLink.py
+++ b/src/Mod/Assembly/CommandInsertLink.py
@@ -165,7 +165,7 @@ class TaskAssemblyInsertLink(QtCore.QObject):
             def process_objects(objs, item):
                 onlyParts = self.form.CheckBox_ShowOnlyParts.isChecked()
                 for obj in objs:
-                    if obj.Name == self.assembly.Name:
+                    if obj == self.assembly:
                         continue  # Skip current assembly
 
                     if (

--- a/src/Mod/Assembly/CommandInsertLink.py
+++ b/src/Mod/Assembly/CommandInsertLink.py
@@ -180,7 +180,7 @@ class TaskAssemblyInsertLink(QtCore.QObject):
                                     (not onlyParts and child.isDerivedFrom("Part::Feature"))
                                     or child.isDerivedFrom("App::Part")
                                 )
-                                for child in obj.OutListRecursive
+                                for child in obj.ViewObject.claimChildrenRecursive()
                             ):
                                 continue  # Skip this object if no relevant children
 
@@ -201,7 +201,7 @@ class TaskAssemblyInsertLink(QtCore.QObject):
                         if obj.isDerivedFrom("App::Part") or obj.isDerivedFrom(
                             "App::DocumentObjectGroup"
                         ):
-                            process_objects(obj.OutList, objItem)
+                            process_objects(obj.ViewObject.claimChildren(), objItem)
 
             guiDoc = Gui.getDocument(doc.Name)
             process_objects(guiDoc.TreeRootObjects, docItem)


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/14933

Fix another unlisted bug where groups where appearing even if they had nothing interesting (joint group were appearing for example). It was because it was using OutListRecursive and groundedObject linked to a part.
So instead it now use claimChildren. So the tree is building correctly.
This PR also adds 'claimChildrenRecursive' to view provider.