### PR TITLE
Sketcher: BSpline DSH: Fix crash #14964

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -88,6 +88,12 @@ public:
         , resetSeekSecond(false) {};
     ~DrawSketchHandlerBSpline() override = default;
 
+    void activated() override
+    {
+        DrawSketchHandlerBSplineBase::activated();
+        Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch bSpline"));
+    }
+
 private:
     void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
@@ -453,7 +459,6 @@ private:
             ? Sketcher::PointPos::mid
             : Sketcher::PointPos::start;
         if (state() == SelectMode::SeekFirst) {
-            Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch bSpline"));
             // insert point for pole/knot, defer internal alignment constraining.
             if (!addPos()) {
                 return false;
@@ -546,6 +551,7 @@ private:
     {
         Gui::Command::abortCommand();
         tryAutoRecomputeIfNotSolve(sketchgui->getSketchObject());
+        Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch bSpline"));
 
         SplineDegree = 3;
         geoIds.clear();


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/14964

If you created a new sketch, then start the bspline tool and change mode, it would crash.
It's because it was doing a abortCommand on reseting the tool before the command was opened. So it cancelled the create sketch command. The sketch object being gone the tool handler caused an illegal storage access while trying to access it.