### PR TITLE
cMake: Make a failure to import Pivy non-fatal

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
+++ b/cMake/FreeCAD_Helpers/SetupCoin3D.cmake
@@ -37,7 +37,7 @@ macro(SetupCoin3D)
         if (RETURN_CODE EQUAL 0)
             message(STATUS "Found Pivy ${PIVY_VERSION}")
         else ()
-            message(FATAL_ERROR "Failed to import Pivy using ${Python3_EXECUTABLE}")
+            message(ERROR "Failed to import Pivy using ${Python3_EXECUTABLE}")
         endif ()
     ENDIF ()
 


### PR DESCRIPTION
Making this a fatal error kills the Snap builds. Fixes #14955