### PR TITLE
[Gui] Preferences - fix the theme combobox index lookup...

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -329,8 +329,9 @@ void DlgSettingsGeneral::loadSettings()
     }
 
     QAbstractItemModel* model = ui->Languages->model();
-    if (model)
+    if (model) {
         model->sort(0);
+    }
 
     addIconSizes(getCurrentIconSize());
 
@@ -435,7 +436,7 @@ void DlgSettingsGeneral::loadThemes()
     QString currentStyleSheet = QString::fromLatin1(hGrp->GetASCII("StyleSheet", "").c_str());
     QFileInfo fi(currentStyleSheet);
     currentStyleSheet = fi.baseName();
-    QString themeClassic = QString::fromStdString("classic");  // handle the upcoming name change
+    QString themeClassic = QStringLiteral("classic");  // handle the upcoming name change
     QString similarTheme;
     QString packName;
     for (const auto& pack : packs) {


### PR DESCRIPTION
...when the user has FreeCAD-themes (and no doubt other theme addons) installed.

When a user deletes their config files, having previously installed FreeCAD-themes and opens Preferences immediately on starting FreeCAD they would see:

![BeforePR_New_User_should_read_Classic](https://github.com/user-attachments/assets/68d4d4d4-f8a6-401b-988d-3c490f6e0175)

and a user upgrading from 0.21 for example with ProDark stylesheet set would see:

![BeforePR_Upgrading_User_with_ProDarkSS](https://github.com/user-attachments/assets/84a3dd45-5203-43fd-9db5-531bff926f39)

With this PR applied the respective theme combobox would be corrected to be:

![AfterPR_New_User_should_read_Classic](https://github.com/user-attachments/assets/58f7121c-19cb-455a-a39d-e3243c67193c)

![AfterPR_Upgrading_User_with_ProDarkSS](https://github.com/user-attachments/assets/e3bf80f0-989b-43f0-b03a-27854b81c1e1)
