### PR TITLE
Core: Add App::PropertyXLinkSubHidden

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1987,6 +1987,7 @@ void Application::initTypes()
     App::PropertyLinkSubListHidden  ::init();
     App::PropertyXLink              ::init();
     App::PropertyXLinkSub           ::init();
+    App::PropertyXLinkSubHidden     ::init();
     App::PropertyXLinkSubList       ::init();
     App::PropertyXLinkList          ::init();
     App::PropertyXLinkContainer     ::init();

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -4074,6 +4074,7 @@ void PropertyXLink::setAllowPartial(bool enable) {
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 TYPESYSTEM_SOURCE(App::PropertyXLinkSub , App::PropertyXLink)
+TYPESYSTEM_SOURCE(App::PropertyXLinkSubHidden, App::PropertyXLinkSub)
 
 PropertyXLinkSub::PropertyXLinkSub(bool allowPartial, PropertyLinkBase *parent)
     :PropertyXLink(allowPartial,parent)

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -1198,6 +1198,14 @@ public:
     { return "Gui::PropertyEditor::PropertyLinkItem"; }
 };
 
+/** The general Link Property that are hidden from dependency checking
+ */
+class AppExport PropertyXLinkSubHidden : public PropertyXLinkSub
+{
+    TYPESYSTEM_HEADER();
+public:
+    PropertyXLinkSubHidden() { _pcScope = LinkScope::Hidden; }
+};
 
 /** Link to one or more (sub)object(s) of one or more object(s) from the same or different document
  */

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -1198,7 +1198,7 @@ public:
     { return "Gui::PropertyEditor::PropertyLinkItem"; }
 };
 
-/** The general Link Property that are hidden from dependency checking
+/** The PropertyXLinkSub that is hidden from dependency checking
  */
 class AppExport PropertyXLinkSubHidden : public PropertyXLinkSub
 {


### PR DESCRIPTION
This PR is adding a PropertyXLinkSubHidden property. Which is just a PropertyXLinkSub with the hidden scope.

This addition is needed to solve the assembly 'getGlobalPlacement' (https://github.com/FreeCAD/FreeCAD/issues/15090) where  PropertyXLinkSub cannot be used because it cause dependency loops.

@wwmayer is this change ok for you? If so it would be great if this can be merged as soon as possible because this change requires almost a full rebuild, so everytime I checkout from my 15090-branch (which is a huge work so i'll be at it for long), I have to rebuild almost the whole project which takes more than 30 minutes on my machine. And currently I have 15 opened PR to maintain so this is bound to be very tedious. Also this change is very trivial.

Thanks!