### PR TITLE
Materials: Catch correct error

### DIFF
--- a/src/Mod/Material/Gui/MaterialTreeWidget.cpp
+++ b/src/Mod/Material/Gui/MaterialTreeWidget.cpp
@@ -234,7 +234,7 @@ void MaterialTreeWidget::updateMaterial(const QString& uuid)
     try {
         material = std::make_shared<Materials::Material>(*getMaterialManager().getMaterial(uuid));
     }
-    catch (Materials::ModelNotFound const&) {
+    catch (Materials::MaterialNotFound const&) {
         Base::Console().Log("*** Unable to load material '%s'\n", uuid.toStdString().c_str());
     }
 
@@ -361,7 +361,7 @@ void MaterialTreeWidget::setActiveFilter(const QString& name)
 
                 // Save the library/folder expansion state
                 saveMaterialTree();
-                
+
                 updateMaterialTree();
                 return;
             }


### PR DESCRIPTION
When the UUID is set to a non-existent material, it was Catching Materials::ModelNotFound instead of Materials::MaterialNotFound