### PR TITLE
Add RefIndex to ExternalGeometryReference and new migration types

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -498,6 +498,7 @@ PyMOD_INIT_FUNC(Part)
     Part::GeometryBoolExtension   	::init();
     Part::GeometryDoubleExtension 	::init();
     Part::GeometryMigrationExtension	::init();
+    Part::GeometryMigrationPersistenceExtension	::init();
     Part::Geometry                	::init();
     Part::GeomPoint               	::init();
     Part::GeomCurve               	::init();

--- a/src/Mod/Part/App/GeometryMigrationExtension.cpp
+++ b/src/Mod/Part/App/GeometryMigrationExtension.cpp
@@ -29,14 +29,22 @@
 
 using namespace Part;
 
+TYPESYSTEM_SOURCE_ABSTRACT(Part::GeometryMigrationPersistenceExtension, Part::GeometryPersistenceExtension)
+
 //---------- Geometry Extension
 TYPESYSTEM_SOURCE(Part::GeometryMigrationExtension,Part::GeometryExtension)
+
 
 void GeometryMigrationExtension::copyAttributes(Part::GeometryExtension * cpy) const
 {
     Part::GeometryExtension::copyAttributes(cpy);
     static_cast<GeometryMigrationExtension *>(cpy)->ConstructionState = this->ConstructionState;
     static_cast<GeometryMigrationExtension *>(cpy)->GeometryMigrationFlags  = this->GeometryMigrationFlags;
+
+    static_cast<GeometryMigrationExtension *>(cpy)->Id = this->Id;
+    static_cast<GeometryMigrationExtension *>(cpy)->Flags = this->Flags;
+    static_cast<GeometryMigrationExtension *>(cpy)->Ref = this->Ref;
+    static_cast<GeometryMigrationExtension *>(cpy)->RefIndex = this->RefIndex;
 }
 
 std::unique_ptr<Part::GeometryExtension> GeometryMigrationExtension::copy() const

--- a/src/Mod/Part/App/GeometryMigrationExtension.cpp
+++ b/src/Mod/Part/App/GeometryMigrationExtension.cpp
@@ -35,11 +35,10 @@ TYPESYSTEM_SOURCE_ABSTRACT(Part::GeometryMigrationPersistenceExtension, Part::Ge
 TYPESYSTEM_SOURCE(Part::GeometryMigrationExtension,Part::GeometryExtension)
 
 
-void GeometryMigrationExtension::copyAttributes(Part::GeometryExtension * cpy) const
-{
+void GeometryMigrationExtension::copyAttributes(Part::GeometryExtension *cpy) const {
     Part::GeometryExtension::copyAttributes(cpy);
     static_cast<GeometryMigrationExtension *>(cpy)->ConstructionState = this->ConstructionState;
-    static_cast<GeometryMigrationExtension *>(cpy)->GeometryMigrationFlags  = this->GeometryMigrationFlags;
+    static_cast<GeometryMigrationExtension *>(cpy)->GeometryMigrationFlags = this->GeometryMigrationFlags;
 
     static_cast<GeometryMigrationExtension *>(cpy)->Id = this->Id;
     static_cast<GeometryMigrationExtension *>(cpy)->Flags = this->Flags;

--- a/src/Mod/Part/App/GeometryMigrationExtension.h
+++ b/src/Mod/Part/App/GeometryMigrationExtension.h
@@ -62,16 +62,26 @@ public:
     PyObject *getPyObject() override;
 
 
-    virtual bool getConstruction() const {return ConstructionState;}
-    virtual void setConstruction(bool construction)
-        {ConstructionState = construction; setMigrationType(Construction);}
+    virtual bool getConstruction() const { return ConstructionState; }
 
-    long getId() const {return Id;}
-    void setId(long id) {Id = id; setMigrationType(GeometryId);}
+    virtual void setConstruction(bool construction) {
+        ConstructionState = construction;
+        setMigrationType(Construction);
+    }
 
-    const std::string &getRef() const {return Ref;}
-    int getRefIndex() const {return RefIndex;}
-    unsigned long getFlags() const {return Flags;}
+    long getId() const { return Id; }
+
+    void setId(long id) {
+        Id = id;
+        setMigrationType(GeometryId);
+    }
+
+    const std::string &getRef() const { return Ref; }
+
+    int getRefIndex() const { return RefIndex; }
+
+    unsigned long getFlags() const { return Flags; }
+
     void setReference(const char *ref, int index, unsigned long flags) {
         Ref = ref ? ref : "";
         RefIndex = index;
@@ -103,9 +113,9 @@ class PartExport GeometryMigrationPersistenceExtension : public Part::GeometryPe
 {
     TYPESYSTEM_HEADER();
 public:
-    // Called to save data as attributes in 'Geometry' XML tag
+    // Called to extend 'Geometry' XML tag with additional attributes (eg Id)
     virtual void preSave(Base::Writer &/*writer*/) const {}
-    // Called to save data after 'GeometryExtensions' XML elements
+    // Called to add additional tag after 'GeometryExtensions' XML elements (eg Construction flag)
     virtual void postSave(Base::Writer &/*writer*/) const {}
 };
 

--- a/src/Mod/Part/App/GeometryMigrationExtension.h
+++ b/src/Mod/Part/App/GeometryMigrationExtension.h
@@ -49,6 +49,8 @@ public:
     enum MigrationType {
             None                    = 0,
             Construction            = 1,
+            GeometryId              = 2,
+            ExternalReference       = 3,
             NumMigrationType        // Must be the last
     };
 
@@ -61,7 +63,21 @@ public:
 
 
     virtual bool getConstruction() const {return ConstructionState;}
-    virtual void setConstruction(bool construction) {ConstructionState = construction;}
+    virtual void setConstruction(bool construction)
+        {ConstructionState = construction; setMigrationType(Construction);}
+
+    long getId() const {return Id;}
+    void setId(long id) {Id = id; setMigrationType(GeometryId);}
+
+    const std::string &getRef() const {return Ref;}
+    int getRefIndex() const {return RefIndex;}
+    unsigned long getFlags() const {return Flags;}
+    void setReference(const char *ref, int index, unsigned long flags) {
+        Ref = ref ? ref : "";
+        RefIndex = index;
+        Flags = flags;
+        setMigrationType(ExternalReference);
+    }
 
     virtual bool testMigrationType(int flag) const { return GeometryMigrationFlags.test((size_t)(flag)); };
     virtual void setMigrationType(int flag, bool v=true) { GeometryMigrationFlags.set((size_t)(flag), v); };
@@ -76,7 +92,21 @@ private:
     using MigrationTypeFlagType = std::bitset<32>;
     MigrationTypeFlagType           GeometryMigrationFlags;
     bool                            ConstructionState{false};
+    long                            Id = 0;
+    int                             RefIndex = -1;
+    unsigned long                   Flags = 0;
+    std::string                     Ref;
+};
 
+
+class PartExport GeometryMigrationPersistenceExtension : public Part::GeometryPersistenceExtension
+{
+    TYPESYSTEM_HEADER();
+public:
+    // Called to save data as attributes in 'Geometry' XML tag
+    virtual void preSave(Base::Writer &/*writer*/) const {}
+    // Called to save data after 'GeometryExtensions' XML elements
+    virtual void postSave(Base::Writer &/*writer*/) const {}
 };
 
 } //namespace Part

--- a/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
@@ -36,13 +36,14 @@ using namespace Sketcher;
 constexpr std::array<const char*, ExternalGeometryExtension::NumFlags>
     ExternalGeometryExtension::flag2str;
 
-TYPESYSTEM_SOURCE(Sketcher::ExternalGeometryExtension, Part::GeometryPersistenceExtension)
+TYPESYSTEM_SOURCE(Sketcher::ExternalGeometryExtension, Part::GeometryMigrationPersistenceExtension)
 
 void ExternalGeometryExtension::copyAttributes(Part::GeometryExtension* cpy) const
 {
     Part::GeometryPersistenceExtension::copyAttributes(cpy);
 
     static_cast<ExternalGeometryExtension*>(cpy)->Ref = this->Ref;
+    static_cast<ExternalGeometryExtension*>(cpy)->RefIndex = this->RefIndex;
     static_cast<ExternalGeometryExtension*>(cpy)->Flags = this->Flags;
 }
 
@@ -50,15 +51,35 @@ void ExternalGeometryExtension::restoreAttributes(Base::XMLReader& reader)
 {
     Part::GeometryPersistenceExtension::restoreAttributes(reader);
 
-    Ref = reader.getAttribute("Ref");
-    Flags = FlagType(reader.getAttribute("Flags"));
+    Ref = reader.getAttribute("Ref", "");
+    RefIndex = reader.getAttributeAsInteger("RefIndex", "-1");
+    Flags = FlagType(reader.getAttributeAsUnsigned("Flags", "0"));
 }
 
 void ExternalGeometryExtension::saveAttributes(Base::Writer& writer) const
 {
     Part::GeometryPersistenceExtension::saveAttributes(writer);
+    // For compatibility with upstream FreeCAD, always save 'Ref' and 'Flags'.
+    // if (Ref.size())
+    writer.Stream() << "\" Ref=\"" << Base::Persistence::encodeAttribute(Ref);
+    // if (Flags.any())
+    writer.Stream() << "\" Flags=\"" << Flags.to_ulong();
+    if (RefIndex >= 0) {
+        writer.Stream() << "\" RefIndex=\"" << RefIndex;
+    }
+}
 
-    writer.Stream() << "\" Ref=\"" << Ref << "\" Flags=\"" << Flags.to_string();
+void ExternalGeometryExtension::preSave(Base::Writer& writer) const
+{
+    if (Ref.size()) {
+        writer.Stream() << " ref=\"" << Base::Persistence::encodeAttribute(Ref) << "\"";
+    }
+    if (RefIndex >= 0) {
+        writer.Stream() << " refIndex=\"" << RefIndex << "\"";
+    }
+    if (Flags.any()) {
+        writer.Stream() << " flags=\"" << Flags.to_ulong() << "\"";
+    }
 }
 
 std::unique_ptr<Part::GeometryExtension> ExternalGeometryExtension::copy() const

--- a/src/Mod/Sketcher/App/ExternalGeometryExtension.h
+++ b/src/Mod/Sketcher/App/ExternalGeometryExtension.h
@@ -27,6 +27,7 @@
 #include <bitset>
 
 #include <Mod/Part/App/Geometry.h>
+#include <Mod/Part/App/GeometryMigrationExtension.h>
 #include <Mod/Sketcher/SketcherGlobal.h>
 
 
@@ -40,18 +41,29 @@ public:
     // START_CREDIT_BLOCK: Credit under LGPL for this block to Zheng, Lei (realthunder)
     // <realthunder.dev@gmail.com>
     virtual bool testFlag(int flag) const = 0;
+
     virtual void setFlag(int flag, bool v = true) = 0;
+
+    virtual unsigned long getFlags() const = 0;
+
+    virtual void setFlags(unsigned long flags) = 0;
     // END_CREDIT_BLOCK: Credit under LGPL for this block to Zheng, Lei (realthunder)
     // <realthunder.dev@gmail.com>
 
     virtual bool isClear() const = 0;
+
     virtual size_t flagSize() const = 0;
 
     virtual const std::string& getRef() const = 0;
+
     virtual void setRef(const std::string& ref) = 0;
+
+    virtual int getRefIndex() const = 0;
+
+    virtual void setRefIndex(int index) = 0;
 };
 
-class SketcherExport ExternalGeometryExtension: public Part::GeometryPersistenceExtension,
+class SketcherExport ExternalGeometryExtension: public Part::GeometryMigrationPersistenceExtension,
                                                 private ISketchExternalGeometryExtension
 {
     TYPESYSTEM_HEADER_WITH_OVERRIDE();
@@ -76,6 +88,7 @@ public:
 
 public:
     ExternalGeometryExtension() = default;
+
     ~ExternalGeometryExtension() override = default;
 
     std::unique_ptr<Part::GeometryExtension> copy() const override;
@@ -88,9 +101,20 @@ public:
     {
         return Flags.test((size_t)(flag));
     }
+
     void setFlag(int flag, bool v = true) override
     {
         Flags.set((size_t)(flag), v);
+    }
+
+    unsigned long getFlags() const override
+    {
+        return Flags.to_ulong();
+    }
+
+    void setFlags(unsigned long flags) override
+    {
+        Flags = flags;
     }
     // END_CREDIT_BLOCK: Credit under LGPL for this block to Zheng, Lei (realthunder)
     // <realthunder.dev@gmail.com>
@@ -99,6 +123,7 @@ public:
     {
         return Flags.none();
     }
+
     size_t flagSize() const override
     {
         return Flags.size();
@@ -108,17 +133,32 @@ public:
     {
         return Ref;
     }
+
     void setRef(const std::string& ref) override
     {
         Ref = ref;
+    }
+
+    int getRefIndex() const override
+    {
+        return RefIndex;
+    }
+
+    void setRefIndex(int index) override
+    {
+        RefIndex = index;
     }
 
     static bool getFlagsFromName(std::string str, ExternalGeometryExtension::Flag& flag);
 
 protected:
     void copyAttributes(Part::GeometryExtension* cpy) const override;
+
     void restoreAttributes(Base::XMLReader& reader) override;
+
     void saveAttributes(Base::Writer& writer) const override;
+
+    void preSave(Base::Writer& writer) const override;
 
 private:
     ExternalGeometryExtension(const ExternalGeometryExtension&) = default;
@@ -128,6 +168,7 @@ private:
     // START_CREDIT_BLOCK: Credit under LGPL for this block to Zheng, Lei (realthunder)
     // <realthunder.dev@gmail.com>
     std::string Ref;
+    int RefIndex = -1;
     FlagType Flags;
     // END_CREDIT_BLOCK: Credit under LGPL for this block to Zheng, Lei (realthunder)
     // <realthunder.dev@gmail.com>

--- a/src/Mod/Sketcher/App/ExternalGeometryFacade.cpp
+++ b/src/Mod/Sketcher/App/ExternalGeometryFacade.cpp
@@ -30,6 +30,7 @@
 #include "ExternalGeometryFacade.h"
 #include "ExternalGeometryFacadePy.h"
 
+FC_LOG_LEVEL_INIT("Sketch", true, true);
 
 using namespace Sketcher;
 
@@ -159,6 +160,31 @@ void ExternalGeometryFacade::copyId(const Part::Geometry* src, Part::Geometry* d
     auto gfdst = ExternalGeometryFacade::getFacade(dst);
     gfdst->setId(gfsrc->getId());
 }
+
+void ExternalGeometryFacade::copyFlags(const Part::Geometry* src, Part::Geometry* dst)
+{
+    auto gfsrc = ExternalGeometryFacade::getFacade(src);
+    auto gfdst = ExternalGeometryFacade::getFacade(dst);
+    gfdst->setFlags(gfsrc->getFlags());
+}
+
+void ExternalGeometryFacade::setRef(const std::string& ref)
+{
+    if (ref.size() && getId() < 0) {
+        FC_ERR("Cannot set reference on root geometries");
+    }
+    else {
+        getExternalGeoExt()->setRef(ref);
+    }
+}
+
+// void ExternalGeometryFacade::setRef(const std::string &ref)
+//{
+//     if (ref.size() && getId() < 0)
+//         FC_ERR("Cannot set reference on root geometries");
+//     else
+//         getExternalGeoExt()->setRef(ref);
+// }
 
 PyObject* ExternalGeometryFacade::getPyObject()
 {

--- a/src/Mod/Sketcher/App/ExternalGeometryFacade.cpp
+++ b/src/Mod/Sketcher/App/ExternalGeometryFacade.cpp
@@ -170,21 +170,13 @@ void ExternalGeometryFacade::copyFlags(const Part::Geometry* src, Part::Geometry
 
 void ExternalGeometryFacade::setRef(const std::string& ref)
 {
-    if (ref.size() && getId() < 0) {
+    if (ref.empty() && getId() < 0) {
         FC_ERR("Cannot set reference on root geometries");
     }
     else {
         getExternalGeoExt()->setRef(ref);
     }
 }
-
-// void ExternalGeometryFacade::setRef(const std::string &ref)
-//{
-//     if (ref.size() && getId() < 0)
-//         FC_ERR("Cannot set reference on root geometries");
-//     else
-//         getExternalGeoExt()->setRef(ref);
-// }
 
 PyObject* ExternalGeometryFacade::getPyObject()
 {

--- a/src/Mod/Sketcher/App/ExternalGeometryFacade.h
+++ b/src/Mod/Sketcher/App/ExternalGeometryFacade.h
@@ -68,6 +68,7 @@ public:  // Factory methods
 public:  // Utility methods
     static void ensureSketchGeometryExtensions(Part::Geometry* geometry);
     static void copyId(const Part::Geometry* src, Part::Geometry* dst);
+    static void copyFlags(const Part::Geometry* src, Part::Geometry* dst);
 
 public:
     void setGeometry(Part::Geometry* geometry);
@@ -80,6 +81,15 @@ public:
     void setFlag(int flag, bool v = true) override
     {
         getExternalGeoExt()->setFlag(flag, v);
+    }
+
+    unsigned long getFlags() const override
+    {
+        return getExternalGeoExt()->getFlags();
+    }
+    void setFlags(unsigned long flags) override
+    {
+        getExternalGeoExt()->setFlags(flags);
     }
 
     bool isClear() const override
@@ -95,9 +105,16 @@ public:
     {
         return getExternalGeoExt()->getRef();
     }
-    void setRef(const std::string& ref) override
+    void setRef(const std::string& ref) override;
+
+    int getRefIndex() const override
     {
-        getExternalGeoExt()->setRef(ref);
+        return getExternalGeoExt()->getRefIndex();
+    }
+
+    void setRefIndex(int index) override
+    {
+        getExternalGeoExt()->setRefIndex(index);
     }
 
     /** GeometryExtension Interface **/

--- a/src/Mod/Sketcher/App/ExternalGeometryFacade.h
+++ b/src/Mod/Sketcher/App/ExternalGeometryFacade.h
@@ -78,6 +78,7 @@ public:
     {
         return getExternalGeoExt()->testFlag(flag);
     }
+
     void setFlag(int flag, bool v = true) override
     {
         getExternalGeoExt()->setFlag(flag, v);
@@ -87,6 +88,7 @@ public:
     {
         return getExternalGeoExt()->getFlags();
     }
+
     void setFlags(unsigned long flags) override
     {
         getExternalGeoExt()->setFlags(flags);
@@ -96,6 +98,7 @@ public:
     {
         return getExternalGeoExt()->isClear();
     }
+
     size_t flagSize() const override
     {
         return getExternalGeoExt()->flagSize();
@@ -105,6 +108,7 @@ public:
     {
         return getExternalGeoExt()->getRef();
     }
+
     void setRef(const std::string& ref) override;
 
     int getRefIndex() const override

--- a/src/Mod/Sketcher/App/GeometryFacade.cpp
+++ b/src/Mod/Sketcher/App/GeometryFacade.cpp
@@ -146,6 +146,18 @@ void GeometryFacade::copyId(const Part::Geometry* src, Part::Geometry* dst)
     gfdst->setId(gfsrc->getId());
 }
 
+int GeometryFacade::getId(const Part::Geometry* geometry)
+{
+    auto gf = GeometryFacade::getFacade(geometry);
+    return gf->getId();
+}
+
+void GeometryFacade::setId(Part::Geometry* geometry, int id)
+{
+    auto gf = GeometryFacade::getFacade(geometry);
+    return gf->setId(id);
+}
+
 bool GeometryFacade::getConstruction(const Part::Geometry* geometry)
 {
     throwOnNullPtr(geometry);

--- a/src/Mod/Sketcher/App/GeometryFacade.h
+++ b/src/Mod/Sketcher/App/GeometryFacade.h
@@ -131,6 +131,8 @@ public:  // Utility methods
     static InternalType::InternalType getInternalType(const Part::Geometry* geometry);
     static void setInternalType(Part::Geometry* geometry, InternalType::InternalType type);
     static bool getBlocked(const Part::Geometry* geometry);
+    static int getId(const Part::Geometry* geometry);
+    static void setId(Part::Geometry* geometry, int id);
 
 public:
     // Explicit deletion to show intent (not that it is needed)

--- a/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
@@ -93,6 +93,17 @@ void SketchGeometryExtension::saveAttributes(Base::Writer& writer) const
         << GeometryModeFlags.to_string() << "\" geometryLayer=\"" << GeometryLayer;
 }
 
+void SketchGeometryExtension::preSave(Base::Writer& writer) const
+{
+    writer.Stream() << " id=\"" << Id << "\"";
+}
+
+void SketchGeometryExtension::postSave(Base::Writer& writer) const
+{
+    writer.Stream() << writer.ind() << "<Construction value=\""
+                    << (GeometryModeFlags.test(GeometryMode::Construction) ? 1 : 0) << "\"/>\n";
+}
+
 std::unique_ptr<Part::GeometryExtension> SketchGeometryExtension::copy() const
 {
     auto cpy = std::make_unique<SketchGeometryExtension>();

--- a/src/Mod/Sketcher/App/SketchGeometryExtension.h
+++ b/src/Mod/Sketcher/App/SketchGeometryExtension.h
@@ -28,6 +28,7 @@
 #include <bitset>
 
 #include <Mod/Part/App/Geometry.h>
+#include <Mod/Part/App/GeometryMigrationExtension.h>
 #include <Mod/Sketcher/SketcherGlobal.h>
 
 
@@ -84,7 +85,7 @@ public:
     virtual void setGeometryLayerId(int geolayer) = 0;
 };
 
-class SketcherExport SketchGeometryExtension: public Part::GeometryPersistenceExtension,
+class SketcherExport SketchGeometryExtension: public Part::GeometryMigrationPersistenceExtension,
                                               private ISketchGeometryExtension
 {
     TYPESYSTEM_HEADER_WITH_OVERRIDE();
@@ -159,6 +160,8 @@ protected:
     void copyAttributes(Part::GeometryExtension* cpy) const override;
     void restoreAttributes(Base::XMLReader& reader) override;
     void saveAttributes(Base::Writer& writer) const override;
+    void preSave(Base::Writer& writer) const override;
+    void postSave(Base::Writer& writer) const override;
 
 private:
     SketchGeometryExtension(const SketchGeometryExtension&) = default;


### PR DESCRIPTION
Second in series of incremental code transfers to solve the save/restore errors with objects with element maps..