### PR TITLE
Toponaming: bring in getHigherElements code

### DIFF
--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -269,7 +269,7 @@ const std::vector<std::string>& GeoFeature::searchElementCache(const std::string
     return none;
 }
 
-std::vector<const char*> GeoFeature::getElementTypes(bool /*all*/) const
+const std::vector<const char*>& GeoFeature::getElementTypes(bool /*all*/) const
 {
     static std::vector<const char*> nil;
     auto prop = getPropertyOfGeometry();
@@ -277,6 +277,15 @@ std::vector<const char*> GeoFeature::getElementTypes(bool /*all*/) const
         return nil;
     }
     return prop->getComplexData()->getElementTypes();
+}
+
+std::vector<Data::IndexedName>
+GeoFeature::getHigherElements(const char *element, bool silent) const
+{
+    auto prop = getPropertyOfGeometry();
+    if (!prop)
+        return {};
+    return prop->getComplexData()->getHigherElements(element, silent);
 }
 
 #endif

--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -269,7 +269,7 @@ const std::vector<std::string>& GeoFeature::searchElementCache(const std::string
     return none;
 }
 
-const std::vector<const char*>& GeoFeature::getElementTypes(bool /*all*/) const
+std::vector<const char*> GeoFeature::getElementTypes(bool /*all*/) const
 {
     static std::vector<const char*> nil;
     auto prop = getPropertyOfGeometry();

--- a/src/App/GeoFeature.h
+++ b/src/App/GeoFeature.h
@@ -175,7 +175,7 @@ public:
     virtual DocumentObject *getElementOwner(const Data::MappedName & /*name*/) const
     {return nullptr;}
 
-    virtual const std::vector<const char *>& getElementTypes(bool all=true) const;
+    virtual std::vector<const char *> getElementTypes(bool all=true) const;
 
     /// Return the higher level element names of the given element
     virtual std::vector<Data::IndexedName> getHigherElements(const char *name, bool silent=false) const;

--- a/src/App/GeoFeature.h
+++ b/src/App/GeoFeature.h
@@ -175,8 +175,10 @@ public:
     virtual DocumentObject *getElementOwner(const Data::MappedName & /*name*/) const
     {return nullptr;}
 
-    virtual std::vector<const char *> getElementTypes(bool all=true) const;
+    virtual const std::vector<const char *>& getElementTypes(bool all=true) const;
 
+    /// Return the higher level element names of the given element
+    virtual std::vector<Data::IndexedName> getHigherElements(const char *name, bool silent=false) const;
 
 protected:
     void onChanged(const Property* prop) override;

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -1496,6 +1496,9 @@ public:
     Data::ElementMapPtr resetElementMap(
         Data::ElementMapPtr elementMap=Data::ElementMapPtr()) override;
 
+    std::vector<Data::IndexedName> getHigherElements(const char *element,
+                                                     bool silent = false) const override;
+
     /** Helper class to return the generated and modified shape given an input shape
      *
      * Shape history information is extracted using OCCT APIs

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -3714,7 +3714,7 @@ struct MapperPrism: MapperMaker
             }
         }
     }
-    virtual const std::vector<TopoDS_Shape>& generated(const TopoDS_Shape& s) const override
+    const std::vector<TopoDS_Shape>& generated(const TopoDS_Shape& s) const override
     {
         _res.clear();
         switch (s.ShapeType()) {

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4775,6 +4775,25 @@ TopoShape& TopoShape::makeElementRefine(const TopoShape& shape, const char* op, 
     return *this;
 }
 
+    std::vector<Data::IndexedName>
+    TopoShape::getHigherElements(const char *element, bool silent) const
+    {
+        TopoShape shape = getSubTopoShape(element, silent);
+        if(shape.isNull())
+            return {};
+
+        std::vector<Data::IndexedName> res;
+        int type = shape.shapeType();
+        for(;;) {
+            if(--type < 0)
+                break;
+            const char *shapetype = shapeName((TopAbs_ShapeEnum)type).c_str();
+            for(int idx : findAncestors(shape.getShape(), (TopAbs_ShapeEnum)type))
+                res.emplace_back(shapetype, idx);
+        }
+        return res;
+    }
+
 TopoShape& TopoShape::makeElementBSplineFace(const TopoShape& shape,
                                              FillingStyle style,
                                              bool keepBezier,

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -201,9 +201,6 @@ void SketchObject::setupObject()
 {
     ParameterGrp::handle hGrpp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/Mod/Sketcher");
-//    ArcFitTolerance.setValue(hGrpp->GetFloat("ArcFitTolerance", Precision::Confusion()*10.0));
-//    ExternalBSplineMaxDegree.setValue(hGrpp->GetInt("ExternalBSplineMaxDegree", 5));
-//    ExternalBSplineTolerance.setValue(hGrpp->GetFloat("ExternalBSplineTolerance", 1e-4));
     MakeInternals.setValue(hGrpp->GetBool("MakeInternals", false));
     inherited::setupObject();
 }
@@ -402,42 +399,31 @@ const std::map<std::string,std::string> SketchObject::getInternalElementMap() co
     return internalElementMap;
 }
 
-Part::TopoShape SketchObject::buildInternals(const Part::TopoShape &edges) const
-{
+Part::TopoShape SketchObject::buildInternals(const Part::TopoShape &edges) const {
     if (!MakeInternals.getValue())
         return Part::TopoShape();
 
     try {
         Part::WireJoiner joiner;
-//        joiner.setTolerance(InternalTolerance.getValue());
         joiner.setTightBound(true);
         joiner.setMergeEdges(true);
         joiner.addShape(edges);
         Part::TopoShape result(getID(), getDocument()->getStringHasher());
         if (!joiner.Shape().IsNull()) {
             joiner.getResultWires(result, "SKF");
-
-            // NOTE: we set minElementNames to 2 (i.e to use at least two
-            // unused edge name to construct face name) in order to reduce the
-            // chance of face jumping.
             result = result.makeElementFace(result.getSubTopoShapes(TopAbs_WIRE),
-                                     /*op*/"",
-                                     /*maker*/"Part::FaceMakerRing",
-                                     /*pln*/nullptr
-#if 1
-//                                     /*minElementNames (revert to 1 for now, see how it fares)*/1
-#else
-                                     /*minElementNames*/2
-#endif
-                                    );
+                    /*op*/"",
+                    /*maker*/"Part::FaceMakerRing",
+                    /*pln*/nullptr
+            );
         }
         Part::TopoShape openWires(getID(), getDocument()->getStringHasher());
         joiner.getOpenWires(openWires, "SKF");
         if (openWires.isNull())
-            return result;
+            return result;  // No open wires, return either face or empty toposhape
         if (result.isNull())
-            return openWires;
-        return result.makeElementCompound({result, openWires});
+            return openWires;   // No face, but we have open wires to return as a shape
+        return result.makeElementCompound({result, openWires}); // Compound and return both
     } catch (Base::Exception &e) {
         FC_WARN("Failed to make face for sketch: " << e.what());
     } catch (Standard_Failure &e) {
@@ -9713,7 +9699,6 @@ std::vector<Data::IndexedName>
 SketchObject::getHigherElements(const char *element, bool silent) const
 {
     std::vector<Data::IndexedName> res;
-//    if (testStatus(App::ObjEditing)) {
         if (boost::istarts_with(element, "vertex")) {
             int n = 0;
             int index = atoi(element+6);
@@ -9730,7 +9715,6 @@ SketchObject::getHigherElements(const char *element, bool silent) const
             }
         }
         return res;
-//    }
 
     auto getNames = [&](const char *element) {
         bool internal = boost::starts_with(element, internalPrefix());
@@ -9756,7 +9740,7 @@ SketchObject::getHigherElements(const char *element, bool silent) const
     return res;
 }
 
-const std::vector<const char *>& SketchObject::getElementTypes(bool all) const
+std::vector<const char *> SketchObject::getElementTypes(bool all) const
 {
     if (!all)
         return Part::Part2DObject::getElementTypes();
@@ -9836,7 +9820,7 @@ App::ElementNamePair SketchObject::getElementName(
         if (mapped)
             mappedElement = InternalShape.getShape().getElementName(name);
         else if (type == ElementNameType::Export)
-            ret.first = getExportElementName(InternalShape.getShape(), realName).first;
+            ret.newName = getExportElementName(InternalShape.getShape(), realName).newName;
         else
             mappedElement = InternalShape.getShape().getElementName(realName);
 
@@ -10002,12 +9986,11 @@ bool SketchObject::geoIdFromShapeType(const Data::IndexedName & indexedName,
     return true;
 }
 
-std::string SketchObject::convertSubName(const char *subname, bool postfix) const
-{
+std::string SketchObject::convertSubName(const char *subname, bool postfix) const {
     return convertSubName(checkSubName(subname), postfix);
 }
 
-std::string SketchObject::convertSubName(const Data::IndexedName & indexedName, bool postfix) const{
+std::string SketchObject::convertSubName(const Data::IndexedName &indexedName, bool postfix) const {
     std::ostringstream ss;
     if (auto realType = convertInternalName(indexedName.getType())) {
         auto mapped = InternalShape.getShape().getMappedName(
@@ -10023,40 +10006,40 @@ std::string SketchObject::convertSubName(const Data::IndexedName & indexedName, 
     }
     int geoId;
     PointPos posId;
-    if(!geoIdFromShapeType(indexedName,geoId,posId)) {
+    if (!geoIdFromShapeType(indexedName, geoId, posId)) {
         ss << indexedName;
         return ss.str();
     }
-    if(geoId == Sketcher::GeoEnum::HAxis ||
-       geoId == Sketcher::GeoEnum::VAxis ||
-       geoId == Sketcher::GeoEnum::RtPnt) {
+    if (geoId == Sketcher::GeoEnum::HAxis ||
+        geoId == Sketcher::GeoEnum::VAxis ||
+        geoId == Sketcher::GeoEnum::RtPnt) {
         if (postfix)
             ss << Data::ELEMENT_MAP_PREFIX;
         ss << indexedName;
-        if(postfix)
-           ss  << '.' << indexedName;
+        if (postfix)
+            ss << '.' << indexedName;
         return ss.str();
     }
 
     auto geo = getGeometry(geoId);
-    if(!geo) {
+    if (!geo) {
         std::string res = indexedName.toString();
         return res;
     }
     if (postfix)
         ss << Data::ELEMENT_MAP_PREFIX;
-    ss << (geoId>=0?'g':'e') << GeometryFacade::getFacade(geo)->getId();
-    if(posId!=PointPos::none)
+    ss << (geoId >= 0 ? 'g' : 'e') << GeometryFacade::getFacade(geo)->getId();
+    if (posId != PointPos::none)
         ss << 'v' << static_cast<int>(posId);
-    if(postfix) {
+    if (postfix) {
         // rename Edge to edge, and Vertex to vertex to avoid ambiguous of
         // element mapping of the public shape and internal geometry.
         if (indexedName.getIndex() <= 0)
             ss << '.' << indexedName;
-        else if(boost::starts_with(indexedName.getType(),"Edge"))
-            ss << ".e" << (indexedName.getType()+1) << indexedName.getIndex();
-        else if(boost::starts_with(indexedName.getType(),"Vertex"))
-            ss << ".v" << (indexedName.getType()+1) << indexedName.getIndex();
+        else if (boost::starts_with(indexedName.getType(), "Edge"))
+            ss << ".e" << (indexedName.getType() + 1) << indexedName.getIndex();
+        else if (boost::starts_with(indexedName.getType(), "Vertex"))
+            ss << ".v" << (indexedName.getType() + 1) << indexedName.getIndex();
         else
             ss << '.' << indexedName;
     }

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -9706,20 +9706,18 @@ SketchObject::getHigherElements(const char *element, bool silent) const
                 ++n;
                 if (cstr->Type != Sketcher::Coincident)
                     continue;
-                for (int i=0; i<2; ++i) {
-                    int geoid = i ? cstr->Second : cstr->First;
-                    const Sketcher::PointPos &pos = i ? cstr->SecondPos : cstr->FirstPos;
-                    if(geoid >= 0 && index == getSolvedSketch().getPointId(geoid, pos) + 1)
-                        res.push_back(Data::IndexedName::fromConst("Constraint", n));
-                };
+                if(cstr->First >= 0 && index == getSolvedSketch().getPointId(cstr->First, cstr->FirstPos) + 1)
+                    res.push_back(Data::IndexedName::fromConst("Constraint", n));
+                if(cstr->Second >= 0 && index == getSolvedSketch().getPointId(cstr->Second, cstr->SecondPos) + 1)
+                    res.push_back(Data::IndexedName::fromConst("Constraint", n));
             }
         }
         return res;
 
-    auto getNames = [&](const char *element) {
+    auto getNames = [this, &silent, &res](const char *element) {
         bool internal = boost::starts_with(element, internalPrefix());
         const auto &shape = internal ? InternalShape.getShape() : Shape.getShape();
-        for (const auto &indexedName : shape.getHigherElements(element+(internal?internalPrefix().size():0), silent)) {
+        for (const auto &indexedName : shape.getHigherElements(element+(internal?internalPrefix().size() : 0), silent)) {
             if (!internal) {
                 res.push_back(indexedName);
             }
@@ -9744,9 +9742,7 @@ std::vector<const char *> SketchObject::getElementTypes(bool all) const
 {
     if (!all)
         return Part::Part2DObject::getElementTypes();
-    static std::vector<const char *> res;
-    if (res.empty()) {
-        res = { Part::TopoShape::shapeName(TopAbs_VERTEX).c_str(),
+    static std::vector<const char *> res { Part::TopoShape::shapeName(TopAbs_VERTEX).c_str(),
                 Part::TopoShape::shapeName(TopAbs_EDGE).c_str(),
                 "ExternalEdge",
                 "Constraint",
@@ -9754,7 +9750,6 @@ std::vector<const char *> SketchObject::getElementTypes(bool all) const
                 "InternalFace",
                 "InternalVertex",
               };
-    }
     return res;
 }
 

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -684,6 +684,11 @@ public:
 
     Part::TopoShape getEdge(const Part::Geometry* geo, const char* name) const;
 
+    std::vector<const char*> getElementTypes(bool all = true) const override;
+
+    std::vector<Data::IndexedName> getHigherElements(const char* element,
+                                                     bool silent = false) const override;
+
     Data::IndexedName checkSubName(const char* subname) const;
 
     bool geoIdFromShapeType(const Data::IndexedName&, int& geoId, PointPos& posId) const;


### PR DESCRIPTION
Seventh in series of incremental code transfers to solve the save/restore errors with objects with element maps.. 