### PR TITLE
Apply result of calculations with copy on change properties

### DIFF
--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -620,6 +620,20 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
                     }
                     if (recomputeCopy && !copied->recomputeFeature(true))
                         copyerror = 2;
+                    if (!copyerror) {
+                        for (auto prop : props) {
+                            if (!App::LinkBaseExtension::isCopyOnChangeProperty(this, *prop))
+                                continue;
+                            auto p = copied->getPropertyByName(prop->getName());
+                            if (p && p->getContainer() == copied
+                                && p->getTypeId() == prop->getTypeId()
+                                && !p->isSame(*prop))
+                            {
+                                std::unique_ptr<App::Property> pcopy(p->Copy());
+                                prop->Paste(*pcopy);
+                            }
+                        }
+                    }
                 }
                 obj = copied;
                 _CopiedLink.setValue(copied, l.getSubValues(false));


### PR DESCRIPTION
## Problem

'Copy on change' properties propagated to SubShapeBinder can be changed there and then updated in the base body (support). But they also might be used as a variable in calculation of some other 'copy on change' properties of the base body which are propagated to the same SubShapeBinder as well. It is expected to see all the 'copy on change' properties in the SubShapeBinder recalculated based on the modified values of propagated properties and using the expressions defined in the base (support) body.

## Example

Here's an example project (seems I can't attach "*.FCStd" file, will describe it here thoroughly).

It contains **Body1** with three user-defined properties: ***Base_Depth*** (set to 200 mm), ***Base_Width*** (with expression `= Base_Depth * 3`) and ***Base_Thickness*** (with expression `= Base_Depth / 10`). All these properties marked with 'CopyOnChange' status. ***Base_Depth*** and ***Base_Width*** used in a sketch to define the dimensions of a rectangle (using expressions with `href()` to reference upstream properties). There's a pad using this sketch to extrude it for the length of ***Base_Thickness***.

The project also has SubShapeBinder **Binder** created from **Body1** (it has **Body1** as its `Support` link) with 'Bind Copy On Change' property initially set to 'Enabled'. Thus it has all the three user-defined properties mentioned above propagated.

Now I change the value of ***Base_Depth*** property in the **Binder** to 300 mm instead of 200 mm ('Bind Copy On Change' property is changed to 'Mutated' here). I see the part recalculated and repainted properly compared to the original **Body1**.
![shot_20240705_013907](https://github.com/FreeCAD/FreeCAD/assets/5575152/baef6ffd-6ceb-4ef9-8479-664fb1f49831)
But I also expect ***Base_Width*** and ***Base_Thickness*** of **Binder** to be updated properly (to 900 mm and 30 mm, correspondingly), which is not the case. They keep containing the original values initially taken from **Body1**.
![shot_20240705_014049](https://github.com/FreeCAD/FreeCAD/assets/5575152/960d078d-48b3-4c42-b92c-57dbe535e74c)

To futher experiment with it I create **Body2** out of **Binder** (as a 'Base Feature'), add another sketch to it to make a pocket. I use ***Base_Width*** of the base feature to define the length of the pocket expecting it to cover all the width of the part. But that's not the case, as ***Base_Width*** is 600 mm here as well and the pocket is done only in the middle.
![изображение](https://github.com/FreeCAD/FreeCAD/assets/5575152/9a90b94a-9848-41d4-96d0-72d72b820a49)

## Fix

For the fix I've added another loop copying all the copy on change properties from temporary copy of document back to the original just after the recalculation. Direct copy looks safe to me here, as all these properties were copied to the temporary right before its recalculation.

I find this little fix very important in my use case as I try to create some prototype part with a suite of top-level input parameters (some key dimensions) and output values (e.g. outer dimensions of complex part) to be used as base for several concrete parts. Now this scenario is hardly possible as the most-derived part is just partially affected by the parameter changes and values may or may not be correct.