### PR TITLE
Tests: Make PD and Sketcher tests independent of user settings

### DIFF
--- a/src/Mod/Part/parttests/TopoShapeTest.py
+++ b/src/Mod/Part/parttests/TopoShapeTest.py
@@ -279,6 +279,7 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
     def testPartFuse(self):
         # Arrange
         self.doc.addObject("Part::Fuse", "Fuse")
+        self.doc.Fuse.Refine = False
         self.doc.Fuse.Base = self.doc.Box1
         self.doc.Fuse.Tool = self.doc.Box2
         # Act

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -1353,6 +1353,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         self.Doc.recompute()
         volume1 = body.Shape.Volume
         fillet = self.Doc.addObject('PartDesign::Fillet', 'Fillet')
+        fillet.Refine = True
         fillet.Base = (box, ['Edge1',
                               'Edge5',
                               'Edge7',
@@ -1398,6 +1399,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         body.addObject(doc.Sketch)
 
         pocket = self.Doc.addObject('PartDesign::Pocket', 'Pocket')
+        pocket.Refine = True
         pocket.Type = "Length"
         pocket.Length = 3
         pocket.Direction = App.Vector(-0.710000000,0.7100000000, 0.0000000000)
@@ -1477,6 +1479,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         doc.addObject("Part::Box","Box")
         doc.ActiveObject.Label = "Cube"
         doc.addObject("Part::MultiFuse","Fusion")
+        doc.Fusion.Refine = False
         doc.Fusion.Shapes = [doc.Box, doc.Box001,]
         doc.recompute()
         self.assertEqual(doc.Fusion.Shape.ElementMapSize, 26)
@@ -1517,6 +1520,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         doc.recompute()
 
         doc.addObject("Part::MultiFuse","Fusion")
+        doc.Fusion.Refine = False
         doc.Fusion.Shapes = [doc.Box, doc.Box001,]
 
         doc.recompute()

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
@@ -493,6 +493,7 @@ class TestSketcherSolver(unittest.TestCase):
         body.addObject(sketch1)
         self.Doc.recompute()
         hole = self.Doc.addObject("PartDesign::Hole", "Hole")
+        hole.Refine = True
         body.addObject(hole)
         hole.Profile = sketch1
         hole.Diameter = 0.250000


### PR DESCRIPTION
The Refine property must be explicitly set as otherwise some tests will break because of different user settings