### PR TITLE
Update Tree view mode tooltip and text in Preferences

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -546,8 +546,8 @@ void DlgSettingsGeneral::saveDockWindowVisibility()
 void DlgSettingsGeneral::loadDockWindowVisibility()
 {
     ui->treeMode->clear();
-    ui->treeMode->addItem(tr("Combo View"));
-    ui->treeMode->addItem(tr("TreeView and PropertyView"));
+    ui->treeMode->addItem(tr("Combined"));
+    ui->treeMode->addItem(tr("Independent"));
 
     auto hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/DockWindows");
     bool propertyView = hGrp->GetGroup("PropertyView")->GetBool("Enabled", false);

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.ui
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.ui
@@ -263,8 +263,7 @@ this according to your screen size or personal taste</string>
           <string>Customize how tree view is shown in the panel (restart required).
 
 'ComboView': combine tree view and property view into one panel.
-'TreeView and PropertyView': split tree view and property view into separate panel.
-'Both': keep all three panels, and you can have two sets of tree view and property view.</string>
+'TreeView and PropertyView': split tree view and property view into separate panel.</string>
          </property>
         </widget>
        </item>

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.ui
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.ui
@@ -253,7 +253,7 @@ this according to your screen size or personal taste</string>
        <item row="2" column="0">
         <widget class="QLabel" name="treeModeLabel">
          <property name="text">
-          <string>Tree view mode:</string>
+          <string>Tree view and Property view mode:</string>
          </property>
         </widget>
        </item>
@@ -262,8 +262,8 @@ this according to your screen size or personal taste</string>
          <property name="toolTip">
           <string>Customize how tree view is shown in the panel (restart required).
 
-'ComboView': combine tree view and property view into one panel.
-'TreeView and PropertyView': split tree view and property view into separate panel.</string>
+'Combined': combine Tree view and Property view into one panel.
+'Independent': split Tree view and Property view into separate panels.</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
For Preferences > General > Application > Tree view mode:

- Remove the 'Both' option from the tooltip, as this option is no longer available.
- Rephrase the ComboView option (and by extension the TreeView and PropertyView) to be simpler and self-descriptive.
- Allows for an easier and more genuine translation

**Before**:
![Captura de pantalla de 2024-06-27 14-01-44](https://github.com/FreeCAD/FreeCAD/assets/148809153/d67e1a4a-778a-40d7-bc9b-19e3780ec441)
![image](https://github.com/FreeCAD/FreeCAD/assets/148809153/c4f4bee3-4d14-4118-96d8-1f3ee16e8aad)

**After**:
![image](https://github.com/FreeCAD/FreeCAD/assets/148809153/944717e5-ec4e-4126-9d9e-f9c9f9644c46)
![image](https://github.com/FreeCAD/FreeCAD/assets/148809153/5c68a48b-b0f9-4ec5-899d-2c3b95a798c7)
