### PR TITLE
MeasureGui: Fix measure dependency violation

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -466,7 +466,6 @@ SET(Dialog_CPP_SRCS
     DownloadManager.cpp
     DocumentRecovery.cpp
     TaskElementColors.cpp
-    TaskMeasure.cpp
     DlgObjectSelection.cpp
     DlgAddProperty.cpp
     DlgAddPropertyVarSet.cpp
@@ -507,7 +506,6 @@ SET(Dialog_HPP_SRCS
     DownloadManager.h
     DocumentRecovery.h
     TaskElementColors.h
-    TaskMeasure.h
     DlgObjectSelection.h
     DlgAddProperty.h
     DlgAddPropertyVarSet.h

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -75,7 +75,6 @@
 #include "SelectionObject.h"
 #include "SoAxisCrossKit.h"
 #include "SoFCOffscreenRenderer.h"
-#include "TaskMeasure.h"
 #include "TextureMapping.h"
 #include "Tools.h"
 #include "Tree.h"
@@ -3137,37 +3136,6 @@ void StdCmdTreeSelectAllInstances::activated(int iMsg)
     Selection().selStackPush();
 }
 
-//===========================================================================
-// Std_Measure
-// this is the Unified Measurement Facility Measure command
-//===========================================================================
-
-
-DEF_STD_CMD_A(StdCmdMeasure)
-
-StdCmdMeasure::StdCmdMeasure()
-  :Command("Std_Measure")
-{
-    sGroup        = "Measure";
-    sMenuText     = QT_TR_NOOP("&Measure");
-    sToolTipText  = QT_TR_NOOP("Measure a feature");
-    sWhatsThis    = "Std_Measure";
-    sStatusTip    = QT_TR_NOOP("Measure a feature");
-    sPixmap       = "umf-measurement";
-}
-
-void StdCmdMeasure::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-
-    TaskMeasure *task = new TaskMeasure();
-    Gui::Control().showDialog(task);
-}
-
-
-bool StdCmdMeasure::isActive(){
-    return true;
-}
 
 //===========================================================================
 // Std_SceneInspector
@@ -4066,7 +4034,6 @@ void CreateViewStdCommands()
     rcCmdMgr.addCommand(new StdCmdTreeExpand());
     rcCmdMgr.addCommand(new StdCmdTreeCollapse());
     rcCmdMgr.addCommand(new StdCmdTreeSelectAllInstances());
-    rcCmdMgr.addCommand(new StdCmdMeasure());
     rcCmdMgr.addCommand(new StdCmdSceneInspector());
     rcCmdMgr.addCommand(new StdCmdTextureMapping());
     rcCmdMgr.addCommand(new StdCmdDemoMode());

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -719,8 +719,6 @@ MenuItem* StdWorkbench::setupMenuBar() const
           << "Std_ExportDependencyGraph"
           << "Std_ProjectUtil"
           << "Separator"
-          << "Std_Measure"
-          << "Separator"
           << "Std_TextDocument"
           << "Separator"
           << "Std_DemoMode"
@@ -803,8 +801,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     auto view = new ToolBarItem( root );
     view->setCommand("View");
     *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_ViewGroup" << "Std_AlignToSelection"
-          << "Separator" << "Std_DrawStyle" << "Std_TreeViewActions"
-          << "Separator" << "Std_Measure";
+          << "Separator" << "Std_DrawStyle" << "Std_TreeViewActions";
 
     // Individual views
     auto individualViews = new ToolBarItem(root, ToolBarItem::DefaultVisibility::Hidden);

--- a/src/Mod/Measure/Gui/AppMeasureGui.cpp
+++ b/src/Mod/Measure/Gui/AppMeasureGui.cpp
@@ -37,6 +37,7 @@
 #include "ViewProviderMeasureAngle.h"
 #include "ViewProviderMeasureDistance.h"
 #include "ViewProviderMeasureBase.h"
+#include "WorkbenchManipulator.h"
 
 
 // use a different name to CreateCommand()
@@ -85,6 +86,9 @@ PyMOD_INIT_FUNC(MeasureGui)
 
     PyObject* mod = MeasureGui::initModule();
     Base::Console().Log("Loading GUI of Measure module... done\n");
+
+    auto manip = std::make_shared<MeasureGui::WorkbenchManipulator>();
+    Gui::WorkbenchManipulator::installManipulator(manip);
 
     // instantiating the commands
     CreateMeasureCommands();

--- a/src/Mod/Measure/Gui/CMakeLists.txt
+++ b/src/Mod/Measure/Gui/CMakeLists.txt
@@ -59,8 +59,8 @@ SET(MeasureGui_SRCS
     ViewProviderMeasureAngle.h
     ViewProviderMeasureDistance.cpp
     ViewProviderMeasureDistance.h
-    # Workbench.cpp
-    # Workbench.h
+    WorkbenchManipulator.cpp
+    WorkbenchManipulator.h
     DlgPrefsMeasureAppearanceImp.ui
     DlgPrefsMeasureAppearanceImp.cpp
     DlgPrefsMeasureAppearanceImp.h

--- a/src/Mod/Measure/Gui/CMakeLists.txt
+++ b/src/Mod/Measure/Gui/CMakeLists.txt
@@ -51,6 +51,8 @@ SET(MeasureGui_SRCS
     QuickMeasurePyImp.cpp
     QuickMeasure.cpp
     QuickMeasure.h
+    TaskMeasure.cpp
+    TaskMeasure.h
     ViewProviderMeasureBase.cpp
     ViewProviderMeasureBase.h
     ViewProviderMeasureAngle.cpp

--- a/src/Mod/Measure/Gui/Command.cpp
+++ b/src/Mod/Measure/Gui/Command.cpp
@@ -23,10 +23,52 @@
 
 #include <Gui/Application.h>
 #include <Gui/Command.h>
+#include <Gui/Control.h>
+
+#include "TaskMeasure.h"
 
 
-using namespace std;
+//===========================================================================
+// Std_Measure
+// this is the Unified Measurement Facility Measure command
+//===========================================================================
+
+
+DEF_STD_CMD_A(StdCmdMeasure)
+
+StdCmdMeasure::StdCmdMeasure()
+    : Command("Std_Measure")
+{
+    sGroup = "Measure";
+    sMenuText = QT_TR_NOOP("&Measure");
+    sToolTipText = QT_TR_NOOP("Measure a feature");
+    sWhatsThis = "Std_Measure";
+    sStatusTip = QT_TR_NOOP("Measure a feature");
+    sPixmap = "umf-measurement";
+}
+
+void StdCmdMeasure::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+
+    Gui::TaskMeasure* task = new Gui::TaskMeasure();
+    Gui::Control().showDialog(task);
+}
+
+
+bool StdCmdMeasure::isActive()
+{
+    return true;
+}
+
+
+
 
 void CreateMeasureCommands() {
-    Base::Console().Log("Init MeasureGui\n");
+    Gui::CommandManager& rcCmdMgr = Gui::Application::Instance->commandManager();
+
+    auto cmd = new StdCmdMeasure();
+    cmd->initAction();
+    rcCmdMgr.addCommand(cmd);
+
 }

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -30,12 +30,12 @@
 
 #include "TaskMeasure.h"
 
-#include "Control.h"
-#include "MainWindow.h"
-#include "Application.h"
-#include "App/Document.h"
-#include "App/DocumentObjectGroup.h"
+#include <App/Document.h>
+#include <App/DocumentObjectGroup.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
+#include <Gui/Control.h>
 
 #include <QFormLayout>
 #include <QPushButton>

--- a/src/Mod/Measure/Gui/TaskMeasure.h
+++ b/src/Mod/Measure/Gui/TaskMeasure.h
@@ -30,9 +30,10 @@
 
 #include <Mod/Measure/App/MeasureBase.h>
 
-#include "TaskView/TaskDialog.h"
-#include "TaskView/TaskView.h"
-#include "Selection.h"
+
+#include <Gui/TaskView/TaskDialog.h>
+#include <Gui/TaskView/TaskView.h>
+#include <Gui/Selection.h>
 
 namespace Gui {
 

--- a/src/Mod/Measure/Gui/WorkbenchManipulator.cpp
+++ b/src/Mod/Measure/Gui/WorkbenchManipulator.cpp
@@ -1,0 +1,50 @@
+/***************************************************************************
+ *   Copyright (c) 2024 David Friedli <david[at]friedli-be.ch>             *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+
+#include "PreCompiled.h"
+#include "WorkbenchManipulator.h"
+#include <Gui/MenuManager.h>
+#include <Gui/ToolBarManager.h>
+
+using namespace MeasureGui;
+
+void WorkbenchManipulator::modifyMenuBar([[maybe_unused]] Gui::MenuItem* menuBar)
+{
+    auto menuTools = menuBar->findItem("&Tools");
+    if (!menuTools) {
+        return;
+    }
+    auto itemMeasure = new Gui::MenuItem();
+    itemMeasure->setCommand("Std_Measure");
+    menuTools->appendItem(itemMeasure);
+}
+
+void WorkbenchManipulator::modifyToolBars(Gui::ToolBarItem* toolBar) {
+    auto tbView = toolBar->findItem("View");
+    if (!tbView) {
+        return;
+    }
+
+    auto itemMeasure = new Gui::ToolBarItem();
+    itemMeasure->setCommand("Std_Measure");
+    tbView->appendItem(itemMeasure);
+}

--- a/src/Mod/Measure/Gui/WorkbenchManipulator.h
+++ b/src/Mod/Measure/Gui/WorkbenchManipulator.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+ *   Copyright (c) 2024 David Friedli <david[at]friedli-be.ch>             *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+
+#ifndef MEASUREGUI_WORKBENCHMANIPULATOR_H
+#define MEASUREGUI_WORKBENCHMANIPULATOR_H
+
+#include <Gui/WorkbenchManipulator.h>
+
+namespace MeasureGui {
+
+class WorkbenchManipulator: public Gui::WorkbenchManipulator
+{
+protected:
+    void modifyMenuBar(Gui::MenuItem* menuBar) override;
+    void modifyToolBars(Gui::ToolBarItem* toolBar) override;
+};
+
+} // namespace MeasureGui
+
+
+#endif // MEASUREGUI_WORKBENCHMANIPULATOR_H


### PR DESCRIPTION
This is an attempt to solve #15125 by moving the measure command (Std_Measure) and task dialog to the measure module. They were moved to the core at some point because the command should be globally available in all workbenches. With this PR the command is inserted into the "View" toolbar at startup.

Note: This currently removes the command from the "Tools" menu which might be a showstopper. I was able to add it there as well but i didn't manage to have it persist. There is some information on that topic [here](https://forum.freecad.org/viewtopic.php?t=30761&start=10) but it seems outdated.

Closes #15125