### PR TITLE
MeasureGui: Add MeasureDistance X, Y and Z components back

### DIFF
--- a/src/Gui/InventorAll.h
+++ b/src/Gui/InventorAll.h
@@ -132,6 +132,7 @@
 #include <Inventor/engines/SoComposeRotationFromTo.h>
 #include <Inventor/engines/SoComposeRotation.h>
 #include <Inventor/engines/SoConcatenate.h>
+#include <Inventor/engines/SoDecomposeVec3f.h>
 #include <Inventor/engines/SoTransformVec3f.h>
 
 #include <Inventor/errors/SoDebugError.h>

--- a/src/Mod/Measure/App/MeasureDistance.cpp
+++ b/src/Mod/Measure/App/MeasureDistance.cpp
@@ -51,6 +51,16 @@ MeasureDistance::MeasureDistance()
                                             "Distance between the two elements");
     Distance.setUnit(Base::Unit::Length);
 
+    ADD_PROPERTY_TYPE(DistanceX,(0.0),"Measurement",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
+                                            "Distance in X direction");
+    DistanceX.setUnit(Base::Unit::Length);
+    ADD_PROPERTY_TYPE(DistanceY,(0.0),"Measurement",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
+                                            "Distance in Y direction");
+    DistanceY.setUnit(Base::Unit::Length);
+    ADD_PROPERTY_TYPE(DistanceZ,(0.0),"Measurement",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
+                                            "Distance in Z direction");
+    DistanceZ.setUnit(Base::Unit::Length);
+
     ADD_PROPERTY_TYPE(Position1,(Base::Vector3d(0.0,0.0,0.0)),"Measurement", App::Prop_Hidden, "Position1");
     ADD_PROPERTY_TYPE(Position2,(Base::Vector3d(0.0,1.0,0.0)),"Measurement", App::Prop_Hidden, "Position2");
 
@@ -197,7 +207,11 @@ App::DocumentObjectExecReturn *MeasureDistance::execute()
         return new App::DocumentObjectExecReturn("Could not get extrema");
     }
 
+    gp_Pnt delta = measure.PointOnShape2(1).XYZ() - measure.PointOnShape1(1).XYZ();
     Distance.setValue(measure.Value());
+    DistanceX.setValue(fabs(delta.X()));
+    DistanceY.setValue(fabs(delta.Y()));
+    DistanceZ.setValue(fabs(delta.Z()));
 
     gp_Pnt p1 = measure.PointOnShape1(1);
     Position1.setValue(p1.X(), p1.Y(), p1.Z());
@@ -239,6 +253,16 @@ MeasureDistanceDetached::MeasureDistanceDetached()
                                             "Distance between the two elements");
     Distance.setUnit(Base::Unit::Length);
 
+    ADD_PROPERTY_TYPE(DistanceX,(0.0),"Measurement",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
+                                            "Distance in X direction");
+    DistanceX.setUnit(Base::Unit::Length);
+    ADD_PROPERTY_TYPE(DistanceY,(0.0),"Measurement",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
+                                            "Distance in Y direction");
+    DistanceY.setUnit(Base::Unit::Length);
+    ADD_PROPERTY_TYPE(DistanceZ,(0.0),"Measurement",App::PropertyType(App::Prop_ReadOnly|App::Prop_Output),
+                                            "Distance in Z direction");
+    DistanceZ.setUnit(Base::Unit::Length);
+
     ADD_PROPERTY_TYPE(Position1,(Base::Vector3d(0.0,0.0,0.0)),"Measurement", App::Prop_None, "Position1");
     ADD_PROPERTY_TYPE(Position2,(Base::Vector3d(0.0,1.0,0.0)),"Measurement", App::Prop_None, "Position2");
 }
@@ -269,6 +293,9 @@ void MeasureDistanceDetached::recalculateDistance()
 {
     auto delta = Position1.getValue() - Position2.getValue();
     Distance.setValue(delta.Length());
+    DistanceX.setValue(fabs(delta.x));
+    DistanceY.setValue(fabs(delta.y));
+    DistanceZ.setValue(fabs(delta.z));
 }
 
 void MeasureDistanceDetached::onChanged(const App::Property* prop)

--- a/src/Mod/Measure/App/MeasureDistance.h
+++ b/src/Mod/Measure/App/MeasureDistance.h
@@ -63,6 +63,9 @@ public:
     App::PropertyLinkSub Element1;
     App::PropertyLinkSub Element2;
     App::PropertyDistance Distance;
+    App::PropertyDistance DistanceX;
+    App::PropertyDistance DistanceY;
+    App::PropertyDistance DistanceZ;
 
     // Position properties for the viewprovider
     App::PropertyVector Position1;
@@ -106,6 +109,9 @@ public:
     ~MeasureDistanceDetached() override;
 
     App::PropertyDistance Distance;
+    App::PropertyDistance DistanceX;
+    App::PropertyDistance DistanceY;
+    App::PropertyDistance DistanceZ;
 
     App::PropertyVector Position1;
     App::PropertyVector Position2;

--- a/src/Mod/Measure/Gui/AppMeasureGui.cpp
+++ b/src/Mod/Measure/Gui/AppMeasureGui.cpp
@@ -89,6 +89,8 @@ PyMOD_INIT_FUNC(MeasureGui)
     // instantiating the commands
     CreateMeasureCommands();
 
+    MeasureGui::DimensionLinear::initClass();
+
     MeasureGui::ViewProviderMeasureGroup               ::init();
     MeasureGui::ViewProviderMeasureBase                ::init();
     MeasureGui::ViewProviderMeasure                    ::init();

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -84,6 +84,10 @@ ViewProviderMeasureBase::ViewProviderMeasureBase()
     ADD_PROPERTY_TYPE(FontSize, (Preferences::defaultFontSize()), agroup, App::Prop_None, "Size of measurement text");
 //NOLINTEND
 
+    pGlobalSeparator = new SoSeparator();
+    pGlobalSeparator->ref();
+    getRoot()->insertChild(pGlobalSeparator, 0);
+
     // setupAnnoSceneGraph() - sets up the annotation scene graph
     pLabel = new Gui::SoFrameLabel();
     pLabel->ref();
@@ -175,6 +179,7 @@ ViewProviderMeasureBase::ViewProviderMeasureBase()
 ViewProviderMeasureBase::~ViewProviderMeasureBase()
 {
     _mVisibilityChangedConnection.disconnect();
+    pGlobalSeparator->unref();
     pLabel->unref();
     pColor->unref();
     pDragger->unref();

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.h
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.h
@@ -134,6 +134,7 @@ protected:
     // TODO: getters & setters and move variables to private?
     bool _mShowTree = true;
 
+    SoSeparator* pGlobalSeparator; // Separator in the global coordinate space
     Gui::SoFrameLabel * pLabel;
     SoTranslate2Dragger* pDragger;
     SoTransform* pDraggerOrientation;

--- a/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
@@ -450,13 +450,16 @@ void ViewProviderMeasureDistance::redrawAnnotation()
 
     // Set delta distance
     auto propDistanceX = static_cast<App::PropertyDistance*>(getMeasureObject()->getPropertyByName("DistanceX"));
-    static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(0))->text.setValue(propDistanceX->getQuantityValue().getUserString().toUtf8());
+    static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(0))
+        ->text.setValue("Δx " + propDistanceX->getQuantityValue().getUserString().toUtf8());
 
     auto propDistanceY = static_cast<App::PropertyDistance*>(getMeasureObject()->getPropertyByName("DistanceY"));
-    static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(1))->text.setValue(propDistanceY->getQuantityValue().getUserString().toUtf8());
+    static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(1))
+        ->text.setValue("Δy " + propDistanceY->getQuantityValue().getUserString().toUtf8());
 
     auto propDistanceZ = static_cast<App::PropertyDistance*>(getMeasureObject()->getPropertyByName("DistanceZ"));
-    static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(2))->text.setValue(propDistanceZ->getQuantityValue().getUserString().toUtf8());
+    static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(2))
+        ->text.setValue("Δz " + propDistanceZ->getQuantityValue().getUserString().toUtf8());
 
     // Set matrix
     SbMatrix matrix = getMatrix();

--- a/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
@@ -451,15 +451,15 @@ void ViewProviderMeasureDistance::redrawAnnotation()
     // Set delta distance
     auto propDistanceX = static_cast<App::PropertyDistance*>(getMeasureObject()->getPropertyByName("DistanceX"));
     static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(0))
-        ->text.setValue("Δx " + propDistanceX->getQuantityValue().getUserString().toUtf8());
+        ->text.setValue("Δx: " + propDistanceX->getQuantityValue().getUserString().toUtf8());
 
     auto propDistanceY = static_cast<App::PropertyDistance*>(getMeasureObject()->getPropertyByName("DistanceY"));
     static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(1))
-        ->text.setValue("Δy " + propDistanceY->getQuantityValue().getUserString().toUtf8());
+        ->text.setValue("Δy: " + propDistanceY->getQuantityValue().getUserString().toUtf8());
 
     auto propDistanceZ = static_cast<App::PropertyDistance*>(getMeasureObject()->getPropertyByName("DistanceZ"));
     static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(2))
-        ->text.setValue("Δz " + propDistanceZ->getQuantityValue().getUserString().toUtf8());
+        ->text.setValue("Δz: " + propDistanceZ->getQuantityValue().getUserString().toUtf8());
 
     // Set matrix
     SbMatrix matrix = getMatrix();

--- a/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
@@ -413,7 +413,7 @@ ViewProviderMeasureDistance::ViewProviderMeasureDistance()
     pDeltaDimensionSwitch->addChild(dimDeltaY);
     pDeltaDimensionSwitch->addChild(dimDeltaZ);
 
-    // This should alredy be touched in ViewProviderMeasureBase
+    // This should already be touched in ViewProviderMeasureBase
     FontSize.touch();
 }
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
@@ -95,6 +95,7 @@ MeasureGui::DimensionLinear::DimensionLinear()
     SO_NODE_ADD_FIELD(origin, (0.0, 0.0, 0.0));       // static
     SO_NODE_ADD_FIELD(text, ("test"));                // dimension text
     SO_NODE_ADD_FIELD(dColor, (1.0, 0.0, 0.0));       // dimension color.
+    SO_NODE_ADD_FIELD(backgroundColor, (1.0, 1.0, 1.0));
     SO_NODE_ADD_FIELD(showArrows, (false));           // display dimension arrows
     SO_NODE_ADD_FIELD(fontSize, (12.0));                // size of the dimension font
 }
@@ -216,9 +217,11 @@ void MeasureGui::DimensionLinear::setupDimension()
     fontNode->size.connectFrom(&fontSize);
     textSep->addChild(fontNode);
 
-    SoText2* textNode = new SoText2();
+    auto textNode = new SoFrameLabel();
     textNode->justification = SoText2::CENTER;
     textNode->string.connectFrom(&text);
+    textNode->textColor.connectFrom(&dColor);
+    textNode->backgroundColor.connectFrom(&backgroundColor);
     textSep->addChild(textNode);
 
     // this prevents the 2d text from screwing up the bounding box for a viewall
@@ -477,7 +480,13 @@ void ViewProviderMeasureDistance::onChanged(const App::Property* prop) {
         static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(0))->fontSize.setValue(FontSize.getValue());
         static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(1))->fontSize.setValue(FontSize.getValue());
         static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(2))->fontSize.setValue(FontSize.getValue());
+    } else if (prop == &TextBackgroundColor) {
+        auto bColor = TextBackgroundColor.getValue();
+        static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(0))->backgroundColor.setValue(bColor.r, bColor.g, bColor.g);
+        static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(1))->backgroundColor.setValue(bColor.r, bColor.g, bColor.g);
+        static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(2))->backgroundColor.setValue(bColor.r, bColor.g, bColor.g);
     }
+    
 
     ViewProviderMeasureBase::onChanged(prop);
 }

--- a/src/Mod/Measure/Gui/ViewProviderMeasureDistance.h
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureDistance.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (c) 2023 David Friedli <david[at]friedli-be.ch>             *
+ *   Copyright (c) 2013 Thomas Anderson <blobfish[at]gmx.com>              *
  *                                                                         *
  *   This file is part of FreeCAD.                                         *
  *                                                                         *
@@ -28,12 +29,57 @@
 #include <Mod/Measure/MeasureGlobal.h>
 #include "ViewProviderMeasureBase.h"
 
+#include <Inventor/engines/SoSubEngine.h>
+#include <Inventor/engines/SoEngine.h>
+#include <Inventor/fields/SoSFBool.h>
+#include <Inventor/fields/SoSFColor.h>
+#include <Inventor/fields/SoSFFloat.h>
+#include <Inventor/fields/SoSFMatrix.h>
+#include <Inventor/fields/SoSFRotation.h>
+#include <Inventor/fields/SoSFString.h>
+#include <Inventor/fields/SoSFVec3f.h>
+#include <Inventor/nodekits/SoSeparatorKit.h>
+
 
 class SoCoordinate3;
 class SoIndexedLineSet;
 
 namespace MeasureGui
 {
+
+class DimensionLinear: public SoSeparatorKit
+{
+    SO_KIT_HEADER(DimensionLinear);
+
+    SO_KIT_CATALOG_ENTRY_HEADER(transformation);
+    SO_KIT_CATALOG_ENTRY_HEADER(annotate);
+    SO_KIT_CATALOG_ENTRY_HEADER(leftArrow);
+    SO_KIT_CATALOG_ENTRY_HEADER(rightArrow);
+    SO_KIT_CATALOG_ENTRY_HEADER(line);
+    SO_KIT_CATALOG_ENTRY_HEADER(textSep);
+
+public:
+    DimensionLinear();
+    static void initClass();
+    SbBool affectsState() const override;
+    void setupDimension();
+
+    SoSFVec3f point1;
+    SoSFVec3f point2;
+    SoSFString text;
+    SoSFColor dColor;
+    SoSFBool showArrows;
+    SoSFFloat fontSize;
+
+protected:
+    SoSFRotation rotate;
+    SoSFFloat length;
+    SoSFVec3f origin;
+
+private:
+    ~DimensionLinear() override;
+};
+
 
 
 class MeasureGuiExport ViewProviderMeasureDistance : public MeasureGui::ViewProviderMeasureBase

--- a/src/Mod/Measure/Gui/ViewProviderMeasureDistance.h
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureDistance.h
@@ -68,6 +68,7 @@ public:
     SoSFVec3f point2;
     SoSFString text;
     SoSFColor dColor;
+    SoSFColor backgroundColor;
     SoSFBool showArrows;
     SoSFFloat fontSize;
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureDistance.h
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureDistance.h
@@ -91,17 +91,25 @@ public:
     ViewProviderMeasureDistance();
     ~ViewProviderMeasureDistance() override;
 
+    App::PropertyBool ShowDelta;
+
     void redrawAnnotation() override;
     void positionAnno(const Measure::MeasureBase* measureObject) override;
 
 protected:
     Base::Vector3d getTextDirection(Base::Vector3d elementDirection, double tolerance = defaultTolerance) override;
+    void onChanged(const App::Property* prop) override;
 
 private:
-    SoCoordinate3    * pCoords;
-    SoIndexedLineSet * pLines;
+    SoCoordinate3* pCoords;
+    SoIndexedLineSet* pLines;
+    SoSwitch* pDeltaDimensionSwitch;
 
-    SoSFFloat         fieldDistance;
+    SoSFVec3f fieldPosition1;
+    SoSFVec3f fieldPosition2;
+
+    SoSFFloat fieldDistance;
+
 
     SbMatrix getMatrix();
 };


### PR DESCRIPTION
As [requested](#13741), this adds back the ability to display the X, Y and Z components of a measured distance. This PR adds the following:
- DistanceX, DistanceY, DistanceZ properties on the MeasureDistance feature
- The previously removed PartGui::DimensionLinear nodekit (now in the MeasureGui namespace)
- ShowDelta property on the ViewProviderMeasureDistance which is set to false by default
- The three component dimensions with a value text and colored in the axis colors

To see the components the user currently has to create a distance constraint and manually set the view property "Show Delta" to true.

![Screenshot from 2024-06-27 11-20-30](https://github.com/FreeCAD/FreeCAD/assets/64740362/664bc00e-1472-402a-a5d9-a0aa051215cd)
![Screenshot from 2024-06-28 14-23-07](https://github.com/FreeCAD/FreeCAD/assets/64740362/41fd5774-ed76-4458-9cfe-6ed7ea757279)

fixes #13741