### PR TITLE
Assembly: Fix conflicting shortcut for Exploded view

### DIFF
--- a/src/Mod/Assembly/CommandCreateView.py
+++ b/src/Mod/Assembly/CommandCreateView.py
@@ -53,7 +53,7 @@ class CommandCreateView:
         return {
             "Pixmap": "Assembly_ExplodedView",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_CreateView", "Create Exploded View"),
-            "Accel": "V",
+            "Accel": "E",
             "ToolTip": "<p>"
             + QT_TRANSLATE_NOOP(
                 "Assembly_CreateView",

--- a/src/Mod/Assembly/CommandExportASMT.py
+++ b/src/Mod/Assembly/CommandExportASMT.py
@@ -45,7 +45,6 @@ class CommandExportASMT:
         return {
             "Pixmap": "Assembly_ExportASMT",
             "MenuText": QT_TRANSLATE_NOOP("Assembly_ExportASMT", "Export ASMT File"),
-            "Accel": "E",
             "ToolTip": QT_TRANSLATE_NOOP(
                 "Assembly_ExportASMT",
                 "Export currently active assembly as a ASMT file.",


### PR DESCRIPTION
Assign E key for Exploded view instead of V that is used by core commands.
Remove E key shortcut of Export ASMT as this tool is mostly for debug it does not need a shortcut.
Fix https://github.com/FreeCAD/FreeCAD/issues/15386