### PR TITLE
Gui: Handle various property types better in VarSet dialog

### DIFF
--- a/src/Base/BaseClass.h
+++ b/src/Base/BaseClass.h
@@ -128,7 +128,7 @@ private:                                                                        
     TYPESYSTEM_SOURCE_ABSTRACT_P(_class_)                                                          \
     void _class_::init(void)                                                                       \
     {                                                                                              \
-        initSubclass(_class_::classTypeId, #_class_, #_parentclass_, &(_class_::create));          \
+        initSubclass(_class_::classTypeId, #_class_, #_parentclass_, nullptr);                     \
     }
 // NOLINTEND(cppcoreguidelines-macro-usage)
 

--- a/src/Base/Type.cpp
+++ b/src/Base/Type.cpp
@@ -65,6 +65,11 @@ void* Type::createInstance()
     return method ? (*method)() : nullptr;
 }
 
+bool Type::canInstantiate() const
+{
+    instantiationMethod method = typedata[index]->instMethod;
+    return method != nullptr;
+}
 
 void* Type::createInstanceByName(const char* TypeName, bool bLoadModule)
 {

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -89,6 +89,8 @@ public:
 
     /// creates a instance of this type
     void* createInstance();
+    /// Checks whether this type can instantiate
+    bool canInstantiate() const;
     /// creates a instance of the named type
     static void* createInstanceByName(const char* TypeName, bool bLoadModule = false);
     static void importModule(const char* TypeName);

--- a/src/Gui/DlgAddProperty.cpp
+++ b/src/Gui/DlgAddProperty.cpp
@@ -54,9 +54,15 @@ DlgAddProperty::DlgAddProperty(QWidget* parent,
     if(defType.isBad())
         defType = App::PropertyString::getClassTypeId();
 
+    std::vector<Base::Type> proptypes;
     std::vector<Base::Type> types;
-    Base::Type::getAllDerivedFrom(Base::Type::fromName("App::Property"),types);
-    std::sort(types.begin(), types.end(), [](Base::Type a, Base::Type b) { return strcmp(a.getName(), b.getName()) < 0; });
+    Base::Type::getAllDerivedFrom(Base::Type::fromName("App::Property"), proptypes);
+    std::copy_if (proptypes.begin(), proptypes.end(), std::back_inserter(types), [](const Base::Type& type) {
+        return type.canInstantiate();
+    });
+    std::sort(types.begin(), types.end(), [](Base::Type a, Base::Type b) {
+        return strcmp(a.getName(), b.getName()) < 0;
+    });
 
     for(const auto& type : types) {
         ui->comboType->addItem(QString::fromLatin1(type.getName()));

--- a/src/Gui/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/DlgAddPropertyVarSet.cpp
@@ -222,11 +222,14 @@ static PropertyEditor::PropertyItem *createPropertyItem(App::Property *prop)
     return item;
 }
 
-void DlgAddPropertyVarSet::addEditor(PropertyEditor::PropertyItem* propertyItem, std::string& /*type*/)
+void DlgAddPropertyVarSet::addEditor(PropertyEditor::PropertyItem* propertyItem, std::string& type)
 {
     editor.reset(propertyItem->createEditor(this, [this]() {
         this->valueChanged();
     }));
+    if (type == "App::PropertyFont") {
+        propertyItem->setEditorData(editor.get(), QVariant());
+    }
     editor->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     editor->setObjectName(QString::fromUtf8("editor"));
     auto formLayout = qobject_cast<QFormLayout*>(layout());
@@ -274,7 +277,7 @@ void DlgAddPropertyVarSet::createProperty(std::string& name, std::string& group)
     if (propertyItem && isTypeWithEditor(type)) {
         propertyItem->setPropertyData({prop});
         propertyItem->bind(*objectIdentifier);
-             addEditor(propertyItem.get(), type);
+        addEditor(propertyItem.get(), type);
     }
 
     setOkEnabled(true);

--- a/src/Gui/DlgAddPropertyVarSet.h
+++ b/src/Gui/DlgAddPropertyVarSet.h
@@ -84,17 +84,22 @@ private:
     void removeEditor();
     void addEditor(PropertyEditor::PropertyItem* propertyItem, std::string& type);
 
-    bool isSupportedType(std::string& type);
+    bool isTypeWithEditor(const std::string& type);
     void createProperty(std::string& name, std::string& group);
 
     void onNamePropertyDetermined();
     void onGroupDetermined();
     void onTypePropertyDetermined();
 
+    void getSupportedTypes(std::vector<Base::Type>& types);
+
 private:
-    std::unordered_set<std::string> unsupportedTypes = {
+    std::unordered_set<std::string> typesWithoutEditor = {
         "App::PropertyVector", "App::PropertyVectorDistance", "App::PropertyMatrix",
-        "App::PropertyRotation", "App::PropertyPlacement", "App::PropertyEnumeration"};
+        "App::PropertyRotation", "App::PropertyPlacement", "App::PropertyEnumeration",
+        "App::PropertyDirection", "App::PropertyPlacementList", "App::PropertyPosition",
+        "App::PropertyExpressionEngine", "App::PropertyIntegerSet",
+        "Sketcher::PropertyConstraintList"};
 
     App::VarSet* varSet;
     std::unique_ptr<Ui_DlgAddPropertyVarSet> ui;


### PR DESCRIPTION
This PR makes a better distinction between property types that should not be supported because they are more for internal use, for example as base classes, such as `App::Property` and `App::PropertyLinkBase`.

It also loads font data for `App::PropertyFont`

Closes #15156

Note that there are other issues related as well. For example, https://github.com/FreeCAD/FreeCAD/issues/15159 has a similar problem with properties that result in exceptions.