### PR TITLE
Replace inconsistent Color per face with Appearance per face

### DIFF
--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -2094,8 +2094,8 @@ CmdColorPerFace::CmdColorPerFace()
 {
     sAppModule    = "Part";
     sGroup        = QT_TR_NOOP("Part");
-    sMenuText     = QT_TR_NOOP("Color per face");
-    sToolTipText  = QT_TR_NOOP("Set the color of each individual face "
+    sMenuText     = QT_TR_NOOP("Appearance per face");
+    sToolTipText  = QT_TR_NOOP("Set the appearance of each individual face "
                                "of the selected object.");
     sStatusTip    = sToolTipText;
     sWhatsThis    = "Part_ColorPerFace";


### PR DESCRIPTION
Replace _View --> Color per face_ with _Appearance per face_

Fixes #15327

I wouldn't change the command itself for now but the menu name is indeed inconsistent with the tool:

![image](https://github.com/FreeCAD/FreeCAD/assets/59876896/8b119647-d750-464c-b026-3e5082d03b29)
