### PR TITLE
Addon Manager Tests: Skip all git tests if git is not present

### DIFF
--- a/src/Mod/AddonManager/AddonManagerTest/app/test_git.py
+++ b/src/Mod/AddonManager/AddonManagerTest/app/test_git.py
@@ -33,7 +33,13 @@ import FreeCAD
 
 from addonmanager_git import GitManager, NoGitFound, GitFailed
 
+try:
+    git_manager = GitManager()
+except NoGitFound:
+    git_manager = None
 
+
+@unittest.skipIf(git_manager is None, "No git executable -- not running git-based tests")
 class TestGit(unittest.TestCase):
 
     MODULE = "test_git"  # file name without extension
@@ -62,10 +68,7 @@ class TestGit(unittest.TestCase):
             zip_repo.extractall(self.test_repo_remote)
         self.test_repo_remote = os.path.join(self.test_repo_remote, "test_repo")
 
-        try:
-            self.git = GitManager()
-        except NoGitFound:
-            self.skipTest("No git found")
+        self.git = git_manager
 
     def tearDown(self):
         """Clean up after the test"""


### PR DESCRIPTION
The previous technique for skipping these tests did not work (and LibPack 3 does not provide git). Try a different way.