### PR TITLE
Sketcher: Rotate: correct the name of the checkbox

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -474,14 +474,15 @@ void DSHRotateController::configureToolWidget()
     if (!init) {  // Code to be executed only upon initialisation
         toolWidget->setCheckboxLabel(
             WCheckbox::FirstBox,
-            QApplication::translate("TaskSketcherTool_c1_offset", "Clone constraints"));
+            QApplication::translate("TaskSketcherTool_c1_offset", "Apply equal constraints"));
         toolWidget->setCheckboxToolTip(
             WCheckbox::FirstBox,
             QString::fromLatin1("<p>")
                 + QApplication::translate("TaskSketcherTool_c1_offset",
-                                          "This concerns the datum constraints (e.g. distance)."
-                                          "If you activate Clone, the tool will copy the datum."
-                                          "Else it will try to replace them with equalities.")
+                                          "If this option is selected dimensional constraints are "
+                                          "excluded from the operation.\n"
+                                          "Instead equal constraints are applied between the "
+                                          "original objects and their copies.")
                 + QString::fromLatin1("</p>"));
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -485,14 +485,14 @@ void DSHTranslateController::configureToolWidget()
     if (!init) {  // Code to be executed only upon initialisation
         toolWidget->setCheckboxLabel(
             WCheckbox::FirstBox,
-            QApplication::translate("TaskSketcherTool_c1_translate", "Clone constraints"));
+            QApplication::translate("TaskSketcherTool_c1_translate", "Apply equal constraints"));
         toolWidget->setCheckboxToolTip(
             WCheckbox::FirstBox,
-            QApplication::translate(
-                "TaskSketcherTool_c1_translate",
-                "This concerns the datum constraints like distances. If you activate Clone, "
-                "then the tool will copy the datum. Else it will try to replace them with "
-                "equalities between the initial geometries and the new copies."));
+            QApplication::translate("TaskSketcherTool_c1_translate",
+                                    "If this option is selected dimensional constraints are "
+                                    "excluded from the operation.\n"
+                                    "Instead equal constraints are applied between the original "
+                                    "objects and their copies."));
     }
 
     onViewParameters[OnViewParameter::First]->setLabelType(Gui::SoDatumLabel::DISTANCEX);


### PR DESCRIPTION
![image](https://github.com/FreeCAD/FreeCAD/assets/19984177/ab8399d5-af9f-41f2-9396-9abd443e14ee)
Fix https://github.com/FreeCAD/FreeCAD/issues/12034

Please @Roy-043 check the screenshot above and let me know if this phrasing is better.
Note the 2 missing spaces are added.