### PR TITLE
Base: Units cleanup

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -2453,56 +2453,12 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
     case ABS:
         unit = v1.getUnit();
         break;
-    case SQRT: {
-        unit = v1.getUnit();
-
-        // All components of unit must be either zero or dividable by 2
-        UnitSignature s = unit.getSignature();
-        if ( !((s.Length % 2) == 0) &&
-              ((s.Mass % 2) == 0) &&
-              ((s.Time % 2) == 0) &&
-              ((s.ElectricCurrent % 2) == 0) &&
-              ((s.ThermodynamicTemperature % 2) == 0) &&
-              ((s.AmountOfSubstance % 2) == 0) &&
-              ((s.LuminousIntensity % 2) == 0) &&
-              ((s.Angle % 2) == 0))
-            _EXPR_THROW("All dimensions must be even to compute the square root.",expr);
-
-        unit = Unit(s.Length /2,
-                    s.Mass / 2,
-                    s.Time / 2,
-                    s.ElectricCurrent / 2,
-                    s.ThermodynamicTemperature / 2,
-                    s.AmountOfSubstance / 2,
-                    s.LuminousIntensity / 2,
-                    s.Angle);
+    case SQRT:
+        unit = v1.getUnit().sqrt();
         break;
-    }
-    case CBRT: {
-        unit = v1.getUnit();
-
-        // All components of unit must be either zero or dividable by 3
-        UnitSignature s = unit.getSignature();
-        if ( !((s.Length % 3) == 0) &&
-              ((s.Mass % 3) == 0) &&
-              ((s.Time % 3) == 0) &&
-              ((s.ElectricCurrent % 3) == 0) &&
-              ((s.ThermodynamicTemperature % 3) == 0) &&
-              ((s.AmountOfSubstance % 3) == 0) &&
-              ((s.LuminousIntensity % 3) == 0) &&
-              ((s.Angle % 3) == 0))
-            _EXPR_THROW("All dimensions must be multiples of 3 to compute the cube root.",expr);
-
-        unit = Unit(s.Length /3,
-                    s.Mass / 3,
-                    s.Time / 3,
-                    s.ElectricCurrent / 3,
-                    s.ThermodynamicTemperature / 3,
-                    s.AmountOfSubstance / 3,
-                    s.LuminousIntensity / 3,
-                    s.Angle);
+    case CBRT:
+        unit = v1.getUnit().cbrt();
         break;
-    }
     case ATAN2:
         if (e2.isNone())
             _EXPR_THROW("Invalid second argument.",expr);

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -2294,7 +2294,7 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
         return Py::String(args[0]->getPyValue().as_string());
     case PARSEQUANT: {
         auto quantity_text = args[0]->getPyValue().as_string();
-        auto quantity_object =  Quantity::parse(QString::fromStdString(quantity_text));
+        auto quantity_object =  Quantity::parse(quantity_text);
         return Py::asObject(new QuantityPy(new Quantity(quantity_object)));
     }
     case TRANSLATIONM: {

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1621,10 +1621,10 @@ void PropertyString::setPathValue(const ObjectIdentifier& path, const boost::any
         setValue(std::to_string(App::any_cast<float>(value)));
     }
     else if (value.type() == typeid(Quantity)) {
-        setValue(boost::any_cast<Quantity>(value).getUserString().toUtf8().constData());
+        setValue(boost::any_cast<Quantity>(value).getUserString().c_str());
     }
     else if (value.type() == typeid(std::string)) {
-        setValue(boost::any_cast<const std::string&>(value));
+        setValue(boost::any_cast<const std::string &>(value));
     }
     else {
         Base::PyGILStateLocker lock;

--- a/src/App/PropertyUnits.cpp
+++ b/src/App/PropertyUnits.cpp
@@ -68,7 +68,7 @@ Base::Quantity PropertyQuantity::createQuantityFromPy(PyObject* value)
     Base::Quantity quant;
 
     if (PyUnicode_Check(value)) {
-        quant = Quantity::parse(QString::fromUtf8(PyUnicode_AsUTF8(value)));
+        quant = Quantity::parse(PyUnicode_AsUTF8(value));
     }
     else if (PyFloat_Check(value)) {
         quant = Quantity(PyFloat_AsDouble(value), _Unit);

--- a/src/Base/Quantity.cpp
+++ b/src/Base/Quantity.cpp
@@ -22,18 +22,17 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#ifdef FC_OS_WIN32
 #define _USE_MATH_DEFINES
-#endif  // FC_OS_WIN32
+#include <cmath>
 #include <array>
 #endif
 
 #include <fmt/format.h>
 #include <Base/Tools.h>
-#include "Quantity.h"
+
 #include "Exception.h"
+#include "Quantity.h"
 #include "UnitsApi.h"
-#include <boost/math/special_functions/fpclassify.hpp>
 
 /** \defgroup Units Units system
     \ingroup BASE
@@ -282,7 +281,7 @@ bool Quantity::isQuantity() const
 // true if it has a number with or without a unit
 bool Quantity::isValid() const
 {
-    return !boost::math::isnan(myValue);
+    return !std::isnan(myValue);
 }
 
 void Quantity::setInvalid()

--- a/src/Base/Quantity.cpp
+++ b/src/Base/Quantity.cpp
@@ -253,7 +253,7 @@ QString Quantity::getSafeUserString() const
         auto feedbackQty = parse(retString);
         auto feedbackVal = feedbackQty.getValue();
         if (feedbackVal == 0) {
-            retString = QStringLiteral("%1 %2").arg(this->myValue).arg(this->getUnit().getString());
+            retString = QStringLiteral("%1 %2").arg(this->myValue).arg(QString::fromStdString(this->getUnit().getString()));
         }
     }
     retString =

--- a/src/Base/Quantity.cpp
+++ b/src/Base/Quantity.cpp
@@ -239,19 +239,13 @@ Quantity Quantity::operator-() const
 
 std::string Quantity::getUserString(double& factor, std::string& unitString) const
 {
-    QString str = QString::fromStdString(unitString);
-    QString ret = Base::UnitsApi::schemaTranslate(*this, factor, str);
-    unitString = str.toStdString();
-    return ret.toStdString();
+    return Base::UnitsApi::schemaTranslate(*this, factor, unitString);
 }
 
 std::string
 Quantity::getUserString(UnitsSchema* schema, double& factor, std::string& unitString) const
 {
-    QString str = QString::fromStdString(unitString);
-    QString ret = schema->schemaTranslate(*this, factor, str);
-    unitString = str.toStdString();
-    return ret.toStdString();
+    return schema->schemaTranslate(*this, factor, unitString);
 }
 
 std::string Quantity::getSafeUserString() const

--- a/src/Base/Quantity.h
+++ b/src/Base/Quantity.h
@@ -25,7 +25,7 @@
 #define BASE_Quantity_H
 
 #include "Unit.h"
-#include <QString>
+#include <string>
 
 // NOLINTBEGIN
 #ifndef DOUBLE_MAX
@@ -130,7 +130,7 @@ public:
     Quantity(const Quantity&) = default;
     Quantity(Quantity&&) = default;
     explicit Quantity(double value, const Unit& unit = Unit());
-    explicit Quantity(double value, const QString& unit);
+    explicit Quantity(double value, const std::string& unit);
     /// Destruction
     ~Quantity() = default;
 
@@ -166,17 +166,17 @@ public:
         myFormat = fmt;
     }
     /// transfer to user preferred unit/potence
-    QString getUserString(double& factor, QString& unitString) const;
-    QString getUserString() const
+    std::string getUserString(double& factor, std::string& unitString) const;
+    std::string getUserString() const
     {  // to satisfy GCC
         double dummy1 {};
-        QString dummy2 {};
+        std::string dummy2 {};
         return getUserString(dummy1, dummy2);
     }
-    QString getUserString(UnitsSchema* schema, double& factor, QString& unitString) const;
-    QString getSafeUserString() const;
+    std::string getUserString(UnitsSchema* schema, double& factor, std::string& unitString) const;
+    std::string getSafeUserString() const;
 
-    static Quantity parse(const QString& string);
+    static Quantity parse(const std::string& string);
 
     /// returns the unit of the quantity
     const Unit& getUnit() const

--- a/src/Base/QuantityPyImp.cpp
+++ b/src/Base/QuantityPyImp.cpp
@@ -127,10 +127,10 @@ int QuantityPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyErr_Clear();  // set by PyArg_ParseTuple()
     char* string {};
     if (PyArg_ParseTuple(args, "et", "utf-8", &string)) {
-        QString qstr = QString::fromUtf8(string);
+        std::string str(string);
         PyMem_Free(string);
         try {
-            *self = Quantity::parse(qstr);
+            *self = Quantity::parse(str);
         }
         catch (const Base::ParserError& e) {
             PyErr_SetString(PyExc_ValueError, e.what());
@@ -142,7 +142,7 @@ int QuantityPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
     PyErr_Clear();  // set by PyArg_ParseTuple()
     if (PyArg_ParseTuple(args, "det", &f, "utf-8", &string)) {
-        QString unit = QString::fromUtf8(string);
+        std::string unit(string);
         PyMem_Free(string);
         try {
             *self = Quantity(f, unit);
@@ -161,15 +161,15 @@ int QuantityPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
 PyObject* QuantityPy::getUserPreferred(PyObject* /*args*/)
 {
-    QString uus;
+    std::string uus;
     double factor {};
     Py::Tuple res(3);
 
-    QString uss = getQuantityPtr()->getUserString(factor, uus);
+    auto uss = getQuantityPtr()->getUserString(factor, uus);
 
-    res[0] = Py::String(uss.toUtf8(), "utf-8");
+    res[0] = Py::String(uss, "utf-8");
     res[1] = Py::Float(factor);
-    res[2] = Py::String(uus.toUtf8(), "utf-8");
+    res[2] = Py::String(uus, "utf-8");
 
     return Py::new_reference_to(res);
 }
@@ -236,9 +236,9 @@ PyObject* QuantityPy::getValueAs(PyObject* args)
         PyErr_Clear();
         char* string {};
         if (PyArg_ParseTuple(args, "et", "utf-8", &string)) {
-            QString qstr = QString::fromUtf8(string);
+            std::string str(string);
             PyMem_Free(string);
-            quant = Quantity::parse(qstr);
+            quant = Quantity::parse(str);
         }
     }
 
@@ -633,7 +633,7 @@ void QuantityPy::setUnit(Py::Object arg)
 
 Py::String QuantityPy::getUserString() const
 {
-    return {getQuantityPtr()->getUserString().toUtf8(), "utf-8"};
+    return {getQuantityPtr()->getUserString(), "utf-8"};
 }
 
 Py::Dict QuantityPy::getFormat() const

--- a/src/Base/QuantityPyImp.cpp
+++ b/src/Base/QuantityPyImp.cpp
@@ -42,7 +42,7 @@ std::string QuantityPy::representation() const
     Py::Float flt(val);
     ret << static_cast<std::string>(flt.repr());
     if (!unit.isEmpty()) {
-        ret << " " << unit.getString().toUtf8().constData();
+        ret << " " << unit.getString();
     }
 
     return ret.str();
@@ -63,7 +63,7 @@ PyObject* QuantityPy::toStr(PyObject* args)
     ret.setf(std::ios::fixed, std::ios::floatfield);
     ret << val;
     if (!unit.isEmpty()) {
-        ret << " " << unit.getString().toUtf8().constData();
+        ret << " " << unit.getString();
     }
 
     return Py_BuildValue("s", ret.str().c_str());

--- a/src/Base/Unit.cpp
+++ b/src/Base/Unit.cpp
@@ -128,7 +128,7 @@ Unit::Unit() //NOLINT
 Unit::Unit(const std::string& expr)  // NOLINT
 {
     try {
-        *this = Quantity::parse(QString::fromStdString(expr)).getUnit();
+        *this = Quantity::parse(expr).getUnit();
     }
     catch (const Base::ParserError&) {
         Val = 0;

--- a/src/Base/Unit.cpp
+++ b/src/Base/Unit.cpp
@@ -35,24 +35,28 @@
 using namespace Base;
 
 // clang-format off
-static inline void checkPow(UnitSignature sig, double exp)
-{
-    auto isInt = [](double value) {
-        return std::fabs(std::round(value) - value) < std::numeric_limits<double>::epsilon();
-    };
-    if (!isInt(sig.Length * exp) ||
-        !isInt(sig.Mass * exp) ||
-        !isInt(sig.Time * exp) ||
-        !isInt(sig.ElectricCurrent * exp) ||
-        !isInt(sig.ThermodynamicTemperature * exp) ||
-        !isInt(sig.AmountOfSubstance * exp) ||
-        !isInt(sig.LuminousIntensity * exp) ||
-        !isInt(sig.Angle * exp)) {
-        throw Base::UnitsMismatchError("pow() of unit not possible");
-    }
-}
+constexpr int UnitSignatureLengthBits                   = 4;
+constexpr int UnitSignatureMassBits                     = 4;
+constexpr int UnitSignatureTimeBits                     = 4;
+constexpr int UnitSignatureElectricCurrentBits          = 4;
+constexpr int UnitSignatureThermodynamicTemperatureBits = 4;
+constexpr int UnitSignatureAmountOfSubstanceBits        = 4;
+constexpr int UnitSignatureLuminousIntensityBits        = 4;
+constexpr int UnitSignatureAngleBits                    = 4;
 
-static inline void checkRange(const char * op, int length, int mass, int time, int electricCurrent,
+struct UnitSignature {
+    int32_t Length: UnitSignatureLengthBits;
+    int32_t Mass: UnitSignatureMassBits;
+    int32_t Time: UnitSignatureTimeBits;
+    int32_t ElectricCurrent: UnitSignatureElectricCurrentBits;
+    int32_t ThermodynamicTemperature: UnitSignatureThermodynamicTemperatureBits;
+    int32_t AmountOfSubstance: UnitSignatureAmountOfSubstanceBits;
+    int32_t LuminousIntensity: UnitSignatureLuminousIntensityBits;
+    int32_t Angle: UnitSignatureAngleBits;
+};
+
+static inline uint32_t sigVal(const std::string &op,
+                              int length, int mass, int time, int electricCurrent,
                               int thermodynamicTemperature, int amountOfSubstance, int luminousIntensity, int angle)
 {
     if ( ( length                   >=  (1 << (UnitSignatureLengthBits                   - 1)) ) ||
@@ -63,7 +67,7 @@ static inline void checkRange(const char * op, int length, int mass, int time, i
          ( amountOfSubstance        >=  (1 << (UnitSignatureAmountOfSubstanceBits        - 1)) ) ||
          ( luminousIntensity        >=  (1 << (UnitSignatureLuminousIntensityBits        - 1)) ) ||
          ( angle                    >=  (1 << (UnitSignatureAngleBits                    - 1)) ) ) {
-        throw Base::OverflowError((std::string("Unit overflow in ") + std::string(op)).c_str());
+        throw Base::OverflowError(("Unit overflow in " + op).c_str());
     }
     if ( ( length                   <  -(1 << (UnitSignatureLengthBits                   - 1)) ) ||
          ( mass                     <  -(1 << (UnitSignatureMassBits                     - 1)) ) ||
@@ -73,9 +77,24 @@ static inline void checkRange(const char * op, int length, int mass, int time, i
          ( amountOfSubstance        <  -(1 << (UnitSignatureAmountOfSubstanceBits        - 1)) ) ||
          ( luminousIntensity        <  -(1 << (UnitSignatureLuminousIntensityBits        - 1)) ) ||
          ( angle                    <  -(1 << (UnitSignatureAngleBits                    - 1)) ) ) {
-        throw Base::UnderflowError((std::string("Unit underflow in ") + std::string(op)).c_str());
+        throw Base::UnderflowError(("Unit underflow in " + op).c_str());
     }
+
+    UnitSignature Sig;
+    Sig.Length                   = length;
+    Sig.Mass                     = mass;
+    Sig.Time                     = time;
+    Sig.ElectricCurrent          = electricCurrent;
+    Sig.ThermodynamicTemperature = thermodynamicTemperature;
+    Sig.AmountOfSubstance        = amountOfSubstance;
+    Sig.LuminousIntensity        = luminousIntensity;
+    Sig.Angle                    = angle;
+
+    uint32_t ret;
+    memcpy(&ret, &Sig, sizeof(ret));
+    return ret;
 }
+
 
 Unit::Unit(int8_t Length, //NOLINT
            int8_t Mass,
@@ -86,37 +105,21 @@ Unit::Unit(int8_t Length, //NOLINT
            int8_t LuminousIntensity,
            int8_t Angle)
 {
-    checkRange("unit",
-               Length,
-               Mass,
-               Time,
-               ElectricCurrent,
-               ThermodynamicTemperature,
-               AmountOfSubstance,
-               LuminousIntensity,
-               Angle);
-
-    Sig.Length                   = Length;
-    Sig.Mass                     = Mass;
-    Sig.Time                     = Time;
-    Sig.ElectricCurrent          = ElectricCurrent;
-    Sig.ThermodynamicTemperature = ThermodynamicTemperature;
-    Sig.AmountOfSubstance        = AmountOfSubstance;
-    Sig.LuminousIntensity        = LuminousIntensity;
-    Sig.Angle                    = Angle;
+    Val = sigVal("unit",
+                 Length,
+                 Mass,
+                 Time,
+                 ElectricCurrent,
+                 ThermodynamicTemperature,
+                 AmountOfSubstance,
+                 LuminousIntensity,
+                 Angle);
 }
 
 
 Unit::Unit() //NOLINT
 {
-    Sig.Length                   = 0;
-    Sig.Mass                     = 0;
-    Sig.Time                     = 0;
-    Sig.ElectricCurrent          = 0;
-    Sig.ThermodynamicTemperature = 0;
-    Sig.AmountOfSubstance        = 0;
-    Sig.LuminousIntensity        = 0;
-    Sig.Angle                    = 0;
+    Val = 0;
 }
 
 Unit::Unit(const QString& expr)  // NOLINT
@@ -125,218 +128,335 @@ Unit::Unit(const QString& expr)  // NOLINT
         *this = Quantity::parse(expr).getUnit();
     }
     catch (const Base::ParserError&) {
-        Sig.Length                   = 0;
-        Sig.Mass                     = 0;
-        Sig.Time                     = 0;
-        Sig.ElectricCurrent          = 0;
-        Sig.ThermodynamicTemperature = 0;
-        Sig.AmountOfSubstance        = 0;
-        Sig.LuminousIntensity        = 0;
-        Sig.Angle                    = 0;
+        Val = 0;
     }
 }
 
 Unit Unit::pow(double exp) const
 {
-    checkPow(Sig, exp);
-    checkRange("pow()",
-               static_cast<int>(Sig.Length * exp),
-               static_cast<int>(Sig.Mass * exp),
-               static_cast<int>(Sig.Time * exp),
-               static_cast<int>(Sig.ElectricCurrent * exp),
-               static_cast<int>(Sig.ThermodynamicTemperature * exp),
-               static_cast<int>(Sig.AmountOfSubstance * exp),
-               static_cast<int>(Sig.LuminousIntensity * exp),
-               static_cast<int>(Sig.Angle * exp));
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+    auto isInt = [](double value) {
+        return std::fabs(std::round(value) - value) < std::numeric_limits<double>::epsilon();
+    };
+    if (!isInt(sig.Length                   * exp) ||
+        !isInt(sig.Mass                     * exp) ||
+        !isInt(sig.Time                     * exp) ||
+        !isInt(sig.ElectricCurrent          * exp) ||
+        !isInt(sig.ThermodynamicTemperature * exp) ||
+        !isInt(sig.AmountOfSubstance        * exp) ||
+        !isInt(sig.LuminousIntensity        * exp) ||
+        !isInt(sig.Angle                    * exp))
+        throw Base::UnitsMismatchError("pow() of unit not possible");
 
     Unit result;
-    result.Sig.Length                   = static_cast<int8_t>(Sig.Length                    * exp);
-    result.Sig.Mass                     = static_cast<int8_t>(Sig.Mass                      * exp);
-    result.Sig.Time                     = static_cast<int8_t>(Sig.Time                      * exp);
-    result.Sig.ElectricCurrent          = static_cast<int8_t>(Sig.ElectricCurrent           * exp);
-    result.Sig.ThermodynamicTemperature = static_cast<int8_t>(Sig.ThermodynamicTemperature  * exp);
-    result.Sig.AmountOfSubstance        = static_cast<int8_t>(Sig.AmountOfSubstance         * exp);
-    result.Sig.LuminousIntensity        = static_cast<int8_t>(Sig.LuminousIntensity         * exp);
-    result.Sig.Angle                    = static_cast<int8_t>(Sig.Angle                     * exp);
+    result.Val = sigVal("pow()",
+               sig.Length                   * exp,
+               sig.Mass                     * exp,
+               sig.Time                     * exp,
+               sig.ElectricCurrent          * exp,
+               sig.ThermodynamicTemperature * exp,
+               sig.AmountOfSubstance        * exp,
+               sig.LuminousIntensity        * exp,
+               sig.Angle                    * exp);
 
     return result;
 }
 
-bool Unit::isEmpty()const
+Unit Unit::sqrt() const
 {
-    return (this->Sig.Length == 0)
-        && (this->Sig.Mass == 0)
-        && (this->Sig.Time == 0)
-        && (this->Sig.ElectricCurrent == 0)
-        && (this->Sig.ThermodynamicTemperature == 0)
-        && (this->Sig.AmountOfSubstance == 0)
-        && (this->Sig.LuminousIntensity == 0)
-        && (this->Sig.Angle == 0);
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+    // All components of unit must be either zero or dividable by 2
+    if (!((sig.Length                   % 2) == 0) &&
+         ((sig.Mass                     % 2) == 0) &&
+         ((sig.Time                     % 2) == 0) &&
+         ((sig.ElectricCurrent          % 2) == 0) &&
+         ((sig.ThermodynamicTemperature % 2) == 0) &&
+         ((sig.AmountOfSubstance        % 2) == 0) &&
+         ((sig.LuminousIntensity        % 2) == 0) &&
+         ((sig.Angle                    % 2) == 0))
+        throw Base::UnitsMismatchError("sqrt() needs even dimensions");
+
+    Unit result;
+    result.Val = sigVal("sqrt()",
+          sig.Length                   >> 1,
+          sig.Mass                     >> 1,
+          sig.Time                     >> 1,
+          sig.ElectricCurrent          >> 1,
+          sig.ThermodynamicTemperature >> 1,
+          sig.AmountOfSubstance        >> 1,
+          sig.LuminousIntensity        >> 1,
+          sig.Angle                    >> 1);
+
+    return result;
+}
+
+Unit Unit::cbrt() const
+{
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+    // All components of unit must be either zero or dividable by 3
+    if (!((sig.Length                   % 3) == 0) &&
+         ((sig.Mass                     % 3) == 0) &&
+         ((sig.Time                     % 3) == 0) &&
+         ((sig.ElectricCurrent          % 3) == 0) &&
+         ((sig.ThermodynamicTemperature % 3) == 0) &&
+         ((sig.AmountOfSubstance        % 3) == 0) &&
+         ((sig.LuminousIntensity        % 3) == 0) &&
+         ((sig.Angle                    % 3) == 0))
+        throw Base::UnitsMismatchError("cbrt() needs dimensions to be multiples of 3");
+
+    Unit result;
+    result.Val = sigVal("cbrt()",
+          sig.Length                   / 3,
+          sig.Mass                     / 3,
+          sig.Time                     / 3,
+          sig.ElectricCurrent          / 3,
+          sig.ThermodynamicTemperature / 3,
+          sig.AmountOfSubstance        / 3,
+          sig.LuminousIntensity        / 3,
+          sig.Angle                    / 3);
+
+    return result;
+}
+
+int Unit::length() const
+{
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+    return sig.Length;
+}
+
+int Unit::mass() const
+{
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+    return sig.Mass;
+}
+
+
+int Unit::time() const
+{
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+    return sig.Time;
+}
+
+int Unit::electricCurrent() const
+{
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+    return sig.ElectricCurrent;
+}
+
+int Unit::thermodynamicTemperature() const
+{
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+    return sig.ThermodynamicTemperature;
+}
+
+int Unit::amountOfSubstance() const
+{
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+    return sig.AmountOfSubstance;
+}
+
+int Unit::luminousIntensity() const
+{
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+    return sig.LuminousIntensity;
+}
+
+int Unit::angle() const
+{
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+    return sig.Angle;
+}
+
+bool Unit::isEmpty() const
+{
+    return Val == 0;
+}
+
+int Unit::operator [](int index) const
+{
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+
+    switch (index) {
+       case 0:
+          return sig.Length;
+       case 1:
+          return sig.Mass;
+       case 2:
+          return sig.Time;
+       case 3:
+          return sig.ElectricCurrent;
+       case 4:
+          return sig.ThermodynamicTemperature;
+       case 5:
+          return sig.AmountOfSubstance;
+       case 6:
+          return sig.LuminousIntensity;
+       case 7:
+          return sig.Angle;
+       default:
+          throw Base::IndexError("Unknown Unit element");
+    }
 }
 
 bool Unit::operator ==(const Unit& that) const
 {
-    return (this->Sig.Length == that.Sig.Length)
-        && (this->Sig.Mass == that.Sig.Mass)
-        && (this->Sig.Time == that.Sig.Time)
-        && (this->Sig.ElectricCurrent == that.Sig.ElectricCurrent)
-        && (this->Sig.ThermodynamicTemperature == that.Sig.ThermodynamicTemperature)
-        && (this->Sig.AmountOfSubstance == that.Sig.AmountOfSubstance)
-        && (this->Sig.LuminousIntensity == that.Sig.LuminousIntensity)
-        && (this->Sig.Angle == that.Sig.Angle);
+    return Val == that.Val;
 }
-
 
 Unit Unit::operator *(const Unit &right) const
 {
-    checkRange("* operator",
-               Sig.Length +right.Sig.Length,
-               Sig.Mass + right.Sig.Mass,
-               Sig.Time + right.Sig.Time,
-               Sig.ElectricCurrent + right.Sig.ElectricCurrent,
-               Sig.ThermodynamicTemperature + right.Sig.ThermodynamicTemperature,
-               Sig.AmountOfSubstance + right.Sig.AmountOfSubstance,
-               Sig.LuminousIntensity + right.Sig.LuminousIntensity,
-               Sig.Angle + right.Sig.Angle);
-
     Unit result;
-    result.Sig.Length                   = Sig.Length                    + right.Sig.Length;
-    result.Sig.Mass                     = Sig.Mass                      + right.Sig.Mass;
-    result.Sig.Time                     = Sig.Time                      + right.Sig.Time;
-    result.Sig.ElectricCurrent          = Sig.ElectricCurrent           + right.Sig.ElectricCurrent;
-    result.Sig.ThermodynamicTemperature = Sig.ThermodynamicTemperature  + right.Sig.ThermodynamicTemperature;
-    result.Sig.AmountOfSubstance        = Sig.AmountOfSubstance         + right.Sig.AmountOfSubstance;
-    result.Sig.LuminousIntensity        = Sig.LuminousIntensity         + right.Sig.LuminousIntensity;
-    result.Sig.Angle                    = Sig.Angle                     + right.Sig.Angle;
+    UnitSignature sig, rsig;
+
+    memcpy(&sig, &Val, sizeof(Val));
+    memcpy(&rsig, &right.Val, sizeof(right.Val));
+    result.Val = sigVal("* operator",
+                        sig.Length                   + rsig.Length,
+                        sig.Mass                     + rsig.Mass,
+                        sig.Time                     + rsig.Time,
+                        sig.ElectricCurrent          + rsig.ElectricCurrent,
+                        sig.ThermodynamicTemperature + rsig.ThermodynamicTemperature,
+                        sig.AmountOfSubstance        + rsig.AmountOfSubstance,
+                        sig.LuminousIntensity        + rsig.LuminousIntensity,
+                        sig.Angle                    + rsig.Angle);
 
     return result;
 }
 
 Unit Unit::operator /(const Unit &right) const
 {
-    checkRange("/ operator",
-               Sig.Length - right.Sig.Length,
-               Sig.Mass - right.Sig.Mass,
-               Sig.Time - right.Sig.Time,
-               Sig.ElectricCurrent - right.Sig.ElectricCurrent,
-               Sig.ThermodynamicTemperature - right.Sig.ThermodynamicTemperature,
-               Sig.AmountOfSubstance - right.Sig.AmountOfSubstance,
-               Sig.LuminousIntensity - right.Sig.LuminousIntensity,
-               Sig.Angle - right.Sig.Angle);
-
     Unit result;
-    result.Sig.Length                   = Sig.Length                    - right.Sig.Length;
-    result.Sig.Mass                     = Sig.Mass                      - right.Sig.Mass;
-    result.Sig.Time                     = Sig.Time                      - right.Sig.Time;
-    result.Sig.ElectricCurrent          = Sig.ElectricCurrent           - right.Sig.ElectricCurrent;
-    result.Sig.ThermodynamicTemperature = Sig.ThermodynamicTemperature  - right.Sig.ThermodynamicTemperature;
-    result.Sig.AmountOfSubstance        = Sig.AmountOfSubstance         - right.Sig.AmountOfSubstance;
-    result.Sig.LuminousIntensity        = Sig.LuminousIntensity         - right.Sig.LuminousIntensity;
-    result.Sig.Angle                    = Sig.Angle                     - right.Sig.Angle;
+    UnitSignature sig, rsig;
+
+    memcpy(&sig, &Val, sizeof(Val));
+    memcpy(&rsig, &right.Val, sizeof(right.Val));
+    result.Val = sigVal("/ operator",
+                        sig.Length                   - rsig.Length,
+                        sig.Mass                     - rsig.Mass,
+                        sig.Time                     - rsig.Time,
+                        sig.ElectricCurrent          - rsig.ElectricCurrent,
+                        sig.ThermodynamicTemperature - rsig.ThermodynamicTemperature,
+                        sig.AmountOfSubstance        - rsig.AmountOfSubstance,
+                        sig.LuminousIntensity        - rsig.LuminousIntensity,
+                        sig.Angle                    - rsig.Angle);
 
     return result;
 }
 
 QString Unit::getString() const
 {
-    std::stringstream ret;
-
     if (isEmpty()) {
         return {};
     }
 
-    if (Sig.Length                  > 0 ||
-        Sig.Mass                    > 0 ||
-        Sig.Time                    > 0 ||
-        Sig.ElectricCurrent         > 0 ||
-        Sig.ThermodynamicTemperature> 0 ||
-        Sig.AmountOfSubstance       > 0 ||
-        Sig.LuminousIntensity       > 0 ||
-        Sig.Angle                   > 0 ){
+    std::stringstream ret;
+    UnitSignature sig;
+    memcpy(&sig, &Val, sizeof(Val));
+
+    if (sig.Length                   > 0 ||
+        sig.Mass                     > 0 ||
+        sig.Time                     > 0 ||
+        sig.ElectricCurrent          > 0 ||
+        sig.ThermodynamicTemperature > 0 ||
+        sig.AmountOfSubstance        > 0 ||
+        sig.LuminousIntensity        > 0 ||
+        sig.Angle                    > 0 ) {
 
         bool mult = false;
-        if (Sig.Length > 0) {
+        if (sig.Length > 0) {
             mult = true;
             ret << "mm";
-            if (Sig.Length > 1) {
-                ret << "^" << Sig.Length;
+            if (sig.Length > 1) {
+                ret << "^" << sig.Length;
             }
         }
 
-        if (Sig.Mass > 0) {
+        if (sig.Mass > 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "kg";
-            if (Sig.Mass > 1) {
-                ret << "^" << Sig.Mass;
+            if (sig.Mass > 1) {
+                ret << "^" << sig.Mass;
             }
         }
 
-        if (Sig.Time > 0) {
+        if (sig.Time > 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "s";
-            if (Sig.Time > 1) {
-                ret << "^" << Sig.Time;
+            if (sig.Time > 1) {
+                ret << "^" << sig.Time;
             }
         }
 
-        if (Sig.ElectricCurrent > 0) {
+        if (sig.ElectricCurrent > 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "A";
-            if (Sig.ElectricCurrent > 1) {
-                ret << "^" << Sig.ElectricCurrent;
+            if (sig.ElectricCurrent > 1) {
+                ret << "^" << sig.ElectricCurrent;
             }
         }
 
-        if (Sig.ThermodynamicTemperature > 0) {
+        if (sig.ThermodynamicTemperature > 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "K";
-            if (Sig.ThermodynamicTemperature > 1) {
-                ret << "^" << Sig.ThermodynamicTemperature;
+            if (sig.ThermodynamicTemperature > 1) {
+                ret << "^" << sig.ThermodynamicTemperature;
             }
         }
 
-        if (Sig.AmountOfSubstance > 0){
+        if (sig.AmountOfSubstance > 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "mol";
-            if (Sig.AmountOfSubstance > 1) {
-                ret << "^" << Sig.AmountOfSubstance;
+            if (sig.AmountOfSubstance > 1) {
+                ret << "^" << sig.AmountOfSubstance;
             }
         }
 
-        if (Sig.LuminousIntensity > 0) {
+        if (sig.LuminousIntensity > 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "cd";
-            if (Sig.LuminousIntensity > 1) {
-                ret << "^" << Sig.LuminousIntensity;
+            if (sig.LuminousIntensity > 1) {
+                ret << "^" << sig.LuminousIntensity;
             }
         }
 
-        if (Sig.Angle > 0) {
+        if (sig.Angle > 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
-            mult = true; //NOLINT
+            mult = true;
             ret << "deg";
-            if (Sig.Angle > 1) {
-                ret << "^" << Sig.Angle;
+            if (sig.Angle > 1) {
+                ret << "^" << sig.Angle;
             }
         }
     }
@@ -344,113 +464,113 @@ QString Unit::getString() const
         ret << "1";
     }
 
-    if (Sig.Length                  < 0 ||
-        Sig.Mass                    < 0 ||
-        Sig.Time                    < 0 ||
-        Sig.ElectricCurrent         < 0 ||
-        Sig.ThermodynamicTemperature< 0 ||
-        Sig.AmountOfSubstance       < 0 ||
-        Sig.LuminousIntensity       < 0 ||
-        Sig.Angle                   < 0 ){
+    if (sig.Length                   < 0 ||
+        sig.Mass                     < 0 ||
+        sig.Time                     < 0 ||
+        sig.ElectricCurrent          < 0 ||
+        sig.ThermodynamicTemperature < 0 ||
+        sig.AmountOfSubstance        < 0 ||
+        sig.LuminousIntensity        < 0 ||
+        sig.Angle                    < 0 ) {
         ret << "/";
 
         int nnom = 0;
-        nnom += Sig.Length<0?1:0;
-        nnom += Sig.Mass<0?1:0;
-        nnom += Sig.Time<0?1:0;
-        nnom += Sig.ElectricCurrent<0?1:0;
-        nnom += Sig.ThermodynamicTemperature<0?1:0;
-        nnom += Sig.AmountOfSubstance<0?1:0;
-        nnom += Sig.LuminousIntensity<0?1:0;
-        nnom += Sig.Angle<0?1:0;
+        nnom += sig.Length                   < 0 ? 1 : 0;
+        nnom += sig.Mass                     < 0 ? 1 : 0;
+        nnom += sig.Time                     < 0 ? 1 : 0;
+        nnom += sig.ElectricCurrent          < 0 ? 1 : 0;
+        nnom += sig.ThermodynamicTemperature < 0 ? 1 : 0;
+        nnom += sig.AmountOfSubstance        < 0 ? 1 : 0;
+        nnom += sig.LuminousIntensity        < 0 ? 1 : 0;
+        nnom += sig.Angle                    < 0 ? 1 : 0;
 
         if (nnom > 1) {
             ret << '(';
         }
 
-        bool mult=false;
-        if (Sig.Length < 0) {
+        bool mult = false;
+        if (sig.Length < 0) {
             ret << "mm";
             mult = true;
-            if (Sig.Length < -1) {
-                ret << "^" << abs(Sig.Length);
+            if (sig.Length < -1) {
+                ret << "^" << abs(sig.Length);
             }
         }
 
-        if (Sig.Mass < 0) {
+        if (sig.Mass < 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "kg";
-            if (Sig.Mass < -1) {
-                ret << "^" << abs(Sig.Mass);
+            if (sig.Mass < -1) {
+                ret << "^" << abs(sig.Mass);
             }
         }
 
-        if (Sig.Time < 0) {
+        if (sig.Time < 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "s";
-            if (Sig.Time < -1) {
-                ret << "^" << abs(Sig.Time);
+            if (sig.Time < -1) {
+                ret << "^" << abs(sig.Time);
             }
         }
 
-        if (Sig.ElectricCurrent < 0) {
+        if (sig.ElectricCurrent < 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "A";
-            if (Sig.ElectricCurrent < -1) {
-                ret << "^" << abs(Sig.ElectricCurrent);
+            if (sig.ElectricCurrent < -1) {
+                ret << "^" << abs(sig.ElectricCurrent);
             }
         }
 
-        if (Sig.ThermodynamicTemperature < 0) {
+        if (sig.ThermodynamicTemperature < 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "K";
-            if (Sig.ThermodynamicTemperature < -1) {
-                ret << "^" << abs(Sig.ThermodynamicTemperature);
+            if (sig.ThermodynamicTemperature < -1) {
+                ret << "^" << abs(sig.ThermodynamicTemperature);
             }
         }
 
-        if (Sig.AmountOfSubstance < 0) {
+        if (sig.AmountOfSubstance < 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "mol";
-            if (Sig.AmountOfSubstance < -1) {
-                ret << "^" << abs(Sig.AmountOfSubstance);
+            if (sig.AmountOfSubstance < -1) {
+                ret << "^" << abs(sig.AmountOfSubstance);
             }
         }
 
-        if (Sig.LuminousIntensity < 0) {
+        if (sig.LuminousIntensity < 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
             mult = true;
             ret << "cd";
-            if (Sig.LuminousIntensity < -1) {
-                ret << "^" << abs(Sig.LuminousIntensity);
+            if (sig.LuminousIntensity < -1) {
+                ret << "^" << abs(sig.LuminousIntensity);
             }
         }
 
-        if (Sig.Angle < 0) {
+        if (sig.Angle < 0) {
             if (mult) {
-                ret<<'*';
+                ret << '*';
             }
-            mult = true; //NOLINT
+            mult = true;
             ret << "deg";
-            if (Sig.Angle < -1) {
-                ret << "^" << abs(Sig.Angle);
+            if (sig.Angle < -1) {
+                ret << "^" << abs(sig.Angle);
             }
         }
 

--- a/src/Base/Unit.cpp
+++ b/src/Base/Unit.cpp
@@ -22,9 +22,12 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
+#include <algorithm>
+#include <array>
 #include <cmath>
 #include <limits>
 #include <sstream>
+#include <utility>
 #endif
 
 #include "Unit.h"
@@ -584,173 +587,73 @@ QString Unit::getString() const
 
 QString Unit::getTypeString() const
 {
-    if (*this == Unit::Acceleration) {
-        return QString::fromLatin1("Acceleration");
-    }
-    if (*this == Unit::AmountOfSubstance) {
-        return QString::fromLatin1("AmountOfSubstance");
-    }
-    if (*this == Unit::Angle) {
-        return QString::fromLatin1("Angle");
-    }
-    if (*this == Unit::AngleOfFriction) {
-        return QString::fromLatin1("AngleOfFriction");
-    }
-    if (*this == Unit::Area) {
-        return QString::fromLatin1("Area");
-    }
-    if (*this == Unit::CurrentDensity) {
-        return QString::fromLatin1("CurrentDensity");
-    }
-    if (*this == Unit::Density) {
-        return QString::fromLatin1("Density");
-    }
-    if (*this == Unit::DissipationRate) {
-        return QString::fromLatin1("DissipationRate");
-    }
-    if (*this == Unit::DynamicViscosity) {
-        return QString::fromLatin1("DynamicViscosity");
-    }
-    if (*this == Unit::ElectricalCapacitance) {
-        return QString::fromLatin1("ElectricalCapacitance");
-    }
-    if (*this == Unit::ElectricalConductance) {
-        return QString::fromLatin1("ElectricalConductance");
-    }
-    if (*this == Unit::ElectricalConductivity) {
-        return QString::fromLatin1("ElectricalConductivity");
-    }
-    if (*this == Unit::ElectricalInductance) {
-        return QString::fromLatin1("ElectricalInductance");
-    }
-    if (*this == Unit::ElectricalResistance) {
-        return QString::fromLatin1("ElectricalResistance");
-    }
-    if (*this == Unit::ElectricCharge) {
-        return QString::fromLatin1("ElectricCharge");
-    }
-    if (*this == Unit::ElectricCurrent) {
-        return QString::fromLatin1("ElectricCurrent");
-    }
-    if (*this == Unit::ElectricPotential) {
-        return QString::fromLatin1("ElectricPotential");
-    }
-    if (*this == Unit::ElectromagneticPotential) {
-        return QString::fromLatin1("ElectromagneticPotential");
-    }
-    if (*this == Unit::Frequency) {
-        return QString::fromLatin1("Frequency");
-    }
-    if (*this == Unit::Force) {
-        return QString::fromLatin1("Force");
-    }
-    if (*this == Unit::HeatFlux) {
-        return QString::fromLatin1("HeatFlux");
-    }
-    if (*this == Unit::InverseArea) {
-        return QString::fromLatin1("InverseArea");
-    }
-    if (*this == Unit::InverseLength) {
-        return QString::fromLatin1("InverseLength");
-    }
-    if (*this == Unit::InverseVolume) {
-        return QString::fromLatin1("InverseVolume");
-    }
-    if (*this == Unit::KinematicViscosity) {
-        return QString::fromLatin1("KinematicViscosity");
-    }
-    if (*this == Unit::Length) {
-        return QString::fromLatin1("Length");
-    }
-    if (*this == Unit::LuminousIntensity) {
-        return QString::fromLatin1("LuminousIntensity");
-    }
-    if (*this == Unit::MagneticFieldStrength) {
-        return QString::fromLatin1("MagneticFieldStrength");
-    }
-    if (*this == Unit::MagneticFlux) {
-        return QString::fromLatin1("MagneticFlux");
-    }
-    if (*this == Unit::MagneticFluxDensity) {
-        return QString::fromLatin1("MagneticFluxDensity");
-    }
-    if (*this == Unit::Magnetization) {
-        return QString::fromLatin1("Magnetization");
-    }
-    if (*this == Unit::Mass) {
-        return QString::fromLatin1("Mass");
-    }
-    if (*this == Unit::Pressure) {
-        return QString::fromLatin1("Pressure");
-    }
-    if (*this == Unit::Power) {
-        return QString::fromLatin1("Power");
-    }
-    if (*this == Unit::ShearModulus) {
-        return QString::fromLatin1("ShearModulus");
-    }
-    if (*this == Unit::SpecificEnergy) {
-        return QString::fromLatin1("SpecificEnergy");
-    }
-    if (*this == Unit::SpecificHeat) {
-        return QString::fromLatin1("SpecificHeat");
-    }
-    if (*this == Unit::Stiffness) {
-        return QString::fromLatin1("Stiffness");
-    }
-    if (*this == Unit::StiffnessDensity) {
-        return QString::fromLatin1("StiffnessDensity");
-    }
-    if (*this == Unit::Stress) {
-        return QString::fromLatin1("Stress");
-    }
-    if (*this == Unit::Temperature) {
-        return QString::fromLatin1("Temperature");
-    }
-    if (*this == Unit::ThermalConductivity) {
-        return QString::fromLatin1("ThermalConductivity");
-    }
-    if (*this == Unit::ThermalExpansionCoefficient) {
-        return QString::fromLatin1("ThermalExpansionCoefficient");
-    }
-    if (*this == Unit::ThermalTransferCoefficient) {
-        return QString::fromLatin1("ThermalTransferCoefficient");
-    }
-    if (*this == Unit::TimeSpan) {
-        return QString::fromLatin1("TimeSpan");
-    }
-    if (*this == Unit::UltimateTensileStrength) {
-        return QString::fromLatin1("UltimateTensileStrength");
-    }
-    if (*this == Unit::VacuumPermittivity) {
-        return QString::fromLatin1("VacuumPermittivity");
-    }
-    if (*this == Unit::Velocity) {
-        return QString::fromLatin1("Velocity");
-    }
-    if (*this == Unit::Volume) {
-        return QString::fromLatin1("Volume");
-    }
-    if (*this == Unit::VolumeFlowRate) {
-        return QString::fromLatin1("VolumeFlowRate");
-    }
-    if (*this == Unit::VolumetricThermalExpansionCoefficient) {
-        return QString::fromLatin1("VolumetricThermalExpansionCoefficient");
-    }
-    if (*this == Unit::Work) {
-        return QString::fromLatin1("Work");
-    }
-    if (*this == Unit::YieldStrength) {
-        return QString::fromLatin1("YieldStrength");
-    }
-    if (*this == Unit::YoungsModulus) {
-        return QString::fromLatin1("YoungsModulus");
-    }
-    if (*this == Unit::Moment) {
-        return QString::fromLatin1("Moment");
-    }
+    static std::array<std::pair<Unit, std::string>, 55> unitSpecs {{
+        { Unit::Acceleration, "Acceleration" },
+        { Unit::AmountOfSubstance, "AmountOfSubstance" },
+        { Unit::Angle, "Angle" },
+        { Unit::AngleOfFriction, "AngleOfFriction" },
+        { Unit::Area, "Area" },
+        { Unit::CurrentDensity, "CurrentDensity" },
+        { Unit::Density, "Density" },
+        { Unit::DissipationRate, "DissipationRate" },
+        { Unit::DynamicViscosity, "DynamicViscosity" },
+        { Unit::ElectricalCapacitance, "ElectricalCapacitance" },
+        { Unit::ElectricalConductance, "ElectricalConductance" },
+        { Unit::ElectricalConductivity, "ElectricalConductivity" },
+        { Unit::ElectricalInductance, "ElectricalInductance" },
+        { Unit::ElectricalResistance, "ElectricalResistance" },
+        { Unit::ElectricCharge, "ElectricCharge" },
+        { Unit::ElectricCurrent, "ElectricCurrent" },
+        { Unit::ElectricPotential, "ElectricPotential" },
+        { Unit::ElectromagneticPotential, "ElectromagneticPotential" },
+        { Unit::Frequency, "Frequency" },
+        { Unit::Force, "Force" },
+        { Unit::HeatFlux, "HeatFlux" },
+        { Unit::InverseArea, "InverseArea" },
+        { Unit::InverseLength, "InverseLength" },
+        { Unit::InverseVolume, "InverseVolume" },
+        { Unit::KinematicViscosity, "KinematicViscosity" },
+        { Unit::Length, "Length" },
+        { Unit::LuminousIntensity, "LuminousIntensity" },
+        { Unit::MagneticFieldStrength, "MagneticFieldStrength" },
+        { Unit::MagneticFlux, "MagneticFlux" },
+        { Unit::MagneticFluxDensity, "MagneticFluxDensity" },
+        { Unit::Magnetization, "Magnetization" },
+        { Unit::Mass, "Mass" },
+        { Unit::Pressure, "Pressure" },
+        { Unit::Power, "Power" },
+        { Unit::ShearModulus, "ShearModulus" },
+        { Unit::SpecificEnergy, "SpecificEnergy" },
+        { Unit::SpecificHeat, "SpecificHeat" },
+        { Unit::Stiffness, "Stiffness" },
+        { Unit::StiffnessDensity, "StiffnessDensity" },
+        { Unit::Stress, "Stress" },
+        { Unit::Temperature, "Temperature" },
+        { Unit::ThermalConductivity, "ThermalConductivity" },
+        { Unit::ThermalExpansionCoefficient, "ThermalExpansionCoefficient" },
+        { Unit::ThermalTransferCoefficient, "ThermalTransferCoefficient" },
+        { Unit::TimeSpan, "TimeSpan" },
+        { Unit::UltimateTensileStrength, "UltimateTensileStrength" },
+        { Unit::VacuumPermittivity, "VacuumPermittivity" },
+        { Unit::Velocity, "Velocity" },
+        { Unit::Volume, "Volume" },
+        { Unit::VolumeFlowRate, "VolumeFlowRate" },
+        { Unit::VolumetricThermalExpansionCoefficient, "VolumetricThermalExpansionCoefficient" },
+        { Unit::Work, "Work" },
+        { Unit::YieldStrength, "YieldStrength" },
+        { Unit::YoungsModulus, "YoungsModulus" },
+        { Unit::Moment, "Moment" },
+    }};
 
-    return {};
+    const auto spec =
+        std::find_if(unitSpecs.begin(), unitSpecs.end(), [&](const auto& pair) {
+            return pair.first == *this;
+        });
+
+    if (spec == std::end(unitSpecs))
+        return QString();
+
+    return QString::fromStdString(spec->second);
 }
 
 // SI base units

--- a/src/Base/Unit.cpp
+++ b/src/Base/Unit.cpp
@@ -125,10 +125,10 @@ Unit::Unit() //NOLINT
     Val = 0;
 }
 
-Unit::Unit(const QString& expr)  // NOLINT
+Unit::Unit(const std::string& expr)  // NOLINT
 {
     try {
-        *this = Quantity::parse(expr).getUnit();
+        *this = Quantity::parse(QString::fromStdString(expr)).getUnit();
     }
     catch (const Base::ParserError&) {
         Val = 0;
@@ -358,7 +358,7 @@ Unit Unit::operator /(const Unit &right) const
     return result;
 }
 
-QString Unit::getString() const
+std::string Unit::getString() const
 {
     if (isEmpty()) {
         return {};
@@ -582,10 +582,10 @@ QString Unit::getString() const
         }
     }
 
-    return QString::fromUtf8(ret.str().c_str());
+    return ret.str();
 }
 
-QString Unit::getTypeString() const
+std::string Unit::getTypeString() const
 {
     static std::array<std::pair<Unit, std::string>, 55> unitSpecs {{
         { Unit::Acceleration, "Acceleration" },
@@ -651,9 +651,9 @@ QString Unit::getTypeString() const
         });
 
     if (spec == std::end(unitSpecs))
-        return QString();
+        return "";
 
-    return QString::fromStdString(spec->second);
+    return spec->second;
 }
 
 // SI base units

--- a/src/Base/Unit.h
+++ b/src/Base/Unit.h
@@ -31,29 +31,6 @@
 namespace Base
 {
 
-#define UnitSignatureLengthBits 4
-#define UnitSignatureMassBits 4
-#define UnitSignatureTimeBits 4
-#define UnitSignatureElectricCurrentBits 4
-#define UnitSignatureThermodynamicTemperatureBits 4
-#define UnitSignatureAmountOfSubstanceBits 4
-#define UnitSignatureLuminousIntensityBits 4
-#define UnitSignatureAngleBits 4
-
-// Hint:
-// https://en.cppreference.com/w/cpp/language/bit_field
-// https://stackoverflow.com/questions/33723631/signed-bit-field-in-c14
-struct UnitSignature
-{
-    int32_t Length: UnitSignatureLengthBits;
-    int32_t Mass: UnitSignatureMassBits;
-    int32_t Time: UnitSignatureTimeBits;
-    int32_t ElectricCurrent: UnitSignatureElectricCurrentBits;
-    int32_t ThermodynamicTemperature: UnitSignatureThermodynamicTemperatureBits;
-    int32_t AmountOfSubstance: UnitSignatureAmountOfSubstanceBits;
-    int32_t LuminousIntensity: UnitSignatureLuminousIntensityBits;
-    int32_t Angle: UnitSignatureAngleBits;
-};
 /**
  * The Unit class.
  */
@@ -76,11 +53,11 @@ public:
     /// Destruction
     ~Unit() = default;
 
-
     /** Operators. */
     //@{
     inline Unit& operator*=(const Unit& that);
     inline Unit& operator/=(const Unit& that);
+    int operator[](int index) const;
     Unit operator*(const Unit&) const;
     Unit operator/(const Unit&) const;
     bool operator==(const Unit&) const;
@@ -91,12 +68,17 @@ public:
     Unit& operator=(const Unit&) = default;
     Unit& operator=(Unit&&) = default;
     Unit pow(double exp) const;
+    Unit sqrt() const;
+    Unit cbrt() const;
     //@}
-    /// get the unit signature
-    const UnitSignature& getSignature() const
-    {
-        return Sig;
-    }
+    int length() const;
+    int mass() const;
+    int time() const;
+    int electricCurrent() const;
+    int thermodynamicTemperature() const;
+    int amountOfSubstance() const;
+    int luminousIntensity() const;
+    int angle() const;
     bool isEmpty() const;
 
     QString getString() const;
@@ -177,7 +159,7 @@ public:
 
     //@}
 private:
-    UnitSignature Sig;
+    uint32_t Val;
 };
 
 inline Unit& Unit::operator*=(const Unit& that)

--- a/src/Base/Unit.h
+++ b/src/Base/Unit.h
@@ -25,7 +25,7 @@
 #define BASE_Unit_H
 
 #include <cstdint>
-#include <QString>
+#include <string>
 #include <FCGlobal.h>
 
 namespace Base
@@ -49,7 +49,7 @@ public:
     Unit();
     Unit(const Unit&) = default;
     Unit(Unit&&) = default;
-    explicit Unit(const QString& expr);
+    explicit Unit(const std::string& expr);
     /// Destruction
     ~Unit() = default;
 
@@ -81,9 +81,9 @@ public:
     int angle() const;
     bool isEmpty() const;
 
-    QString getString() const;
+    std::string getString() const;
     /// get the type as an string such as "Area", "Length" or "Pressure".
-    QString getTypeString() const;
+    std::string getTypeString() const;
 
     /** Predefined Unit types. */
     //@{

--- a/src/Base/UnitPyImp.cpp
+++ b/src/Base/UnitPyImp.cpp
@@ -38,7 +38,7 @@ std::string UnitPy::representation() const
     Unit* self = getUnitPtr();
 
     ret << "Unit: ";
-    ret << self->getString().toUtf8().constData() << " (";
+    ret << self->getString() << " (";
     ret << (*self).length() << ",";
     ret << (*self).mass() << ",";
     ret << (*self).time() << ",";
@@ -48,7 +48,7 @@ std::string UnitPy::representation() const
     ret << (*self).luminousIntensity() << ",";
     ret << (*self).angle() << ")";
 
-    std::string type = self->getTypeString().toUtf8().constData();
+    std::string type = self->getTypeString();
     if (!type.empty()) {
         ret << " [" << type << "]";
     }
@@ -207,7 +207,7 @@ PyObject* UnitPy::richCompare(PyObject* v, PyObject* w, int op)
 
 Py::String UnitPy::getType() const
 {
-    return {getUnitPtr()->getTypeString().toUtf8(), "utf-8"};
+    return {getUnitPtr()->getTypeString(), "utf-8"};
 }
 
 Py::Tuple UnitPy::getSignature() const

--- a/src/Base/UnitPyImp.cpp
+++ b/src/Base/UnitPyImp.cpp
@@ -34,23 +34,24 @@ using namespace Base;
 // returns a string which represents the object e.g. when printed in python
 std::string UnitPy::representation() const
 {
-    const UnitSignature& Sig = getUnitPtr()->getSignature();
     std::stringstream ret;
+    Unit* self = getUnitPtr();
+
     ret << "Unit: ";
-    ret << getUnitPtr()->getString().toUtf8().constData() << " (";
-    ret << Sig.Length << ",";
-    ret << Sig.Mass << ",";
-    ret << Sig.Time << ",";
-    ret << Sig.ElectricCurrent << ",";
-    ret << Sig.ThermodynamicTemperature << ",";
-    ret << Sig.AmountOfSubstance << ",";
-    ret << Sig.LuminousIntensity << ",";
-    ret << Sig.Angle << ")";
-    std::string type = getUnitPtr()->getTypeString().toUtf8().constData();
+    ret << self->getString().toUtf8().constData() << " (";
+    ret << (*self).length() << ",";
+    ret << (*self).mass() << ",";
+    ret << (*self).time() << ",";
+    ret << (*self).electricCurrent() << ",";
+    ret << (*self).thermodynamicTemperature() << ",";
+    ret << (*self).amountOfSubstance() << ",";
+    ret << (*self).luminousIntensity() << ",";
+    ret << (*self).angle() << ")";
+
+    std::string type = self->getTypeString().toUtf8().constData();
     if (!type.empty()) {
         ret << " [" << type << "]";
     }
-
     return ret.str();
 }
 
@@ -211,19 +212,15 @@ Py::String UnitPy::getType() const
 
 Py::Tuple UnitPy::getSignature() const
 {
-    const UnitSignature& Sig = getUnitPtr()->getSignature();
     Py::Tuple tuple(8);
-    tuple.setItem(0, Py::Long(Sig.Length));
-    tuple.setItem(1, Py::Long(Sig.Mass));
-    tuple.setItem(2, Py::Long(Sig.Time));
-    tuple.setItem(3, Py::Long(Sig.ElectricCurrent));
-    tuple.setItem(4, Py::Long(Sig.ThermodynamicTemperature));
-    tuple.setItem(5, Py::Long(Sig.AmountOfSubstance));
-    tuple.setItem(6, Py::Long(Sig.LuminousIntensity));
-    tuple.setItem(7, Py::Long(Sig.Angle));
+    Unit* self = getUnitPtr();
+
+    for (auto i = 0; i < tuple.size(); i++) {
+        tuple.setItem(i, Py::Long((*self)[i]));
+    }
+
     return tuple;
 }
-
 
 PyObject* UnitPy::getCustomAttributes(const char* /*attr*/) const
 {

--- a/src/Base/UnitPyImp.cpp
+++ b/src/Base/UnitPyImp.cpp
@@ -84,10 +84,10 @@ int UnitPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     // get string
     char* string {};
     if (PyArg_ParseTuple(args, "et", "utf-8", &string)) {
-        QString qstr = QString::fromUtf8(string);
+        std::string str(string);
         PyMem_Free(string);
         try {
-            *self = Quantity::parse(qstr).getUnit();
+            *self = Quantity::parse(str).getUnit();
             return 0;
         }
         catch (const Base::ParserError& e) {

--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -42,19 +42,6 @@
 #include "UnitsSchemaFemMilliMeterNewton.h"
 #include "UnitsSchemaMeterDecimal.h"
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-#ifndef M_E
-#define M_E 2.71828182845904523536
-#endif
-#ifndef DOUBLE_MAX
-#define DOUBLE_MAX 1.7976931348623157E+308 /* max decimal value of a "double"*/
-#endif
-#ifndef DOUBLE_MIN
-#define DOUBLE_MIN 2.2250738585072014E-308 /* min decimal value of a "double"*/
-#endif
-
 using namespace Base;
 
 // === static attributes  ================================================

--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -184,7 +184,7 @@ QString UnitsApi::schemaTranslate(const Base::Quantity& quant, double& factor, Q
 double UnitsApi::toDouble(PyObject* args, const Base::Unit& u)
 {
     if (PyUnicode_Check(args)) {
-        QString str = QString::fromUtf8(PyUnicode_AsUTF8(args));
+        std::string str(PyUnicode_AsUTF8(args));
         // Parse the string
         Quantity q = Quantity::parse(str);
         if (q.getUnit() == u) {
@@ -207,7 +207,7 @@ Quantity UnitsApi::toQuantity(PyObject* args, const Base::Unit& u)
 {
     double d {};
     if (PyUnicode_Check(args)) {
-        QString str = QString::fromUtf8(PyUnicode_AsUTF8(args));
+        std::string str(PyUnicode_AsUTF8(args));
         // Parse the string
         Quantity q = Quantity::parse(str);
         d = q.getValue();

--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -176,7 +176,8 @@ std::string UnitsApi::getBasicLengthUnit()
 
 // === static translation methods ==========================================
 
-QString UnitsApi::schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString)
+std::string
+UnitsApi::schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString)
 {
     return UserPrefSystem->schemaTranslate(quant, factor, unitString);
 }

--- a/src/Base/UnitsApi.h
+++ b/src/Base/UnitsApi.h
@@ -73,22 +73,22 @@ public:
      * The string is a number in C locale (i.e. the decimal separator is always a dot) and if
      * needed represented in scientific notation. The string also includes the unit of the quantity.
      */
-    static QString toString(const Base::Quantity& q,
-                            const QuantityFormat& f = QuantityFormat(QuantityFormat::Default));
+    static std::string toString(const Base::Quantity& q,
+                                const QuantityFormat& f = QuantityFormat(QuantityFormat::Default));
     /** Get a number as string for a quantity of a given format.
      * The string is a number in C locale (i.e. the decimal separator is always a dot) and if
      * needed represented in scientific notation. The string doesn't include the unit of the
      * quantity.
      */
-    static QString toNumber(const Base::Quantity& q,
-                            const QuantityFormat& f = QuantityFormat(QuantityFormat::Default));
+    static std::string toNumber(const Base::Quantity& q,
+                                const QuantityFormat& f = QuantityFormat(QuantityFormat::Default));
     /** Get a number as string for a double of a given format.
      * The string is a number in C locale (i.e. the decimal separator is always a dot) and if
      * needed represented in scientific notation. The string doesn't include the unit of the
      * quantity.
      */
-    static QString toNumber(double value,
-                            const QuantityFormat& f = QuantityFormat(QuantityFormat::Default));
+    static std::string toNumber(double value,
+                                const QuantityFormat& f = QuantityFormat(QuantityFormat::Default));
 
     /// generate a value for a quantity with default user preferred system
     static double toDouble(PyObject* args, const Base::Unit& u = Base::Unit());

--- a/src/Base/UnitsApi.h
+++ b/src/Base/UnitsApi.h
@@ -60,12 +60,12 @@ public:
     /// Returns a brief description of a schema
     static QString getDescription(UnitSystem);
 
-    static QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString);
-    static QString schemaTranslate(const Base::Quantity& quant)
+    static std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString);
+    static std::string schemaTranslate(const Base::Quantity& quant)
     {  // to satisfy GCC
         double dummy1 {};
-        QString dummy2;
+        std::string dummy2;
         return UnitsApi::schemaTranslate(quant, dummy1, dummy2);
     }
 

--- a/src/Base/UnitsApiPy.cpp
+++ b/src/Base/UnitsApiPy.cpp
@@ -87,10 +87,10 @@ PyObject* UnitsApi::sParseQuantity(PyObject* /*self*/, PyObject* args)
     }
 
     Quantity rtn;
-    QString qstr = QString::fromUtf8(pstr);
+    std::string str(pstr);
     PyMem_Free(pstr);
     try {
-        rtn = Quantity::parse(qstr);
+        rtn = Quantity::parse(str);
     }
     catch (const Base::ParserError&) {
         PyErr_Format(PyExc_ValueError, "invalid unit expression \n");

--- a/src/Base/UnitsApiPy.cpp
+++ b/src/Base/UnitsApiPy.cpp
@@ -174,13 +174,13 @@ PyObject* UnitsApi::sSchemaTranslate(PyObject* /*self*/, PyObject* args)
     }
 
     double factor {};
-    QString uus;
-    QString uss = schema->schemaTranslate(quant, factor, uus);
+    std::string uus;
+    std::string uss = schema->schemaTranslate(quant, factor, uus);
 
     Py::Tuple res(3);
-    res[0] = Py::String(uss.toUtf8(), "utf-8");
+    res[0] = Py::String(uss, "utf-8");
     res[1] = Py::Float(factor);
-    res[2] = Py::String(uus.toUtf8(), "utf-8");
+    res[2] = Py::String(uus, "utf-8");
 
     return Py::new_reference_to(res);
 }

--- a/src/Base/UnitsApiPy.cpp
+++ b/src/Base/UnitsApiPy.cpp
@@ -221,6 +221,5 @@ PyObject* UnitsApi::sToNumber(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
-    QString string = toNumber(value, qf);
-    return Py::new_reference_to(Py::String(string.toStdString()));
+    return Py::new_reference_to(Py::String(toNumber(value, qf)));
 }

--- a/src/Base/UnitsSchema.cpp
+++ b/src/Base/UnitsSchema.cpp
@@ -20,7 +20,6 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #include "PreCompiled.h"
 #ifdef __GNUC__
 #include <unistd.h>
@@ -31,11 +30,11 @@
 
 #include "UnitsSchema.h"
 
-
 using namespace Base;
 
-QString
-UnitsSchema::toLocale(const Base::Quantity& quant, double factor, const QString& unitString) const
+std::string UnitsSchema::toLocale(const Base::Quantity& quant,
+                                  double factor,
+                                  const std::string& unitString) const
 {
     QLocale Lc;
     const QuantityFormat& format = quant.getFormat();
@@ -45,5 +44,7 @@ UnitsSchema::toLocale(const Base::Quantity& quant, double factor, const QString&
     }
 
     QString Ln = Lc.toString((quant.getValue() / factor), format.toFormat(), format.precision);
-    return QString::fromUtf8("%1 %2").arg(Ln, unitString);
+    return QString::fromStdString("%1 %2")
+        .arg(Ln, QString::fromStdString(unitString))
+        .toStdString();
 }

--- a/src/Base/UnitsSchema.h
+++ b/src/Base/UnitsSchema.h
@@ -20,13 +20,11 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #ifndef BASE_UNITSSCHEMA_H
 #define BASE_UNITSSCHEMA_H
 
-#include <QString>
+#include <string>
 #include <Base/Quantity.h>
-
 
 namespace Base
 {
@@ -73,10 +71,11 @@ public:
     {}
 
     /// This method translates the quantity in a string as the user may expect it.
-    virtual QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString) = 0;
+    virtual std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString) = 0;
 
-    QString toLocale(const Base::Quantity& quant, double factor, const QString& unitString) const;
+    std::string
+    toLocale(const Base::Quantity& quant, double factor, const std::string& unitString) const;
 
     // return true if this schema uses multiple units for length (ex. Ft/In)
     virtual bool isMultiUnitLength() const
@@ -97,8 +96,6 @@ public:
     }
 };
 
-
 }  // namespace Base
-
 
 #endif  // BASE_UNITSSCHEMA_H

--- a/src/Base/UnitsSchemaCentimeters.cpp
+++ b/src/Base/UnitsSchemaCentimeters.cpp
@@ -22,57 +22,41 @@
 
 
 #include "PreCompiled.h"
-#ifdef __GNUC__
-#include <unistd.h>
+#ifndef _PreComp_
+#include <algorithm>
+#include <array>
+#include <utility>
 #endif
-
-#include <QString>
 
 #include "UnitsSchemaCentimeters.h"
 
-
 using namespace Base;
 
-
-QString UnitsSchemaCentimeters::schemaTranslate(const Base::Quantity& quant,
-                                                double& factor,
-                                                QString& unitString)
+std::string UnitsSchemaCentimeters::schemaTranslate(const Base::Quantity& quant,
+                                                    double& factor,
+                                                    std::string& unitString)
 {
-    Unit unit = quant.getUnit();
-    if (unit == Unit::Length) {
-        // all length units in centimeters
-        unitString = QString::fromLatin1("cm");
-        factor = 10.0;
-    }
-    else if (unit == Unit::Area) {
-        // all area units in square meters
-        unitString = QString::fromLatin1("m^2");
-        factor = 1000000.0;
-    }
-    else if (unit == Unit::Volume) {
-        // all area units in cubic meters
-        unitString = QString::fromLatin1("m^3");
-        factor = 1000000000.0;
-    }
-    else if (unit == Unit::Power) {
-        unitString = QString::fromLatin1("W");
-        factor = 1000000;
-    }
-    else if (unit == Unit::ElectricPotential) {
-        unitString = QString::fromLatin1("V");
-        factor = 1000000;
-    }
-    else if (unit == Unit::HeatFlux) {
-        unitString = QString::fromLatin1("W/m^2");
-        factor = 1.0;
-    }
-    else if (unit == Unit::Velocity) {
-        unitString = QString::fromLatin1("mm/min");
-        factor = 1.0 / 60;
+    static std::array<std::pair<Unit, std::pair<std::string, double>>, 7> unitSpecs {{
+        {Unit::Length, {"cm", 10.0}},
+        {Unit::Area, {"m^2", 1000000.0}},
+        {Unit::Volume, {"m^3", 1000000000.0}},
+        {Unit::Power, {"W", 1000000.0}},
+        {Unit::ElectricPotential, {"V", 1000000.0}},
+        {Unit::HeatFlux, {"W/m^2", 1.0}},
+        {Unit::Velocity, {"mm/min", 1.0 / 60}},
+    }};
+
+    const auto unit = quant.getUnit();
+    const auto spec = std::find_if(unitSpecs.begin(), unitSpecs.end(), [&](const auto& pair) {
+        return pair.first == unit;
+    });
+
+    if (spec != std::end(unitSpecs)) {
+        unitString = spec->second.first;
+        factor = spec->second.second;
     }
     else {
-        // default action for all cases without special treatment:
-        unitString = QString::fromStdString(quant.getUnit().getString());
+        unitString = quant.getUnit().getString();
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaCentimeters.cpp
+++ b/src/Base/UnitsSchemaCentimeters.cpp
@@ -72,7 +72,7 @@ QString UnitsSchemaCentimeters::schemaTranslate(const Base::Quantity& quant,
     }
     else {
         // default action for all cases without special treatment:
-        unitString = quant.getUnit().getString();
+        unitString = QString::fromStdString(quant.getUnit().getString());
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaCentimeters.h
+++ b/src/Base/UnitsSchemaCentimeters.h
@@ -20,13 +20,10 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #ifndef BASE_UNITSSCHEMACENTIMETERS_H
 #define BASE_UNITSSCHEMACENTIMETERS_H
 
-#include <QString>
 #include "UnitsSchema.h"
-
 
 namespace Base
 {
@@ -37,8 +34,8 @@ namespace Base
 class UnitsSchemaCentimeters: public UnitsSchema
 {
 public:
-    QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString) override;
+    std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString) override;
 
     std::string getBasicLengthUnit() const override
     {

--- a/src/Base/UnitsSchemaFemMilliMeterNewton.cpp
+++ b/src/Base/UnitsSchemaFemMilliMeterNewton.cpp
@@ -52,7 +52,7 @@ QString UnitsSchemaFemMilliMeterNewton::schemaTranslate(const Quantity& quant,
     }
     else {
         // default action for all cases without special treatment:
-        unitString = quant.getUnit().getString();
+        unitString = QString::fromStdString(quant.getUnit().getString());
         factor = 1.0;
     }
     return toLocale(quant, factor, unitString);

--- a/src/Base/UnitsSchemaFemMilliMeterNewton.cpp
+++ b/src/Base/UnitsSchemaFemMilliMeterNewton.cpp
@@ -23,37 +23,38 @@
 
 
 #include "PreCompiled.h"
-#ifdef __GNUC__
-#include <unistd.h>
+#ifndef _PreComp_
+#include <algorithm>
+#include <array>
+#include <utility>
 #endif
-
-#include <QString>
 
 #include "UnitsSchemaFemMilliMeterNewton.h"
 
-
 using namespace Base;
 
-
-QString UnitsSchemaFemMilliMeterNewton::schemaTranslate(const Quantity& quant,
-                                                        double& factor,
-                                                        QString& unitString)
+std::string UnitsSchemaFemMilliMeterNewton::schemaTranslate(const Quantity& quant,
+                                                            double& factor,
+                                                            std::string& unitString)
 {
-    Unit unit = quant.getUnit();
-    if (unit == Unit::Length) {
-        // all length units in millimeters
-        unitString = QString::fromLatin1("mm");
-        factor = 1.0;
-    }
-    else if (unit == Unit::Mass) {
-        // all mass units in t
-        unitString = QString::fromUtf8("t");
-        factor = 1e3;
+    static std::array<std::pair<Unit, std::pair<std::string, double>>, 2> unitSpecs {{
+        {Unit::Length, {"mm", 1.0}},
+        {Unit::Mass, {"t", 1e3}},
+    }};
+
+    const auto unit = quant.getUnit();
+    const auto spec = std::find_if(unitSpecs.begin(), unitSpecs.end(), [&](const auto& pair) {
+        return pair.first == unit;
+    });
+
+    if (spec != std::end(unitSpecs)) {
+        unitString = spec->second.first;
+        factor = spec->second.second;
     }
     else {
-        // default action for all cases without special treatment:
-        unitString = QString::fromStdString(quant.getUnit().getString());
+        unitString = quant.getUnit().getString();
         factor = 1.0;
     }
+
     return toLocale(quant, factor, unitString);
 }

--- a/src/Base/UnitsSchemaFemMilliMeterNewton.h
+++ b/src/Base/UnitsSchemaFemMilliMeterNewton.h
@@ -21,17 +21,13 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #ifndef BASE_UNITSSCHEMAFEMMLLIMETERNEWTON_H
 #define BASE_UNITSSCHEMAFEMMLLIMETERNEWTON_H
 
-#include <QString>
 #include "UnitsSchema.h"
-
 
 namespace Base
 {
-
 
 /*  Milli metric / Newton / Seconds unit schema for use in FEM.
  *  Lengths are always in mm.
@@ -42,12 +38,10 @@ namespace Base
 class UnitsSchemaFemMilliMeterNewton: public UnitsSchema
 {
 public:
-    QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString) override;
+    std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString) override;
 };
 
-
 }  // namespace Base
-
 
 #endif  // BASE_UNITSSCHEMAFEMMLLIMETERNEWTON_H

--- a/src/Base/UnitsSchemaImperial1.cpp
+++ b/src/Base/UnitsSchemaImperial1.cpp
@@ -30,16 +30,13 @@
 #include <unistd.h>
 #endif
 
-#include <QString>
-
 #include "UnitsSchemaImperial1.h"
-
 
 using namespace Base;
 
-
-QString
-UnitsSchemaImperial1::schemaTranslate(const Quantity& quant, double& factor, QString& unitString)
+std::string UnitsSchemaImperial1::schemaTranslate(const Quantity& quant,
+                                                  double& factor,
+                                                  std::string& unitString)
 {
     double UnitValue = std::abs(quant.getValue());
     Unit unit = quant.getUnit();
@@ -49,157 +46,156 @@ UnitsSchemaImperial1::schemaTranslate(const Quantity& quant, double& factor, QSt
     // now do special treatment on all cases seems necessary:
     if (unit == Unit::Length) {        // Length handling ============================
         if (UnitValue < 0.00000254) {  // smaller then 0.001 thou -> inch and scientific notation
-            unitString = QString::fromLatin1("in");
+            unitString = "in";
             factor = 25.4;
         }
         else if (UnitValue < 2.54) {  // smaller then 0.1 inch -> Thou (mil)
-            unitString = QString::fromLatin1("thou");
+            unitString = "thou";
             factor = 0.0254;
         }
         else if (UnitValue < 304.8) {
-            unitString = QString::fromLatin1("\"");
+            unitString = "\"";
             factor = 25.4;
         }
         else if (UnitValue < 914.4) {
-            unitString = QString::fromLatin1("\'");
+            unitString = "\'";
             factor = 304.8;
         }
         else if (UnitValue < 1609344.0) {
-            unitString = QString::fromLatin1("yd");
+            unitString = "yd";
             factor = 914.4;
         }
         else if (UnitValue < 1609344000.0) {
-            unitString = QString::fromLatin1("mi");
+            unitString = "mi";
             factor = 1609344.0;
         }
         else {  // bigger then 1000 mi -> scientific notation
-            unitString = QString::fromLatin1("in");
+            unitString = "in";
             factor = 25.4;
         }
     }
     else if (unit == Unit::Angle) {
-        unitString = QString::fromUtf8("\xC2\xB0");
+        unitString = "\xC2\xB0";
         factor = 1.0;
     }
     else if (unit == Unit::Area) {
         // TODO: Cascade for the Areas
         // default action for all cases without special treatment:
-        unitString = QString::fromLatin1("in^2");
+        unitString = "in^2";
         factor = 645.16;
     }
     else if (unit == Unit::Volume) {
         // TODO: Cascade for the Volume
         // default action for all cases without special treatment:
-        unitString = QString::fromLatin1("in^3");
+        unitString = "in^3";
         factor = 16387.064;
     }
     else if (unit == Unit::Mass) {
         // TODO: Cascade for the weights
         // default action for all cases without special treatment:
-        unitString = QString::fromLatin1("lb");
+        unitString = "lb";
         factor = 0.45359237;
     }
     else if (unit == Unit::Pressure) {
         if (UnitValue < 6894.744) {  // psi is the smallest
-            unitString = QString::fromLatin1("psi");
+            unitString = "psi";
             factor = 6.894744825494;
         }
         else if (UnitValue < 6894744.825) {
-            unitString = QString::fromLatin1("ksi");
+            unitString = "ksi";
             factor = 6894.744825494;
         }
         else {  // bigger then 1000 ksi -> psi + scientific notation
-            unitString = QString::fromLatin1("psi");
+            unitString = "psi";
             factor = 6.894744825494;
         }
     }
     else if (unit == Unit::Stiffness) {  // Conversion to lbf/in
-        unitString = QString::fromLatin1("lbf/in");
+        unitString = "lbf/in";
         factor = 4.448222 / 0.0254;
     }
     else if (unit == Unit::Velocity) {
-        unitString = QString::fromLatin1("in/min");
+        unitString = "in/min";
         factor = 25.4 / 60;
     }
     else {
         // default action for all cases without special treatment:
-        unitString = QString::fromStdString(quant.getUnit().getString());
+        unitString = quant.getUnit().getString();
         factor = 1.0;
     }
 
     return toLocale(quant, factor, unitString);
 }
 
-QString UnitsSchemaImperialDecimal::schemaTranslate(const Base::Quantity& quant,
-                                                    double& factor,
-                                                    QString& unitString)
+std::string UnitsSchemaImperialDecimal::schemaTranslate(const Base::Quantity& quant,
+                                                        double& factor,
+                                                        std::string& unitString)
 {
-    // double UnitValue = std::abs(quant.getValue());
     Unit unit = quant.getUnit();
     // for imperial user/programmer mind; UnitValue is in internal system, that means
     // mm/kg/s. And all combined units have to be calculated from there!
 
     // now do special treatment on all cases seems necessary:
     if (unit == Unit::Length) {  // Length handling ============================
-        unitString = QString::fromLatin1("in");
+        unitString = "in";
         factor = 25.4;
     }
     else if (unit == Unit::Angle) {
-        unitString = QString::fromUtf8("\xC2\xB0");
+        unitString = "\xC2\xB0";
         factor = 1.0;
     }
     else if (unit == Unit::Area) {
         // TODO: Cascade for the Areas
         // default action for all cases without special treatment:
-        unitString = QString::fromLatin1("in^2");
+        unitString = "in^2";
         factor = 645.16;
     }
     else if (unit == Unit::Volume) {
         // TODO: Cascade for the Volume
         // default action for all cases without special treatment:
-        unitString = QString::fromLatin1("in^3");
+        unitString = "in^3";
         factor = 16387.064;
     }
     else if (unit == Unit::Mass) {
         // TODO: Cascade for the weights
         // default action for all cases without special treatment:
-        unitString = QString::fromLatin1("lb");
+        unitString = "lb";
         factor = 0.45359237;
     }
     else if (unit == Unit::Pressure) {
-        unitString = QString::fromLatin1("psi");
+        unitString = "psi";
         factor = 6.894744825494;
     }
     else if (unit == Unit::Stiffness) {
-        unitString = QString::fromLatin1("lbf/in");
+        unitString = "lbf/in";
         factor = 4.448222 / 0.0254;
     }
     else if (unit == Unit::Velocity) {
-        unitString = QString::fromLatin1("in/min");
+        unitString = "in/min";
         factor = 25.4 / 60;
     }
     else if (unit == Unit::Acceleration) {
-        unitString = QString::fromLatin1("in/min^2");
+        unitString = "in/min^2";
         factor = 25.4 / 3600;
     }
     else {
         // default action for all cases without special treatment:
-        unitString = QString::fromStdString(quant.getUnit().getString());
+        unitString = quant.getUnit().getString();
         factor = 1.0;
     }
 
     return toLocale(quant, factor, unitString);
 }
 
-QString UnitsSchemaImperialBuilding::schemaTranslate(const Quantity& quant,
-                                                     double& factor,
-                                                     QString& unitString)
+std::string UnitsSchemaImperialBuilding::schemaTranslate(const Quantity& quant,
+                                                         double& factor,
+                                                         std::string& unitString)
 {
     // this schema expresses distances in feet + inches + fractions
     // ex: 3'- 4 1/4" with proper rounding
     Unit unit = quant.getUnit();
     if (unit == Unit::Length) {
-        unitString = QString::fromLatin1("in");
+        unitString = "in";
         factor = 25.4;
 
         // Total number of inches to format
@@ -227,7 +223,7 @@ QString UnitsSchemaImperialBuilding::schemaTranslate(const Quantity& quant,
 
         // If this is zero, nothing to do but return
         if (ntot == 0) {
-            return QString::fromLatin1("0");
+            return "0";
         }
 
         // Compute the whole number of feet and remaining units
@@ -293,77 +289,76 @@ QString UnitsSchemaImperialBuilding::schemaTranslate(const Quantity& quant,
         }
 
         // Done!
-        return QString::fromLatin1(output.str().c_str());
+        return output.str();
     }
     else if (unit == Unit::Angle) {
-        unitString = QString::fromUtf8("\xC2\xB0");
+        unitString = "\xC2\xB0";
         factor = 1.0;
     }
     else if (unit == Unit::Area) {
-        unitString = QString::fromLatin1("sqft");
+        unitString = "sqft";
         factor = 92903.04;
     }
     else if (unit == Unit::Volume) {
-        unitString = QString::fromLatin1("cft");
+        unitString = "cft";
         factor = 28316846.592;
     }
     else if (unit == Unit::Velocity) {
-        unitString = QString::fromLatin1("in/min");
+        unitString = "in/min";
         factor = 25.4 / 60;
     }
     else {
-        unitString = QString::fromStdString(quant.getUnit().getString());
+        unitString = quant.getUnit().getString();
         factor = 1.0;
     }
 
     return toLocale(quant, factor, unitString);
 }
 
-QString UnitsSchemaImperialCivil::schemaTranslate(const Base::Quantity& quant,
-                                                  double& factor,
-                                                  QString& unitString)
+std::string UnitsSchemaImperialCivil::schemaTranslate(const Base::Quantity& quant,
+                                                      double& factor,
+                                                      std::string& unitString)
 {
-    //    double UnitValue = std::abs(quant.getValue());
     Unit unit = quant.getUnit();
     // for imperial user/programmer mind; UnitValue is in internal system, that means
     // mm/kg/s. And all combined units have to be calculated from there!
 
     // now do special treatment on all cases seems necessary:
-    if (unit == Unit::Length) {                  // Length handling ============================
-        unitString = QString::fromLatin1("ft");  // always ft
-        factor = 304.8;                          // 12 * 25.4
+    if (unit == Unit::Length) {  // Length handling ============================
+        unitString = "ft";       // always ft
+        factor = 304.8;          // 12 * 25.4
     }
     else if (unit == Unit::Area) {
-        unitString = QString::fromLatin1("ft^2");  // always sq.ft
+        unitString = "ft^2";  // always sq.ft
         factor = 92903.04;
     }
     else if (unit == Unit::Volume) {
-        unitString = QString::fromLatin1("ft^3");  // always cu. ft
+        unitString = "ft^3";  // always cu. ft
         factor = 28316846.592;
     }
     else if (unit == Unit::Mass) {
-        unitString = QString::fromLatin1("lb");  // always lbs.
+        unitString = "lb";  // always lbs.
         factor = 0.45359237;
     }
     else if (unit == Unit::Pressure) {
-        unitString = QString::fromLatin1("psi");
+        unitString = "psi";
         factor = 6.894744825494;
     }
     else if (unit == Unit::Stiffness) {
-        unitString = QString::fromLatin1("lbf/in");
+        unitString = "lbf/in";
         factor = 4.448222 / 0.0254;
     }
     else if (unit == Unit::Velocity) {
-        unitString = QString::fromLatin1("mph");
+        unitString = "mph";
         factor = 447.04;  // 1mm/sec => mph
     }
     // this schema expresses angles in degrees + minutes + seconds
     else if (unit == Unit::Angle) {
-        unitString = QString::fromUtf8("deg");
-        QString degreeString = QString::fromUtf8("\xC2\xB0");      // degree symbol
-        QString minuteString = QString::fromUtf8("\xE2\x80\xB2");  // prime symbol
-        QString secondString = QString::fromUtf8("\xE2\x80\xB3");  // double prime symbol
-        factor = 1.0;                                              // 1deg = 1"\xC2\xB0 "
+        unitString = "deg";
+        std::string degreeString = "\xC2\xB0";      // degree symbol
+        std::string minuteString = "\xE2\x80\xB2";  // prime symbol
+        std::string secondString = "\xE2\x80\xB3";  // double prime symbol
+        factor = 1.0;                               // 1deg = 1"\xC2\xB0 "
 
         double totalDegrees = quant.getValue() / factor;
         double wholeDegrees = std::floor(totalDegrees);
@@ -378,12 +373,12 @@ QString UnitsSchemaImperialCivil::schemaTranslate(const Base::Quantity& quant,
         int outSec = static_cast<int>(std::round(rawSeconds));
 
         std::stringstream output;
-        output << outDeg << degreeString.toUtf8().constData();
+        output << outDeg << degreeString;
         if ((outMin > 0) || (outSec > 0)) {
-            output << outMin << minuteString.toUtf8().constData();
+            output << outMin << minuteString;
         }
         if (outSec > 0) {
-            output << outSec << secondString.toUtf8().constData();
+            output << outSec << secondString;
         }
         // uncomment this for decimals on seconds
         //        if (remainSeconds < (1.0 * pow(10.0,-Base::UnitsApi::getDecimals())) ) {
@@ -392,11 +387,11 @@ QString UnitsSchemaImperialCivil::schemaTranslate(const Base::Quantity& quant,
         //            output << std::setprecision(Base::UnitsApi::getDecimals()) << std::fixed <<
         //                      rawSeconds << secondString.toStdString();
         //        }
-        return QString::fromStdString(output.str());
+        return output.str();
     }
     else {
         // default action for all cases without special treatment:
-        unitString = QString::fromStdString(quant.getUnit().getString());
+        unitString = quant.getUnit().getString();
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaImperial1.cpp
+++ b/src/Base/UnitsSchemaImperial1.cpp
@@ -123,7 +123,7 @@ UnitsSchemaImperial1::schemaTranslate(const Quantity& quant, double& factor, QSt
     }
     else {
         // default action for all cases without special treatment:
-        unitString = quant.getUnit().getString();
+        unitString = QString::fromStdString(quant.getUnit().getString());
         factor = 1.0;
     }
 
@@ -184,7 +184,7 @@ QString UnitsSchemaImperialDecimal::schemaTranslate(const Base::Quantity& quant,
     }
     else {
         // default action for all cases without special treatment:
-        unitString = quant.getUnit().getString();
+        unitString = QString::fromStdString(quant.getUnit().getString());
         factor = 1.0;
     }
 
@@ -312,7 +312,7 @@ QString UnitsSchemaImperialBuilding::schemaTranslate(const Quantity& quant,
         factor = 25.4 / 60;
     }
     else {
-        unitString = quant.getUnit().getString();
+        unitString = QString::fromStdString(quant.getUnit().getString());
         factor = 1.0;
     }
 
@@ -392,11 +392,11 @@ QString UnitsSchemaImperialCivil::schemaTranslate(const Base::Quantity& quant,
         //            output << std::setprecision(Base::UnitsApi::getDecimals()) << std::fixed <<
         //                      rawSeconds << secondString.toStdString();
         //        }
-        return QString::fromUtf8(output.str().c_str());
+        return QString::fromStdString(output.str());
     }
     else {
         // default action for all cases without special treatment:
-        unitString = quant.getUnit().getString();
+        unitString = QString::fromStdString(quant.getUnit().getString());
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaImperial1.h
+++ b/src/Base/UnitsSchemaImperial1.h
@@ -20,17 +20,13 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #ifndef BASE_UNITSSCHEMAIMPERIAL1_H
 #define BASE_UNITSSCHEMAIMPERIAL1_H
 
-#include <QString>
 #include "UnitsSchema.h"
-
 
 namespace Base
 {
-
 
 /** The schema class for the imperial unit system
  *  Here are the definitions for the imperial unit system.
@@ -39,10 +35,8 @@ namespace Base
 class UnitsSchemaImperial1: public UnitsSchema
 {
 public:
-    // virtual void setSchemaUnits(void);
-    // virtual void resetSchemaUnits(void);
-    QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString) override;
+    std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString) override;
     std::string getBasicLengthUnit() const override
     {
         return {"in"};
@@ -56,10 +50,8 @@ public:
 class UnitsSchemaImperialDecimal: public UnitsSchema
 {
 public:
-    // virtual void setSchemaUnits(void);
-    // virtual void resetSchemaUnits(void);
-    QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString) override;
+    std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString) override;
     std::string getBasicLengthUnit() const override
     {
         return {"in"};
@@ -73,10 +65,8 @@ public:
 class UnitsSchemaImperialBuilding: public UnitsSchema
 {
 public:
-    // virtual void setSchemaUnits(void);
-    // virtual void resetSchemaUnits(void);
-    QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString) override;
+    std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString) override;
     std::string getBasicLengthUnit() const override
     {
         return {"ft"};
@@ -96,10 +86,8 @@ public:
 class UnitsSchemaImperialCivil: public UnitsSchema
 {
 public:
-    // virtual void setSchemaUnits(void);
-    // virtual void resetSchemaUnits(void);
-    QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString) override;
+    std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString) override;
     std::string getBasicLengthUnit() const override
     {
         return {"ft"};
@@ -112,8 +100,6 @@ public:
     }
 };
 
-
 }  // namespace Base
-
 
 #endif  // BASE_UNITSSCHEMAIMPERIAL1_H

--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -26,17 +26,13 @@
 #include <unistd.h>
 #endif
 
-#include <QString>
-
 #include "UnitsSchemaInternal.h"
 #include <cmath>
 
-
 using namespace Base;
 
-
-QString
-UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, QString& unitString)
+std::string
+UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, std::string& unitString)
 {
     double UnitValue = std::abs(quant.getValue());
     Unit unit = quant.getUnit();
@@ -52,585 +48,585 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, QStr
     // now do special treatment on all cases seems necessary:
     if (unit == Unit::Length) {  // Length handling ============================
         if (UnitValue < 1e-6) {  // smaller than 0.001 nm -> scientific notation
-            unitString = QString::fromLatin1("mm");
+            unitString = "mm";
             factor = 1.0;
         }
         else if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("nm");
+            unitString = "nm";
             factor = 1e-6;
         }
         else if (UnitValue < 0.1) {
-            unitString = QString::fromUtf8("\xC2\xB5m");
+            unitString = "\xC2\xB5m";
             factor = 1e-3;
         }
         else if (UnitValue < 1e4) {
-            unitString = QString::fromLatin1("mm");
+            unitString = "mm";
             factor = 1.0;
         }
         else if (UnitValue < 1e7) {
-            unitString = QString::fromLatin1("m");
+            unitString = "m";
             factor = 1e3;
         }
         else if (UnitValue < 1e10) {
-            unitString = QString::fromLatin1("km");
+            unitString = "km";
             factor = 1e6;
         }
         else {  // bigger than 1000 km -> scientific notation
-            unitString = QString::fromLatin1("m");
+            unitString = "m";
             factor = 1e3;
         }
     }
     else if (unit == Unit::Area) {
         if (UnitValue < 100) {
-            unitString = QString::fromLatin1("mm^2");
+            unitString = "mm^2";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("cm^2");
+            unitString = "cm^2";
             factor = 100;
         }
         else if (UnitValue < 1e12) {
-            unitString = QString::fromLatin1("m^2");
+            unitString = "m^2";
             factor = 1e6;
         }
         else {  // bigger than 1 square kilometer
-            unitString = QString::fromLatin1("km^2");
+            unitString = "km^2";
             factor = 1e12;
         }
     }
     else if (unit == Unit::Volume) {
         if (UnitValue < 1e3) {  // smaller than 1 ul
-            unitString = QString::fromLatin1("mm^3");
+            unitString = "mm^3";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("ml");
+            unitString = "ml";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("l");
+            unitString = "l";
             factor = 1e6;
         }
         else {  // bigger than 1000 l
-            unitString = QString::fromLatin1("m^3");
+            unitString = "m^3";
             factor = 1e9;
         }
     }
     else if (unit == Unit::Angle) {
         // TODO: Cascade for the Areas
         // default action for all cases without special treatment:
-        unitString = QString::fromUtf8("\xC2\xB0");
+        unitString = "\xC2\xB0";
         factor = 1.0;
     }
     else if (unit == Unit::Mass) {
         if (UnitValue < 1e-6) {
-            unitString = QString::fromUtf8("\xC2\xB5g");
+            unitString = "\xC2\xB5g";
             factor = 1e-9;
         }
         else if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("mg");
+            unitString = "mg";
             factor = 1e-6;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("g");
+            unitString = "g";
             factor = 1e-3;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("kg");
+            unitString = "kg";
             factor = 1.0;
         }
         else {
-            unitString = QString::fromLatin1("t");
+            unitString = "t";
             factor = 1e3;
         }
     }
     else if (unit == Unit::Density) {
         if (UnitValue < 0.0001) {
-            unitString = QString::fromLatin1("kg/m^3");
+            unitString = "kg/m^3";
             factor = 1e-9;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("kg/cm^3");
+            unitString = "kg/cm^3";
             factor = 0.001;
         }
         else {
-            unitString = QString::fromLatin1("kg/mm^3");
+            unitString = "kg/mm^3";
             factor = 1.0;
         }
     }
     else if (unit == Unit::ThermalConductivity) {
         if (UnitValue > 1e6) {
-            unitString = QString::fromLatin1("W/mm/K");
+            unitString = "W/mm/K";
             factor = 1e6;
         }
         else {
-            unitString = QString::fromLatin1("W/m/K");
+            unitString = "W/m/K";
             factor = 1000.0;
         }
     }
     else if (unit == Unit::ThermalExpansionCoefficient) {
         if (UnitValue < 0.001) {
-            unitString = QString::fromUtf8("\xC2\xB5m/m/K");  // micro-meter/meter/K
+            unitString = "\xC2\xB5m/m/K";  // micro-meter/meter/K
             factor = 1e-6;
         }
         else {
-            unitString = QString::fromLatin1("mm/mm/K");
+            unitString = "mm/mm/K";
             factor = 1.0;
         }
     }
     else if (unit == Unit::VolumetricThermalExpansionCoefficient) {
         if (UnitValue < 0.001) {
-            unitString = QString::fromUtf8("mm^3/m^3/K");
+            unitString = "mm^3/m^3/K";
             factor = 1e-9;
         }
         else {
-            unitString = QString::fromLatin1("m^3/m^3/K");
+            unitString = "m^3/m^3/K";
             factor = 1.0;
         }
     }
     else if (unit == Unit::SpecificHeat) {
-        unitString = QString::fromLatin1("J/kg/K");
+        unitString = "J/kg/K";
         factor = 1e6;
     }
     else if (unit == Unit::ThermalTransferCoefficient) {
-        unitString = QString::fromLatin1("W/m^2/K");
+        unitString = "W/m^2/K";
         factor = 1.0;
     }
     else if ((unit == Unit::Pressure) || (unit == Unit::Stress)) {
         if (UnitValue < 10.0) {  // Pa is the smallest
-            unitString = QString::fromLatin1("Pa");
+            unitString = "Pa";
             factor = 0.001;
         }
         else if (UnitValue < 10000.0) {
-            unitString = QString::fromLatin1("kPa");
+            unitString = "kPa";
             factor = 1.0;
         }
         else if (UnitValue < 10000000.0) {
-            unitString = QString::fromLatin1("MPa");
+            unitString = "MPa";
             factor = 1000.0;
         }
         else if (UnitValue < 10000000000.0) {
-            unitString = QString::fromLatin1("GPa");
+            unitString = "GPa";
             factor = 1e6;
         }
         else {  // bigger -> scientific notation
-            unitString = QString::fromLatin1("Pa");
+            unitString = "Pa";
             factor = 0.001;
         }
     }
     else if ((unit == Unit::Stiffness)) {
         if (UnitValue < 1) {  // mN/m is the smallest
-            unitString = QString::fromLatin1("mN/m");
+            unitString = "mN/m";
             factor = 1e-3;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("N/m");
+            unitString = "N/m";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("kN/m");
+            unitString = "kN/m";
             factor = 1e3;
         }
         else {
-            unitString = QString::fromLatin1("MN/m");
+            unitString = "MN/m";
             factor = 1e6;
         }
     }
     else if ((unit == Unit::StiffnessDensity)) {
         if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("Pa/m");
+            unitString = "Pa/m";
             factor = 1e-6;
         }
         else if (UnitValue < 1) {
-            unitString = QString::fromLatin1("kPa/m");
+            unitString = "kPa/m";
             factor = 1e-3;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("MPa/m");
+            unitString = "MPa/m";
             factor = 1.0;
         }
         else {
-            unitString = QString::fromLatin1("GPa/m");
+            unitString = "GPa/m";
             factor = 1e3;
         }
     }
     else if (unit == Unit::Force) {
         if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("mN");
+            unitString = "mN";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("N");
+            unitString = "N";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("kN");
+            unitString = "kN";
             factor = 1e6;
         }
         else {
-            unitString = QString::fromLatin1("MN");
+            unitString = "MN";
             factor = 1e9;
         }
     }
     //    else if (unit == Unit::Moment) {
     //        if (UnitValue < 1e6) {
-    //            unitString = QString::fromLatin1("mNm");
+    //            unitString = "mNm";
     //            factor = 1e3;
     //        }
     //        else if (UnitValue < 1e9) {
-    //            unitString = QString::fromLatin1("Nm");
+    //            unitString = "Nm";
     //            factor = 1e6;
     //        }
     //        else if (UnitValue < 1e12) {
-    //            unitString = QString::fromLatin1("kNm");
+    //            unitString = "kNm";
     //            factor = 1e9;
     //        }
     //        else {
-    //            unitString = QString::fromLatin1("MNm");
+    //            unitString = "MNm";
     //            factor = 1e12;
     //        }
     //    }
     else if (unit == Unit::Power) {
         if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("mW");
+            unitString = "mW";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("W");
+            unitString = "W";
             factor = 1e6;
         }
         else {
-            unitString = QString::fromLatin1("kW");
+            unitString = "kW";
             factor = 1e9;
         }
     }
     else if (unit == Unit::ElectricPotential) {
         if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("mV");
+            unitString = "mV";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("V");
+            unitString = "V";
             factor = 1e6;
         }
         else if (UnitValue < 1e12) {
-            unitString = QString::fromLatin1("kV");
+            unitString = "kV";
             factor = 1e9;
         }
         else {  // > 1000 kV scientificc notation
-            unitString = QString::fromLatin1("V");
+            unitString = "V";
             factor = 1e6;
         }
     }
     else if (unit == Unit::Work) {
         if (UnitValue < 1.602176634e-10) {
-            unitString = QString::fromLatin1("eV");
+            unitString = "eV";
             factor = 1.602176634e-13;
         }
         else if (UnitValue < 1.602176634e-7) {
-            unitString = QString::fromLatin1("keV");
+            unitString = "keV";
             factor = 1.602176634e-10;
         }
         else if (UnitValue < 1.602176634e-4) {
-            unitString = QString::fromLatin1("MeV");
+            unitString = "MeV";
             factor = 1.602176634e-7;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("mJ");
+            unitString = "mJ";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("J");
+            unitString = "J";
             factor = 1e6;
         }
         else if (UnitValue < 1e12) {
-            unitString = QString::fromLatin1("kJ");
+            unitString = "kJ";
             factor = 1e9;
         }
         else if (UnitValue < 3.6e+15) {
-            unitString = QString::fromLatin1("kWh");
+            unitString = "kWh";
             factor = 3.6e+12;
         }
         else {  // bigger than 1000 kWh -> scientific notation
-            unitString = QString::fromLatin1("J");
+            unitString = "J";
             factor = 1e6;
         }
     }
     else if (unit == Unit::SpecificEnergy) {
-        unitString = QString::fromLatin1("m^2/s^2");
+        unitString = "m^2/s^2";
         factor = 1e6;
     }
     else if (unit == Unit::HeatFlux) {
-        unitString = QString::fromLatin1("W/m^2");
+        unitString = "W/m^2";
         factor = 1;  //  unit signature (0,1,-3,0,0) is length independent
     }
     else if (unit == Unit::ElectricCharge) {
-        unitString = QString::fromLatin1("C");
+        unitString = "C";
         factor = 1.0;
     }
     else if (unit == Unit::CurrentDensity) {
         if (UnitValue <= 1e3) {
-            unitString = QString::fromLatin1("A/m^2");
+            unitString = "A/m^2";
             factor = 1e-6;
         }
         else {
-            unitString = QString::fromLatin1("A/mm^2");
+            unitString = "A/mm^2";
             factor = 1;
         }
     }
     else if (unit == Unit::MagneticFluxDensity) {
         if (UnitValue <= 1e-3) {
-            unitString = QString::fromLatin1("G");
+            unitString = "G";
             factor = 1e-4;
         }
         else {
-            unitString = QString::fromLatin1("T");
+            unitString = "T";
             factor = 1.0;
         }
     }
     else if (unit == Unit::MagneticFieldStrength) {
-        unitString = QString::fromLatin1("A/m");
+        unitString = "A/m";
         factor = 1e-3;
     }
     else if (unit == Unit::MagneticFlux) {
-        unitString = QString::fromLatin1("Wb");
+        unitString = "Wb";
         factor = 1e6;
     }
     else if (unit == Unit::Magnetization) {
-        unitString = QString::fromLatin1("A/m");
+        unitString = "A/m";
         factor = 1e-3;
     }
     else if (unit == Unit::ElectromagneticPotential) {
-        unitString = QString::fromLatin1("Wb/m");
+        unitString = "Wb/m";
         factor = 1e3;
     }
     else if (unit == Unit::ElectricalConductance) {
         if (UnitValue < 1e-9) {
-            unitString = QString::fromUtf8("\xC2\xB5S");
+            unitString = "\xC2\xB5S";
             factor = 1e-12;
         }
         else if (UnitValue < 1e-6) {
-            unitString = QString::fromLatin1("mS");
+            unitString = "mS";
             factor = 1e-9;
         }
         else {
-            unitString = QString::fromLatin1("S");
+            unitString = "S";
             factor = 1e-6;
         }
     }
     else if (unit == Unit::ElectricalResistance) {
         if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("Ohm");
+            unitString = "Ohm";
             factor = 1e6;
         }
         else if (UnitValue < 1e12) {
-            unitString = QString::fromLatin1("kOhm");
+            unitString = "kOhm";
             factor = 1e9;
         }
         else {
-            unitString = QString::fromLatin1("MOhm");
+            unitString = "MOhm";
             factor = 1e12;
         }
     }
     else if (unit == Unit::ElectricalConductivity) {
         if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("mS/m");
+            unitString = "mS/m";
             factor = 1e-12;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("S/m");
+            unitString = "S/m";
             factor = 1e-9;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("kS/m");
+            unitString = "kS/m";
             factor = 1e-6;
         }
         else {
-            unitString = QString::fromLatin1("MS/m");
+            unitString = "MS/m";
             factor = 1e-3;
         }
     }
     else if (unit == Unit::ElectricalCapacitance) {
         if (UnitValue < 1e-15) {
-            unitString = QString::fromLatin1("pF");
+            unitString = "pF";
             factor = 1e-18;
         }
         else if (UnitValue < 1e-12) {
-            unitString = QString::fromLatin1("nF");
+            unitString = "nF";
             factor = 1e-15;
         }
         else if (UnitValue < 1e-9) {
             // \x reads everything to the end, therefore split
-            unitString = QString::fromUtf8("\xC2\xB5"
-                                           "F");
+            unitString = "\xC2\xB5"
+                         "F";
             factor = 1e-12;
         }
         else if (UnitValue < 1e-6) {
-            unitString = QString::fromLatin1("mF");
+            unitString = "mF";
             factor = 1e-9;
         }
         else {
-            unitString = QString::fromLatin1("F");
+            unitString = "F";
             factor = 1e-6;
         }
     }
     else if (unit == Unit::ElectricalInductance) {
         if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("nH");
+            unitString = "nH";
             factor = 1e-3;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromUtf8("\xC2\xB5H");
+            unitString = "\xC2\xB5H";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("mH");
+            unitString = "mH";
             factor = 1e3;
         }
         else {
-            unitString = QString::fromLatin1("H");
+            unitString = "H";
             factor = 1e6;
         }
     }
     else if (unit == Unit::VacuumPermittivity) {
-        unitString = QString::fromLatin1("F/m");
+        unitString = "F/m";
         factor = 1e-9;
     }
     else if (unit == Unit::Frequency) {
         if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("Hz");
+            unitString = "Hz";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("kHz");
+            unitString = "kHz";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("MHz");
+            unitString = "MHz";
             factor = 1e6;
         }
         else if (UnitValue < 1e12) {
-            unitString = QString::fromLatin1("GHz");
+            unitString = "GHz";
             factor = 1e9;
         }
         else {
-            unitString = QString::fromLatin1("THz");
+            unitString = "THz";
             factor = 1e12;
         }
     }
     else if (unit == Unit::Velocity) {
-        unitString = QString::fromLatin1("mm/s");
+        unitString = "mm/s";
         factor = 1.0;
     }
     else if (unit == Unit::DynamicViscosity) {
-        unitString = QString::fromLatin1("Pa*s");
+        unitString = "Pa*s";
         factor = 0.001;
     }
     else if (unit == Unit::KinematicViscosity) {
         if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("mm^2/s");
+            unitString = "mm^2/s";
             factor = 1.0;
         }
         else {
-            unitString = QString::fromLatin1("m^2/s");
+            unitString = "m^2/s";
             factor = 1e6;
         }
     }
     else if (unit == Unit::VolumeFlowRate) {
         if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("mm^3/s");
+            unitString = "mm^3/s";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("ml/s");
+            unitString = "ml/s";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("l/s");
+            unitString = "l/s";
             factor = 1e6;
         }
         else {
-            unitString = QString::fromLatin1("m^3/s");
+            unitString = "m^3/s";
             factor = 1e9;
         }
     }
     else if (unit == Unit::DissipationRate) {
-        unitString = QString::fromLatin1("W/kg");
+        unitString = "W/kg";
         factor = 1e6;
     }
     else if (unit == Unit::InverseLength) {
         if (UnitValue < 1e-6) {  // smaller than 0.001 1/km -> scientific notation
-            unitString = QString::fromLatin1("1/m");
+            unitString = "1/m";
             factor = 1e-3;
         }
         else if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("1/km");
+            unitString = "1/km";
             factor = 1e-6;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("1/m");
+            unitString = "1/m";
             factor = 1e-3;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("1/mm");
+            unitString = "1/mm";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromUtf8("1/\xC2\xB5m");
+            unitString = "1/\xC2\xB5m";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("1/nm");
+            unitString = "1/nm";
             factor = 1e6;
         }
         else {  // larger -> scientific notation
-            unitString = QString::fromLatin1("1/m");
+            unitString = "1/m";
             factor = 1e-3;
         }
     }
     else if (unit == Unit::InverseArea) {
         if (UnitValue < 1e-12) {  // smaller than 0.001 1/km^2 -> scientific notation
-            unitString = QString::fromLatin1("1/m^2");
+            unitString = "1/m^2";
             factor = 1e-6;
         }
         else if (UnitValue < 1e-6) {
-            unitString = QString::fromLatin1("1/km^2");
+            unitString = "1/km^2";
             factor = 1e-12;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("1/m^2");
+            unitString = "1/m^2";
             factor = 1e-6;
         }
         else if (UnitValue < 1e2) {
-            unitString = QString::fromLatin1("1/cm^2");
+            unitString = "1/cm^2";
             factor = 1e-2;
         }
         else {
-            unitString = QString::fromLatin1("1/mm^2");
+            unitString = "1/mm^2";
             factor = 1.0;
         }
     }
     else if (unit == Unit::InverseVolume) {
         if (UnitValue < 1e-6) {
-            unitString = QString::fromLatin1("1/m^3");
+            unitString = "1/m^3";
             factor = 1e-9;
         }
         else if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("1/l");
+            unitString = "1/l";
             factor = 1e-6;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("1/ml");
+            unitString = "1/ml";
             factor = 1e-3;
         }
         else {
-            unitString = QString::fromLatin1("1/mm^3");
+            unitString = "1/mm^3";
             factor = 1.0;
         }
     }
     else {
         // default action for all cases without special treatment:
-        unitString = QString::fromStdString(quant.getUnit().getString());
+        unitString = quant.getUnit().getString();
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -630,7 +630,7 @@ UnitsSchemaInternal::schemaTranslate(const Quantity& quant, double& factor, QStr
     }
     else {
         // default action for all cases without special treatment:
-        unitString = quant.getUnit().getString();
+        unitString = QString::fromStdString(quant.getUnit().getString());
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaInternal.h
+++ b/src/Base/UnitsSchemaInternal.h
@@ -20,17 +20,13 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #ifndef BASE_UNITSSCHEMAINTERNAL_H
 #define BASE_UNITSSCHEMAINTERNAL_H
 
-#include <QString>
 #include "UnitsSchema.h"
-
 
 namespace Base
 {
-
 
 /** The standard units schema
  *  Here is defined what internal (base) units FreeCAD uses.
@@ -40,12 +36,10 @@ namespace Base
 class UnitsSchemaInternal: public UnitsSchema
 {
 public:
-    QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString) override;
+    std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString) override;
 };
 
-
 }  // namespace Base
-
 
 #endif  // BASE_UNITSSCHEMAINTERNAL_H

--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -26,16 +26,13 @@
 #include <unistd.h>
 #endif
 
-#include <QString>
-
 #include "UnitsSchemaMKS.h"
 #include <cmath>
 
-
 using namespace Base;
 
-
-QString UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, QString& unitString)
+std::string
+UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, std::string& unitString)
 {
     double UnitValue = std::abs(quant.getValue());
     Unit unit = quant.getUnit();
@@ -43,581 +40,581 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, Q
     // now do special treatment on all cases seems necessary:
     if (unit == Unit::Length) {  // Length handling ============================
         if (UnitValue < 1e-6) {  // smaller than 0.001 nm -> scientific notation
-            unitString = QString::fromLatin1("mm");
+            unitString = "mm";
             factor = 1.0;
         }
         else if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("nm");
+            unitString = "nm";
             factor = 1e-6;
         }
         else if (UnitValue < 0.1) {
-            unitString = QString::fromUtf8("\xC2\xB5m");
+            unitString = "\xC2\xB5m";
             factor = 1e-3;
         }
         else if (UnitValue < 1e4) {
-            unitString = QString::fromLatin1("mm");
+            unitString = "mm";
             factor = 1.0;
         }
         else if (UnitValue < 1e7) {
-            unitString = QString::fromLatin1("m");
+            unitString = "m";
             factor = 1e3;
         }
         else if (UnitValue < 1e10) {
-            unitString = QString::fromLatin1("km");
+            unitString = "km";
             factor = 1e6;
         }
         else {  // bigger than 1000 km -> scientific notation
-            unitString = QString::fromLatin1("m");
+            unitString = "m";
             factor = 1e3;
         }
     }
     else if (unit == Unit::Area) {
         if (UnitValue < 100) {
-            unitString = QString::fromLatin1("mm^2");
+            unitString = "mm^2";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("cm^2");
+            unitString = "cm^2";
             factor = 100;
         }
         else if (UnitValue < 1e12) {
-            unitString = QString::fromLatin1("m^2");
+            unitString = "m^2";
             factor = 1e6;
         }
         else {  // bigger than 1 square kilometer
-            unitString = QString::fromLatin1("km^2");
+            unitString = "km^2";
             factor = 1e12;
         }
     }
     else if (unit == Unit::Volume) {
         if (UnitValue < 1e3) {  // smaller than 1 ul
-            unitString = QString::fromLatin1("mm^3");
+            unitString = "mm^3";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("ml");
+            unitString = "ml";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("l");
+            unitString = "l";
             factor = 1e6;
         }
         else {  // bigger than 1000 l
-            unitString = QString::fromLatin1("m^3");
+            unitString = "m^3";
             factor = 1e9;
         }
     }
     else if (unit == Unit::Mass) {
         if (UnitValue < 1e-6) {
-            unitString = QString::fromUtf8("\xC2\xB5g");
+            unitString = "\xC2\xB5g";
             factor = 1e-9;
         }
         else if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("mg");
+            unitString = "mg";
             factor = 1e-6;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("g");
+            unitString = "g";
             factor = 1e-3;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("kg");
+            unitString = "kg";
             factor = 1.0;
         }
         else {
-            unitString = QString::fromLatin1("t");
+            unitString = "t";
             factor = 1e3;
         }
     }
     else if (unit == Unit::Density) {
         if (UnitValue < 0.0001) {
-            unitString = QString::fromLatin1("kg/m^3");
+            unitString = "kg/m^3";
             factor = 0.000000001;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("kg/cm^3");
+            unitString = "kg/cm^3";
             factor = 0.001;
         }
         else {
-            unitString = QString::fromLatin1("kg/mm^3");
+            unitString = "kg/mm^3";
             factor = 1.0;
         }
     }
     else if (unit == Unit::Acceleration) {
-        unitString = QString::fromLatin1("m/s^2");
+        unitString = "m/s^2";
         factor = 1000.0;
     }
     else if ((unit == Unit::Pressure) || (unit == Unit::Stress)) {
         if (UnitValue < 10.0) {  // Pa is the smallest
-            unitString = QString::fromLatin1("Pa");
+            unitString = "Pa";
             factor = 0.001;
         }
         else if (UnitValue < 10000.0) {
-            unitString = QString::fromLatin1("kPa");
+            unitString = "kPa";
             factor = 1.0;
         }
         else if (UnitValue < 10000000.0) {
-            unitString = QString::fromLatin1("MPa");
+            unitString = "MPa";
             factor = 1000.0;
         }
         else if (UnitValue < 10000000000.0) {
-            unitString = QString::fromLatin1("GPa");
+            unitString = "GPa";
             factor = 1000000.0;
         }
         else {  // bigger then 1000 GPa -> scientific notation
-            unitString = QString::fromLatin1("Pa");
+            unitString = "Pa";
             factor = 0.001;
         }
     }
     else if ((unit == Unit::Stiffness)) {
         if (UnitValue < 1) {  // mN/m is the smallest
-            unitString = QString::fromLatin1("mN/m");
+            unitString = "mN/m";
             factor = 1e-3;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("N/m");
+            unitString = "N/m";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("kN/m");
+            unitString = "kN/m";
             factor = 1e3;
         }
         else {
-            unitString = QString::fromLatin1("MN/m");
+            unitString = "MN/m";
             factor = 1e6;
         }
     }
     else if ((unit == Unit::StiffnessDensity)) {
         if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("Pa/m");
+            unitString = "Pa/m";
             factor = 1e-6;
         }
         else if (UnitValue < 1) {
-            unitString = QString::fromLatin1("kPa/m");
+            unitString = "kPa/m";
             factor = 1e-3;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("MPa/m");
+            unitString = "MPa/m";
             factor = 1.0;
         }
         else {
-            unitString = QString::fromLatin1("GPa/m");
+            unitString = "GPa/m";
             factor = 1e3;
         }
     }
     else if (unit == Unit::ThermalConductivity) {
         if (UnitValue > 1000000) {
-            unitString = QString::fromLatin1("W/mm/K");
+            unitString = "W/mm/K";
             factor = 1000000.0;
         }
         else {
-            unitString = QString::fromLatin1("W/m/K");
+            unitString = "W/m/K";
             factor = 1000.0;
         }
     }
     else if (unit == Unit::ThermalExpansionCoefficient) {
         if (UnitValue < 0.001) {
-            unitString = QString::fromUtf8("\xC2\xB5m/m/K");
+            unitString = "\xC2\xB5m/m/K";
             factor = 0.000001;
         }
         else {
-            unitString = QString::fromLatin1("m/m/K");
+            unitString = "m/m/K";
             factor = 1.0;
         }
     }
     else if (unit == Unit::VolumetricThermalExpansionCoefficient) {
         if (UnitValue < 0.001) {
-            unitString = QString::fromUtf8("mm^3/m^3/K");
+            unitString = "mm^3/m^3/K";
             factor = 1e-9;
         }
         else {
-            unitString = QString::fromLatin1("m^3/m^3/K");
+            unitString = "m^3/m^3/K";
             factor = 1.0;
         }
     }
     else if (unit == Unit::SpecificHeat) {
-        unitString = QString::fromLatin1("J/kg/K");
+        unitString = "J/kg/K";
         factor = 1000000.0;
     }
     else if (unit == Unit::ThermalTransferCoefficient) {
-        unitString = QString::fromLatin1("W/m^2/K");
+        unitString = "W/m^2/K";
         factor = 1.0;
     }
     else if (unit == Unit::Force) {
         if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("mN");
+            unitString = "mN";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("N");
+            unitString = "N";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("kN");
+            unitString = "kN";
             factor = 1e6;
         }
         else {
-            unitString = QString::fromLatin1("MN");
+            unitString = "MN";
             factor = 1e9;
         }
     }
     //    else if (unit == Unit::Moment) {
     //        if (UnitValue < 1e6) {
-    //            unitString = QString::fromLatin1("mNm");
+    //            unitString = "mNm";
     //            factor = 1e3;
     //        }
     //        else if (UnitValue < 1e9) {
-    //            unitString = QString::fromLatin1("Nm");
+    //            unitString = "Nm";
     //            factor = 1e6;
     //        }
     //        else if (UnitValue < 1e12) {
-    //            unitString = QString::fromLatin1("kNm");
+    //            unitString = "kNm";
     //            factor = 1e9;
     //        }
     //        else {
-    //            unitString = QString::fromLatin1("MNm");
+    //            unitString = "MNm";
     //            factor = 1e12;
     //        }
     //    }
     else if (unit == Unit::Power) {
         if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("mW");
+            unitString = "mW";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("W");
+            unitString = "W";
             factor = 1e6;
         }
         else {
-            unitString = QString::fromLatin1("kW");
+            unitString = "kW";
             factor = 1e9;
         }
     }
     else if (unit == Unit::ElectricPotential) {
         if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("mV");
+            unitString = "mV";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("V");
+            unitString = "V";
             factor = 1e6;
         }
         else if (UnitValue < 1e12) {
-            unitString = QString::fromLatin1("kV");
+            unitString = "kV";
             factor = 1e9;
         }
         else {  // > 1000 kV scientificc notation
-            unitString = QString::fromLatin1("V");
+            unitString = "V";
             factor = 1e6;
         }
     }
     else if (unit == Unit::ElectricCharge) {
-        unitString = QString::fromLatin1("C");
+        unitString = "C";
         factor = 1.0;
     }
     else if (unit == Unit::CurrentDensity) {
         if (UnitValue <= 1e3) {
-            unitString = QString::fromLatin1("A/m^2");
+            unitString = "A/m^2";
             factor = 1e-6;
         }
         else {
-            unitString = QString::fromLatin1("A/mm^2");
+            unitString = "A/mm^2";
             factor = 1;
         }
     }
     else if (unit == Unit::MagneticFluxDensity) {
         if (UnitValue <= 1e-3) {
-            unitString = QString::fromLatin1("G");
+            unitString = "G";
             factor = 1e-4;
         }
         else {
-            unitString = QString::fromLatin1("T");
+            unitString = "T";
             factor = 1.0;
         }
     }
     else if (unit == Unit::MagneticFieldStrength) {
-        unitString = QString::fromLatin1("A/m");
+        unitString = "A/m";
         factor = 1e-3;
     }
     else if (unit == Unit::MagneticFlux) {
-        unitString = QString::fromLatin1("Wb");
+        unitString = "Wb";
         factor = 1e6;
     }
     else if (unit == Unit::Magnetization) {
-        unitString = QString::fromLatin1("A/m");
+        unitString = "A/m";
         factor = 1e-3;
     }
     else if (unit == Unit::ElectromagneticPotential) {
-        unitString = QString::fromLatin1("Wb/m");
+        unitString = "Wb/m";
         factor = 1e3;
     }
     else if (unit == Unit::ElectricalConductance) {
         if (UnitValue < 1e-9) {
-            unitString = QString::fromUtf8("\xC2\xB5S");
+            unitString = "\xC2\xB5S";
             factor = 1e-12;
         }
         else if (UnitValue < 1e-6) {
-            unitString = QString::fromLatin1("mS");
+            unitString = "mS";
             factor = 1e-9;
         }
         else {
-            unitString = QString::fromLatin1("S");
+            unitString = "S";
             factor = 1e-6;
         }
     }
     else if (unit == Unit::ElectricalResistance) {
         if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("Ohm");
+            unitString = "Ohm";
             factor = 1e6;
         }
         else if (UnitValue < 1e12) {
-            unitString = QString::fromLatin1("kOhm");
+            unitString = "kOhm";
             factor = 1e9;
         }
         else {
-            unitString = QString::fromLatin1("MOhm");
+            unitString = "MOhm";
             factor = 1e12;
         }
     }
     else if (unit == Unit::ElectricalConductivity) {
         if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("mS/m");
+            unitString = "mS/m";
             factor = 1e-12;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("S/m");
+            unitString = "S/m";
             factor = 1e-9;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("kS/m");
+            unitString = "kS/m";
             factor = 1e-6;
         }
         else {
-            unitString = QString::fromLatin1("MS/m");
+            unitString = "MS/m";
             factor = 1e-3;
         }
     }
     else if (unit == Unit::ElectricalCapacitance) {
         if (UnitValue < 1e-15) {
-            unitString = QString::fromLatin1("pF");
+            unitString = "pF";
             factor = 1e-18;
         }
         else if (UnitValue < 1e-12) {
-            unitString = QString::fromLatin1("nF");
+            unitString = "nF";
             factor = 1e-15;
         }
         else if (UnitValue < 1e-9) {
             // \x reads everything to the end, therefore split
-            unitString = QString::fromUtf8("\xC2\xB5"
-                                           "F");
+            unitString = "\xC2\xB5"
+                         "F";
             factor = 1e-12;
         }
         else if (UnitValue < 1e-6) {
-            unitString = QString::fromLatin1("mF");
+            unitString = "mF";
             factor = 1e-9;
         }
         else {
-            unitString = QString::fromLatin1("F");
+            unitString = "F";
             factor = 1e-6;
         }
     }
     else if (unit == Unit::ElectricalInductance) {
         if (UnitValue < 1e-6) {
-            unitString = QString::fromLatin1("nH");
+            unitString = "nH";
             factor = 1e-3;
         }
         else if (UnitValue < 1e-3) {
-            unitString = QString::fromUtf8("\xC2\xB5H");
+            unitString = "\xC2\xB5H";
             factor = 1.0;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("mH");
+            unitString = "mH";
             factor = 1e3;
         }
         else {
-            unitString = QString::fromLatin1("H");
+            unitString = "H";
             factor = 1e6;
         }
     }
     else if (unit == Unit::VacuumPermittivity) {
-        unitString = QString::fromLatin1("F/m");
+        unitString = "F/m";
         factor = 1e-9;
     }
     else if (unit == Unit::Work) {
         if (UnitValue < 1.602176634e-10) {
-            unitString = QString::fromLatin1("eV");
+            unitString = "eV";
             factor = 1.602176634e-13;
         }
         else if (UnitValue < 1.602176634e-7) {
-            unitString = QString::fromLatin1("keV");
+            unitString = "keV";
             factor = 1.602176634e-10;
         }
         else if (UnitValue < 1.602176634e-4) {
-            unitString = QString::fromLatin1("MeV");
+            unitString = "MeV";
             factor = 1.602176634e-7;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("mJ");
+            unitString = "mJ";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("J");
+            unitString = "J";
             factor = 1e6;
         }
         else if (UnitValue < 1e12) {
-            unitString = QString::fromLatin1("kJ");
+            unitString = "kJ";
             factor = 1e9;
         }
         else if (UnitValue < 3.6e+15) {
-            unitString = QString::fromLatin1("kWh");
+            unitString = "kWh";
             factor = 3.6e+12;
         }
         else {  // bigger than 1000 kWh -> scientific notation
-            unitString = QString::fromLatin1("J");
+            unitString = "J";
             factor = 1e6;
         }
     }
     else if (unit == Unit::SpecificEnergy) {
-        unitString = QString::fromLatin1("m^2/s^2");
+        unitString = "m^2/s^2";
         factor = 1000000;
     }
     else if (unit == Unit::HeatFlux) {
-        unitString = QString::fromLatin1("W/m^2");
+        unitString = "W/m^2";
         factor = 1.0;
     }
     else if (unit == Unit::Frequency) {
         if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("Hz");
+            unitString = "Hz";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("kHz");
+            unitString = "kHz";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("MHz");
+            unitString = "MHz";
             factor = 1e6;
         }
         else if (UnitValue < 1e12) {
-            unitString = QString::fromLatin1("GHz");
+            unitString = "GHz";
             factor = 1e9;
         }
         else {
-            unitString = QString::fromLatin1("THz");
+            unitString = "THz";
             factor = 1e12;
         }
     }
     else if (unit == Unit::Velocity) {
-        unitString = QString::fromLatin1("m/s");
+        unitString = "m/s";
         factor = 1000.0;
     }
     else if (unit == Unit::DynamicViscosity) {
-        unitString = QString::fromLatin1("Pa*s");
+        unitString = "Pa*s";
         factor = 0.001;
     }
     else if (unit == Unit::KinematicViscosity) {
-        unitString = QString::fromLatin1("m^2/s");
+        unitString = "m^2/s";
         factor = 1e6;
     }
     else if (unit == Unit::VolumeFlowRate) {
         if (UnitValue < 1e-3) {  // smaller than 0.001 mm^3/s -> scientific notation
-            unitString = QString::fromLatin1("m^3/s");
+            unitString = "m^3/s";
             factor = 1e9;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("mm^3/s");
+            unitString = "mm^3/s";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromLatin1("ml/s");
+            unitString = "ml/s";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("l/s");
+            unitString = "l/s";
             factor = 1e6;
         }
         else {
-            unitString = QString::fromLatin1("m^3/s");
+            unitString = "m^3/s";
             factor = 1e9;
         }
     }
     else if (unit == Unit::DissipationRate) {
-        unitString = QString::fromLatin1("W/kg");
+        unitString = "W/kg";
         factor = 1e6;
     }
     else if (unit == Unit::InverseLength) {
         if (UnitValue < 1e-6) {  // smaller than 0.001 1/km -> scientific notation
-            unitString = QString::fromLatin1("1/m");
+            unitString = "1/m";
             factor = 1e-3;
         }
         else if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("1/km");
+            unitString = "1/km";
             factor = 1e-6;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("1/m");
+            unitString = "1/m";
             factor = 1e-3;
         }
         else if (UnitValue < 1e3) {
-            unitString = QString::fromLatin1("1/mm");
+            unitString = "1/mm";
             factor = 1.0;
         }
         else if (UnitValue < 1e6) {
-            unitString = QString::fromUtf8("1/\xC2\xB5m");
+            unitString = "1/\xC2\xB5m";
             factor = 1e3;
         }
         else if (UnitValue < 1e9) {
-            unitString = QString::fromLatin1("1/nm");
+            unitString = "1/nm";
             factor = 1e6;
         }
         else {  // larger -> scientific notation
-            unitString = QString::fromLatin1("1/m");
+            unitString = "1/m";
             factor = 1e-3;
         }
     }
     else if (unit == Unit::InverseArea) {
         if (UnitValue < 1e-12) {  // smaller than 0.001 1/km^2 -> scientific notation
-            unitString = QString::fromLatin1("1/m^2");
+            unitString = "1/m^2";
             factor = 1e-6;
         }
         else if (UnitValue < 1e-6) {
-            unitString = QString::fromLatin1("1/km^2");
+            unitString = "1/km^2";
             factor = 1e-12;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("1/m^2");
+            unitString = "1/m^2";
             factor = 1e-6;
         }
         else if (UnitValue < 1e2) {
-            unitString = QString::fromLatin1("1/cm^2");
+            unitString = "1/cm^2";
             factor = 1e-2;
         }
         else {
-            unitString = QString::fromLatin1("1/mm^2");
+            unitString = "1/mm^2";
             factor = 1.0;
         }
     }
     else if (unit == Unit::InverseVolume) {
         if (UnitValue < 1e-6) {
-            unitString = QString::fromLatin1("1/m^3");
+            unitString = "1/m^3";
             factor = 1e-9;
         }
         else if (UnitValue < 1e-3) {
-            unitString = QString::fromLatin1("1/l");
+            unitString = "1/l";
             factor = 1e-6;
         }
         else if (UnitValue < 1.0) {
-            unitString = QString::fromLatin1("1/ml");
+            unitString = "1/ml";
             factor = 1e-3;
         }
         else {
-            unitString = QString::fromLatin1("1/mm^3");
+            unitString = "1/mm^3";
             factor = 1.0;
         }
     }
     else {
         // default action for all cases without special treatment:
-        unitString = QString::fromStdString(quant.getUnit().getString());
+        unitString = quant.getUnit().getString();
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -617,7 +617,7 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity& quant, double& factor, Q
     }
     else {
         // default action for all cases without special treatment:
-        unitString = quant.getUnit().getString();
+        unitString = QString::fromStdString(quant.getUnit().getString());
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaMKS.h
+++ b/src/Base/UnitsSchemaMKS.h
@@ -20,17 +20,13 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #ifndef BASE_UNITSSCHEMAMKS_H
 #define BASE_UNITSSCHEMAMKS_H
 
-#include <QString>
 #include "UnitsSchema.h"
-
 
 namespace Base
 {
-
 
 /**
  * The UnitSchema class
@@ -38,12 +34,10 @@ namespace Base
 class UnitsSchemaMKS: public UnitsSchema
 {
 public:
-    QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString) override;
+    std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString) override;
 };
 
-
 }  // namespace Base
-
 
 #endif  // BASE_UNITSSCHEMAMKS_H

--- a/src/Base/UnitsSchemaMeterDecimal.cpp
+++ b/src/Base/UnitsSchemaMeterDecimal.cpp
@@ -29,61 +29,41 @@
  */
 
 #include "PreCompiled.h"
-#ifdef __GNUC__
-#include <unistd.h>
+#ifndef _PreComp_
+#include <algorithm>
+#include <array>
+#include <utility>
 #endif
-
-#include <QString>
 
 #include "UnitsSchemaMeterDecimal.h"
 
-
 using namespace Base;
 
-
-QString UnitsSchemaMeterDecimal::schemaTranslate(const Base::Quantity& quant,
-                                                 double& factor,
-                                                 QString& unitString)
+std::string UnitsSchemaMeterDecimal::schemaTranslate(const Base::Quantity& quant,
+                                                     double& factor,
+                                                     std::string& unitString)
 {
-    Unit unit = quant.getUnit();
-    if (unit == Unit::Length) {
-        // all length units in metres
-        unitString = QString::fromLatin1("m");
-        factor = 1e3;
-    }
-    else if (unit == Unit::Area) {
-        // all area units in square meters
-        unitString = QString::fromLatin1("m^2");
-        factor = 1e6;
-    }
-    else if (unit == Unit::Volume) {
-        // all area units in cubic meters
-        unitString = QString::fromLatin1("m^3");
-        factor = 1e9;
-    }
-    else if (unit == Unit::Power) {
-        // watts
-        unitString = QString::fromLatin1("W");
-        factor = 1000000;
-    }
-    else if (unit == Unit::ElectricPotential) {
-        // volts
-        unitString = QString::fromLatin1("V");
-        factor = 1000000;
-    }
-    else if (unit == Unit::HeatFlux) {
-        // watts per square metre
-        unitString = QString::fromLatin1("W/m^2");
-        factor = 1.0;
-    }
-    else if (unit == Unit::Velocity) {
-        // metres per second
-        unitString = QString::fromLatin1("m/s");
-        factor = 1e3;
+    static std::array<std::pair<Unit, std::pair<std::string, double>>, 7> unitSpecs {{
+        {Unit::Length, {"m", 1e0}},
+        {Unit::Area, {"m^2", 1e6}},
+        {Unit::Volume, {"m^3", 1e9}},
+        {Unit::Power, {"W", 1000000}},
+        {Unit::ElectricPotential, {"V", 1000000}},
+        {Unit::HeatFlux, {"W/m^2", 1.0}},
+        {Unit::Velocity, {"m/s", 1e3}},
+    }};
+
+    const auto unit = quant.getUnit();
+    const auto spec = std::find_if(unitSpecs.begin(), unitSpecs.end(), [&](const auto& pair) {
+        return pair.first == unit;
+    });
+
+    if (spec != std::end(unitSpecs)) {
+        unitString = spec->second.first;
+        factor = spec->second.second;
     }
     else {
-        // default action for all cases without special treatment:
-        unitString = QString::fromStdString(quant.getUnit().getString());
+        unitString = quant.getUnit().getString();
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaMeterDecimal.cpp
+++ b/src/Base/UnitsSchemaMeterDecimal.cpp
@@ -83,7 +83,7 @@ QString UnitsSchemaMeterDecimal::schemaTranslate(const Base::Quantity& quant,
     }
     else {
         // default action for all cases without special treatment:
-        unitString = quant.getUnit().getString();
+        unitString = QString::fromStdString(quant.getUnit().getString());
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaMeterDecimal.h
+++ b/src/Base/UnitsSchemaMeterDecimal.h
@@ -29,9 +29,7 @@
 #ifndef BASE_UNITSSCHEMAMETERS_H
 #define BASE_UNITSSCHEMAMETERS_H
 
-#include <QString>
 #include "UnitsSchema.h"
-
 
 namespace Base
 {
@@ -42,8 +40,8 @@ namespace Base
 class UnitsSchemaMeterDecimal: public UnitsSchema
 {
 public:
-    QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString) override;
+    std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString) override;
 
     std::string getBasicLengthUnit() const override
     {

--- a/src/Base/UnitsSchemaMmMin.cpp
+++ b/src/Base/UnitsSchemaMmMin.cpp
@@ -52,7 +52,7 @@ UnitsSchemaMmMin::schemaTranslate(const Quantity& quant, double& factor, QString
     }
     else {
         // default action for all cases without special treatment:
-        unitString = quant.getUnit().getString();
+        unitString = QString::fromStdString(quant.getUnit().getString());
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaMmMin.cpp
+++ b/src/Base/UnitsSchemaMmMin.cpp
@@ -22,37 +22,36 @@
 
 
 #include "PreCompiled.h"
-#ifdef __GNUC__
-#include <unistd.h>
+#ifndef _PreComp_
+#include <algorithm>
+#include <array>
+#include <utility>
 #endif
-
-#include <QString>
 
 #include "UnitsSchemaMmMin.h"
 
-
 using namespace Base;
 
-
-QString
-UnitsSchemaMmMin::schemaTranslate(const Quantity& quant, double& factor, QString& unitString)
+std::string
+UnitsSchemaMmMin::schemaTranslate(const Quantity& quant, double& factor, std::string& unitString)
 {
-    Unit unit = quant.getUnit();
-    if (unit == Unit::Length) {
-        unitString = QString::fromLatin1("mm");
-        factor = 1.0;
-    }
-    else if (unit == Unit::Angle) {
-        unitString = QString::fromUtf8("\xC2\xB0");
-        factor = 1.0;
-    }
-    else if (unit == Unit::Velocity) {
-        unitString = QString::fromLatin1("mm/min");
-        factor = 1. / 60.;
+    static std::array<std::pair<Unit, std::pair<std::string, double>>, 3> unitSpecs {{
+        {Unit::Length, {"mm", 1.0}},
+        {Unit::Angle, {"\xC2\xB0", 1.0}},
+        {Unit::Velocity, {"mm/min", 1.0 / 60.0}},
+    }};
+
+    const auto unit = quant.getUnit();
+    const auto spec = std::find_if(unitSpecs.begin(), unitSpecs.end(), [&](const auto& pair) {
+        return pair.first == unit;
+    });
+
+    if (spec != std::end(unitSpecs)) {
+        unitString = spec->second.first;
+        factor = spec->second.second;
     }
     else {
-        // default action for all cases without special treatment:
-        unitString = QString::fromStdString(quant.getUnit().getString());
+        unitString = quant.getUnit().getString();
         factor = 1.0;
     }
 

--- a/src/Base/UnitsSchemaMmMin.h
+++ b/src/Base/UnitsSchemaMmMin.h
@@ -20,17 +20,13 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #ifndef BASE_UNITSSCHEMAMMMIN_H
 #define BASE_UNITSSCHEMAMMMIN_H
 
-#include <QString>
 #include "UnitsSchema.h"
-
 
 namespace Base
 {
-
 
 /*  Metric units schema intended for design of small parts and for CNC
  *  Lengths are always in mm.
@@ -40,12 +36,10 @@ namespace Base
 class UnitsSchemaMmMin: public UnitsSchema
 {
 public:
-    QString
-    schemaTranslate(const Base::Quantity& quant, double& factor, QString& unitString) override;
+    std::string
+    schemaTranslate(const Base::Quantity& quant, double& factor, std::string& unitString) override;
 };
 
-
 }  // namespace Base
-
 
 #endif  // BASE_UNITSSCHEMAMMMIN_H

--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -174,7 +174,7 @@ Base::Type DlgExpressionInput::determineTypeVarSet()
     // varset.  Since unit properties are derived from App::PropertyFloat, it
     // allows us to create a property and set the value.
 
-    std::string unitTypeString = impliedUnit.getTypeString().toStdString();
+    std::string unitTypeString = impliedUnit.getTypeString();
     if (unitTypeString.empty()) {
         // no type was provided
         return Base::Type::badType();
@@ -187,7 +187,7 @@ Base::Type DlgExpressionInput::determineTypeVarSet()
 
 bool DlgExpressionInput::typeOkForVarSet()
 {
-    std::string unitType = impliedUnit.getTypeString().toStdString();
+    std::string unitType = impliedUnit.getTypeString();
     return determineTypeVarSet() != Base::Type::badType();
 }
 

--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -28,6 +28,8 @@
 #include <QTreeWidget>
 #endif
 
+#include <fmt/format.h>
+
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
@@ -242,12 +244,10 @@ void NumberRange::throwIfOutOfRange(const Base::Quantity& value) const
     if (value.getValue() < minimum || value.getValue() > maximum) {
         Base::Quantity minVal(minimum, value.getUnit());
         Base::Quantity maxVal(maximum, value.getUnit());
-        QString valStr = value.getUserString();
-        QString minStr = minVal.getUserString();
-        QString maxStr = maxVal.getUserString();
-        QString error = QString::fromLatin1("Value out of range (%1 out of [%2, %3])").arg(valStr, minStr, maxStr);
-
-        throw Base::ValueError(error.toStdString());
+        auto valStr = value.getUserString();
+        auto minStr = minVal.getUserString();
+        auto maxStr = maxVal.getUserString();
+        throw Base::ValueError(fmt::format("Value out of range ({} out of [{}, {}])", valStr, minStr, maxStr));
     }
 }
 
@@ -289,12 +289,12 @@ void DlgExpressionInput::checkExpression(const QString& text)
             auto * n = Base::freecad_dynamic_cast<NumberExpression>(result.get());
             if (n) {
                 Base::Quantity value = n->getQuantity();
-                QString msg = value.getUserString();
-
                 if (!value.isValid()) {
                     throw Base::ValueError("Not a number");
                 }
-                else if (!impliedUnit.isEmpty()) {
+
+                auto msg = value.getUserString();
+                if (!impliedUnit.isEmpty()) {
                     if (!value.getUnit().isEmpty() && value.getUnit() != impliedUnit)
                         throw Base::UnitsMismatchError("Unit mismatch between result and required unit");
 
@@ -302,7 +302,7 @@ void DlgExpressionInput::checkExpression(const QString& text)
 
                 }
                 else if (!value.getUnit().isEmpty()) {
-                    msg += QString::fromUtf8(" (Warning: unit discarded)");
+                    msg += " (Warning: unit discarded)";
 
                     QPalette p(ui->msg->palette());
                     p.setColor(QPalette::WindowText, Qt::red);
@@ -311,7 +311,7 @@ void DlgExpressionInput::checkExpression(const QString& text)
 
                 numberRange.throwIfOutOfRange(value);
 
-                ui->msg->setText(msg);
+                ui->msg->setText(QString::fromStdString(msg));
             }
             else {
                 ui->msg->setText(QString::fromStdString(result->toString()));

--- a/src/Gui/DlgUnitsCalculatorImp.cpp
+++ b/src/Gui/DlgUnitsCalculatorImp.cpp
@@ -105,7 +105,7 @@ DlgUnitsCalculator::DlgUnitsCalculator(QWidget* parent, Qt::WindowFlags fl)
           << Base::Unit::Volume << Base::Unit::VolumeFlowRate
           << Base::Unit::VolumetricThermalExpansionCoefficient << Base::Unit::Work;
     for (const Base::Unit& it : units) {
-        ui->unitsBox->addItem(it.getTypeString());
+        ui->unitsBox->addItem(QString::fromStdString(it.getTypeString()));
     }
 
     ui->quantitySpinBox->setValue(1.0);
@@ -138,14 +138,15 @@ void DlgUnitsCalculator::valueChanged(const Base::Quantity& quant)
     // explicitly check for "ee" like in "eeV" because this would trigger an exception in Base::Unit
     // since it expects then a scientific notation number like "1e3"
     if ((ui->UnitInput->text().mid(0, 2) == QString::fromLatin1("ee"))
-        || Base::Unit(ui->UnitInput->text()).getTypeString().isEmpty()) {
+        || Base::Unit(ui->UnitInput->text().toStdString()).getTypeString().empty()) {
         ui->ValueOutput->setText(
             QString::fromLatin1("%1 %2").arg(tr("unknown unit:"), ui->UnitInput->text()));
         ui->pushButton_Copy->setEnabled(false);
     }
     else {  // the unit is valid
         // we can only convert units of the same type, thus check
-        if (Base::Unit(ui->UnitInput->text()).getTypeString() != quant.getUnit().getTypeString()) {
+        if (Base::Unit(ui->UnitInput->text().toStdString()).getTypeString()
+            != quant.getUnit().getTypeString()) {
             ui->ValueOutput->setText(tr("unit mismatch"));
             ui->pushButton_Copy->setEnabled(false);
         }

--- a/src/Gui/DlgUnitsCalculatorImp.cpp
+++ b/src/Gui/DlgUnitsCalculatorImp.cpp
@@ -152,7 +152,7 @@ void DlgUnitsCalculator::valueChanged(const Base::Quantity& quant)
         }
         else {  // the unit is valid and has the same type
             double convertValue =
-                Base::Quantity::parse(QString::fromLatin1("1") + ui->UnitInput->text()).getValue();
+                Base::Quantity::parse("1" + ui->UnitInput->text().toStdString()).getValue();
             // we got now e.g. for "1 in" the value '25.4' because 1 in = 25.4 mm
             // the result is now just quant / convertValue because the input is always in a base
             // unit (an input of "1 cm" will immediately be converted to "10 mm" by Gui::InputField

--- a/src/Gui/DlgUnitsCalculatorImp.cpp
+++ b/src/Gui/DlgUnitsCalculatorImp.cpp
@@ -201,11 +201,11 @@ void DlgUnitsCalculator::onUnitsBoxActivated(int index)
     // SI units use [m], not [mm] for lengths
     //
     Base::Quantity q = ui->quantitySpinBox->value();
-    int32_t old = q.getUnit().getSignature().Length;
+    int32_t old = q.getUnit().length();
     double value = q.getValue();
 
     Base::Unit unit = units[index];
-    int32_t len = unit.getSignature().Length;
+    int32_t len = unit.length();
     ui->quantitySpinBox->setValue(Base::Quantity(value * std::pow(10.0, 3 * (len - old)), unit));
 }
 

--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -180,10 +180,10 @@ void EditableDatumLabel::stopEdit()
         Base::Quantity quantity = spinBox->value();
 
         double factor{};
-        QString unitStr;
-        QString valueStr;
+        std::string unitStr;
+        std::string valueStr;
         valueStr = quantity.getUserString(factor, unitStr);
-        label->string = SbString(valueStr.toUtf8().constData());
+        label->string = SbString(valueStr.c_str());
 
         spinBox->deleteLater();
         spinBox = nullptr;

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -120,7 +120,7 @@ public:
                 result = quantity;
 
                 // Now translate the quantity into its string representation using the user-defined unit system
-                input = Base::UnitsApi::schemaTranslate(result);
+                input = QString::fromStdString(Base::UnitsApi::schemaTranslate(result));
             }
         }
 

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -608,7 +608,7 @@ void QuantitySpinBox::setUnit(const Base::Unit &unit)
 void QuantitySpinBox::setUnitText(const QString& str)
 {
     try {
-        Base::Quantity quant = Base::Quantity::parse(str);
+        Base::Quantity quant = Base::Quantity::parse(str.toStdString());
         setUnit(quant.getUnit());
     }
     catch (const Base::ParserError&) {
@@ -712,25 +712,26 @@ void QuantitySpinBox::clearSchema()
 QString QuantitySpinBox::getUserString(const Base::Quantity& val, double& factor, QString& unitString) const
 {
     Q_D(const QuantitySpinBox);
-    if (d->scheme) {
-        return val.getUserString(d->scheme.get(), factor, unitString);
-    }
-    else {
-        return val.getUserString(factor, unitString);
-    }
+    std::string unitStr;
+    std::string str = d->scheme ? val.getUserString(d->scheme.get(), factor, unitStr)
+                                : val.getUserString(factor, unitStr);
+    unitString = QString::fromStdString(unitStr);
+    return QString::fromStdString(str);
 }
 
 QString QuantitySpinBox::getUserString(const Base::Quantity& val) const
 {
     Q_D(const QuantitySpinBox);
+    std::string str;
     if (d->scheme) {
         double factor;
-        QString unitString;
-        return val.getUserString(d->scheme.get(), factor, unitString);
+        std::string unitString;
+        str = val.getUserString(d->scheme.get(), factor, unitString);
     }
     else {
-        return val.getUserString();
+        str = val.getUserString();
     }
+    return QString::fromStdString(str);
 }
 
 void QuantitySpinBox::setExpression(std::shared_ptr<Expression> expr)
@@ -767,7 +768,7 @@ void QuantitySpinBox::stepBy(int steps)
     else if (val < d->minimum)
         val = d->minimum;
 
-    Quantity quant(val, d->unitStr);
+    Quantity quant(val, d->unitStr.toStdString());
     updateText(quant);
     updateFromCache(true);
     update();
@@ -909,9 +910,7 @@ void QuantitySpinBox::selectNumber()
 
 QString QuantitySpinBox::textFromValue(const Base::Quantity& value) const
 {
-    double factor;
-    QString unitStr;
-    QString str = getUserString(value, factor, unitStr);
+    QString str = getUserString(value);
     if (qAbs(value.getValue()) >= 1000.0) {
         str.remove(locale().groupSeparator());
     }

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -702,7 +702,7 @@ std::array<std::pair<double, std::string>, 3> schemaTranslatePoint(double x, dou
     mmz.setValue(fabs(z) > precision ? z : 0.0);
 
     double xfactor, yfactor, zfactor;
-    QString xunit, yunit, zunit;
+    std::string xunit, yunit, zunit;
 
     Base::UnitsApi::schemaTranslate(mmx, xfactor, xunit);
     Base::UnitsApi::schemaTranslate(mmy, yfactor, yunit);
@@ -712,9 +712,9 @@ std::array<std::pair<double, std::string>, 3> schemaTranslatePoint(double x, dou
     double yuser = fabs(y) > precision ? y / yfactor : 0.0;
     double zuser = fabs(z) > precision ? z / zfactor : 0.0;
 
-    std::array<std::pair<double, std::string>, 3> ret = {std::make_pair(xuser, xunit.toUtf8().constBegin()),
-                                                         std::make_pair(yuser, yunit.toUtf8().constBegin()),
-                                                         std::make_pair(zuser, zunit.toUtf8().constBegin())};
+    std::array<std::pair<double, std::string>, 3> ret = {std::make_pair(xuser, xunit),
+                                                         std::make_pair(yuser, yunit),
+                                                         std::make_pair(zuser, zunit)};
     return ret;
 }
 

--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -327,7 +327,7 @@ void TDragger::drag()
                             Base::Unit::Length);
 
     QString message =
-        QString::fromLatin1("%1 %2").arg(QObject::tr("Translation:"), quantity.getUserString());
+        QString::fromLatin1("%1 %2").arg(QObject::tr("Translation:"), QString::fromStdString(quantity.getUserString()));
     getMainWindow()->showMessage(message, 3000);
 }
 
@@ -614,8 +614,8 @@ void TPlanarDragger::drag()
 
     QString message = QString::fromLatin1("%1 %2, %3")
                           .arg(QObject::tr("Translation XY:"),
-                               quantityX.getUserString(),
-                               quantityY.getUserString());
+                               QString::fromStdString(quantityX.getUserString()),
+                               QString::fromStdString(quantityY.getUserString()));
     getMainWindow()->showMessage(message, 3000);
 }
 
@@ -940,7 +940,7 @@ void RDragger::drag()
                             Base::Unit::Angle);
 
     QString message =
-        QString::fromLatin1("%1 %2").arg(QObject::tr("Rotation:"), quantity.getUserString());
+        QString::fromLatin1("%1 %2").arg(QObject::tr("Rotation:"), QString::fromStdString(quantity.getUserString()));
     getMainWindow()->showMessage(message, 3000);
 }
 

--- a/src/Gui/TaskView/TaskImage.cpp
+++ b/src/Gui/TaskView/TaskImage.cpp
@@ -534,10 +534,10 @@ void InteractiveScale::setDistance(const SbVec3f& pos3d)
 
     // Update the displayed distance
     double factor {};
-    QString unitStr;
-    QString valueStr;
+    std::string unitStr;
+    std::string valueStr;
     valueStr = quantity.getUserString(factor, unitStr);
-    measureLabel->label->string = SbString(valueStr.toUtf8().constData());
+    measureLabel->label->string = SbString(valueStr.c_str());
     measureLabel->label->setPoints(getCoordsOnImagePlane(points[0]), getCoordsOnImagePlane(pos3d));
 }
 

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -35,6 +35,8 @@
 # include <GL/glu.h>
 # endif
 
+# include <fmt/format.h>
+
 # include <Inventor/SbBox.h>
 # include <Inventor/SoEventManager.h>
 # include <Inventor/SoPickedPoint.h>
@@ -2510,7 +2512,7 @@ void View3DInventorViewer::printDimension() const
     float fWidth = -1.0;
     getDimensions(fHeight, fWidth);
 
-    QString dim;
+    std::string dim;
 
     if (fWidth >= 0.0 && fHeight >= 0.0) {
         // Translate screen units into user's unit schema
@@ -2518,14 +2520,14 @@ void View3DInventorViewer::printDimension() const
         Base::Quantity qHeight(Base::Quantity::MilliMetre);
         qWidth.setValue(fWidth);
         qHeight.setValue(fHeight);
-        QString wStr = Base::UnitsApi::schemaTranslate(qWidth);
-        QString hStr = Base::UnitsApi::schemaTranslate(qHeight);
+        auto wStr = Base::UnitsApi::schemaTranslate(qWidth);
+        auto hStr = Base::UnitsApi::schemaTranslate(qHeight);
 
         // Create final string and update window
-        dim = QString::fromLatin1("%1 x %2").arg(wStr, hStr);
+        dim = fmt::format("{} x {}", wStr, hStr);
     }
 
-    getMainWindow()->setPaneText(2, dim);
+    getMainWindow()->setPaneText(2, QString::fromStdString(dim));
 }
 
 void View3DInventorViewer::selectAll()

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -1186,8 +1186,7 @@ void PropertyUnitItem::setValue(const QVariant& value)
     if (!hasExpression() && value.canConvert<Base::Quantity>()) {
         const Base::Quantity& val = value.value<Base::Quantity>();
         Base::QuantityFormat format(Base::QuantityFormat::Default, highPrec);
-        QString unit = Base::UnitsApi::toString(val, format);
-        setPropertyValue(unit);
+        setPropertyValue(Base::UnitsApi::toString(val, format));
     }
 }
 
@@ -1801,11 +1800,11 @@ void PropertyVectorDistanceItem::setValue(const QVariant& variant)
     Base::Quantity z = Base::Quantity(value.z, Base::Unit::Length);
 
     Base::QuantityFormat format(Base::QuantityFormat::Default, highPrec);
-    QString data = QString::fromLatin1("(%1, %2, %3)")
-                       .arg(Base::UnitsApi::toNumber(x, format),
-                            Base::UnitsApi::toNumber(y, format),
-                            Base::UnitsApi::toNumber(z, format));
-    setPropertyValue(data);
+    std::string val = fmt::format("({}, {}, {})",
+                                  Base::UnitsApi::toNumber(x, format),
+                                  Base::UnitsApi::toNumber(y, format),
+                                  Base::UnitsApi::toNumber(z, format));
+    setPropertyValue(val);
 }
 
 void PropertyVectorDistanceItem::setEditorData(QWidget* editor, const QVariant& data) const
@@ -2557,12 +2556,12 @@ void PropertyRotationItem::setValue(const QVariant& value)
     double angle {};
     h.getValue(axis, angle);
     Base::QuantityFormat format(Base::QuantityFormat::Default, highPrec);
-    QString data = QString::fromLatin1("App.Rotation(App.Vector(%1,%2,%3),%4)")
-                       .arg(Base::UnitsApi::toNumber(axis.x, format),
-                            Base::UnitsApi::toNumber(axis.y, format),
-                            Base::UnitsApi::toNumber(axis.z, format),
-                            Base::UnitsApi::toNumber(angle, format));
-    setPropertyValue(data);
+    std::string val = fmt::format("App.Rotation(App.Vector({},{},{}),{})",
+                                  Base::UnitsApi::toNumber(axis.x, format),
+                                  Base::UnitsApi::toNumber(axis.y, format),
+                                  Base::UnitsApi::toNumber(axis.z, format),
+                                  Base::UnitsApi::toNumber(angle, format));
+    setPropertyValue(val);
 }
 
 QWidget* PropertyRotationItem::createEditor(QWidget* parent,
@@ -2872,17 +2871,17 @@ void PropertyPlacementItem::setValue(const QVariant& value)
     h.getValue(axis, angle);
 
     Base::QuantityFormat format(Base::QuantityFormat::Default, highPrec);
-    QString data = QString::fromLatin1("App.Placement("
-                                       "App.Vector(%1,%2,%3),"
-                                       "App.Rotation(App.Vector(%4,%5,%6),%7))")
-                       .arg(Base::UnitsApi::toNumber(pos.x, format),
-                            Base::UnitsApi::toNumber(pos.y, format),
-                            Base::UnitsApi::toNumber(pos.z, format),
-                            Base::UnitsApi::toNumber(axis.x, format),
-                            Base::UnitsApi::toNumber(axis.y, format),
-                            Base::UnitsApi::toNumber(axis.z, format),
-                            Base::UnitsApi::toNumber(angle, format));
-    setPropertyValue(data);
+    std::string str = fmt::format("App.Placement("
+                                  "App.Vector({},{},{}),"
+                                  "App.Rotation(App.Vector({},{},{}),{}))",
+                                  Base::UnitsApi::toNumber(pos.x, format),
+                                  Base::UnitsApi::toNumber(pos.y, format),
+                                  Base::UnitsApi::toNumber(pos.z, format),
+                                  Base::UnitsApi::toNumber(axis.x, format),
+                                  Base::UnitsApi::toNumber(axis.y, format),
+                                  Base::UnitsApi::toNumber(axis.z, format),
+                                  Base::UnitsApi::toNumber(angle, format));
+    setPropertyValue(str);
 }
 
 QWidget* PropertyPlacementItem::createEditor(QWidget* parent,

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -1163,13 +1163,12 @@ PropertyUnitItem::PropertyUnitItem() = default;
 QVariant PropertyUnitItem::toString(const QVariant& prop) const
 {
     const Base::Quantity& unit = prop.value<Base::Quantity>();
-    QString string = unit.getUserString();
+    std::string str = unit.getUserString();
     if (hasExpression()) {
-        string +=
-            QString::fromLatin1("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
+        str += fmt::format("  ( {} )", getExpressionString());
     }
 
-    return {string};
+    return {QString::fromStdString(str)};
 }
 
 QVariant PropertyUnitItem::value(const App::Property* prop) const
@@ -1769,14 +1768,14 @@ PropertyVectorDistanceItem::PropertyVectorDistanceItem()
 QVariant PropertyVectorDistanceItem::toString(const QVariant& prop) const
 {
     const Base::Vector3d& value = prop.value<Base::Vector3d>();
-    QString data = QString::fromLatin1("[")
-        + Base::Quantity(value.x, Base::Unit::Length).getUserString() + QString::fromLatin1("  ")
-        + Base::Quantity(value.y, Base::Unit::Length).getUserString() + QString::fromLatin1("  ")
-        + Base::Quantity(value.z, Base::Unit::Length).getUserString() + QString::fromLatin1("]");
+    std::string str = fmt::format("[{} {} {}]",
+                                  Base::Quantity(value.x, Base::Unit::Length).getUserString(),
+                                  Base::Quantity(value.y, Base::Unit::Length).getUserString(),
+                                  Base::Quantity(value.z, Base::Unit::Length).getUserString());
     if (hasExpression()) {
-        data += QString::fromLatin1("  ( %1 )").arg(QString::fromStdString(getExpressionString()));
+        str += fmt::format("  ( {} )", getExpressionString());
     }
-    return {data};
+    return {QString::fromStdString(str)};
 }
 
 
@@ -2515,12 +2514,13 @@ QVariant PropertyRotationItem::toolTip(const App::Property* prop) const
     angle = Base::toDegrees<double>(angle);
 
     QLocale loc;
-    QString data = QString::fromUtf8("Axis: (%1 %2 %3)\n"
-                                     "Angle: %4")
-                       .arg(loc.toString(dir.x, 'f', decimals()),
-                            loc.toString(dir.y, 'f', decimals()),
-                            loc.toString(dir.z, 'f', decimals()),
-                            Base::Quantity(angle, Base::Unit::Angle).getUserString());
+    QString data =
+        QString::fromUtf8("Axis: (%1 %2 %3)\n"
+                          "Angle: %4")
+            .arg(loc.toString(dir.x, 'f', decimals()),
+                 loc.toString(dir.y, 'f', decimals()),
+                 loc.toString(dir.z, 'f', decimals()),
+                 QString::fromStdString(Base::Quantity(angle, Base::Unit::Angle).getUserString()));
     return {data};
 }
 
@@ -2533,11 +2533,12 @@ QVariant PropertyRotationItem::toString(const QVariant& prop) const
     angle = Base::toDegrees<double>(angle);
 
     QLocale loc;
-    QString data = QString::fromUtf8("[(%1 %2 %3); %4]")
-                       .arg(loc.toString(dir.x, 'f', lowPrec),
-                            loc.toString(dir.y, 'f', lowPrec),
-                            loc.toString(dir.z, 'f', lowPrec),
-                            Base::Quantity(angle, Base::Unit::Angle).getUserString());
+    QString data =
+        QString::fromUtf8("[(%1 %2 %3); %4]")
+            .arg(loc.toString(dir.x, 'f', lowPrec),
+                 loc.toString(dir.y, 'f', lowPrec),
+                 loc.toString(dir.z, 'f', lowPrec),
+                 QString::fromStdString(Base::Quantity(angle, Base::Unit::Angle).getUserString()));
     return {data};
 }
 
@@ -2817,16 +2818,17 @@ QVariant PropertyPlacementItem::toolTip(const App::Property* prop) const
     pos = p.getPosition();
 
     QLocale loc;
-    QString data = QString::fromUtf8("Axis: (%1 %2 %3)\n"
-                                     "Angle: %4\n"
-                                     "Position: (%5  %6  %7)")
-                       .arg(loc.toString(dir.x, 'f', decimals()),
-                            loc.toString(dir.y, 'f', decimals()),
-                            loc.toString(dir.z, 'f', decimals()),
-                            Base::Quantity(angle, Base::Unit::Angle).getUserString(),
-                            Base::Quantity(pos.x, Base::Unit::Length).getUserString(),
-                            Base::Quantity(pos.y, Base::Unit::Length).getUserString(),
-                            Base::Quantity(pos.z, Base::Unit::Length).getUserString());
+    QString data =
+        QString::fromUtf8("Axis: (%1 %2 %3)\n"
+                          "Angle: %4\n"
+                          "Position: (%5  %6  %7)")
+            .arg(loc.toString(dir.x, 'f', decimals()),
+                 loc.toString(dir.y, 'f', decimals()),
+                 loc.toString(dir.z, 'f', decimals()),
+                 QString::fromStdString(Base::Quantity(angle, Base::Unit::Angle).getUserString()),
+                 QString::fromStdString(Base::Quantity(pos.x, Base::Unit::Length).getUserString()),
+                 QString::fromStdString(Base::Quantity(pos.y, Base::Unit::Length).getUserString()),
+                 QString::fromStdString(Base::Quantity(pos.z, Base::Unit::Length).getUserString()));
     return {data};
 }
 
@@ -2841,14 +2843,15 @@ QVariant PropertyPlacementItem::toString(const QVariant& prop) const
     pos = p.getPosition();
 
     QLocale loc;
-    QString data = QString::fromUtf8("[(%1 %2 %3); %4; (%5  %6  %7)]")
-                       .arg(loc.toString(dir.x, 'f', lowPrec),
-                            loc.toString(dir.y, 'f', lowPrec),
-                            loc.toString(dir.z, 'f', lowPrec),
-                            Base::Quantity(angle, Base::Unit::Angle).getUserString(),
-                            Base::Quantity(pos.x, Base::Unit::Length).getUserString(),
-                            Base::Quantity(pos.y, Base::Unit::Length).getUserString(),
-                            Base::Quantity(pos.z, Base::Unit::Length).getUserString());
+    QString data =
+        QString::fromUtf8("[(%1 %2 %3); %4; (%5  %6  %7)]")
+            .arg(loc.toString(dir.x, 'f', lowPrec),
+                 loc.toString(dir.y, 'f', lowPrec),
+                 loc.toString(dir.z, 'f', lowPrec),
+                 QString::fromStdString(Base::Quantity(angle, Base::Unit::Angle).getUserString()),
+                 QString::fromStdString(Base::Quantity(pos.x, Base::Unit::Length).getUserString()),
+                 QString::fromStdString(Base::Quantity(pos.y, Base::Unit::Length).getUserString()),
+                 QString::fromStdString(Base::Quantity(pos.z, Base::Unit::Length).getUserString()));
     return {data};
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
@@ -473,12 +473,12 @@ const std::string TaskFemConstraintContact::getReferences() const
 
 const std::string TaskFemConstraintContact::getSlope() const
 {
-    return ui->spbSlope->value().getSafeUserString().toStdString();
+    return ui->spbSlope->value().getSafeUserString();
 }
 
 const std::string TaskFemConstraintContact::getAdjust() const
 {
-    return ui->spbAdjust->value().getSafeUserString().toStdString();
+    return ui->spbAdjust->value().getSafeUserString();
 }
 
 bool TaskFemConstraintContact::getFriction() const
@@ -493,7 +493,7 @@ double TaskFemConstraintContact::getFrictionCoeff() const
 
 const std::string TaskFemConstraintContact::getStickSlope() const
 {
-    return ui->spbStickSlope->value().getSafeUserString().toStdString();
+    return ui->spbStickSlope->value().getSafeUserString();
 }
 
 void TaskFemConstraintContact::changeEvent(QEvent*)

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -378,32 +378,32 @@ const std::string TaskFemConstraintDisplacement::getReferences() const
 
 std::string TaskFemConstraintDisplacement::get_spinxDisplacement() const
 {
-    return ui->spinxDisplacement->value().getSafeUserString().toStdString();
+    return ui->spinxDisplacement->value().getSafeUserString();
 }
 
 std::string TaskFemConstraintDisplacement::get_spinyDisplacement() const
 {
-    return ui->spinyDisplacement->value().getSafeUserString().toStdString();
+    return ui->spinyDisplacement->value().getSafeUserString();
 }
 
 std::string TaskFemConstraintDisplacement::get_spinzDisplacement() const
 {
-    return ui->spinzDisplacement->value().getSafeUserString().toStdString();
+    return ui->spinzDisplacement->value().getSafeUserString();
 }
 
 std::string TaskFemConstraintDisplacement::get_spinxRotation() const
 {
-    return ui->spinxRotation->value().getSafeUserString().toStdString();
+    return ui->spinxRotation->value().getSafeUserString();
 }
 
 std::string TaskFemConstraintDisplacement::get_spinyRotation() const
 {
-    return ui->spinyRotation->value().getSafeUserString().toStdString();
+    return ui->spinyRotation->value().getSafeUserString();
 }
 
 std::string TaskFemConstraintDisplacement::get_spinzRotation() const
 {
-    return ui->spinzRotation->value().getSafeUserString().toStdString();
+    return ui->spinzRotation->value().getSafeUserString();
 }
 
 std::string TaskFemConstraintDisplacement::get_xFormula() const

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -338,7 +338,7 @@ void TaskFemConstraintForce::onCheckReverse(const bool pressed)
 
 const std::string TaskFemConstraintForce::getForce() const
 {
-    return ui->spinForce->value().getSafeUserString().toStdString();
+    return ui->spinForce->value().getSafeUserString();
 }
 
 const std::string TaskFemConstraintForce::getReferences() const

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -401,29 +401,24 @@ const std::string TaskFemConstraintHeatflux::getReferences() const
 
 std::string TaskFemConstraintHeatflux::getAmbientTemp() const
 {
-    std::string temp;
     if (ui->rb_convection->isChecked()) {
-        temp = ui->qsb_ambienttemp_conv->value().getSafeUserString().toStdString();
+        return ui->qsb_ambienttemp_conv->value().getSafeUserString();
     }
-    else if (ui->rb_radiation->isChecked()) {
-        temp = ui->qsb_ambienttemp_rad->value().getSafeUserString().toStdString();
+    if (ui->rb_radiation->isChecked()) {
+        return ui->qsb_ambienttemp_rad->value().getSafeUserString();
     }
-    else {
-        auto obj = ConstraintView->getObject<Fem::ConstraintHeatflux>();
-        temp = obj->AmbientTemp.getQuantityValue().getSafeUserString().toStdString();
-    }
-
-    return temp;
+    auto obj = ConstraintView->getObject<Fem::ConstraintHeatflux>();
+    return obj->AmbientTemp.getQuantityValue().getSafeUserString();
 }
 
 std::string TaskFemConstraintHeatflux::getFilmCoef() const
 {
-    return ui->qsb_film_coef->value().getSafeUserString().toStdString();
+    return ui->qsb_film_coef->value().getSafeUserString();
 }
 
 std::string TaskFemConstraintHeatflux::getDFlux() const
 {
-    return ui->qsb_heat_flux->value().getSafeUserString().toStdString();
+    return ui->qsb_heat_flux->value().getSafeUserString();
 }
 
 double TaskFemConstraintHeatflux::getEmissivity() const

--- a/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
@@ -70,7 +70,7 @@ TaskFemConstraintInitialTemperature::~TaskFemConstraintInitialTemperature() = de
 
 std::string TaskFemConstraintInitialTemperature::get_temperature() const
 {
-    return ui->if_temperature->value().getSafeUserString().toStdString();
+    return ui->if_temperature->value().getSafeUserString();
 }
 
 void TaskFemConstraintInitialTemperature::changeEvent(QEvent*)

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -250,7 +250,7 @@ const std::string TaskFemConstraintPressure::getReferences() const
 
 std::string TaskFemConstraintPressure::getPressure() const
 {
-    return ui->if_pressure->value().getSafeUserString().toStdString();
+    return ui->if_pressure->value().getSafeUserString();
 }
 
 bool TaskFemConstraintPressure::getReverse() const

--- a/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.cpp
@@ -116,7 +116,7 @@ TaskFemConstraintRigidBody::TaskFemConstraintRigidBody(
     Base::Vector3d rotDir;
     double rotAngleRad;
     pcConstraint->Rotation.getValue().getValue(rotDir, rotAngleRad);
-    Base::Quantity rotAngle(rotAngleRad, QString::fromUtf8("rad"));
+    Base::Quantity rotAngle(rotAngleRad, "rad");
     Base::Quantity forceX = pcConstraint->ForceX.getQuantityValue();
     Base::Quantity forceY = pcConstraint->ForceY.getQuantityValue();
     Base::Quantity forceZ = pcConstraint->ForceZ.getQuantityValue();
@@ -581,18 +581,18 @@ Base::Rotation TaskFemConstraintRigidBody::getRotation() const
 
 std::vector<std::string> TaskFemConstraintRigidBody::getForce() const
 {
-    std::string x = ui->qsb_force_x->value().getSafeUserString().toStdString();
-    std::string y = ui->qsb_force_y->value().getSafeUserString().toStdString();
-    std::string z = ui->qsb_force_z->value().getSafeUserString().toStdString();
+    std::string x = ui->qsb_force_x->value().getSafeUserString();
+    std::string y = ui->qsb_force_y->value().getSafeUserString();
+    std::string z = ui->qsb_force_z->value().getSafeUserString();
 
     return {x, y, z};
 }
 
 std::vector<std::string> TaskFemConstraintRigidBody::getMoment() const
 {
-    std::string x = ui->qsb_moment_x->value().getSafeUserString().toStdString();
-    std::string y = ui->qsb_moment_y->value().getSafeUserString().toStdString();
-    std::string z = ui->qsb_moment_z->value().getSafeUserString().toStdString();
+    std::string x = ui->qsb_moment_x->value().getSafeUserString();
+    std::string y = ui->qsb_moment_y->value().getSafeUserString();
+    std::string z = ui->qsb_moment_z->value().getSafeUserString();
 
     return std::vector<std::string>({x, y, z});
 }

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
@@ -248,12 +248,12 @@ const std::string TaskFemConstraintSpring::getReferences() const
 
 std::string TaskFemConstraintSpring::getNormalStiffness() const
 {
-    return ui->qsb_norm->value().getSafeUserString().toStdString();
+    return ui->qsb_norm->value().getSafeUserString();
 }
 
 std::string TaskFemConstraintSpring::getTangentialStiffness() const
 {
-    return ui->qsb_tan->value().getSafeUserString().toStdString();
+    return ui->qsb_tan->value().getSafeUserString();
 }
 
 std::string TaskFemConstraintSpring::getElmerStiffness() const

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -306,12 +306,12 @@ const std::string TaskFemConstraintTemperature::getReferences() const
 
 std::string TaskFemConstraintTemperature::get_temperature() const
 {
-    return ui->qsb_temperature->value().getSafeUserString().toStdString();
+    return ui->qsb_temperature->value().getSafeUserString();
 }
 
 std::string TaskFemConstraintTemperature::get_cflux() const
 {
-    return ui->qsb_cflux->value().getSafeUserString().toStdString();
+    return ui->qsb_cflux->value().getSafeUserString();
 }
 
 std::string TaskFemConstraintTemperature::get_constraint_type() const

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -118,7 +118,7 @@ TaskFemConstraintTransform::TaskFemConstraintTransform(
     ui->spb_rot_axis_x->setValue(axis.x);
     ui->spb_rot_axis_y->setValue(axis.y);
     ui->spb_rot_axis_z->setValue(axis.z);
-    Base::Quantity rotAngle(angle, QString::fromUtf8("rad"));
+    Base::Quantity rotAngle(angle, "rad");
     ui->qsb_rot_angle->setValue(rotAngle.getValueAs(Base::Quantity::Degree));
 
     ui->spb_rot_axis_x->bind(
@@ -406,7 +406,7 @@ void TaskFemConstraintTransform::addToSelection()
         ui->spb_rot_axis_x->setValue(axis.x);
         ui->spb_rot_axis_y->setValue(axis.y);
         ui->spb_rot_axis_z->setValue(axis.z);
-        Base::Quantity rotAngle(angle, QString::fromUtf8("rad"));
+        Base::Quantity rotAngle(angle, "rad");
         ui->qsb_rot_angle->setValue(rotAngle.getValueAs(Base::Quantity::Degree));
     }
 }

--- a/src/Mod/Material/App/MaterialLoader.cpp
+++ b/src/Mod/Material/App/MaterialLoader.cpp
@@ -115,8 +115,7 @@ std::shared_ptr<Material2DArray> MaterialYamlEntry::read2DArray(const YAML::Node
 
             auto row = std::make_shared<QList<QVariant>>();
             for (std::size_t j = 0; j < yamlRow.size(); j++) {
-                Base::Quantity qq =
-                    Base::Quantity::parse(QString::fromStdString(yamlRow[j].as<std::string>()));
+                Base::Quantity qq = Base::Quantity::parse(yamlRow[j].as<std::string>());
                 qq.setFormat(MaterialValue::getQuantityFormat());
                 row->push_back(QVariant::fromValue(qq));
             }
@@ -142,10 +141,8 @@ std::shared_ptr<Material3DArray> MaterialYamlEntry::read3DArray(const YAML::Node
         for (std::size_t depth = 0; depth < yamlArray.size(); depth++) {
             auto yamlDepth = yamlArray[depth];
             for (auto it = yamlDepth.begin(); it != yamlDepth.end(); it++) {
-                auto depthValue =
-                    Base::Quantity::parse(QString::fromStdString(it->first.as<std::string>()));
+                auto depthValue = Base::Quantity::parse(it->first.as<std::string>());
                 depthValue.setFormat(MaterialValue::getQuantityFormat());
-
                 array3d->addDepth(depth, depthValue);
 
                 auto yamlTable = it->second;
@@ -154,8 +151,7 @@ std::shared_ptr<Material3DArray> MaterialYamlEntry::read3DArray(const YAML::Node
 
                     auto row = std::make_shared<QList<Base::Quantity>>();
                     for (std::size_t j = 0; j < yamlRow.size(); j++) {
-                        auto qq = Base::Quantity::parse(
-                            QString::fromStdString(yamlRow[j].as<std::string>()));
+                        auto qq = Base::Quantity::parse(yamlRow[j].as<std::string>());
                         qq.setFormat(MaterialValue::getQuantityFormat());
                         row->push_back(qq);
                     }

--- a/src/Mod/Material/App/MaterialValue.cpp
+++ b/src/Mod/Material/App/MaterialValue.cpp
@@ -288,7 +288,7 @@ QString MaterialValue::getYAMLString() const
         }
         if (getType() == MaterialValue::Quantity) {
             auto quantity = getValue().value<Base::Quantity>();
-            yaml += quantity.getUserString();
+            yaml += QString::fromStdString(quantity.getUserString());
         }
         else if (getType() == MaterialValue::Float) {
             auto value = getValue();
@@ -500,7 +500,7 @@ QString Material2DArray::getYAMLString() const
             }
             yaml += QString::fromStdString("\"");
             auto quantity = column.value<Base::Quantity>();
-            yaml += quantity.getUserString();
+            yaml += QString::fromStdString(quantity.getUserString());
             yaml += QString::fromStdString("\"");
         }
 
@@ -814,7 +814,7 @@ QString Material3DArray::getYAMLString() const
         }
 
         yaml += QString::fromStdString("\"");
-        auto value = getDepthValue(depth).getUserString();
+        auto value = QString::fromStdString(getDepthValue(depth).getUserString());
         yaml += value;
         yaml += QString::fromStdString("\": [");
 
@@ -844,7 +844,7 @@ QString Material3DArray::getYAMLString() const
                 }
                 yaml += QString::fromStdString("\"");
                 // Base::Quantity quantity = column.value<Base::Quantity>();
-                yaml += column.getUserString();
+                yaml += QString::fromStdString(column.getUserString());
                 yaml += QString::fromStdString("\"");
             }
 

--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -125,7 +125,7 @@ QString MaterialProperty::getString() const
     }
     if (getType() == MaterialValue::Quantity) {
         auto quantity = getValue().value<Base::Quantity>();
-        return quantity.getUserString();
+        return QString::fromStdString(quantity.getUserString());
     }
     if (getType() == MaterialValue::Float) {
         auto value = getValue();
@@ -266,7 +266,7 @@ QVariant MaterialProperty::getColumnNull(int column) const
 
     switch (valueType) {
         case MaterialValue::Quantity: {
-            Base::Quantity quant = Base::Quantity(0, getColumnUnits(column));
+            Base::Quantity quant = Base::Quantity(0, getColumnUnits(column).toStdString());
             return QVariant::fromValue(quant);
         }
 
@@ -306,7 +306,7 @@ void MaterialProperty::setValue(const QString& value)
     }
     else if (_valuePtr->getType() == MaterialValue::Quantity) {
         try {
-            setQuantity(Base::Quantity::parse(value));
+            setQuantity(Base::Quantity::parse(value.toStdString()));
         }
         catch (const Base::ParserError& e) {
             Base::Console().Log("MaterialProperty::setValue Error '%s' - '%s'\n",
@@ -392,12 +392,12 @@ void MaterialProperty::setQuantity(const Base::Quantity& value)
 
 void MaterialProperty::setQuantity(double value, const QString& units)
 {
-    setQuantity(Base::Quantity(value, units));
+    setQuantity(Base::Quantity(value, units.toStdString()));
 }
 
 void MaterialProperty::setQuantity(const QString& value)
 {
-    setQuantity(Base::Quantity::parse(value));
+    setQuantity(Base::Quantity::parse(value.toStdString()));
 }
 
 void MaterialProperty::setList(const QList<QVariant>& value)
@@ -1038,7 +1038,7 @@ Material::getValueString(const std::map<QString, std::shared_ptr<MaterialPropert
             if (value.isNull()) {
                 return {};
             }
-            return value.value<Base::Quantity>().getUserString();
+            return QString::fromStdString(value.value<Base::Quantity>().getUserString());
         }
         if (property->getType() == MaterialValue::Float) {
             auto value = property->getValue();

--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -179,7 +179,7 @@ QString MaterialProperty::getDictionaryString() const
         auto quantity = getValue().value<Base::Quantity>();
         auto string = QString(QLatin1String("%1 %2"))
                           .arg(quantity.getValue(), 0, 'g', MaterialValue::PRECISION)
-                          .arg(quantity.getUnit().getString());
+                          .arg(QString::fromStdString(quantity.getUnit().getString()));
         return string;
     }
     if (getType() == MaterialValue::Float) {

--- a/src/Mod/Material/Gui/ArrayDelegate.cpp
+++ b/src/Mod/Material/Gui/ArrayDelegate.cpp
@@ -72,16 +72,13 @@ void ArrayDelegate::paint(QPainter* painter,
         auto* tableModel = dynamic_cast<const AbstractArrayModel*>(index.model());
         painter->save();
 
-        if (tableModel->newRow(index)) {
-            painter->drawText(option.rect, 0, QString());
-        }
-        else {
+        QString text;
+        if (!tableModel->newRow(index)) {
             QVariant item = tableModel->data(index);
             auto quantity = item.value<Base::Quantity>();
-            QString text = quantity.getUserString();
-            painter->drawText(option.rect, 0, text);
+            text = QString::fromStdString(quantity.getUserString());
         }
-
+        painter->drawText(option.rect, 0, text);
         painter->restore();
     }
     else {

--- a/src/Mod/Material/Gui/ArrayModel.cpp
+++ b/src/Mod/Material/Gui/ArrayModel.cpp
@@ -93,7 +93,7 @@ QVariant Array2DModel::data(const QModelIndex& index, int role) const
         try {
             auto column = _property->getColumnType(index.column());
             if (column == Materials::MaterialValue::Quantity) {
-                Base::Quantity qq = Base::Quantity(0, _property->getColumnUnits(index.column()));
+                Base::Quantity qq = Base::Quantity(0, _property->getColumnUnits(index.column()).toStdString());
                 qq.setFormat(Materials::MaterialValue::getQuantityFormat());
                 return QVariant::fromValue(qq);
             }
@@ -237,7 +237,7 @@ QVariant Array3DDepthModel::data(const QModelIndex& index, int role) const
         }
 
         try {
-            Base::Quantity qq = Base::Quantity(0, _property->getColumnUnits(0));
+            Base::Quantity qq = Base::Quantity(0, _property->getColumnUnits(0).toStdString());
             qq.setFormat(Materials::MaterialValue::getQuantityFormat());
             return QVariant::fromValue(qq);
         }
@@ -293,7 +293,7 @@ bool Array3DDepthModel::insertRows(int row, int count, const QModelIndex& parent
     beginInsertRows(parent, row, row + count - 1);
 
     for (int i = 0; i < count; i++) {
-        auto qq = Base::Quantity(0, _property->getColumnUnits(0));
+        auto qq = Base::Quantity(0, _property->getColumnUnits(0).toStdString());
         qq.setFormat(Materials::MaterialValue::getQuantityFormat());
         _value->addDepth(row, qq);
     }
@@ -395,7 +395,7 @@ QVariant Array3DModel::data(const QModelIndex& index, int role) const
         }
 
         try {
-            Base::Quantity qq = Base::Quantity(0, _property->getColumnUnits(index.column() + 1));
+            Base::Quantity qq = Base::Quantity(0, _property->getColumnUnits(index.column() + 1).toStdString());
             qq.setFormat(Materials::MaterialValue::getQuantityFormat());
             return QVariant::fromValue(qq);
         }

--- a/src/Mod/Material/Gui/BaseDelegate.cpp
+++ b/src/Mod/Material/Gui/BaseDelegate.cpp
@@ -103,15 +103,13 @@ void BaseDelegate::paintQuantity(QPainter* painter,
         painter->drawText(option.rect, 0, QString());
     }
     else {
+        QString text;
         QVariant item = getValue(index);
         auto quantity = item.value<Base::Quantity>();
         if (quantity.isValid()) {
-            QString text = quantity.getUserString();
-            painter->drawText(option.rect, 0, text);
+            text = QString::fromStdString(quantity.getUserString());
         }
-        else {
-            painter->drawText(option.rect, 0, QString());
-        }
+        painter->drawText(option.rect, 0, text);
     }
 
     painter->restore();

--- a/src/Mod/Measure/App/MeasureBase.cpp
+++ b/src/Mod/Measure/App/MeasureBase.cpp
@@ -180,7 +180,8 @@ QString MeasureBase::getResultString()
     }
 
     if (prop->isDerivedFrom(App::PropertyQuantity::getClassTypeId())) {
-        return static_cast<App::PropertyQuantity*>(prop)->getQuantityValue().getUserString();
+        return QString::fromStdString(
+            static_cast<App::PropertyQuantity*>(prop)->getQuantityValue().getUserString());
     }
 
 

--- a/src/Mod/Measure/App/MeasurePosition.cpp
+++ b/src/Mod/Measure/App/MeasurePosition.cpp
@@ -131,7 +131,7 @@ QString MeasurePosition::getResultString()
     }
 
     Base::Vector3d value = Position.getValue();
-    QString unit = Position.getUnit().getString();
+    QString unit = QString::fromStdString(Position.getUnit().getString());
     int precision = 2;
     QString text;
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -179,12 +179,23 @@ void QuickMeasure::addSelectionToMeasurement()
     }
 }
 
+static QString areaStr(double value)
+{
+    Base::Quantity area(value, Base::Unit::Area);
+    return QString::fromStdString(area.getUserString());
+}
+
+static QString lenghtStr(double value)
+{
+    Base::Quantity dist(value, Base::Unit::Length);
+    return QString::fromStdString(dist.getUserString());
+}
+
 void QuickMeasure::printResult()
 {
     MeasureType mtype = measurement->getType();
     if (mtype == MeasureType::Surfaces) {
-        Base::Quantity area(measurement->area(), Base::Unit::Area);
-        print(tr("Total area: %1").arg(area.getUserString()));
+        print(tr("Total area: %1").arg(areaStr(measurement->area())));
     }
     /* deactivated because computing the volumes/area of solids makes a significant
     slow down in selection of complex solids.
@@ -195,48 +206,37 @@ void QuickMeasure::printResult()
     %2").arg(vol.getSafeUserString()).arg(area.getSafeUserString()));
     }*/
     else if (mtype == MeasureType::TwoPlanes) {
-        Base::Quantity dist(measurement->planePlaneDistance(), Base::Unit::Length);
-        print(tr("Nominal distance: %1").arg(dist.getSafeUserString()));
+        print(tr("Nominal distance: %1").arg(lenghtStr(measurement->planePlaneDistance())));
     }
     else if (mtype == MeasureType::Cone || mtype == MeasureType::Plane) {
-        Base::Quantity area(measurement->area(), Base::Unit::Area);
-        print(tr("Area: %1").arg(area.getUserString()));
+        print(tr("Area: %1").arg(areaStr(measurement->area())));
     }
     else if (mtype == MeasureType::Cylinder || mtype == MeasureType::Sphere
              || mtype == MeasureType::Torus) {
-        Base::Quantity area(measurement->area(), Base::Unit::Area);
-        Base::Quantity rad(measurement->radius(), Base::Unit::Length);
-        print(tr("Area: %1, Radius: %2").arg(area.getSafeUserString(), rad.getSafeUserString()));
+        print(tr("Area: %1, Radius: %2")
+                  .arg(areaStr(measurement->area()), lenghtStr(measurement->radius())));
     }
     else if (mtype == MeasureType::Edges) {
-        Base::Quantity dist(measurement->length(), Base::Unit::Length);
-        print(tr("Total length: %1").arg(dist.getSafeUserString()));
+        print(tr("Total length: %1").arg(lenghtStr(measurement->length())));
     }
     else if (mtype == MeasureType::TwoParallelLines) {
-        Base::Quantity dist(measurement->lineLineDistance(), Base::Unit::Length);
-        print(tr("Nominal distance: %1").arg(dist.getSafeUserString()));
+        print(tr("Nominal distance: %1").arg(lenghtStr(measurement->lineLineDistance())));
     }
     else if (mtype == MeasureType::TwoLines) {
-        Base::Quantity angle(measurement->angle(), Base::Unit::Length);
-        Base::Quantity dist(measurement->length(), Base::Unit::Length);
         print(tr("Angle: %1, Total length: %2")
-                  .arg(angle.getSafeUserString(), dist.getSafeUserString()));
+                  .arg(lenghtStr(measurement->angle()), lenghtStr(measurement->length())));
     }
     else if (mtype == MeasureType::Line) {
-        Base::Quantity dist(measurement->length(), Base::Unit::Length);
-        print(tr("Length: %1").arg(dist.getSafeUserString()));
+        print(tr("Length: %1").arg(lenghtStr(measurement->length())));
     }
     else if (mtype == MeasureType::Circle) {
-        Base::Quantity dist(measurement->radius(), Base::Unit::Length);
-        print(tr("Radius: %1").arg(dist.getSafeUserString()));
+        print(tr("Radius: %1").arg(lenghtStr(measurement->radius())));
     }
     else if (mtype == MeasureType::PointToPoint) {
-        Base::Quantity dist(measurement->length(), Base::Unit::Length);
-        print(tr("Distance: %1").arg(dist.getSafeUserString()));
+        print(tr("Distance: %1").arg(lenghtStr(measurement->length())));
     }
     else if (mtype == MeasureType::PointToEdge || mtype == MeasureType::PointToSurface) {
-        Base::Quantity dist(measurement->length(), Base::Unit::Length);
-        print(tr("Minimum distance: %1").arg(dist.getSafeUserString()));
+        print(tr("Minimum distance: %1").arg(lenghtStr(measurement->length())));
     }
     else {
         print(QString::fromLatin1(""));

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -263,7 +263,7 @@ void ViewProviderMeasureBase::draggerChangedCallback(void* data, SoDragger*)
 
 void ViewProviderMeasureBase::setLabelValue(const Base::Quantity& value)
 {
-    pLabel->string.setValue(value.getUserString().toUtf8().constData());
+    pLabel->string.setValue(value.getUserString().c_str());
 }
 
 void ViewProviderMeasureBase::setLabelValue(const QString& value)

--- a/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureDistance.cpp
@@ -478,23 +478,23 @@ void ViewProviderMeasureDistance::redrawAnnotation()
 
     auto propDistance =
         dynamic_cast<App::PropertyDistance*>(pcObject->getPropertyByName("Distance"));
-    setLabelValue(propDistance->getQuantityValue().getUserString());
+    setLabelValue(QString::fromStdString(propDistance->getQuantityValue().getUserString()));
 
     // Set delta distance
     auto propDistanceX =
         static_cast<App::PropertyDistance*>(getMeasureObject()->getPropertyByName("DistanceX"));
     static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(0))
-        ->text.setValue("Δx: " + propDistanceX->getQuantityValue().getUserString().toUtf8());
+        ->text.setValue(("Δx: " + propDistanceX->getQuantityValue().getUserString()).c_str());
 
     auto propDistanceY =
         static_cast<App::PropertyDistance*>(getMeasureObject()->getPropertyByName("DistanceY"));
     static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(1))
-        ->text.setValue("Δy: " + propDistanceY->getQuantityValue().getUserString().toUtf8());
+        ->text.setValue(("Δy: " + propDistanceY->getQuantityValue().getUserString()).c_str());
 
     auto propDistanceZ =
         static_cast<App::PropertyDistance*>(getMeasureObject()->getPropertyByName("DistanceZ"));
     static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(2))
-        ->text.setValue("Δz: " + propDistanceZ->getQuantityValue().getUserString().toUtf8());
+        ->text.setValue(("Δz: " + propDistanceZ->getQuantityValue().getUserString()).c_str());
 
     // Set matrix
     SbMatrix matrix = getMatrix();
@@ -528,7 +528,6 @@ void ViewProviderMeasureDistance::onChanged(const App::Property* prop)
         static_cast<DimensionLinear*>(pDeltaDimensionSwitch->getChild(2))
             ->backgroundColor.setValue(bColor.r, bColor.g, bColor.g);
     }
-
 
     ViewProviderMeasureBase::onChanged(prop);
 }

--- a/src/Mod/Mesh/Gui/DlgRegularSolidImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgRegularSolidImp.cpp
@@ -118,97 +118,93 @@ void DlgRegularSolidImp::onCreateSolidButtonClicked()
 {
     try {
         Gui::WaitCursor wc;
-        QString cmd; std::string name;
+        std::string cmd, name;
         App::Document* doc = App::GetApplication().getActiveDocument();
         if (!doc) {
             QMessageBox::warning(this, tr("Create %1").arg(ui->comboBox1->currentText()), tr("No active document"));
             return;
         }
-        if (ui->comboBox1->currentIndex() == 0) {         // cube
-            name = doc->getUniqueObjectName("Cube");
-            cmd = QString(QLatin1String(
-                "App.ActiveDocument.addObject(\"Mesh::Cube\",\"%1\")\n"
-                "App.ActiveDocument.%1.Length=%2\n"
-                "App.ActiveDocument.%1.Width=%3\n"
-                "App.ActiveDocument.%1.Height=%4\n"))
-                .arg(QLatin1String(name.c_str()),
-                     Base::UnitsApi::toNumber(ui->boxLength->value()),
-                     Base::UnitsApi::toNumber(ui->boxWidth->value()),
-                     Base::UnitsApi::toNumber(ui->boxHeight->value()));
-        }
-        else if (ui->comboBox1->currentIndex() == 1) {  // cylinder
-            name = doc->getUniqueObjectName("Cylinder");
-            cmd = QString(QLatin1String(
-                "App.ActiveDocument.addObject(\"Mesh::Cylinder\",\"%1\")\n"
-                "App.ActiveDocument.%1.Radius=%2\n"
-                "App.ActiveDocument.%1.Length=%3\n"
-                "App.ActiveDocument.%1.EdgeLength=%4\n"
-                "App.ActiveDocument.%1.Closed=%5\n"
-                "App.ActiveDocument.%1.Sampling=%6\n"))
-                .arg(QLatin1String(name.c_str()),
-                     Base::UnitsApi::toNumber(ui->cylinderRadius->value()),
-                     Base::UnitsApi::toNumber(ui->cylinderLength->value()),
-                     Base::UnitsApi::toNumber(ui->cylinderEdgeLength->value()),
-                     QLatin1String((ui->cylinderClosed->isChecked()?"True":"False")))
-                .arg(ui->cylinderCount->value());
-        }
-        else if (ui->comboBox1->currentIndex() == 2) {  // cone
-            name = doc->getUniqueObjectName("Cone");
-            cmd = QString(QLatin1String(
-                "App.ActiveDocument.addObject(\"Mesh::Cone\",\"%1\")\n"
-                "App.ActiveDocument.%1.Radius1=%2\n"
-                "App.ActiveDocument.%1.Radius2=%3\n"
-                "App.ActiveDocument.%1.Length=%4\n"
-                "App.ActiveDocument.%1.EdgeLength=%5\n"
-                "App.ActiveDocument.%1.Closed=%6\n"
-                "App.ActiveDocument.%1.Sampling=%7\n"))
-                .arg(QLatin1String(name.c_str()),
-                     Base::UnitsApi::toNumber(ui->coneRadius1->value()),
-                     Base::UnitsApi::toNumber(ui->coneRadius2->value()),
-                     Base::UnitsApi::toNumber(ui->coneLength->value()),
-                     Base::UnitsApi::toNumber(ui->coneEdgeLength->value()),
-                     QLatin1String((ui->coneClosed->isChecked()?"True":"False")))
-                .arg(ui->coneCount->value());
-        }
-        else if (ui->comboBox1->currentIndex() == 3) {  // sphere
-            name = doc->getUniqueObjectName("Sphere");
-            cmd = QString(QLatin1String(
-                "App.ActiveDocument.addObject(\"Mesh::Sphere\",\"%1\")\n"
-                "App.ActiveDocument.%1.Radius=%2\n"
-                "App.ActiveDocument.%1.Sampling=%3\n"))
-                .arg(QLatin1String(name.c_str()),
-                     Base::UnitsApi::toNumber(ui->sphereRadius->value()))
-                .arg(ui->sphereCount->value());
-        }
-        else if (ui->comboBox1->currentIndex() == 4) {  // ellipsoid
-            name = doc->getUniqueObjectName("Ellipsoid");
-            cmd = QString(QLatin1String(
-                "App.ActiveDocument.addObject(\"Mesh::Ellipsoid\",\"%1\")\n"
-                "App.ActiveDocument.%1.Radius1=%2\n"
-                "App.ActiveDocument.%1.Radius2=%3\n"
-                "App.ActiveDocument.%1.Sampling=%4\n"))
-                .arg(QLatin1String(name.c_str()),
-                     Base::UnitsApi::toNumber(ui->ellipsoidRadius1->value()),
-                     Base::UnitsApi::toNumber(ui->ellipsoidRadius2->value()))
-                .arg(ui->ellipsoidCount->value());
-        }
-        else if (ui->comboBox1->currentIndex() == 5) {  // toroid
-            name = doc->getUniqueObjectName("Torus");
-            cmd = QString(QLatin1String(
-                "App.ActiveDocument.addObject(\"Mesh::Torus\",\"%1\")\n"
-                "App.ActiveDocument.%1.Radius1=%2\n"
-                "App.ActiveDocument.%1.Radius2=%3\n"
-                "App.ActiveDocument.%1.Sampling=%4\n"))
-                .arg(QLatin1String(name.c_str()),
-                     Base::UnitsApi::toNumber(ui->toroidRadius1->value()),
-                     Base::UnitsApi::toNumber(ui->toroidRadius2->value()))
-                .arg(ui->toroidCount->value());
+        switch (ui->comboBox1->currentIndex()) {
+            case 0:
+                name = doc->getUniqueObjectName("Cube");
+                cmd = fmt::format(
+                    "App.ActiveDocument.addObject(\"Mesh::Cube\",\"{0}\")\n"
+                    "App.ActiveDocument.{0}.Length={1}\n"
+                    "App.ActiveDocument.{0}.Width={2}\n"
+                    "App.ActiveDocument.{0}.Height={3}\n", name,
+                        Base::UnitsApi::toNumber(ui->boxLength->value()),
+                        Base::UnitsApi::toNumber(ui->boxWidth->value()),
+                        Base::UnitsApi::toNumber(ui->boxHeight->value()));
+                break;
+            case 1:
+                name = doc->getUniqueObjectName("Cylinder");
+                cmd = fmt::format(
+                    "App.ActiveDocument.addObject(\"Mesh::Cylinder\",\"{0}\")\n"
+                    "App.ActiveDocument.{0}.Radius={1}\n"
+                    "App.ActiveDocument.{0}.Length={2}\n"
+                    "App.ActiveDocument.{0}.EdgeLength={3}\n"
+                    "App.ActiveDocument.{0}.Closed={4}\n"
+                    "App.ActiveDocument.{0}.Sampling={5}\n", name,
+                        Base::UnitsApi::toNumber(ui->cylinderRadius->value()),
+                        Base::UnitsApi::toNumber(ui->cylinderLength->value()),
+                        Base::UnitsApi::toNumber(ui->cylinderEdgeLength->value()),
+                        ui->cylinderClosed->isChecked() ? "True" : "False",
+                        ui->cylinderCount->value());
+                break;
+            case 2:
+                name = doc->getUniqueObjectName("Cone");
+                cmd = fmt::format(
+                    "App.ActiveDocument.addObject(\"Mesh::Cone\",\"{0}\")\n"
+                    "App.ActiveDocument.{0}.Radius1={1}\n"
+                    "App.ActiveDocument.{0}.Radius2={2}\n"
+                    "App.ActiveDocument.{0}.Length={3}\n"
+                    "App.ActiveDocument.{0}.EdgeLength={4}\n"
+                    "App.ActiveDocument.{0}.Closed={5}\n"
+                    "App.ActiveDocument.{0}.Sampling={6}\n", name,
+                        Base::UnitsApi::toNumber(ui->coneRadius1->value()),
+                        Base::UnitsApi::toNumber(ui->coneRadius2->value()),
+                        Base::UnitsApi::toNumber(ui->coneLength->value()),
+                        Base::UnitsApi::toNumber(ui->coneEdgeLength->value()),
+                        ui->coneClosed->isChecked() ? "True" : "False",
+                        ui->coneCount->value());
+                break;
+            case 3:
+                name = doc->getUniqueObjectName("Sphere");
+                cmd = fmt::format(
+                    "App.ActiveDocument.addObject(\"Mesh::Sphere\",\"{0}\")\n"
+                    "App.ActiveDocument.{0}.Radius={1}\n"
+                    "App.ActiveDocument.{0}.Sampling={2}\n", name,
+                        Base::UnitsApi::toNumber(ui->sphereRadius->value()),
+                        ui->sphereCount->value());
+                break;
+            case 4:
+                name = doc->getUniqueObjectName("Ellipsoid");
+                cmd = fmt::format(
+                    "App.ActiveDocument.addObject(\"Mesh::Ellipsoid\",\"{0}\")\n"
+                    "App.ActiveDocument.{0}.Radius1={1}\n"
+                    "App.ActiveDocument.{0}.Radius2={2}\n"
+                    "App.ActiveDocument.{0}.Sampling={3}\n", name,
+                        Base::UnitsApi::toNumber(ui->ellipsoidRadius1->value()),
+                        Base::UnitsApi::toNumber(ui->ellipsoidRadius2->value()),
+                        ui->ellipsoidCount->value());
+                break;
+            case 5:
+                name = doc->getUniqueObjectName("Torus");
+                cmd = fmt::format(
+                    "App.ActiveDocument.addObject(\"Mesh::Torus\",\"{0}\")\n"
+                    "App.ActiveDocument.{0}.Radius1={1}\n"
+                    "App.ActiveDocument.{0}.Radius2={2}\n"
+                    "App.ActiveDocument.{0}.Sampling={3}\n", name,
+                        Base::UnitsApi::toNumber(ui->toroidRadius1->value()),
+                        Base::UnitsApi::toNumber(ui->toroidRadius2->value()),
+                        ui->toroidCount->value());
+                break;
         }
 
         // Execute the Python block
         QString solid = tr("Create %1").arg(ui->comboBox1->currentText());
         Gui::Application::Instance->activeDocument()->openCommand(solid.toUtf8());
-        Gui::Command::doCommand(Gui::Command::Doc, (const char*)cmd.toLatin1());
+        Gui::Command::doCommand(Gui::Command::Doc, cmd.c_str());
         Gui::Application::Instance->activeDocument()->commitCommand();
         Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().recompute()");
         Gui::Command::doCommand(Gui::Command::Gui, "Gui.SendMsgToActiveView(\"ViewFit\")");

--- a/src/Mod/Part/Gui/DlgFilletEdges.cpp
+++ b/src/Mod/Part/Gui/DlgFilletEdges.cpp
@@ -155,7 +155,7 @@ QVariant FilletRadiusModel::data(const QModelIndex& index, int role) const
     QVariant value = QStandardItemModel::data(index, role);
     if (role == Qt::DisplayRole && index.column() >= 1) {
         Base::Quantity q = value.value<Base::Quantity>();
-        QString str = q.getUserString();
+        QString str = QString::fromStdString(q.getUserString());
         return str;
     }
     return value;

--- a/src/Mod/Part/Gui/DlgPrimitives.cpp
+++ b/src/Mod/Part/Gui/DlgPrimitives.cpp
@@ -111,6 +111,11 @@ const char* gce_ErrorStatusText(gce_ErrorType et)
     }
 }
 
+static QString safeQuantityQString(Gui::QuantitySpinBox *qs)
+{
+    return QString::fromStdString(qs->value().getSafeUserString());
+}
+
 void Picker::createPrimitive(QWidget* widget, const QString& descr, Gui::Document* doc)
 {
     try {
@@ -268,8 +273,8 @@ QString PlanePrimitive::create(const QString& objectName, const QString& placeme
         "App.ActiveDocument.%1.Placement=%4\n"
         "App.ActiveDocument.%1.Label='%5'\n")
         .arg(objectName,
-             ui->planeLength->value().getSafeUserString(),
-             ui->planeWidth->value().getSafeUserString(),
+             safeQuantityQString(ui->planeLength),
+             safeQuantityQString(ui->planeWidth),
              placement,
              DlgPrimitives::tr("Plane"));
 }
@@ -281,8 +286,8 @@ QString PlanePrimitive::change(const QString& objectName, const QString& placeme
         "%1.Width='%3'\n"
         "%1.Placement=%4\n")
         .arg(objectName,
-             ui->planeLength->value().getSafeUserString(),
-             ui->planeWidth->value().getSafeUserString(),
+             safeQuantityQString(ui->planeLength),
+             safeQuantityQString(ui->planeWidth),
              placement);
 }
 
@@ -342,9 +347,9 @@ QString BoxPrimitive::create(const QString& objectName, const QString& placement
         "App.ActiveDocument.%1.Placement=%5\n"
         "App.ActiveDocument.%1.Label='%6'\n")
         .arg(objectName,
-             ui->boxLength->value().getSafeUserString(),
-             ui->boxWidth->value().getSafeUserString(),
-             ui->boxHeight->value().getSafeUserString(),
+             safeQuantityQString(ui->boxLength),
+             safeQuantityQString(ui->boxWidth),
+             safeQuantityQString(ui->boxHeight),
              placement,
              DlgPrimitives::tr("Box"));
 }
@@ -357,9 +362,9 @@ QString BoxPrimitive::change(const QString& objectName, const QString& placement
         "%1.Height='%4'\n"
         "%1.Placement=%5\n")
         .arg(objectName,
-             ui->boxLength->value().getSafeUserString(),
-             ui->boxWidth->value().getSafeUserString(),
-             ui->boxHeight->value().getSafeUserString(),
+             safeQuantityQString(ui->boxLength),
+             safeQuantityQString(ui->boxWidth),
+             safeQuantityQString(ui->boxHeight),
              placement);
 }
 
@@ -430,11 +435,11 @@ QString CylinderPrimitive::create(const QString& objectName, const QString& plac
         "App.ActiveDocument.%1.Placement=%7\n"
         "App.ActiveDocument.%1.Label='%8'\n")
         .arg(objectName,
-             ui->cylinderRadius->value().getSafeUserString(),
-             ui->cylinderHeight->value().getSafeUserString(),
-             ui->cylinderAngle->value().getSafeUserString(),
-             ui->cylinderXSkew->value().getSafeUserString(),
-             ui->cylinderYSkew->value().getSafeUserString(),
+             safeQuantityQString(ui->cylinderRadius),
+             safeQuantityQString(ui->cylinderHeight),
+             safeQuantityQString(ui->cylinderAngle),
+             safeQuantityQString(ui->cylinderXSkew),
+             safeQuantityQString(ui->cylinderYSkew),
              placement,
              DlgPrimitives::tr("Cylinder"));
 }
@@ -449,11 +454,11 @@ QString CylinderPrimitive::change(const QString& objectName, const QString& plac
         "%1.SecondAngle='%6'\n"
         "%1.Placement=%7\n")
         .arg(objectName,
-             ui->cylinderRadius->value().getSafeUserString(),
-             ui->cylinderHeight->value().getSafeUserString(),
-             ui->cylinderAngle->value().getSafeUserString(),
-             ui->cylinderXSkew->value().getSafeUserString(),
-             ui->cylinderYSkew->value().getSafeUserString(),
+             safeQuantityQString(ui->cylinderRadius),
+             safeQuantityQString(ui->cylinderHeight),
+             safeQuantityQString(ui->cylinderAngle),
+             safeQuantityQString(ui->cylinderXSkew),
+             safeQuantityQString(ui->cylinderYSkew),
              placement);
 }
 
@@ -527,10 +532,10 @@ QString ConePrimitive::create(const QString& objectName, const QString& placemen
         "App.ActiveDocument.%1.Placement=%6\n"
         "App.ActiveDocument.%1.Label='%7'\n")
         .arg(objectName,
-             ui->coneRadius1->value().getSafeUserString(),
-             ui->coneRadius2->value().getSafeUserString(),
-             ui->coneHeight->value().getSafeUserString(),
-             ui->coneAngle->value().getSafeUserString(),
+             safeQuantityQString(ui->coneRadius1),
+             safeQuantityQString(ui->coneRadius2),
+             safeQuantityQString(ui->coneHeight),
+             safeQuantityQString(ui->coneAngle),
              placement,
              DlgPrimitives::tr("Cone"));
 }
@@ -544,10 +549,10 @@ QString ConePrimitive::change(const QString& objectName, const QString& placemen
         "%1.Angle='%5'\n"
         "%1.Placement=%6\n")
         .arg(objectName,
-             ui->coneRadius1->value().getSafeUserString(),
-             ui->coneRadius2->value().getSafeUserString(),
-             ui->coneHeight->value().getSafeUserString(),
-             ui->coneAngle->value().getSafeUserString(),
+             safeQuantityQString(ui->coneRadius1),
+             safeQuantityQString(ui->coneRadius2),
+             safeQuantityQString(ui->coneHeight),
+             safeQuantityQString(ui->coneAngle),
              placement);
 }
 
@@ -618,10 +623,10 @@ QString SpherePrimitive::create(const QString& objectName, const QString& placem
         "App.ActiveDocument.%1.Placement=%6\n"
         "App.ActiveDocument.%1.Label='%7'\n")
         .arg(objectName,
-             ui->sphereRadius->value().getSafeUserString(),
-             ui->sphereAngle1->value().getSafeUserString(),
-             ui->sphereAngle2->value().getSafeUserString(),
-             ui->sphereAngle3->value().getSafeUserString(),
+             safeQuantityQString(ui->sphereRadius),
+             safeQuantityQString(ui->sphereAngle1),
+             safeQuantityQString(ui->sphereAngle2),
+             safeQuantityQString(ui->sphereAngle3),
              placement,
              DlgPrimitives::tr("Sphere"));
 }
@@ -635,10 +640,10 @@ QString SpherePrimitive::change(const QString& objectName, const QString& placem
         "%1.Angle3='%5'\n"
         "%1.Placement=%6\n")
         .arg(objectName,
-             ui->sphereRadius->value().getSafeUserString(),
-             ui->sphereAngle1->value().getSafeUserString(),
-             ui->sphereAngle2->value().getSafeUserString(),
-             ui->sphereAngle3->value().getSafeUserString(),
+             safeQuantityQString(ui->sphereRadius),
+             safeQuantityQString(ui->sphereAngle1),
+             safeQuantityQString(ui->sphereAngle2),
+             safeQuantityQString(ui->sphereAngle3),
              placement);
 }
 
@@ -720,12 +725,12 @@ QString EllipsoidPrimitive::create(const QString& objectName, const QString& pla
         "App.ActiveDocument.%1.Placement=%8\n"
         "App.ActiveDocument.%1.Label='%9'\n")
         .arg(objectName,
-             ui->ellipsoidRadius1->value().getSafeUserString(),
-             ui->ellipsoidRadius2->value().getSafeUserString(),
-             ui->ellipsoidRadius3->value().getSafeUserString(),
-             ui->ellipsoidAngle1->value().getSafeUserString(),
-             ui->ellipsoidAngle2->value().getSafeUserString(),
-             ui->ellipsoidAngle3->value().getSafeUserString(),
+             safeQuantityQString(ui->ellipsoidRadius1),
+             safeQuantityQString(ui->ellipsoidRadius2),
+             safeQuantityQString(ui->ellipsoidRadius3),
+             safeQuantityQString(ui->ellipsoidAngle1),
+             safeQuantityQString(ui->ellipsoidAngle2),
+             safeQuantityQString(ui->ellipsoidAngle3),
              placement,
              DlgPrimitives::tr("Ellipsoid"));
 }
@@ -741,12 +746,12 @@ QString EllipsoidPrimitive::change(const QString& objectName, const QString& pla
         "%1.Angle3='%7'\n"
         "%1.Placement=%8\n")
         .arg(objectName,
-             ui->ellipsoidRadius1->value().getSafeUserString(),
-             ui->ellipsoidRadius2->value().getSafeUserString(),
-             ui->ellipsoidRadius3->value().getSafeUserString(),
-             ui->ellipsoidAngle1->value().getSafeUserString(),
-             ui->ellipsoidAngle2->value().getSafeUserString(),
-             ui->ellipsoidAngle3->value().getSafeUserString(),
+             safeQuantityQString(ui->ellipsoidRadius1),
+             safeQuantityQString(ui->ellipsoidRadius2),
+             safeQuantityQString(ui->ellipsoidRadius3),
+             safeQuantityQString(ui->ellipsoidAngle1),
+             safeQuantityQString(ui->ellipsoidAngle2),
+             safeQuantityQString(ui->ellipsoidAngle3),
              placement);
 }
 
@@ -828,11 +833,11 @@ QString TorusPrimitive::create(const QString& objectName, const QString& placeme
         "App.ActiveDocument.%1.Placement=%7\n"
         "App.ActiveDocument.%1.Label='%8'\n")
         .arg(objectName,
-             ui->torusRadius1->value().getSafeUserString(),
-             ui->torusRadius2->value().getSafeUserString(),
-             ui->torusAngle1->value().getSafeUserString(),
-             ui->torusAngle2->value().getSafeUserString(),
-             ui->torusAngle3->value().getSafeUserString(),
+             safeQuantityQString(ui->torusRadius1),
+             safeQuantityQString(ui->torusRadius2),
+             safeQuantityQString(ui->torusAngle1),
+             safeQuantityQString(ui->torusAngle2),
+             safeQuantityQString(ui->torusAngle3),
              placement,
              DlgPrimitives::tr("Torus"));
 }
@@ -847,11 +852,11 @@ QString TorusPrimitive::change(const QString& objectName, const QString& placeme
         "%1.Angle3='%6'\n"
         "%1.Placement=%7\n")
         .arg(objectName,
-             ui->torusRadius1->value().getSafeUserString(),
-             ui->torusRadius2->value().getSafeUserString(),
-             ui->torusAngle1->value().getSafeUserString(),
-             ui->torusAngle2->value().getSafeUserString(),
-             ui->torusAngle3->value().getSafeUserString(),
+             safeQuantityQString(ui->torusRadius1),
+             safeQuantityQString(ui->torusRadius2),
+             safeQuantityQString(ui->torusAngle1),
+             safeQuantityQString(ui->torusAngle2),
+             safeQuantityQString(ui->torusAngle3),
              placement);
 }
 
@@ -927,10 +932,10 @@ QString PrismPrimitive::create(const QString& objectName, const QString& placeme
         "App.ActiveDocument.%1.Label='%8'\n")
         .arg(objectName,
              QString::number(ui->prismPolygon->value()),
-             ui->prismCircumradius->value().getSafeUserString(),
-             ui->prismHeight->value().getSafeUserString(),
-             ui->prismXSkew->value().getSafeUserString(),
-             ui->prismYSkew->value().getSafeUserString(),
+             safeQuantityQString(ui->prismCircumradius),
+             safeQuantityQString(ui->prismHeight),
+             safeQuantityQString(ui->prismXSkew),
+             safeQuantityQString(ui->prismYSkew),
              placement,
              DlgPrimitives::tr("Prism"));
 }
@@ -946,10 +951,10 @@ QString PrismPrimitive::change(const QString& objectName, const QString& placeme
         "%1.Placement=%7\n")
         .arg(objectName,
              QString::number(ui->prismPolygon->value()),
-             ui->prismCircumradius->value().getSafeUserString(),
-             ui->prismHeight->value().getSafeUserString(),
-             ui->prismXSkew->value().getSafeUserString(),
-             ui->prismYSkew->value().getSafeUserString(),
+             safeQuantityQString(ui->prismCircumradius),
+             safeQuantityQString(ui->prismHeight),
+             safeQuantityQString(ui->prismXSkew),
+             safeQuantityQString(ui->prismYSkew),
              placement);
 }
 
@@ -1063,16 +1068,16 @@ QString WedgePrimitive::create(const QString& objectName, const QString& placeme
         "App.ActiveDocument.%1.Placement=%12\n"
         "App.ActiveDocument.%1.Label='%13'\n")
         .arg(objectName,
-             ui->wedgeXmin->value().getSafeUserString(),
-             ui->wedgeYmin->value().getSafeUserString(),
-             ui->wedgeZmin->value().getSafeUserString(),
-             ui->wedgeX2min->value().getSafeUserString(),
-             ui->wedgeZ2min->value().getSafeUserString(),
-             ui->wedgeXmax->value().getSafeUserString(),
-             ui->wedgeYmax->value().getSafeUserString())
-        .arg(ui->wedgeZmax->value().getSafeUserString(),
-             ui->wedgeX2max->value().getSafeUserString(),
-             ui->wedgeZ2max->value().getSafeUserString(),
+             safeQuantityQString(ui->wedgeXmin),
+             safeQuantityQString(ui->wedgeYmin),
+             safeQuantityQString(ui->wedgeZmin),
+             safeQuantityQString(ui->wedgeX2min),
+             safeQuantityQString(ui->wedgeZ2min),
+             safeQuantityQString(ui->wedgeXmax),
+             safeQuantityQString(ui->wedgeYmax))
+        .arg(safeQuantityQString(ui->wedgeZmax),
+             safeQuantityQString(ui->wedgeX2max),
+             safeQuantityQString(ui->wedgeZ2max),
              placement,
              DlgPrimitives::tr("Wedge"));
 }
@@ -1092,16 +1097,16 @@ QString WedgePrimitive::change(const QString& objectName, const QString& placeme
         "%1.Z2max='%11'\n"
         "%1.Placement=%12\n")
         .arg(objectName,
-             ui->wedgeXmin->value().getSafeUserString(),
-             ui->wedgeYmin->value().getSafeUserString(),
-             ui->wedgeZmin->value().getSafeUserString(),
-             ui->wedgeX2min->value().getSafeUserString(),
-             ui->wedgeZ2min->value().getSafeUserString(),
-             ui->wedgeXmax->value().getSafeUserString(),
-             ui->wedgeYmax->value().getSafeUserString(),
-             ui->wedgeZmax->value().getSafeUserString())
-        .arg(ui->wedgeX2max->value().getSafeUserString(),
-             ui->wedgeZ2max->value().getSafeUserString(),
+             safeQuantityQString(ui->wedgeXmin),
+             safeQuantityQString(ui->wedgeYmin),
+             safeQuantityQString(ui->wedgeZmin),
+             safeQuantityQString(ui->wedgeX2min),
+             safeQuantityQString(ui->wedgeZ2min),
+             safeQuantityQString(ui->wedgeXmax),
+             safeQuantityQString(ui->wedgeYmax),
+             safeQuantityQString(ui->wedgeZmax))
+        .arg(safeQuantityQString(ui->wedgeX2max),
+             safeQuantityQString(ui->wedgeZ2max),
              placement);
 }
 
@@ -1194,10 +1199,10 @@ QString HelixPrimitive::create(const QString& objectName, const QString& placeme
         "App.ActiveDocument.%1.Placement=%7\n"
         "App.ActiveDocument.%1.Label='%8'\n")
         .arg(objectName,
-             ui->helixPitch->value().getSafeUserString(),
-             ui->helixHeight->value().getSafeUserString(),
-             ui->helixRadius->value().getSafeUserString(),
-             ui->helixAngle->value().getSafeUserString(),
+             safeQuantityQString(ui->helixPitch),
+             safeQuantityQString(ui->helixHeight),
+             safeQuantityQString(ui->helixRadius),
+             safeQuantityQString(ui->helixAngle),
              QString::number(ui->helixLocalCS->currentIndex()),
              placement,
              DlgPrimitives::tr("Helix"));
@@ -1213,10 +1218,10 @@ QString HelixPrimitive::change(const QString& objectName, const QString& placeme
         "%1.LocalCoord=%6\n"
         "%1.Placement=%7\n")
         .arg(objectName,
-             ui->helixPitch->value().getSafeUserString(),
-             ui->helixHeight->value().getSafeUserString(),
-             ui->helixRadius->value().getSafeUserString(),
-             ui->helixAngle->value().getSafeUserString(),
+             safeQuantityQString(ui->helixPitch),
+             safeQuantityQString(ui->helixHeight),
+             safeQuantityQString(ui->helixRadius),
+             safeQuantityQString(ui->helixAngle),
              QString::number(ui->helixLocalCS->currentIndex()),
              placement);
 }
@@ -1285,9 +1290,9 @@ QString SpiralPrimitive::create(const QString& objectName, const QString& placem
         "App.ActiveDocument.%1.Placement=%5\n"
         "App.ActiveDocument.%1.Label='%6'\n")
         .arg(objectName,
-             ui->spiralGrowth->value().getSafeUserString(),
+             safeQuantityQString(ui->spiralGrowth),
              QString::number(ui->spiralRotation->value()),
-             ui->spiralRadius->value().getSafeUserString(),
+             safeQuantityQString(ui->spiralRadius),
              placement,
              DlgPrimitives::tr("Spiral"));
 }
@@ -1300,9 +1305,9 @@ QString SpiralPrimitive::change(const QString& objectName, const QString& placem
         "%1.Radius='%4'\n"
         "%1.Placement=%5\n")
         .arg(objectName,
-             ui->spiralGrowth->value().getSafeUserString(),
+             safeQuantityQString(ui->spiralGrowth),
              QString::number(ui->spiralRotation->value()),
-             ui->spiralRadius->value().getSafeUserString(),
+             safeQuantityQString(ui->spiralRadius),
              placement);
 }
 
@@ -1365,9 +1370,9 @@ QString CirclePrimitive::create(const QString& objectName, const QString& placem
         "App.ActiveDocument.%1.Placement=%5\n"
         "App.ActiveDocument.%1.Label='%6'\n")
         .arg(objectName,
-             ui->circleRadius->value().getSafeUserString(),
-             ui->circleAngle1->value().getSafeUserString(),
-             ui->circleAngle2->value().getSafeUserString(),
+             safeQuantityQString(ui->circleRadius),
+             safeQuantityQString(ui->circleAngle1),
+             safeQuantityQString(ui->circleAngle2),
              placement,
              DlgPrimitives::tr("Circle"));
 }
@@ -1380,9 +1385,9 @@ QString CirclePrimitive::change(const QString& objectName, const QString& placem
         "%1.Angle2='%4'\n"
         "%1.Placement=%5\n")
         .arg(objectName,
-             ui->circleRadius->value().getSafeUserString(),
-             ui->circleAngle1->value().getSafeUserString(),
-             ui->circleAngle2->value().getSafeUserString(),
+             safeQuantityQString(ui->circleRadius),
+             safeQuantityQString(ui->circleAngle1),
+             safeQuantityQString(ui->circleAngle2),
              placement);
 }
 
@@ -1450,10 +1455,10 @@ QString EllipsePrimitive::create(const QString& objectName, const QString& place
         "App.ActiveDocument.%1.Placement=%6\n"
         "App.ActiveDocument.%1.Label='%7'\n")
         .arg(objectName,
-             ui->ellipseMajorRadius->value().getSafeUserString(),
-             ui->ellipseMinorRadius->value().getSafeUserString(),
-             ui->ellipseAngle1->value().getSafeUserString(),
-             ui->ellipseAngle2->value().getSafeUserString(),
+             safeQuantityQString(ui->ellipseMajorRadius),
+             safeQuantityQString(ui->ellipseMinorRadius),
+             safeQuantityQString(ui->ellipseAngle1),
+             safeQuantityQString(ui->ellipseAngle2),
              placement,
              DlgPrimitives::tr("Ellipse"));
 }
@@ -1467,10 +1472,10 @@ QString EllipsePrimitive::change(const QString& objectName, const QString& place
         "%1.Angle2='%5'\n"
         "%1.Placement=%6\n")
         .arg(objectName,
-             ui->ellipseMajorRadius->value().getSafeUserString(),
-             ui->ellipseMinorRadius->value().getSafeUserString(),
-             ui->ellipseAngle1->value().getSafeUserString(),
-             ui->ellipseAngle2->value().getSafeUserString(),
+             safeQuantityQString(ui->ellipseMajorRadius),
+             safeQuantityQString(ui->ellipseMinorRadius),
+             safeQuantityQString(ui->ellipseAngle1),
+             safeQuantityQString(ui->ellipseAngle2),
              placement);
 }
 
@@ -1530,7 +1535,7 @@ QString PolygonPrimitive::create(const QString& objectName, const QString& place
         "App.ActiveDocument.%1.Label='%5'\n")
         .arg(objectName,
              QString::number(ui->regularPolygonPolygon->value()),
-             ui->regularPolygonCircumradius->value().getSafeUserString(),
+             safeQuantityQString(ui->regularPolygonCircumradius),
              placement,
              DlgPrimitives::tr("Regular polygon"));
 }
@@ -1543,7 +1548,7 @@ QString PolygonPrimitive::change(const QString& objectName, const QString& place
         "%1.Placement=%4\n")
         .arg(objectName,
              QString::number(ui->regularPolygonPolygon->value()),
-             ui->regularPolygonCircumradius->value().getSafeUserString(),
+             safeQuantityQString(ui->regularPolygonCircumradius),
              placement);
 }
 
@@ -1624,12 +1629,12 @@ QString LinePrimitive::create(const QString& objectName, const QString& placemen
         "App.ActiveDocument.%1.Placement=%8\n"
         "App.ActiveDocument.%1.Label='%9'\n")
         .arg(objectName,
-             ui->edgeX1->value().getSafeUserString(),
-             ui->edgeY1->value().getSafeUserString(),
-             ui->edgeZ1->value().getSafeUserString(),
-             ui->edgeX2->value().getSafeUserString(),
-             ui->edgeY2->value().getSafeUserString(),
-             ui->edgeZ2->value().getSafeUserString(),
+             safeQuantityQString(ui->edgeX1),
+             safeQuantityQString(ui->edgeY1),
+             safeQuantityQString(ui->edgeZ1),
+             safeQuantityQString(ui->edgeX2),
+             safeQuantityQString(ui->edgeY2),
+             safeQuantityQString(ui->edgeZ2),
              placement,
              DlgPrimitives::tr("Line"));
 }
@@ -1645,12 +1650,12 @@ QString LinePrimitive::change(const QString& objectName, const QString& placemen
         "%1.Z2='%7'\n"
         "%1.Placement=%8\n")
         .arg(objectName,
-             ui->edgeX1->value().getSafeUserString(),
-             ui->edgeY1->value().getSafeUserString(),
-             ui->edgeZ1->value().getSafeUserString(),
-             ui->edgeX2->value().getSafeUserString(),
-             ui->edgeY2->value().getSafeUserString(),
-             ui->edgeZ2->value().getSafeUserString(),
+             safeQuantityQString(ui->edgeX1),
+             safeQuantityQString(ui->edgeY1),
+             safeQuantityQString(ui->edgeZ1),
+             safeQuantityQString(ui->edgeX2),
+             safeQuantityQString(ui->edgeY2),
+             safeQuantityQString(ui->edgeZ2),
              placement);
 }
 
@@ -1725,9 +1730,9 @@ QString VertexPrimitive::create(const QString& objectName, const QString& placem
         "App.ActiveDocument.%1.Placement=%5\n"
         "App.ActiveDocument.%1.Label='%6'\n")
         .arg(objectName,
-             ui->vertexX->value().getSafeUserString(),
-             ui->vertexY->value().getSafeUserString(),
-             ui->vertexZ->value().getSafeUserString(),
+             safeQuantityQString(ui->vertexX),
+             safeQuantityQString(ui->vertexY),
+             safeQuantityQString(ui->vertexZ),
              placement,
              DlgPrimitives::tr("Vertex"));
 }
@@ -1740,9 +1745,9 @@ QString VertexPrimitive::change(const QString& objectName, const QString& placem
         "%1.Z='%4'\n"
         "%1.Placement=%5\n")
         .arg(objectName,
-             ui->vertexX->value().getSafeUserString(),
-             ui->vertexY->value().getSafeUserString(),
-             ui->vertexZ->value().getSafeUserString(),
+             safeQuantityQString(ui->vertexX),
+             safeQuantityQString(ui->vertexY),
+             safeQuantityQString(ui->vertexZ),
              placement);
 }
 

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -811,103 +811,103 @@ void TaskBoxPrimitives::onWedgeZmaxChanged(double v)
 bool TaskBoxPrimitives::setPrimitive(App::DocumentObject* obj)
 {
     try {
-        QString name(QString::fromLatin1(Gui::Command::getObjectCmd(obj).c_str()));
-        QString cmd;
         App::Document* doc = App::GetApplication().getActiveDocument();
         if (!doc) {
             return false;
         }
 
+        std::string cmd;
+        std::string name(Gui::Command::getObjectCmd(obj));
         Base::QuantityFormat format(Base::QuantityFormat::Fixed, Base::UnitsApi::getDecimals());
         switch (ui->widgetStack->currentIndex()) {
             case 1:  // box
-                cmd = QString::fromLatin1("%1.Length='%2'\n"
-                                          "%1.Width='%3'\n"
-                                          "%1.Height='%4'\n")
-                          .arg(name,
-                               ui->boxLength->value().getSafeUserString(),
-                               ui->boxWidth->value().getSafeUserString(),
-                               ui->boxHeight->value().getSafeUserString());
+                cmd = fmt::format("{0}.Length='{1}'\n"
+                                  "{0}.Width='{2}'\n"
+                                  "{0}.Height='{3}'\n",
+                                  name,
+                                  ui->boxLength->value().getSafeUserString(),
+                                  ui->boxWidth->value().getSafeUserString(),
+                                  ui->boxHeight->value().getSafeUserString());
                 break;
 
             case 2:  // cylinder
-                cmd = QString::fromLatin1("%1.Radius='%2'\n"
-                                          "%1.Height='%3'\n"
-                                          "%1.Angle='%4'\n"
-                                          "%1.FirstAngle='%5'\n"
-                                          "%1.SecondAngle='%6'\n")
-                          .arg(name,
-                               ui->cylinderRadius->value().getSafeUserString(),
-                               ui->cylinderHeight->value().getSafeUserString(),
-                               ui->cylinderAngle->value().getSafeUserString(),
-                               ui->cylinderXSkew->value().getSafeUserString(),
-                               ui->cylinderYSkew->value().getSafeUserString());
+                cmd = fmt::format("{0}.Radius='{1}'\n"
+                                  "{0}.Height='{2}'\n"
+                                  "{0}.Angle='{3}'\n"
+                                  "{0}.FirstAngle='{4}'\n"
+                                  "{0}.SecondAngle='{5}'\n",
+                                  name,
+                                  ui->cylinderRadius->value().getSafeUserString(),
+                                  ui->cylinderHeight->value().getSafeUserString(),
+                                  ui->cylinderAngle->value().getSafeUserString(),
+                                  ui->cylinderXSkew->value().getSafeUserString(),
+                                  ui->cylinderYSkew->value().getSafeUserString());
                 break;
 
             case 3:  // cone
-                cmd = QString::fromLatin1("%1.Radius1='%2'\n"
-                                          "%1.Radius2='%3'\n"
-                                          "%1.Height='%4'\n"
-                                          "%1.Angle='%5'\n")
-                          .arg(name,
-                               ui->coneRadius1->value().getSafeUserString(),
-                               ui->coneRadius2->value().getSafeUserString(),
-                               ui->coneHeight->value().getSafeUserString(),
-                               ui->coneAngle->value().getSafeUserString());
+                cmd = fmt::format("{0}.Radius1='{1}'\n"
+                                  "{0}.Radius2='{2}'\n"
+                                  "{0}.Height='{3}'\n"
+                                  "{0}.Angle='{4}'\n",
+                                  name,
+                                  ui->coneRadius1->value().getSafeUserString(),
+                                  ui->coneRadius2->value().getSafeUserString(),
+                                  ui->coneHeight->value().getSafeUserString(),
+                                  ui->coneAngle->value().getSafeUserString());
                 break;
 
             case 4:  // sphere
-                cmd = QString::fromLatin1("%1.Radius='%2'\n"
-                                          "%1.Angle1='%3'\n"
-                                          "%1.Angle2='%4'\n"
-                                          "%1.Angle3='%5'\n")
-                          .arg(name,
-                               ui->sphereRadius->value().getSafeUserString(),
-                               ui->sphereAngle1->value().getSafeUserString(),
-                               ui->sphereAngle2->value().getSafeUserString(),
-                               ui->sphereAngle3->value().getSafeUserString());
+                cmd = fmt::format("{0}.Radius='{1}'\n"
+                                  "{0}.Angle1='{2}'\n"
+                                  "{0}.Angle2='{3}'\n"
+                                  "{0}.Angle3='{4}'\n",
+                                  name,
+                                  ui->sphereRadius->value().getSafeUserString(),
+                                  ui->sphereAngle1->value().getSafeUserString(),
+                                  ui->sphereAngle2->value().getSafeUserString(),
+                                  ui->sphereAngle3->value().getSafeUserString());
                 break;
             case 5:  // ellipsoid
-                cmd = QString::fromLatin1("%1.Radius1='%2'\n"
-                                          "%1.Radius2='%3'\n"
-                                          "%1.Radius3='%4'\n"
-                                          "%1.Angle1='%5'\n"
-                                          "%1.Angle2='%6'\n"
-                                          "%1.Angle3='%7'\n")
-                          .arg(name,
-                               ui->ellipsoidRadius1->value().getSafeUserString(),
-                               ui->ellipsoidRadius2->value().getSafeUserString(),
-                               ui->ellipsoidRadius3->value().getSafeUserString(),
-                               ui->ellipsoidAngle1->value().getSafeUserString(),
-                               ui->ellipsoidAngle2->value().getSafeUserString(),
-                               ui->ellipsoidAngle3->value().getSafeUserString());
+                cmd = fmt::format("{0}.Radius1='{1}'\n"
+                                  "{0}.Radius2='{2}'\n"
+                                  "{0}.Radius3='{3}'\n"
+                                  "{0}.Angle1='{4}'\n"
+                                  "{0}.Angle2='{5}'\n"
+                                  "{0}.Angle3='{6}'\n",
+                                  name,
+                                  ui->ellipsoidRadius1->value().getSafeUserString(),
+                                  ui->ellipsoidRadius2->value().getSafeUserString(),
+                                  ui->ellipsoidRadius3->value().getSafeUserString(),
+                                  ui->ellipsoidAngle1->value().getSafeUserString(),
+                                  ui->ellipsoidAngle2->value().getSafeUserString(),
+                                  ui->ellipsoidAngle3->value().getSafeUserString());
                 break;
 
             case 6:  // torus
-                cmd = QString::fromLatin1("%1.Radius1='%2'\n"
-                                          "%1.Radius2='%3'\n"
-                                          "%1.Angle1='%4'\n"
-                                          "%1.Angle2='%5'\n"
-                                          "%1.Angle3='%6'\n")
-                          .arg(name,
-                               ui->torusRadius1->value().getSafeUserString(),
-                               ui->torusRadius2->value().getSafeUserString(),
-                               ui->torusAngle1->value().getSafeUserString(),
-                               ui->torusAngle2->value().getSafeUserString(),
-                               ui->torusAngle3->value().getSafeUserString());
+                cmd = fmt::format("{0}.Radius1='{1}'\n"
+                                  "{0}.Radius2='{2}'\n"
+                                  "{0}.Angle1='{3}'\n"
+                                  "{0}.Angle2='{4}'\n"
+                                  "{0}.Angle3='{5}'\n",
+                                  name,
+                                  ui->torusRadius1->value().getSafeUserString(),
+                                  ui->torusRadius2->value().getSafeUserString(),
+                                  ui->torusAngle1->value().getSafeUserString(),
+                                  ui->torusAngle2->value().getSafeUserString(),
+                                  ui->torusAngle3->value().getSafeUserString());
                 break;
             case 7:  // prism
-                cmd = QString::fromLatin1("%1.Polygon=%2\n"
-                                          "%1.Circumradius='%3'\n"
-                                          "%1.Height='%4'\n"
-                                          "%1.FirstAngle='%5'\n"
-                                          "%1.SecondAngle='%6'\n")
-                          .arg(name,
-                               QString::number(ui->prismPolygon->value()),
-                               ui->prismCircumradius->value().getSafeUserString(),
-                               ui->prismHeight->value().getSafeUserString(),
-                               ui->prismXSkew->value().getSafeUserString(),
-                               ui->prismYSkew->value().getSafeUserString());
+                cmd = fmt::format("{0}.Polygon={1}\n"
+                                  "{0}.Circumradius='{2}'\n"
+                                  "{0}.Height='{3}'\n"
+                                  "{0}.FirstAngle='{4}'\n"
+                                  "{0}.SecondAngle='{5}'\n",
+                                  name,
+                                  ui->prismPolygon->value(),
+                                  ui->prismCircumradius->value().getSafeUserString(),
+                                  ui->prismHeight->value().getSafeUserString(),
+                                  ui->prismXSkew->value().getSafeUserString(),
+                                  ui->prismYSkew->value().getSafeUserString());
                 break;
             case 8:  // wedge
                 // Xmin/max, Ymin/max and Zmin/max must each not be equal
@@ -929,27 +929,27 @@ bool TaskBoxPrimitives::setPrimitive(App::DocumentObject* obj)
                                          tr("Z min must not be equal to Z max!"));
                     return false;
                 }
-                cmd = QString::fromLatin1("%1.Xmin='%2'\n"
-                                          "%1.Ymin='%3'\n"
-                                          "%1.Zmin='%4'\n"
-                                          "%1.X2min='%5'\n"
-                                          "%1.Z2min='%6'\n"
-                                          "%1.Xmax='%7'\n"
-                                          "%1.Ymax='%8'\n"
-                                          "%1.Zmax='%9'\n"
-                                          "%1.X2max='%10'\n"
-                                          "%1.Z2max='%11'\n")
-                          .arg(name,
-                               ui->wedgeXmin->value().getSafeUserString(),
-                               ui->wedgeYmin->value().getSafeUserString(),
-                               ui->wedgeZmin->value().getSafeUserString(),
-                               ui->wedgeX2min->value().getSafeUserString(),
-                               ui->wedgeZ2min->value().getSafeUserString(),
-                               ui->wedgeXmax->value().getSafeUserString(),
-                               ui->wedgeYmax->value().getSafeUserString(),
-                               ui->wedgeZmax->value().getSafeUserString())
-                          .arg(ui->wedgeX2max->value().getSafeUserString(),
-                               ui->wedgeZ2max->value().getSafeUserString());
+                cmd = fmt::format("{0}.Xmin='{1}'\n"
+                                  "{0}.Ymin='{2}'\n"
+                                  "{0}.Zmin='{3}'\n"
+                                  "{0}.X2min='{4}'\n"
+                                  "{0}.Z2min='{5}'\n"
+                                  "{0}.Xmax='{6}'\n"
+                                  "{0}.Ymax='{7}'\n"
+                                  "{0}.Zmax='{8}'\n"
+                                  "{0}.X2max='{9}'\n"
+                                  "{0}.Z2max='{10}'\n",
+                                  name,
+                                  ui->wedgeXmin->value().getSafeUserString(),
+                                  ui->wedgeYmin->value().getSafeUserString(),
+                                  ui->wedgeZmin->value().getSafeUserString(),
+                                  ui->wedgeX2min->value().getSafeUserString(),
+                                  ui->wedgeZ2min->value().getSafeUserString(),
+                                  ui->wedgeXmax->value().getSafeUserString(),
+                                  ui->wedgeYmax->value().getSafeUserString(),
+                                  ui->wedgeZmax->value().getSafeUserString(),
+                                  ui->wedgeX2max->value().getSafeUserString(),
+                                  ui->wedgeZ2max->value().getSafeUserString());
                 break;
 
             default:
@@ -959,7 +959,7 @@ bool TaskBoxPrimitives::setPrimitive(App::DocumentObject* obj)
         // Execute the Python block
         // No need to open a transaction because this is already done in the command
         // class or when starting to edit a primitive.
-        Gui::Command::runCommand(Gui::Command::Doc, cmd.toUtf8());
+        Gui::Command::runCommand(Gui::Command::Doc, cmd.c_str());
         Gui::Command::runCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
     }
     catch (const Base::PyException& e) {

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -765,8 +765,8 @@ PyObject* SketchObjectPy::setDatum(PyObject* args)
             str << "Cannot set the datum because the sketch contains conflicting constraints";
         }
         else if (err == -2) {
-            str << "Datum " << (const char*)Quantity.getUserString().toUtf8()
-                << " for the constraint with index " << Index << " is invalid";
+            str << "Datum " << Quantity.getUserString() << " for the constraint with index "
+                << Index << " is invalid";
         }
         else if (err == -4) {
             str << "Negative datum values are not valid for the constraint with index " << Index;
@@ -778,8 +778,7 @@ PyObject* SketchObjectPy::setDatum(PyObject* args)
             str << "Cannot set the datum because of invalid geometry";
         }
         else {
-            str << "Unexpected problem at setting datum "
-                << (const char*)Quantity.getUserString().toUtf8()
+            str << "Unexpected problem at setting datum " << Quantity.getUserString()
                 << " for the constraint with index " << Index;
         }
         PyErr_SetString(PyExc_ValueError, str.str().c_str());

--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -203,7 +203,7 @@ void EditDatumDialog::accepted()
                     ui_ins_datum->labelEdit->apply();
                 }
                 else {
-                    auto unitString = newQuant.getUnit().getString().toUtf8().toStdString();
+                    auto unitString = newQuant.getUnit().getString();
                     unitString = Base::Tools::escapeQuotesFromString(unitString);
                     Gui::cmdAppObjectArgs(sketch,
                                           "setDatum(%i,App.Units.Quantity('%f %s'))",

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2095,11 +2095,10 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
 
 QString EditModeConstraintCoinManager::getPresentationString(const Constraint* constraint)
 {
-    QString nameStr;           // name parameter string
+    std::string nameStr;       // name parameter string
     QString valueStr;          // dimensional value string
-    QString presentationStr;   // final return string
-    QString unitStr;           // the actual unit string
-    QString baseUnitStr;       // the expected base unit string
+    std::string unitStr;       // the actual unit string
+    std::string baseUnitStr;   // the expected base unit string
     double factor;             // unit scaling factor, currently not used
     Base::UnitSystem unitSys;  // current unit system
 
@@ -2108,10 +2107,11 @@ QString EditModeConstraintCoinManager::getPresentationString(const Constraint* c
     }
 
     // Get the current name parameter string of the constraint
-    nameStr = QString::fromStdString(constraint->Name);
+    nameStr = constraint->Name;
 
     // Get the current value string including units
-    valueStr = constraint->getPresentationValue().getUserString(factor, unitStr);
+    valueStr =
+        QString::fromStdString(constraint->getPresentationValue().getUserString(factor, unitStr));
 
     // Hide units if user has requested it, is being displayed in the base
     // units, and the schema being used has a clear base unit in the first
@@ -2127,19 +2127,19 @@ QString EditModeConstraintCoinManager::getPresentationString(const Constraint* c
         switch (unitSys) {
             case Base::UnitSystem::SI1:
             case Base::UnitSystem::MmMin:
-                baseUnitStr = QString::fromLatin1("mm");
+                baseUnitStr = "mm";
                 break;
 
             case Base::UnitSystem::SI2:
-                baseUnitStr = QString::fromLatin1("m");
+                baseUnitStr = "m";
                 break;
 
             case Base::UnitSystem::ImperialDecimal:
-                baseUnitStr = QString::fromLatin1("in");
+                baseUnitStr = "in";
                 break;
 
             case Base::UnitSystem::Centimeters:
-                baseUnitStr = QString::fromLatin1("cm");
+                baseUnitStr = "cm";
                 break;
 
             default:
@@ -2147,9 +2147,9 @@ QString EditModeConstraintCoinManager::getPresentationString(const Constraint* c
                 break;
         }
 
-        if (!baseUnitStr.isEmpty()) {
+        if (!baseUnitStr.empty()) {
             // expected unit string matches actual unit string. remove.
-            if (QString::compare(baseUnitStr, unitStr) == 0) {
+            if (baseUnitStr.compare(unitStr) == 0) {
                 // Example code from: Mod/TechDraw/App/DrawViewDimension.cpp:372
                 QRegularExpression rxUnits(
                     QString::fromUtf8(" \\D*$"));  // space + any non digits at end of string
@@ -2171,17 +2171,19 @@ QString EditModeConstraintCoinManager::getPresentationString(const Constraint* c
     %N - the constraint name parameter
     %V - the value of the dimensional constraint, including any unit characters
     */
-    if (constraintParameters.bShowDimensionalName && !nameStr.isEmpty()) {
+    if (constraintParameters.bShowDimensionalName && !nameStr.empty()) {
+        QString presentationStr;
         if (constraintParameters.sDimensionalStringFormat.contains(QLatin1String("%V"))
             || constraintParameters.sDimensionalStringFormat.contains(QLatin1String("%N"))) {
             presentationStr = constraintParameters.sDimensionalStringFormat;
-            presentationStr.replace(QLatin1String("%N"), nameStr);
+            presentationStr.replace(QLatin1String("%N"), QString::fromStdString(nameStr));
             presentationStr.replace(QLatin1String("%V"), valueStr);
         }
         else {
             // user defined format string does not contain any valid parameter, using default format
             // "%N = %V"
-            presentationStr = nameStr + QLatin1String(" = ") + valueStr;
+            presentationStr =
+                QString::fromStdString(nameStr) + QString::fromLatin1(" = ") + valueStr;
         }
 
         return presentationStr;

--- a/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
+++ b/src/Mod/Sketcher/Gui/PropertyConstraintListItem.cpp
@@ -50,8 +50,7 @@ PropertyConstraintListItem::~PropertyConstraintListItem()
 QVariant PropertyConstraintListItem::toString(const QVariant& prop) const
 {
     const QList<Base::Quantity>& value = prop.value<QList<Base::Quantity>>();
-    QString str;
-    QTextStream out(&str);
+    std::stringstream out;
     out << "[";
     for (QList<Base::Quantity>::const_iterator it = value.begin(); it != value.end(); ++it) {
         if (it != value.begin()) {
@@ -60,7 +59,7 @@ QVariant PropertyConstraintListItem::toString(const QVariant& prop) const
         out << it->getUserString();
     }
     out << "]";
-    return QVariant(str);
+    return QVariant(QString::fromStdString(out.str()));
 }
 
 void PropertyConstraintListItem::initialize()

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -158,7 +158,8 @@ public:
                 case Sketcher::Diameter:
                 case Sketcher::Angle:
                     name = QString::fromLatin1("%1 (%2)").arg(
-                        name, constraint->getPresentationValue().getUserString());
+                        name,
+                        QString::fromStdString(constraint->getPresentationValue().getUserString()));
                     break;
                 case Sketcher::SnellsLaw: {
                     double v = constraint->getPresentationValue().getValue();

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -719,10 +719,10 @@ std::string SketcherGui::lengthToDisplayFormat(double value, int digits)
     Base::Quantity asQuantity;
     asQuantity.setValue(value);
     asQuantity.setUnit(Base::Unit::Length);
-    QString qUserString = asQuantity.getUserString();
+    std::string userString = asQuantity.getUserString();
     if (Base::UnitsApi::isMultiUnitLength() || (!hideUnits() && useSystemDecimals())) {
         // just return the user string
-        return qUserString.toStdString();
+        return userString;
     }
 
     // find the unit of measure
@@ -734,26 +734,26 @@ std::string SketcherGui::lengthToDisplayFormat(double value, int digits)
     // get the numeric part of the user string
     QRegularExpression rxNoUnits(
         QString::fromUtf8("(.*) \\D*$"));  // text before space + any non digits at end of string
-    QRegularExpressionMatch match = rxNoUnits.match(qUserString);
+    QRegularExpressionMatch match = rxNoUnits.match(QString::fromStdString(userString));
     if (!match.hasMatch()) {
         // no units in userString?
-        return qUserString.toStdString();
+        return userString;
     }
     QString matched = match.captured(1);  // matched is the numeric part of user string
+    auto smatched = matched.toStdString();
     int dpPos = matched.indexOf(QLocale().decimalPoint());
     if (dpPos < 0) {
-        auto ret = matched.toStdString();
         // no decimal separator (ie an integer), return all the digits
         if (!hideUnits()) {
-            ret.append(unitPart.toStdString());
+            smatched.append(unitPart.toStdString());
         }
-        return ret;
+        return smatched;
     }
 
     // real number
     if (useSystemDecimals() && hideUnits()) {
         // return just the numeric part of the user string
-        return matched.toStdString();
+        return smatched;
     }
 
     // real number and not using system decimals
@@ -779,7 +779,7 @@ std::string SketcherGui::angleToDisplayFormat(double value, int digits)
     Base::Quantity asQuantity;
     asQuantity.setValue(value);
     asQuantity.setUnit(Base::Unit::Angle);
-    QString qUserString = asQuantity.getUserString();
+    QString qUserString = QString::fromStdString(asQuantity.getUserString());
     if (Base::UnitsApi::isMultiUnitAngle()) {
         // just return the user string
         // Coin SbString doesn't handle utf8 well, so we convert to ascii
@@ -794,7 +794,7 @@ std::string SketcherGui::angleToDisplayFormat(double value, int digits)
 
     // we always use use U+00B0 (°) as the unit of measure for angles in
     // single unit schema.  Will need a change to support rads or grads.
-    auto qUnitString = QString::fromUtf8("°");
+    std::string unitString = "°";
     auto decimalSep = QLocale().decimalPoint();
 
     // get the numeric part of the user string
@@ -806,18 +806,12 @@ std::string SketcherGui::angleToDisplayFormat(double value, int digits)
         return qUserString.toStdString();
     }
     QString matched = match.captured(1);  // matched is the numeric part of user string
-    auto smatched = matched.toStdString();
-    auto sUnitString = qUnitString.toStdString();
     int dpPos = matched.indexOf(decimalSep);
-    if (dpPos < 0) {
-        // no decimal separator (ie an integer), return all the digits
-        return smatched + sUnitString;
-    }
-
-    // real number
-    if (useSystemDecimals()) {
-        // return just the numeric part of the user string + degree symbol
-        return smatched + sUnitString;
+    if (dpPos < 0 || useSystemDecimals()) {
+        // just the numeric part of the user string + degree symbol
+        auto angle = matched.toStdString();
+        angle.append(unitString);
+        return angle;
     }
 
     // real number and not using system decimals
@@ -827,7 +821,7 @@ std::string SketcherGui::angleToDisplayFormat(double value, int digits)
         requiredLength = matched.size();
     }
     auto numericPart = matched.left(requiredLength).toStdString();
-    numericPart.append(sUnitString);
+    numericPart.append(unitString);
     return numericPart;
 }
 

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -727,9 +727,9 @@ std::string SketcherGui::lengthToDisplayFormat(double value, int digits)
 
     // find the unit of measure
     double factor = 1.0;
-    QString qUnitString;
-    QString qtranslate = Base::UnitsApi::schemaTranslate(asQuantity, factor, qUnitString);
-    QString unitPart = QString::fromUtf8(" ") + qUnitString;
+    std::string unitString;
+    std::string translate = Base::UnitsApi::schemaTranslate(asQuantity, factor, unitString);
+    std::string unitPart = " " + unitString;
 
     // get the numeric part of the user string
     QRegularExpression rxNoUnits(
@@ -745,7 +745,7 @@ std::string SketcherGui::lengthToDisplayFormat(double value, int digits)
     if (dpPos < 0) {
         // no decimal separator (ie an integer), return all the digits
         if (!hideUnits()) {
-            smatched.append(unitPart.toStdString());
+            smatched.append(unitPart);
         }
         return smatched;
     }
@@ -764,7 +764,7 @@ std::string SketcherGui::lengthToDisplayFormat(double value, int digits)
     }
     auto numericPart = matched.left(requiredLength).toStdString();
     if (!hideUnits()) {
-        numericPart.append(unitPart.toStdString());
+        numericPart.append(unitPart);
     }
     return numericPart;
 }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -158,8 +158,7 @@ void ViewProviderSketch::ParameterObserver::updateGridSize(const std::string& st
         "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
 
     Client.GridSize.setValue(
-        Base::Quantity::parse(
-            QString::fromLatin1(hGrp->GetGroup("GridSize")->GetASCII("GridSize", "10.0").c_str()))
+        Base::Quantity::parse(hGrp->GetGroup("GridSize")->GetASCII("GridSize", "10.0"))
             .getValue());
 }
 

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -378,7 +378,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
                     // When displaying a quantity then use the globally set scheme
                     // See: https://forum.freecad.org/viewtopic.php?f=3&t=50078
                     Base::Quantity value = floatProp->getQuantityValue();
-                    v = value.getUserString();
+                    v = QString::fromStdString(value.getUserString());
                 }
                 return formatCellDisplay(v, cell);
             }

--- a/src/Mod/TechDraw/App/DimensionFormatter.cpp
+++ b/src/Mod/TechDraw/App/DimensionFormatter.cpp
@@ -78,9 +78,9 @@ std::string DimensionFormatter::formatValue(const qreal value,
         asQuantity.setUnit(Base::Unit::Length);
     }
 
-    QString qUserString = asQuantity.getUserString();  // this handles mm to inch/km/parsec etc
-                                                       // and decimal positions but won't give more than
-                                                       // Global_Decimals precision
+    // this handles mm to inch/km/parsec etc and decimal positions but
+    // won't give more than Global_Decimals precision
+    QString qUserString = QString::fromStdString(asQuantity.getUserString());
 
     //get formatSpec prefix/suffix/specifier
     QStringList qsl = getPrefixSuffixSpec(qFormatSpec);
@@ -132,7 +132,7 @@ std::string DimensionFormatter::formatValue(const qreal value,
             qBasicUnit = QString::fromUtf8("°");
         }
         else {
-            double convertValue = Base::Quantity::parse(QString::fromLatin1("1") + qBasicUnit).getValue();
+            double convertValue = Base::Quantity::parse("1" + qBasicUnit.toStdString()).getValue();
             userVal = asQuantity.getValue() / convertValue;
             if (areaMeasure) {
                 userVal = userVal / convertValue; // divide again as area is length²

--- a/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
+++ b/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
@@ -182,13 +182,13 @@ void DrawSVGTemplate::extractTemplateAttributes(QDomDocument& templateDocument)
 
     // Obtain the width
     QString str = docElement.attribute(QString::fromLatin1("width"));
-    quantity = Base::Quantity::parse(str);
+    quantity = Base::Quantity::parse(str.toStdString());
     quantity.setUnit(Base::Unit::Length);
 
     Width.setValue(quantity.getValue());
 
     str = docElement.attribute(QString::fromLatin1("height"));
-    quantity = Base::Quantity::parse(str);
+    quantity = Base::Quantity::parse(str.toStdString());
     quantity.setUnit(Base::Unit::Length);
 
     Height.setValue(quantity.getValue());

--- a/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
@@ -272,8 +272,7 @@ std::string DrawViewSpreadsheet::getSheetImage()
             if (prop && cell) {
                 if (prop->isDerivedFrom(App::PropertyQuantity::getClassTypeId())) {
                     auto contentAsQuantity = static_cast<App::PropertyQuantity*>(prop)->getQuantityValue();
-                    auto ustring = contentAsQuantity.getUserString();
-                    field << ustring.toStdString();
+                    field << contentAsQuantity.getUserString();
                 } else if (prop->isDerivedFrom(App::PropertyFloat::getClassTypeId()) ||
                            prop->isDerivedFrom(App::PropertyInteger::getClassTypeId())) {
                     std::string temp = cell->getFormattedQuantity();

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -1840,7 +1840,7 @@ void CmdTechDrawExtensionAreaAnnotation::activated(int iMsg)
     asQuantity.setValue(totalArea);
     asQuantity.setUnit(Base::Unit::Area);
 
-    QString qUserString = asQuantity.getUserString();
+    QString qUserString = QString::fromStdString(asQuantity.getUserString());
     if (qUserString.endsWith(QString::fromUtf8("^2"))) {
         qUserString.chop(2);
         qUserString.append(QString::fromUtf8("²"));

--- a/tests/src/App/ExpressionParser.cpp
+++ b/tests/src/App/ExpressionParser.cpp
@@ -44,8 +44,8 @@ protected:
     }
 
     Base::Quantity parse_quantity_text_as_quantity(const char* quantity_text) {
-        auto quantity_qstr = QString::fromStdString(std::string(quantity_text));
-        auto quantity_result = Base::Quantity::parse(quantity_qstr);
+        auto quantity_str = std::string(quantity_text);
+        auto quantity_result = Base::Quantity::parse(quantity_str);
         return quantity_result;
     }
 
@@ -95,8 +95,8 @@ TEST_F(ExpressionParserTest, functionPARSEQUANT)
         EXPECT_EQ(expression_result, quantity_result) << "mismatch:"
             " expression_text='" + std::string(expression_text) + "'"
             " quantity_text='" + std::string(quantity_text) + "'"
-            " expression_representation='" + expression_result.getUserString().toStdString() + "'"
-            " quantity_representation='" + quantity_result.getUserString().toStdString() + "'"
+            " expression_representation='" + expression_result.getUserString() + "'"
+            " quantity_representation='" + quantity_result.getUserString() + "'"
         ;
     }
 

--- a/tests/src/App/PropertyExpressionEngine.cpp
+++ b/tests/src/App/PropertyExpressionEngine.cpp
@@ -82,7 +82,7 @@ TEST_F(PropertyExpressionEngineTest, executeCrossPropertyReference)
     auto target_value = target_quant.getValue();
     auto target_unit = target_quant.getUnit().getString();
 
-    auto verify_quant = Base::Quantity::parse(QString::fromStdString(target_text));
+    auto verify_quant = Base::Quantity::parse(target_text);
 
     EXPECT_EQ(target_quant, verify_quant) << ""
         "expecting equal: source_text='" + source_text + "' target_text='" + target_text + "'"

--- a/tests/src/App/PropertyExpressionEngine.cpp
+++ b/tests/src/App/PropertyExpressionEngine.cpp
@@ -80,7 +80,7 @@ TEST_F(PropertyExpressionEngineTest, executeCrossPropertyReference)
     ASSERT_TRUE(target_entry.type() == typeid(Base::Quantity));
     auto target_quant = App::any_cast<Base::Quantity>(target_entry);
     auto target_value = target_quant.getValue();
-    auto target_unit = target_quant.getUnit().getString().toStdString();
+    auto target_unit = target_quant.getUnit().getString();
 
     auto verify_quant = Base::Quantity::parse(QString::fromStdString(target_text));
 

--- a/tests/src/Base/Quantity.cpp
+++ b/tests/src/Base/Quantity.cpp
@@ -190,10 +190,10 @@ TEST_F(Quantity, TestSchemeImperialTwo)
     Base::Quantity quantity {1.0, Base::Unit::Length};
 
     double factor {};
-    QString unitString;
+    std::string unitString;
     auto scheme = Base::UnitsApi::createSchema(Base::UnitSystem::ImperialDecimal);
-    QString result = scheme->schemaTranslate(quantity, factor, unitString);
-    EXPECT_EQ(result.toStdString(), "0.04 in");
+    std::string result = scheme->schemaTranslate(quantity, factor, unitString);
+    EXPECT_EQ(result, "0.04 in");
 }
 
 TEST_F(Quantity, TestSchemeImperialOne)
@@ -205,11 +205,11 @@ TEST_F(Quantity, TestSchemeImperialOne)
     quantity.setFormat(format);
 
     double factor {};
-    QString unitString;
+    std::string unitString;
     auto scheme = Base::UnitsApi::createSchema(Base::UnitSystem::ImperialDecimal);
-    QString result = scheme->schemaTranslate(quantity, factor, unitString);
+    std::string result = scheme->schemaTranslate(quantity, factor, unitString);
 
-    EXPECT_EQ(result.toStdString(), "0.0 in");
+    EXPECT_EQ(result, "0.0 in");
 }
 
 TEST_F(Quantity, TestSafeUserString)

--- a/tests/src/Base/Quantity.cpp
+++ b/tests/src/Base/Quantity.cpp
@@ -19,12 +19,10 @@ TEST(BaseQuantity, TestValid)
 
 TEST(BaseQuantity, TestParse)
 {
-    Base::Quantity q1 = Base::Quantity::parse(QString::fromLatin1("1,234 kg"));
+    Base::Quantity q1 = Base::Quantity::parse("1,234 kg");
 
     EXPECT_EQ(q1, Base::Quantity(1.2340, Base::Unit::Mass));
-    EXPECT_THROW(
-        boost::ignore_unused(Base::Quantity::parse(QString::fromLatin1("1,234,500.12 kg"))),
-        Base::ParserError);
+    EXPECT_THROW(boost::ignore_unused(Base::Quantity::parse("1,234,500.12 kg")), Base::ParserError);
 }
 
 TEST(BaseQuantity, TestDim)
@@ -74,10 +72,10 @@ TEST(BaseQuantity, TestPow3DIV2)
 
 TEST(BaseQuantity, TestString)
 {
-    Base::Quantity q1 {2, QString::fromLatin1("kg*m/s^2")};
+    Base::Quantity q1 {2, "kg*m/s^2"};
     EXPECT_EQ(q1.getUnit(), Base::Unit::Force);
 
-    Base::Quantity q2 {2, QString::fromLatin1("kg*m^2/s^2")};
+    Base::Quantity q2 {2, "kg*m^2/s^2"};
     EXPECT_EQ(q2.getUnit(), Base::Unit::Work);
 }
 
@@ -91,7 +89,7 @@ TEST(BaseQuantity, TestCopy)
 TEST(BaseQuantity, TestEqual)
 {
     Base::Quantity q1 {1.0, Base::Unit::Force};
-    Base::Quantity q2 {1.0, QString::fromLatin1("kg*mm/s^2")};
+    Base::Quantity q2 {1.0, "kg*mm/s^2"};
 
     EXPECT_EQ(q1 == q1, true);
     EXPECT_EQ(q1 == q2, true);
@@ -100,7 +98,7 @@ TEST(BaseQuantity, TestEqual)
 TEST(BaseQuantity, TestNotEqual)
 {
     Base::Quantity q1 {1.0, Base::Unit::Force};
-    Base::Quantity q2 {2.0, QString::fromLatin1("kg*m/s^2")};
+    Base::Quantity q2 {2.0, "kg*m/s^2"};
     Base::Quantity q3 {1.0, Base::Unit::Work};
 
     EXPECT_EQ(q1 != q2, true);
@@ -110,7 +108,7 @@ TEST(BaseQuantity, TestNotEqual)
 TEST(BaseQuantity, TestLessOrGreater)
 {
     Base::Quantity q1 {1.0, Base::Unit::Force};
-    Base::Quantity q2 {2.0, QString::fromLatin1("kg*m/s^2")};
+    Base::Quantity q2 {2.0, "kg*m/s^2"};
     Base::Quantity q3 {2.0, Base::Unit::Work};
 
     EXPECT_EQ(q1 < q2, true);
@@ -223,9 +221,9 @@ TEST_F(Quantity, TestSafeUserString)
     format.precision = 1;
     quantity.setFormat(format);
 
-    QString result = quantity.getSafeUserString();
+    std::string result = quantity.getSafeUserString();
 
-    EXPECT_EQ(result.toStdString(), "1 mm");
+    EXPECT_EQ(result, "1 mm");
 
     Base::UnitsApi::setSchema(Base::UnitSystem::Imperial1);
 
@@ -234,13 +232,13 @@ TEST_F(Quantity, TestSafeUserString)
 
     result = quantity.getSafeUserString();
 
-    EXPECT_EQ(result.toStdString(), "1.0 \\'");
+    EXPECT_EQ(result, "1.0 \\'");
 
     quantity = Base::Quantity {25.4, Base::Unit::Length};
     quantity.setFormat(format);
 
     result = quantity.getSafeUserString();
 
-    EXPECT_EQ(result.toStdString(), "1.0 \\\"");
+    EXPECT_EQ(result, "1.0 \\\"");
 }
 // NOLINTEND

--- a/tests/src/Base/Unit.cpp
+++ b/tests/src/Base/Unit.cpp
@@ -6,7 +6,7 @@
 TEST(Unit, TestString)
 {
     auto toString = [](const Base::Unit& unit) {
-        return unit.getString().toStdString();
+        return unit.getString();
     };
     EXPECT_EQ(toString(Base::Unit(0, 0, 0, 0, 0, 0, 0, 0)), "");
     EXPECT_EQ(toString(Base::Unit(1, 0, 0, 0, 0, 0, 0, 0)), "mm");
@@ -24,7 +24,7 @@ TEST(Unit, TestString)
 TEST(Unit, TestTypeString)
 {
     auto toString = [](const Base::Unit& unit) {
-        return unit.getTypeString().toStdString();
+        return unit.getTypeString();
     };
     EXPECT_EQ(toString(Base::Unit::Acceleration), "Acceleration");
     EXPECT_EQ(toString(Base::Unit::AmountOfSubstance), "AmountOfSubstance");
@@ -83,14 +83,14 @@ TEST(Unit, TestTypeString)
 }
 TEST(Unit, strings)
 {
-    EXPECT_STREQ(Base::Unit::Acceleration.getString().toStdString().c_str(), "mm/s^2");
-    EXPECT_STREQ(Base::Unit::AmountOfSubstance.getString().toStdString().c_str(), "mol");
-    EXPECT_STREQ(Base::Unit::Angle.getString().toStdString().c_str(), "deg");
-    EXPECT_STREQ(Base::Unit::AngleOfFriction.getString().toStdString().c_str(), "deg");
-    EXPECT_STREQ(Base::Unit::Area.getString().toStdString().c_str(), "mm^2");
-    EXPECT_STREQ(Base::Unit::CurrentDensity.getString().toStdString().c_str(), "A/mm^2");
-    EXPECT_STREQ(Base::Unit::Density.getString().toStdString().c_str(), "kg/mm^3");
-    EXPECT_STREQ(Base::Unit::DissipationRate.getString().toStdString().c_str(), "mm^2/s^3");
+    EXPECT_STREQ(Base::Unit::Acceleration.getString().c_str(), "mm/s^2");
+    EXPECT_STREQ(Base::Unit::AmountOfSubstance.getString().c_str(), "mol");
+    EXPECT_STREQ(Base::Unit::Angle.getString().c_str(), "deg");
+    EXPECT_STREQ(Base::Unit::AngleOfFriction.getString().c_str(), "deg");
+    EXPECT_STREQ(Base::Unit::Area.getString().c_str(), "mm^2");
+    EXPECT_STREQ(Base::Unit::CurrentDensity.getString().c_str(), "A/mm^2");
+    EXPECT_STREQ(Base::Unit::Density.getString().c_str(), "kg/mm^3");
+    EXPECT_STREQ(Base::Unit::DissipationRate.getString().c_str(), "mm^2/s^3");
 }
 
 TEST(Unit, TestEqual)

--- a/tests/src/Gui/QuantitySpinBox.cpp
+++ b/tests/src/Gui/QuantitySpinBox.cpp
@@ -32,19 +32,19 @@ private Q_SLOTS:
     void test_SimpleBaseUnit()  // NOLINT
     {
         auto result = qsb->valueFromText("1mm");
-        QCOMPARE(result, Base::Quantity(1, QLatin1String("mm")));
+        QCOMPARE(result, Base::Quantity(1, "mm"));
     }
 
     void test_UnitInNumerator()  // NOLINT
     {
         auto result = qsb->valueFromText("1mm/10");
-        QCOMPARE(result, Base::Quantity(0.1, QLatin1String("mm")));
+        QCOMPARE(result, Base::Quantity(0.1, "mm"));
     }
 
     void test_UnitInDenominator()  // NOLINT
     {
         auto result = qsb->valueFromText("1/10mm");
-        QCOMPARE(result, Base::Quantity(0.1, QLatin1String("mm")));
+        QCOMPARE(result, Base::Quantity(0.1, "mm"));
     }
 
     void test_KeepFormat()  // NOLINT

--- a/tests/src/Mod/Material/App/TestMaterialValue.cpp
+++ b/tests/src/Mod/Material/App/TestMaterialValue.cpp
@@ -130,7 +130,7 @@ TEST_F(TestMaterialValue, TestQuantityType)
     EXPECT_EQ(variant.toString().size(), 0);
     auto quantity = variant.value<Base::Quantity>();
     EXPECT_FALSE(quantity.isValid());
-    EXPECT_EQ(quantity.getUserString(), QString::fromStdString("nan "));
+    EXPECT_EQ(quantity.getUserString(), "nan ");
     EXPECT_TRUE(std::isnan(quantity.getValue()));
 
     // Test a copy
@@ -146,7 +146,7 @@ TEST_F(TestMaterialValue, TestQuantityType)
     EXPECT_EQ(variant.toString().size(), 0);
     quantity = variant.value<Base::Quantity>();
     EXPECT_FALSE(quantity.isValid());
-    EXPECT_EQ(quantity.getUserString(), QString::fromStdString("nan "));
+    EXPECT_EQ(quantity.getUserString(), "nan ");
     EXPECT_TRUE(std::isnan(quantity.getValue()));
 }
 
@@ -246,27 +246,27 @@ TEST_F(TestMaterialValue, TestArray3DType)
     EXPECT_EQ(mat2.rows(1), 1);
     EXPECT_EQ(mat2.rows(2), 2);
 
-    quantity = Base::Quantity::parse(QString::fromStdString("32 C"));
+    quantity = Base::Quantity::parse("32 C");
     mat2.setDepthValue(quantity);
     EXPECT_FALSE(mat2.getDepthValue(0).isValid());
     EXPECT_FALSE(mat2.getDepthValue(1).isValid());
     EXPECT_TRUE(mat2.getDepthValue(2).isValid());
-    EXPECT_EQ(mat2.getDepthValue(2), Base::Quantity::parse(QString::fromStdString("32 C")));
+    EXPECT_EQ(mat2.getDepthValue(2), Base::Quantity::parse("32 C"));
 
-    mat2.setDepthValue(0, Base::Quantity::parse(QString::fromStdString("9.8 m/s/s")));
+    mat2.setDepthValue(0, Base::Quantity::parse("9.8 m/s/s"));
     EXPECT_TRUE(mat2.getDepthValue(0).isValid());
     EXPECT_FALSE(mat2.getDepthValue(1).isValid());
     EXPECT_TRUE(mat2.getDepthValue(2).isValid());
-    EXPECT_EQ(mat2.getDepthValue(0), Base::Quantity::parse(QString::fromStdString("9.8 m/s/s")));
-    EXPECT_EQ(mat2.getDepthValue(2), Base::Quantity::parse(QString::fromStdString("32 C")));
+    EXPECT_EQ(mat2.getDepthValue(0), Base::Quantity::parse("9.8 m/s/s"));
+    EXPECT_EQ(mat2.getDepthValue(2), Base::Quantity::parse("32 C"));
 
-    mat2.setDepthValue(1, Base::Quantity::parse(QString::fromStdString("120 MPa")));
+    mat2.setDepthValue(1, Base::Quantity::parse("120 MPa"));
     EXPECT_TRUE(mat2.getDepthValue(0).isValid());
     EXPECT_TRUE(mat2.getDepthValue(1).isValid());
     EXPECT_TRUE(mat2.getDepthValue(2).isValid());
-    EXPECT_EQ(mat2.getDepthValue(0), Base::Quantity::parse(QString::fromStdString("9.8 m/s/s")));
-    EXPECT_EQ(mat2.getDepthValue(1), Base::Quantity::parse(QString::fromStdString("120 MPa")));
-    EXPECT_EQ(mat2.getDepthValue(2), Base::Quantity::parse(QString::fromStdString("32 C")));
+    EXPECT_EQ(mat2.getDepthValue(0), Base::Quantity::parse("9.8 m/s/s"));
+    EXPECT_EQ(mat2.getDepthValue(1), Base::Quantity::parse("120 MPa"));
+    EXPECT_EQ(mat2.getDepthValue(2), Base::Quantity::parse("32 C"));
 
     // Rows are currently empty
     EXPECT_THROW(mat2.getValue(2, 0), Materials::InvalidIndex);
@@ -275,12 +275,11 @@ TEST_F(TestMaterialValue, TestArray3DType)
     EXPECT_FALSE(mat2.getValue(0, 1).isValid());
 
     // set to a valid quantity
-    mat2.setValue(0, 0, Base::Quantity::parse(QString::fromStdString("120 MPa")));
+    mat2.setValue(0, 0, Base::Quantity::parse("120 MPa"));
     EXPECT_TRUE(mat2.getValue(0, 0).isValid());
-    mat2.setValue(0, 1, Base::Quantity::parse(QString::fromStdString("9.8 m/s/s")));
+    mat2.setValue(0, 1, Base::Quantity::parse("9.8 m/s/s"));
     EXPECT_TRUE(mat2.getValue(0, 1).isValid());
-    EXPECT_THROW(mat2.setValue(0, 2, Base::Quantity::parse(QString::fromStdString("32 C"))), Materials::InvalidIndex);
-
+    EXPECT_THROW(mat2.setValue(0, 2, Base::Quantity::parse("32 C")), Materials::InvalidIndex);
 }
 
 // clang-format on

--- a/tests/src/Mod/Material/App/TestMaterials.cpp
+++ b/tests/src/Mod/Material/App/TestMaterials.cpp
@@ -221,12 +221,11 @@ TEST_F(TestMaterial, TestAddAppearanceModel)
     EXPECT_EQ(models->size(), 0);
 }
 
-QString parseQuantity(const char *string)
+QString parseQuantity(const std::string& value)
 {
-    QString value = QString::fromStdString(string);
     auto quantity = Base::Quantity::parse(value);
     quantity.setFormat(Materials::MaterialValue::getQuantityFormat());
-    return quantity.getUserString();
+    return QString::fromStdString(quantity.getUserString());
 }
 
 TEST_F(TestMaterial, TestCalculiXSteel)
@@ -343,12 +342,11 @@ TEST_F(TestMaterial, TestCalculiXSteel)
     EXPECT_EQ(steel->getAppearanceValue(QString::fromStdString("SpecularColor")), QString::fromStdString("(0.9800, 0.9800, 0.9800, 1.0)"));
     EXPECT_DOUBLE_EQ(steel->getAppearanceValue(QString::fromStdString("Transparency")).toDouble(), 0.0);
 
-    EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("Density")).getUserString(), parseQuantity("7900.00 kg/m^3"));
-    EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("YoungsModulus")).getUserString(), parseQuantity("210.00 GPa"));
-    EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("SpecificHeat")).getUserString(), parseQuantity("590.00 J/kg/K"));
-    EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("ThermalConductivity")).getUserString(), parseQuantity("43.00 W/m/K"));
-    EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("ThermalExpansionCoefficient")).getUserString(), parseQuantity("12.00 µm/m/K"));
-
+    EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("Density")).getUserString(), parseQuantity("7900.00 kg/m^3").toStdString());
+    EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("YoungsModulus")).getUserString(), parseQuantity("210.00 GPa").toStdString());
+    EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("SpecificHeat")).getUserString(), parseQuantity("590.00 J/kg/K").toStdString());
+    EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("ThermalConductivity")).getUserString(), parseQuantity("43.00 W/m/K").toStdString());
+    EXPECT_EQ(steel->getPhysicalQuantity(QString::fromStdString("ThermalExpansionCoefficient")).getUserString(), parseQuantity("12.00 µm/m/K").toStdString());
 }
 
 TEST_F(TestMaterial, TestColumns)


### PR DESCRIPTION
Basic Units cleanup...
- hide internal implementation details
- use containers instead of if...else
- use std::string for return values to prevent conversion