### PR TITLE
TechDraw: Fix 14038 and Refactor CommandCreateDims 

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -96,6 +96,7 @@ void execAngle3Pt(Gui::Command* cmd);
 void execRadius(Gui::Command* cmd);
 void execDiameter(Gui::Command* cmd);
 void execArea(Gui::Command* cmd);
+void execDim(Gui::Command* cmd, std::string type, StringVector acceptableGeometry, std::vector<int> minimumCounts, std::vector<DimensionGeometryType> acceptableDimensionGeometrys);
 
 void execExtent(Gui::Command* cmd, const std::string& dimType);
 
@@ -1520,85 +1521,13 @@ bool CmdTechDrawRadiusDimension::isActive()
 
 void execRadius(Gui::Command* cmd)
 {
-    bool result = _checkDrawViewPart(cmd);
-    if (!result) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect selection"),
-                             QObject::tr("No View of a Part in selection."));
-        return;
-    }
-
-    ReferenceVector references2d;
-    ReferenceVector references3d;
-    TechDraw::DrawViewPart* partFeat =
-        TechDraw::getReferencesFromSelection(references2d, references3d);
-
     //Define the geometric configuration required for a radius dimension
     StringVector acceptableGeometry({"Edge"});
     std::vector<int> minimumCounts({1});
     std::vector<DimensionGeometryType> acceptableDimensionGeometrys(
         {isCircle, isEllipse, isBSplineCircle, isBSpline});
 
-    //what 2d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs2d = validateDimSelection(
-        references2d, acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
-    if (geometryRefs2d == TechDraw::isInvalid) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect Selection"),
-                             QObject::tr("Can not make 2d radius dimension from selection"));
-        return;
-    }
-
-    //what 3d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs3d(isInvalid);
-    if (geometryRefs2d == TechDraw::isViewReference && !references3d.empty()) {
-        geometryRefs3d = validateDimSelection3d(partFeat,
-                                                references3d,
-                                                acceptableGeometry,
-                                                minimumCounts,
-                                                acceptableDimensionGeometrys);
-        if (geometryRefs3d == TechDraw::isInvalid) {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Incorrect Selection"),
-                                 QObject::tr("Can not make 3d radius dimension from selection"));
-            return;
-        }
-    }
-
-    //errors and warnings
-    if (geometryRefs2d == isEllipse || geometryRefs3d == isEllipse) {
-        QMessageBox::StandardButton result = QMessageBox::warning(
-            Gui::getMainWindow(),
-            QObject::tr("Ellipse Curve Warning"),
-            QObject::tr("Selected edge is an Ellipse.  Radius will be approximate. Continue?"),
-            QMessageBox::Ok | QMessageBox::Cancel,
-            QMessageBox::Cancel);
-        if (result != QMessageBox::Ok) {
-            return;
-        }
-    }
-    if (geometryRefs2d == isBSplineCircle || geometryRefs3d == isBSplineCircle) {
-        QMessageBox::StandardButton result = QMessageBox::warning(
-            Gui::getMainWindow(),
-            QObject::tr("BSpline Curve Warning"),
-            QObject::tr("Selected edge is a BSpline.  Radius will be approximate. Continue?"),
-            QMessageBox::Ok | QMessageBox::Cancel,
-            QMessageBox::Cancel);
-        if (result != QMessageBox::Ok) {
-            return;
-        }
-    }
-    if (geometryRefs2d == isBSpline || geometryRefs3d == isBSpline) {
-        QMessageBox::critical(
-            Gui::getMainWindow(),
-            QObject::tr("BSpline Curve Error"),
-            QObject::tr("Selected edge is a BSpline and a radius can not be calculated."));
-        return;
-    }
-
-    //build the dimension
-    //    DrawViewDimension* dim =
-    dimensionMaker(partFeat, "Radius", references2d, references3d);
+    execDim(cmd, "Radius", acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
 }
 
 //===========================================================================
@@ -1642,85 +1571,13 @@ bool CmdTechDrawDiameterDimension::isActive()
 
 void execDiameter(Gui::Command* cmd)
 {
-    bool result = _checkDrawViewPart(cmd);
-    if (!result) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect selection"),
-                             QObject::tr("No View of a Part in selection."));
-        return;
-    }
-
-    ReferenceVector references2d;
-    ReferenceVector references3d;
-    TechDraw::DrawViewPart* partFeat =
-        TechDraw::getReferencesFromSelection(references2d, references3d);
-
     //Define the geometric configuration required for a diameter dimension
     StringVector acceptableGeometry({"Edge"});
     std::vector<int> minimumCounts({1});
     std::vector<DimensionGeometryType> acceptableDimensionGeometrys(
         {isCircle, isEllipse, isBSplineCircle, isBSpline});
 
-    //what 2d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs2d = validateDimSelection(
-        references2d, acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
-    if (geometryRefs2d == TechDraw::isInvalid) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect Selection"),
-                             QObject::tr("Can not make 2d diameter dimension from selection"));
-        return;
-    }
-
-    //what 3d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs3d(isInvalid);
-    if (geometryRefs2d == TechDraw::isViewReference && !references3d.empty()) {
-        geometryRefs3d = validateDimSelection3d(partFeat,
-                                                references3d,
-                                                acceptableGeometry,
-                                                minimumCounts,
-                                                acceptableDimensionGeometrys);
-        if (geometryRefs3d == TechDraw::isInvalid) {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Incorrect Selection"),
-                                 QObject::tr("Can not make 3d diameter dimension from selection"));
-            return;
-        }
-    }
-
-    //errors and warnings
-    if (geometryRefs2d == isEllipse || geometryRefs3d == isEllipse) {
-        QMessageBox::StandardButton result = QMessageBox::warning(
-            Gui::getMainWindow(),
-            QObject::tr("Ellipse Curve Warning"),
-            QObject::tr("Selected edge is an Ellipse.  Diameter will be approximate. Continue?"),
-            QMessageBox::Ok | QMessageBox::Cancel,
-            QMessageBox::Cancel);
-        if (result != QMessageBox::Ok) {
-            return;
-        }
-    }
-    if (geometryRefs2d == isBSplineCircle || geometryRefs3d == isBSplineCircle) {
-        QMessageBox::StandardButton result = QMessageBox::warning(
-            Gui::getMainWindow(),
-            QObject::tr("BSpline Curve Warning"),
-            QObject::tr("Selected edge is a BSpline.  Diameter will be approximate. Continue?"),
-            QMessageBox::Ok | QMessageBox::Cancel,
-            QMessageBox::Cancel);
-        if (result != QMessageBox::Ok) {
-            return;
-        }
-    }
-    if (geometryRefs2d == isBSpline || geometryRefs3d == isBSpline) {
-        QMessageBox::critical(
-            Gui::getMainWindow(),
-            QObject::tr("BSpline Curve Error"),
-            QObject::tr("Selected edge is a BSpline and a diameter can not be calculated."));
-        return;
-    }
-
-    //build the dimension
-    //    DrawViewDimension* dim =
-    dimensionMaker(partFeat, "Diameter", references2d, references3d);
+    execDim(cmd, "Diameter", acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
 }
 
 //===========================================================================
@@ -1764,58 +1621,12 @@ bool CmdTechDrawLengthDimension::isActive()
 
 void execDistance(Gui::Command* cmd)
 {
-    bool result = _checkDrawViewPart(cmd);
-    if (!result) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect selection"),
-                             QObject::tr("No View of a Part in selection."));
-        return;
-    }
-
-    ReferenceVector references2d;
-    ReferenceVector references3d;
-    TechDraw::DrawViewPart* partFeat =
-        TechDraw::getReferencesFromSelection(references2d, references3d);
-
-    //Define the geometric configuration required for a length dimension
     StringVector acceptableGeometry({"Edge", "Vertex"});
     std::vector<int> minimumCounts({1, 2});
     std::vector<DimensionGeometryType> acceptableDimensionGeometrys(
         {isVertical, isHorizontal, isDiagonal, isHybrid});
 
-    //what 2d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs2d = validateDimSelection(
-        references2d, acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
-
-    if (geometryRefs2d == TechDraw::isInvalid) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect Selection"),
-                             QObject::tr("Can not make 2d linear dimension from selection"));
-        return;
-    }
-
-    //what 3d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs3d;
-    if (geometryRefs2d == TechDraw::isViewReference && !references3d.empty()) {
-        geometryRefs3d = validateDimSelection3d(partFeat,
-                                                references3d,
-                                                acceptableGeometry,
-                                                minimumCounts,
-                                                acceptableDimensionGeometrys);
-
-        if (geometryRefs3d == TechDraw::isInvalid) {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Incorrect Selection"),
-                                 QObject::tr("Can not make 3d linear dimension from selection"));
-            return;
-        }
-    }
-
-    //build the dimension
-    DrawViewDimension* dim = dimensionMaker(partFeat, "Distance", references2d, references3d);
-
-    //position the Dimension text on the view
-    positionDimText(dim);
+    execDim(cmd, "Distance", acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
 }
 
 //===========================================================================
@@ -1860,56 +1671,12 @@ bool CmdTechDrawHorizontalDimension::isActive()
 
 void execDistanceX(Gui::Command* cmd)
 {
-    bool result = _checkDrawViewPart(cmd);
-    if (!result) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect selection"),
-                             QObject::tr("No View of a Part in selection."));
-        return;
-    }
-
-    ReferenceVector references2d;
-    ReferenceVector references3d;
-    TechDraw::DrawViewPart* partFeat =
-        TechDraw::getReferencesFromSelection(references2d, references3d);
-
     //Define the geometric configuration required for a length dimension
     StringVector acceptableGeometry({"Edge", "Vertex"});
     std::vector<int> minimumCounts({1, 2});
     std::vector<DimensionGeometryType> acceptableDimensionGeometrys({isHorizontal, isDiagonal, isHybrid});
 
-    //what 2d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs2d = validateDimSelection(
-        references2d, acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
-    if (geometryRefs2d == TechDraw::isInvalid) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect Selection"),
-                             QObject::tr("Can not make 2d horizontal dimension from selection"));
-        return;
-    }
-
-    //what 3d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs3d;
-    if (geometryRefs2d == TechDraw::isViewReference && !references3d.empty()) {
-        geometryRefs3d = validateDimSelection3d(partFeat,
-                                                references3d,
-                                                acceptableGeometry,
-                                                minimumCounts,
-                                                acceptableDimensionGeometrys);
-        if (geometryRefs3d == TechDraw::isInvalid) {
-            QMessageBox::warning(
-                Gui::getMainWindow(),
-                QObject::tr("Incorrect Selection"),
-                QObject::tr("Can not make 3d horizontal dimension from selection"));
-            return;
-        }
-    }
-
-    //build the dimension
-    DrawViewDimension* dim = dimensionMaker(partFeat, "DistanceX", references2d, references3d);
-
-    //position the Dimension text on the view
-    positionDimText(dim);
+    execDim(cmd, "DistanceX", acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
 }
 
 //===========================================================================
@@ -1954,55 +1721,12 @@ bool CmdTechDrawVerticalDimension::isActive()
 
 void execDistanceY(Gui::Command* cmd)
 {
-    bool result = _checkDrawViewPart(cmd);
-    if (!result) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect selection"),
-                             QObject::tr("No View of a Part in selection."));
-        return;
-    }
-
-    ReferenceVector references2d;
-    ReferenceVector references3d;
-    TechDraw::DrawViewPart* partFeat =
-        TechDraw::getReferencesFromSelection(references2d, references3d);
-
     //Define the geometric configuration required for a length dimension
     StringVector acceptableGeometry({"Edge", "Vertex"});
     std::vector<int> minimumCounts({1, 2});
     std::vector<DimensionGeometryType> acceptableDimensionGeometrys({isVertical, isDiagonal, isHybrid});
 
-    //what 2d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs2d = validateDimSelection(
-        references2d, acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
-    if (geometryRefs2d == TechDraw::isInvalid) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect Selection"),
-                             QObject::tr("Can not make 2d vertical dimension from selection"));
-        return;
-    }
-
-    //what 3d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs3d;
-    if (geometryRefs2d == TechDraw::isViewReference && !references3d.empty()) {
-        geometryRefs3d = validateDimSelection3d(partFeat,
-                                                references3d,
-                                                acceptableGeometry,
-                                                minimumCounts,
-                                                acceptableDimensionGeometrys);
-        if (geometryRefs3d == TechDraw::isVertical) {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Incorrect Selection"),
-                                 QObject::tr("Can not make 3d vertical dimension from selection"));
-            return;
-        }
-    }
-
-    //build the dimension
-    DrawViewDimension* dim = dimensionMaker(partFeat, "DistanceY", references2d, references3d);
-
-    //position the Dimension text on the view
-    positionDimText(dim);
+    execDim(cmd, "DistanceY", acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
 }
 
 //===========================================================================
@@ -2046,55 +1770,12 @@ bool CmdTechDrawAngleDimension::isActive()
 
 void execAngle(Gui::Command* cmd)
 {
-    bool result = _checkDrawViewPart(cmd);
-    if (!result) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect selection"),
-                             QObject::tr("No View of a Part in selection."));
-        return;
-    }
-
-    ReferenceVector references2d;
-    ReferenceVector references3d;
-    TechDraw::DrawViewPart* partFeat =
-        TechDraw::getReferencesFromSelection(references2d, references3d);
-
     //Define the geometric configuration required for a length dimension
     StringVector acceptableGeometry({"Edge"});
     std::vector<int> minimumCounts({2});
     std::vector<DimensionGeometryType> acceptableDimensionGeometrys({isAngle});
 
-    //what 2d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs2d = validateDimSelection(
-        references2d, acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
-    if (geometryRefs2d == TechDraw::isInvalid) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect Selection"),
-                             QObject::tr("Can not make 2d angle dimension from selection"));
-        return;
-    }
-
-    //what 3d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs3d;
-    if (geometryRefs2d == TechDraw::isViewReference && !references3d.empty()) {
-        geometryRefs3d = validateDimSelection3d(partFeat,
-                                                references3d,
-                                                acceptableGeometry,
-                                                minimumCounts,
-                                                acceptableDimensionGeometrys);
-        if (geometryRefs3d == TechDraw::isInvalid) {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Incorrect Selection"),
-                                 QObject::tr("Can not make 3d angle dimension from selection"));
-            return;
-        }
-    }
-
-    //build the dimension
-    DrawViewDimension* dim = dimensionMaker(partFeat, "Angle", references2d, references3d);
-
-    //position the Dimension text on the view
-    positionDimText(dim);
+    execDim(cmd, "Angle", acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
 }
 
 //===========================================================================
@@ -2138,55 +1819,12 @@ bool CmdTechDraw3PtAngleDimension::isActive()
 
 void execAngle3Pt(Gui::Command* cmd)
 {
-    bool result = _checkDrawViewPart(cmd);
-    if (!result) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect selection"),
-                             QObject::tr("No View of a Part in selection."));
-        return;
-    }
-
-    ReferenceVector references2d;
-    ReferenceVector references3d;
-    TechDraw::DrawViewPart* partFeat =
-        TechDraw::getReferencesFromSelection(references2d, references3d);
-
     //Define the geometric configuration required for a length dimension
     StringVector acceptableGeometry({"Vertex"});
     std::vector<int> minimumCounts({3});
     std::vector<DimensionGeometryType> acceptableDimensionGeometrys({isAngle3Pt});
 
-    //what 2d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs2d = validateDimSelection(
-        references2d, acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
-    if (geometryRefs2d == TechDraw::isInvalid) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect Selection"),
-                             QObject::tr("Can not make 2d angle dimension from selection"));
-        return;
-    }
-
-    //what 3d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs3d;
-    if (geometryRefs2d == TechDraw::isViewReference && !references3d.empty()) {
-        geometryRefs3d = validateDimSelection3d(partFeat,
-                                                references3d,
-                                                acceptableGeometry,
-                                                minimumCounts,
-                                                acceptableDimensionGeometrys);
-        if (geometryRefs3d == TechDraw::isInvalid) {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Incorrect Selection"),
-                                 QObject::tr("Can not make 3d angle dimension from selection"));
-            return;
-        }
-    }
-
-    //build the dimension
-    DrawViewDimension* dim = dimensionMaker(partFeat, "Angle3Pt", references2d, references3d);
-
-    //position the Dimension text on the view
-    positionDimText(dim);
+    execDim(cmd, "Angle3Pt", acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
 }
 
 //===========================================================================
@@ -2230,52 +1868,12 @@ bool CmdTechDrawAreaDimension::isActive()
 
 void execArea(Gui::Command* cmd)
 {
-    bool result = _checkDrawViewPart(cmd);
-    if (!result) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect selection"),
-                             QObject::tr("No View of a Part in selection."));
-        return;
-    }
-
-    ReferenceVector references2d;
-    ReferenceVector references3d;
-    TechDraw::DrawViewPart* partFeat =
-        TechDraw::getReferencesFromSelection(references2d, references3d);
-
-    //Define the geometric configuration required for a length dimension
+    //Define the geometric configuration required for a area dimension
     StringVector acceptableGeometry({"Face"});
     std::vector<int> minimumCounts({1});
     std::vector<DimensionGeometryType> acceptableDimensionGeometrys({isFace});
 
-    //what 2d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs2d = validateDimSelection(
-        references2d, acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
-    if (geometryRefs2d == TechDraw::isInvalid) {
-        QMessageBox::warning(Gui::getMainWindow(),
-                             QObject::tr("Incorrect Selection"),
-                             QObject::tr("Can not make 2d angle dimension from selection"));
-        return;
-    }
-
-    //what 3d geometry configuration did we receive?
-    DimensionGeometryType geometryRefs3d;
-    if (geometryRefs2d == TechDraw::isViewReference && !references3d.empty()) {
-        geometryRefs3d = validateDimSelection3d(partFeat,
-                                                references3d,
-                                                acceptableGeometry,
-                                                minimumCounts,
-                                                acceptableDimensionGeometrys);
-        if (geometryRefs3d == TechDraw::isInvalid) {
-            QMessageBox::warning(Gui::getMainWindow(),
-                                 QObject::tr("Incorrect Selection"),
-                                 QObject::tr("Can not make 3d angle dimension from selection"));
-            return;
-        }
-    }
-
-    //build the dimension
-    dimensionMaker(partFeat, "Area", references2d, references3d);
+    execDim(cmd, "Area", acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
 }
 
 
@@ -2796,6 +2394,95 @@ void CreateTechDrawCommandsDims()
 //------------------------------------------------------------------------------
 
 //Common code to build a dimension feature
+
+void execDim(Gui::Command* cmd, std::string type, StringVector acceptableGeometry, std::vector<int> minimumCounts, std::vector<DimensionGeometryType> acceptableDimensionGeometrys)
+{
+    bool result = _checkDrawViewPart(cmd);
+    if (!result) {
+        QMessageBox::warning(Gui::getMainWindow(),
+            QObject::tr("Incorrect selection"),
+            QObject::tr("No View of a Part in selection."));
+        return;
+    }
+
+    ReferenceVector references2d;
+    ReferenceVector references3d;
+    TechDraw::DrawViewPart* partFeat =
+        TechDraw::getReferencesFromSelection(references2d, references3d);
+
+    //what 2d geometry configuration did we receive?
+    DimensionGeometryType geometryRefs2d = validateDimSelection(
+        references2d, acceptableGeometry, minimumCounts, acceptableDimensionGeometrys);
+
+    if (geometryRefs2d == TechDraw::isInvalid) {
+        QMessageBox::warning(Gui::getMainWindow(),
+            QObject::tr("Incorrect Selection"),
+            QObject::tr("Can not make 2d dimension from selection"));
+        return;
+    }
+
+    //what 3d geometry configuration did we receive?
+    DimensionGeometryType geometryRefs3d;
+    if (geometryRefs2d == TechDraw::isViewReference && !references3d.empty()) {
+        geometryRefs3d = validateDimSelection3d(partFeat,
+            references3d,
+            acceptableGeometry,
+            minimumCounts,
+            acceptableDimensionGeometrys);
+
+        if (geometryRefs3d == TechDraw::isInvalid) {
+            QMessageBox::warning(Gui::getMainWindow(),
+                QObject::tr("Incorrect Selection"),
+                QObject::tr("Can not make 3d dimension from selection"));
+            return;
+        }
+    }
+    else {
+        references3d.clear();
+    }
+
+    //errors and warnings
+    if (type == "Radius" || type == "Diameter") {
+        if (geometryRefs2d == isEllipse || geometryRefs3d == isEllipse) {
+            QMessageBox::StandardButton result = QMessageBox::warning(
+                Gui::getMainWindow(),
+                QObject::tr("Ellipse Curve Warning"),
+                QObject::tr("Selected edge is an Ellipse. Value will be approximate. Continue?"),
+                QMessageBox::Ok | QMessageBox::Cancel,
+                QMessageBox::Cancel);
+            if (result != QMessageBox::Ok) {
+                return;
+            }
+        }
+        if (geometryRefs2d == isBSplineCircle || geometryRefs3d == isBSplineCircle) {
+            QMessageBox::StandardButton result = QMessageBox::warning(
+                Gui::getMainWindow(),
+                QObject::tr("BSpline Curve Warning"),
+                QObject::tr("Selected edge is a BSpline. Value will be approximate. Continue?"),
+                QMessageBox::Ok | QMessageBox::Cancel,
+                QMessageBox::Cancel);
+            if (result != QMessageBox::Ok) {
+                return;
+            }
+        }
+        if (geometryRefs2d == isBSpline || geometryRefs3d == isBSpline) {
+            QMessageBox::critical(
+                Gui::getMainWindow(),
+                QObject::tr("BSpline Curve Error"),
+                QObject::tr("Selected edge is a BSpline and a radius/diameter can not be calculated."));
+            return;
+        }
+    }
+
+    //build the dimension
+    DrawViewDimension* dim = dimensionMaker(partFeat, type, references2d, references3d);
+
+    if (type == "Distance" || type == "DistanceX" || type == "DistanceY" || type == "Angle" || type == "Angle3Pt") {
+        //position the Dimension text on the view
+        positionDimText(dim);
+    }
+}
+
 DrawViewDimension* dimensionMaker(TechDraw::DrawViewPart* dvp, std::string dimType,
                                   ReferenceVector references2d, ReferenceVector references3d)
 {


### PR DESCRIPTION
- Fix #14038 by adding 
```
    else {
        references3d.clear();
    }
```
to make sure no unwanted reference3d is added.
- Refactor CommandCreateDims by adding execDim to reduce code duplicity.