### PR TITLE
[Base] [Post 1.0] Give constructive user feedback on failing to read StringHasherTable

### DIFF
--- a/src/Base/Reader.cpp
+++ b/src/Base/Reader.cpp
@@ -38,6 +38,7 @@
 #include "Persistence.h"
 #include "Sequencer.h"
 #include "Stream.h"
+#include "Tools.h"
 #include "XMLTools.h"
 
 #ifdef _MSC_VER
@@ -448,6 +449,13 @@ void Base::XMLReader::readFiles(zipios::ZipInputStream& zipstream) const
                 // failure.
                 Base::Console().Error("Reading failed from embedded file: %s\n",
                                       entry->toString().c_str());
+                if (jt->FileName == "StringHasher.Table.txt") {
+                    Base::Console().Error(QT_TRANSLATE_NOOP(
+                        "Notifications",
+                        "\nIt is recommended that the user right-click the root of "
+                        "the document and select Mark to recompute.\n"
+                        "The user should then click the Refresh button in the main toolbar.\n"));
+                }
             }
             // Go to the next registered file name
             it = jt + 1;


### PR DESCRIPTION
This error was detected after loading a valid 0.21 file, making a modification to a fillet deep inside the model, close & saving the file and then reopening the same model. The model was quite complex at 119 objects and a size of 13.7Mb.

Original error and subsequent warnings:

```
11:15:03  Reading failed from embedded file: StringHasher.Table.txt (75249 bytes, 4129 bytes compressed)
11:15:03  <ElementMap> <string>(1): No hasherRef
11:15:03  <ElementMap> <string>(1): No hasherRef
11:15:03  <ElementMap> <string>(1): No hasherRef
11:15:04  <ElementMap> <string>(1): No hasherRef
11:15:04  <ElementMap> <string>(1): No hasherRef
```