### PR TITLE
PD: Remove the Migrate tool from GUI

### DIFF
--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -572,7 +572,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
           << "Separator"
           << "Part_CheckGeometry"
           << "Separator"
-          << "PartDesign_Migrate"
+          // << "PartDesign_Migrate"
           << "PartDesign_Sprocket";
 
     // For 0.13 a couple of python packages like numpy, matplotlib and others


### PR DESCRIPTION
Fixes #15162

This tool has no toolbar button so the PR only removes it from the PD menu.