### PR TITLE
Path (and PathSimulator): Trim trailing newlines

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
+++ b/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
@@ -100,12 +100,12 @@ class CAMSimulation:
             z2 = edge.valueAt(p2).z
             if IsSame(px, rad2) and IsSame(pz, z2):
                 return edge, p2, p1
-            # sometimes a flat circle is without edge, so return edge with 
+            # sometimes a flat circle is without edge, so return edge with
             # same height and later a connecting edge will be interpolated
             if IsSame(pz, z1):
                 return edge, p1, p2
             if IsSame(pz, z2):
-                return edge, p2, p1           
+                return edge, p2, p1
         return None, 0.0, 0.0
 
     def FindTopMostEdge(self, edges):
@@ -130,7 +130,7 @@ class CAMSimulation:
                 maxz = z
         return topedge, top_p1, top_p2
 
-    #the algo is based on locating the side edge that OCC creates on any revolved object 
+    #the algo is based on locating the side edge that OCC creates on any revolved object
     def GetToolProfile(self, tool, resolution):
         shape = tool.Shape
         sideEdgeList = []
@@ -177,7 +177,7 @@ class CAMSimulation:
                 profile.append(startrad)
                 startz = edge.valueAt(p1).z
                 profile.append(startz)
-                        
+
         return profile
 
     def Activate(self):

--- a/src/Mod/CAM/Path/Post/scripts/generic_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/generic_post.py
@@ -66,7 +66,7 @@ class Generic(PostProcessor):
     def tooltip(self):
 
         tooltip = """
-        This is a generic post processor. 
+        This is a generic post processor.
         It doesn't do anything yet because we haven't immplemented it.
 
         Implementing it would be a good idea

--- a/src/Mod/CAM/PathSimulator/AppGL/SimShapes.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimShapes.cpp
@@ -363,7 +363,7 @@ void MillSim::Shape::GenerateModel(float* vbuffer, GLushort* ibuffer, int numVer
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, x));
     glEnableVertexAttribArray(1);
     glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void*)offsetof(Vertex, nx));
-    
+
     numIndices = nIndices;
 }
 


### PR DESCRIPTION
Cleans code, doesn't touch translations.