### PR TITLE
Gui: Fix background of non-alternate rows of Property View

### DIFF
--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -529,28 +529,27 @@ void PropertyEditor::onRowsRemoved(const QModelIndex &, int, int)
     removingRows = 0;
 }
 
-void PropertyEditor::drawBranches(QPainter *painter, const QRect &rect, const QModelIndex &index) const
+void PropertyEditor::drawBranches(QPainter* painter,
+                                  const QRect& rect,
+                                  const QModelIndex& index) const
 {
     QTreeView::drawBranches(painter, rect, index);
 
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-    //QStyleOptionViewItem opt = viewOptions();
-#else
-    //QStyleOptionViewItem opt;
-    //initViewItemOption(&opt);
-#endif
     auto property = static_cast<PropertyItem*>(index.internalPointer());
+
     if (property && property->isSeparator()) {
         painter->fillRect(rect, this->background);
-    //} else if (selectionModel()->isSelected(index)) {
-    //    painter->fillRect(rect, opt.palette.brush(QPalette::Highlight));
     }
+}
 
-    //QPen savedPen = painter->pen();
-    //QColor color = static_cast<QRgb>(QApplication::style()->styleHint(QStyle::SH_Table_GridLineColor, &opt));
-    //painter->setPen(QPen(color));
-    //painter->drawLine(rect.x(), rect.bottom(), rect.right(), rect.bottom());
-    //painter->setPen(savedPen);
+void Gui::PropertyEditor::PropertyEditor::drawRow(QPainter* painter,
+                                                  const QStyleOptionViewItem& options,
+                                                  const QModelIndex& index) const
+{
+    // render background also for non alternate rows based on the `itemBackground` property.
+    painter->fillRect(options.rect, itemBackground());
+
+    QTreeView::drawRow(painter, options, index);
 }
 
 void PropertyEditor::buildUp(PropertyModel::PropertyList &&props, bool _checkDocument)

--- a/src/Gui/propertyeditor/PropertyEditor.h
+++ b/src/Gui/propertyeditor/PropertyEditor.h
@@ -108,6 +108,7 @@ protected:
     void rowsInserted (const QModelIndex & parent, int start, int end) override;
     void rowsAboutToBeRemoved (const QModelIndex & parent, int start, int end) override;
     void drawBranches(QPainter *painter, const QRect &rect, const QModelIndex &index) const override;
+    void drawRow(QPainter *painter, const QStyleOptionViewItem &options, const QModelIndex &index) const override;
 #if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     QStyleOptionViewItem viewOptions() const override;
 #else


### PR DESCRIPTION
This forces background to be rendered using `itemBackground` QProperty.

This can be done like so:
```
  Gui--PropertyEditor--PropertyEditor {
    qproperty-itemBackground: white;
  }
```

After:
![image](https://github.com/FreeCAD/FreeCAD/assets/747404/98e064dc-086e-4089-9b8e-982c5f1aeef9)

Before:
![image](https://github.com/FreeCAD/FreeCAD/assets/747404/435d8532-c482-4c31-94af-82b26d3c5a53)


Fixes: #15263

FYI: @obelisk79 @MisterMakerNL 