### PR TITLE
Toponaming: Missing suppress property and code

### DIFF
--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -1438,6 +1438,8 @@ public:
                                                          const char* marker = nullptr,
                                                          std::string* postfix = nullptr) const;
 
+    long isElementGenerated(const Data::MappedName &name, int depth=1) const;
+
     /** @name sub shape cached functions
      *
      * Mapped element names introduces some overhead when getting sub shapes

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -5756,6 +5756,32 @@ bool TopoShape::isSame(const Data::ComplexGeoData& _other) const
     const auto& other = static_cast<const TopoShape&>(_other);
     return Tag == other.Tag && Hasher == other.Hasher && _Shape.IsEqual(other._Shape);
 }
+
+long TopoShape::isElementGenerated(const Data::MappedName& _name, int depth) const
+{
+    long res = 0;
+    long tag = 0;
+    traceElement(_name, [&](const Data::MappedName& name, int offset, long tag2, long) {
+        (void)offset;
+        if (tag2 < 0) {
+            tag2 = -tag2;
+        }
+        if (tag && tag2 != tag) {
+            if (--depth < 1) {
+                return true;
+            }
+        }
+        tag = tag2;
+        if (depth == 1 && name.startsWith(genPostfix(), offset)) {
+            res = tag;
+            return true;
+        }
+        return false;
+    });
+
+    return res;
+}
+
 void TopoShape::cacheRelatedElements(const Data::MappedName& name,
                                      HistoryTraceType sameType,
                                      const QVector<Data::MappedElement>& names) const

--- a/src/Mod/PartDesign/App/Feature.h
+++ b/src/Mod/PartDesign/App/Feature.h
@@ -58,6 +58,8 @@ public:
     App::PropertyLink   BaseFeature;
     App::PropertyLinkHidden _Body;
 
+    /// Keep a copy of suppressed shapes so that we can restore them (and maybe display them)
+    Part::PropertyPartShape SuppressedShape;
     App::DocumentObjectExecReturn* recompute() override;
 
     short mustExecute() const override;
@@ -107,6 +109,8 @@ protected:
      */
     bool isSingleSolidRuleSatisfied(const TopoDS_Shape&, TopAbs_ShapeEnum type = TopAbs_SOLID);
     SingleSolidRuleMode singleSolidRuleMode();
+
+    void updateSuppressedShape();
 
     /// Grab any point from the given face
     static const gp_Pnt getPointFromFace(const TopoDS_Face& f);


### PR DESCRIPTION
Fix #15054  Add the necessary property to hold the pre-suppression shape so that it can be restored when unsuppressed.  Correct the Feature code to use it.