### PR TITLE
[Icons]TechDraw_PageTemplate.svg fix

### DIFF
--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_PageTemplate.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_PageTemplate.svg
@@ -49,204 +49,6 @@
   </metadata>
   <defs
      id="defs3">
-    <radialGradient
-       cx="605.71002"
-       cy="486.64999"
-       r="117.14"
-       id="radialGradient6719"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.7744,0,0,1.9697,112.76,-872.89)" />
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71002"
-       cy="486.64999"
-       r="117.14"
-       id="radialGradient6717"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7744,0,0,1.9697,-1891.6,-872.89)" />
-    <linearGradient
-       x1="302.85999"
-       y1="366.64999"
-       x2="302.85999"
-       y2="609.51001"
-       id="linearGradient6715"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7744,0,0,1.9697,-1892.2,-872.89)">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="20.705999"
-       cy="37.518002"
-       r="30.905001"
-       id="radialGradient238"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.055,-0.027345,0.1777,1.1909,-3.5722,-7.1253)">
-      <stop
-         id="stop1790"
-         style="stop-color:#202020;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop1791"
-         style="stop-color:#b9b9b9;stop-opacity:1"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       x1="6.2298002"
-       y1="13.773"
-       x2="9.8980999"
-       y2="66.834"
-       id="linearGradient491"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5168,0,0,0.70898,-0.87957,-1.3182)">
-      <stop
-         id="stop3984"
-         style="stop-color:#ffffff;stop-opacity:0.87629002"
-         offset="0" />
-      <stop
-         id="stop3985"
-         style="stop-color:#fffffe;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="13.036"
-       y1="32.567001"
-       x2="12.854"
-       y2="46.688999"
-       id="linearGradient322"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3175,0,0,0.81626,-0.87957,-1.3182)">
-      <stop
-         id="stop320"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop321"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="18.113001"
-       y1="31.368"
-       x2="15.515"
-       y2="6.1803002"
-       id="linearGradient3104"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop3098"
-         style="stop-color:#424242;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3100"
-         style="stop-color:#777777;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="22.176001"
-       y1="36.987999"
-       x2="22.065001"
-       y2="32.049999"
-       id="linearGradient9772"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop9768"
-         style="stop-color:#6194cb;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop9770"
-         style="stop-color:#729fcf;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="6.2298002"
-       y1="13.773"
-       x2="9.8980999"
-       y2="66.834"
-       id="linearGradient4034"
-       xlink:href="#linearGradient491"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.143042,0,0,1.0143654,-2.9497932,-3.4882311)" />
-    <radialGradient
-       cx="20.705999"
-       cy="37.518002"
-       r="30.905001"
-       id="radialGradient4052"
-       xlink:href="#radialGradient238"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5229824,-0.03951002,0.25652509,1.7206972,-7.2818443,-12.450124)" />
-    <linearGradient
-       x1="18.113001"
-       y1="31.368"
-       x2="15.515"
-       y2="6.1803002"
-       id="linearGradient4054"
-       xlink:href="#linearGradient3104"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4435853,0,0,1.4448713,-2.1250691,-2.1549833)" />
-    <radialGradient
-       cx="55"
-       cy="125"
-       r="14.375"
-       fx="55"
-       fy="125"
-       id="radialGradient278"
-       xlink:href="#linearGradient12512"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient12512">
-      <stop
-         id="stop12513"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop12517"
-         style="stop-color:#fff520;stop-opacity:0.89108908"
-         offset="0.5" />
-      <stop
-         id="stop12514"
-         style="stop-color:#fff300;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="55"
-       cy="125"
-       r="14.375"
-       fx="55"
-       fy="125"
-       id="radialGradient4252"
-       xlink:href="#linearGradient12512"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0434782,0,0,1.0434782,-8.391303,-115.43478)" />
-    <linearGradient
-       xlink:href="#linearGradient4383"
-       id="linearGradient9"
-       x1="32"
-       y1="64"
-       x2="32"
-       y2="14.419661"
-       gradientUnits="userSpaceOnUse" />
     <linearGradient
        id="linearGradient4383">
       <stop
@@ -258,15 +60,6 @@
          offset="1"
          id="stop4" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3765"
-       id="linearGradient3771"
-       x1="98"
-       y1="1047.3622"
-       x2="81"
-       y2="993.36218"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-60,-988.36218)" />
     <linearGradient
        id="linearGradient3765">
       <stop
@@ -287,51 +80,96 @@
        y2="14.419661"
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(0,2)" />
+    <linearGradient
+       xlink:href="#linearGradient3765"
+       id="linearGradient3781-9-1"
+       x1="10"
+       y1="39.999996"
+       x2="53"
+       y2="25.999996"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-48)" />
   </defs>
-  <path
-     style="display:inline;fill:#204a87;fill-opacity:1;stroke:#0c1522;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-     id="path4-2"
-     d="M 29.921921,12.073012 26.993293,8.1977395 C 26.21651,7.1698698 25.163057,6.5924975 24.064598,6.5924975 H 7.0714589 c -1.1437425,0 -2.0708717,1.2268134 -2.0708717,2.740257 V 58.484215 c 0,0.504481 0.309043,0.913419 0.6902905,0.913419 H 58.294706 c 0.381247,0 0.690291,-0.408938 0.690291,-0.913419 V 14.813269 c 0,-1.513445 -0.927129,-2.740257 -2.070872,-2.740257 z" />
-  <path
-     style="display:inline;fill:#204a87;fill-opacity:1;stroke:#3465a4;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-     id="path7-1"
-     d="M 7.2089844,8.5917969 H 24.064453 c 0.375444,0 0.874561,0.2026195 1.333984,0.8105468 l 3.527344,4.6699223 h 27.84961 c 0.0082,0.01044 0.01784,0.02289 0.02734,0.03711 0.01056,0.0158 0.02193,0.03237 0.0332,0.05273 0.08049,0.145363 0.148438,0.361331 0.148438,0.650391 v 42.58594 H 7 V 9.3320312 C 7,9.0436394 7.0678061,8.828994 7.1484375,8.6835937 c 0.011294,-0.020366 0.022609,-0.038859 0.033203,-0.054687 0.00953,-0.014245 0.019073,-0.026632 0.027344,-0.03711 z" />
   <g
-     id="layer3-3"
+     id="layer1"
      style="display:inline">
     <path
-       style="fill:url(#linearGradient3771);fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-       d="m 11,3 v 56.00002 h 42 v -46 L 43,3 Z"
-       id="path2991" />
+       style="display:inline;fill:#204a87;fill-opacity:1;stroke:#0c1522;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       id="path4-2"
+       d="M 29.921921,12.073012 26.993293,8.1977395 C 26.21651,7.1698698 25.163057,6.5924975 24.064598,6.5924975 H 7.0714589 c -1.1437425,0 -2.0708717,1.2268134 -2.0708717,2.740257 V 58.484215 c 0,0.504481 0.309043,0.913419 0.6902905,0.913419 H 58.294706 c 0.381247,0 0.690291,-0.408938 0.690291,-0.913419 V 14.813269 c 0,-1.513445 -0.927129,-2.740257 -2.070872,-2.740257 z" />
     <path
-       style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 13,5 V 59.00002 H 51 V 13.81392 L 41.99741,5 Z"
-       id="path3763" />
+       style="display:inline;fill:#204a87;fill-opacity:1;stroke:#3465a4;stroke-width:2;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       id="path7-1"
+       d="M 7.2089844,8.5917969 H 24.064453 c 0.375444,0 0.874561,0.2026195 1.333984,0.8105468 l 3.527344,4.6699223 h 27.84961 c 0.0082,0.01044 0.01784,0.02289 0.02734,0.03711 0.01056,0.0158 0.02193,0.03237 0.0332,0.05273 0.08049,0.145363 0.148438,0.361331 0.148438,0.650391 v 42.58594 H 7 V 9.3320312 C 7,9.0436394 7.0678061,8.828994 7.1484375,8.6835937 c 0.011294,-0.020366 0.022609,-0.038859 0.033203,-0.054687 0.00953,-0.014245 0.019073,-0.026632 0.027344,-0.03711 z" />
+    <g
+       id="layer4-3"
+       style="display:inline;stroke-width:1.0477"
+       transform="matrix(0,-0.91102286,1,0,16.047695,58.526872)">
+      <rect
+         style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2.09539;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect2987-4"
+         width="45.999996"
+         height="58.000004"
+         x="-38.999996"
+         y="3"
+         transform="rotate(-90)" />
+      <rect
+         style="fill:url(#linearGradient3781-9-1);fill-opacity:1;stroke:#ffffff;stroke-width:2.09539;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect2987-1-8"
+         width="41.999996"
+         height="54.000004"
+         x="-36.999996"
+         y="5"
+         transform="rotate(-90)" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#555753;stroke-width:2.09539;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect3894-32"
+         width="50"
+         height="38"
+         x="7"
+         y="-3" />
+      <g
+         id="g22"
+         transform="matrix(1.2327162,0,0,1.2483813,-13.253192,-8.7051925)"
+         style="stroke-width:0.844562">
+        <rect
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#555753;stroke-width:1.68912;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect4664-4"
+           width="23.999994"
+           height="12.000004"
+           x="33"
+           y="23" />
+        <path
+           style="fill:none;stroke:#555753;stroke-width:1.68912;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 37,27 h 15.398794 v 0"
+           id="path4666-19" />
+        <path
+           style="fill:none;stroke:#555753;stroke-width:1.68912;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 37,31 h 15.642526 v 0"
+           id="path4666-7-0" />
+      </g>
+    </g>
     <path
-       style="fill:#2e3436;fill-opacity:0.392157;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-       d="M 43,3 V 13.00002 H 53 Z"
-       id="path2993" />
-  </g>
-  <path
-     style="fill:#729fcf;fill-opacity:1;stroke:#0c1522;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-     id="path6"
-     d="m 29.919347,30.419661 -2.927223,3.534545 C 26.215716,34.891703 25.16247,35.41831 24.064012,35.41831 H 5.0000008 l 0.015588,23.156085 c 2.171e-4,0.460126 0.3093777,0.833108 0.6906252,0.833108 h 52.603828 c 0.381248,0 0.690139,-0.372982 0.689957,-0.833108 L 58.983419,32.918986 C 58.982865,31.538609 58.055293,30.419661 56.91155,30.419661 H 29.919344 Z" />
-  <path
-     style="fill:url(#linearGradient9-3);fill-opacity:1;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
-     id="path8-5"
-     d="m 30.861328,32.419922 h 26.050781 c 0,0 0.07225,0.463543 0.07227,0.5 L 57,57.408203 H 7.015625 L 7,37.417969 h 17.064453 c 1.756119,0 3.349555,-0.836095 4.46875,-2.1875 z" />
-  <g
-     id="g5"
-     style="stroke:#2e3436">
-    <circle
-       style="fill:#eeeeec;stroke:#555753;stroke-width:2.00001;stroke-linecap:round;stroke-linejoin:round"
-       id="path2"
-       cx="45.99572"
-       cy="45.994976"
-       r="15.005042" />
+       style="fill:#729fcf;fill-opacity:1;stroke:#0c1522;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       id="path6"
+       d="m 29.919347,30.419661 -2.927223,3.534545 C 26.215716,34.891703 25.16247,35.41831 24.064012,35.41831 H 5.0000008 l 0.015588,23.156085 c 2.171e-4,0.460126 0.3093777,0.833108 0.6906252,0.833108 h 52.603828 c 0.381248,0 0.690139,-0.372982 0.689957,-0.833108 L 58.983419,32.918986 C 58.982865,31.538609 58.055293,30.419661 56.91155,30.419661 H 29.919344 Z" />
     <path
-       id="path1"
-       style="fill:#8ae234;stroke:#17230b;stroke-width:1.99998;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="m 43.99572,35.994976 h 4 v 8 h 8 v 4 h -8 v 8 h -4 v -8 h -8 v -4 h 8 z" />
+       style="fill:url(#linearGradient9-3);fill-opacity:1;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       id="path8-5"
+       d="m 30.861328,32.419922 h 26.050781 c 0,0 0.07225,0.463543 0.07227,0.5 L 57,57.408203 H 7.015625 L 7,37.417969 h 17.064453 c 1.756119,0 3.349555,-0.836095 4.46875,-2.1875 z" />
+    <g
+       id="g5"
+       style="display:inline;stroke:#2e3436">
+      <circle
+         style="fill:#eeeeec;stroke:#555753;stroke-width:2.00001;stroke-linecap:round;stroke-linejoin:round"
+         id="path2"
+         cx="45.99572"
+         cy="45.994976"
+         r="15.005042" />
+      <path
+         id="path1"
+         style="fill:#8ae234;stroke:#17230b;stroke-width:1.99998;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 43.99572,35.994976 h 4 v 8 h 8 v 4 h -8 v 8 h -4 v -8 h -8 v -4 h 8 z" />
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
It was made based on the following topic in the forum: [techdraw: a new symbol is heavily misleading](https://forum.freecad.org/viewtopic.php?t=88910)
I'm not sure it completely solves the problem, but it's definitely an attempt. Other attempts are as follows:
![TechDraw_PageTemplate8](https://github.com/FreeCAD/FreeCAD/assets/39885728/1e6b5d2a-9594-431e-b989-895dbc47f46f)![TechDraw_PageTemplate7](https://github.com/FreeCAD/FreeCAD/assets/39885728/91536643-76af-4af0-bba9-77691335f915)![TechDraw_PageTemplate6](https://github.com/FreeCAD/FreeCAD/assets/39885728/3951a424-484a-4ae8-8522-08c42c78edc9)![TechDraw_PageTemplate5](https://github.com/FreeCAD/FreeCAD/assets/39885728/5ba886b7-1ee4-447b-a30f-b470ea8d35a5)![TechDraw_PageTemplate4](https://github.com/FreeCAD/FreeCAD/assets/39885728/b97bb757-ef6d-4282-85c8-6de58b430b8d)![TechDraw_PageTemplate3](https://github.com/FreeCAD/FreeCAD/assets/39885728/8b6a5974-71eb-4a52-8b92-3ac632b703da)![TechDraw_PageTemplate2](https://github.com/FreeCAD/FreeCAD/assets/39885728/ec86f62f-0aee-4184-9483-443e8c54e17d)![TechDraw_PageTemplate1](https://github.com/FreeCAD/FreeCAD/assets/39885728/38494db7-ef36-44e3-b774-6b70a8daf8e2)
