### PR TITLE
[TD]Fix template autofill - show autofill value and handle multiple spellings

### DIFF
--- a/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
+++ b/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
@@ -86,7 +86,7 @@ void DrawSVGTemplate::onChanged(const App::Property* prop)
         replaceFileIncluded(Template.getValue());
         EditableTexts.setValues(getEditableTextsFromTemplate());
         QDomDocument templateDocument;
-        if (getTemplateDocument(Template.getValue(), templateDocument)) {
+        if (getTemplateDocument(PageResult.getValue(), templateDocument)) {
             extractTemplateAttributes(templateDocument);
         }
     }
@@ -251,7 +251,7 @@ std::map<std::string, std::string> DrawSVGTemplate::getEditableTextsFromTemplate
     std::map<std::string, std::string> editables;
 
     QDomDocument templateDocument;
-    if (!getTemplateDocument(Template.getValue(), templateDocument)) {
+    if (!getTemplateDocument(PageResult.getValue(), templateDocument)) {
         return editables;
     }
 
@@ -294,7 +294,7 @@ QString  DrawSVGTemplate::getAutofillByEditableName(QString nameToMatch)
     QString nameCapture{nameToMatch};
 
     QDomDocument templateDocument;
-    if (!getTemplateDocument(Template.getValue(), templateDocument)) {
+    if (!getTemplateDocument(PageResult.getValue(), templateDocument)) {
         return {};
     }
 

--- a/src/Mod/TechDraw/App/DrawTemplate.cpp
+++ b/src/Mod/TechDraw/App/DrawTemplate.cpp
@@ -145,8 +145,11 @@ QString DrawTemplate::getAutofillValue(const QString &id) const
         QDateTime date = QDateTime::currentDateTime();
         return date.toString(QLocale().dateFormat(QLocale::ShortFormat));
     }
-    // organization
-    else if (id.compare(QString::fromUtf8(Autofill::Organization)) == 0) {
+    // organization ( also organisation/owner/company )
+    else if (id.compare(QString::fromUtf8(Autofill::Organization)) == 0 ||
+             id.compare(QString::fromUtf8(Autofill::Organisation)) == 0 ||
+             id.compare(QString::fromUtf8(Autofill::Owner)) == 0 ||
+             id.compare(QString::fromUtf8(Autofill::Company)) == 0 ) {
         auto value = QString::fromUtf8(doc->Company.getValue());
         if (!value.isEmpty()) {
             return value;

--- a/src/Mod/TechDraw/App/DrawTemplate.h
+++ b/src/Mod/TechDraw/App/DrawTemplate.h
@@ -74,6 +74,9 @@ public:
             static constexpr const char *Author       = "author";
             static constexpr const char *Date         = "date";
             static constexpr const char *Organization = "organization";
+            static constexpr const char *Organisation = "organisation";
+            static constexpr const char *Owner        = "owner";
+            static constexpr const char *Company      = "company";
             static constexpr const char *Scale        = "scale";
             static constexpr const char *Sheet        = "sheet";
             static constexpr const char *Title        = "title";

--- a/src/Mod/TechDraw/Gui/DlgTemplateField.cpp
+++ b/src/Mod/TechDraw/Gui/DlgTemplateField.cpp
@@ -62,6 +62,12 @@ void DlgTemplateField::setFieldContent(std::string content)
     ui->leInput->setText(qs);
 }
 
+void DlgTemplateField::setAutofillContent(std::string content)
+{
+    QString qs = QString::fromUtf8(content.data(), content.size());
+    ui->leAutofill->setText(qs);
+}
+
 QString DlgTemplateField::getFieldContent()
 {
     return ui->leInput->text();

--- a/src/Mod/TechDraw/Gui/DlgTemplateField.h
+++ b/src/Mod/TechDraw/Gui/DlgTemplateField.h
@@ -44,6 +44,7 @@ public:
     void setFieldName(std::string name);
     void setFieldLength(int length);
     void setFieldContent(std::string content);
+    void setAutofillContent(std::string content);
     QString getFieldContent();
     bool getAutofillState();
 

--- a/src/Mod/TechDraw/Gui/DlgTemplateField.ui
+++ b/src/Mod/TechDraw/Gui/DlgTemplateField.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>340</width>
-    <height>127</height>
+    <height>132</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -53,6 +53,19 @@
        </property>
        <property name="text">
         <string>Autofill</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="leAutofill">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>The autofill replacement value.</string>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -230,6 +230,8 @@ void QGISVGTemplate::createClickHandles()
         textLength = std::max(charWidth, textLength);
 
         auto item(new TemplateTextField(this, svgTemplate, name.toStdString()));
+        auto autoValue = svgTemplate->getAutofillByEditableName(name);
+        item->setAutofill(autoValue);
 
         double pad = 1.0;
         double top = Rez::guiX(-svgTemplate->getHeight()) + y - textHeight - pad;

--- a/src/Mod/TechDraw/Gui/TemplateTextField.cpp
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.cpp
@@ -78,6 +78,7 @@ void TemplateTextField::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 
         ui.setFieldName(fieldNameStr);
         ui.setFieldContent(tmplte->EditableTexts[fieldNameStr]);
+        ui.setAutofillContent(Base::Tools::toStdString(m_autofillString));
 
         if (ui.exec() == QDialog::Accepted) {
             QString qsClean = ui.getFieldContent();
@@ -99,6 +100,13 @@ void TemplateTextField::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         QGraphicsItemGroup::mouseReleaseEvent(event);
     }
 }
+
+//void setAutofill(std::string autofillString);
+void TemplateTextField::setAutofill(QString autofillString)
+{
+    m_autofillString = autofillString;
+}
+
 
 void TemplateTextField::setRectangle(QRectF rect)
 {

--- a/src/Mod/TechDraw/Gui/TemplateTextField.h
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.h
@@ -55,6 +55,7 @@ class TechDrawGuiExport TemplateTextField : public QGraphicsItemGroup
         /// Returns the field name that this TemplateTextField represents
         std::string fieldName() const { return fieldNameStr; }
 
+        void setAutofill(QString autofillString);
         void setRectangle(QRectF rect);
         void setLine(QPointF from, QPointF to);
         void setLineColor(QColor color);
@@ -62,6 +63,7 @@ class TechDrawGuiExport TemplateTextField : public QGraphicsItemGroup
     protected:
         TechDraw::DrawTemplate *tmplte;
         std::string fieldNameStr;
+        QString m_autofillString;
 
         /// Need this to properly handle mouse release
         void mousePressEvent(QGraphicsSceneMouseEvent *event) override;


### PR DESCRIPTION
This PR is a continuation of PR #14863 and implements a fix for the display of autofill value and handling of various common spellings in svg code as discussed here: https://forum.freecad.org/viewtopic.php?t=88142