### PR TITLE
Gui: Extend TaskDialog

### DIFF
--- a/src/Gui/TaskView/TaskDialog.cpp
+++ b/src/Gui/TaskView/TaskDialog.cpp
@@ -93,10 +93,7 @@ bool TaskDialog::canClose() const
     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     msgBox.setDefaultButton(QMessageBox::Yes);
     int ret = msgBox.exec();
-    if (ret == QMessageBox::Yes)
-        return true;
-    else
-        return false;
+    return (ret == QMessageBox::Yes);
 }
 
 //==== calls from the TaskView ===============================================================
@@ -112,6 +109,11 @@ void TaskDialog::closed()
 }
 
 void TaskDialog::autoClosedOnTransactionChange()
+{
+
+}
+
+void TaskDialog::autoClosedOnDeletedDocument()
 {
 
 }

--- a/src/Gui/TaskView/TaskDialog.h
+++ b/src/Gui/TaskView/TaskDialog.h
@@ -91,6 +91,15 @@ public:
         return autoCloseTransaction;
     }
 
+    /// Defines whether a task dialog must be closed if the document is
+    /// deleted.
+    void setAutoCloseOnDeletedDocument(bool on) {
+        autoCloseDeletedDocument = on;
+    }
+    bool isAutoCloseOnDeletedDocument() const {
+        return autoCloseDeletedDocument;
+    }
+
     const std::string& getDocumentName() const
     { return documentName; }
     void setDocumentName(const std::string& doc)
@@ -124,6 +133,9 @@ public:
     /// is called by the framework when the dialog is automatically closed due to
     /// changing the active transaction
     virtual void autoClosedOnTransactionChange();
+    /// is called by the framework when the dialog is automatically closed due to
+    /// deleting the document
+    virtual void autoClosedOnDeletedDocument();
     /// is called by the framework if a button is clicked which has no accept or reject role
     virtual void clicked(int);
     /// is called by the framework if the dialog is accepted (Ok)
@@ -150,6 +162,7 @@ private:
     std::string documentName;
     bool escapeButton;
     bool autoCloseTransaction;
+    bool autoCloseDeletedDocument;
 
     friend class TaskDialogAttorney;
 };

--- a/src/Gui/TaskView/TaskDialogPython.h
+++ b/src/Gui/TaskView/TaskDialogPython.h
@@ -99,8 +99,11 @@ public:
     /// active transaction.
     Py::Object setAutoCloseOnTransactionChange(const Py::Tuple&);
     Py::Object isAutoCloseOnTransactionChange(const Py::Tuple&);
+    Py::Object setAutoCloseOnDeletedDocument(const Py::Tuple&);
+    Py::Object isAutoCloseOnDeletedDocument(const Py::Tuple&);
 
     Py::Object getDocumentName(const Py::Tuple&);
+    Py::Object setDocumentName(const Py::Tuple&);
 
     /*!
       Indicates whether this task dialog allows other commands to modify
@@ -159,6 +162,9 @@ public:
     */
     bool isAllowedAlterSelection() const override;
     bool needsFullSpace() const override;
+
+    void autoClosedOnTransactionChange() override;
+    void autoClosedOnDeletedDocument() override;
 
 public:
     /// is called by the framework when the dialog is opened

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -34,6 +34,7 @@
 # include <QTimer>
 #endif
 
+#include <App/Document.h>
 #include <Gui/ActionFunction.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
@@ -292,8 +293,8 @@ TaskView::TaskView(QWidget *parent)
     App::GetApplication().signalActiveDocument.connect
         (std::bind(&Gui::TaskView::TaskView::slotActiveDocument, this, sp::_1));
     connectApplicationDeleteDocument = 
-    App::GetApplication().signalDeletedDocument.connect
-        (std::bind(&Gui::TaskView::TaskView::slotDeletedDocument, this));
+    App::GetApplication().signalDeleteDocument.connect
+        (std::bind(&Gui::TaskView::TaskView::slotDeletedDocument, this, sp::_1));
     connectApplicationUndoDocument = 
     App::GetApplication().signalUndoDocument.connect
         (std::bind(&Gui::TaskView::TaskView::slotUndoDocument, this, sp::_1));
@@ -456,32 +457,58 @@ void TaskView::slotActiveDocument(const App::Document& doc)
         updateWatcher();
 }
 
-void TaskView::slotDeletedDocument()
+void TaskView::slotDeletedDocument(const App::Document& doc)
 {
-    if (!ActiveDialog)
-        updateWatcher();
-}
+    if (ActiveDialog) {
+        if (ActiveDialog->isAutoCloseOnDeletedDocument()) {
+            std::string name = ActiveDialog->getDocumentName();
+            if (name.empty()) {
+                Base::Console().Warning(std::string("TaskView::slotDeletedDocument"),
+                                        "No document name set\n");
+            }
 
-void TaskView::slotUndoDocument(const App::Document&)
-{
-    if (ActiveDialog && ActiveDialog->isAutoCloseOnTransactionChange()) {
-        ActiveDialog->autoClosedOnTransactionChange();
-        removeDialog();
+            if (name == doc.getName()) {
+                ActiveDialog->autoClosedOnDeletedDocument();
+                removeDialog();
+            }
+        }
     }
 
-    if (!ActiveDialog)
+    if (!ActiveDialog) {
         updateWatcher();
+    }
 }
 
-void TaskView::slotRedoDocument(const App::Document&)
+void TaskView::transactionChangeOnDocument(const App::Document& doc)
 {
-    if (ActiveDialog && ActiveDialog->isAutoCloseOnTransactionChange()) {
-        ActiveDialog->autoClosedOnTransactionChange();
-        removeDialog();
+    if (ActiveDialog) {
+        if (ActiveDialog->isAutoCloseOnTransactionChange()) {
+            std::string name = ActiveDialog->getDocumentName();
+            if (name.empty()) {
+                Base::Console().Warning(std::string("TaskView::transactionChangeOnDocument"),
+                                        "No document name set\n");
+            }
+
+            if (name == doc.getName()) {
+                ActiveDialog->autoClosedOnTransactionChange();
+                removeDialog();
+            }
+        }
     }
 
-    if (!ActiveDialog)
+    if (!ActiveDialog) {
         updateWatcher();
+    }
+}
+
+void TaskView::slotUndoDocument(const App::Document& doc)
+{
+    transactionChangeOnDocument(doc);
+}
+
+void TaskView::slotRedoDocument(const App::Document& doc)
+{
+    transactionChangeOnDocument(doc);
 }
 
 /// @cond DOXERR

--- a/src/Gui/TaskView/TaskView.h
+++ b/src/Gui/TaskView/TaskView.h
@@ -181,6 +181,11 @@ private:
     void adjustMinimumSizeHint();
     void saveCurrentWidth();
     void tryRestoreWidth();
+    void slotActiveDocument(const App::Document&);
+    void slotDeletedDocument(const App::Document&);
+    void slotUndoDocument(const App::Document&);
+    void slotRedoDocument(const App::Document&);
+    void transactionChangeOnDocument(const App::Document&);
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
@@ -194,11 +199,6 @@ protected:
     void showDialog(TaskDialog *dlg);
     // removes the running dialog after accept() or reject() from the TaskView
     void removeDialog();
-
-    void slotActiveDocument(const App::Document&);
-    void slotDeletedDocument();
-    void slotUndoDocument(const App::Document&);
-    void slotRedoDocument(const App::Document&);
 
     std::vector<TaskWatcher*> ActiveWatcher;
 


### PR DESCRIPTION
* Add TaskDialog::autoClosedOnDeletedDocument()
* Add option to automatically close task dialog when document is deleted
* Expose autoClosedOnDeletedDocument() to Python
* Expose autoClosedOnTransactionChange() to Python
* Change ControlPy::showDialog() to directly return the task dialog wrapper
* Change TaskView::slotDeletedDocument() to close task dialog if requested