### PR TITLE
Materials: Add tooltips to buttons

### DIFF
--- a/src/Mod/Material/Gui/MaterialsEditor.ui
+++ b/src/Mod/Material/Gui/MaterialsEditor.ui
@@ -198,8 +198,11 @@
           </item>
           <item>
            <widget class="QPushButton" name="buttonFavorite">
+            <property name="toolTip">
+             <string>Add to favorites</string>
+            </property>
             <property name="text">
-             <string>*</string>
+             <string notr="true">*</string>
             </property>
            </widget>
           </item>
@@ -229,15 +232,21 @@
           </item>
           <item>
            <widget class="QPushButton" name="buttonPhysicalAdd">
+            <property name="toolTip">
+             <string>Add physical model</string>
+            </property>
             <property name="text">
-             <string>+</string>
+             <string notr="true">+</string>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QPushButton" name="buttonPhysicalRemove">
+            <property name="toolTip">
+             <string>Delete physical model</string>
+            </property>
             <property name="text">
-             <string>-</string>
+             <string notr="true">-</string>
             </property>
            </widget>
           </item>
@@ -273,15 +282,21 @@
           </item>
           <item>
            <widget class="QPushButton" name="buttonAppearanceAdd">
+            <property name="toolTip">
+             <string>Add appearance model</string>
+            </property>
             <property name="text">
-             <string>+</string>
+             <string notr="true">+</string>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QPushButton" name="buttonAppearanceRemove">
+            <property name="toolTip">
+             <string>Delete appearance model</string>
+            </property>
             <property name="text">
-             <string>-</string>
+             <string notr="true">-</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/Material/Gui/ModelSelect.ui
+++ b/src/Mod/Material/Gui/ModelSelect.ui
@@ -159,7 +159,7 @@
              <string>Add to favorites</string>
             </property>
             <property name="text">
-             <string>*</string>
+             <string notr="true">*</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Having only `*`, `+` & `-` as reference is not intuitive. Tooltips help users to know what each button does.

Also marked symbols as not translatable as they appear on CrowdIn.

![image](https://github.com/FreeCAD/FreeCAD/assets/53124818/e93e46d8-219a-4665-be39-d7a80c3227c2)
