### PR TITLE
[MeasureGui] Use temporary measure object creation

### DIFF
--- a/src/Gui/TaskMeasure.cpp
+++ b/src/Gui/TaskMeasure.cpp
@@ -36,6 +36,8 @@
 #include "App/Document.h"
 #include "App/DocumentObjectGroup.h"
 #include <Gui/BitmapFactory.h>
+#include <Gui/Document.h>
+#include <Gui/ViewProviderDocumentObject.h>
 
 #include <QFormLayout>
 #include <QPushButton>
@@ -149,6 +151,54 @@ void TaskMeasure::setMeasureObject(Measure::MeasureBase* obj) {
 }
 
 
+App::DocumentObject* TaskMeasure::createObject(std::string& measureClass) {
+    auto type = Base::Type::fromName(measureClass.c_str());
+
+    if (type == Base::Type::badType()) {
+        return nullptr;
+    }
+
+    auto measureObj = static_cast<App::DocumentObject*> (type.createInstance());
+    return measureObj;
+}
+
+
+Gui::ViewProviderDocumentObject* TaskMeasure::createViewObject(App::DocumentObject* measureObj) {
+    // Add view object
+    auto guiDoc = Gui::Application::Instance->activeDocument();
+    auto vpName = measureObj->getViewProviderName();
+    if ((vpName == nullptr) || (vpName[0] == '\0')) {
+        return nullptr;
+    }
+
+    auto vpType = Base::Type::fromName(vpName);
+    if (vpType == Base::Type::badType()) {
+        return nullptr;
+    }
+
+    auto vp = static_cast<Gui::ViewProviderDocumentObject*>(vpType.createInstance());
+
+    guiDoc->setAnnotationViewProvider(vp->getTypeId().getName(), vp);
+    vp->attach(measureObj);
+    vp->updateView();
+    vp->setActiveMode();
+
+    return vp;
+}
+
+
+void TaskMeasure::saveObject() {
+    if (_mViewObject) {
+        auto guiDoc = Gui::Application::Instance->activeDocument();
+        guiDoc->removeAnnotationViewProvider(_mViewObject->getTypeId().getName());
+        _mViewObject = nullptr;
+    }
+
+    App::Document* appDoc = App::GetApplication().getActiveDocument();
+    appDoc->addObject(_mMeasureObject, _mMeasureType->label.c_str());
+}
+
+
 void TaskMeasure::update() {
     App::Document *doc = App::GetApplication().getActiveDocument();
 
@@ -183,7 +233,6 @@ void TaskMeasure::update() {
     if (measureTypes.size() > 0) {
         _mMeasureType = measureTypes.front();
     }
-    
 
 
     if (!_mMeasureType) {
@@ -227,7 +276,7 @@ void TaskMeasure::update() {
         else {
             // Create measure object
             setMeasureObject(
-                (Measure::MeasureBase*)doc->addObject(_mMeasureType->measureObject.c_str(), _mMeasureType->label.c_str())
+                (Measure::MeasureBase*)createObject(_mMeasureType->measureObject)
             );
         }
     }
@@ -240,6 +289,8 @@ void TaskMeasure::update() {
 
     // Get result
     valueResult->setText(_mMeasureObject->getResultString());
+    
+    _mViewObject = createViewObject(_mMeasureObject);
 }
 
 void TaskMeasure::close(){
@@ -272,6 +323,7 @@ void TaskMeasure::invoke() {
 }
 
 bool TaskMeasure::apply(){
+    saveObject();
     ensureGroup(_mMeasureObject);
     _mMeasureType = nullptr;
     _mMeasureObject = nullptr;
@@ -312,7 +364,14 @@ void TaskMeasure::removeObject() {
     if (_mMeasureObject->isRemoving() ) {
         return;
     }
-    _mMeasureObject->getDocument()->removeObject (_mMeasureObject->getNameInDocument());
+
+    if (_mViewObject) {
+        auto guiDoc = Gui::Application::Instance->activeDocument();
+        guiDoc->removeAnnotationViewProvider(_mViewObject->getTypeId().getName());
+        _mViewObject = nullptr;
+    }
+
+    delete _mMeasureObject;
     setMeasureObject(nullptr);
 }
 

--- a/src/Gui/TaskMeasure.cpp
+++ b/src/Gui/TaskMeasure.cpp
@@ -168,8 +168,6 @@ void TaskMeasure::update() {
     valueResult->setText(QString::asprintf("-"));
 
     // Get valid measure type
-    App::MeasureType *measureType(nullptr);
-
 
     std::string mode = explicitMode ? modeSwitch->currentText().toStdString() : "";
 
@@ -183,11 +181,12 @@ void TaskMeasure::update() {
 
     auto measureTypes = App::MeasureManager::getValidMeasureTypes(selection, mode);
     if (measureTypes.size() > 0) {
-        measureType = measureTypes.front();
+        _mMeasureType = measureTypes.front();
     }
     
 
-    if (!measureType) {
+
+    if (!_mMeasureType) {
 
         // Note: If there's no valid measure type we might just restart the selection,
         // however this requires enough coverage of measuretypes that we can access all of them
@@ -206,18 +205,18 @@ void TaskMeasure::update() {
     }
 
     // Update tool mode display
-    setModeSilent(measureType);
+    setModeSilent(_mMeasureType);
 
-    if (!_mMeasureObject || measureType->measureObject != _mMeasureObject->getTypeId().getName()) {
+    if (!_mMeasureObject || _mMeasureType->measureObject != _mMeasureObject->getTypeId().getName()) {
         // we don't already have a measureobject or it isn't the same type as the new one
         removeObject();
 
-        if (measureType->isPython) {
+        if (_mMeasureType->isPython) {
             Base::PyGILStateLocker lock;
-            auto pyMeasureClass = measureType->pythonClass;
-            
+            auto pyMeasureClass = _mMeasureType->pythonClass;
+
             // Create a MeasurePython instance
-            auto featurePython = doc->addObject("Measure::MeasurePython", measureType->label.c_str());
+            auto featurePython = doc->addObject("Measure::MeasurePython", _mMeasureType->label.c_str());
             setMeasureObject((Measure::MeasureBase*)featurePython);
 
             // Create an instance of the pyMeasureClass, the classe's initializer sets the object as proxy
@@ -228,7 +227,7 @@ void TaskMeasure::update() {
         else {
             // Create measure object
             setMeasureObject(
-                (Measure::MeasureBase*)doc->addObject(measureType->measureObject.c_str(), measureType->label.c_str())
+                (Measure::MeasureBase*)doc->addObject(_mMeasureType->measureObject.c_str(), _mMeasureType->label.c_str())
             );
         }
     }
@@ -274,6 +273,7 @@ void TaskMeasure::invoke() {
 
 bool TaskMeasure::apply(){
     ensureGroup(_mMeasureObject);
+    _mMeasureType = nullptr;
     _mMeasureObject = nullptr;
     reset();
 
@@ -294,6 +294,7 @@ bool TaskMeasure::reject(){
 
 void TaskMeasure::reset() {
     // Reset tool state
+    _mMeasureType = nullptr;
     this->clearSelection();
 
     // Should the explicit mode also be reset? 

--- a/src/Gui/TaskMeasure.h
+++ b/src/Gui/TaskMeasure.h
@@ -62,6 +62,7 @@ public:
 private:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
 
+    App::MeasureType* _mMeasureType = nullptr;
     Measure::MeasureBase *_mMeasureObject = nullptr;
 
     QLineEdit* valueResult{nullptr};

--- a/src/Gui/TaskMeasure.h
+++ b/src/Gui/TaskMeasure.h
@@ -64,6 +64,7 @@ private:
 
     App::MeasureType* _mMeasureType = nullptr;
     Measure::MeasureBase *_mMeasureObject = nullptr;
+    Gui::ViewProviderDocumentObject* _mViewObject = nullptr;
 
     QLineEdit* valueResult{nullptr};
     QComboBox* modeSwitch{nullptr};
@@ -73,6 +74,10 @@ private:
     void setModeSilent(App::MeasureType* mode);
     App::MeasureType* getMeasureType();
     void enableAnnotateButton(bool state);
+    App::DocumentObject* createObject(std::string& measureClass);
+    Gui::ViewProviderDocumentObject* createViewObject(App::DocumentObject* measureObj);
+    void saveObject();
+
 
     // List of measure types
     std::vector<App::DocumentObject> measureObjects;

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -401,9 +401,9 @@ Gui::MDIView* ViewProviderDocumentObject::getActiveView() const
 {
     if(!pcObject)
         throw Base::RuntimeError("View provider detached");
-    App::Document* pAppDoc = pcObject->getDocument();
-    Gui::Document* pGuiDoc = Gui::Application::Instance->getDocument(pAppDoc);
-    return pGuiDoc->getActiveView();
+    
+    return Gui::Application::Instance->activeView();
+
 }
 
 Gui::MDIView* ViewProviderDocumentObject::getEditingView() const


### PR DESCRIPTION
The measure tool currently always makes document changes as described in #13735.

With this PR the tool creates an instance of the measure object type and only adds it to the document when it is saved. Same with the view object which is added to the scenegraph through the setAnnotationViewProvider method of the Gui Document.

The method "ViewProviderDocumentObject::getActiveView" was edited as it causes issues when trying to access it from a view object which' feature isn't yet added to the document.

Closes #13735  