### PR TITLE
FEM: Remove empty preference list item

### DIFF
--- a/src/Mod/Fem/Gui/DlgSettingsFemInOutVtk.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemInOutVtk.ui
@@ -76,11 +76,6 @@ exported from FreeCAD.</string>
             <string>FreeCAD result object</string>
            </property>
           </item>
-          <item>
-           <property name="text">
-            <string/>
-           </property>
-          </item>
          </widget>
         </item>
        </layout>


### PR DESCRIPTION
Removes an empty item from the drop-down list in Preferences --> Import-Export --> VTK --> Which object to import into