### PR TITLE
Sketcher/Techdraw: add resetSettingsToDefaults to reset correctly dimension tool settings

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -261,6 +261,29 @@ void SketcherSettings::changeEvent(QEvent* e)
     }
 }
 
+void SketcherSettings::resetSettingsToDefaults()
+{
+    ParameterGrp::handle hGrp;
+
+    hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/dimensioning");
+    // reset "Dimension tools" parameters
+    hGrp->RemoveBool("SingleDimensioningTool");
+    hGrp->RemoveBool("SeparatedDimensioningTools");
+
+    // reset "radius/diameter mode for dimensioning" parameter
+    hGrp->RemoveBool("DimensioningDiameter");
+    hGrp->RemoveBool("DimensioningRadius");
+
+    hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/Tools");
+    // reset "OVP visibility" parameter
+    hGrp->RemoveInt("OnViewParameterVisibility");
+
+    // finally reset all the parameters associated to Gui::Pref* widgets
+    PreferencePage::resetSettingsToDefaults();
+}
+
 /* TRANSLATOR SketcherGui::SketcherSettingsGrid */
 
 SketcherSettingsGrid::SketcherSettingsGrid(QWidget* parent)

--- a/src/Mod/Sketcher/Gui/SketcherSettings.h
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.h
@@ -49,6 +49,8 @@ public:
     void saveSettings() override;
     void loadSettings() override;
 
+    void resetSettingsToDefaults() override;
+
 protected:
     void changeEvent(QEvent* e) override;
     void dimensioningModeChanged(int index);

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.cpp
@@ -208,6 +208,24 @@ void DlgPrefsTechDrawDimensionsImp::changeEvent(QEvent *e)
     }
 }
 
+void DlgPrefsTechDrawDimensionsImp::resetSettingsToDefaults()
+{
+    ParameterGrp::handle hGrp;
+
+    hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/TechDraw/dimensioning");
+    // reset "Dimension tools" parameters
+    hGrp->RemoveBool("SingleDimensioningTool");
+    hGrp->RemoveBool("SeparatedDimensioningTools");
+
+    // reset "radius/diameter mode for dimensioning" parameter
+    hGrp->RemoveBool("DimensioningDiameter");
+    hGrp->RemoveBool("DimensioningRadius");
+
+    // finally reset all the parameters associated to Gui::Pref* widgets
+    PreferencePage::resetSettingsToDefaults();
+}
+
 int DlgPrefsTechDrawDimensionsImp::prefArrowStyle() const
 {
     return PreferencesGui::dimArrowStyle();

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.h
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensionsImp.h
@@ -41,6 +41,7 @@ public:
     explicit DlgPrefsTechDrawDimensionsImp( QWidget* parent = nullptr );
     ~DlgPrefsTechDrawDimensionsImp() override;
 
+    void resetSettingsToDefaults() override;
 protected:
     void saveSettings() override;
     void loadSettings() override;


### PR DESCRIPTION
- add SketcherSettings::resetSettingsToDefaults to reset correctly some settings.
- add DlgPrefsTechDrawDimensionsImp::resetSettingsToDefaults to reset correctly some settings

fix https://github.com/FreeCAD/FreeCAD/issues/14107