### PR TITLE
Fix possible crashes in PD task panels

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -340,20 +340,12 @@ TaskDlgChamferParameters::~TaskDlgChamferParameters() = default;
 
 //==== calls from the TaskView ===============================================================
 
-
-//void TaskDlgChamferParameters::open()
-//{
-//    // a transaction is already open at creation time of the chamfer
-//    if (!Gui::Command::hasPendingCommand()) {
-//        QString msg = tr("Edit chamfer");
-//        Gui::Command::openCommand((const char*)msg.toUtf8());
-//    }
-//}
 bool TaskDlgChamferParameters::accept()
 {
-    auto obj = vp->getObject();
-    if (!obj->isError())
+    auto obj = getObject();
+    if (!obj->isError()) {
         parameter->showObject();
+    }
 
     parameter->apply();
 

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -162,13 +162,16 @@ void TaskChamferParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 
 void TaskChamferParameters::onCheckBoxUseAllEdgesToggled(bool checked)
 {
-    if(checked)
-        setSelectionMode(none);
-    PartDesign::Chamfer* pcChamfer = static_cast<PartDesign::Chamfer*>(DressUpView->getObject());
-    ui->buttonRefSel->setEnabled(!checked);
-    ui->listWidgetReferences->setEnabled(!checked);
-    pcChamfer->UseAllEdges.setValue(checked);
-    pcChamfer->getDocument()->recomputeFeature(pcChamfer);
+    if (auto chamfer = getObject<PartDesign::Chamfer>()) {
+        if (checked) {
+            setSelectionMode(none);
+        }
+
+        ui->buttonRefSel->setEnabled(!checked);
+        ui->listWidgetReferences->setEnabled(!checked);
+        chamfer->UseAllEdges.setValue(checked);
+        chamfer->recomputeFeature();
+    }
 }
 
 void TaskChamferParameters::setButtons(const selectionModes mode)
@@ -189,58 +192,63 @@ void TaskChamferParameters::onAddAllEdges()
 
 void TaskChamferParameters::onTypeChanged(int index)
 {
-    setSelectionMode(none);
-    PartDesign::Chamfer* pcChamfer = static_cast<PartDesign::Chamfer*>(DressUpView->getObject());
-    pcChamfer->ChamferType.setValue(index);
-    ui->stackedWidget->setCurrentIndex(index);
-    ui->flipDirection->setEnabled(index != 0); // Enable if type is not "Equal distance"
-    pcChamfer->getDocument()->recomputeFeature(pcChamfer);
-    // hide the chamfer if there was a computation error
-    hideOnError();
+    if (auto chamfer = getObject<PartDesign::Chamfer>()) {
+        setSelectionMode(none);
+        chamfer->ChamferType.setValue(index);
+        ui->stackedWidget->setCurrentIndex(index);
+        ui->flipDirection->setEnabled(index != 0); // Enable if type is not "Equal distance"
+        chamfer->recomputeFeature();
+        // hide the chamfer if there was a computation error
+        hideOnError();
+    }
 }
 
 void TaskChamferParameters::onSizeChanged(double len)
 {
-    setSelectionMode(none);
-    PartDesign::Chamfer* pcChamfer = static_cast<PartDesign::Chamfer*>(DressUpView->getObject());
-    setupTransaction();
-    pcChamfer->Size.setValue(len);
-    pcChamfer->getDocument()->recomputeFeature(pcChamfer);
-    // hide the chamfer if there was a computation error
-    hideOnError();
+    if (auto chamfer = getObject<PartDesign::Chamfer>()) {
+        setSelectionMode(none);
+        setupTransaction();
+        chamfer->Size.setValue(len);
+        chamfer->recomputeFeature();
+        // hide the chamfer if there was a computation error
+        hideOnError();
+    }
 }
 
 void TaskChamferParameters::onSize2Changed(double len)
 {
-    setSelectionMode(none);
-    PartDesign::Chamfer* pcChamfer = static_cast<PartDesign::Chamfer*>(DressUpView->getObject());
-    setupTransaction();
-    pcChamfer->Size2.setValue(len);
-    pcChamfer->getDocument()->recomputeFeature(pcChamfer);
-    // hide the chamfer if there was a computation error
-    hideOnError();
+    if (auto chamfer = getObject<PartDesign::Chamfer>()) {
+        setSelectionMode(none);
+        setupTransaction();
+        chamfer->Size2.setValue(len);
+        chamfer->recomputeFeature();
+        // hide the chamfer if there was a computation error
+        hideOnError();
+    }
 }
 
 void TaskChamferParameters::onAngleChanged(double angle)
 {
-    setSelectionMode(none);
-    PartDesign::Chamfer* pcChamfer = static_cast<PartDesign::Chamfer*>(DressUpView->getObject());
-    setupTransaction();
-    pcChamfer->Angle.setValue(angle);
-    pcChamfer->getDocument()->recomputeFeature(pcChamfer);
-    // hide the chamfer if there was a computation error
-    hideOnError();
+    if (auto chamfer = getObject<PartDesign::Chamfer>()) {
+        setSelectionMode(none);
+        setupTransaction();
+        chamfer->Angle.setValue(angle);
+        chamfer->recomputeFeature();
+        // hide the chamfer if there was a computation error
+        hideOnError();
+    }
 }
 
 void TaskChamferParameters::onFlipDirection(bool flip)
 {
-    setSelectionMode(none);
-    PartDesign::Chamfer* pcChamfer = static_cast<PartDesign::Chamfer*>(DressUpView->getObject());
-    setupTransaction();
-    pcChamfer->FlipDirection.setValue(flip);
-    pcChamfer->getDocument()->recomputeFeature(pcChamfer);
-    // hide the chamfer if there was a computation error
-    hideOnError();
+    if (auto chamfer = getObject<PartDesign::Chamfer>()) {
+        setSelectionMode(none);
+        setupTransaction();
+        chamfer->FlipDirection.setValue(flip);
+        chamfer->recomputeFeature();
+        // hide the chamfer if there was a computation error
+        hideOnError();
+    }
 }
 
 int TaskChamferParameters::getType() const
@@ -295,13 +303,9 @@ void TaskChamferParameters::changeEvent(QEvent *e)
 
 void TaskChamferParameters::apply()
 {
-    std::string name = DressUpView->getObject()->getNameInDocument();
+    auto chamfer = getObject<PartDesign::Chamfer>();
 
-    //Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Chamfer changed"));
-
-    PartDesign::Chamfer* pcChamfer = static_cast<PartDesign::Chamfer*>(DressUpView->getObject());
-
-    const int chamfertype = pcChamfer->ChamferType.getValue();
+    const int chamfertype = chamfer->ChamferType.getValue();
 
     switch(chamfertype) {
 

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
@@ -126,9 +126,9 @@ void TaskDraftParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
             referenceSelected(msg, ui->listWidgetReferences);
         }
         else if (selectionMode == plane) {
-            PartDesign::Draft* pcDraft = static_cast<PartDesign::Draft*>(DressUpView->getObject());
+            auto pcDraft = getObject<PartDesign::Draft>();
             std::vector<std::string> planes;
-            App::DocumentObject* selObj;
+            App::DocumentObject* selObj {};
             getReferencedSelection(pcDraft, msg, selObj, planes);
             if(!selObj)
                 return;
@@ -138,12 +138,12 @@ void TaskDraftParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 
             pcDraft->getDocument()->recomputeFeature(pcDraft);
             // highlight existing references for possible further selections
-            DressUpView->highlightReferences(true);
+            getDressUpView()->highlightReferences(true);
             // hide the draft if there was a computation error
             hideOnError();
         } 
         else if (selectionMode == line) {
-            PartDesign::Draft* pcDraft = static_cast<PartDesign::Draft*>(DressUpView->getObject());
+            auto pcDraft = getObject<PartDesign::Draft>();
             std::vector<std::string> edges;
             App::DocumentObject* selObj;
             getReferencedSelection(pcDraft, msg, selObj, edges);
@@ -155,7 +155,7 @@ void TaskDraftParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 
             pcDraft->getDocument()->recomputeFeature(pcDraft);
             // highlight existing references for possible further selections
-            DressUpView->highlightReferences(true);
+            getDressUpView()->highlightReferences(true);
             // hide the draft if there was a computation error
             hideOnError();
         }
@@ -204,7 +204,7 @@ void TaskDraftParameters::getPlane(App::DocumentObject*& obj, std::vector<std::s
 {
     sub = std::vector<std::string>(1,"");
     QStringList parts = ui->linePlane->text().split(QChar::fromLatin1(':'));
-    obj = DressUpView->getObject()->getDocument()->getObject(parts[0].toStdString().c_str());
+    obj = getObject()->getDocument()->getObject(parts[0].toStdString().c_str());
     if (parts.size() > 1)
         sub[0] = parts[1].toStdString();
 }
@@ -213,20 +213,21 @@ void TaskDraftParameters::getLine(App::DocumentObject*& obj, std::vector<std::st
 {
     sub = std::vector<std::string>(1,"");
     QStringList parts = ui->lineLine->text().split(QChar::fromLatin1(':'));
-    obj = DressUpView->getObject()->getDocument()->getObject(parts[0].toStdString().c_str());
+    obj = getObject()->getDocument()->getObject(parts[0].toStdString().c_str());
     if (parts.size() > 1)
         sub[0] = parts[1].toStdString();
 }
 
 void TaskDraftParameters::onAngleChanged(double angle)
 {
-    setButtons(none);
-    PartDesign::Draft* pcDraft = static_cast<PartDesign::Draft*>(DressUpView->getObject());
-    setupTransaction();
-    pcDraft->Angle.setValue(angle);
-    pcDraft->getDocument()->recomputeFeature(pcDraft);
-    // hide the draft if there was a computation error
-    hideOnError();
+    if (auto draft = getObject<PartDesign::Draft>()) {
+        setButtons(none);
+        setupTransaction();
+        draft->Angle.setValue(angle);
+        draft->recomputeFeature();
+        // hide the draft if there was a computation error
+        hideOnError();
+    }
 }
 
 double TaskDraftParameters::getAngle() const
@@ -234,14 +235,16 @@ double TaskDraftParameters::getAngle() const
     return ui->draftAngle->value().getValue();
 }
 
-void TaskDraftParameters::onReversedChanged(const bool on) {
-    setButtons(none);
-    PartDesign::Draft* pcDraft = static_cast<PartDesign::Draft*>(DressUpView->getObject());
-    setupTransaction();
-    pcDraft->Reversed.setValue(on);
-    pcDraft->getDocument()->recomputeFeature(pcDraft);
-    // hide the draft if there was a computation error
-    hideOnError();
+void TaskDraftParameters::onReversedChanged(const bool on)
+{
+    if (auto draft = getObject<PartDesign::Draft>()) {
+        setButtons(none);
+        setupTransaction();
+        draft->Reversed.setValue(on);
+        draft->recomputeFeature();
+        // hide the draft if there was a computation error
+        hideOnError();
+    }
 }
 
 bool TaskDraftParameters::getReversed() const

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
@@ -302,9 +302,10 @@ TaskDlgDraftParameters::~TaskDlgDraftParameters() = default;
 
 bool TaskDlgDraftParameters::accept()
 {
-    auto tobj = vp->getObject();
-    if (!tobj->isError())
+    auto tobj = getObject();
+    if (!tobj->isError()) {
         parameter->showObject();
+    }
 
     parameter->apply();
 

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
@@ -300,16 +300,6 @@ TaskDlgDraftParameters::~TaskDlgDraftParameters() = default;
 
 //==== calls from the TaskView ===============================================================
 
-
-//void TaskDlgDraftParameters::open()
-//{
-//    // a transaction is already open at creation time of the draft
-//    if (!Gui::Command::hasPendingCommand()) {
-//        QString msg = QObject::tr("Edit draft");
-//        Gui::Command::openCommand((const char*)msg.toUtf8());
-//    }
-//}
-
 bool TaskDlgDraftParameters::accept()
 {
     auto tobj = vp->getObject();
@@ -327,13 +317,6 @@ bool TaskDlgDraftParameters::accept()
 
     draftparameter->getLine(obj, strings);
     std::string pullDirection = buildLinkSingleSubPythonStr(obj, strings);
-
-    // Force the user to select a neutral plane
-    // if (neutralPlane.empty() || neutralPlane == "None") {
-    //     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Missing neutral plane"),
-    //         QObject::tr("Please select a plane or an edge plus a pull direction"));
-    //     return false;
-    // }
 
     FCMD_OBJ_CMD(tobj,"Angle = " << draftparameter->getAngle());
     FCMD_OBJ_CMD(tobj,"Reversed = " << draftparameter->getReversed());

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -456,10 +456,10 @@ TaskDlgDressUpParameters::~TaskDlgDressUpParameters() = default;
 
 bool TaskDlgDressUpParameters::accept()
 {
-    getDressUpView()->highlightReferences(false);
+    getViewObject<ViewProviderDressUp>()->highlightReferences(false);
     std::vector<std::string> refs = parameter->getReferences();
     std::stringstream str;
-    str << Gui::Command::getObjectCmd(vp->getObject()) << ".Base = ("
+    str << Gui::Command::getObjectCmd(getObject()) << ".Base = ("
         << Gui::Command::getObjectCmd(parameter->getBase()) << ",[";
     for (const auto & ref : refs)
         str << "\"" << ref << "\",";
@@ -470,7 +470,7 @@ bool TaskDlgDressUpParameters::accept()
 
 bool TaskDlgDressUpParameters::reject()
 {
-    getDressUpView()->highlightReferences(false);
+    getViewObject<ViewProviderDressUp>()->highlightReferences(false);
     return TaskDlgFeatureParameters::reject();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -60,11 +60,11 @@ TaskDressUpParameters::TaskDressUpParameters(ViewProviderDressUp *DressUpView, b
               true,
               parent)
     , proxy(nullptr)
-    , DressUpView(DressUpView)
     , deleteAction(nullptr)
     , addAllEdgesAction(nullptr)
     , allowFaces(selectFaces)
     , allowEdges(selectEdges)
+    , DressUpView(DressUpView)
 {
     // remember initial transaction ID
     App::GetApplication().getActiveTransaction(&transactionID);
@@ -93,7 +93,7 @@ const QString TaskDressUpParameters::btnSelectStr()
 
 void TaskDressUpParameters::setupTransaction()
 {
-    if (!DressUpView)
+    if (DressUpView.expired())
         return;
 
     int tid = 0;
@@ -143,7 +143,7 @@ void TaskDressUpParameters::addAllEdges(QListWidget* widget)
 #ifdef FC_USE_TNP_FIX
     Q_UNUSED(widget)
 
-    if (!DressUpView) {
+    if (DressUpView.expired()) {
         return;
     }
 
@@ -401,18 +401,31 @@ void TaskDressUpParameters::showObject()
     }
 }
 
+ViewProviderDressUp* TaskDressUpParameters::getDressUpView() const
+{
+    return DressUpView.expired() ? nullptr : DressUpView.get();
+}
+
 Part::Feature* TaskDressUpParameters::getBase() const
 {
-    PartDesign::DressUp* pcDressUp = static_cast<PartDesign::DressUp*>(DressUpView->getObject());
-    // Unlikely but this may throw an exception in case we are started to edit an object which base feature
-    // was deleted. This exception will be likely unhandled inside the dialog and pass upper, But an error
-    // message inside the report view is better than a SEGFAULT.
-    // Generally this situation should be prevented in ViewProviderDressUp::setEdit()
-    return pcDressUp->getBaseObject();
+    if (ViewProviderDressUp* vp = getDressUpView()) {
+        auto dressUp = dynamic_cast<PartDesign::DressUp*>(vp->getObject());
+        // Unlikely but this may throw an exception in case we are started to edit an object which
+        // base feature was deleted. This exception will be likely unhandled inside the dialog and
+        // pass upper. But an error message inside the report view is better than a SEGFAULT.
+        // Generally this situation should be prevented in ViewProviderDressUp::setEdit()
+        return dressUp->getBaseObject();
+    }
+
+    return nullptr;
 }
 
 void TaskDressUpParameters::setSelectionMode(selectionModes mode)
 {
+    if (DressUpView.expired()) {
+        return;
+    }
+
     selectionMode = mode;
     setButtons(mode);
 

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
@@ -24,6 +24,7 @@
 #ifndef GUI_TASKVIEW_TaskDressUpParameters_H
 #define GUI_TASKVIEW_TaskDressUpParameters_H
 
+#include <Gui/DocumentObserver.h>
 #include <Gui/TaskView/TaskView.h>
 #include <Mod/PartDesign/App/FeatureDressUp.h>
 
@@ -87,12 +88,20 @@ protected:
     virtual void setButtons(const selectionModes mode) = 0;
     static void removeItemFromListWidget(QListWidget* widget, const char* itemstr);
 
-    ViewProviderDressUp* getDressUpView() const
-    { return DressUpView; }
+    ViewProviderDressUp* getDressUpView() const;
+
+    template<typename T = App::DocumentObject> T* getObject() const
+    {
+        static_assert(std::is_base_of<App::DocumentObject, T>::value, "Wrong template argument");
+        if (!DressUpView.expired()) {
+            return dynamic_cast<T*>(DressUpView->getObject());
+        }
+
+        return nullptr;
+    }
 
 protected:
     QWidget* proxy;
-    ViewProviderDressUp *DressUpView;
     QAction* deleteAction;
     QAction* addAllEdgesAction;
 
@@ -102,6 +111,9 @@ protected:
 
     static const QString btnPreviewStr();
     static const QString btnSelectStr();
+
+private:
+    Gui::WeakPtrT<ViewProviderDressUp> DressUpView;
 };
 
 /// simulation dialog for the TaskView

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
@@ -113,9 +113,6 @@ public:
     explicit TaskDlgDressUpParameters(ViewProviderDressUp *DressUpView);
     ~TaskDlgDressUpParameters() override;
 
-    ViewProviderDressUp* getDressUpView() const
-    { return static_cast<ViewProviderDressUp*>(vp); }
-
 public:
     /// is called by the framework if the dialog is accepted (Ok)
     bool accept() override;

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <App/Document.h>
+#include <Base/Tools.h>
 #include <Base/UnitsApi.h>
 #include <Gui/Command.h>
 #include <Mod/PartDesign/App/FeatureExtrude.h>
@@ -564,8 +565,7 @@ bool TaskExtrudeParameters::hasProfileFace(PartDesign::ProfileBased* profile) co
 
 void TaskExtrudeParameters::fillDirectionCombo()
 {
-    bool oldVal_blockUpdate = blockUpdate;
-    blockUpdate = true;
+    Base::StateLocker lock(getUpdateBlockRef(), true);
 
     if (axesInList.empty()) {
         bool hasFace = false;
@@ -628,8 +628,6 @@ void TaskExtrudeParameters::fillDirectionCombo()
         ui->directionCB->setCurrentIndex(indexOfCurrent);
     if (hasCustom)
         ui->directionCB->setCurrentIndex(DirectionModes::Custom);
-
-    blockUpdate = oldVal_blockUpdate;
 }
 
 void TaskExtrudeParameters::addAxisToCombo(App::DocumentObject* linkObj, std::string linkSubname,

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -68,7 +68,7 @@ TaskExtrudeParameters::~TaskExtrudeParameters() = default;
 void TaskExtrudeParameters::setupDialog()
 {
     // Get the feature data
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
     Base::Quantity l = extrude->Length.getQuantityValue();
     Base::Quantity l2 = extrude->Length2.getQuantityValue();
     Base::Quantity off = extrude->Offset.getQuantityValue();
@@ -268,7 +268,7 @@ void PartDesignGui::TaskExtrudeParameters::onUnselectShapeFacesTrigger()
     auto selected = ui->listWidgetReferences->selectedItems();
     auto faces = getShapeFaces();
 
-    auto extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
 
     faces.erase(std::remove_if(faces.begin(), faces.end(), [selected](const std::string &face) { 
         for (auto &item : selected) {
@@ -307,13 +307,13 @@ void TaskExtrudeParameters::setSelectionMode(SelectionMode mode)
             break;
         case SelectShapeFaces:
             onSelectReference(AllowSelection::FACE);
-            static_cast<ViewProviderExtrude*>(vp)->highlightShapeFaces(getShapeFaces());
+            getViewObject<ViewProviderExtrude>()->highlightShapeFaces(getShapeFaces());
             break;
         case SelectReferenceAxis:
             onSelectReference(AllowSelection::EDGE | AllowSelection::PLANAR | AllowSelection::CIRCLE);
             break;
         default:
-            static_cast<ViewProviderExtrude*>(vp)->highlightShapeFaces({});
+            getViewObject<ViewProviderExtrude>()->highlightShapeFaces({});
             onSelectReference(AllowSelection::NONE);
     }
 }
@@ -364,7 +364,7 @@ void TaskExtrudeParameters::selectedReferenceAxis(const Gui::SelectionChanges& m
     std::vector<std::string> edge;
     App::DocumentObject* selObj;
 
-    if (getReferencedSelection(vp->getObject(), msg, selObj, edge) && selObj) {
+    if (getReferencedSelection(getObject(), msg, selObj, edge) && selObj) {
         setSelectionMode(None);
 
         propReferenceAxis->setValue(selObj, edge);
@@ -377,7 +377,7 @@ void TaskExtrudeParameters::selectedReferenceAxis(const Gui::SelectionChanges& m
 
 void TaskExtrudeParameters::selectedShapeFace(const Gui::SelectionChanges& msg)
 {
-    auto extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
     auto document = extrude->getDocument();
 
     if (strcmp(msg.pDocName, document->getName()) != 0) {
@@ -436,7 +436,7 @@ void PartDesignGui::TaskExtrudeParameters::selectedFace(const Gui::SelectionChan
 
 void PartDesignGui::TaskExtrudeParameters::selectedShape(const Gui::SelectionChanges& msg)
 {
-    auto extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
     auto document = extrude->getDocument();
 
     if (strcmp(msg.pDocName, document->getName()) != 0) {
@@ -472,12 +472,13 @@ void TaskExtrudeParameters::updateShapeName()
 {
     QSignalBlocker block(ui->lineShapeName);
 
-    auto extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
     auto shape = extrude->UpToShape.getValue();
 
     if (shape) {
         ui->lineShapeName->setText(QString::fromStdString(shape->getFullName()));
-    } else {
+    }
+    else {
         ui->lineShapeName->setText({});
         ui->lineShapeName->setPlaceholderText(tr("No shape selected"));
     }
@@ -493,7 +494,7 @@ void TaskExtrudeParameters::updateShapeFaces()
     }
 
     if (selectionMode == SelectShapeFaces) {
-        static_cast<ViewProviderExtrude*>(vp)->highlightShapeFaces(faces);
+        getViewObject<ViewProviderExtrude>()->highlightShapeFaces(faces);
     }
 }
 
@@ -501,7 +502,7 @@ std::vector<std::string> PartDesignGui::TaskExtrudeParameters::getShapeFaces()
 {
     std::vector<std::string> faces;
 
-    auto extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
     auto allRefs = extrude->UpToShape.getSubValues();
 
     std::copy_if(
@@ -515,37 +516,42 @@ std::vector<std::string> PartDesignGui::TaskExtrudeParameters::getShapeFaces()
 
 void TaskExtrudeParameters::onLengthChanged(double len)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-    extrude->Length.setValue(len);
-    tryRecomputeFeature();
+    if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+        extrude->Length.setValue(len);
+        tryRecomputeFeature();
+    }
 }
 
 void TaskExtrudeParameters::onLength2Changed(double len)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-    extrude->Length2.setValue(len);
-    tryRecomputeFeature();
+    if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+        extrude->Length2.setValue(len);
+        tryRecomputeFeature();
+    }
 }
 
 void TaskExtrudeParameters::onOffsetChanged(double len)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-    extrude->Offset.setValue(len);
-    tryRecomputeFeature();
+    if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+        extrude->Offset.setValue(len);
+        tryRecomputeFeature();
+    }
 }
 
 void TaskExtrudeParameters::onTaperChanged(double angle)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-    extrude->TaperAngle.setValue(angle);
-    tryRecomputeFeature();
+    if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+        extrude->TaperAngle.setValue(angle);
+        tryRecomputeFeature();
+    }
 }
 
 void TaskExtrudeParameters::onTaper2Changed(double angle)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-    extrude->TaperAngle2.setValue(angle);
-    tryRecomputeFeature();
+    if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+        extrude->TaperAngle2.setValue(angle);
+        tryRecomputeFeature();
+    }
 }
 
 bool TaskExtrudeParameters::hasProfileFace(PartDesign::ProfileBased* profile) const
@@ -572,7 +578,7 @@ void TaskExtrudeParameters::fillDirectionCombo()
         ui->directionCB->clear();
         // we can have sketches or faces
         // for sketches just get the sketch normal
-        PartDesign::ProfileBased* pcFeat = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+        auto pcFeat = getObject<PartDesign::ProfileBased>();
         Part::Part2DObject* pcSketch = dynamic_cast<Part::Part2DObject*>(pcFeat->Profile.getValue());
         // for faces we test if it is verified and if we can get its normal
         if (!pcSketch) {
@@ -622,7 +628,7 @@ void TaskExtrudeParameters::fillDirectionCombo()
     }
 
     // highlight either current index or set custom direction
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
     bool hasCustom = extrude->UseCustomVector.getValue();
     if (indexOfCurrent != -1 && !hasCustom)
         ui->directionCB->setCurrentIndex(indexOfCurrent);
@@ -745,8 +751,6 @@ void TaskExtrudeParameters::setCheckboxes(Mode mode, Type type)
 
 void TaskExtrudeParameters::onDirectionCBChanged(int num)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-
     if (axesInList.empty())
         return;
 
@@ -766,7 +770,7 @@ void TaskExtrudeParameters::onDirectionCBChanged(int num)
         setSelectionMode(SelectReferenceAxis);
         setDirectionMode(num);
     }
-    else {
+    else if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
         if (lnk.getValue()) {
             if (!extrude->getDocument()->isIn(lnk.getValue())) {
                 Base::Console().Error("Object was deleted\n");
@@ -787,9 +791,10 @@ void TaskExtrudeParameters::onDirectionCBChanged(int num)
 
 void TaskExtrudeParameters::onAlongSketchNormalChanged(bool on)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-    extrude->AlongSketchNormal.setValue(on);
-    tryRecomputeFeature();
+    if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+        extrude->AlongSketchNormal.setValue(on);
+        tryRecomputeFeature();
+    }
 }
 
 void TaskExtrudeParameters::onDirectionToggled(bool on)
@@ -808,45 +813,55 @@ void PartDesignGui::TaskExtrudeParameters::onAllFacesToggled(bool on)
     ui->buttonShapeFace->setChecked(false);
 
     if (on) {
-        auto extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-        extrude->UpToShape.setValue(extrude->UpToShape.getValue());
+        if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+            extrude->UpToShape.setValue(extrude->UpToShape.getValue());
 
-        updateShapeFaces();
+            updateShapeFaces();
 
-        tryRecomputeFeature();
+            tryRecomputeFeature();
+        }
     }
 }
 
 void TaskExtrudeParameters::onXDirectionEditChanged(double len)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-    extrude->Direction.setValue(len, extrude->Direction.getValue().y, extrude->Direction.getValue().z);
-    tryRecomputeFeature();
-    // checking for case of a null vector is done in FeatureExtrude.cpp
-    // if there was a null vector, the normal vector of the sketch is used.
-    // therefore the vector component edits must be updated
-    updateDirectionEdits();
+    if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+        extrude->Direction.setValue(len,
+                                    extrude->Direction.getValue().y,
+                                    extrude->Direction.getValue().z);
+        tryRecomputeFeature();
+        // checking for case of a null vector is done in FeatureExtrude.cpp
+        // if there was a null vector, the normal vector of the sketch is used.
+        // therefore the vector component edits must be updated
+        updateDirectionEdits();
+    }
 }
 
 void TaskExtrudeParameters::onYDirectionEditChanged(double len)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-    extrude->Direction.setValue(extrude->Direction.getValue().x, len, extrude->Direction.getValue().z);
-    tryRecomputeFeature();
-    updateDirectionEdits();
+    if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+        extrude->Direction.setValue(extrude->Direction.getValue().x,
+                                    len,
+                                    extrude->Direction.getValue().z);
+        tryRecomputeFeature();
+        updateDirectionEdits();
+    }
 }
 
 void TaskExtrudeParameters::onZDirectionEditChanged(double len)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-    extrude->Direction.setValue(extrude->Direction.getValue().x, extrude->Direction.getValue().y, len);
-    tryRecomputeFeature();
-    updateDirectionEdits();
+    if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+        extrude->Direction.setValue(extrude->Direction.getValue().x,
+                                    extrude->Direction.getValue().y,
+                                    len);
+        tryRecomputeFeature();
+        updateDirectionEdits();
+    }
 }
 
 void TaskExtrudeParameters::updateDirectionEdits()
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
     // we don't want to execute the onChanged edits, but just update their contents
     QSignalBlocker xdir(ui->XDirectionEdit);
     QSignalBlocker ydir(ui->YDirectionEdit);
@@ -858,7 +873,11 @@ void TaskExtrudeParameters::updateDirectionEdits()
 
 void TaskExtrudeParameters::setDirectionMode(int index)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
+    if (!extrude) {
+        return;
+    }
+
     // disable AlongSketchNormal when the direction is already normal
     if (index == DirectionModes::Normal)
         ui->checkBoxAlongDirection->setEnabled(false);
@@ -890,20 +909,22 @@ void TaskExtrudeParameters::setDirectionMode(int index)
 
 void TaskExtrudeParameters::onMidplaneChanged(bool on)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-    extrude->Midplane.setValue(on);
-    ui->checkBoxReversed->setEnabled(!on);
-    tryRecomputeFeature();
+    if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+        extrude->Midplane.setValue(on);
+        ui->checkBoxReversed->setEnabled(!on);
+        tryRecomputeFeature();
+    }
 }
 
 void TaskExtrudeParameters::onReversedChanged(bool on)
 {
-    PartDesign::FeatureExtrude* extrude = static_cast<PartDesign::FeatureExtrude*>(vp->getObject());
-    extrude->Reversed.setValue(on);
-    ui->checkBoxMidplane->setEnabled(!on);
-    // update the direction
-    tryRecomputeFeature();
-    updateDirectionEdits();
+    if (auto extrude = getObject<PartDesign::FeatureExtrude>()) {
+        extrude->Reversed.setValue(on);
+        ui->checkBoxMidplane->setEnabled(!on);
+        // update the direction
+        tryRecomputeFeature();
+        updateDirectionEdits();
+    }
 }
 
 void TaskExtrudeParameters::getReferenceAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const
@@ -919,7 +940,7 @@ void TaskExtrudeParameters::getReferenceAxis(App::DocumentObject*& obj, std::vec
         sub.clear();
     }
     else {
-        PartDesign::ProfileBased* pcDirection = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+        auto pcDirection = getObject<PartDesign::ProfileBased>();
         if (!pcDirection->getDocument()->isIn(lnk.getValue()))
             throw Base::RuntimeError("Object was deleted");
 
@@ -1114,7 +1135,7 @@ void TaskExtrudeParameters::saveHistory()
 
 void TaskExtrudeParameters::applyParameters(QString facename)
 {
-    auto obj = vp->getObject();
+    auto obj = getObject();
 
     ui->lengthEdit->apply();
     ui->lengthEdit2->apply();

--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.cpp
@@ -45,9 +45,10 @@ using namespace Gui;
  *********************************************************************/
 
 TaskFeatureParameters::TaskFeatureParameters(PartDesignGui::ViewProvider *vp, QWidget *parent,
-                                                     const std::string& pixmapname, const QString& parname)
-    : TaskBox(Gui::BitmapFactory().pixmap(pixmapname.c_str()),parname,true, parent),
-      vp(vp), blockUpdate(false)
+                                             const std::string& pixmapname, const QString& parname)
+    : TaskBox(Gui::BitmapFactory().pixmap(pixmapname.c_str()), parname, true, parent)
+    , vp(vp)
+    , blockUpdate(false)
 {
     Gui::Document* doc = vp->getDocument();
     this->attachDocument(doc);
@@ -55,8 +56,9 @@ TaskFeatureParameters::TaskFeatureParameters(PartDesignGui::ViewProvider *vp, QW
 
 void TaskFeatureParameters::slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj)
 {
-    if (this->vp == &Obj)
+    if (this->vp == &Obj) {
         this->vp = nullptr;
+    }
 }
 
 void TaskFeatureParameters::onUpdateView(bool on)
@@ -68,9 +70,9 @@ void TaskFeatureParameters::onUpdateView(bool on)
 void TaskFeatureParameters::recomputeFeature()
 {
     if (!blockUpdate) {
-        App::DocumentObject* obj = vp->getObject ();
+        App::DocumentObject* obj = getObject();
         assert (obj);
-        obj->getDocument()->recomputeFeature ( obj );
+        obj->getDocument()->recomputeFeature (obj);
     }
 }
 
@@ -78,15 +80,16 @@ void TaskFeatureParameters::recomputeFeature()
  *                            Task Dialog                            *
  *********************************************************************/
 TaskDlgFeatureParameters::TaskDlgFeatureParameters(PartDesignGui::ViewProvider *vp)
-    : TaskDialog(),vp(vp)
+    : vp(vp)
 {
     assert(vp);
 }
 
 TaskDlgFeatureParameters::~TaskDlgFeatureParameters() = default;
 
-bool TaskDlgFeatureParameters::accept() {
-    App::DocumentObject* feature = vp->getObject();
+bool TaskDlgFeatureParameters::accept()
+{
+    App::DocumentObject* feature = getObject();
 
     try {
         // Iterate over parameter dialogs and apply all parameters from them
@@ -107,7 +110,7 @@ bool TaskDlgFeatureParameters::accept() {
         Gui::cmdAppDocument(feature, "recompute()");
 
         if (!feature->isValid()) {
-            throw Base::RuntimeError(vp->getObject()->getStatusString());
+            throw Base::RuntimeError(getObject()->getStatusString());
         }
 
         App::DocumentObject* previous = static_cast<PartDesign::Feature*>(feature)->getBaseObject(/* silent = */ true );
@@ -136,7 +139,7 @@ bool TaskDlgFeatureParameters::accept() {
 
 bool TaskDlgFeatureParameters::reject()
 {
-    PartDesign::Feature* feature = static_cast<PartDesign::Feature*>(vp->getObject());
+    auto feature = getObject<PartDesign::Feature>();
     App::DocumentObjectWeakPtrT weakptr(feature);
     App::Document* document = feature->getDocument();
 

--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
@@ -59,6 +59,34 @@ private:
     void slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj) override;
 
 protected:
+    template<typename T = PartDesignGui::ViewProvider> T* getViewObject() const
+    {
+        static_assert(std::is_base_of<PartDesignGui::ViewProvider, T>::value,
+                "Wrong template argument");
+        return dynamic_cast<T*>(vp);
+    }
+
+    template<typename T = App::DocumentObject> T* getObject() const
+    {
+        static_assert(std::is_base_of<App::DocumentObject, T>::value, "Wrong template argument");
+        if (vp) {
+            return dynamic_cast<T*>(vp->getObject());
+        }
+
+        return nullptr;
+    }
+
+    Gui::Document* getGuiDocument() const
+    {
+        return vp ? vp->getDocument() : nullptr;
+    }
+
+    App::Document* getAppDocument() const
+    {
+        auto obj = getObject();
+        return obj ? obj->getDocument() : nullptr;
+    }
+
     bool isUpdateBlocked() const
     {
         return blockUpdate;
@@ -98,11 +126,25 @@ public:
     /// is called by the framework if the dialog is rejected (Cancel)
     bool reject() override;
 
-    /// Returns the view provider dialog is runed for
-     PartDesignGui::ViewProvider *viewProvider() const { return vp; }
+    template<typename T = PartDesignGui::ViewProvider> T* getViewObject() const
+    {
+        static_assert(std::is_base_of<PartDesignGui::ViewProvider, T>::value,
+                "Wrong template argument");
+        return dynamic_cast<T*>(vp);
+    }
 
-protected:
-    PartDesignGui::ViewProvider *vp;
+    template<typename T = App::DocumentObject> T* getObject() const
+    {
+        static_assert(std::is_base_of<App::DocumentObject, T>::value, "Wrong template argument");
+        if (vp) {
+            return dynamic_cast<T*>(vp->getObject());
+        }
+
+        return nullptr;
+    }
+
+private:
+    PartDesignGui::ViewProvider* vp;
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
@@ -59,8 +59,27 @@ private:
     void slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj) override;
 
 protected:
+    bool isUpdateBlocked() const
+    {
+        return blockUpdate;
+    }
+
+    bool& getUpdateBlockRef()
+    {
+        return blockUpdate;
+    }
+
+    void setUpdateBlocked(bool value)
+    {
+        blockUpdate = value;
+    }
+
+
+protected:
     PartDesignGui::ViewProvider *vp;
     /// Lock updateUI(), applying changes to the underlying feature and calling recomputeFeature()
+
+private:
     bool blockUpdate;
 };
 

--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
@@ -24,6 +24,7 @@
 #define TASKFEATUREPARAMETERS_H_NAHKE2YZ
 
 
+#include <type_traits>
 #include <Gui/TaskView/TaskDialog.h>
 #include <Gui/TaskView/TaskView.h>
 #include <Gui/DocumentObserver.h>
@@ -102,12 +103,8 @@ protected:
         blockUpdate = value;
     }
 
-
-protected:
-    PartDesignGui::ViewProvider *vp;
-    /// Lock updateUI(), applying changes to the underlying feature and calling recomputeFeature()
-
 private:
+    PartDesignGui::ViewProvider *vp;
     bool blockUpdate;
 };
 

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -209,20 +209,12 @@ TaskDlgFilletParameters::~TaskDlgFilletParameters() = default;
 
 //==== calls from the TaskView ===============================================================
 
-
-//void TaskDlgFilletParameters::open()
-//{
-//    // a transaction is already open at creation time of the fillet
-//    if (!Gui::Command::hasPendingCommand()) {
-//        QString msg = tr("Edit fillet");
-//        Gui::Command::openCommand((const char*)msg.toUtf8());
-//    }
-//}
 bool TaskDlgFilletParameters::accept()
 {
-    auto obj = vp->getObject();
-    if (!obj->isError())
+    auto obj = getObject();
+    if (!obj->isError()) {
         parameter->showObject();
+    }
 
     parameter->apply();
 

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -115,13 +115,16 @@ void TaskFilletParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 
 void TaskFilletParameters::onCheckBoxUseAllEdgesToggled(bool checked)
 {
-    if (checked)
-        setSelectionMode(none);
-    PartDesign::Fillet* pcFillet = static_cast<PartDesign::Fillet*>(DressUpView->getObject());
-    ui->buttonRefSel->setEnabled(!checked);
-    ui->listWidgetReferences->setEnabled(!checked);
-    pcFillet->UseAllEdges.setValue(checked);
-    pcFillet->getDocument()->recomputeFeature(pcFillet);
+    if (auto fillet = getObject<PartDesign::Fillet>()) {
+        if (checked) {
+            setSelectionMode(none);
+        }
+
+        ui->buttonRefSel->setEnabled(!checked);
+        ui->listWidgetReferences->setEnabled(!checked);
+        fillet->UseAllEdges.setValue(checked);
+        fillet->recomputeFeature();
+    }
 }
 
 void TaskFilletParameters::setButtons(const selectionModes mode)
@@ -142,13 +145,14 @@ void TaskFilletParameters::onAddAllEdges()
 
 void TaskFilletParameters::onLengthChanged(double len)
 {
-    setSelectionMode(none);
-    PartDesign::Fillet* pcFillet = static_cast<PartDesign::Fillet*>(DressUpView->getObject());
-    setupTransaction();
-    pcFillet->Radius.setValue(len);
-    pcFillet->getDocument()->recomputeFeature(pcFillet);
-    // hide the fillet if there was a computation error
-    hideOnError();
+    if (auto fillet = getObject<PartDesign::Fillet>()) {
+        setSelectionMode(none);
+        setupTransaction();
+        fillet->Radius.setValue(len);
+        fillet->recomputeFeature();
+        // hide the fillet if there was a computation error
+        hideOnError();
+    }
 }
 
 double TaskFilletParameters::getLength() const

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -74,7 +74,7 @@ TaskHelixParameters::TaskHelixParameters(PartDesignGui::ViewProviderHelix* Helix
 
 void TaskHelixParameters::initializeHelix()
 {
-    PartDesign::Helix* helix = static_cast<PartDesign::Helix*>(vp->getObject());
+    auto helix = getObject<PartDesign::Helix>();
     if (!(helix->HasBeenEdited).getValue()) {
         helix->proposeParameters();
         recomputeFeature();
@@ -83,7 +83,7 @@ void TaskHelixParameters::initializeHelix()
 
 void TaskHelixParameters::assignProperties()
 {
-    PartDesign::Helix* helix = static_cast<PartDesign::Helix*>(vp->getObject());
+    auto helix = getObject<PartDesign::Helix>();
     propAngle = &(helix->Angle);
     propGrowth = &(helix->Growth);
     propPitch = &(helix->Pitch);
@@ -123,7 +123,7 @@ void TaskHelixParameters::setValuesFromProperties()
 
 void TaskHelixParameters::bindProperties()
 {
-    PartDesign::Helix* helix = static_cast<PartDesign::Helix*>(vp->getObject());
+    auto helix = getObject<PartDesign::Helix>();
     ui->pitch->bind(helix->Pitch);
     ui->height->bind(helix->Height);
     ui->turns->bind(helix->Turns);
@@ -162,8 +162,7 @@ void TaskHelixParameters::connectSlots()
 void TaskHelixParameters::showCoordinateAxes()
 {
     //show the parts coordinate system axis for selection
-    PartDesign::Body* body = PartDesign::Body::findBodyOf(vp->getObject());
-    if (body) {
+    if (PartDesign::Body* body = PartDesign::Body::findBodyOf(getObject())) {
         try {
             App::Origin* origin = body->getOrigin();
             ViewProviderOrigin* vpOrigin;
@@ -205,26 +204,25 @@ void TaskHelixParameters::fillAxisCombo(bool forceRefill)
 
 void TaskHelixParameters::addSketchAxes()
 {
-    PartDesign::ProfileBased* pcFeat = static_cast<PartDesign::ProfileBased*>(vp->getObject());
-    Part::Part2DObject* pcSketch = dynamic_cast<Part::Part2DObject*>(pcFeat->Profile.getValue());
-    if (pcSketch) {
-        addAxisToCombo(pcSketch, "N_Axis", tr("Normal sketch axis"));
-        addAxisToCombo(pcSketch, "V_Axis", tr("Vertical sketch axis"));
-        addAxisToCombo(pcSketch, "H_Axis", tr("Horizontal sketch axis"));
-        for (int i = 0; i < pcSketch->getAxisCount(); i++) {
+    auto profile = getObject<PartDesign::ProfileBased>();
+    auto sketch = dynamic_cast<Part::Part2DObject*>(profile->Profile.getValue());
+    if (sketch) {
+        addAxisToCombo(sketch, "N_Axis", tr("Normal sketch axis"));
+        addAxisToCombo(sketch, "V_Axis", tr("Vertical sketch axis"));
+        addAxisToCombo(sketch, "H_Axis", tr("Horizontal sketch axis"));
+        for (int i = 0; i < sketch->getAxisCount(); i++) {
             QString itemText = tr("Construction line %1").arg(i + 1);
             std::stringstream sub;
             sub << "Axis" << i;
-            addAxisToCombo(pcSketch, sub.str(), itemText);
+            addAxisToCombo(sketch, sub.str(), itemText);
         }
     }
 }
 
 void TaskHelixParameters::addPartAxes()
 {
-    PartDesign::ProfileBased* pcFeat = static_cast<PartDesign::ProfileBased*>(vp->getObject());
-    PartDesign::Body* body = PartDesign::Body::findBodyOf(pcFeat);
-    if (body) {
+    auto profile = getObject<PartDesign::ProfileBased>();
+    if (PartDesign::Body* body = PartDesign::Body::findBodyOf(profile)) {
         try {
             App::Origin* orig = body->getOrigin();
             addAxisToCombo(orig->getX(), "", tr("Base X axis"));
@@ -271,11 +269,11 @@ void TaskHelixParameters::addAxisToCombo(App::DocumentObject* linkObj, std::stri
 
 void TaskHelixParameters::updateStatus()
 {
-    auto pcHelix = static_cast<PartDesign::Helix*>(vp->getObject());
-    auto status = std::string(pcHelix->getStatusString());
+    auto helix = getObject<PartDesign::Helix>();
+    auto status = std::string(helix->getStatusString());
     QString translatedStatus;
     if (status.compare("Valid") == 0 || status.compare("Touched") == 0) {
-        if (pcHelix->safePitch() > pcHelix->Pitch.getValue()) {
+        if (helix->safePitch() > helix->Pitch.getValue()) {
             translatedStatus = tr("Warning: helix might be self intersecting");
         }
     }
@@ -303,8 +301,8 @@ void TaskHelixParameters::adaptVisibilityToMode()
     bool isAngleVisible = false;
     bool isGrowthVisible = false;
 
-    auto pcHelix = static_cast<PartDesign::Helix*>(vp->getObject());
-    if (pcHelix->getAddSubType() == PartDesign::FeatureAddSub::Subtractive)
+    auto helix = getObject<PartDesign::Helix>();
+    if (helix->getAddSubType() == PartDesign::FeatureAddSub::Subtractive)
         isOutsideVisible = true;
 
     HelixMode mode = static_cast<HelixMode>(propMode->getValue());
@@ -352,47 +350,48 @@ void TaskHelixParameters::adaptVisibilityToMode()
 
 void TaskHelixParameters::assignToolTipsFromPropertyDocs()
 {
-    auto pcHelix = static_cast<PartDesign::Helix*>(vp->getObject());
+    auto helix = getObject<PartDesign::Helix>();
     const char* propCategory = "App::Property"; // cf. https://tracker.freecad.org/view.php?id=0002524
     QString toolTip;
 
     // Beware that "Axis" in the GUI actually represents the property "ReferenceAxis"!
-    // The property "Axis" holds only the directional part of the reference axis and has no corresponding GUI element.
-    toolTip = QApplication::translate(propCategory, pcHelix->ReferenceAxis.getDocumentation());
+    // The property "Axis" holds only the directional part of the reference axis and has no
+    // corresponding GUI element.
+    toolTip = QApplication::translate(propCategory, helix->ReferenceAxis.getDocumentation());
     ui->axis->setToolTip(toolTip);
     ui->labelAxis->setToolTip(toolTip);
 
-    toolTip = QApplication::translate(propCategory, pcHelix->Mode.getDocumentation());
+    toolTip = QApplication::translate(propCategory, helix->Mode.getDocumentation());
     ui->inputMode->setToolTip(toolTip);
     ui->labelInputMode->setToolTip(toolTip);
 
-    toolTip = QApplication::translate(propCategory, pcHelix->Pitch.getDocumentation());
+    toolTip = QApplication::translate(propCategory, helix->Pitch.getDocumentation());
     ui->pitch->setToolTip(toolTip);
     ui->labelPitch->setToolTip(toolTip);
 
-    toolTip = QApplication::translate(propCategory, pcHelix->Height.getDocumentation());
+    toolTip = QApplication::translate(propCategory, helix->Height.getDocumentation());
     ui->height->setToolTip(toolTip);
     ui->labelHeight->setToolTip(toolTip);
 
-    toolTip = QApplication::translate(propCategory, pcHelix->Turns.getDocumentation());
+    toolTip = QApplication::translate(propCategory, helix->Turns.getDocumentation());
     ui->turns->setToolTip(toolTip);
     ui->labelTurns->setToolTip(toolTip);
 
-    toolTip = QApplication::translate(propCategory, pcHelix->Angle.getDocumentation());
+    toolTip = QApplication::translate(propCategory, helix->Angle.getDocumentation());
     ui->coneAngle->setToolTip(toolTip);
     ui->labelConeAngle->setToolTip(toolTip);
 
-    toolTip = QApplication::translate(propCategory, pcHelix->Growth.getDocumentation());
+    toolTip = QApplication::translate(propCategory, helix->Growth.getDocumentation());
     ui->growth->setToolTip(toolTip);
     ui->labelGrowth->setToolTip(toolTip);
 
-    toolTip = QApplication::translate(propCategory, pcHelix->LeftHanded.getDocumentation());
+    toolTip = QApplication::translate(propCategory, helix->LeftHanded.getDocumentation());
     ui->checkBoxLeftHanded->setToolTip(toolTip);
 
-    toolTip = QApplication::translate(propCategory, pcHelix->Reversed.getDocumentation());
+    toolTip = QApplication::translate(propCategory, helix->Reversed.getDocumentation());
     ui->checkBoxReversed->setToolTip(toolTip);
 
-    toolTip = QApplication::translate(propCategory, pcHelix->Outside.getDocumentation());
+    toolTip = QApplication::translate(propCategory, helix->Outside.getDocumentation());
     ui->checkBoxOutside->setToolTip(toolTip);
 }
 
@@ -400,8 +399,8 @@ void TaskHelixParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
     if (msg.Type == Gui::SelectionChanges::AddSelection) {
         std::vector<std::string> axis;
-        App::DocumentObject* selObj;
-        if (getReferencedSelection(vp->getObject(), msg, selObj, axis) && selObj) {
+        App::DocumentObject* selObj {};
+        if (getReferencedSelection(getObject(), msg, selObj, axis) && selObj) {
             exitSelectionMode();
             propReferenceAxis->setValue(selObj, axis);
             recomputeFeature();
@@ -412,42 +411,52 @@ void TaskHelixParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 
 void TaskHelixParameters::onPitchChanged(double len)
 {
-    propPitch->setValue(len);
-    recomputeFeature();
-    updateUI();
+    if (getObject()) {
+        propPitch->setValue(len);
+        recomputeFeature();
+        updateUI();
+    }
 }
 
 void TaskHelixParameters::onHeightChanged(double len)
 {
-    propHeight->setValue(len);
-    recomputeFeature();
-    updateUI();
+    if (getObject()) {
+        propHeight->setValue(len);
+        recomputeFeature();
+        updateUI();
+    }
 }
 
 void TaskHelixParameters::onTurnsChanged(double len)
 {
-    propTurns->setValue(len);
-    recomputeFeature();
-    updateUI();
+    if (getObject()) {
+        propTurns->setValue(len);
+        recomputeFeature();
+        updateUI();
+    }
 }
 
 void TaskHelixParameters::onAngleChanged(double len)
 {
-    propAngle->setValue(len);
-    recomputeFeature();
-    updateUI();
+    if (getObject()) {
+        propAngle->setValue(len);
+        recomputeFeature();
+        updateUI();
+    }
 }
 
 void TaskHelixParameters::onGrowthChanged(double len)
 {
-    propGrowth->setValue(len);
-    recomputeFeature();
-    updateUI();
+    if (getObject()) {
+        propGrowth->setValue(len);
+        recomputeFeature();
+        updateUI();
+    }
 }
 
 void TaskHelixParameters::onAxisChanged(int num)
 {
-    PartDesign::ProfileBased* pcHelix = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+    auto helix = getObject<PartDesign::ProfileBased>();
 
     if (axesInList.empty())
         return;
@@ -462,7 +471,7 @@ void TaskHelixParameters::onAxisChanged(int num)
     if (!lnk.getValue()) {
         // enter reference selection mode
         // assure the sketch is visible
-        if (auto sketch = dynamic_cast<Part::Part2DObject *>(pcHelix->Profile.getValue())) {
+        if (auto sketch = dynamic_cast<Part::Part2DObject *>(helix->Profile.getValue())) {
             Gui::cmdAppObjectShow(sketch);
         }
         TaskSketchBasedParameters::onSelectReference(
@@ -472,7 +481,7 @@ void TaskHelixParameters::onAxisChanged(int num)
         return;
     }
     else {
-        if (!pcHelix->getDocument()->isIn(lnk.getValue())) {
+        if (!helix->getDocument()->isIn(lnk.getValue())) {
             Base::Console().Error("Object was deleted\n");
             return;
         }
@@ -525,23 +534,29 @@ void TaskHelixParameters::onModeChanged(int index)
 
 void TaskHelixParameters::onLeftHandedChanged(bool on)
 {
-    propLeftHanded->setValue(on);
-    recomputeFeature();
-    updateUI();
+    if (getObject()) {
+        propLeftHanded->setValue(on);
+        recomputeFeature();
+        updateUI();
+    }
 }
 
 void TaskHelixParameters::onReversedChanged(bool on)
 {
-    propReversed->setValue(on);
-    recomputeFeature();
-    updateUI();
+    if (getObject()) {
+        propReversed->setValue(on);
+        recomputeFeature();
+        updateUI();
+    }
 }
 
 void TaskHelixParameters::onOutsideChanged(bool on)
 {
-    propOutside->setValue(on);
-    recomputeFeature();
-    updateUI();
+    if (getObject()) {
+        propOutside->setValue(on);
+        recomputeFeature();
+        updateUI();
+    }
 }
 
 
@@ -549,10 +564,11 @@ TaskHelixParameters::~TaskHelixParameters()
 {
     try {
         //hide the parts coordinate system axis for selection
-        PartDesign::Body* body = vp ? PartDesign::Body::findBodyOf(vp->getObject()) : nullptr;
+        auto obj = getObject();
+        PartDesign::Body* body = obj ? PartDesign::Body::findBodyOf(obj) : nullptr;
         if (body) {
             App::Origin* origin = body->getOrigin();
-            ViewProviderOrigin* vpOrigin;
+            ViewProviderOrigin* vpOrigin {};
             vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->resetTemporaryVisibility();
         }
@@ -585,8 +601,9 @@ void TaskHelixParameters::changeEvent(QEvent* e)
 
 void TaskHelixParameters::getReferenceAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const
 {
-    if (axesInList.empty())
+    if (axesInList.empty()) {
         throw Base::RuntimeError("Not initialized!");
+    }
 
     int num = ui->axis->currentIndex();
     const App::PropertyLinkSub& lnk = *(axesInList.at(num));
@@ -594,8 +611,8 @@ void TaskHelixParameters::getReferenceAxis(App::DocumentObject*& obj, std::vecto
         throw Base::RuntimeError("Still in reference selection mode; reference wasn't selected yet");
     }
     else {
-        PartDesign::ProfileBased* pcRevolution = static_cast<PartDesign::ProfileBased*>(vp->getObject());
-        if (!pcRevolution->getDocument()->isIn(lnk.getValue())) {
+        auto revolution = getObject<PartDesign::ProfileBased>();
+        if (!revolution->getDocument()->isIn(lnk.getValue())) {
             throw Base::RuntimeError("Object was deleted");
         }
 
@@ -617,40 +634,42 @@ bool TaskHelixParameters::showPreview(PartDesign::Helix* helix)
 
 void TaskHelixParameters::startReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base)
 {
-    PartDesign::Helix* pcHelix = dynamic_cast<PartDesign::Helix*>(vp->getObject());
-    if (pcHelix && showPreview(pcHelix)) {
-        Gui::Document* doc = vp->getDocument();
-        if (doc) {
-            doc->setHide(profile->getNameInDocument());
+    if (auto helix = getObject<PartDesign::Helix>()) {
+        if (helix && showPreview(helix)) {
+            Gui::Document* doc = getGuiDocument();
+            if (doc) {
+                doc->setHide(profile->getNameInDocument());
+            }
         }
-    }
-    else {
-        TaskSketchBasedParameters::startReferenceSelection(profile, base);
+        else {
+            TaskSketchBasedParameters::startReferenceSelection(profile, base);
+        }
     }
 }
 
 void TaskHelixParameters::finishReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base)
 {
-    PartDesign::Helix* pcHelix = dynamic_cast<PartDesign::Helix*>(vp->getObject());
-    if (pcHelix && showPreview(pcHelix)) {
-        Gui::Document* doc = vp->getDocument();
-        if (doc) {
-            doc->setShow(profile->getNameInDocument());
+    if (auto helix = getObject<PartDesign::Helix>()) {
+        if (helix && showPreview(helix)) {
+            Gui::Document* doc = getGuiDocument();
+            if (doc) {
+                doc->setShow(profile->getNameInDocument());
+            }
         }
-    }
-    else {
-        TaskSketchBasedParameters::finishReferenceSelection(profile, base);
+        else {
+            TaskSketchBasedParameters::finishReferenceSelection(profile, base);
+        }
     }
 }
 
 // this is used for logging the command fully when recording macros
-void TaskHelixParameters::apply()
+void TaskHelixParameters::apply()  // NOLINT
 {
     std::vector<std::string> sub;
-    App::DocumentObject* obj;
+    App::DocumentObject* obj {};
     getReferenceAxis(obj, sub);
     std::string axis = buildLinkSingleSubPythonStr(obj, sub);
-    auto tobj = vp->getObject();
+    auto tobj = getObject();
     FCMD_OBJ_CMD(tobj, "ReferenceAxis = " << axis);
     FCMD_OBJ_CMD(tobj, "Mode = " << propMode->getValue());
     FCMD_OBJ_CMD(tobj, "Pitch = " << propPitch->getValue());

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -27,6 +27,7 @@
 #include <App/DocumentObject.h>
 #include <App/Origin.h>
 #include <Base/Console.h>
+#include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/CommandT.h>
 #include <Gui/Document.h>
@@ -177,8 +178,7 @@ void TaskHelixParameters::showCoordinateAxes()
 
 void TaskHelixParameters::fillAxisCombo(bool forceRefill)
 {
-    bool oldVal_blockUpdate = blockUpdate;
-    blockUpdate = true;
+    Base::StateLocker lock(getUpdateBlockRef(), true);
 
     if (axesInList.empty())
         forceRefill = true;//not filled yet, full refill
@@ -201,8 +201,6 @@ void TaskHelixParameters::fillAxisCombo(bool forceRefill)
     int indexOfCurrent = addCurrentLink();
     if (indexOfCurrent != -1)
         ui->axis->setCurrentIndex(indexOfCurrent);
-
-    blockUpdate = oldVal_blockUpdate;
 }
 
 void TaskHelixParameters::addSketchAxes()

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.h
@@ -134,9 +134,6 @@ class TaskDlgHelixParameters : public TaskDlgSketchBasedParameters
 
 public:
     explicit TaskDlgHelixParameters(ViewProviderHelix* HelixView);
-
-    ViewProviderHelix* getHelixView() const
-    { return static_cast<ViewProviderHelix*>(vp); }
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -1185,7 +1185,7 @@ TaskDlgHoleParameters::TaskDlgHoleParameters(ViewProviderHole* HoleView)
     : TaskDlgSketchBasedParameters(HoleView)
 {
     assert(HoleView);
-    parameter = new TaskHoleParameters(static_cast<ViewProviderHole*>(vp));
+    parameter = new TaskHoleParameters(HoleView);
 
     Content.push_back(parameter);
 }

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -281,7 +281,7 @@ void TaskHoleParameters::threadedChanged()
     // update view not active if modeling threads
     // this will also ensure that the feature is recomputed.
     ui->UpdateView->setEnabled(ui->Threaded->isChecked() && ui->ModelThread->isChecked());
-    blockUpdate = ui->Threaded->isChecked() && ui->ModelThread->isChecked() && !(ui->UpdateView->isChecked());
+    setUpdateBlocked(ui->Threaded->isChecked() && ui->ModelThread->isChecked() && !(ui->UpdateView->isChecked()));
 
     pcHole->Threaded.setValue(ui->Threaded->isChecked());
     recomputeFeature();
@@ -296,7 +296,7 @@ void TaskHoleParameters::modelThreadChanged()
     // update view not active if modeling threads
     // this will also ensure that the feature is recomputed.
     ui->UpdateView->setEnabled(ui->Threaded->isChecked() && ui->ModelThread->isChecked());
-    blockUpdate = ui->Threaded->isChecked() && ui->ModelThread->isChecked() && !(ui->UpdateView->isChecked());
+    setUpdateBlocked(ui->Threaded->isChecked() && ui->ModelThread->isChecked() && !(ui->UpdateView->isChecked()));
 
     // conditional enabling of thread modeling options
     ui->UseCustomThreadClearance->setEnabled(ui->Threaded->isChecked() && ui->ModelThread->isChecked());
@@ -310,7 +310,7 @@ void TaskHoleParameters::modelThreadChanged()
 
 void TaskHoleParameters::updateViewChanged(bool isChecked)
 {
-    blockUpdate = !isChecked;
+    setUpdateBlocked(!isChecked);
     recomputeFeature();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -51,7 +51,7 @@ namespace sp = std::placeholders;
 
 TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* parent)
     : TaskSketchBasedParameters(HoleView, parent, "PartDesign_Hole", tr("Hole parameters"))
-    , observer(new Observer(this, static_cast<PartDesign::Hole*>(vp->getObject())))
+    , observer(new Observer(this, getObject<PartDesign::Hole>()))
     , isApplying(false)
     , ui(new Ui_TaskHoleParameters)
 {
@@ -68,7 +68,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
     ui->ThreadType->addItem(tr("UTS extra fine profile"), QByteArray("UTS"));
 
     // read values from the hole properties
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    auto pcHole = getObject<PartDesign::Hole>();
 
     ui->Threaded->setChecked(pcHole->Threaded.getValue());
     ui->Threaded->setDisabled(std::string(pcHole->ThreadType.getValueAsString()) == "None");
@@ -238,7 +238,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
     connect(ui->ThreadDepth, qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
             this, &TaskHoleParameters::threadDepthChanged);
 
-    vp->show();
+    getViewObject()->show();
 
     ui->Diameter->bind(pcHole->Diameter);
     ui->HoleCutDiameter->bind(pcHole->HoleCutDiameter);
@@ -262,7 +262,7 @@ TaskHoleParameters::~TaskHoleParameters() = default;
 
 void TaskHoleParameters::threadedChanged()
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    auto pcHole = getObject<PartDesign::Hole>();
 
     bool isChecked = ui->Threaded->isChecked();
     pcHole->Threaded.setValue(isChecked);
@@ -289,7 +289,7 @@ void TaskHoleParameters::threadedChanged()
 
 void TaskHoleParameters::modelThreadChanged()
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    auto pcHole = getObject<PartDesign::Hole>();
 
     pcHole->ModelThread.setValue(ui->ModelThread->isChecked());
 
@@ -316,20 +316,20 @@ void TaskHoleParameters::updateViewChanged(bool isChecked)
 
 void TaskHoleParameters::threadDepthTypeChanged(int index)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->ThreadDepthType.setValue(index);
-    ui->ThreadDepth->setEnabled(index == 1);
-    ui->ThreadDepth->setValue(pcHole->ThreadDepth.getValue());
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->ThreadDepthType.setValue(index);
+        ui->ThreadDepth->setEnabled(index == 1);
+        ui->ThreadDepth->setValue(hole->ThreadDepth.getValue());
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::threadDepthChanged(double value)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->ThreadDepth.setValue(value);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->ThreadDepth.setValue(value);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::useCustomThreadClearanceChanged()
@@ -338,26 +338,26 @@ void TaskHoleParameters::useCustomThreadClearanceChanged()
     ui->CustomThreadClearance->setEnabled(isChecked);
     ui->ThreadClass->setDisabled(isChecked);
 
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->UseCustomThreadClearance.setValue(isChecked);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->UseCustomThreadClearance.setValue(isChecked);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::customThreadClearanceChanged(double value)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->CustomThreadClearance.setValue(value);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->CustomThreadClearance.setValue(value);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::threadPitchChanged(double value)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->ThreadPitch.setValue(value);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->ThreadPitch.setValue(value);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::holeCutTypeChanged(int index)
@@ -365,30 +365,30 @@ void TaskHoleParameters::holeCutTypeChanged(int index)
     if (index < 0)
         return;
 
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    auto hole = getObject<PartDesign::Hole>();
 
     // the HoleCutDepth is something different for countersinks and counterbores
     // therefore reset it, it will be reset to sensible values by setting the new HoleCutType
-    pcHole->HoleCutDepth.setValue(0.0);
-    pcHole->HoleCutType.setValue(index);
+    hole->HoleCutDepth.setValue(0.0);
+    hole->HoleCutType.setValue(index);
 
     // when holeCutType was changed, reset HoleCutCustomValues to false because it should
     // be a purpose decision to overwrite the normed values
     // we will handle the case that there is no normed value later in this routine
     ui->HoleCutCustomValues->setChecked(false);
-    pcHole->HoleCutCustomValues.setValue(false);
+    hole->HoleCutCustomValues.setValue(false);
 
     // recompute to get the info about the HoleCutType properties
     recomputeFeature();
 
     // apply the result to the widgets
-    ui->HoleCutCustomValues->setDisabled(pcHole->HoleCutCustomValues.isReadOnly());
-    ui->HoleCutCustomValues->setChecked(pcHole->HoleCutCustomValues.getValue());
+    ui->HoleCutCustomValues->setDisabled(hole->HoleCutCustomValues.isReadOnly());
+    ui->HoleCutCustomValues->setChecked(hole->HoleCutCustomValues.getValue());
 
     // HoleCutCustomValues is only enabled for screw definitions
     // we must do this after recomputeFeature() because this gives us the info if
     // the type is a countersink and thus if HoleCutCountersinkAngle can be enabled
-    std::string HoleCutTypeString = pcHole->HoleCutType.getValueAsString();
+    std::string HoleCutTypeString = hole->HoleCutType.getValueAsString();
     if (HoleCutTypeString == "None" || HoleCutTypeString == "Counterbore"
         || HoleCutTypeString == "Countersink" || HoleCutTypeString == "Counterdrill") {
         ui->HoleCutCustomValues->setEnabled(false);
@@ -408,7 +408,7 @@ void TaskHoleParameters::holeCutTypeChanged(int index)
         if (ui->HoleCutCustomValues->isChecked()) {
             ui->HoleCutDiameter->setEnabled(true);
             ui->HoleCutDepth->setEnabled(true);
-            if (!pcHole->HoleCutCountersinkAngle.isReadOnly())
+            if (!hole->HoleCutCountersinkAngle.isReadOnly())
                 ui->HoleCutCountersinkAngle->setEnabled(true);
         }
         else {
@@ -422,54 +422,58 @@ void TaskHoleParameters::holeCutTypeChanged(int index)
 
 void TaskHoleParameters::holeCutCustomValuesChanged()
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->HoleCutCustomValues.setValue(ui->HoleCutCustomValues->isChecked());
 
-    pcHole->HoleCutCustomValues.setValue(ui->HoleCutCustomValues->isChecked());
+        if (ui->HoleCutCustomValues->isChecked()) {
+            ui->HoleCutDiameter->setEnabled(true);
+            ui->HoleCutDepth->setEnabled(true);
+            if (!hole->HoleCutCountersinkAngle.isReadOnly())
+                ui->HoleCutCountersinkAngle->setEnabled(true);
+        }
+        else {
+            ui->HoleCutDiameter->setEnabled(false);
+            ui->HoleCutDepth->setEnabled(false);
+            ui->HoleCutCountersinkAngle->setEnabled(false);
+        }
 
-    if (ui->HoleCutCustomValues->isChecked()) {
-        ui->HoleCutDiameter->setEnabled(true);
-        ui->HoleCutDepth->setEnabled(true);
-        if (!pcHole->HoleCutCountersinkAngle.isReadOnly())
-            ui->HoleCutCountersinkAngle->setEnabled(true);
+        recomputeFeature();
     }
-    else {
-        ui->HoleCutDiameter->setEnabled(false);
-        ui->HoleCutDepth->setEnabled(false);
-        ui->HoleCutCountersinkAngle->setEnabled(false);
-    }
-
-    recomputeFeature();
 }
 
 void TaskHoleParameters::holeCutDiameterChanged(double value)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->HoleCutDiameter.setValue(value);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->HoleCutDiameter.setValue(value);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::holeCutDepthChanged(double value)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-    std::string HoleCutTypeString = pcHole->HoleCutType.getValueAsString();
+    auto hole = getObject<PartDesign::Hole>();
+    if (!hole) {
+        return;
+    }
+
+    std::string HoleCutTypeString = hole->HoleCutType.getValueAsString();
 
     if (ui->HoleCutCountersinkAngle->isEnabled() && HoleCutTypeString != "Counterdrill") {
         // we have a countersink and recalculate the HoleCutDiameter
 
         // store current depth
-        double DepthDifference = value - pcHole->HoleCutDepth.getValue();
+        double DepthDifference = value - hole->HoleCutDepth.getValue();
         // new diameter is the old one + 2 * tan(angle / 2) * DepthDifference
-        double newDiameter = pcHole->HoleCutDiameter.getValue()
-            + 2 * tan(Base::toRadians(pcHole->HoleCutCountersinkAngle.getValue() / 2)) * DepthDifference;
+        double newDiameter = hole->HoleCutDiameter.getValue()
+            + 2 * tan(Base::toRadians(hole->HoleCutCountersinkAngle.getValue() / 2)) * DepthDifference;
         // only apply if the result is not smaller than the hole diameter
-        if (newDiameter > pcHole->Diameter.getValue()) {
-            pcHole->HoleCutDiameter.setValue(newDiameter);
-            pcHole->HoleCutDepth.setValue(value);
+        if (newDiameter > hole->Diameter.getValue()) {
+            hole->HoleCutDiameter.setValue(newDiameter);
+            hole->HoleCutDepth.setValue(value);
         }
     }
     else {
-        pcHole->HoleCutDepth.setValue(value);
+        hole->HoleCutDepth.setValue(value);
     }
 
     recomputeFeature();
@@ -477,20 +481,23 @@ void TaskHoleParameters::holeCutDepthChanged(double value)
 
 void TaskHoleParameters::holeCutCountersinkAngleChanged(double value)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->HoleCutCountersinkAngle.setValue(value);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->HoleCutCountersinkAngle.setValue(value);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::depthChanged(int index)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    auto hole = getObject<PartDesign::Hole>();
+    if (!hole) {
+        return;
+    }
 
-    pcHole->DepthType.setValue(index);
+    hole->DepthType.setValue(index);
 
     // disable drill point widgets if not 'Dimension'
-    if (std::string(pcHole->DepthType.getValueAsString()) == "Dimension") {
+    if (std::string(hole->DepthType.getValueAsString()) == "Dimension") {
         ui->drillPointFlat->setEnabled(true);
         ui->drillPointAngled->setEnabled(true);
         ui->DrillPointAngle->setEnabled(true);
@@ -504,73 +511,73 @@ void TaskHoleParameters::depthChanged(int index)
     }
     recomputeFeature();
     // enabling must be handled after recompute
-    ui->ThreadDepth->setEnabled(std::string(pcHole->ThreadDepthType.getValueAsString()) == "Dimension");
+    ui->ThreadDepth->setEnabled(std::string(hole->ThreadDepthType.getValueAsString()) == "Dimension");
 }
 
 void TaskHoleParameters::depthValueChanged(double value)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->Depth.setValue(value);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->Depth.setValue(value);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::drillPointChanged()
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    if (sender() == ui->drillPointFlat) {
-        pcHole->DrillPoint.setValue((long)0);
-        ui->DrillForDepth->setEnabled(false);
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        if (sender() == ui->drillPointFlat) {
+            hole->DrillPoint.setValue(0L);
+            ui->DrillForDepth->setEnabled(false);
+        }
+        else if (sender() == ui->drillPointAngled) {
+            hole->DrillPoint.setValue(1L);
+            ui->DrillForDepth->setEnabled(true);
+        }
+        else {
+            assert(0);
+        }
+        recomputeFeature();
     }
-    else if (sender() == ui->drillPointAngled) {
-        pcHole->DrillPoint.setValue((long)1);
-        ui->DrillForDepth->setEnabled(true);
-    }
-    else {
-        assert(0);
-    }
-    recomputeFeature();
 }
 
 void TaskHoleParameters::drillPointAngledValueChanged(double value)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->DrillPointAngle.setValue((double)value);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->DrillPointAngle.setValue(value);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::drillForDepthChanged()
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->DrillForDepth.setValue(ui->DrillForDepth->isChecked());
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->DrillForDepth.setValue(ui->DrillForDepth->isChecked());
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::taperedChanged()
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->Tapered.setValue(ui->Tapered->isChecked());
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->Tapered.setValue(ui->Tapered->isChecked());
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::reversedChanged()
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->Reversed.setValue(ui->Reversed->isChecked());
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->Reversed.setValue(ui->Reversed->isChecked());
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::taperedAngleChanged(double value)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->TaperedAngle.setValue(value);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->TaperedAngle.setValue(value);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::threadTypeChanged(int index)
@@ -578,7 +585,10 @@ void TaskHoleParameters::threadTypeChanged(int index)
     if (index < 0)
         return;
 
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    auto hole = getObject<PartDesign::Hole>();
+    if (!hole) {
+        return;
+    }
 
     // A typical case is that users change from an ISO profile to another one.
     // When they had e.g. the size "M3" in one profile they expect
@@ -596,10 +606,10 @@ void TaskHoleParameters::threadTypeChanged(int index)
     QString CutTypeString = ui->HoleCutType->currentText();
 
     // now set the new type, this will reset the comboboxes to item 0
-    pcHole->ThreadType.setValue(index);
+    hole->ThreadType.setValue(index);
 
     // Threaded checkbox is meaningless if no thread profile is selected.
-    ui->Threaded->setDisabled(std::string(pcHole->ThreadType.getValueAsString()) == "None");
+    ui->Threaded->setDisabled(std::string(hole->ThreadType.getValueAsString()) == "None");
 
     // size and clearance
     if (TypeClass == QByteArray("ISO")) {
@@ -654,14 +664,14 @@ void TaskHoleParameters::threadSizeChanged(int index)
     if (index < 0)
         return;
 
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->ThreadSize.setValue(index);
+        recomputeFeature();
 
-    pcHole->ThreadSize.setValue(index);
-    recomputeFeature();
-
-    // apply the recompute result to the widgets
-    ui->HoleCutCustomValues->setDisabled(pcHole->HoleCutCustomValues.isReadOnly());
-    ui->HoleCutCustomValues->setChecked(pcHole->HoleCutCustomValues.getValue());
+        // apply the recompute result to the widgets
+        ui->HoleCutCustomValues->setDisabled(hole->HoleCutCustomValues.isReadOnly());
+        ui->HoleCutCustomValues->setChecked(hole->HoleCutCustomValues.getValue());
+    }
 }
 
 void TaskHoleParameters::threadClassChanged(int index)
@@ -669,41 +679,41 @@ void TaskHoleParameters::threadClassChanged(int index)
     if (index < 0)
         return;
 
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->ThreadClass.setValue(index);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->ThreadClass.setValue(index);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::threadDiameterChanged(double value)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->Diameter.setValue(value);
 
-    pcHole->Diameter.setValue(value);
+        // HoleCutDiameter must not be smaller or equal than the Diameter
+        ui->HoleCutDiameter->setMinimum(value + 0.1);
 
-    // HoleCutDiameter must not be smaller or equal than the Diameter
-    ui->HoleCutDiameter->setMinimum(value + 0.1);
-
-    recomputeFeature();
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::threadFitChanged(int index)
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->ThreadFit.setValue(index);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        hole->ThreadFit.setValue(index);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::threadDirectionChanged()
 {
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    if (sender() == ui->directionRightHand)
-        pcHole->ThreadDirection.setValue((long)0);
-    else
-        pcHole->ThreadDirection.setValue((long)1);
-    recomputeFeature();
+    if (auto hole = getObject<PartDesign::Hole>()) {
+        if (sender() == ui->directionRightHand)
+            hole->ThreadDirection.setValue(0L);
+        else
+            hole->ThreadDirection.setValue(1L);
+        recomputeFeature();
+    }
 }
 
 void TaskHoleParameters::changeEvent(QEvent* e)
@@ -716,102 +726,102 @@ void TaskHoleParameters::changeEvent(QEvent* e)
 
 void TaskHoleParameters::changedObject(const App::Document&, const App::Property& Prop)
 {
-    // happens when aborting the command
-    if (!vp)
+    auto hole = getObject<PartDesign::Hole>();
+    if (!hole) {
+        // happens when aborting the command
         return;
-
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    }
     bool ro = Prop.isReadOnly();
 
     Base::Console().Log("Parameter %s was updated\n", Prop.getName());
 
-    if (&Prop == &pcHole->Threaded) {
+    if (&Prop == &hole->Threaded) {
         ui->Threaded->setEnabled(true);
-        if (ui->Threaded->isChecked() ^ pcHole->Threaded.getValue()) {
+        if (ui->Threaded->isChecked() ^ hole->Threaded.getValue()) {
             ui->Threaded->blockSignals(true);
-            ui->Threaded->setChecked(pcHole->Threaded.getValue());
+            ui->Threaded->setChecked(hole->Threaded.getValue());
             ui->Threaded->blockSignals(false);
         }
         ui->Threaded->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->ThreadType) {
+    else if (&Prop == &hole->ThreadType) {
         ui->ThreadType->setEnabled(true);
 
         ui->ThreadSize->blockSignals(true);
         ui->ThreadSize->clear();
-        std::vector<std::string> cursor = pcHole->ThreadSize.getEnumVector();
+        std::vector<std::string> cursor = hole->ThreadSize.getEnumVector();
         for (const auto& it : cursor) {
             ui->ThreadSize->addItem(QString::fromStdString(it));
         }
-        ui->ThreadSize->setCurrentIndex(pcHole->ThreadSize.getValue());
+        ui->ThreadSize->setCurrentIndex(hole->ThreadSize.getValue());
         ui->ThreadSize->blockSignals(false);
 
         // Thread type also updates HoleCutType and ThreadClass
         ui->HoleCutType->blockSignals(true);
         ui->HoleCutType->clear();
-        cursor = pcHole->HoleCutType.getEnumVector();
+        cursor = hole->HoleCutType.getEnumVector();
         for (const auto& it: cursor) {
             ui->HoleCutType->addItem(QString::fromStdString(it));
         }
-        ui->HoleCutType->setCurrentIndex(pcHole->HoleCutType.getValue());
+        ui->HoleCutType->setCurrentIndex(hole->HoleCutType.getValue());
         ui->HoleCutType->blockSignals(false);
 
         ui->ThreadClass->blockSignals(true);
         ui->ThreadClass->clear();
-        cursor = pcHole->ThreadClass.getEnumVector();
+        cursor = hole->ThreadClass.getEnumVector();
         for (const auto& it : cursor) {
             ui->ThreadClass->addItem(QString::fromStdString(it));
         }
-        ui->ThreadClass->setCurrentIndex(pcHole->ThreadClass.getValue());
+        ui->ThreadClass->setCurrentIndex(hole->ThreadClass.getValue());
         ui->ThreadClass->blockSignals(false);
 
-        if (ui->ThreadType->currentIndex() != pcHole->ThreadType.getValue()) {
+        if (ui->ThreadType->currentIndex() != hole->ThreadType.getValue()) {
             ui->ThreadType->blockSignals(true);
-            ui->ThreadType->setCurrentIndex(pcHole->ThreadType.getValue());
+            ui->ThreadType->setCurrentIndex(hole->ThreadType.getValue());
             ui->ThreadType->blockSignals(false);
         }
         ui->ThreadType->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->ThreadSize) {
+    else if (&Prop == &hole->ThreadSize) {
         ui->ThreadSize->setEnabled(true);
-        if (ui->ThreadSize->currentIndex() != pcHole->ThreadSize.getValue()) {
+        if (ui->ThreadSize->currentIndex() != hole->ThreadSize.getValue()) {
             ui->ThreadSize->blockSignals(true);
-            ui->ThreadSize->setCurrentIndex(pcHole->ThreadSize.getValue());
+            ui->ThreadSize->setCurrentIndex(hole->ThreadSize.getValue());
             ui->ThreadSize->blockSignals(false);
         }
         ui->ThreadSize->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->ThreadClass) {
+    else if (&Prop == &hole->ThreadClass) {
         ui->ThreadClass->setEnabled(true);
-        if (ui->ThreadClass->currentIndex() != pcHole->ThreadClass.getValue()) {
+        if (ui->ThreadClass->currentIndex() != hole->ThreadClass.getValue()) {
             ui->ThreadClass->blockSignals(true);
-            ui->ThreadClass->setCurrentIndex(pcHole->ThreadClass.getValue());
+            ui->ThreadClass->setCurrentIndex(hole->ThreadClass.getValue());
             ui->ThreadClass->blockSignals(false);
         }
         ui->ThreadClass->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->ThreadFit) {
+    else if (&Prop == &hole->ThreadFit) {
         ui->ThreadFit->setEnabled(true);
-        if (ui->ThreadFit->currentIndex() != pcHole->ThreadFit.getValue()) {
+        if (ui->ThreadFit->currentIndex() != hole->ThreadFit.getValue()) {
             ui->ThreadFit->blockSignals(true);
-            ui->ThreadFit->setCurrentIndex(pcHole->ThreadFit.getValue());
+            ui->ThreadFit->setCurrentIndex(hole->ThreadFit.getValue());
             ui->ThreadFit->blockSignals(false);
         }
         ui->ThreadFit->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->Diameter) {
+    else if (&Prop == &hole->Diameter) {
         ui->Diameter->setEnabled(true);
-        if (ui->Diameter->value().getValue() != pcHole->Diameter.getValue()) {
+        if (ui->Diameter->value().getValue() != hole->Diameter.getValue()) {
             ui->Diameter->blockSignals(true);
-            ui->Diameter->setValue(pcHole->Diameter.getValue());
+            ui->Diameter->setValue(hole->Diameter.getValue());
             ui->Diameter->blockSignals(false);
         }
         ui->Diameter->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->ThreadDirection) {
+    else if (&Prop == &hole->ThreadDirection) {
         ui->directionRightHand->setEnabled(true);
         ui->directionLeftHand->setEnabled(true);
-        std::string direction(pcHole->ThreadDirection.getValueAsString());
+        std::string direction(hole->ThreadDirection.getValueAsString());
         if (direction == "Right" && !ui->directionRightHand->isChecked()) {
             ui->directionRightHand->blockSignals(true);
             ui->directionRightHand->setChecked(true);
@@ -825,64 +835,64 @@ void TaskHoleParameters::changedObject(const App::Document&, const App::Property
         ui->directionRightHand->setDisabled(ro);
         ui->directionLeftHand->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->HoleCutType) {
+    else if (&Prop == &hole->HoleCutType) {
         ui->HoleCutType->setEnabled(true);
-        if (ui->HoleCutType->currentIndex() != pcHole->HoleCutType.getValue()) {
+        if (ui->HoleCutType->currentIndex() != hole->HoleCutType.getValue()) {
             ui->HoleCutType->blockSignals(true);
-            ui->HoleCutType->setCurrentIndex(pcHole->HoleCutType.getValue());
+            ui->HoleCutType->setCurrentIndex(hole->HoleCutType.getValue());
             ui->HoleCutType->blockSignals(false);
         }
         ui->HoleCutType->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->HoleCutDiameter) {
+    else if (&Prop == &hole->HoleCutDiameter) {
         ui->HoleCutDiameter->setEnabled(true);
-        if (ui->HoleCutDiameter->value().getValue() != pcHole->HoleCutDiameter.getValue()) {
+        if (ui->HoleCutDiameter->value().getValue() != hole->HoleCutDiameter.getValue()) {
             ui->HoleCutDiameter->blockSignals(true);
-            ui->HoleCutDiameter->setValue(pcHole->HoleCutDiameter.getValue());
+            ui->HoleCutDiameter->setValue(hole->HoleCutDiameter.getValue());
             ui->HoleCutDiameter->blockSignals(false);
         }
         ui->HoleCutDiameter->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->HoleCutDepth) {
+    else if (&Prop == &hole->HoleCutDepth) {
         ui->HoleCutDepth->setEnabled(true);
-        if (ui->HoleCutDepth->value().getValue() != pcHole->HoleCutDepth.getValue()) {
+        if (ui->HoleCutDepth->value().getValue() != hole->HoleCutDepth.getValue()) {
             ui->HoleCutDepth->blockSignals(true);
-            ui->HoleCutDepth->setValue(pcHole->HoleCutDepth.getValue());
+            ui->HoleCutDepth->setValue(hole->HoleCutDepth.getValue());
             ui->HoleCutDepth->blockSignals(false);
         }
         ui->HoleCutDepth->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->HoleCutCountersinkAngle) {
+    else if (&Prop == &hole->HoleCutCountersinkAngle) {
         ui->HoleCutCountersinkAngle->setEnabled(true);
-        if (ui->HoleCutCountersinkAngle->value().getValue() != pcHole->HoleCutCountersinkAngle.getValue()) {
+        if (ui->HoleCutCountersinkAngle->value().getValue() != hole->HoleCutCountersinkAngle.getValue()) {
             ui->HoleCutCountersinkAngle->blockSignals(true);
-            ui->HoleCutCountersinkAngle->setValue(pcHole->HoleCutCountersinkAngle.getValue());
+            ui->HoleCutCountersinkAngle->setValue(hole->HoleCutCountersinkAngle.getValue());
             ui->HoleCutCountersinkAngle->blockSignals(false);
         }
         ui->HoleCutCountersinkAngle->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->DepthType) {
+    else if (&Prop == &hole->DepthType) {
         ui->DepthType->setEnabled(true);
-        if (ui->DepthType->currentIndex() != pcHole->DepthType.getValue()) {
+        if (ui->DepthType->currentIndex() != hole->DepthType.getValue()) {
             ui->DepthType->blockSignals(true);
-            ui->DepthType->setCurrentIndex(pcHole->DepthType.getValue());
+            ui->DepthType->setCurrentIndex(hole->DepthType.getValue());
             ui->DepthType->blockSignals(false);
         }
         ui->DepthType->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->Depth) {
+    else if (&Prop == &hole->Depth) {
         ui->Depth->setEnabled(true);
-        if (ui->Depth->value().getValue() != pcHole->Depth.getValue()) {
+        if (ui->Depth->value().getValue() != hole->Depth.getValue()) {
             ui->Depth->blockSignals(true);
-            ui->Depth->setValue(pcHole->Depth.getValue());
+            ui->Depth->setValue(hole->Depth.getValue());
             ui->Depth->blockSignals(false);
         }
         ui->Depth->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->DrillPoint) {
+    else if (&Prop == &hole->DrillPoint) {
         ui->drillPointFlat->setEnabled(true);
         ui->drillPointAngled->setEnabled(true);
-        std::string drillPoint(pcHole->DrillPoint.getValueAsString());
+        std::string drillPoint(hole->DrillPoint.getValueAsString());
         if (drillPoint == "Flat" && !ui->drillPointFlat->isChecked()) {
             ui->drillPointFlat->blockSignals(true);
             ui->drillPointFlat->setChecked(true);
@@ -896,83 +906,83 @@ void TaskHoleParameters::changedObject(const App::Document&, const App::Property
         ui->drillPointFlat->setDisabled(ro);
         ui->drillPointAngled->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->DrillPointAngle) {
+    else if (&Prop == &hole->DrillPointAngle) {
         ui->DrillPointAngle->setEnabled(true);
-        if (ui->DrillPointAngle->value().getValue() != pcHole->DrillPointAngle.getValue()) {
+        if (ui->DrillPointAngle->value().getValue() != hole->DrillPointAngle.getValue()) {
             ui->DrillPointAngle->blockSignals(true);
-            ui->DrillPointAngle->setValue(pcHole->DrillPointAngle.getValue());
+            ui->DrillPointAngle->setValue(hole->DrillPointAngle.getValue());
             ui->DrillPointAngle->blockSignals(false);
         }
         ui->DrillPointAngle->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->DrillForDepth) {
+    else if (&Prop == &hole->DrillForDepth) {
         ui->DrillForDepth->setEnabled(true);
-        if (ui->DrillForDepth->isChecked() ^ pcHole->DrillForDepth.getValue()) {
+        if (ui->DrillForDepth->isChecked() ^ hole->DrillForDepth.getValue()) {
             ui->DrillForDepth->blockSignals(true);
-            ui->DrillForDepth->setChecked(pcHole->DrillForDepth.getValue());
+            ui->DrillForDepth->setChecked(hole->DrillForDepth.getValue());
             ui->DrillForDepth->blockSignals(false);
         }
         ui->DrillForDepth->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->Tapered) {
+    else if (&Prop == &hole->Tapered) {
         ui->Tapered->setEnabled(true);
-        if (ui->Tapered->isChecked() ^ pcHole->Tapered.getValue()) {
+        if (ui->Tapered->isChecked() ^ hole->Tapered.getValue()) {
             ui->Tapered->blockSignals(true);
-            ui->Tapered->setChecked(pcHole->Tapered.getValue());
+            ui->Tapered->setChecked(hole->Tapered.getValue());
             ui->Tapered->blockSignals(false);
         }
         ui->Tapered->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->TaperedAngle) {
+    else if (&Prop == &hole->TaperedAngle) {
         ui->TaperedAngle->setEnabled(true);
-        if (ui->TaperedAngle->value().getValue() != pcHole->TaperedAngle.getValue()) {
+        if (ui->TaperedAngle->value().getValue() != hole->TaperedAngle.getValue()) {
             ui->TaperedAngle->blockSignals(true);
-            ui->TaperedAngle->setValue(pcHole->TaperedAngle.getValue());
+            ui->TaperedAngle->setValue(hole->TaperedAngle.getValue());
             ui->TaperedAngle->blockSignals(false);
         }
         ui->TaperedAngle->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->ModelThread) {
+    else if (&Prop == &hole->ModelThread) {
         ui->ModelThread->setEnabled(true);
-        if (ui->ModelThread->isChecked() ^ pcHole->ModelThread.getValue()) {
+        if (ui->ModelThread->isChecked() ^ hole->ModelThread.getValue()) {
             ui->ModelThread->blockSignals(true);
-            ui->ModelThread->setChecked(pcHole->ModelThread.getValue());
+            ui->ModelThread->setChecked(hole->ModelThread.getValue());
             ui->ModelThread->blockSignals(false);
         }
         ui->ModelThread->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->UseCustomThreadClearance) {
+    else if (&Prop == &hole->UseCustomThreadClearance) {
         ui->UseCustomThreadClearance->setEnabled(true);
-        if (ui->UseCustomThreadClearance->isChecked() ^ pcHole->UseCustomThreadClearance.getValue()) {
+        if (ui->UseCustomThreadClearance->isChecked() ^ hole->UseCustomThreadClearance.getValue()) {
             ui->UseCustomThreadClearance->blockSignals(true);
-            ui->UseCustomThreadClearance->setChecked(pcHole->UseCustomThreadClearance.getValue());
+            ui->UseCustomThreadClearance->setChecked(hole->UseCustomThreadClearance.getValue());
             ui->UseCustomThreadClearance->blockSignals(false);
         }
         ui->UseCustomThreadClearance->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->CustomThreadClearance) {
+    else if (&Prop == &hole->CustomThreadClearance) {
         ui->CustomThreadClearance->setEnabled(true);
-        if (ui->CustomThreadClearance->value().getValue() != pcHole->CustomThreadClearance.getValue()) {
+        if (ui->CustomThreadClearance->value().getValue() != hole->CustomThreadClearance.getValue()) {
             ui->CustomThreadClearance->blockSignals(true);
-            ui->CustomThreadClearance->setValue(pcHole->CustomThreadClearance.getValue());
+            ui->CustomThreadClearance->setValue(hole->CustomThreadClearance.getValue());
             ui->CustomThreadClearance->blockSignals(false);
         }
         ui->CustomThreadClearance->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->ThreadDepthType) {
+    else if (&Prop == &hole->ThreadDepthType) {
         ui->ThreadDepthType->setEnabled(true);
-        if (ui->ThreadDepthType->currentIndex() != pcHole->ThreadDepthType.getValue()) {
+        if (ui->ThreadDepthType->currentIndex() != hole->ThreadDepthType.getValue()) {
             ui->ThreadDepthType->blockSignals(true);
-            ui->ThreadDepthType->setCurrentIndex(pcHole->ThreadDepthType.getValue());
+            ui->ThreadDepthType->setCurrentIndex(hole->ThreadDepthType.getValue());
             ui->ThreadDepthType->blockSignals(false);
         }
         ui->ThreadDepthType->setDisabled(ro);
     }
-    else if (&Prop == &pcHole->ThreadDepth) {
+    else if (&Prop == &hole->ThreadDepth) {
         ui->ThreadDepth->setEnabled(true);
-        if (ui->ThreadDepth->value().getValue() != pcHole->ThreadDepth.getValue()) {
+        if (ui->ThreadDepth->value().getValue() != hole->ThreadDepth.getValue()) {
             ui->ThreadDepth->blockSignals(true);
-            ui->ThreadDepth->setValue(pcHole->ThreadDepth.getValue());
+            ui->ThreadDepth->setValue(hole->ThreadDepth.getValue());
             ui->ThreadDepth->blockSignals(false);
         }
         ui->ThreadDepth->setDisabled(ro);
@@ -1125,8 +1135,7 @@ double TaskHoleParameters::getThreadDepth() const
 
 void TaskHoleParameters::apply()
 {
-    auto obj = vp->getObject();
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    auto hole = getObject<PartDesign::Hole>();
 
     isApplying = true;
 
@@ -1138,40 +1147,40 @@ void TaskHoleParameters::apply()
     ui->DrillPointAngle->apply();
     ui->TaperedAngle->apply();
 
-    if (!pcHole->Threaded.isReadOnly())
-        FCMD_OBJ_CMD(obj, "Threaded = " << (getThreaded() ? 1 : 0));
-    if (!pcHole->ModelThread.isReadOnly())
-        FCMD_OBJ_CMD(obj, "ModelThread = " << (getModelThread() ? 1 : 0));
-    if (!pcHole->ThreadDepthType.isReadOnly())
-        FCMD_OBJ_CMD(obj, "ThreadDepthType = " << getThreadDepthType());
-    if (!pcHole->ThreadDepth.isReadOnly())
-        FCMD_OBJ_CMD(obj, "ThreadDepth = " << getThreadDepth());
-    if (!pcHole->UseCustomThreadClearance.isReadOnly())
-        FCMD_OBJ_CMD(obj, "UseCustomThreadClearance = " << (getUseCustomThreadClearance() ? 1 : 0));
-    if (!pcHole->CustomThreadClearance.isReadOnly())
-        FCMD_OBJ_CMD(obj, "CustomThreadClearance = " << getCustomThreadClearance());
-    if (!pcHole->ThreadType.isReadOnly())
-        FCMD_OBJ_CMD(obj, "ThreadType = " << getThreadType());
-    if (!pcHole->ThreadSize.isReadOnly())
-        FCMD_OBJ_CMD(obj, "ThreadSize = " << getThreadSize());
-    if (!pcHole->ThreadClass.isReadOnly())
-        FCMD_OBJ_CMD(obj, "ThreadClass = " << getThreadClass());
-    if (!pcHole->ThreadFit.isReadOnly())
-        FCMD_OBJ_CMD(obj, "ThreadFit = " << getThreadFit());
-    if (!pcHole->ThreadDirection.isReadOnly())
-        FCMD_OBJ_CMD(obj, "ThreadDirection = " << getThreadDirection());
-    if (!pcHole->HoleCutType.isReadOnly())
-        FCMD_OBJ_CMD(obj, "HoleCutType = " << getHoleCutType());
-    if (!pcHole->HoleCutCustomValues.isReadOnly())
-        FCMD_OBJ_CMD(obj, "HoleCutCustomValues = " << (getHoleCutCustomValues() ? 1 : 0));
-    if (!pcHole->DepthType.isReadOnly())
-        FCMD_OBJ_CMD(obj, "DepthType = " << getDepthType());
-    if (!pcHole->DrillPoint.isReadOnly())
-        FCMD_OBJ_CMD(obj, "DrillPoint = " << getDrillPoint());
-    if (!pcHole->DrillForDepth.isReadOnly())
-        FCMD_OBJ_CMD(obj, "DrillForDepth = " << (getDrillForDepth() ? 1 : 0));
-    if (!pcHole->Tapered.isReadOnly())
-        FCMD_OBJ_CMD(obj, "Tapered = " << getTapered());
+    if (!hole->Threaded.isReadOnly())
+        FCMD_OBJ_CMD(hole, "Threaded = " << (getThreaded() ? 1 : 0));
+    if (!hole->ModelThread.isReadOnly())
+        FCMD_OBJ_CMD(hole, "ModelThread = " << (getModelThread() ? 1 : 0));
+    if (!hole->ThreadDepthType.isReadOnly())
+        FCMD_OBJ_CMD(hole, "ThreadDepthType = " << getThreadDepthType());
+    if (!hole->ThreadDepth.isReadOnly())
+        FCMD_OBJ_CMD(hole, "ThreadDepth = " << getThreadDepth());
+    if (!hole->UseCustomThreadClearance.isReadOnly())
+        FCMD_OBJ_CMD(hole, "UseCustomThreadClearance = " << (getUseCustomThreadClearance() ? 1 : 0));
+    if (!hole->CustomThreadClearance.isReadOnly())
+        FCMD_OBJ_CMD(hole, "CustomThreadClearance = " << getCustomThreadClearance());
+    if (!hole->ThreadType.isReadOnly())
+        FCMD_OBJ_CMD(hole, "ThreadType = " << getThreadType());
+    if (!hole->ThreadSize.isReadOnly())
+        FCMD_OBJ_CMD(hole, "ThreadSize = " << getThreadSize());
+    if (!hole->ThreadClass.isReadOnly())
+        FCMD_OBJ_CMD(hole, "ThreadClass = " << getThreadClass());
+    if (!hole->ThreadFit.isReadOnly())
+        FCMD_OBJ_CMD(hole, "ThreadFit = " << getThreadFit());
+    if (!hole->ThreadDirection.isReadOnly())
+        FCMD_OBJ_CMD(hole, "ThreadDirection = " << getThreadDirection());
+    if (!hole->HoleCutType.isReadOnly())
+        FCMD_OBJ_CMD(hole, "HoleCutType = " << getHoleCutType());
+    if (!hole->HoleCutCustomValues.isReadOnly())
+        FCMD_OBJ_CMD(hole, "HoleCutCustomValues = " << (getHoleCutCustomValues() ? 1 : 0));
+    if (!hole->DepthType.isReadOnly())
+        FCMD_OBJ_CMD(hole, "DepthType = " << getDepthType());
+    if (!hole->DrillPoint.isReadOnly())
+        FCMD_OBJ_CMD(hole, "DrillPoint = " << getDrillPoint());
+    if (!hole->DrillForDepth.isReadOnly())
+        FCMD_OBJ_CMD(hole, "DrillForDepth = " << (getDrillForDepth() ? 1 : 0));
+    if (!hole->Tapered.isReadOnly())
+        FCMD_OBJ_CMD(hole, "Tapered = " << getTapered());
 
     isApplying = false;
 }

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -146,8 +146,6 @@ public:
     explicit TaskDlgHoleParameters(ViewProviderHole *HoleView);
     ~TaskDlgHoleParameters() override;
 
-    ViewProviderHole* getHoleView() const { return static_cast<ViewProviderHole*>(vp); }
-
 protected:
     TaskHoleParameters  *parameter;
 };

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -128,8 +128,11 @@ void TaskLoftParameters::updateUI()
 {
     // we must assure the changed loft is kept visible on section changes,
     // see https://forum.freecad.org/viewtopic.php?f=3&t=63252
-    PartDesign::Loft* loft = static_cast<PartDesign::Loft*>(vp->getObject());
-    vp->makeTemporaryVisible(!loft->Sections.getValues().empty());
+    auto loft = getObject<PartDesign::Loft>();
+    if (loft) {
+        auto view = getViewObject();
+        view->makeTemporaryVisible(!loft->Sections.getValues().empty());
+    }
 }
 
 void TaskLoftParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
@@ -173,11 +176,11 @@ bool TaskLoftParameters::referenceSelected(const Gui::SelectionChanges& msg) con
 
     if (msg.Type == Gui::SelectionChanges::AddSelection && selectionMode != none) {
 
-        if (strcmp(msg.pDocName, vp->getObject()->getDocument()->getName()) != 0)
+        if (strcmp(msg.pDocName, getObject()->getDocument()->getName()) != 0)
             return false;
 
         // not allowed to reference ourself
-        const char* fname = vp->getObject()->getNameInDocument();
+        const char* fname = getObject()->getNameInDocument();
         if (strcmp(msg.pObjectName, fname) == 0)
             return false;
 
@@ -185,11 +188,13 @@ bool TaskLoftParameters::referenceSelected(const Gui::SelectionChanges& msg) con
         //supported, not individual edges of a part
 
         //change the references
-        PartDesign::Loft* loft = static_cast<PartDesign::Loft*>(vp->getObject());
-        App::DocumentObject* obj = loft->getDocument()->getObject(msg.pObjectName);
+        auto loft = getObject<PartDesign::Loft>();
+        App::Document* doc = loft->getDocument();
+        App::DocumentObject* obj = doc->getObject(msg.pObjectName);
 
         if (selectionMode == refProfile) {
-            static_cast<ViewProviderLoft*>(vp)->highlightReferences(ViewProviderLoft::Profile, false);
+            auto view = getViewObject<ViewProviderLoft>();
+            view->highlightReferences(ViewProviderLoft::Profile, false);
             loft->Profile.setValue(obj, {msg.pSubName});
             return true;
         }
@@ -199,18 +204,18 @@ bool TaskLoftParameters::referenceSelected(const Gui::SelectionChanges& msg) con
             std::vector<App::DocumentObject*>::iterator f = std::find(refs.begin(), refs.end(), obj);
 
             if (selectionMode == refAdd) {
-                if (f == refs.end())
-                    loft->Sections.addValue(obj, {msg.pSubName});
-                else
+                if (f != refs.end()) {
                     return false; // duplicate selection
+                }
+
+                loft->Sections.addValue(obj, {msg.pSubName});
             }
             else if (selectionMode == refRemove) {
-                if (f != refs.end())
-                    // Removing just the object this way instead of `refs.erase` and
-                    // `setValues(ref)` cleanly ensures subnames are preserved.
-                    loft->Sections.removeValue(obj);
-                else
+                if (f == refs.end()) {
                     return false;
+                }
+
+                loft->Sections.removeValue(obj);
             }
 
             return true;
@@ -241,17 +246,16 @@ void TaskLoftParameters::onDeleteSection()
         delete item;
 
         // search inside the list of sections
-        PartDesign::Loft* loft = static_cast<PartDesign::Loft*>(vp->getObject());
-        std::vector<App::DocumentObject*> refs = loft->Sections.getValues();
-        App::DocumentObject* obj = loft->getDocument()->getObject(data.constData());
-        std::vector<App::DocumentObject*>::iterator f = std::find(refs.begin(), refs.end(), obj);
-        if (f != refs.end()) {
-            // Removing just the object this way instead of `refs.erase` and
-            // `setValues(ref)` cleanly ensures subnames are preserved.
-            loft->Sections.removeValue(obj);
+        if (auto loft = getObject<PartDesign::Loft>()) {
+            std::vector<App::DocumentObject*> refs = loft->Sections.getValues();
+            App::DocumentObject* obj = loft->getDocument()->getObject(data.constData());
+            std::vector<App::DocumentObject*>::iterator f = std::find(refs.begin(), refs.end(), obj);
+            if (f != refs.end()) {
+                loft->Sections.removeValue(obj);
 
-            recomputeFeature();
-            updateUI();
+                recomputeFeature();
+                updateUI();
+            }
         }
     }
 }
@@ -259,31 +263,36 @@ void TaskLoftParameters::onDeleteSection()
 void TaskLoftParameters::indexesMoved()
 {
     QAbstractItemModel* model = qobject_cast<QAbstractItemModel*>(sender());
-    if (!model)
+    if (!model) {
         return;
-
-    PartDesign::Loft* loft = static_cast<PartDesign::Loft*>(vp->getObject());
-    auto originals = loft->Sections.getSubListValues();
-
-    int rows = model->rowCount();
-    for (int i = 0; i < rows; i++) {
-        QModelIndex index = model->index(i, 0);
-        originals[i] = index.data(Qt::UserRole).value<App::PropertyLinkSubList::SubSet>();
     }
 
-    loft->Sections.setSubListValues(originals);
-    recomputeFeature();
-    updateUI();
+    if (auto loft = getObject<PartDesign::Loft>()) {
+        auto originals = loft->Sections.getSubListValues();
+
+        int rows = model->rowCount();
+        for (int i = 0; i < rows; i++) {
+            QModelIndex index = model->index(i, 0);
+            originals[i] = index.data(Qt::UserRole).value<App::PropertyLinkSubList::SubSet>();
+        }
+
+        loft->Sections.setSubListValues(originals);
+        recomputeFeature();
+        updateUI();
+    }
 }
 
 void TaskLoftParameters::clearButtons(const selectionModes notThis)
 {
-    if (notThis != refProfile)
+    if (notThis != refProfile) {
         ui->buttonProfileBase->setChecked(false);
-    if (notThis != refAdd)
+    }
+    if (notThis != refAdd) {
         ui->buttonRefAdd->setChecked(false);
-    if (notThis != refRemove)
+    }
+    if (notThis != refRemove) {
         ui->buttonRefRemove->setChecked(false);
+    }
 }
 
 void TaskLoftParameters::exitSelectionMode()
@@ -297,62 +306,52 @@ void TaskLoftParameters::changeEvent(QEvent * /*e*/)
 {
 }
 
-void TaskLoftParameters::onClosed(bool val) {
-    static_cast<PartDesign::Loft*>(vp->getObject())->Closed.setValue(val);
-    recomputeFeature();
+void TaskLoftParameters::onClosed(bool val)
+{
+    if (auto loft = getObject<PartDesign::Loft>()) {
+        loft->Closed.setValue(val);
+        recomputeFeature();
+    }
 }
 
-void TaskLoftParameters::onRuled(bool val) {
-    static_cast<PartDesign::Loft*>(vp->getObject())->Ruled.setValue(val);
-    recomputeFeature();
+void TaskLoftParameters::onRuled(bool val)
+{
+    if (auto loft = getObject<PartDesign::Loft>()) {
+        loft->Ruled.setValue(val);
+        recomputeFeature();
+    }
+}
+
+void TaskLoftParameters::setSelectionMode(selectionModes mode, bool checked)
+{
+    if (checked) {
+        clearButtons(mode);
+        Gui::Selection().clearSelection();
+        selectionMode = mode;
+        this->blockSelection(false);
+    }
+    else {
+        Gui::Selection().clearSelection();
+        selectionMode = none;
+    }
+
+    auto view = getViewObject<ViewProviderLoft>();
+    view->highlightReferences(ViewProviderLoft::Both, checked);
 }
 
 void TaskLoftParameters::onProfileButton(bool checked)
 {
-    if (checked) {
-        clearButtons(refProfile);
-        Gui::Selection().clearSelection();
-        selectionMode = refProfile;
-        this->blockSelection(false);
-        static_cast<ViewProviderLoft*>(vp)->highlightReferences(ViewProviderLoft::Both, true);
-    }
-    else {
-        Gui::Selection().clearSelection();
-        selectionMode = none;
-        static_cast<ViewProviderLoft*>(vp)->highlightReferences(ViewProviderLoft::Both, false);
-    }
+    setSelectionMode(refProfile, checked);
 }
 
 void TaskLoftParameters::onRefButtonAdd(bool checked)
 {
-    if (checked) {
-        clearButtons(refAdd);
-        Gui::Selection().clearSelection();
-        selectionMode = refAdd;
-        this->blockSelection(false);
-        static_cast<ViewProviderLoft*>(vp)->highlightReferences(ViewProviderLoft::Both, true);
-    }
-    else {
-        Gui::Selection().clearSelection();
-        selectionMode = none;
-        static_cast<ViewProviderLoft*>(vp)->highlightReferences(ViewProviderLoft::Both, false);
-    }
+    setSelectionMode(refAdd, checked);
 }
 
 void TaskLoftParameters::onRefButtonRemove(bool checked)
 {
-    if (checked) {
-        clearButtons(refRemove);
-        Gui::Selection().clearSelection();
-        selectionMode = refRemove;
-        this->blockSelection(false);
-        static_cast<ViewProviderLoft*>(vp)->highlightReferences(ViewProviderLoft::Both, true);
-    }
-    else {
-        Gui::Selection().clearSelection();
-        selectionMode = none;
-        static_cast<ViewProviderLoft*>(vp)->highlightReferences(ViewProviderLoft::Both, false);
-    }
+    setSelectionMode(refRemove, checked);
 }
 
 

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -375,17 +375,18 @@ TaskDlgLoftParameters::~TaskDlgLoftParameters() = default;
 
 bool TaskDlgLoftParameters::accept()
 {
-    PartDesign::Loft* pcLoft = static_cast<PartDesign::Loft*>(vp->getObject());
-    static_cast<ViewProviderLoft*>(vp)->highlightReferences(ViewProviderLoft::Both, false);
+    if (auto loft = getObject<PartDesign::Loft>()) {
+        getViewObject<ViewProviderLoft>()->highlightReferences(ViewProviderLoft::Both, false);
 
-    // First verify that the loft can be built and then hide the sections as otherwise
-    // they will remain hidden if the loft's recompute fails
-    if (TaskDlgSketchBasedParameters::accept()) {
-        for (App::DocumentObject* obj : pcLoft->Sections.getValues()) {
-            Gui::cmdAppObjectHide(obj);
+        // First verify that the loft can be built and then hide the sections as otherwise
+        // they will remain hidden if the loft's recompute fails
+        if (TaskDlgSketchBasedParameters::accept()) {
+            for (App::DocumentObject* obj : loft->Sections.getValues()) {
+                Gui::cmdAppObjectHide(obj);
+            }
+
+            return true;
         }
-
-        return true;
     }
 
     return false;

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.h
@@ -70,6 +70,7 @@ private:
     void removeFromListWidget(QListWidget*w, QString name);
     void clearButtons(const selectionModes notThis=none);
     void exitSelectionMode();
+    void setSelectionMode(selectionModes mode, bool checked);
 
 private:
     QWidget* proxy;

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.h
@@ -87,9 +87,6 @@ public:
     explicit TaskDlgLoftParameters(ViewProviderLoft *LoftView,bool newObj=false);
     ~TaskDlgLoftParameters() override;
 
-    ViewProviderLoft* getLoftView() const
-    { return static_cast<ViewProviderLoft*>(vp); }
-
     /// is called by the framework if the dialog is accepted (Ok)
     bool accept() override;
 

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -86,7 +86,7 @@ void TaskPadParameters::updateUI(int index)
 
 void TaskPadParameters::onModeChanged(int index)
 {
-    PartDesign::Pad* pcPad = static_cast<PartDesign::Pad*>(vp->getObject());
+   auto pcPad = getObject<PartDesign::Pad>();
 
     switch (static_cast<Mode>(index)) {
     case Mode::Dimension:

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.h
@@ -62,10 +62,11 @@ class TaskDlgPadParameters : public TaskDlgExtrudeParameters
 public:
     explicit TaskDlgPadParameters(ViewProviderPad *PadView, bool newObj=false);
 
-    ViewProviderPad* getPadView() const { return static_cast<ViewProviderPad*>(vp); }
-
 protected:
-    TaskExtrudeParameters* getTaskParameters() override { return parameters; };
+    TaskExtrudeParameters* getTaskParameters() override
+    {
+        return parameters;
+    }
 
 private:
     TaskPadParameters* parameters;

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -142,13 +142,11 @@ TaskPipeParameters::TaskPipeParameters(ViewProviderPipe *PipeView, bool /*newObj
 TaskPipeParameters::~TaskPipeParameters()
 {
     try {
-        if (vp) {
-            PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(vp->getObject());
-
+        if (auto pipe = getObject<PartDesign::Pipe>()) {
             // setting visibility to true is needed when preselecting profile and path prior to invoking sweep
             Gui::cmdGuiObject(pipe, "Visibility = True");
-            static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Spine, false);
-            static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Profile, false);
+            getViewObject<ViewProviderPipe>()->highlightReferences(ViewProviderPipe::Spine, false);
+            getViewObject<ViewProviderPipe>()->highlightReferences(ViewProviderPipe::Profile, false);
         }
     }
     catch (const Standard_OutOfRange&) {
@@ -228,27 +226,32 @@ void TaskPipeParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 
 void TaskPipeParameters::onTransitionChanged(int idx)
 {
-    static_cast<PartDesign::Pipe*>(vp->getObject())->Transition.setValue(idx);
-    recomputeFeature();
+    if (auto pipe = getObject<PartDesign::Pipe>()) {
+        pipe->Transition.setValue(idx);
+        recomputeFeature();
+    }
 }
 
 void TaskPipeParameters::onProfileButton(bool checked)
 {
     if (checked) {
-        PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(vp->getObject());
-        Gui::Document* doc = vp->getDocument();
+        if (auto pipe = getObject<PartDesign::Pipe>()) {
+            Gui::Document* doc = getGuiDocument();
 
-        if (pipe->Profile.getValue()) {
-            auto* pvp = doc->getViewProvider(pipe->Profile.getValue());
-            pvp->setVisible(true);
+            if (pipe->Profile.getValue()) {
+                auto* pvp = doc->getViewProvider(pipe->Profile.getValue());
+                pvp->setVisible(true);
+            }
         }
     }
 }
 
 void TaskPipeParameters::onTangentChanged(bool checked)
 {
-    static_cast<PartDesign::Pipe*>(vp->getObject())->SpineTangent.setValue(checked);
-    recomputeFeature();
+    if (auto pipe = getObject<PartDesign::Pipe>()) {
+        pipe->SpineTangent.setValue(checked);
+        recomputeFeature();
+    }
 }
 
 void TaskPipeParameters::removeFromListWidget(QListWidget* widget, QString itemstr)
@@ -272,7 +275,7 @@ void TaskPipeParameters::onDeleteEdge()
         delete item;
 
         // search inside the list of spines
-        PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(vp->getObject());
+        auto pipe = getObject<PartDesign::Pipe>();
         std::vector<std::string> refs = pipe->Spine.getSubValues();
         std::string obj = data.constData();
         std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), obj);
@@ -293,21 +296,21 @@ bool TaskPipeParameters::referenceSelected(const SelectionChanges& msg) const
 
     if (msg.Type == Gui::SelectionChanges::AddSelection &&
         selectionMode != StateHandlerTaskPipe::SelectionModes::none) {
-        if (strcmp(msg.pDocName, vp->getObject()->getDocument()->getName()) != 0)
+        if (strcmp(msg.pDocName, getAppDocument()->getName()) != 0)
             return false;
 
         // not allowed to reference ourself
-        const char* fname = vp->getObject()->getNameInDocument();
+        const char* fname = getObject()->getNameInDocument();
         if (strcmp(msg.pObjectName, fname) == 0)
             return false;
 
         switch (selectionMode) {
         case StateHandlerTaskPipe::SelectionModes::refProfile:
         {
-            PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(vp->getObject());
-            Gui::Document* doc = vp->getDocument();
+            auto pipe = getObject<PartDesign::Pipe>();
+            Gui::Document* doc = getGuiDocument();
 
-            static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Profile, false);
+            getViewObject<ViewProviderPipe>()->highlightReferences(ViewProviderPipe::Profile, false);
 
             bool success = true;
             App::DocumentObject* profile = pipe->getDocument()->getObject(msg.pObjectName);
@@ -335,11 +338,12 @@ bool TaskPipeParameters::referenceSelected(const SelectionChanges& msg) const
         {
             //change the references
             std::string subName(msg.pSubName);
-            std::vector<std::string> refs = static_cast<PartDesign::Pipe*>(vp->getObject())->Spine.getSubValues();
+            auto pipe = getObject<PartDesign::Pipe>();
+            std::vector<std::string> refs = pipe->Spine.getSubValues();
             std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), subName);
 
             if (selectionMode == StateHandlerTaskPipe::SelectionModes::refSpine) {
-                static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Spine, false);
+                getViewObject<ViewProviderPipe>()->highlightReferences(ViewProviderPipe::Spine, false);
                 refs.clear();
             }
             else if (selectionMode == StateHandlerTaskPipe::SelectionModes::refSpineEdgeAdd) {
@@ -355,8 +359,7 @@ bool TaskPipeParameters::referenceSelected(const SelectionChanges& msg) const
                     return false;
             }
 
-            static_cast<PartDesign::Pipe*>(vp->getObject())->Spine.setValue(
-                        vp->getObject()->getDocument()->getObject(msg.pObjectName), refs);
+            pipe->Spine.setValue(getAppDocument()->getObject(msg.pObjectName), refs);
             return true;
         }
         default:
@@ -384,9 +387,8 @@ void TaskPipeParameters::exitSelectionMode()
 
 void TaskPipeParameters::setVisibilityOfSpineAndProfile()
 {
-    if (vp) {
-        PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(vp->getObject());
-        Gui::Document* doc = vp->getDocument();
+    if (auto pipe = getObject<PartDesign::Pipe>()) {
+        Gui::Document* doc = getGuiDocument();
 
         // set visibility to the state when the pipe was opened
         for (auto obj : pipe->Sections.getValues()) {
@@ -416,8 +418,8 @@ bool TaskPipeParameters::accept()
     //see what to do with external references
     //check the prerequisites for the selected objects
     //the user has to decide which option we should take if external references are used
-    PartDesign::Pipe* pcPipe = static_cast<PartDesign::Pipe*>(getPipeView()->getObject());
-    auto pcActiveBody = PartDesignGui::getBodyFor (pcPipe, false);
+    auto pipe = getObject<PartDesign::Pipe>();
+    auto pcActiveBody = PartDesignGui::getBodyFor (pipe, false);
     if (!pcActiveBody) {
         QMessageBox::warning(this, tr("Input error"), tr("No active body"));
         return false;
@@ -426,16 +428,16 @@ bool TaskPipeParameters::accept()
     std::vector<App::DocumentObject*> copies;
 
     bool extReference = false;
-    App::DocumentObject* spine = pcPipe->Spine.getValue();
-    App::DocumentObject* auxSpine = pcPipe->AuxillerySpine.getValue();
+    App::DocumentObject* spine = pipe->Spine.getValue();
+    App::DocumentObject* auxSpine = pipe->AuxillerySpine.getValue();
 
     // If a spine isn't set but user entered a label then search for the appropriate document object
     QString label = ui->spineBaseEdit->text();
     if (!spine && !label.isEmpty()) {
         QByteArray ba = label.toUtf8();
-        std::vector<App::DocumentObject*> objs = pcPipe->getDocument()->findObjects(App::DocumentObject::getClassTypeId(), nullptr, ba.constData());
+        std::vector<App::DocumentObject*> objs = pipe->getDocument()->findObjects(App::DocumentObject::getClassTypeId(), nullptr, ba.constData());
         if (!objs.empty()) {
-            pcPipe->Spine.setValue(objs.front());
+            pipe->Spine.setValue(objs.front());
             spine = objs.front();
         }
     }
@@ -447,7 +449,7 @@ bool TaskPipeParameters::accept()
         extReference = true;
     }
     else {
-        for (App::DocumentObject* obj : pcPipe->Sections.getValues()) {
+        for (App::DocumentObject* obj : pipe->Sections.getValues()) {
             if (!pcActiveBody->hasObject(obj) && !pcActiveBody->getOrigin()->hasObject(obj)) {
                 extReference = true;
                 break;
@@ -466,20 +468,20 @@ bool TaskPipeParameters::accept()
 
         if (!dlg.radioXRef->isChecked()) {
             if (!pcActiveBody->hasObject(spine) && !pcActiveBody->getOrigin()->hasObject(spine)) {
-                pcPipe->Spine.setValue(PartDesignGui::TaskFeaturePick::makeCopy(spine, "",
+                pipe->Spine.setValue(PartDesignGui::TaskFeaturePick::makeCopy(spine, "",
                                        dlg.radioIndependent->isChecked()),
-                                       pcPipe->Spine.getSubValues());
-                copies.push_back(pcPipe->Spine.getValue());
+                                       pipe->Spine.getSubValues());
+                copies.push_back(pipe->Spine.getValue());
             }
             else if (!pcActiveBody->hasObject(auxSpine) && !pcActiveBody->getOrigin()->hasObject(auxSpine)){
-                pcPipe->AuxillerySpine.setValue(PartDesignGui::TaskFeaturePick::makeCopy(auxSpine, "",
+                pipe->AuxillerySpine.setValue(PartDesignGui::TaskFeaturePick::makeCopy(auxSpine, "",
                                                 dlg.radioIndependent->isChecked()),
-                                                pcPipe->AuxillerySpine.getSubValues());
-                copies.push_back(pcPipe->AuxillerySpine.getValue());
+                                                pipe->AuxillerySpine.getSubValues());
+                copies.push_back(pipe->AuxillerySpine.getValue());
             }
 
             std::vector<App::PropertyLinkSubList::SubSet> subSets;
-            for (auto &subSet : pcPipe->Sections.getSubListValues()) {
+            for (auto &subSet : pipe->Sections.getSubListValues()) {
                 if (!pcActiveBody->hasObject(subSet.first) &&
                     !pcActiveBody->getOrigin()->hasObject(subSet.first)) {
                     subSets.emplace_back(
@@ -493,22 +495,22 @@ bool TaskPipeParameters::accept()
                 }
             }
 
-            pcPipe->Sections.setSubListValues(subSets);
+            pipe->Sections.setSubListValues(subSets);
         }
     }
 
     try {
         setVisibilityOfSpineAndProfile();
 
-        App::DocumentObject* spine = pcPipe->Spine.getValue();
-        std::vector<std::string> subNames = pcPipe->Spine.getSubValues();
+        App::DocumentObject* spine = pipe->Spine.getValue();
+        std::vector<std::string> subNames = pipe->Spine.getSubValues();
         App::PropertyLinkT propT(spine, subNames);
-        Gui::cmdAppObjectArgs(pcPipe, "Spine = %s", propT.getPropertyPython());
+        Gui::cmdAppObjectArgs(pipe, "Spine = %s", propT.getPropertyPython());
 
-        Gui::cmdAppDocument(pcPipe, "recompute()");
-        if (!vp->getObject()->isValid())
-            throw Base::RuntimeError(vp->getObject()->getStatusString());
-        Gui::cmdGuiDocument(pcPipe, "resetEdit()");
+        Gui::cmdAppDocument(pipe, "recompute()");
+        if (!getObject()->isValid())
+            throw Base::RuntimeError(getObject()->getStatusString());
+        Gui::cmdGuiDocument(pipe, "resetEdit()");
         Gui::Command::commitCommand();
 
         //we need to add the copied features to the body after the command action, as otherwise FreeCAD crashes unexplainably
@@ -597,8 +599,8 @@ TaskPipeOrientation::TaskPipeOrientation(ViewProviderPipe* PipeView, bool /*newO
 TaskPipeOrientation::~TaskPipeOrientation()
 {
     try {
-        if (vp) {
-            static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::AuxiliarySpine, false);
+        if (auto view = getViewObject<ViewProviderPipe>()) {
+            view->highlightReferences(ViewProviderPipe::AuxiliarySpine, false);
         }
     }
     catch (const Standard_OutOfRange&) {
@@ -607,8 +609,10 @@ TaskPipeOrientation::~TaskPipeOrientation()
 
 void TaskPipeOrientation::onOrientationChanged(int idx)
 {
-    static_cast<PartDesign::Pipe*>(vp->getObject())->Mode.setValue(idx);
-    recomputeFeature();
+    if (auto pipe = getObject<PartDesign::Pipe>()) {
+        pipe->Mode.setValue(idx);
+        recomputeFeature();
+    }
 }
 
 void TaskPipeOrientation::clearButtons()
@@ -620,34 +624,37 @@ void TaskPipeOrientation::clearButtons()
 
 void TaskPipeOrientation::exitSelectionMode()
 {
-    // commenting because this should be handled by buttonToggled signal
-    // selectionMode = none;
     Gui::Selection().clearSelection();
 }
 
 void TaskPipeOrientation::onClearButton()
 {
-    static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::AuxiliarySpine, false);
-
     ui->listWidgetReferences->clear();
     ui->profileBaseEdit->clear();
-    static_cast<PartDesign::Pipe*>(vp->getObject())->AuxillerySpine.setValue(nullptr);
+    if (auto view = getViewObject<ViewProviderPipe>()) {
+        view->highlightReferences(ViewProviderPipe::AuxiliarySpine, false);
+        getObject<PartDesign::Pipe>()->AuxillerySpine.setValue(nullptr);
+    }
 }
 
 void TaskPipeOrientation::onCurvelinearChanged(bool checked)
 {
-    static_cast<PartDesign::Pipe*>(vp->getObject())->AuxilleryCurvelinear.setValue(checked);
-    recomputeFeature();
+    if (auto pipe = getObject<PartDesign::Pipe>()) {
+        pipe->AuxilleryCurvelinear.setValue(checked);
+        recomputeFeature();
+    }
 }
 
 void TaskPipeOrientation::onBinormalChanged(double)
 {
-    Base::Vector3d vec(ui->doubleSpinBoxX->value(),
-                       ui->doubleSpinBoxY->value(),
-                       ui->doubleSpinBoxZ->value());
+    if (auto pipe = getObject<PartDesign::Pipe>()) {
+        Base::Vector3d vec(ui->doubleSpinBoxX->value(),
+                           ui->doubleSpinBoxY->value(),
+                           ui->doubleSpinBoxZ->value());
 
-    static_cast<PartDesign::Pipe*>(vp->getObject())->Binormal.setValue(vec);
-    recomputeFeature();
+        pipe->Binormal.setValue(vec);
+        recomputeFeature();
+    }
 }
 
 void TaskPipeOrientation::onSelectionChanged(const SelectionChanges& msg)
@@ -675,8 +682,9 @@ void TaskPipeOrientation::onSelectionChanged(const SelectionChanges& msg)
             }
             else if (stateHandler->getSelectionMode() == StateHandlerTaskPipe::SelectionModes::refAuxSpineEdgeRemove) {
                 QString sub = QString::fromLatin1(msg.pSubName);
-                if (!sub.isEmpty())
+                if (!sub.isEmpty()) {
                     removeFromListWidget(ui->listWidgetReferences, sub);
+                }
                 else {
                     ui->profileBaseEdit->clear();
                 }
@@ -693,7 +701,8 @@ void TaskPipeOrientation::onSelectionChanged(const SelectionChanges& msg)
             }
 
             clearButtons();
-            static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::AuxiliarySpine, false);
+            auto view = getViewObject<ViewProviderPipe>();
+            view->highlightReferences(ViewProviderPipe::AuxiliarySpine, false);
             recomputeFeature();
         }
 
@@ -710,38 +719,42 @@ bool TaskPipeOrientation::referenceSelected(const SelectionChanges& msg) const
         (selectionMode == StateHandlerTaskPipe::SelectionModes::refAuxSpine ||
         selectionMode == StateHandlerTaskPipe::SelectionModes::refAuxSpineEdgeAdd ||
         selectionMode == StateHandlerTaskPipe::SelectionModes::refAuxSpineEdgeRemove)) {
-        if (strcmp(msg.pDocName, vp->getObject()->getDocument()->getName()) != 0)
+        if (strcmp(msg.pDocName, getObject()->getDocument()->getName()) != 0)
             return false;
 
         // not allowed to reference ourself
-        const char* fname = vp->getObject()->getNameInDocument();
+        const char* fname = getObject()->getNameInDocument();
         if (strcmp(msg.pObjectName, fname) == 0)
             return false;
 
-        //change the references
-        std::string subName(msg.pSubName);
-        std::vector<std::string> refs = static_cast<PartDesign::Pipe*>(vp->getObject())->AuxillerySpine.getSubValues();
-        std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), subName);
+        if (auto pipe = getObject<PartDesign::Pipe>()) {
+            //change the references
+            std::string subName(msg.pSubName);
+            std::vector<std::string> refs = pipe->AuxillerySpine.getSubValues();
+            std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), subName);
 
-        if (selectionMode == StateHandlerTaskPipe::SelectionModes::refAuxSpine) {
-            refs.clear();
-        }
-        else if (selectionMode == StateHandlerTaskPipe::SelectionModes::refAuxSpineEdgeAdd) {
-            if (f == refs.end())
+            if (selectionMode == StateHandlerTaskPipe::SelectionModes::refAuxSpine) {
+                refs.clear();
+            }
+            else if (selectionMode == StateHandlerTaskPipe::SelectionModes::refAuxSpineEdgeAdd) {
+                if (f != refs.end()) {
+                    return false; // duplicate selection
+                }
+
                 refs.push_back(subName);
-            else
-                return false; // duplicate selection
-        }
-        else if (selectionMode == StateHandlerTaskPipe::SelectionModes::refAuxSpineEdgeRemove) {
-            if (f != refs.end())
-                refs.erase(f);
-            else
-                return false;
-        }
+            }
+            else if (selectionMode == StateHandlerTaskPipe::SelectionModes::refAuxSpineEdgeRemove) {
+                if (f == refs.end()) {
+                    return false;
+                }
 
-        static_cast<PartDesign::Pipe*>(vp->getObject())->AuxillerySpine.setValue
-                    (vp->getObject()->getDocument()->getObject(msg.pObjectName), refs);
-        return true;
+                refs.erase(f);
+            }
+
+            App::Document* doc = pipe->getDocument();
+            pipe->AuxillerySpine.setValue(doc->getObject(msg.pObjectName), refs);
+            return true;
+        }
     }
 
     return false;
@@ -768,17 +781,18 @@ void TaskPipeOrientation::onDeleteItem()
         delete item;
 
         // search inside the list of spines
-        PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(vp->getObject());
-        std::vector<std::string> refs = pipe->AuxillerySpine.getSubValues();
-        std::string obj = data.constData();
-        std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), obj);
+        if (auto pipe = getObject<PartDesign::Pipe>()) {
+            std::vector<std::string> refs = pipe->AuxillerySpine.getSubValues();
+            std::string obj = data.constData();
+            std::vector<std::string>::iterator f = std::find(refs.begin(), refs.end(), obj);
 
-        // if something was found, delete it and update the spine list
-        if (f != refs.end()) {
-            refs.erase(f);
-            pipe->AuxillerySpine.setValue(pipe->AuxillerySpine.getValue(), refs);
-            clearButtons();
-            recomputeFeature();
+            // if something was found, delete it and update the spine list
+            if (f != refs.end()) {
+                refs.erase(f);
+                pipe->AuxillerySpine.setValue(pipe->AuxillerySpine.getValue(), refs);
+                clearButtons();
+                recomputeFeature();
+            }
         }
     }
 }
@@ -852,8 +866,8 @@ TaskPipeScaling::TaskPipeScaling(ViewProviderPipe* PipeView, bool /*newObj*/, QW
 TaskPipeScaling::~TaskPipeScaling()
 {
     try {
-        if (vp) {
-            static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Section, false);
+        if (auto view = getViewObject<ViewProviderPipe>()) {
+            view->highlightReferences(ViewProviderPipe::Section, false);
         }
     }
     catch (const Standard_OutOfRange&) {
@@ -863,21 +877,22 @@ TaskPipeScaling::~TaskPipeScaling()
 void TaskPipeScaling::indexesMoved()
 {
     QAbstractItemModel* model = qobject_cast<QAbstractItemModel*>(sender());
-    if (!model)
+    if (!model) {
         return;
-
-    PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(vp->getObject());
-    auto originals = pipe->Sections.getSubListValues();
-
-    int rows = model->rowCount();
-    for (int i = 0; i < rows; i++) {
-        QModelIndex index = model->index(i, 0);
-        originals[i] = index.data(Qt::UserRole).value<App::PropertyLinkSubList::SubSet>();
     }
 
-    pipe->Sections.setSubListValues(originals);
-    recomputeFeature();
-    updateUI(ui->stackedWidget->currentIndex());
+    if (auto pipe = getObject<PartDesign::Pipe>()) {
+        auto originals = pipe->Sections.getSubListValues();
+        int rows = model->rowCount();
+        for (int i = 0; i < rows; i++) {
+            QModelIndex index = model->index(i, 0);
+            originals[i] = index.data(Qt::UserRole).value<App::PropertyLinkSubList::SubSet>();
+        }
+
+        pipe->Sections.setSubListValues(originals);
+        recomputeFeature();
+        updateUI(ui->stackedWidget->currentIndex());
+    }
 }
 
 void TaskPipeScaling::clearButtons()
@@ -888,15 +903,15 @@ void TaskPipeScaling::clearButtons()
 
 void TaskPipeScaling::exitSelectionMode()
 {
-    // commenting because this should be handled by buttonToggled signal
-    // selectionMode = none;
     Gui::Selection().clearSelection();
 }
 
 void TaskPipeScaling::onScalingChanged(int idx)
 {
-    updateUI(idx);
-    static_cast<PartDesign::Pipe*>(vp->getObject())->Transformation.setValue(idx);
+    if (auto pipe = getObject<PartDesign::Pipe>()) {
+        updateUI(idx);
+        pipe->Transformation.setValue(idx);
+    }
 }
 
 void TaskPipeScaling::onSelectionChanged(const SelectionChanges& msg)
@@ -937,40 +952,39 @@ bool TaskPipeScaling::referenceSelected(const SelectionChanges& msg) const
     if ((msg.Type == Gui::SelectionChanges::AddSelection) &&
         ((selectionMode == StateHandlerTaskPipe::SelectionModes::refSectionAdd) ||
          (selectionMode == StateHandlerTaskPipe::SelectionModes::refSectionRemove))) {
-        if (strcmp(msg.pDocName, vp->getObject()->getDocument()->getName()) != 0)
+        if (strcmp(msg.pDocName, getObject()->getDocument()->getName()) != 0)
             return false;
 
         // not allowed to reference ourself
-        const char* fname = vp->getObject()->getNameInDocument();
+        const char* fname = getObject()->getNameInDocument();
         if (strcmp(msg.pObjectName, fname) == 0)
             return false;
 
-        //every selection needs to be a profile in itself, hence currently only full objects are
-        //supported, not individual edges of a part
-
         //change the references
-        PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(vp->getObject());
-        std::vector<App::DocumentObject*> refs = pipe->Sections.getValues();
-        App::DocumentObject* obj = vp->getObject()->getDocument()->getObject(msg.pObjectName);
-        std::vector<App::DocumentObject*>::iterator f = std::find(refs.begin(), refs.end(), obj);
+        if (auto pipe = getObject<PartDesign::Pipe>()) {
+            std::vector<App::DocumentObject*> refs = pipe->Sections.getValues();
+            App::DocumentObject* obj = pipe->getDocument()->getObject(msg.pObjectName);
+            std::vector<App::DocumentObject*>::iterator f = std::find(refs.begin(), refs.end(), obj);
 
-        if (selectionMode == StateHandlerTaskPipe::SelectionModes::refSectionAdd) {
-            if (f == refs.end())
+            if (selectionMode == StateHandlerTaskPipe::SelectionModes::refSectionAdd) {
+                if (f != refs.end()) {
+                    return false; // duplicate selection
+                }
+
                 pipe->Sections.addValue(obj, {msg.pSubName});
-            else
-                return false; // duplicate selection
-        }
-        else {
-            if (f != refs.end())
-                // Removing just the object this way instead of `refs.erase` and
-                // `setValues(ref)` cleanly ensures subnames are preserved.
-                pipe->Sections.removeValue(obj);
-            else
-                return false;
-        }
+            }
+            else {
+                if (f == refs.end()) {
+                    return false;
+                }
 
-        static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Section, false);
-        return true;
+                pipe->Sections.removeValue(obj);
+            }
+
+            auto view = getViewObject<ViewProviderPipe>();
+            view->highlightReferences(ViewProviderPipe::Section, false);
+            return true;
+        }
     }
 
     return false;
@@ -996,19 +1010,16 @@ void TaskPipeScaling::onDeleteSection()
         QByteArray data(item->data(Qt::UserRole).value<App::PropertyLinkSubList::SubSet>().first->getNameInDocument());
         delete item;
 
-        // search inside the list of sections
-        PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(vp->getObject());
-        std::vector<App::DocumentObject*> refs = pipe->Sections.getValues();
-        App::DocumentObject* obj = pipe->getDocument()->getObject(data.constData());
-        std::vector<App::DocumentObject*>::iterator f = std::find(refs.begin(), refs.end(), obj);
+        if (auto pipe = getObject<PartDesign::Pipe>()) {
+            std::vector<App::DocumentObject*> refs = pipe->Sections.getValues();
+            App::DocumentObject* obj = pipe->getDocument()->getObject(data.constData());
+            std::vector<App::DocumentObject*>::iterator f = std::find(refs.begin(), refs.end(), obj);
 
-        // if something was found, delete it and update the section list
-        if (f != refs.end()) {
-            // Removing just the object this way instead of `refs.erase` and
-            // `setValues(ref)` cleanly ensures subnames are preserved.
-            pipe->Sections.removeValue(obj);
-            clearButtons();
-            recomputeFeature();
+            if (f != refs.end()) {
+                pipe->Sections.removeValue(obj);
+                clearButtons();
+                recomputeFeature();
+            }
         }
     }
 }

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -1097,21 +1097,21 @@ void TaskDlgPipeParameters::onButtonToggled(QAbstractButton *button, bool checke
 
     switch (id) {
     case StateHandlerTaskPipe::SelectionModes::refProfile:
-        static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Profile, checked);
+        getViewObject<ViewProviderPipe>()->highlightReferences(ViewProviderPipe::Profile, checked);
         break;
     case StateHandlerTaskPipe::SelectionModes::refSpine:
     case StateHandlerTaskPipe::SelectionModes::refSpineEdgeAdd:
     case StateHandlerTaskPipe::SelectionModes::refSpineEdgeRemove:
-        static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Spine, checked);
+        getViewObject<ViewProviderPipe>()->highlightReferences(ViewProviderPipe::Spine, checked);
         break;
     case StateHandlerTaskPipe::SelectionModes::refAuxSpine:
     case StateHandlerTaskPipe::SelectionModes::refAuxSpineEdgeAdd:
     case StateHandlerTaskPipe::SelectionModes::refAuxSpineEdgeRemove:
-        static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::AuxiliarySpine, checked);
+        getViewObject<ViewProviderPipe>()->highlightReferences(ViewProviderPipe::AuxiliarySpine, checked);
         break;
     case StateHandlerTaskPipe::SelectionModes::refSectionAdd:
     case StateHandlerTaskPipe::SelectionModes::refSectionRemove:
-        static_cast<ViewProviderPipe*>(vp)->highlightReferences(ViewProviderPipe::Section, checked);
+        getViewObject<ViewProviderPipe>()->highlightReferences(ViewProviderPipe::Section, checked);
         break;
     default:
         break;

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.h
@@ -101,9 +101,6 @@ private:
     void exitSelectionMode();
     void setVisibilityOfSpineAndProfile();
 
-    ViewProviderPipe* getPipeView() const
-    { return static_cast<ViewProviderPipe*>(vp); }
-
     bool spineShow = false;
     bool profileShow = false;
     bool auxSpineShow = false;

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.cpp
@@ -87,7 +87,7 @@ void TaskPocketParameters::updateUI(int index)
 
 void TaskPocketParameters::onModeChanged(int index)
 {
-    PartDesign::Pocket* pcPocket = static_cast<PartDesign::Pocket*>(vp->getObject());
+    auto pcPocket = getObject<PartDesign::Pocket>();
 
     switch (static_cast<Mode>(index)) {
         case Mode::Dimension:

--- a/src/Mod/PartDesign/Gui/TaskPocketParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPocketParameters.h
@@ -65,11 +65,11 @@ class TaskDlgPocketParameters : public TaskDlgExtrudeParameters
 public:
     explicit TaskDlgPocketParameters(ViewProviderPocket *PocketView);
 
-    ViewProviderPocket* getPocketView() const
-    { return static_cast<ViewProviderPocket*>(vp); }
-
 protected:
-    TaskExtrudeParameters* getTaskParameters() override { return parameters; }
+    TaskExtrudeParameters* getTaskParameters() override
+    {
+        return parameters;
+    }
 
 private:
     TaskPocketParameters* parameters;

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -56,171 +56,171 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
     this->groupLayout()->addWidget(proxy);
 
     int index = 0;
-    switch(static_cast<PartDesign::FeaturePrimitive*>(vp->getObject())->getPrimitiveType()) {
+    switch(getObject<PartDesign::FeaturePrimitive>()->getPrimitiveType()) {
 
         case PartDesign::FeaturePrimitive::Box:
             index = 1;
-            ui->boxLength->setValue(static_cast<PartDesign::Box*>(vp->getObject())->Length.getValue());
-            ui->boxLength->bind(static_cast<PartDesign::Box*>(vp->getObject())->Length);
-            ui->boxHeight->setValue(static_cast<PartDesign::Box*>(vp->getObject())->Height.getValue());
-            ui->boxHeight->bind(static_cast<PartDesign::Box*>(vp->getObject())->Height);
-            ui->boxWidth->setValue(static_cast<PartDesign::Box*>(vp->getObject())->Width.getValue());
-            ui->boxWidth->bind(static_cast<PartDesign::Box*>(vp->getObject())->Width);
-            ui->boxLength->setMinimum(static_cast<PartDesign::Box*>(vp->getObject())->Length.getMinimum());
-            ui->boxLength->setMaximum(static_cast<PartDesign::Box*>(vp->getObject())->Length.getMaximum());
-            ui->boxWidth->setMinimum(static_cast<PartDesign::Box*>(vp->getObject())->Width.getMinimum());
-            ui->boxWidth->setMaximum(static_cast<PartDesign::Box*>(vp->getObject())->Width.getMaximum());
-            ui->boxHeight->setMinimum(static_cast<PartDesign::Box*>(vp->getObject())->Height.getMinimum());
-            ui->boxHeight->setMaximum(static_cast<PartDesign::Box*>(vp->getObject())->Height.getMaximum());
+            ui->boxLength->setValue(getObject<PartDesign::Box>()->Length.getValue());
+            ui->boxLength->bind(getObject<PartDesign::Box>()->Length);
+            ui->boxHeight->setValue(getObject<PartDesign::Box>()->Height.getValue());
+            ui->boxHeight->bind(getObject<PartDesign::Box>()->Height);
+            ui->boxWidth->setValue(getObject<PartDesign::Box>()->Width.getValue());
+            ui->boxWidth->bind(getObject<PartDesign::Box>()->Width);
+            ui->boxLength->setMinimum(getObject<PartDesign::Box>()->Length.getMinimum());
+            ui->boxLength->setMaximum(getObject<PartDesign::Box>()->Length.getMaximum());
+            ui->boxWidth->setMinimum(getObject<PartDesign::Box>()->Width.getMinimum());
+            ui->boxWidth->setMaximum(getObject<PartDesign::Box>()->Width.getMaximum());
+            ui->boxHeight->setMinimum(getObject<PartDesign::Box>()->Height.getMinimum());
+            ui->boxHeight->setMaximum(getObject<PartDesign::Box>()->Height.getMaximum());
             break;
         case PartDesign::FeaturePrimitive::Cylinder:
             index = 2;
-            ui->cylinderAngle->setValue(static_cast<PartDesign::Cylinder*>(vp->getObject())->Angle.getValue());
-            ui->cylinderAngle->bind(static_cast<PartDesign::Cylinder*>(vp->getObject())->Angle);
-            ui->cylinderHeight->setValue(static_cast<PartDesign::Cylinder*>(vp->getObject())->Height.getValue());
-            ui->cylinderHeight->bind(static_cast<PartDesign::Cylinder*>(vp->getObject())->Height);
-            ui->cylinderRadius->setValue(static_cast<PartDesign::Cylinder*>(vp->getObject())->Radius.getValue());
-            ui->cylinderRadius->bind(static_cast<PartDesign::Cylinder*>(vp->getObject())->Radius);
-            ui->cylinderXSkew->setValue(static_cast<PartDesign::Cylinder*>(vp->getObject())->FirstAngle.getValue());
-            ui->cylinderXSkew->bind(static_cast<PartDesign::Cylinder*>(vp->getObject())->FirstAngle);
-            ui->cylinderYSkew->setValue(static_cast<PartDesign::Cylinder*>(vp->getObject())->SecondAngle.getValue());
-            ui->cylinderYSkew->bind(static_cast<PartDesign::Cylinder*>(vp->getObject())->SecondAngle);
-            ui->cylinderAngle->setMaximum(static_cast<PartDesign::Cylinder*>(vp->getObject())->Angle.getMaximum());
-            ui->cylinderAngle->setMinimum(static_cast<PartDesign::Cylinder*>(vp->getObject())->Angle.getMinimum());
-            ui->cylinderHeight->setMaximum(static_cast<PartDesign::Cylinder*>(vp->getObject())->Height.getMaximum());
-            ui->cylinderHeight->setMinimum(static_cast<PartDesign::Cylinder*>(vp->getObject())->Height.getMinimum());
-            ui->cylinderRadius->setMaximum(static_cast<PartDesign::Cylinder*>(vp->getObject())->Radius.getMaximum());
-            ui->cylinderRadius->setMinimum(static_cast<PartDesign::Cylinder*>(vp->getObject())->Radius.getMinimum());
+            ui->cylinderAngle->setValue(getObject<PartDesign::Cylinder>()->Angle.getValue());
+            ui->cylinderAngle->bind(getObject<PartDesign::Cylinder>()->Angle);
+            ui->cylinderHeight->setValue(getObject<PartDesign::Cylinder>()->Height.getValue());
+            ui->cylinderHeight->bind(getObject<PartDesign::Cylinder>()->Height);
+            ui->cylinderRadius->setValue(getObject<PartDesign::Cylinder>()->Radius.getValue());
+            ui->cylinderRadius->bind(getObject<PartDesign::Cylinder>()->Radius);
+            ui->cylinderXSkew->setValue(getObject<PartDesign::Cylinder>()->FirstAngle.getValue());
+            ui->cylinderXSkew->bind(getObject<PartDesign::Cylinder>()->FirstAngle);
+            ui->cylinderYSkew->setValue(getObject<PartDesign::Cylinder>()->SecondAngle.getValue());
+            ui->cylinderYSkew->bind(getObject<PartDesign::Cylinder>()->SecondAngle);
+            ui->cylinderAngle->setMaximum(getObject<PartDesign::Cylinder>()->Angle.getMaximum());
+            ui->cylinderAngle->setMinimum(getObject<PartDesign::Cylinder>()->Angle.getMinimum());
+            ui->cylinderHeight->setMaximum(getObject<PartDesign::Cylinder>()->Height.getMaximum());
+            ui->cylinderHeight->setMinimum(getObject<PartDesign::Cylinder>()->Height.getMinimum());
+            ui->cylinderRadius->setMaximum(getObject<PartDesign::Cylinder>()->Radius.getMaximum());
+            ui->cylinderRadius->setMinimum(getObject<PartDesign::Cylinder>()->Radius.getMinimum());
             break;
         case PartDesign::FeaturePrimitive::Sphere:
             index = 4;
-            ui->sphereAngle1->setValue(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle1.getValue());
-            ui->sphereAngle1->bind(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle1);
-            ui->sphereAngle2->setValue(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle2.getValue());
-            ui->sphereAngle2->bind(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle2);
-            ui->sphereAngle3->setValue(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle3.getValue());
-            ui->sphereAngle3->bind(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle3);
-            ui->sphereRadius->setValue(static_cast<PartDesign::Sphere*>(vp->getObject())->Radius.getValue());
-            ui->sphereRadius->bind(static_cast<PartDesign::Sphere*>(vp->getObject())->Radius);
+            ui->sphereAngle1->setValue(getObject<PartDesign::Sphere>()->Angle1.getValue());
+            ui->sphereAngle1->bind(getObject<PartDesign::Sphere>()->Angle1);
+            ui->sphereAngle2->setValue(getObject<PartDesign::Sphere>()->Angle2.getValue());
+            ui->sphereAngle2->bind(getObject<PartDesign::Sphere>()->Angle2);
+            ui->sphereAngle3->setValue(getObject<PartDesign::Sphere>()->Angle3.getValue());
+            ui->sphereAngle3->bind(getObject<PartDesign::Sphere>()->Angle3);
+            ui->sphereRadius->setValue(getObject<PartDesign::Sphere>()->Radius.getValue());
+            ui->sphereRadius->bind(getObject<PartDesign::Sphere>()->Radius);
             ui->sphereAngle1->setMaximum(ui->sphereAngle2->rawValue()); // must geometrically be <= than sphereAngle2
-            ui->sphereAngle1->setMinimum(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle1.getMinimum());
-            ui->sphereAngle2->setMaximum(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle2.getMaximum());
+            ui->sphereAngle1->setMinimum(getObject<PartDesign::Sphere>()->Angle1.getMinimum());
+            ui->sphereAngle2->setMaximum(getObject<PartDesign::Sphere>()->Angle2.getMaximum());
             ui->sphereAngle2->setMinimum(ui->sphereAngle1->rawValue());
-            ui->sphereAngle3->setMaximum(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle3.getMaximum());
-            ui->sphereAngle3->setMinimum(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle3.getMinimum());
-            ui->sphereRadius->setMaximum(static_cast<PartDesign::Sphere*>(vp->getObject())->Radius.getMaximum());
-            ui->sphereRadius->setMinimum(static_cast<PartDesign::Sphere*>(vp->getObject())->Radius.getMinimum());
+            ui->sphereAngle3->setMaximum(getObject<PartDesign::Sphere>()->Angle3.getMaximum());
+            ui->sphereAngle3->setMinimum(getObject<PartDesign::Sphere>()->Angle3.getMinimum());
+            ui->sphereRadius->setMaximum(getObject<PartDesign::Sphere>()->Radius.getMaximum());
+            ui->sphereRadius->setMinimum(getObject<PartDesign::Sphere>()->Radius.getMinimum());
             break;
         case PartDesign::FeaturePrimitive::Cone:
             index = 3;
-            ui->coneAngle->setValue(static_cast<PartDesign::Cone*>(vp->getObject())->Angle.getValue());
-            ui->coneAngle->bind(static_cast<PartDesign::Cone*>(vp->getObject())->Angle);
-            ui->coneHeight->setValue(static_cast<PartDesign::Cone*>(vp->getObject())->Height.getValue());
-            ui->coneHeight->bind(static_cast<PartDesign::Cone*>(vp->getObject())->Height);
-            ui->coneRadius1->setValue(static_cast<PartDesign::Cone*>(vp->getObject())->Radius1.getValue());
-            ui->coneRadius1->bind(static_cast<PartDesign::Cone*>(vp->getObject())->Radius1);
-            ui->coneRadius2->setValue(static_cast<PartDesign::Cone*>(vp->getObject())->Radius2.getValue());
-            ui->coneRadius2->bind(static_cast<PartDesign::Cone*>(vp->getObject())->Radius2);
-            ui->coneAngle->setMaximum(static_cast<PartDesign::Cone*>(vp->getObject())->Angle.getMaximum());
-            ui->coneAngle->setMinimum(static_cast<PartDesign::Cone*>(vp->getObject())->Angle.getMinimum());
-            ui->coneHeight->setMaximum(static_cast<PartDesign::Cone*>(vp->getObject())->Height.getMaximum());
-            ui->coneHeight->setMinimum(static_cast<PartDesign::Cone*>(vp->getObject())->Height.getMinimum());
-            ui->coneRadius1->setMaximum(static_cast<PartDesign::Cone*>(vp->getObject())->Radius1.getMaximum());
-            ui->coneRadius1->setMinimum(static_cast<PartDesign::Cone*>(vp->getObject())->Radius1.getMinimum());
-            ui->coneRadius2->setMaximum(static_cast<PartDesign::Cone*>(vp->getObject())->Radius2.getMaximum());
-            ui->coneRadius2->setMinimum(static_cast<PartDesign::Cone*>(vp->getObject())->Radius2.getMinimum());
+            ui->coneAngle->setValue(getObject<PartDesign::Cone>()->Angle.getValue());
+            ui->coneAngle->bind(getObject<PartDesign::Cone>()->Angle);
+            ui->coneHeight->setValue(getObject<PartDesign::Cone>()->Height.getValue());
+            ui->coneHeight->bind(getObject<PartDesign::Cone>()->Height);
+            ui->coneRadius1->setValue(getObject<PartDesign::Cone>()->Radius1.getValue());
+            ui->coneRadius1->bind(getObject<PartDesign::Cone>()->Radius1);
+            ui->coneRadius2->setValue(getObject<PartDesign::Cone>()->Radius2.getValue());
+            ui->coneRadius2->bind(getObject<PartDesign::Cone>()->Radius2);
+            ui->coneAngle->setMaximum(getObject<PartDesign::Cone>()->Angle.getMaximum());
+            ui->coneAngle->setMinimum(getObject<PartDesign::Cone>()->Angle.getMinimum());
+            ui->coneHeight->setMaximum(getObject<PartDesign::Cone>()->Height.getMaximum());
+            ui->coneHeight->setMinimum(getObject<PartDesign::Cone>()->Height.getMinimum());
+            ui->coneRadius1->setMaximum(getObject<PartDesign::Cone>()->Radius1.getMaximum());
+            ui->coneRadius1->setMinimum(getObject<PartDesign::Cone>()->Radius1.getMinimum());
+            ui->coneRadius2->setMaximum(getObject<PartDesign::Cone>()->Radius2.getMaximum());
+            ui->coneRadius2->setMinimum(getObject<PartDesign::Cone>()->Radius2.getMinimum());
             break;
         case PartDesign::FeaturePrimitive::Ellipsoid:
             index = 5;
-            ui->ellipsoidAngle1->setValue(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle1.getValue());
-            ui->ellipsoidAngle1->bind(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle1);
-            ui->ellipsoidAngle2->setValue(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle2.getValue());
-            ui->ellipsoidAngle2->bind(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle2);
-            ui->ellipsoidAngle3->setValue(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle3.getValue());
-            ui->ellipsoidAngle3->bind(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle3);
-            ui->ellipsoidRadius1->setValue(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius1.getValue());
-            ui->ellipsoidRadius1->bind(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius1);
-            ui->ellipsoidRadius2->setValue(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius2.getValue());
-            ui->ellipsoidRadius2->bind(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius2);
-            ui->ellipsoidRadius3->setValue(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius3.getValue());
-            ui->ellipsoidRadius3->bind(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius3);
+            ui->ellipsoidAngle1->setValue(getObject<PartDesign::Ellipsoid>()->Angle1.getValue());
+            ui->ellipsoidAngle1->bind(getObject<PartDesign::Ellipsoid>()->Angle1);
+            ui->ellipsoidAngle2->setValue(getObject<PartDesign::Ellipsoid>()->Angle2.getValue());
+            ui->ellipsoidAngle2->bind(getObject<PartDesign::Ellipsoid>()->Angle2);
+            ui->ellipsoidAngle3->setValue(getObject<PartDesign::Ellipsoid>()->Angle3.getValue());
+            ui->ellipsoidAngle3->bind(getObject<PartDesign::Ellipsoid>()->Angle3);
+            ui->ellipsoidRadius1->setValue(getObject<PartDesign::Ellipsoid>()->Radius1.getValue());
+            ui->ellipsoidRadius1->bind(getObject<PartDesign::Ellipsoid>()->Radius1);
+            ui->ellipsoidRadius2->setValue(getObject<PartDesign::Ellipsoid>()->Radius2.getValue());
+            ui->ellipsoidRadius2->bind(getObject<PartDesign::Ellipsoid>()->Radius2);
+            ui->ellipsoidRadius3->setValue(getObject<PartDesign::Ellipsoid>()->Radius3.getValue());
+            ui->ellipsoidRadius3->bind(getObject<PartDesign::Ellipsoid>()->Radius3);
             ui->ellipsoidAngle1->setMaximum(ui->ellipsoidAngle2->rawValue()); // must geometrically be <= than sphereAngle2
-            ui->ellipsoidAngle1->setMinimum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle1.getMinimum());
-            ui->ellipsoidAngle2->setMaximum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle2.getMaximum());
+            ui->ellipsoidAngle1->setMinimum(getObject<PartDesign::Ellipsoid>()->Angle1.getMinimum());
+            ui->ellipsoidAngle2->setMaximum(getObject<PartDesign::Ellipsoid>()->Angle2.getMaximum());
             ui->ellipsoidAngle2->setMinimum(ui->ellipsoidAngle1->rawValue());
-            ui->ellipsoidAngle3->setMaximum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle3.getMaximum());
-            ui->ellipsoidAngle3->setMinimum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Angle3.getMinimum());
-            ui->ellipsoidRadius1->setMinimum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius1.getMinimum());
-            ui->ellipsoidRadius1->setMaximum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius1.getMaximum());
-            ui->ellipsoidRadius2->setMinimum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius2.getMinimum());
-            ui->ellipsoidRadius2->setMaximum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius2.getMaximum());
-            ui->ellipsoidRadius3->setMinimum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius3.getMinimum());
-            ui->ellipsoidRadius3->setMaximum(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius3.getMaximum());
+            ui->ellipsoidAngle3->setMaximum(getObject<PartDesign::Ellipsoid>()->Angle3.getMaximum());
+            ui->ellipsoidAngle3->setMinimum(getObject<PartDesign::Ellipsoid>()->Angle3.getMinimum());
+            ui->ellipsoidRadius1->setMinimum(getObject<PartDesign::Ellipsoid>()->Radius1.getMinimum());
+            ui->ellipsoidRadius1->setMaximum(getObject<PartDesign::Ellipsoid>()->Radius1.getMaximum());
+            ui->ellipsoidRadius2->setMinimum(getObject<PartDesign::Ellipsoid>()->Radius2.getMinimum());
+            ui->ellipsoidRadius2->setMaximum(getObject<PartDesign::Ellipsoid>()->Radius2.getMaximum());
+            ui->ellipsoidRadius3->setMinimum(getObject<PartDesign::Ellipsoid>()->Radius3.getMinimum());
+            ui->ellipsoidRadius3->setMaximum(getObject<PartDesign::Ellipsoid>()->Radius3.getMaximum());
             break;
         case PartDesign::FeaturePrimitive::Torus:
             index = 6;
-            ui->torusAngle1->setValue(static_cast<PartDesign::Torus*>(vp->getObject())->Angle1.getValue());
-            ui->torusAngle1->bind(static_cast<PartDesign::Torus*>(vp->getObject())->Angle1);
-            ui->torusAngle2->setValue(static_cast<PartDesign::Torus*>(vp->getObject())->Angle2.getValue());
-            ui->torusAngle2->bind(static_cast<PartDesign::Torus*>(vp->getObject())->Angle2);
-            ui->torusAngle3->setValue(static_cast<PartDesign::Torus*>(vp->getObject())->Angle3.getValue());
-            ui->torusAngle3->bind(static_cast<PartDesign::Torus*>(vp->getObject())->Angle3);
-            ui->torusRadius1->setValue(static_cast<PartDesign::Torus*>(vp->getObject())->Radius1.getValue());
-            ui->torusRadius1->bind(static_cast<PartDesign::Torus*>(vp->getObject())->Radius1);
-            ui->torusRadius2->setValue(static_cast<PartDesign::Torus*>(vp->getObject())->Radius2.getValue());
-            ui->torusRadius2->bind(static_cast<PartDesign::Torus*>(vp->getObject())->Radius2);
+            ui->torusAngle1->setValue(getObject<PartDesign::Torus>()->Angle1.getValue());
+            ui->torusAngle1->bind(getObject<PartDesign::Torus>()->Angle1);
+            ui->torusAngle2->setValue(getObject<PartDesign::Torus>()->Angle2.getValue());
+            ui->torusAngle2->bind(getObject<PartDesign::Torus>()->Angle2);
+            ui->torusAngle3->setValue(getObject<PartDesign::Torus>()->Angle3.getValue());
+            ui->torusAngle3->bind(getObject<PartDesign::Torus>()->Angle3);
+            ui->torusRadius1->setValue(getObject<PartDesign::Torus>()->Radius1.getValue());
+            ui->torusRadius1->bind(getObject<PartDesign::Torus>()->Radius1);
+            ui->torusRadius2->setValue(getObject<PartDesign::Torus>()->Radius2.getValue());
+            ui->torusRadius2->bind(getObject<PartDesign::Torus>()->Radius2);
             ui->torusAngle1->setMaximum(ui->torusAngle2->rawValue()); // must geometrically be <= than sphereAngle2
-            ui->torusAngle1->setMinimum(static_cast<PartDesign::Torus*>(vp->getObject())->Angle1.getMinimum());
-            ui->torusAngle2->setMaximum(static_cast<PartDesign::Torus*>(vp->getObject())->Angle2.getMaximum());
+            ui->torusAngle1->setMinimum(getObject<PartDesign::Torus>()->Angle1.getMinimum());
+            ui->torusAngle2->setMaximum(getObject<PartDesign::Torus>()->Angle2.getMaximum());
             ui->torusAngle2->setMinimum(ui->torusAngle1->rawValue());
-            ui->torusAngle3->setMaximum(static_cast<PartDesign::Torus*>(vp->getObject())->Angle3.getMaximum());
-            ui->torusAngle3->setMinimum(static_cast<PartDesign::Torus*>(vp->getObject())->Angle3.getMinimum());
+            ui->torusAngle3->setMaximum(getObject<PartDesign::Torus>()->Angle3.getMaximum());
+            ui->torusAngle3->setMinimum(getObject<PartDesign::Torus>()->Angle3.getMinimum());
             // this is the outer radius that must not be smaller than the inner one
             // otherwise the geometry is impossible and we can even get a crash:
             // https://forum.freecad.org/viewtopic.php?f=3&t=44467
-            ui->torusRadius1->setMaximum(static_cast<PartDesign::Torus*>(vp->getObject())->Radius1.getMaximum());
+            ui->torusRadius1->setMaximum(getObject<PartDesign::Torus>()->Radius1.getMaximum());
             ui->torusRadius1->setMinimum(ui->torusRadius2->rawValue());
             ui->torusRadius2->setMaximum(ui->torusRadius1->rawValue());
-            ui->torusRadius2->setMinimum(static_cast<PartDesign::Torus*>(vp->getObject())->Radius2.getMinimum());
+            ui->torusRadius2->setMinimum(getObject<PartDesign::Torus>()->Radius2.getMinimum());
             break;
         case PartDesign::FeaturePrimitive::Prism:
             index = 7;
-            ui->prismPolygon->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->Polygon.getValue());
-            ui->prismCircumradius->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->Circumradius.getValue());
-            ui->prismCircumradius->bind(static_cast<PartDesign::Prism*>(vp->getObject())->Circumradius);
-            ui->prismHeight->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->Height.getValue());
-            ui->prismHeight->bind(static_cast<PartDesign::Prism*>(vp->getObject())->Height);
-            ui->prismXSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->FirstAngle.getValue());
-            ui->prismXSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->FirstAngle);
-            ui->prismYSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->SecondAngle.getValue());
-            ui->prismYSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->SecondAngle);
-            ui->prismCircumradius->setMaximum(static_cast<PartDesign::Prism*>(vp->getObject())->Circumradius.getMaximum());
-            ui->prismCircumradius->setMinimum(static_cast<PartDesign::Prism*>(vp->getObject())->Circumradius.getMinimum());
-            ui->prismHeight->setMaximum(static_cast<PartDesign::Prism*>(vp->getObject())->Height.getMaximum());
-            ui->prismHeight->setMinimum(static_cast<PartDesign::Prism*>(vp->getObject())->Height.getMinimum());
+            ui->prismPolygon->setValue(getObject<PartDesign::Prism>()->Polygon.getValue());
+            ui->prismCircumradius->setValue(getObject<PartDesign::Prism>()->Circumradius.getValue());
+            ui->prismCircumradius->bind(getObject<PartDesign::Prism>()->Circumradius);
+            ui->prismHeight->setValue(getObject<PartDesign::Prism>()->Height.getValue());
+            ui->prismHeight->bind(getObject<PartDesign::Prism>()->Height);
+            ui->prismXSkew->setValue(getObject<PartDesign::Prism>()->FirstAngle.getValue());
+            ui->prismXSkew->bind(getObject<PartDesign::Prism>()->FirstAngle);
+            ui->prismYSkew->setValue(getObject<PartDesign::Prism>()->SecondAngle.getValue());
+            ui->prismYSkew->bind(getObject<PartDesign::Prism>()->SecondAngle);
+            ui->prismCircumradius->setMaximum(getObject<PartDesign::Prism>()->Circumradius.getMaximum());
+            ui->prismCircumradius->setMinimum(getObject<PartDesign::Prism>()->Circumradius.getMinimum());
+            ui->prismHeight->setMaximum(getObject<PartDesign::Prism>()->Height.getMaximum());
+            ui->prismHeight->setMinimum(getObject<PartDesign::Prism>()->Height.getMinimum());
             break;
         case PartDesign::FeaturePrimitive::Wedge:
             index = 8;
-            ui->wedgeXmax->setValue(static_cast<PartDesign::Wedge*>(vp->getObject())->Xmax.getValue());
-            ui->wedgeXmax->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->Xmax);
-            ui->wedgeXmin->setValue(static_cast<PartDesign::Wedge*>(vp->getObject())->Xmin.getValue());
-            ui->wedgeXmin->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->Xmin);
-            ui->wedgeX2max->setValue(static_cast<PartDesign::Wedge*>(vp->getObject())->X2max.getValue());
-            ui->wedgeX2max->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->X2max);
-            ui->wedgeX2min->setValue(static_cast<PartDesign::Wedge*>(vp->getObject())->X2min.getValue());
-            ui->wedgeX2min->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->X2min);
-            ui->wedgeYmax->setValue(static_cast<PartDesign::Wedge*>(vp->getObject())->Ymax.getValue());
-            ui->wedgeYmax->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->Ymax);
-            ui->wedgeYmin->setValue(static_cast<PartDesign::Wedge*>(vp->getObject())->Ymin.getValue());
-            ui->wedgeYmin->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->Ymin);
-            ui->wedgeZmax->setValue(static_cast<PartDesign::Wedge*>(vp->getObject())->Zmax.getValue());
-            ui->wedgeZmax->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->Zmax);
-            ui->wedgeZmin->setValue(static_cast<PartDesign::Wedge*>(vp->getObject())->Zmin.getValue());
-            ui->wedgeZmin->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->Zmin);
-            ui->wedgeZ2max->setValue(static_cast<PartDesign::Wedge*>(vp->getObject())->Z2max.getValue());
-            ui->wedgeZ2max->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->Z2max);
-            ui->wedgeZ2min->setValue(static_cast<PartDesign::Wedge*>(vp->getObject())->Z2min.getValue());
-            ui->wedgeZ2min->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->Z2min);
+            ui->wedgeXmax->setValue(getObject<PartDesign::Wedge>()->Xmax.getValue());
+            ui->wedgeXmax->bind(getObject<PartDesign::Wedge>()->Xmax);
+            ui->wedgeXmin->setValue(getObject<PartDesign::Wedge>()->Xmin.getValue());
+            ui->wedgeXmin->bind(getObject<PartDesign::Wedge>()->Xmin);
+            ui->wedgeX2max->setValue(getObject<PartDesign::Wedge>()->X2max.getValue());
+            ui->wedgeX2max->bind(getObject<PartDesign::Wedge>()->X2max);
+            ui->wedgeX2min->setValue(getObject<PartDesign::Wedge>()->X2min.getValue());
+            ui->wedgeX2min->bind(getObject<PartDesign::Wedge>()->X2min);
+            ui->wedgeYmax->setValue(getObject<PartDesign::Wedge>()->Ymax.getValue());
+            ui->wedgeYmax->bind(getObject<PartDesign::Wedge>()->Ymax);
+            ui->wedgeYmin->setValue(getObject<PartDesign::Wedge>()->Ymin.getValue());
+            ui->wedgeYmin->bind(getObject<PartDesign::Wedge>()->Ymin);
+            ui->wedgeZmax->setValue(getObject<PartDesign::Wedge>()->Zmax.getValue());
+            ui->wedgeZmax->bind(getObject<PartDesign::Wedge>()->Zmax);
+            ui->wedgeZmin->setValue(getObject<PartDesign::Wedge>()->Zmin.getValue());
+            ui->wedgeZmin->bind(getObject<PartDesign::Wedge>()->Zmin);
+            ui->wedgeZ2max->setValue(getObject<PartDesign::Wedge>()->Z2max.getValue());
+            ui->wedgeZ2max->bind(getObject<PartDesign::Wedge>()->Z2max);
+            ui->wedgeZ2min->setValue(getObject<PartDesign::Wedge>()->Z2min.getValue());
+            ui->wedgeZ2min->bind(getObject<PartDesign::Wedge>()->Z2min);
             ui->wedgeXmin->setMinimum(INT_MIN);
             ui->wedgeXmin->setMaximum(ui->wedgeXmax->rawValue()); // must be < than wedgeXmax
             ui->wedgeYmin->setMinimum(INT_MIN);
@@ -256,11 +256,10 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
     this->attachDocument(doc);
 
     //show the parts coordinate system axis for selection
-    PartDesign::Body * body = PartDesign::Body::findBodyOf(vp->getObject());
-    if(body) {
+    if(PartDesign::Body * body = PartDesign::Body::findBodyOf(getObject())) {
         try {
             App::Origin *origin = body->getOrigin();
-            Gui::ViewProviderOrigin* vpOrigin;
+            Gui::ViewProviderOrigin* vpOrigin {};
             vpOrigin = static_cast<Gui::ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->setTemporaryVisibility(true, true);
         } catch (const Base::Exception &ex) {
@@ -376,343 +375,425 @@ TaskBoxPrimitives::~TaskBoxPrimitives()
 {
     //hide the parts coordinate system axis for selection
     try {
-        PartDesign::Body * body = vp ? PartDesign::Body::findBodyOf(vp->getObject()) : nullptr;
-        if (body) {
+        auto obj = getObject();
+        if (PartDesign::Body * body = obj ? PartDesign::Body::findBodyOf(obj) : nullptr) {
             App::Origin *origin = body->getOrigin();
             Gui::ViewProviderOrigin* vpOrigin;
             vpOrigin = static_cast<Gui::ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->resetTemporaryVisibility();
         }
-    } catch (const Base::Exception &ex) {
+    }
+    catch (const Base::Exception &ex) {
         Base::Console().Error ("%s\n", ex.what () );
     }
 }
 
 void TaskBoxPrimitives::slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj)
 {
-    if (this->vp == &Obj)
+    if (this->vp == &Obj) {
         this->vp = nullptr;
-}
-
-void TaskBoxPrimitives::onBoxHeightChanged(double v) {
-    PartDesign::Box* box = static_cast<PartDesign::Box*>(vp->getObject());
-    box->Height.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onBoxWidthChanged(double v) {
-    PartDesign::Box* box = static_cast<PartDesign::Box*>(vp->getObject());
-    box->Width.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onBoxLengthChanged(double v) {
-    PartDesign::Box* box = static_cast<PartDesign::Box*>(vp->getObject());
-    box->Length.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onCylinderAngleChanged(double v) {
-    PartDesign::Cylinder* cyl = static_cast<PartDesign::Cylinder*>(vp->getObject());
-    cyl->Angle.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onCylinderHeightChanged(double v) {
-    PartDesign::Cylinder* cyl = static_cast<PartDesign::Cylinder*>(vp->getObject());
-    cyl->Height.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onCylinderRadiusChanged(double v) {
-    PartDesign::Cylinder* cyl = static_cast<PartDesign::Cylinder*>(vp->getObject());
-    cyl->Radius.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onCylinderXSkewChanged(double v) {
-    PartDesign::Cylinder* cyl = static_cast<PartDesign::Cylinder*>(vp->getObject());
-    // we must assure that if the user incremented from e.g. 85 degree with the
-    // spin buttons, they do not end at 90.0 but at 89.9999 which is shown rounded to 90 degree
-    if ((v < 90.0) && (v > -90.0)) {
-        cyl->FirstAngle.setValue(v);
     }
-    else {
-        if (v == 90.0)
-            cyl->FirstAngle.setValue(cyl->FirstAngle.getMaximum());
-        else if (v == -90.0)
-            cyl->FirstAngle.setValue(cyl->FirstAngle.getMinimum());
-        ui->cylinderXSkew->setValue(cyl->FirstAngle.getQuantityValue());
+}
+
+void TaskBoxPrimitives::onBoxHeightChanged(double v)
+{
+    if (auto box = getObject<PartDesign::Box>()) {
+        box->Height.setValue(v);
+        box->recomputeFeature();
     }
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
-void TaskBoxPrimitives::onCylinderYSkewChanged(double v) {
-    PartDesign::Cylinder* cyl = static_cast<PartDesign::Cylinder*>(vp->getObject());
-    // we must assure that if the user incremented from e.g. 85 degree with the
-    // spin buttons, they do not end at 90.0 but at 89.9999 which is shown rounded to 90 degree
-    if ((v < 90.0) && (v > -90.0)) {
-        cyl->SecondAngle.setValue(v);
+void TaskBoxPrimitives::onBoxWidthChanged(double v)
+{
+    if (auto box = getObject<PartDesign::Box>()) {
+        box->Width.setValue(v);
+        box->recomputeFeature();
     }
-    else {
-        if (v == 90.0)
-            cyl->SecondAngle.setValue(cyl->SecondAngle.getMaximum());
-        else if (v == -90.0)
-            cyl->SecondAngle.setValue(cyl->SecondAngle.getMinimum());
-        ui->cylinderYSkew->setValue(cyl->SecondAngle.getQuantityValue());
+}
+
+void TaskBoxPrimitives::onBoxLengthChanged(double v)
+{
+    if (auto box = getObject<PartDesign::Box>()) {
+        box->Length.setValue(v);
+        box->recomputeFeature();
     }
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
-void TaskBoxPrimitives::onSphereAngle1Changed(double v) {
-    PartDesign::Sphere* sph = static_cast<PartDesign::Sphere*>(vp->getObject());
-    ui->sphereAngle2->setMinimum(v); // Angle1 must geometrically be <= than Angle2
-    sph->Angle1.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onSphereAngle2Changed(double v) {
-    PartDesign::Sphere* sph = static_cast<PartDesign::Sphere*>(vp->getObject());
-    ui->sphereAngle1->setMaximum(v); // Angle1 must geometrically be <= than Angle2
-    sph->Angle2.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onSphereAngle3Changed(double v) {
-    PartDesign::Sphere* sph = static_cast<PartDesign::Sphere*>(vp->getObject());
-    sph->Angle3.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onSphereRadiusChanged(double  v) {
-    PartDesign::Sphere* sph = static_cast<PartDesign::Sphere*>(vp->getObject());
-    sph->Radius.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onConeAngleChanged(double v) {
-
-    PartDesign::Cone* sph = static_cast<PartDesign::Cone*>(vp->getObject());
-    sph->Angle.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onConeHeightChanged(double v) {
-    PartDesign::Cone* sph = static_cast<PartDesign::Cone*>(vp->getObject());
-    sph->Height.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onConeRadius1Changed(double v) {
-
-    PartDesign::Cone* sph = static_cast<PartDesign::Cone*>(vp->getObject());
-    sph->Radius1.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onConeRadius2Changed(double v) {
-
-    PartDesign::Cone* sph = static_cast<PartDesign::Cone*>(vp->getObject());
-    sph->Radius2.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onEllipsoidAngle1Changed(double v) {
-    PartDesign::Ellipsoid* sph = static_cast<PartDesign::Ellipsoid*>(vp->getObject());
-    ui->ellipsoidAngle2->setMinimum(v); // Angle1 must geometrically be <= than Angle2
-    sph->Angle1.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onEllipsoidAngle2Changed(double v) {
-    PartDesign::Ellipsoid* sph = static_cast<PartDesign::Ellipsoid*>(vp->getObject());
-    ui->ellipsoidAngle1->setMaximum(v); // Angle1 must geometrically be <= than Angle22
-    sph->Angle2.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onEllipsoidAngle3Changed(double v) {
-    PartDesign::Ellipsoid* sph = static_cast<PartDesign::Ellipsoid*>(vp->getObject());
-    sph->Angle3.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onEllipsoidRadius1Changed(double v) {
-    PartDesign::Ellipsoid* sph = static_cast<PartDesign::Ellipsoid*>(vp->getObject());
-    sph->Radius1.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onEllipsoidRadius2Changed(double v) {
-    PartDesign::Ellipsoid* sph = static_cast<PartDesign::Ellipsoid*>(vp->getObject());
-    sph->Radius2.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onEllipsoidRadius3Changed(double v) {
-    PartDesign::Ellipsoid* sph = static_cast<PartDesign::Ellipsoid*>(vp->getObject());
-    sph->Radius3.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onTorusAngle1Changed(double v) {
-    PartDesign::Torus* sph = static_cast<PartDesign::Torus*>(vp->getObject());
-    ui->torusAngle2->setMinimum(v); // Angle1 must geometrically be <= than Angle2
-    sph->Angle1.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onTorusAngle2Changed(double v) {
-    PartDesign::Torus* sph = static_cast<PartDesign::Torus*>(vp->getObject());
-    ui->torusAngle1->setMaximum(v); // Angle1 must geometrically be <= than Angle2
-    sph->Angle2.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onTorusAngle3Changed(double v) {
-    PartDesign::Torus* sph = static_cast<PartDesign::Torus*>(vp->getObject());
-    sph->Angle3.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onTorusRadius1Changed(double v) {
-    PartDesign::Torus* sph = static_cast<PartDesign::Torus*>(vp->getObject());
-    // this is the outer radius that must not be smaller than the inner one
-    // otherwise the geometry is impossible and we can even get a crash:
-    // https://forum.freecad.org/viewtopic.php?f=3&t=44467
-    ui->torusRadius2->setMaximum(v);
-    sph->Radius1.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onTorusRadius2Changed(double v) {
-    PartDesign::Torus* sph = static_cast<PartDesign::Torus*>(vp->getObject());
-    ui->torusRadius1->setMinimum(v);
-    sph->Radius2.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onPrismCircumradiusChanged(double v) {
-    PartDesign::Prism* sph = static_cast<PartDesign::Prism*>(vp->getObject());
-    sph->Circumradius.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onPrismHeightChanged(double v) {
-    PartDesign::Prism* sph = static_cast<PartDesign::Prism*>(vp->getObject());
-    sph->Height.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
-}
-
-void TaskBoxPrimitives::onPrismXSkewChanged(double v) {
-    PartDesign::Prism* sph = static_cast<PartDesign::Prism*>(vp->getObject());
-    // we must assure that if the user incremented from e.g. 85 degree with the
-    // spin buttons, they do not end at 90.0 but at 89.9999 which is shown rounded to 90 degree
-    if ((v < 90.0) && (v > -90.0)) {
-        sph->FirstAngle.setValue(v);
+void TaskBoxPrimitives::onCylinderAngleChanged(double v)
+{
+    if (auto cyl = getObject<PartDesign::Cylinder>()) {
+        cyl->Angle.setValue(v);
+        cyl->recomputeFeature();
     }
-    else {
-        if (v == 90.0)
-            sph->FirstAngle.setValue(89.99999);
-        else if (v == -90.0)
-            sph->FirstAngle.setValue(-89.99999);
-        ui->prismXSkew->setValue(sph->FirstAngle.getQuantityValue());
+}
+
+void TaskBoxPrimitives::onCylinderHeightChanged(double v)
+{
+    if (auto cyl = getObject<PartDesign::Cylinder>()) {
+        cyl->Height.setValue(v);
+        cyl->recomputeFeature();
     }
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
-void TaskBoxPrimitives::onPrismYSkewChanged(double v) {
-    PartDesign::Prism* sph = static_cast<PartDesign::Prism*>(vp->getObject());
-    // we must assure that if the user incremented from e.g. 85 degree with the
-    // spin buttons, they do not end at 90.0 but at 89.9999 which is shown rounded to 90 degree
-    if ((v < 90.0) && (v > -90.0)) {
-        sph->SecondAngle.setValue(v);
+void TaskBoxPrimitives::onCylinderRadiusChanged(double v)
+{
+    if (auto cyl = getObject<PartDesign::Cylinder>()) {
+        cyl->Radius.setValue(v);
+        cyl->recomputeFeature();
     }
-    else {
-        if (v == 90.0)
-            sph->SecondAngle.setValue(89.99999);
-        else if (v == -90.0)
-            sph->SecondAngle.setValue(-89.99999);
-        ui->prismYSkew->setValue(sph->SecondAngle.getQuantityValue());
+}
+
+void TaskBoxPrimitives::onCylinderXSkewChanged(double v)
+{
+    if (auto cyl = getObject<PartDesign::Cylinder>()) {
+        // we must assure that if the user incremented from e.g. 85 degree with the
+        // spin buttons, they do not end at 90.0 but at 89.9999 which is shown rounded to 90 degree
+        if ((v < 90.0) && (v > -90.0)) {
+            cyl->FirstAngle.setValue(v);
+        }
+        else {
+            if (v == 90.0)
+                cyl->FirstAngle.setValue(cyl->FirstAngle.getMaximum());
+            else if (v == -90.0)
+                cyl->FirstAngle.setValue(cyl->FirstAngle.getMinimum());
+            ui->cylinderXSkew->setValue(cyl->FirstAngle.getQuantityValue());
+        }
+        cyl->recomputeFeature();
     }
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
-void TaskBoxPrimitives::onPrismPolygonChanged(int v) {
-    PartDesign::Prism* sph = static_cast<PartDesign::Prism*>(vp->getObject());
-    sph->Polygon.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+void TaskBoxPrimitives::onCylinderYSkewChanged(double v)
+{
+    if (auto cyl = getObject<PartDesign::Cylinder>()) {
+        // we must assure that if the user incremented from e.g. 85 degree with the
+        // spin buttons, they do not end at 90.0 but at 89.9999 which is shown rounded to 90 degree
+        if ((v < 90.0) && (v > -90.0)) {
+            cyl->SecondAngle.setValue(v);
+        }
+        else {
+            if (v == 90.0)
+                cyl->SecondAngle.setValue(cyl->SecondAngle.getMaximum());
+            else if (v == -90.0)
+                cyl->SecondAngle.setValue(cyl->SecondAngle.getMinimum());
+            ui->cylinderYSkew->setValue(cyl->SecondAngle.getQuantityValue());
+        }
+        cyl->recomputeFeature();
+    }
 }
 
-
-void TaskBoxPrimitives::onWedgeX2minChanged(double v) {
-    PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
-    ui->wedgeX2max->setMinimum(v); // wedgeX2min must be <= than wedgeX2max
-    sph->X2min.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+void TaskBoxPrimitives::onSphereAngle1Changed(double v)
+{
+    if (auto sph = getObject<PartDesign::Sphere>()) {
+        ui->sphereAngle2->setMinimum(v); // Angle1 must geometrically be <= than Angle2
+        sph->Angle1.setValue(v);
+        sph->recomputeFeature();
+    }
 }
 
-void TaskBoxPrimitives::onWedgeX2maxChanged(double v) {
-    PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
-    ui->wedgeX2min->setMaximum(v); // wedgeX2min must be <= than wedgeX2max
-    sph->X2max.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+void TaskBoxPrimitives::onSphereAngle2Changed(double v)
+{
+    if (auto sph = getObject<PartDesign::Sphere>()) {
+        ui->sphereAngle1->setMaximum(v); // Angle1 must geometrically be <= than Angle2
+        sph->Angle2.setValue(v);
+        sph->recomputeFeature();
+    }
 }
 
-void TaskBoxPrimitives::onWedgeXminChanged(double v) {
-    PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
-    ui->wedgeXmax->setMinimum(v);
-    sph->Xmin.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+void TaskBoxPrimitives::onSphereAngle3Changed(double v)
+{
+    if (auto sph = getObject<PartDesign::Sphere>()) {
+        sph->Angle3.setValue(v);
+        sph->recomputeFeature();
+    }
 }
 
-void TaskBoxPrimitives::onWedgeXmaxChanged(double v) {
-    PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
-    ui->wedgeXmin->setMaximum(v); // must be < than wedgeXmax
-    sph->Xmax.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+void TaskBoxPrimitives::onSphereRadiusChanged(double  v)
+{
+    if (auto sph = getObject<PartDesign::Sphere>()) {
+        sph->Radius.setValue(v);
+        sph->recomputeFeature();
+    }
 }
 
-void TaskBoxPrimitives::onWedgeYminChanged(double v) {
-    PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
-    ui->wedgeYmax->setMinimum(v); // must be > than wedgeYmin
-    sph->Ymin.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+void TaskBoxPrimitives::onConeAngleChanged(double v)
+{
+    if (auto cone = getObject<PartDesign::Cone>()) {
+        cone->Angle.setValue(v);
+        cone->recomputeFeature();
+    }
 }
 
-void TaskBoxPrimitives::onWedgeYmaxChanged(double v) {
-    PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
-    ui->wedgeYmin->setMaximum(v); // must be < than wedgeYmax
-    sph->Ymax.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+void TaskBoxPrimitives::onConeHeightChanged(double v)
+{
+    if (auto cone = getObject<PartDesign::Cone>()) {
+        cone->Height.setValue(v);
+        cone->recomputeFeature();
+    }
 }
 
-void TaskBoxPrimitives::onWedgeZ2minChanged(double v) {
-    PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
-    ui->wedgeZ2max->setMinimum(v); // must be >= than wedgeZ2min
-    sph->Z2min.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+void TaskBoxPrimitives::onConeRadius1Changed(double v)
+{
+    if (auto cone = getObject<PartDesign::Cone>()) {
+        cone->Radius1.setValue(v);
+        cone->recomputeFeature();
+    }
 }
 
-void TaskBoxPrimitives::onWedgeZ2maxChanged(double v) {
-    PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
-    ui->wedgeZ2min->setMaximum(v); // must be <= than wedgeZ2max
-    sph->Z2max.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+void TaskBoxPrimitives::onConeRadius2Changed(double v)
+{
+    if (auto cone = getObject<PartDesign::Cone>()) {
+        cone->Radius2.setValue(v);
+        cone->recomputeFeature();
+    }
 }
 
-void TaskBoxPrimitives::onWedgeZminChanged(double v) {
-    PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
-    ui->wedgeZmax->setMinimum(v); // must be > than wedgeZmin
-    sph->Zmin.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+void TaskBoxPrimitives::onEllipsoidAngle1Changed(double v)
+{
+    if (auto ell = getObject<PartDesign::Ellipsoid>()) {
+        ui->ellipsoidAngle2->setMinimum(v); // Angle1 must geometrically be <= than Angle2
+        ell->Angle1.setValue(v);
+        ell->recomputeFeature();
+    }
 }
 
-void TaskBoxPrimitives::onWedgeZmaxChanged(double v) {
-    PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
-    ui->wedgeZmin->setMaximum(v); // must be < than wedgeZmax
-    sph->Zmax.setValue(v);
-    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+void TaskBoxPrimitives::onEllipsoidAngle2Changed(double v)
+{
+    if (auto ell = getObject<PartDesign::Ellipsoid>()) {
+        ui->ellipsoidAngle1->setMaximum(v); // Angle1 must geometrically be <= than Angle22
+        ell->Angle2.setValue(v);
+        ell->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onEllipsoidAngle3Changed(double v)
+{
+    if (auto ell = getObject<PartDesign::Ellipsoid>()) {
+        ell->Angle3.setValue(v);
+        ell->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onEllipsoidRadius1Changed(double v)
+{
+    if (auto ell = getObject<PartDesign::Ellipsoid>()) {
+        ell->Radius1.setValue(v);
+        ell->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onEllipsoidRadius2Changed(double v)
+{
+    if (auto ell = getObject<PartDesign::Ellipsoid>()) {
+        ell->Radius2.setValue(v);
+        ell->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onEllipsoidRadius3Changed(double v)
+{
+    if (auto ell = getObject<PartDesign::Ellipsoid>()) {
+        ell->Radius3.setValue(v);
+        ell->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onTorusAngle1Changed(double v)
+{
+    if (auto tor = getObject<PartDesign::Torus>()) {
+        ui->torusAngle2->setMinimum(v); // Angle1 must geometrically be <= than Angle2
+        tor->Angle1.setValue(v);
+        tor->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onTorusAngle2Changed(double v)
+{
+    if (auto tor = getObject<PartDesign::Torus>()) {
+        ui->torusAngle1->setMaximum(v); // Angle1 must geometrically be <= than Angle2
+        tor->Angle2.setValue(v);
+        tor->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onTorusAngle3Changed(double v)
+{
+    if (auto tor = getObject<PartDesign::Torus>()) {
+        tor->Angle3.setValue(v);
+        tor->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onTorusRadius1Changed(double v)
+{
+    if (auto tor = getObject<PartDesign::Torus>()) {
+        // this is the outer radius that must not be smaller than the inner one
+        // otherwise the geometry is impossible and we can even get a crash:
+        // https://forum.freecad.org/viewtopic.php?f=3&t=44467
+        ui->torusRadius2->setMaximum(v);
+        tor->Radius1.setValue(v);
+        tor->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onTorusRadius2Changed(double v)
+{
+    if (auto tor = getObject<PartDesign::Torus>()) {
+        ui->torusRadius1->setMinimum(v);
+        tor->Radius2.setValue(v);
+        tor->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onPrismCircumradiusChanged(double v)
+{
+    if (auto prim = getObject<PartDesign::Prism>()) {
+        prim->Circumradius.setValue(v);
+        prim->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onPrismHeightChanged(double v)
+{
+    if (auto prim = getObject<PartDesign::Prism>()) {
+        prim->Height.setValue(v);
+        prim->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onPrismXSkewChanged(double v)
+{
+    if (auto prim = getObject<PartDesign::Prism>()) {
+        // we must assure that if the user incremented from e.g. 85 degree with the
+        // spin buttons, they do not end at 90.0 but at 89.9999 which is shown rounded to 90 degree
+        if ((v < 90.0) && (v > -90.0)) {
+            prim->FirstAngle.setValue(v);
+        }
+        else {
+            if (v == 90.0)
+                prim->FirstAngle.setValue(89.99999);
+            else if (v == -90.0)
+                prim->FirstAngle.setValue(-89.99999);
+            ui->prismXSkew->setValue(prim->FirstAngle.getQuantityValue());
+        }
+        prim->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onPrismYSkewChanged(double v)
+{
+    if (auto prim = getObject<PartDesign::Prism>()) {
+        // we must assure that if the user incremented from e.g. 85 degree with the
+        // spin buttons, they do not end at 90.0 but at 89.9999 which is shown rounded to 90 degree
+        if ((v < 90.0) && (v > -90.0)) {
+            prim->SecondAngle.setValue(v);
+        }
+        else {
+            if (v == 90.0)
+                prim->SecondAngle.setValue(89.99999);
+            else if (v == -90.0)
+                prim->SecondAngle.setValue(-89.99999);
+            ui->prismYSkew->setValue(prim->SecondAngle.getQuantityValue());
+        }
+        prim->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onPrismPolygonChanged(int v)
+{
+    if (auto prim = getObject<PartDesign::Prism>()) {
+        prim->Polygon.setValue(v);
+        prim->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onWedgeX2minChanged(double v)
+{
+    if (auto wedge = getObject<PartDesign::Wedge>()) {
+        ui->wedgeX2max->setMinimum(v); // wedgeX2min must be <= than wedgeX2max
+        wedge->X2min.setValue(v);
+        wedge->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onWedgeX2maxChanged(double v)
+{
+    if (auto wedge = getObject<PartDesign::Wedge>()) {
+        ui->wedgeX2min->setMaximum(v); // wedgeX2min must be <= than wedgeX2max
+        wedge->X2max.setValue(v);
+        wedge->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onWedgeXminChanged(double v)
+{
+    if (auto wedge = getObject<PartDesign::Wedge>()) {
+        ui->wedgeXmax->setMinimum(v);
+        wedge->Xmin.setValue(v);
+        wedge->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onWedgeXmaxChanged(double v)
+{
+    if (auto wedge = getObject<PartDesign::Wedge>()) {
+        ui->wedgeXmin->setMaximum(v); // must be < than wedgeXmax
+        wedge->Xmax.setValue(v);
+        wedge->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onWedgeYminChanged(double v)
+{
+    if (auto wedge = getObject<PartDesign::Wedge>()) {
+        ui->wedgeYmax->setMinimum(v); // must be > than wedgeYmin
+        wedge->Ymin.setValue(v);
+        wedge->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onWedgeYmaxChanged(double v)
+{
+    if (auto wedge = getObject<PartDesign::Wedge>()) {
+        ui->wedgeYmin->setMaximum(v); // must be < than wedgeYmax
+        wedge->Ymax.setValue(v);
+        wedge->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onWedgeZ2minChanged(double v)
+{
+    if (auto wedge = getObject<PartDesign::Wedge>()) {
+        ui->wedgeZ2max->setMinimum(v); // must be >= than wedgeZ2min
+        wedge->Z2min.setValue(v);
+        wedge->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onWedgeZ2maxChanged(double v)
+{
+    if (auto wedge = getObject<PartDesign::Wedge>()) {
+        ui->wedgeZ2min->setMaximum(v); // must be <= than wedgeZ2max
+        wedge->Z2max.setValue(v);
+        wedge->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onWedgeZminChanged(double v)
+{
+    if (auto wedge = getObject<PartDesign::Wedge>()) {
+        ui->wedgeZmax->setMinimum(v); // must be > than wedgeZmin
+        wedge->Zmin.setValue(v);
+        wedge->recomputeFeature();
+    }
+}
+
+void TaskBoxPrimitives::onWedgeZmaxChanged(double v)
+{
+    if (auto wedge = getObject<PartDesign::Wedge>()) {
+        ui->wedgeZmin->setMaximum(v); // must be < than wedgeZmax
+        wedge->Zmax.setValue(v);
+        wedge->recomputeFeature();
+    }
 }
 
 
@@ -884,48 +965,10 @@ bool TaskBoxPrimitives::setPrimitive(App::DocumentObject *obj)
 
 TaskPrimitiveParameters::TaskPrimitiveParameters(ViewProviderPrimitive* PrimitiveView) : vp_prm(PrimitiveView)
 {
-
     assert(PrimitiveView);
 
     primitive = new TaskBoxPrimitives(PrimitiveView);
     Content.push_back(primitive);
-
-    /*
-    // handle visibility automation differently to the default method
-    auto customvisfunc = [] (bool opening_not_closing,
-                             const std::string &postfix,
-                             Gui::ViewProviderDocumentObject* vp,
-                             App::DocumentObject *editObj,
-                             const std::string& editSubName) {
-        if (opening_not_closing) {
-            QString code = QString::fromLatin1(
-                "import Show\n"
-                "_tv_%4 = Show.TempoVis(App.ActiveDocument, tag= 'PartGui::TaskAttacher')\n"
-                "tvObj = %1\n"
-                "dep_features = _tv_%4.get_all_dependent(%2, '%3')\n"
-                "if tvObj.isDerivedFrom('PartDesign::CoordinateSystem'):\n"
-                "\tvisible_features = [feat for feat in tvObj.InList if feat.isDerivedFrom('PartDesign::FeaturePrimitive')]\n"
-                "\tdep_features = [feat for feat in dep_features if feat not in visible_features]\n"
-                "\tdel(visible_features)\n"
-                "_tv_%4.hide(dep_features)\n"
-                "del(dep_features)\n"
-                "del(tvObj)"
-                ).arg(
-                    QString::fromLatin1(Gui::Command::getObjectCmd(vp->getObject()).c_str()),
-                    QString::fromLatin1(Gui::Command::getObjectCmd(editObj).c_str()),
-                    QString::fromLatin1(editSubName.c_str()),
-                    QString::fromLatin1(postfix.c_str()));
-            Gui::Command::runCommand(Gui::Command::Gui,code.toLatin1().constData());
-        } else if(postfix.size()) {
-            QString code = QString::fromLatin1(
-                "_tv_%1.restore()\n"
-                "del(_tv_%1)"
-                ).arg(QString::fromLatin1(postfix.c_str()));
-            Gui::Command::runCommand(Gui::Command::Gui,code.toLatin1().constData());
-        }
-    };
-    parameter = new PartGui::TaskAttacher(PrimitiveView, nullptr, QString(), tr("Attachment"), customvisfunc);
-    */
     parameter = new PartGui::TaskAttacher(PrimitiveView, nullptr, QString(), tr("Attachment"));
     Content.push_back(parameter);
 }
@@ -952,7 +995,8 @@ bool TaskPrimitiveParameters::reject()
     return true;
 }
 
-QDialogButtonBox::StandardButtons TaskPrimitiveParameters::getStandardButtons() const {
+QDialogButtonBox::StandardButtons TaskPrimitiveParameters::getStandardButtons() const
+{
     return Gui::TaskView::TaskDialog::getStandardButtons();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.h
@@ -101,6 +101,16 @@ private:
     /** Notifies when the object is about to be removed. */
     void slotDeletedObject(const Gui::ViewProviderDocumentObject& Obj) override;
 
+    template<typename T = App::DocumentObject> T* getObject() const
+    {
+        static_assert(std::is_base_of<App::DocumentObject, T>::value, "Wrong template argument");
+        if (vp) {
+            return dynamic_cast<T*>(vp->getObject());
+        }
+
+        return nullptr;
+    }
+
 private:
     QWidget* proxy;
     std::unique_ptr<Ui_DlgPrimitives> ui;

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -86,7 +86,7 @@ TaskRevolutionParameters::TaskRevolutionParameters(PartDesignGui::ViewProvider* 
 
     setupDialog();
 
-    blockUpdate = false;
+    setUpdateBlocked(false);
     updateUI(ui->changeMode->currentIndex());
     connectSignals();
 
@@ -185,7 +185,7 @@ void TaskRevolutionParameters::translateModeList(int index)
 
 void TaskRevolutionParameters::fillAxisCombo(bool forceRefill)
 {
-    Base::StateLocker lock(blockUpdate, true);
+    Base::StateLocker lock(getUpdateBlockRef(), true);
 
     if (axesInList.empty())
         forceRefill = true;//not filled yet, full refill
@@ -348,9 +348,9 @@ void TaskRevolutionParameters::connectSignals()
 
 void TaskRevolutionParameters::updateUI(int index)
 {
-    if (blockUpdate)
+    if (isUpdateBlocked())
         return;
-    Base::StateLocker lock(blockUpdate, true);
+    Base::StateLocker lock(getUpdateBlockRef(), true);
     fillAxisCombo();
     setCheckboxes(static_cast<PartDesign::Revolution::RevolMethod>(index));
 }
@@ -485,7 +485,7 @@ void TaskRevolutionParameters::onAngle2Changed(double len)
 
 void TaskRevolutionParameters::onAxisChanged(int num)
 {
-    if (blockUpdate)
+    if (isUpdateBlocked())
         return;
     PartDesign::ProfileBased* pcRevolution = static_cast<PartDesign::ProfileBased*>(vp->getObject());
 

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -59,7 +59,7 @@ TaskRevolutionParameters::TaskRevolutionParameters(PartDesignGui::ViewProvider* 
     this->groupLayout()->addWidget(proxy);
 
     // bind property mirrors
-    if (auto *rev = dynamic_cast<PartDesign::Revolution *>(vp->getObject())) {
+    if (auto rev = getObject<PartDesign::Revolution>()) {
         this->propAngle = &(rev->Angle);
         this->propAngle2 = &(rev->Angle2);
         this->propMidPlane = &(rev->Midplane);
@@ -69,7 +69,7 @@ TaskRevolutionParameters::TaskRevolutionParameters(PartDesignGui::ViewProvider* 
         ui->revolveAngle->bind(rev->Angle);
         ui->revolveAngle2->bind(rev->Angle2);
     }
-    else if (auto *rev = dynamic_cast<PartDesign::Groove *>(vp->getObject())) {
+    else if (auto rev = getObject<PartDesign::Groove>()) {
         isGroove = true;
         this->propAngle = &(rev->Angle);
         this->propAngle2 = &(rev->Angle2);
@@ -93,7 +93,7 @@ TaskRevolutionParameters::TaskRevolutionParameters(PartDesignGui::ViewProvider* 
     setFocus();
 
     // show the parts coordinate system axis for selection
-    PartDesign::Body * body = PartDesign::Body::findBodyOf ( vp->getObject () );
+    PartDesign::Body * body = PartDesign::Body::findBodyOf(getObject());
     if (body) {
         try {
             App::Origin *origin = body->getOrigin();
@@ -148,7 +148,7 @@ void TaskRevolutionParameters::setupDialog()
 
     // TODO: This should also be implemented for groove
     if (!isGroove) {
-        PartDesign::Revolution* rev = static_cast<PartDesign::Revolution*>(vp->getObject());
+        auto rev = getObject<PartDesign::Revolution>();
         ui->revolveAngle2->setValue(propAngle2->getValue());
         ui->revolveAngle2->setMaximum(propAngle2->getMaximum());
         ui->revolveAngle2->setMinimum(propAngle2->getMinimum());
@@ -156,7 +156,7 @@ void TaskRevolutionParameters::setupDialog()
         index = rev->Type.getValue();
     }
     else {
-        PartDesign::Groove* rev = static_cast<PartDesign::Groove*>(vp->getObject());
+        auto rev = getObject<PartDesign::Groove>();
         ui->revolveAngle2->setValue(propAngle2->getValue());
         ui->revolveAngle2->setMaximum(propAngle2->getMaximum());
         ui->revolveAngle2->setMinimum(propAngle2->getMinimum());
@@ -194,9 +194,10 @@ void TaskRevolutionParameters::fillAxisCombo(bool forceRefill)
         ui->axis->clear();
         axesInList.clear();
 
-        auto *pcFeat = dynamic_cast<PartDesign::ProfileBased*>(vp->getObject());
-        if (!pcFeat)
+        auto *pcFeat = getObject<PartDesign::ProfileBased>();
+        if (!pcFeat) {
             throw Base::TypeError("The object is not ProfileBased.");
+        }
 
         //add sketch axes
         if (auto *pcSketch = dynamic_cast<Part::Part2DObject*>(pcFeat->Profile.getValue())) {
@@ -377,7 +378,7 @@ void TaskRevolutionParameters::onSelectionChanged(const Gui::SelectionChanges& m
             exitSelectionMode();
             std::vector<std::string> axis;
             App::DocumentObject* selObj;
-            if (getReferencedSelection(vp->getObject(), msg, selObj, axis) && selObj) {
+            if (getReferencedSelection(getObject(), msg, selObj, axis) && selObj) {
                 propReferenceAxis->setValue(selObj, axis);
 
                 recomputeFeature();
@@ -470,24 +471,29 @@ void TaskRevolutionParameters::clearFaceName()
 
 void TaskRevolutionParameters::onAngleChanged(double len)
 {
-    propAngle->setValue(len);
-    exitSelectionMode();
-    recomputeFeature();
+    if (getObject()) {
+        propAngle->setValue(len);
+        exitSelectionMode();
+        recomputeFeature();
+    }
 }
 
 void TaskRevolutionParameters::onAngle2Changed(double len)
 {
-    if (propAngle2)
-        propAngle2->setValue(len);
-    exitSelectionMode();
-    recomputeFeature();
+    if (getObject()) {
+        if (propAngle2) {
+            propAngle2->setValue(len);
+        }
+        exitSelectionMode();
+        recomputeFeature();
+    }
 }
 
 void TaskRevolutionParameters::onAxisChanged(int num)
 {
     if (isUpdateBlocked())
         return;
-    PartDesign::ProfileBased* pcRevolution = static_cast<PartDesign::ProfileBased*>(vp->getObject());
+    auto pcRevolution = getObject<PartDesign::ProfileBased>();
 
     if (axesInList.empty())
         return;
@@ -549,30 +555,31 @@ void TaskRevolutionParameters::onAxisChanged(int num)
 
 void TaskRevolutionParameters::onMidplane(bool on)
 {
-    propMidPlane->setValue(on);
-    recomputeFeature();
+    if (getObject()) {
+        propMidPlane->setValue(on);
+        recomputeFeature();
+    }
 }
 
 void TaskRevolutionParameters::onReversed(bool on)
 {
-    propReversed->setValue(on);
-    recomputeFeature();
+    if (getObject()) {
+        propReversed->setValue(on);
+        recomputeFeature();
+    }
 }
 
 void TaskRevolutionParameters::onModeChanged(int index)
 {
-    App::PropertyEnumeration* pcType;
+    App::PropertyEnumeration* pcType {};
     if (!isGroove)
-        pcType = &(static_cast<PartDesign::Revolution*>(vp->getObject())->Type);
+        pcType = &(getObject<PartDesign::Revolution>()->Type);
     else
-        pcType = &(static_cast<PartDesign::Groove*>(vp->getObject())->Type);
+        pcType = &(getObject<PartDesign::Groove>()->Type);
 
     switch (static_cast<PartDesign::Revolution::RevolMethod>(index)) {
     case PartDesign::Revolution::RevolMethod::Dimension:
         pcType->setValue("Angle");
-        // Avoid error message
-        // if (ui->revolveAngle->value() < Base::Quantity(Precision::Angular(), Base::Unit::Angle)) // TODO: Ensure radians/degree consistency
-        //     ui->revolveAngle->setValue(5.0);
         break;
     case PartDesign::Revolution::RevolMethod::ToLast:
         if (!isGroove)
@@ -597,16 +604,18 @@ void TaskRevolutionParameters::onModeChanged(int index)
 
 void TaskRevolutionParameters::getReferenceAxis(App::DocumentObject*& obj, std::vector<std::string>& sub) const
 {
-    if (axesInList.empty())
+    if (axesInList.empty()) {
         throw Base::RuntimeError("Not initialized!");
+    }
 
     int num = ui->axis->currentIndex();
     const App::PropertyLinkSub &lnk = *(axesInList[num]);
     if (!lnk.getValue()) {
         throw Base::RuntimeError("Still in reference selection mode; reference wasn't selected yet");
-    } else {
-        PartDesign::ProfileBased* pcRevolution = static_cast<PartDesign::ProfileBased*>(vp->getObject());
-        if (!pcRevolution->getDocument()->isIn(lnk.getValue())){
+    }
+    else {
+        auto revolution = getObject<PartDesign::ProfileBased>();
+        if (!revolution->getDocument()->isIn(lnk.getValue())){
             throw Base::RuntimeError("Object was deleted");
         }
 
@@ -629,14 +638,16 @@ TaskRevolutionParameters::~TaskRevolutionParameters()
 {
     try {
         //hide the parts coordinate system axis for selection
-        PartDesign::Body * body = vp ? PartDesign::Body::findBodyOf(vp->getObject()) : nullptr;
+        auto obj = getObject();
+        PartDesign::Body * body = obj ? PartDesign::Body::findBodyOf(obj) : nullptr;
         if (body) {
             App::Origin *origin = body->getOrigin();
             ViewProviderOrigin* vpOrigin;
             vpOrigin = static_cast<ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
             vpOrigin->resetTemporaryVisibility();
         }
-    } catch (const Base::Exception &ex) {
+    }
+    catch (const Base::Exception &ex) {
         ex.ReportException();
     }
 
@@ -663,7 +674,7 @@ void TaskRevolutionParameters::apply()
     App::DocumentObject* obj;
     getReferenceAxis(obj, sub);
     std::string axis = buildLinkSingleSubPythonStr(obj, sub);
-    auto tobj = vp->getObject();
+    auto tobj = getObject();
     FCMD_OBJ_CMD(tobj, "ReferenceAxis = " << axis);
     FCMD_OBJ_CMD(tobj, "Midplane = " << (getMidplane() ? 1 : 0));
     FCMD_OBJ_CMD(tobj, "Reversed = " << (getReversed() ? 1 : 0));

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
@@ -122,11 +122,6 @@ class TaskDlgRevolutionParameters : public TaskDlgSketchBasedParameters
 
 public:
     explicit TaskDlgRevolutionParameters(PartDesignGui::ViewProvider *RevolutionView);
-
-    ViewProvider* getRevolutionView() const
-    {
-        return vp;
-    }
 };
 
 } //namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -61,10 +61,12 @@ TaskSketchBasedParameters::TaskSketchBasedParameters(PartDesignGui::ViewProvider
 const QString TaskSketchBasedParameters::onAddSelection(const Gui::SelectionChanges& msg)
 {
     // Note: The validity checking has already been done in ReferenceSelection.cpp
-    PartDesign::ProfileBased* pcSketchBased = static_cast<PartDesign::ProfileBased*>(vp->getObject());
-    App::DocumentObject* selObj = pcSketchBased->getDocument()->getObject(msg.pObjectName);
-    if (selObj == pcSketchBased)
+    auto sketchBased = getObject<PartDesign::ProfileBased>();
+    App::DocumentObject* selObj = sketchBased->getDocument()->getObject(msg.pObjectName);
+    if (selObj == sketchBased) {
         return QString();
+    }
+
     std::string subname = msg.pSubName;
     QString refStr;
 
@@ -72,54 +74,57 @@ const QString TaskSketchBasedParameters::onAddSelection(const Gui::SelectionChan
     if (PartDesign::Feature::isDatum(selObj)) {
         subname = "";
         refStr = QString::fromLatin1(selObj->getNameInDocument());
-    } else if (subname.size() > 4) {
+    }
+    else if (subname.size() > 4) {
         int faceId = std::atoi(&subname[4]);
         refStr = QString::fromLatin1(selObj->getNameInDocument()) + QString::fromLatin1(":") + QObject::tr("Face") + QString::number(faceId);
     }
 
     std::vector<std::string> upToFaces(1,subname);
-    pcSketchBased->UpToFace.setValue(selObj, upToFaces);
+    sketchBased->UpToFace.setValue(selObj, upToFaces);
     recomputeFeature();
 
     return refStr;
 }
 
-void TaskSketchBasedParameters::startReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base)
+void TaskSketchBasedParameters::startReferenceSelection(App::DocumentObject* profile,
+                                                        App::DocumentObject* base)
 {
-    Gui::Document* doc = vp->getDocument();
-    if (doc) {
+    if (Gui::Document* doc = getGuiDocument()) {
         doc->setHide(profile->getNameInDocument());
-        if (base)
+        if (base) {
             doc->setShow(base->getNameInDocument());
+        }
     }
 }
 
-void TaskSketchBasedParameters::finishReferenceSelection(App::DocumentObject* profile, App::DocumentObject* base)
+void TaskSketchBasedParameters::finishReferenceSelection(App::DocumentObject* profile,
+                                                         App::DocumentObject* base)
 {
-    Gui::Document* doc = vp->getDocument();
-    if (doc) {
+    if (Gui::Document* doc = getGuiDocument()) {
         doc->setShow(profile->getNameInDocument());
-        if (base)
+        if (base) {
             doc->setHide(base->getNameInDocument());
+        }
     }
 }
 
-void TaskSketchBasedParameters::onSelectReference(AllowSelectionFlags allow) {
+void TaskSketchBasedParameters::onSelectReference(AllowSelectionFlags allow)
+{
     // Note: Even if there is no solid, App::Plane and Part::Datum can still be selected
-    PartDesign::ProfileBased* pcSketchBased = dynamic_cast<PartDesign::ProfileBased*>(vp->getObject());
-    if (pcSketchBased) {
+    if (auto sketchBased = getObject<PartDesign::ProfileBased>()) {
         // The solid this feature will be fused to
-        App::DocumentObject* prevSolid = pcSketchBased->getBaseObject( /* silent =*/ true );
+        App::DocumentObject* prevSolid = sketchBased->getBaseObject( /* silent =*/ true );
 
         if (AllowSelectionFlags::Int(allow) != int(AllowSelection::NONE)) {
-            startReferenceSelection(pcSketchBased, prevSolid);
+            startReferenceSelection(sketchBased, prevSolid);
             this->blockSelection(false);
             Gui::Selection().clearSelection();
             Gui::Selection().addSelectionGate(new ReferenceSelection(prevSolid, allow));
         }
         else {
             Gui::Selection().rmvSelectionGate();
-            finishReferenceSelection(pcSketchBased, prevSolid);
+            finishReferenceSelection(sketchBased, prevSolid);
             this->blockSelection(true);
         }
     }
@@ -137,51 +142,63 @@ QVariant TaskSketchBasedParameters::setUpToFace(const QString& text)
         return {};
 
     QStringList parts = text.split(QChar::fromLatin1(':'));
-    if (parts.length() < 2)
-        parts.push_back(QString::fromLatin1(""));
+    if (parts.length() < 2) {
+        parts.push_back(QString());
+    }
 
     // Check whether this is the name of an App::Plane or Part::Datum feature
-    App::DocumentObject* obj = vp->getObject()->getDocument()->getObject(parts[0].toLatin1());
-    if (!obj)
-        return {};
-
-    if (obj->isDerivedFrom<App::Plane>()) {
-        // everything is OK (we assume a Part can only have exactly 3 App::Plane objects located at the base of the feature tree)
+    App::Document* doc = getAppDocument();
+    if (!doc) {
         return {};
     }
-    else if (obj->isDerivedFrom<Part::Datum>()) {
+
+    App::DocumentObject* obj = doc->getObject(parts[0].toLatin1());
+    if (!obj) {
+        return {};
+    }
+
+    if (obj->isDerivedFrom<App::Plane>()) {
+        // everything is OK (we assume a Part can only have exactly 3 App::Plane objects
+        // located at the base of the feature tree)
+        return {};
+    }
+
+    if (obj->isDerivedFrom<Part::Datum>()) {
         // it's up to the document to check that the datum plane is in the same body
         return {};
     }
-    else {
-        // We must expect that "parts[1]" is the translation of "Face" followed by an ID.
-        QString name;
-        QTextStream str(&name);
-        str << "^" << tr("Face") << "(\\d+)$";
-        QRegularExpression rx(name);
-        QRegularExpressionMatch match;
-        if (parts[1].indexOf(rx, 0, &match) < 0) {
-            return {};
-        }
 
-        int faceId = match.captured(1).toInt();
-        std::stringstream ss;
-        ss << "Face" << faceId;
-
-        std::vector<std::string> upToFaces(1, ss.str());
-        PartDesign::ProfileBased* pcSketchBased = static_cast<PartDesign::ProfileBased*>(vp->getObject());
-        pcSketchBased->UpToFace.setValue(obj, upToFaces);
-        recomputeFeature();
-
-        return QByteArray(ss.str().c_str());
+    // We must expect that "parts[1]" is the translation of "Face" followed by an ID.
+    QString name;
+    QTextStream str(&name);
+    str << "^" << tr("Face") << "(\\d+)$";
+    QRegularExpression rx(name);
+    QRegularExpressionMatch match;
+    if (parts[1].indexOf(rx, 0, &match) < 0) {
+        return {};
     }
+
+    int faceId = match.captured(1).toInt();
+    std::stringstream ss;
+    ss << "Face" << faceId;
+
+    std::vector<std::string> upToFaces(1, ss.str());
+    auto sketchBased = getObject<PartDesign::ProfileBased>();
+    sketchBased->UpToFace.setValue(obj, upToFaces);
+    recomputeFeature();
+
+    return QByteArray(ss.str().c_str());
 }
 
 QVariant TaskSketchBasedParameters::objectNameByLabel(const QString& label,
                                                       const QVariant& suggest) const
 {
     // search for an object with the given label
-    App::Document* doc = this->vp->getObject()->getDocument();
+    App::Document* doc = getAppDocument();
+    if (!doc) {
+        return {};
+    }
+
     // for faster access try the suggestion
     if (suggest.isValid()) {
         App::DocumentObject* obj = doc->getObject(suggest.toByteArray());
@@ -204,11 +221,15 @@ QVariant TaskSketchBasedParameters::objectNameByLabel(const QString& label,
 
 QString TaskSketchBasedParameters::getFaceReference(const QString& obj, const QString& sub) const
 {
-    App::Document* doc = this->vp->getObject()->getDocument();
-    QString o = obj.left(obj.indexOf(QString::fromLatin1(":")));
-
-    if (o.isEmpty())
+    App::Document* doc = getAppDocument();
+    if (!doc) {
         return {};
+    }
+
+    QString o = obj.left(obj.indexOf(QString::fromLatin1(":")));
+    if (o.isEmpty()) {
+        return {};
+    }
 
     return QString::fromLatin1(R"((App.getDocument("%1").%2, ["%3"]))")
             .arg(QString::fromLatin1(doc->getName()), o, sub);

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -280,7 +280,7 @@ TaskDlgThicknessParameters::~TaskDlgThicknessParameters() = default;
 
 bool TaskDlgThicknessParameters::accept()
 {
-    auto obj = vp->getObject();
+    auto obj = getObject();
     if (!obj->isError()) {
         parameter->showObject();
     }

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -63,8 +63,8 @@ void TaskThicknessParameters::addContainerWidget()
 
 void TaskThicknessParameters::initControls()
 {
-    auto pcThickness = dynamic_cast<PartDesign::Thickness*>(DressUpView->getObject());
-    double a = pcThickness->Value.getValue();
+    auto thickness = getObject<PartDesign::Thickness>();
+    double a = thickness->Value.getValue();
 
     ui->Value->setMinimum(0.0);
     ui->Value->setValue(a);
@@ -72,25 +72,25 @@ void TaskThicknessParameters::initControls()
     QMetaObject::invokeMethod(ui->Value, "setFocus", Qt::QueuedConnection);
 
     // Bind input fields to properties
-    ui->Value->bind(pcThickness->Value);
+    ui->Value->bind(thickness->Value);
 
-    bool r = pcThickness->Reversed.getValue();
+    bool r = thickness->Reversed.getValue();
     ui->checkReverse->setChecked(r);
 
-    bool i = pcThickness->Intersection.getValue();
+    bool i = thickness->Intersection.getValue();
     ui->checkIntersection->setChecked(i);
 
-    std::vector<std::string> strings = pcThickness->Base.getSubValues();
+    std::vector<std::string> strings = thickness->Base.getSubValues();
     for (const auto& string : strings) {
         ui->listWidgetReferences->addItem(QString::fromStdString(string));
     }
 
     setupConnections();
 
-    int mode = static_cast<int>(pcThickness->Mode.getValue());
+    int mode = static_cast<int>(thickness->Mode.getValue());
     ui->modeComboBox->setCurrentIndex(mode);
 
-    int join = static_cast<int>(pcThickness->Join.getValue());
+    int join = static_cast<int>(thickness->Join.getValue());
     ui->joinComboBox->setCurrentIndex(join);
 
     if (strings.empty()) {
@@ -156,7 +156,7 @@ PartDesign::Thickness* TaskThicknessParameters::onBeforeChange()
 {
     setButtons(none);
     setupTransaction();
-    return dynamic_cast<PartDesign::Thickness*>(DressUpView->getObject());
+    return getObject<PartDesign::Thickness>();
 }
 
 void TaskThicknessParameters::onAfterChange(PartDesign::Thickness* obj)
@@ -168,25 +168,26 @@ void TaskThicknessParameters::onAfterChange(PartDesign::Thickness* obj)
 
 void TaskThicknessParameters::onValueChanged(double angle)
 {
-    PartDesign::Thickness* thickness = onBeforeChange();
-    thickness->Value.setValue(angle);
-    onAfterChange(thickness);
+    if (PartDesign::Thickness* thickness = onBeforeChange()) {
+        thickness->Value.setValue(angle);
+        onAfterChange(thickness);
+    }
 }
 
 void TaskThicknessParameters::onJoinTypeChanged(int join)
 {
-
-    PartDesign::Thickness* thickness = onBeforeChange();
-    thickness->Join.setValue(join);
-    onAfterChange(thickness);
+    if (PartDesign::Thickness* thickness = onBeforeChange()) {
+        thickness->Join.setValue(join);
+        onAfterChange(thickness);
+    }
 }
 
 void TaskThicknessParameters::onModeChanged(int mode)
 {
-
-    PartDesign::Thickness* thickness = onBeforeChange();
-    thickness->Mode.setValue(mode);
-    onAfterChange(thickness);
+    if (PartDesign::Thickness* thickness = onBeforeChange()) {
+        thickness->Mode.setValue(mode);
+        onAfterChange(thickness);
+    }
 }
 
 double TaskThicknessParameters::getValue() const
@@ -196,9 +197,10 @@ double TaskThicknessParameters::getValue() const
 
 void TaskThicknessParameters::onReversedChanged(bool on)
 {
-    PartDesign::Thickness* thickness = onBeforeChange();
-    thickness->Reversed.setValue(on);
-    onAfterChange(thickness);
+    if (PartDesign::Thickness* thickness = onBeforeChange()) {
+        thickness->Reversed.setValue(on);
+        onAfterChange(thickness);
+    }
 }
 
 bool TaskThicknessParameters::getReversed() const
@@ -208,9 +210,10 @@ bool TaskThicknessParameters::getReversed() const
 
 void TaskThicknessParameters::onIntersectionChanged(bool on)
 {
-    PartDesign::Thickness* thickness = onBeforeChange();
-    thickness->Intersection.setValue(on);
-    onAfterChange(thickness);
+    if (PartDesign::Thickness* thickness = onBeforeChange()) {
+        thickness->Intersection.setValue(on);
+        onAfterChange(thickness);
+    }
 }
 
 bool TaskThicknessParameters::getIntersection() const

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
@@ -615,13 +615,10 @@ void TaskTransformedParameters::indexesMoved()
 // TaskDialog
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-TaskDlgTransformedParameters::TaskDlgTransformedParameters(
-    ViewProviderTransformed* TransformedView_)
-    : TaskDlgFeatureParameters(TransformedView_)
+TaskDlgTransformedParameters::TaskDlgTransformedParameters(ViewProviderTransformed* viewProvider)
+    : TaskDlgFeatureParameters(viewProvider)
 {
-    assert(vp);
-    message = new TaskTransformedMessages(getTransformedView());
-
+    message = new TaskTransformedMessages(viewProvider);
     Content.push_back(message);
 }
 
@@ -639,7 +636,6 @@ bool TaskDlgTransformedParameters::reject()
 {
     // ensure that we are not in selection mode
     parameter->exitSelectionMode();
-
     return TaskDlgFeatureParameters::reject();
 }
 

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -295,11 +295,6 @@ class TaskDlgTransformedParameters: public PartDesignGui::TaskDlgFeatureParamete
 public:
     explicit TaskDlgTransformedParameters(ViewProviderTransformed* TransformedView);
 
-    ViewProviderTransformed* getTransformedView() const
-    {
-        return static_cast<ViewProviderTransformed*>(vp);
-    }
-
     /// is called by the framework if the dialog is accepted (Ok)
     bool accept() override;
     /// is called by the framework if the dialog is rejected (Cancel)

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -88,7 +88,7 @@ bool ViewProvider::setEdit(int ModNum)
         Gui::TaskView::TaskDialog *dlg = Gui::Control().activeDialog();
         TaskDlgFeatureParameters *featureDlg = qobject_cast<TaskDlgFeatureParameters *>(dlg);
         // NOTE: if the dialog is not partDesigan dialog the featureDlg will be NULL
-        if (featureDlg && featureDlg->viewProvider() != this) {
+        if (featureDlg && featureDlg->getViewObject() != this) {
             featureDlg = nullptr; // another feature left open its task panel
         }
         if (dlg && !featureDlg) {

--- a/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
@@ -70,7 +70,7 @@ bool ViewProviderHole::setEdit(int ModNum)
         // the task panel
         Gui::TaskView::TaskDialog *dlg = Gui::Control().activeDialog();
         TaskDlgHoleParameters *holeDlg = qobject_cast<TaskDlgHoleParameters *>(dlg);
-        if (holeDlg && holeDlg->getHoleView() != this)
+        if (holeDlg && holeDlg->getViewObject() != this)
             holeDlg = nullptr; // another hole left open its task panel
         if (dlg && !holeDlg) {
             QMessageBox msgBox;


### PR DESCRIPTION
* Fix possible crashes in dress-up task panels
* Fix possible crash in primitive dialog
* Add template helper functions to safely access feature or view provider
* In subclasses of TaskFeatureParameters use the new helper functions and check for null pointer.
* Replace helper functions in subclasses of TaskDlgFeatureParameters with a template function

This fixes #15453
