### PR TITLE
Fix visual artifacts when line smoothing is enabled

### DIFF
--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -97,26 +97,11 @@ View3DInventor::View3DInventor(Gui::Document* pcDocument, QWidget* parent,
     setAcceptDrops(true);
 
     //anti-aliasing settings
-    bool smoothing = false;
-    bool glformat = false;
-    int samples = View3DInventorViewer::getNumSamples();
-    QtGLFormat f;
+    QtGLFormat format;
+    if (const int samples = View3DInventorViewer::getNumSamples(); samples != 0)
+        format.setSamples(samples);
 
-    if (samples > 1) {
-        glformat = true;
-        f.setSamples(samples);
-    }
-    else if (samples > 0) {
-        smoothing = true;
-    }
-
-    if (glformat)
-        _viewer = new View3DInventorViewer(f, this, sharewidget);
-    else
-        _viewer = new View3DInventorViewer(this, sharewidget);
-
-    if (smoothing)
-        _viewer->getSoRenderManager()->getGLRenderAction()->setSmoothing(true);
+    _viewer = new View3DInventorViewer(format, this, sharewidget);
 
     // create the inventor widget and set the defaults
     _viewer->setDocument(this->_pcDocument);


### PR DESCRIPTION
Line smoothing is buggy. The possible solution is to just turn it off. _MSAA x1_ provides line smoothing anyway.

Closes #11541, closes #11444.