### PR TITLE
Fix enabling/disabling notificationWidth

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsNotificationArea.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNotificationArea.cpp
@@ -89,11 +89,11 @@ void DlgSettingsNotificationArea::adaptUiToAreaEnabledState(bool enabled)
 {
     ui->NonIntrusiveNotificationsEnabled->setEnabled(enabled);
     ui->maxDuration->setEnabled(enabled);
-    ui->maxDuration->setEnabled(enabled);
     ui->minDuration->setEnabled(enabled);
     ui->maxNotifications->setEnabled(enabled);
     ui->maxWidgetMessages->setEnabled(enabled);
     ui->autoRemoveUserNotifications->setEnabled(enabled);
+    ui->notificationWidth->setEnabled(enabled);
     ui->hideNonIntrusiveNotificationsWhenWindowDeactivated->setEnabled(enabled);
     ui->preventNonIntrusiveNotificationsWhenWindowNotActive->setEnabled(enabled);
     ui->developerErrorSubscriptionEnabled->setEnabled(enabled);


### PR DESCRIPTION
Fixes: #15187

Before:
![image](https://github.com/FreeCAD/FreeCAD/assets/148809153/b66b3b0d-c342-466b-ace0-3c34263b2c92)
_Notification width enabled_

After:
![Captura de pantalla de 2024-07-04 14-30-43](https://github.com/FreeCAD/FreeCAD/assets/148809153/7f8f9017-8059-4093-b843-92b45da1575d)
_Notification width disabled_

Not addressed:
- Improved grouping of settings in groupboxes
- Labels not being greyed out
- Unchecked `Enable non-intrusive notifications` checkbox should make its associated settings non-editable