### PR TITLE
cMake: Fix LibPack3 install target DLL locations

### DIFF
--- a/cMake/FreeCAD_Helpers/CopyLibpackDirectories.cmake
+++ b/cMake/FreeCAD_Helpers/CopyLibpackDirectories.cmake
@@ -62,6 +62,13 @@ macro(CopyLibpackDirectories)
         install(DIRECTORY ${FREECAD_LIBPACK_DIR}/resources DESTINATION ${CMAKE_INSTALL_PREFIX})
         install(DIRECTORY ${FREECAD_LIBPACK_DIR}/bin DESTINATION ${CMAKE_INSTALL_PREFIX})
         install(DIRECTORY ${FREECAD_LIBPACK_DIR}/lib DESTINATION ${CMAKE_INSTALL_PREFIX} FILES_MATCHING PATTERN "*.dll")
+        if(FREECAD_LIBPACK_VERSION VERSION_GREATER_EQUAL "3.0.0")
+            # Trailing slashes make sure that cMake extracts the files from the directory, rather than taking the
+            # directory with it
+            install(DIRECTORY ${FREECAD_LIBPACK_DIR}/lib/ DESTINATION ${CMAKE_INSTALL_PREFIX}/bin FILES_MATCHING PATTERN "*.dll")
+            install(DIRECTORY ${FREECAD_LIBPACK_DIR}/bin/Lib/site-packages/shiboken6/ DESTINATION ${CMAKE_INSTALL_PREFIX}/bin FILES_MATCHING PATTERN "shiboken*.dll")
+            install(DIRECTORY ${FREECAD_LIBPACK_DIR}/bin/Lib/site-packages/PySide6/ DESTINATION ${CMAKE_INSTALL_PREFIX}/bin FILES_MATCHING PATTERN "pyside6*.dll")
+        endif()
         message(STATUS "Created install commands for INSTALL target.\n")
     endif()
 endmacro()

--- a/cMake/UseLibPack3.cmake
+++ b/cMake/UseLibPack3.cmake
@@ -4,7 +4,7 @@ list(PREPEND CMAKE_PREFIX_PATH "${FREECAD_LIBPACK_DIR}")
 set (Python3_EXECUTABLE ${FREECAD_LIBPACK_DIR}/bin/python.exe)
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 
-# Make sure we are using the static versions of Boost here: the LibPack includes both
+# Make sure we are using the shared versions of Boost here: the LibPack includes both
 set(Boost_USE_STATIC_LIBS OFF)
 find_package(Boost COMPONENTS filesystem program_options regex system thread date_time REQUIRED PATHS ${FREECAD_LIBPACK_DIR}/lib/cmake NO_DEFAULT_PATH)
 


### PR DESCRIPTION
Make sure the DLLs are all going into bin. This leaves a (possibly vestigial) copy of Boost going into lib as well. That can probably be removed in another PR (but needs to be tested with Libpack2).