### PR TITLE
Generate compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ OpenSCAD_rc.py
 tags
 /CMakeUserPresets.json
 Testing
+compile_commands.json
 
 # crowdin file
 src/Tools/freecad.zip

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,6 +10,10 @@
         "name": "common",
         "hidden": true,
         "cacheVariables": {
+          "CMAKE_EXPORT_COMPILE_COMMANDS": {
+            "type": "BOOL",
+            "value": "ON"
+          }
         }
       },
       {


### PR DESCRIPTION
Modify CMakePresets.json to use -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON in all the presets.

The compile_commands.json file can be used by tools like clangd to get autocompletion and go-to-definition.

This patch also adds compile_commands.json to the .gitignore, as often you need to symlink the compile_commands.json from the build directory into the source directory for it to be picked by tools. That is the case with clangd at least.