### PR TITLE
Gui: Prevent invalid editors in VarSet dialog

### DIFF
--- a/src/Gui/DlgAddPropertyVarSet.h
+++ b/src/Gui/DlgAddPropertyVarSet.h
@@ -87,7 +87,7 @@ private:
     bool isSupportedType(std::string& type);
     void createProperty(std::string& name, std::string& group);
 
-    void onNamePropertyDetermined();
+    void onNamePropertyDetermined(const QString& text);
     void onGroupDetermined();
     void onTypePropertyDetermined();
 


### PR DESCRIPTION
In the VarSet dialog, we can create an editor after the name and type has been determined.  However, if the name is changed after an editor has been created, the editor is invalid because the underlying property has been removed.  In that case, the function `onNamePropertyDetermined()` should clean up the invalid editor and this happens in most cases. Unfortunately, it cannot handle the case in which a click happens on the invalid editor itself.  This click should result in `onNamePropertyDetermined()` but since the editor is already invalid, `onNamePropertyDetermined()` is triggered too late.

The current commit solves this by listening for every change in the name of the property and handle the editors accordingly.

Closes #15157