### PR TITLE
Sketcher: Fix offset crash that was caused by coincident wires ...

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -1029,8 +1029,20 @@ private:
 
     bool areCoincident(int geoId1, int geoId2)
     {
-        CoincidencePointPos ppc = checkForCoincidence(geoId1, geoId2);
-        return ppc.firstPos1 != PointPos::none;
+        // Instead of checking for constraints like so:
+        // CoincidencePointPos ppc = checkForCoincidence(geoId1, geoId2);
+        // return ppc.firstPos1 != PointPos::none;
+        // we are going to check if the points are effectively coincident:
+
+        Base::Vector3d p11, p12, p21, p22;
+        if (!getFirstSecondPoints(geoId1, p11, p12) || !getFirstSecondPoints(geoId2, p21, p22)) {
+            return false;
+        }
+
+        return ((p11 - p21).Length() < Precision::Confusion()
+                || (p11 - p22).Length() < Precision::Confusion()
+                || (p12 - p21).Length() < Precision::Confusion()
+                || (p12 - p22).Length() < Precision::Confusion());
     }
 
     bool areTangentCoincident(int geoId1, int geoId2)


### PR DESCRIPTION
Fix offset crash that was caused by coincident edges that were unconstrained.

Fix https://github.com/Ondsel-Development/FreeCAD/issues/111
