### PR TITLE
Gui: Ability to target new file buttons via QSS.

### DIFF
--- a/src/Gui/Stylesheets/Dark theme.qss
+++ b/src/Gui/Stylesheets/Dark theme.qss
@@ -1197,6 +1197,11 @@ QPushButton {
   min-width: 80px;
 }
 
+#CreateNewRow > QPushButton {
+  /* Reset min width to default */
+  min-width: -1;
+}
+
 QPushButton:disabled {
   background-color: #444444;
   color: #adadad;

--- a/src/Gui/Stylesheets/Light theme.qss
+++ b/src/Gui/Stylesheets/Light theme.qss
@@ -1123,6 +1123,11 @@ QPushButton {
   min-width: 80px;
 }
 
+#CreateNewRow > QPushButton {
+  /* Reset min width to default */
+  min-width: -1;
+}
+
 QPushButton:disabled {
   background-color: #d8d8d8;
   color: #adadad;

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -147,8 +147,18 @@ StartView::StartView(QWidget* parent)
 
     _newFileLabel = gsl::owner<QLabel*>(new QLabel());
     layout->addWidget(_newFileLabel);
+
+    auto createNewRow = gsl::owner<QWidget*>(new QWidget);
     auto flowLayout = gsl::owner<FlowLayout*>(new FlowLayout);
-    layout->addLayout(flowLayout);
+
+    // reset margins of layout to provide consistent spacing
+    flowLayout->setContentsMargins({});
+
+    // this allows new file widgets to be targeted via QSS
+    createNewRow->setObjectName(QStringLiteral("CreateNewRow"));
+    createNewRow->setLayout(flowLayout);
+
+    layout->addWidget(createNewRow);
     configureNewFileButtons(flowLayout);
 
     _recentFilesLabel = gsl::owner<QLabel*>(new QLabel());


### PR DESCRIPTION
This adds ability to target New File buttons via `#CreateNewRow > QPushButton` selector.

This issue is related to problem with QSS resetting the minimum width of a widget. It is well known problem: https://stackoverflow.com/questions/56035625/setting-minimum-width-of-qpushbutton-while-keeping-default-minimumsizehint-behav and the simplest solution is to simply not set minimum width via QSS for widgets. minimum width is however required for some QPushButtons so we need a way to target only buttons in this specific row of Start View.

After
![image](https://github.com/FreeCAD/FreeCAD/assets/747404/a1f0e82e-7896-48b5-8d48-dc610ca53d61)

Before
![image](https://github.com/FreeCAD/FreeCAD/assets/747404/25fba682-c4a1-4cd3-b41c-7759ce951deb)

Fixes https://github.com/FreeCAD/FreeCAD/issues/14347
