### PR TITLE
Start: Make the Start Page a passive view

### DIFF
--- a/src/Mod/Start/Gui/Manipulator.cpp
+++ b/src/Mod/Start/Gui/Manipulator.cpp
@@ -56,10 +56,9 @@ void CmdStart::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     auto mw = Gui::getMainWindow();
-    auto doc = Gui::Application::Instance->activeDocument();
     auto existingView = mw->findChild<StartGui::StartView*>(QLatin1String("StartView"));
     if (!existingView) {
-        existingView = gsl::owner<StartGui::StartView*>(new StartGui::StartView(doc, mw));
+        existingView = gsl::owner<StartGui::StartView*>(new StartGui::StartView(mw));
         mw->addWindow(existingView);  // Transfers ownership
     }
     Gui::getMainWindow()->setActiveWindow(existingView);

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -100,8 +100,8 @@ gsl::owner<QPushButton*> createNewButton(const NewButton& newButton)
 
 }  // namespace
 
-StartView::StartView(Gui::Document* pcDocument, QWidget* parent)
-    : Gui::MDIView(pcDocument, parent)
+StartView::StartView(QWidget* parent)
+    : Gui::MDIView(nullptr, parent)
     , _contents(new QScrollArea(parent))
     , _newFileLabel {nullptr}
     , _examplesLabel {nullptr}

--- a/src/Mod/Start/Gui/StartView.h
+++ b/src/Mod/Start/Gui/StartView.h
@@ -54,7 +54,7 @@ class StartGuiExport StartView: public Gui::MDIView
     TYPESYSTEM_HEADER_WITH_OVERRIDE();  // NOLINT
 
 public:
-    StartView(Gui::Document* pcDocument, QWidget* parent);
+    StartView(QWidget* parent);
 
     const char* getName() const override
     {


### PR DESCRIPTION
Do not attach the Start Page to an existing document as otherwise weird behaviour can be observed:
1. Start FreeCAD
2. Open a project file or data file
3. Open the Start Page
4. Make a change to the document
5. Close the document. You won't be asked to save your change
6. In the tree view the document is still shown because the Start Page is attached to the document
7. Close the Start Page. Now you will be asked to save your change