### PR TITLE
[TNP] Fix python get element. partially fixes #15095

### DIFF
--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -817,7 +817,7 @@ infos contains additional info on the solutions. It is a list of tuples:
 Returns a SubElement
 getElement(elementName, [silent = False]) -> Face | Edge | Vertex
 elementName:  SubElement name - i.e. 'Edge1', 'Face3' etc. 
-              Accepts TNP names as well
+              Accepts TNP mitigation mapped names as well
 silent:  True to suppress the exception throw if the shape isn't found.
         </UserDocu>
       </Documentation>

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -813,8 +813,12 @@ infos contains additional info on the solutions. It is a list of tuples:
     </Methode>
     <Methode Name="getElement" Const="true">
       <Documentation>
-        <UserDocu>Returns a SubElement
-getElement(elementName) -> Face | Edge | Vertex
+        <UserDocu>
+Returns a SubElement
+getElement(elementName, [silent = False]) -> Face | Edge | Vertex
+elementName:  SubElement name - i.e. 'Edge1', 'Face3' etc. 
+              Accepts TNP names as well
+silent:  True to suppress the exception throw if the shape isn't found.
         </UserDocu>
       </Documentation>
     </Methode>

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -1455,6 +1455,27 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         else:
             self.assertEqual(App.Gui.Selection.getSelectionEx("", 0)[0].SubElementNames[0][-8:],",F.Face2")
 
+    def testGetElementFunctionality(self):
+        # Arrange
+        body = self.Doc.addObject('PartDesign::Body', 'Body')
+        padSketch = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad')
+        pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        body.addObject(padSketch)
+        body.addObject(pad)
+        TestSketcherApp.CreateRectangleSketch(padSketch, (0, 0), (1, 1))
+        pad.Profile = padSketch
+        pad.Length = 1
+        # Act
+        self.Doc.recompute()
+        if body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
+            return
+        map = pad.Shape.ElementMap
+        # Assert
+        for tnpName in map.keys():
+            element1 = body.Shape.getElement(tnpName)
+            element2 = body.Shape.getElement(map[tnpName])
+            self.assertTrue(element1.isSame(element2))
+
     def testFileSaveRestore(self):
         # Arrange
         self.Body = self.Doc.addObject('PartDesign::Body', 'Body')

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -1467,13 +1467,14 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         pad.Length = 1
         # Act
         self.Doc.recompute()
-        if body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
+        if pad.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
             return
         map = pad.Shape.ElementMap
         # Assert
+        self.assertGreater(pad.Shape.ElementMapSize,0)
         for tnpName in map.keys():
-            element1 = body.Shape.getElement(tnpName)
-            element2 = body.Shape.getElement(map[tnpName])
+            element1 = pad.Shape.getElement(tnpName)
+            element2 = pad.Shape.getElement(map[tnpName])
             self.assertTrue(element1.isSame(element2))
 
     def testFileSaveRestore(self):


### PR DESCRIPTION
As discussed with @bgbsww [here:](https://github.com/FreeCAD/FreeCAD/issues/15095#issuecomment-2204279479)
The python shape function getElement does not handle TNP names. 
This is one of the reasons that causes issues with App::propertyLinkSub as mentioned in  #15095
When testing on LS3 this function indeed supports TNP long names.
The fix is basically using LS3 implementation.
A unit test function wad added as well. 

  