### PR TITLE
Core: In dialog to add property only list types that can be instantiated

### DIFF
--- a/src/Base/BaseClass.h
+++ b/src/Base/BaseClass.h
@@ -128,7 +128,7 @@ private:                                                                        
     TYPESYSTEM_SOURCE_ABSTRACT_P(_class_)                                                          \
     void _class_::init(void)                                                                       \
     {                                                                                              \
-        initSubclass(_class_::classTypeId, #_class_, #_parentclass_, &(_class_::create));          \
+        initSubclass(_class_::classTypeId, #_class_, #_parentclass_, nullptr);                     \
     }
 // NOLINTEND(cppcoreguidelines-macro-usage)
 

--- a/src/Base/Type.cpp
+++ b/src/Base/Type.cpp
@@ -65,6 +65,11 @@ void* Type::createInstance()
     return method ? (*method)() : nullptr;
 }
 
+bool Type::canInstantiate() const
+{
+    instantiationMethod method = typedata[index]->instMethod;
+    return method != nullptr;
+}
 
 void* Type::createInstanceByName(const char* TypeName, bool bLoadModule)
 {

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -89,6 +89,8 @@ public:
 
     /// creates a instance of this type
     void* createInstance();
+    /// Checks whether this type can instantiate
+    bool canInstantiate() const;
     /// creates a instance of the named type
     static void* createInstanceByName(const char* TypeName, bool bLoadModule = false);
     static void importModule(const char* TypeName);

--- a/src/Gui/DlgAddProperty.cpp
+++ b/src/Gui/DlgAddProperty.cpp
@@ -54,9 +54,15 @@ DlgAddProperty::DlgAddProperty(QWidget* parent,
     if(defType.isBad())
         defType = App::PropertyString::getClassTypeId();
 
+    std::vector<Base::Type> proptypes;
     std::vector<Base::Type> types;
-    Base::Type::getAllDerivedFrom(Base::Type::fromName("App::Property"),types);
-    std::sort(types.begin(), types.end(), [](Base::Type a, Base::Type b) { return strcmp(a.getName(), b.getName()) < 0; });
+    Base::Type::getAllDerivedFrom(Base::Type::fromName("App::Property"), proptypes);
+    std::copy_if (proptypes.begin(), proptypes.end(), std::back_inserter(types), [](const Base::Type& type) {
+        return type.canInstantiate();
+    });
+    std::sort(types.begin(), types.end(), [](Base::Type a, Base::Type b) {
+        return strcmp(a.getName(), b.getName()) < 0;
+    });
 
     for(const auto& type : types) {
         ui->comboType->addItem(QString::fromLatin1(type.getName()));


### PR DESCRIPTION
Fixes #15159: Dialog for adding properties allows property types that give exceptions