### PR TITLE
Sketcher: Increase default width of dashed lines

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -151,15 +151,15 @@ void EditModeCoinManager::ParameterObserver::initParameters()
          }},
         {"ConstructionWidth",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
-             updateWidth(drawingParameters.ConstructionWidth, param, 1);
+             updateWidth(drawingParameters.ConstructionWidth, param, 2);
          }},
         {"InternalWidth",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
-             updateWidth(drawingParameters.InternalWidth, param, 1);
+             updateWidth(drawingParameters.InternalWidth, param, 2);
          }},
         {"ExternalWidth",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {
-             updateWidth(drawingParameters.ExternalWidth, param, 1);
+             updateWidth(drawingParameters.ExternalWidth, param, 2);
          }},
         {"EdgePattern",
          [this, &drawingParameters = Client.drawingParameters](const std::string& param) {

--- a/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsAppearance.ui
@@ -371,7 +371,7 @@
          <number>99</number>
         </property>
         <property name="value">
-         <number>1</number>
+         <number>2</number>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>ConstructionWidth</cstring>
@@ -465,7 +465,7 @@
          <number>99</number>
         </property>
         <property name="value">
-         <number>1</number>
+         <number>2</number>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>InternalWidth</cstring>
@@ -533,7 +533,7 @@
          <number>99</number>
         </property>
         <property name="value">
-         <number>1</number>
+         <number>2</number>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>ExternalWidth</cstring>


### PR DESCRIPTION
A tiny step towards #13318, makes the construction, external and internal alignment lines a bit more visible by default.

Before:

![before](https://github.com/FreeCAD/FreeCAD/assets/59876896/6fb1338a-89c8-4bed-8f9d-6329771567da)

After:

![after](https://github.com/FreeCAD/FreeCAD/assets/59876896/51ea7216-9be7-4fff-a5e6-9ef934f94f96)
