### PR TITLE
Assembly: Prevent insertion of parent objects that cause dependency loop

### DIFF
--- a/src/Mod/Assembly/CommandInsertLink.py
+++ b/src/Mod/Assembly/CommandInsertLink.py
@@ -168,6 +168,10 @@ class TaskAssemblyInsertLink(QtCore.QObject):
                     if obj == self.assembly:
                         continue  # Skip current assembly
 
+                    if obj in self.assembly.InListRecursive:
+                        continue  # Prevent dependency loop.
+                        # For instance if asm1/asm2 with asm2 active, we don't want to have asm1 in the list
+
                     if (
                         obj.isDerivedFrom("Part::Feature")
                         or obj.isDerivedFrom("App::Part")


### PR DESCRIPTION
Prevent insertion of parent objects that cause dependency loop and crash.
Fix https://github.com/FreeCAD/FreeCAD/issues/15221