### PR TITLE
Core: Fix a missing Python interpreter lock

### DIFF
--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -377,11 +377,13 @@ public:
     ~Data()
     {
         if (replace_stdout) {
+            Base::PyGILStateLocker lock;
             Py_DECREF(replace_stdout);
             replace_stdout = nullptr;
         }
 
         if (replace_stderr) {
+            Base::PyGILStateLocker lock;
             Py_DECREF(replace_stderr);
             replace_stderr = nullptr;
         }


### PR DESCRIPTION
ReportView has a missing Python interpreter lock.  It is not breaking FreeCAD in general but it is deemed a bug nonetheless.  See #14957.

Closes #14957.