### PR TITLE
cMake: Remove use of Core5Compat from Qt6

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupQt.cmake
+++ b/cMake/FreeCAD_Helpers/SetupQt.cmake
@@ -15,7 +15,6 @@ if(BUILD_GUI)
     elseif (FREECAD_QT_MAJOR_VERSION EQUAL 6)
         list (APPEND FREECAD_QT_COMPONENTS GuiTools)
         list (APPEND FREECAD_QT_COMPONENTS SvgWidgets)
-        list (APPEND FREECAD_QT_COMPONENTS Core5Compat)
     endif()
 
     list (APPEND FREECAD_QT_COMPONENTS OpenGL PrintSupport Svg UiTools Widgets LinguistTools)


### PR DESCRIPTION
We should no longer need this module.