### PR TITLE
Toponaming: update findSubShapesWithSharedVertex

### DIFF
--- a/src/App/ComplexGeoData.h
+++ b/src/App/ComplexGeoData.h
@@ -54,11 +54,12 @@ namespace Data
 
 //struct MappedChildElements;
 /// Option for App::GeoFeature::searchElementCache()
-enum class SearchOptions {
+enum class SearchOption {
     /// Whether to compare shape geometry
     CheckGeometry = 1,
     SingleResult = 2,
 };
+typedef Base::Flags<SearchOption> SearchOptions;
 
 /** Segments
  *  Sub-element type of the ComplexGeoData type
@@ -483,5 +484,5 @@ protected:
 
 } //namespace App
 
-
+ENABLE_BITMASK_OPERATORS(Data::SearchOption)
 #endif

--- a/src/App/GeoFeature.h
+++ b/src/App/GeoFeature.h
@@ -165,7 +165,7 @@ public:
      * reference to the same geometry of the old element.
      */
     virtual const std::vector<std::string>& searchElementCache(const std::string &element,
-                                                               Data::SearchOptions options = Data::SearchOptions::CheckGeometry,
+                                                               Data::SearchOptions options = Data::SearchOption::CheckGeometry,
                                                                double tol = 1e-7,
                                                                double atol = 1e-10) const;
 

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -1105,22 +1105,18 @@ void PropertyExpressionEngine::getLinksTo(std::vector<App::ObjectIdentifier>& id
                 identifiers.push_back(expressionId);
                 break;
             }
-            bool found = false;
-            for (const auto& path : paths) {
-                if (path.getSubObjectName() == subname) {
-                    identifiers.push_back(expressionId);
-                    found = true;
-                    break;
-                }
-                App::SubObjectT sobjT(obj, path.getSubObjectName().c_str());
-                if (sobjT.getSubObject() == sobj && sobjT.getOldElementName() == subElement) {
-                    identifiers.push_back(expressionId);
-                    found = true;
-                    break;
-                }
-            }
-            if (found) {
-                break;
+            if (std::any_of(paths.begin(),
+                            paths.end(),
+                            [subname, obj, sobj, &subElement](const auto& path) {
+                                if (path.getSubObjectName() == subname) {
+                                    return true;
+                                }
+
+                                App::SubObjectT sobjT(obj, path.getSubObjectName().c_str());
+                                return (sobjT.getSubObject() == sobj
+                                        && sobjT.getOldElementName() == subElement);
+                            })) {
+                identifiers.push_back(expressionId);
             }
         }
     }

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -183,7 +183,7 @@ public:
     virtual void getLinks(std::vector<App::DocumentObject *> &objs,
             bool all=false, std::vector<std::string> *subs=nullptr, bool newStyle=true) const = 0;
 
-    /** Obtain identifiers from this link property that link to a give object
+    /** Obtain identifiers from this link property that link to a given object
      * @param identifiers: holds the returned identifier to reference the given object
      * @param obj: the referenced object
      * @param subname: optional subname reference

--- a/src/Base/Bitmask.h
+++ b/src/Base/Bitmask.h
@@ -113,7 +113,7 @@ class Flags {
     Enum i;
 
 public:
-    constexpr inline Flags(Enum f) : i(f) {}
+    constexpr inline Flags(Enum f = Enum()) : i(f) {}
     constexpr bool testFlag(Enum f) const {
         using u = typename std::underlying_type<Enum>::type;
         return (i & f) == f && (static_cast<u>(f) != 0 || i == f);
@@ -124,6 +124,48 @@ public:
     constexpr bool isEqual(Flags f) const {
         using u = typename std::underlying_type<Enum>::type;
         return static_cast<u>(i) == static_cast<u>(f.i);
+    }
+    constexpr Enum getFlags() const {
+        return i;
+    }
+    constexpr Flags<Enum> &operator|=(const Flags<Enum> &other) {
+        i |= other.i;
+        return *this;
+    }
+    constexpr Flags<Enum> &operator|=(const Enum &f) {
+        i |= f;
+        return *this;
+    }
+    constexpr Flags<Enum> operator|(const Flags<Enum> &other) const {
+        return i | other.i;
+    }
+    constexpr Flags<Enum> operator|(const Enum &f) const {
+        return i | f;
+    }
+    constexpr Flags<Enum> &operator&=(const Flags<Enum> &other) {
+        i &= other.i;
+        return *this;
+    }
+    constexpr Flags<Enum> &operator&=(const Enum &f) {
+        i &= f;
+        return *this;
+    }
+    constexpr Flags<Enum> operator&(const Flags<Enum> &other) const {
+        return i & other.i;
+    }
+    constexpr Flags<Enum> operator&(const Enum &f) const {
+        return i & f;
+    }
+    constexpr Flags<Enum> operator~() const {
+        return ~i;
+    }
+
+    constexpr bool operator!() const {
+        return !i;
+    }
+
+    explicit operator bool() const {
+        return toUnderlyingType() != 0;
     }
     typename std::underlying_type<Enum>::type toUnderlyingType() const {
         return static_cast<typename std::underlying_type<Enum>::type>(i);

--- a/src/Base/Bitmask.h
+++ b/src/Base/Bitmask.h
@@ -113,7 +113,8 @@ class Flags {
     Enum i;
 
 public:
-    constexpr inline Flags(Enum f = Enum()) : i(f) {}
+    // Linter seems wrong on next line, don't want explicit here forcing downstream changes
+    constexpr inline Flags(Enum f = Enum()) : i(f) {}   // NOLINT (runtime/explicit)
     constexpr bool testFlag(Enum f) const {
         using u = typename std::underlying_type<Enum>::type;
         return (i & f) == f && (static_cast<u>(f) != 0 || i == f);

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -1499,7 +1499,7 @@ const std::vector<std::string>& Feature::searchElementCache(const std::string& e
         it->second.searched = true;
         propShape->getShape().findSubShapesWithSharedVertex(it->second.shape,
                                                             &it->second.names,
-                                                            static_cast<CheckGeometry>(options),
+                                                            options,
                                                             tol,
                                                             atol);
         if (prefix) {

--- a/src/Mod/Part/App/PartFeature.h
+++ b/src/Mod/Part/App/PartFeature.h
@@ -157,7 +157,7 @@ public:
 #ifdef FC_USE_TNP_FIX
 
     const std::vector<std::string>& searchElementCache(const std::string &element,
-                                                       Data::SearchOptions options = Data::SearchOptions::CheckGeometry,
+                                                       Data::SearchOptions options = Data::SearchOption::CheckGeometry,
                                                        double tol = 1e-7,
                                                        double atol = 1e-10) const override;
 #endif

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -1472,7 +1472,7 @@ public:
      */
      std::vector<TopoShape> findSubShapesWithSharedVertex(const TopoShape &subshape,
                                           std::vector<std::string> *names=nullptr,
-                                          CheckGeometry checkGeometry=CheckGeometry::checkGeometry,
+                                          Data::SearchOptions = Data::SearchOption::CheckGeometry,
                                           double tol=1e-7, double atol=1e-12) const;
     //@}
 

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -3112,10 +3112,11 @@ PyObject* TopoShapePy::findSubShape(PyObject* args)
 
 PyObject* TopoShapePy::findSubShapesWithSharedVertex(PyObject* args, PyObject* keywds)
 {
-    static const std::array<const char*, 6> kwlist {"shape", "needName", "checkGeometry", "tol", "atol", nullptr};
+    static const std::array<const char*, 7> kwlist {"shape", "needName", "checkGeometry", "tol", "atol", "singleResult", nullptr};
     PyObject* pyobj;
     PyObject* needName = Py_False;
     PyObject* checkGeometry = Py_True;
+    PyObject* singleResult = Py_False;
     double tol = 1e-7;
     double atol = 1e-12;
     if (!Base::Wrapped_ParseTupleAndKeywords(args,
@@ -3127,7 +3128,8 @@ PyObject* TopoShapePy::findSubShapesWithSharedVertex(PyObject* args, PyObject* k
                                              &needName,
                                              &checkGeometry,
                                              &tol,
-                                             &atol)) {
+                                             &atol,
+                                             &singleResult)) {
         return nullptr;
     }
 
@@ -3135,13 +3137,17 @@ PyObject* TopoShapePy::findSubShapesWithSharedVertex(PyObject* args, PyObject* k
     {
         Py::List res;
         const TopoShape& shape = *static_cast<TopoShapePy*>(pyobj)->getTopoShapePtr();
+        Data::SearchOptions options;
+        if (PyObject_IsTrue(checkGeometry))
+            options.setFlag(Data::SearchOption::CheckGeometry);
+        if (PyObject_IsTrue(singleResult))
+            options.setFlag(Data::SearchOption::SingleResult);
         if (PyObject_IsTrue(needName)) {
             std::vector<std::string> names;
             auto shapes = getTopoShapePtr()->findSubShapesWithSharedVertex(
                 shape,
                 &names,
-                PyObject_IsTrue(checkGeometry) ? CheckGeometry::checkGeometry
-                                               : CheckGeometry::ignoreGeometry,
+                options,
                 tol,
                 atol);
             for (std::size_t i = 0; i < shapes.size(); ++i) {
@@ -3152,8 +3158,7 @@ PyObject* TopoShapePy::findSubShapesWithSharedVertex(PyObject* args, PyObject* k
             for (auto& s : getTopoShapePtr()->findSubShapesWithSharedVertex(
                      shape,
                      nullptr,
-                     PyObject_IsTrue(checkGeometry) ? CheckGeometry::checkGeometry
-                                                    : CheckGeometry::ignoreGeometry,
+                     options,
                      tol,
                      atol)) {
                 res.append(shape2pyshape(s));

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -2295,23 +2295,18 @@ void PropertySheet::getLinksTo(std::vector<App::ObjectIdentifier>& identifiers,
                     identifiers.emplace_back(owner, cellName.toString().c_str());
                     break;
                 }
-                bool found = false;
-                for (const auto& path : paths) {
-                    if (path.getSubObjectName() == subname) {
-                        identifiers.emplace_back(owner, cellName.toString().c_str());
-                        found = true;
-                        break;
-                    }
-                    App::SubObjectT sobjT(obj, path.getSubObjectName().c_str());
-                    if (sobjT.getSubObject() == subObject
-                        && sobjT.getOldElementName() == subElement) {
-                        identifiers.emplace_back(owner, cellName.toString().c_str());
-                        found = true;
-                        break;
-                    }
-                }
-                if (found) {
-                    break;
+                if (std::any_of(paths.begin(),
+                                paths.end(),
+                                [subname, obj, subObject, &subElement](const auto& path) {
+                                    if (path.getSubObjectName() == subname) {
+                                        return true;
+                                    }
+
+                                    App::SubObjectT sobjT(obj, path.getSubObjectName().c_str());
+                                    return (sobjT.getSubObject() == subObject
+                                            && sobjT.getOldElementName() == subElement);
+                                })) {
+                    identifiers.emplace_back(owner, cellName.toString().c_str());
                 }
             }
         }

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1140,16 +1140,19 @@ TEST_F(TopoShapeExpansionTest, findSubShapesWithSharedVertexEverything)
     exp.Init(box1, TopAbs_VERTEX);
     auto vertex = exp.Current();
     // Act
-    auto shapes =
-        box1TS.findSubShapesWithSharedVertex(face, &names, CheckGeometry::checkGeometry, tol, atol);
+    auto shapes = box1TS.findSubShapesWithSharedVertex(face,
+                                                       &names,
+                                                       Data::SearchOption::CheckGeometry,
+                                                       tol,
+                                                       atol);
     auto shapes1 = box1TS.findSubShapesWithSharedVertex(edge,
                                                         &names1,
-                                                        CheckGeometry::checkGeometry,
+                                                        Data::SearchOption::CheckGeometry,
                                                         tol,
                                                         atol);
     auto shapes2 = box1TS.findSubShapesWithSharedVertex(vertex,
                                                         &names2,
-                                                        CheckGeometry::checkGeometry,
+                                                        Data::SearchOption::CheckGeometry,
                                                         tol,
                                                         atol);
     //  Assert
@@ -1185,16 +1188,19 @@ TEST_F(TopoShapeExpansionTest, findSubShapesWithSharedVertexMid)
     exp.Init(box1, TopAbs_VERTEX);
     auto vertex = exp.Current();
     // Act
-    auto shapes =
-        box1TS.findSubShapesWithSharedVertex(face, &names, CheckGeometry::checkGeometry, tol, atol);
+    auto shapes = box1TS.findSubShapesWithSharedVertex(face,
+                                                       &names,
+                                                       Data::SearchOption::CheckGeometry,
+                                                       tol,
+                                                       atol);
     auto shapes1 = box1TS.findSubShapesWithSharedVertex(edge,
                                                         &names1,
-                                                        CheckGeometry::checkGeometry,
+                                                        Data::SearchOption::CheckGeometry,
                                                         tol,
                                                         atol);
     auto shapes2 = box1TS.findSubShapesWithSharedVertex(vertex,
                                                         &names2,
-                                                        CheckGeometry::checkGeometry,
+                                                        Data::SearchOption::CheckGeometry,
                                                         tol,
                                                         atol);
     //  Assert
@@ -1224,16 +1230,19 @@ TEST_F(TopoShapeExpansionTest, findSubShapesWithSharedVertexClose)
     exp.Init(box1, TopAbs_VERTEX);
     auto vertex = exp.Current();
     // Act
-    auto shapes =
-        box1TS.findSubShapesWithSharedVertex(face, &names, CheckGeometry::checkGeometry, tol, atol);
+    auto shapes = box1TS.findSubShapesWithSharedVertex(face,
+                                                       &names,
+                                                       Data::SearchOption::CheckGeometry,
+                                                       tol,
+                                                       atol);
     auto shapes1 = box1TS.findSubShapesWithSharedVertex(edge,
                                                         &names1,
-                                                        CheckGeometry::checkGeometry,
+                                                        Data::SearchOption::CheckGeometry,
                                                         tol,
                                                         atol);
     auto shapes2 = box1TS.findSubShapesWithSharedVertex(vertex,
                                                         &names2,
-                                                        CheckGeometry::checkGeometry,
+                                                        Data::SearchOption::CheckGeometry,
                                                         tol,
                                                         atol);
     //  Assert


### PR DESCRIPTION
Fifth in series of incremental code transfers to solve the save/restore errors with objects with element maps..  Support multiple options in support of a future sketcher InternalShape port.