### PR TITLE
Gui: Reduce Transform Dragger size

### DIFF
--- a/src/Gui/ViewParams.h
+++ b/src/Gui/ViewParams.h
@@ -66,6 +66,7 @@ public:
     FC_VIEW_PARAM(AxisXColor,unsigned long,Unsigned,0xCC333300) \
     FC_VIEW_PARAM(AxisYColor,unsigned long,Unsigned,0x33CC3300) \
     FC_VIEW_PARAM(AxisZColor,unsigned long,Unsigned,0x3333CC00) \
+    FC_VIEW_PARAM(DraggerScale,double,Float,0.03) \
 
 
 #undef FC_VIEW_PARAM

--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -124,12 +124,13 @@ bool ViewProviderDragger::setEdit(int ModNum)
 {
   Q_UNUSED(ModNum);
 
-  if(checkLink())
+  if (checkLink()) {
       return true;
+  }
 
   App::DocumentObject *genericObject = this->getObject();
-  if (genericObject->isDerivedFrom(App::GeoFeature::getClassTypeId()))
-  {
+
+  if (genericObject->isDerivedFrom(App::GeoFeature::getClassTypeId())) {
     auto geoFeature = static_cast<App::GeoFeature *>(genericObject);
     const Base::Placement &placement = geoFeature->Placement.getValue();
     auto tempTransform = new SoTransform();
@@ -143,7 +144,7 @@ bool ViewProviderDragger::setEdit(int ModNum)
       Gui::ViewParams::instance()->getAxisYColor(),
       Gui::ViewParams::instance()->getAxisZColor()
     );
-    csysDragger->draggerSize.setValue(0.05f);
+    csysDragger->draggerSize.setValue(ViewParams::instance()->getDraggerScale());
     csysDragger->translation.setValue(tempTransform->translation.getValue());
     csysDragger->rotation.setValue(tempTransform->rotation.getValue());
 

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2865,9 +2865,9 @@ void ViewProviderLink::setEditViewer(Gui::View3DInventorViewer* viewer, int ModN
             cube->depth = length;
 
             viewer->setupEditingRoot(group,&dragCtx->preTransform);
-        }else{
+        } else {
             auto dragger = static_cast<SoFCCSysDragger*>(pcDragger.get());
-            dragger->draggerSize.setValue(0.05f);
+            dragger->draggerSize.setValue(ViewParams::instance()->getDraggerScale());
             dragger->setUpAutoScale(viewer->getSoRenderManager()->getCamera());
             viewer->setupEditingRoot(pcDragger,&dragCtx->preTransform);
 

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -239,7 +239,7 @@ void ViewProviderAssembly::setDragger()
     asmDragger->setAxisColors(Gui::ViewParams::instance()->getAxisXColor(),
                               Gui::ViewParams::instance()->getAxisYColor(),
                               Gui::ViewParams::instance()->getAxisZColor());
-    asmDragger->draggerSize.setValue(0.05f);
+    asmDragger->draggerSize.setValue(Gui::ViewParams::instance()->getDraggerScale());
 
     asmDraggerSwitch = new SoSwitch(SO_SWITCH_NONE);
     asmDraggerSwitch->addChild(asmDragger);


### PR DESCRIPTION
The size can now be configured using `User parameter:BaseApp/Preferences/View/DraggerScale` parameter.

In code value of this parameter is exposed as convenience function `SoFCCSysDragger::getScaleFromUserParameters` which adds dependency from `Gui` to `Application.h`. I'm not sure if this is ok - @wwmayer if it is not please point to a better place for such function.

Before:
![image](https://github.com/user-attachments/assets/731dad6a-8b3b-445a-a9d8-3251e8ccf812)

After:
![image](https://github.com/user-attachments/assets/a4cd4cee-9bea-40c5-826e-c31b4571999f)

Fixes: #13853