### PR TITLE
[AddonManager] Fix transferTimeout AttributeError

### DIFF
--- a/src/Mod/AddonManager/NetworkManager.py
+++ b/src/Mod/AddonManager/NetworkManager.py
@@ -583,7 +583,8 @@ if HAVE_QTNETWORK:
                 timeout_ms = default_timeout
                 if hasattr(reply, "request"):
                     request = reply.request()
-                    timeout_ms = request.transferTimeout()
+                    if hasattr(request, "transferTimeout"):
+                        timeout_ms = request.transferTimeout()
                 new_url = reply.attribute(QtNetwork.QNetworkRequest.RedirectionTargetAttribute)
                 self.__launch_request(index, self.__create_get_request(new_url, timeout_ms))
                 return  # The task is not done, so get out of this method now


### PR DESCRIPTION
Errors received updating local cache in AddonManager:

```
Traceback (most recent call last):
  File "/home/john/freecad-main-build781/Mod/AddonManager/NetworkManager.py", line 587, in __reply_finished
    timeout_ms = request.transferTimeout()
AttributeError: 'PySide2.QtNetwork.QNetworkRequest' object has no attribute 'transferTimeout'
```

This PR fixes these errors and allows the cache update to complete.