### PR TITLE
Gui: Fix Shiboken version detection and compilation error

### DIFF
--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -79,6 +79,9 @@
 // This helps to avoid to include the PySide2 headers since MSVC has a compiler bug when
 // compiling together with std::bitset (https://bugreports.qt.io/browse/QTBUG-72073)
 
+// Include shiboken first to get the version
+#  include <shiboken.h>
+
 // Do not use SHIBOKEN_MICRO_VERSION; it might contain a dot
 #  define SHIBOKEN_FULL_VERSION QT_VERSION_CHECK(SHIBOKEN_MAJOR_VERSION, SHIBOKEN_MINOR_VERSION, 0)
 #  if (SHIBOKEN_FULL_VERSION >= QT_VERSION_CHECK(5, 12, 0))
@@ -340,9 +343,7 @@ getPyTypeObjectForTypeName()
 #if defined (HAVE_SHIBOKEN_TYPE_FOR_TYPENAME)
 # if defined (HAVE_SHIBOKEN2)
     auto sbkType = Shiboken::ObjectType::typeForTypeName(typeid(qttype).name());
-    if (sbkType) {
-        return reinterpret_cast<SbkObjectType*>&(sbkType->type);
-    }
+    return reinterpret_cast<SbkObjectType*>(&sbkType->type);
 # else
     return Shiboken::ObjectType::typeForTypeName(typeid(qttype).name());
 # endif


### PR DESCRIPTION
- Shiboken headers need to be included first to get MAJOR/MINOR version flags. Without them the code would still compile, but fail the version check a few lines below assuming Shiboken is always older than 5.12
- Fix typo in cast when HAVE_SHIBOKEN_TYPE_FOR_TYPENAME is defined and remove the conditional: we have to assume typeForTypeName() always results in a valid name, as for the other implementations. There's no error handling of any kind in callers.

This fixes the build on debian unstable with shiboken 5.15.