### PR TITLE
Addon manager: Reduce fetches from GitHub

### DIFF
--- a/src/Mod/AddonManager/addonmanager_freecad_interface.py
+++ b/src/Mod/AddonManager/addonmanager_freecad_interface.py
@@ -63,7 +63,7 @@ except ImportError:
         return string
 
     def Version():
-        return 0, 21, 0, "dev"
+        return 0, 22, 0, "dev"
 
     class ConsoleReplacement:
         """If FreeCAD's Console is not available, create a replacement by redirecting FreeCAD

--- a/src/Mod/AddonManager/addonmanager_preferences_defaults.json
+++ b/src/Mod/AddonManager/addonmanager_preferences_defaults.json
@@ -3,6 +3,7 @@
         "https://raw.githubusercontent.com/FreeCAD/FreeCAD-addons/master/addonflags.json",
     "AddonsRemoteCacheURL": "https://addons.freecad.org/metadata.zip",
     "AddonsStatsURL": "https://freecad.org/addon_stats.json",
+    "AddonsCacheURL": "https://freecad.org/addons/addon_cache.json",
     "AddonsScoreURL": "NONE",
     "AutoCheck": false,
     "BlockedMacros": "BOLTS,WorkFeatures,how to install,documentation,PartsLibrary,FCGear",

--- a/src/Mod/AddonManager/addonmanager_workers_installation.py
+++ b/src/Mod/AddonManager/addonmanager_workers_installation.py
@@ -207,10 +207,9 @@ class UpdateMetadataCacheWorker(QtCore.QThread):
     def _ensure_string(self, arbitrary_data, addon_name, file_name) -> str:
         if isinstance(arbitrary_data, str):
             return arbitrary_data
-        elif isinstance(arbitrary_data, QtCore.QByteArray):
+        if isinstance(arbitrary_data, QtCore.QByteArray):
             return self._decode_data(arbitrary_data.data(), addon_name, file_name)
-        else:
-            return self._decode_data(arbitrary_data, addon_name, file_name)
+        return self._decode_data(arbitrary_data, addon_name, file_name)
 
     def _decode_data(self, byte_data, addon_name, file_name) -> str:
         """UTF-8 decode data, and print an error message if that fails"""

--- a/src/Mod/AddonManager/addonmanager_workers_startup.py
+++ b/src/Mod/AddonManager/addonmanager_workers_startup.py
@@ -45,6 +45,7 @@ from AddonStats import AddonStats
 import NetworkManager
 from addonmanager_git import initialize_git, GitFailed
 from addonmanager_metadata import MetadataReader, get_branch_from_metadata
+import addonmanager_freecad_interface as fci
 
 translate = FreeCAD.Qt.translate
 


### PR DESCRIPTION
Reduce the number of GitHub fetches when rebuilding the local addon cache by using a remote cache stored on FreeCAD's servers.

Intended to mitigate the Addon Manager hitting GitHub's rate limiters.

Addresses, but does not fully close, #15059