### PR TITLE
BIM: Space: Remove superfluous ShapeColor code, Improve DisplayMode handling

### DIFF
--- a/src/Mod/BIM/ArchSpace.py
+++ b/src/Mod/BIM/ArchSpace.py
@@ -443,8 +443,6 @@ class _ViewProviderSpace(ArchComponent.ViewProviderComponent):
         vobj.LineWidth = params.get_param_view("DefaultShapeLineWidth")
         vobj.LineColor = ArchCommands.getDefaultColor("Space")
         vobj.DrawStyle = ["Solid","Dashed","Dotted","Dashdot"][params.get_param_arch("defaultSpaceStyle")]
-        if vobj.Transparency == 100:
-            vobj.DisplayMode = "Wireframe"
 
     def setProperties(self,vobj):
 
@@ -666,13 +664,9 @@ class _ViewProviderSpace(ArchComponent.ViewProviderComponent):
             else:
                 self.label.whichChild = -1
 
-        elif prop == "ShapeColor":
-            if hasattr(vobj,"ShapeColor"):
-                self.fmat = vobj.ShapeColor.getValue()
-
         elif prop == "Transparency":
-            if hasattr(vobj,"Transparency"):
-                self.fmat.transparency.setValue(vobj.Transparency/100.0)
+            if hasattr(vobj,"DisplayMode"):
+                vobj.DisplayMode = "Wireframe" if vobj.Transparency == 100 else "Flat Lines"
 
     def setEdit(self, vobj, mode):
         if mode != 0:


### PR DESCRIPTION
The code to handle the ShapeColor no longer executed in V0.22 and everything works fine without it.

Additionally: Changing the transparency to/from 100% now changes the DisplayMode of existing space objects. Changing the transparency of `self.fmat` (the `coin.SoMaterial`) already happens automatically.
