### PR TITLE
Fix and add menu accelerators

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -848,6 +848,25 @@ void RecentFilesAction::appendFile(const QString& filename)
     _pimpl->trySaveUserParameter();
 }
 
+static QString numberToLabel(int number) {
+    if (number > 0 && number < 10) { // NOLINT: *-magic-numbers
+        return QString::fromLatin1("&%1").arg(number);
+    }
+    if (number == 10) { // NOLINT: *-magic-numbers
+        return QString::fromLatin1("1&0");
+    }
+    // If we have a number greater than 10, we start using the alphabet.
+    // So 11 becomes 'A' and so on.
+    constexpr char lettersStart = 11;
+    constexpr char lettersEnd = lettersStart + ('Z' - 'A');
+    if (number >= lettersStart && number < lettersEnd) {
+        QChar letter = QChar::fromLatin1('A' + (number - lettersStart));
+        return QString::fromLatin1("%1 (&%2)").arg(number).arg(letter);
+    }
+    // Not enough accelerators to cover this number.
+    return QString::fromLatin1("%1").arg(number);
+}
+
 /**
  * Set the list of recent files. For each item an action object is
  * created and added to this action group.
@@ -858,8 +877,9 @@ void RecentFilesAction::setFiles(const QStringList& files)
 
     int numRecentFiles = std::min<int>(recentFiles.count(), files.count());
     for (int index = 0; index < numRecentFiles; index++) {
+        QString numberLabel = numberToLabel(index + 1);
         QFileInfo fi(files[index]);
-        recentFiles[index]->setText(QString::fromLatin1("%1 %2").arg(index+1).arg(fi.fileName()));
+        recentFiles[index]->setText(QString::fromLatin1("%1 %2").arg(numberLabel).arg(fi.fileName()));
         recentFiles[index]->setStatusTip(tr("Open file %1").arg(files[index]));
         recentFiles[index]->setToolTip(files[index]); // set the full name that we need later for saving
         recentFiles[index]->setData(QVariant(index));
@@ -1020,7 +1040,8 @@ void RecentMacrosAction::setFiles(const QStringList& files)
     auto accel_col = QString::fromStdString(shortcut_modifiers);
     for (int index = 0; index < numRecentFiles; index++) {
         QFileInfo fi(files[index]);
-        recentFiles[index]->setText(QString::fromLatin1("%1 %2").arg(index+1).arg(fi.completeBaseName()));
+        QString numberLabel = numberToLabel(index + 1);
+        recentFiles[index]->setText(QString::fromLatin1("%1 %2").arg(numberLabel).arg(fi.completeBaseName()));
         recentFiles[index]->setToolTip(files[index]); // set the full name that we need later for saving
         recentFiles[index]->setData(QVariant(index));
         QString accel(tr("none"));

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -263,22 +263,22 @@ protected:
     const std::map<int, std::pair<std::string, std::string>> userEditModes {
         {0,
          std::make_pair(
-             QT_TRANSLATE_NOOP("EditMode", "Default"),
+             QT_TRANSLATE_NOOP("EditMode", "&Default"),
              QT_TRANSLATE_NOOP("EditMode",
                                "The object will be edited using the mode defined internally to be "
                                "the most appropriate for the object type"))},
         {1,
-         std::make_pair(QT_TRANSLATE_NOOP("EditMode", "Transform"),
+         std::make_pair(QT_TRANSLATE_NOOP("EditMode", "Trans&form"),
                         QT_TRANSLATE_NOOP("EditMode",
                                           "The object will have its placement editable with the "
                                           "Std TransformManip command"))},
         {2,
-         std::make_pair(QT_TRANSLATE_NOOP("EditMode", "Cutting"),
+         std::make_pair(QT_TRANSLATE_NOOP("EditMode", "Cu&tting"),
                         QT_TRANSLATE_NOOP("EditMode",
                                           "This edit mode is implemented as available but "
                                           "currently does not seem to be used by any object"))},
         {3,
-         std::make_pair(QT_TRANSLATE_NOOP("EditMode", "Color"),
+         std::make_pair(QT_TRANSLATE_NOOP("EditMode", "&Color"),
                         QT_TRANSLATE_NOOP("EditMode",
                                           "The object will have the color of its individual faces "
                                           "editable with the Part FaceAppearances command"))},

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -521,7 +521,7 @@ StdCmdMergeProjects::StdCmdMergeProjects()
 {
     sAppModule    = "File";
     sGroup        = "File";
-    sMenuText     = QT_TR_NOOP("Merge document...");
+    sMenuText     = QT_TR_NOOP("&Merge document...");
     sToolTipText  = QT_TR_NOOP("Merge document");
     sWhatsThis    = "Std_MergeProjects";
     sStatusTip    = QT_TR_NOOP("Merge document");
@@ -574,7 +574,7 @@ StdCmdDependencyGraph::StdCmdDependencyGraph()
 {
     // setting the
     sGroup        = "Tools";
-    sMenuText     = QT_TR_NOOP("Dependency graph...");
+    sMenuText     = QT_TR_NOOP("Dependency gra&ph...");
     sToolTipText  = QT_TR_NOOP("Show the dependency graph of the objects in the active document");
     sStatusTip    = QT_TR_NOOP("Show the dependency graph of the objects in the active document");
     sWhatsThis    = "Std_DependencyGraph";
@@ -606,7 +606,7 @@ StdCmdExportDependencyGraph::StdCmdExportDependencyGraph()
   : Command("Std_ExportDependencyGraph")
 {
     sGroup        = "Tools";
-    sMenuText     = QT_TR_NOOP("Export dependency graph...");
+    sMenuText     = QT_TR_NOOP("Export dependency &graph...");
     sToolTipText  = QT_TR_NOOP("Export the dependency graph to a file");
     sStatusTip    = QT_TR_NOOP("Export the dependency graph to a file");
     sWhatsThis    = "Std_ExportDependencyGraph";
@@ -735,7 +735,7 @@ StdCmdSaveCopy::StdCmdSaveCopy()
   :Command("Std_SaveCopy")
 {
   sGroup        = "File";
-  sMenuText     = QT_TR_NOOP("Save a &Copy...");
+  sMenuText     = QT_TR_NOOP("Save a Cop&y...");
   sToolTipText  = QT_TR_NOOP("Save a copy of the active document under a new file name");
   sWhatsThis    = "Std_SaveCopy";
   sStatusTip    = QT_TR_NOOP("Save a copy of the active document under a new file name");
@@ -762,7 +762,7 @@ StdCmdSaveAll::StdCmdSaveAll()
   :Command("Std_SaveAll")
 {
   sGroup        = "File";
-  sMenuText     = QT_TR_NOOP("Save All");
+  sMenuText     = QT_TR_NOOP("Sa&ve All");
   sToolTipText  = QT_TR_NOOP("Save all opened document");
   sWhatsThis    = "Std_SaveAll";
   sStatusTip    = QT_TR_NOOP("Save all opened document");
@@ -790,7 +790,7 @@ StdCmdRevert::StdCmdRevert()
   :Command("Std_Revert")
 {
     sGroup        = "File";
-    sMenuText     = QT_TR_NOOP("Revert");
+    sMenuText     = QT_TR_NOOP("Rever&t");
     sToolTipText  = QT_TR_NOOP("Reverts to the saved version of this file");
     sWhatsThis    = "Std_Revert";
     sStatusTip    = QT_TR_NOOP("Reverts to the saved version of this file");
@@ -829,7 +829,7 @@ StdCmdProjectInfo::StdCmdProjectInfo()
 {
   // setting the
   sGroup        = "File";
-  sMenuText     = QT_TR_NOOP("Document i&nformation...");
+  sMenuText     = QT_TR_NOOP("Doc&ument information...");
   sToolTipText  = QT_TR_NOOP("Show details of the currently active document");
   sWhatsThis    = "Std_ProjectInfo";
   sStatusTip    = QT_TR_NOOP("Show details of the currently active document");
@@ -860,7 +860,7 @@ StdCmdProjectUtil::StdCmdProjectUtil()
     // setting the
     sGroup        = "Tools";
     sWhatsThis    = "Std_ProjectUtil";
-    sMenuText     = QT_TR_NOOP("Document utility...");
+    sMenuText     = QT_TR_NOOP("Do&cument utility...");
     sToolTipText  = QT_TR_NOOP("Utility to extract or create document files");
     sStatusTip    = QT_TR_NOOP("Utility to extract or create document files");
     sPixmap       = "Std_ProjectUtil";
@@ -919,7 +919,7 @@ StdCmdPrintPreview::StdCmdPrintPreview()
   :Command("Std_PrintPreview")
 {
     sGroup        = "File";
-    sMenuText     = QT_TR_NOOP("&Print preview...");
+    sMenuText     = QT_TR_NOOP("Print previe&w...");
     sToolTipText  = QT_TR_NOOP("Print the document");
     sWhatsThis    = "Std_PrintPreview";
     sStatusTip    = QT_TR_NOOP("Print preview");
@@ -949,7 +949,7 @@ StdCmdPrintPdf::StdCmdPrintPdf()
   :Command("Std_PrintPdf")
 {
     sGroup        = "File";
-    sMenuText     = QT_TR_NOOP("&Export PDF...");
+    sMenuText     = QT_TR_NOOP("Export P&DF...");
     sToolTipText  = QT_TR_NOOP("Export the document as PDF");
     sWhatsThis    = "Std_PrintPdf";
     sStatusTip    = QT_TR_NOOP("Export the document as PDF");
@@ -1094,7 +1094,7 @@ StdCmdCut::StdCmdCut()
   : Command("Std_Cut")
 {
     sGroup        = "Edit";
-    sMenuText     = QT_TR_NOOP("&Cut");
+    sMenuText     = QT_TR_NOOP("Cu&t");
     sToolTipText  = QT_TR_NOOP("Cut out");
     sWhatsThis    = "Std_Cut";
     sStatusTip    = QT_TR_NOOP("Cut out");
@@ -1122,7 +1122,7 @@ StdCmdCopy::StdCmdCopy()
   : Command("Std_Copy")
 {
     sGroup        = "Edit";
-    sMenuText     = QT_TR_NOOP("C&opy");
+    sMenuText     = QT_TR_NOOP("&Copy");
     sToolTipText  = QT_TR_NOOP("Copy operation");
     sWhatsThis    = "Std_Copy";
     sStatusTip    = QT_TR_NOOP("Copy operation");
@@ -1197,7 +1197,7 @@ StdCmdDuplicateSelection::StdCmdDuplicateSelection()
 {
     sAppModule    = "Edit";
     sGroup        = "Edit";
-    sMenuText     = QT_TR_NOOP("Duplicate selection");
+    sMenuText     = QT_TR_NOOP("Duplicate selecti&on");
     sToolTipText  = QT_TR_NOOP("Put duplicates of the selected objects to the active document");
     sWhatsThis    = "Std_DuplicateSelection";
     sStatusTip    = QT_TR_NOOP("Put duplicates of the selected objects to the active document");
@@ -1463,7 +1463,7 @@ StdCmdRefresh::StdCmdRefresh()
   : Command("Std_Refresh")
 {
     sGroup        = "Edit";
-    sMenuText     = QT_TR_NOOP("&Refresh");
+    sMenuText     = QT_TR_NOOP("Refres&h");
     sToolTipText  = QT_TR_NOOP("Recomputes the current active document");
     sWhatsThis    = "Std_Refresh";
     sStatusTip    = QT_TR_NOOP("Recomputes the current active document");
@@ -1543,7 +1543,7 @@ StdCmdPlacement::StdCmdPlacement()
   : Command("Std_Placement")
 {
     sGroup        = "Edit";
-    sMenuText     = QT_TR_NOOP("Placement...");
+    sMenuText     = QT_TR_NOOP("P&lacement...");
     sToolTipText  = QT_TR_NOOP("Place the selected objects");
     sStatusTip    = QT_TR_NOOP("Place the selected objects");
     sWhatsThis    = "Std_Placement";
@@ -1589,7 +1589,7 @@ StdCmdTransformManip::StdCmdTransformManip()
   : Command("Std_TransformManip")
 {
     sGroup        = "Edit";
-    sMenuText     = QT_TR_NOOP("Transform");
+    sMenuText     = QT_TR_NOOP("Trans&form");
     sToolTipText  = QT_TR_NOOP("Transform the selected object in the 3D view");
     sStatusTip    = QT_TR_NOOP("Transform the selected object in the 3D view");
     sWhatsThis    = "Std_TransformManip";
@@ -1623,7 +1623,7 @@ StdCmdAlignment::StdCmdAlignment()
   : Command("Std_Alignment")
 {
     sGroup        = "Edit";
-    sMenuText     = QT_TR_NOOP("Alignment...");
+    sMenuText     = QT_TR_NOOP("Ali&gnment...");
     sToolTipText  = QT_TR_NOOP("Align the selected objects");
     sStatusTip    = QT_TR_NOOP("Align the selected objects");
     sWhatsThis    = "Std_Alignment";
@@ -1733,7 +1733,7 @@ StdCmdProperties::StdCmdProperties()
     : Command("Std_Properties")
 {
     sGroup = "Edit";
-    sMenuText = QT_TR_NOOP("Properties");
+    sMenuText = QT_TR_NOOP("Propert&ies");
     sToolTipText = QT_TR_NOOP("Show the property view, which displays the properties of the selected object.");
     sWhatsThis = "Std_Properties";
     sStatusTip = sToolTipText;

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -77,7 +77,7 @@ StdCmdRandomColor::StdCmdRandomColor()
   :Command("Std_RandomColor")
 {
     sGroup        = "File";
-    sMenuText     = QT_TR_NOOP("Random color");
+    sMenuText     = QT_TR_NOOP("Random &color");
     sToolTipText  = QT_TR_NOOP("Set each selected object to a randomly-selected color");
     sWhatsThis    = "Std_RandomColor";
     sStatusTip    = QT_TR_NOOP("Set each selected object to a randomly-selected color");

--- a/src/Gui/CommandLink.cpp
+++ b/src/Gui/CommandLink.cpp
@@ -646,7 +646,7 @@ StdCmdLinkSelectLinked::StdCmdLinkSelectLinked()
   : Command("Std_LinkSelectLinked")
 {
     sGroup        = "Link";
-    sMenuText     = QT_TR_NOOP("Go to linked object");
+    sMenuText     = QT_TR_NOOP("&Go to linked object");
     sToolTipText  = QT_TR_NOOP("Select the linked object and switch to its owner document");
     sWhatsThis    = "Std_LinkSelectLinked";
     sStatusTip    = sToolTipText;
@@ -774,7 +774,7 @@ StdCmdLinkSelectLinkedFinal::StdCmdLinkSelectLinkedFinal()
   : Command("Std_LinkSelectLinkedFinal")
 {
     sGroup        = "Link";
-    sMenuText     = QT_TR_NOOP("Go to the deepest linked object");
+    sMenuText     = QT_TR_NOOP("Go to the &deepest linked object");
     sToolTipText  = QT_TR_NOOP("Select the deepest linked object and switch to its owner document");
     sWhatsThis    = "Std_LinkSelectLinkedFinal";
     sStatusTip    = sToolTipText;
@@ -809,7 +809,7 @@ StdCmdLinkSelectAllLinks::StdCmdLinkSelectAllLinks()
   : Command("Std_LinkSelectAllLinks")
 {
     sGroup        = "Link";
-    sMenuText     = QT_TR_NOOP("Select all links");
+    sMenuText     = QT_TR_NOOP("Select &all links");
     sToolTipText  = QT_TR_NOOP("Select all links to the current selected object");
     sWhatsThis    = "Std_LinkSelectAllLinks";
     sStatusTip    = sToolTipText;
@@ -849,7 +849,7 @@ public:
         : GroupCommand("Std_LinkSelectActions")
     {
         sGroup        = "View";
-        sMenuText     = QT_TR_NOOP("Link navigation");
+        sMenuText     = QT_TR_NOOP("&Link navigation");
         sToolTipText  = QT_TR_NOOP("Link navigation actions");
         sWhatsThis    = "Std_LinkSelectActions";
         sStatusTip    = QT_TR_NOOP("Link navigation actions");

--- a/src/Gui/CommandMacro.cpp
+++ b/src/Gui/CommandMacro.cpp
@@ -48,7 +48,7 @@ StdCmdDlgMacroRecord::StdCmdDlgMacroRecord()
   : Command("Std_DlgMacroRecord")
 {
     sGroup        = "Macro";
-    sMenuText     = QT_TR_NOOP("&Macro recording ...");
+    sMenuText     = QT_TR_NOOP("&Macro recording...");
     sToolTipText  = QT_TR_NOOP("Opens a dialog to record a macro");
     sWhatsThis    = "Std_DlgMacroRecord";
     sStatusTip    = QT_TR_NOOP("Opens a dialog to record a macro");
@@ -91,7 +91,7 @@ StdCmdDlgMacroExecute::StdCmdDlgMacroExecute()
   : Command("Std_DlgMacroExecute")
 {
     sGroup        = "Macro";
-    sMenuText     = QT_TR_NOOP("Macros ...");
+    sMenuText     = QT_TR_NOOP("Ma&cros...");
     sToolTipText  = QT_TR_NOOP("Opens a dialog to let you execute a recorded macro");
     sWhatsThis    = "Std_DlgMacroExecute";
     sStatusTip    = QT_TR_NOOP("Opens a dialog to let you execute a recorded macro");
@@ -120,7 +120,7 @@ StdCmdDlgMacroExecuteDirect::StdCmdDlgMacroExecuteDirect()
   : Command("Std_DlgMacroExecuteDirect")
 {
     sGroup        = "Macro";
-    sMenuText     = QT_TR_NOOP("Execute macro");
+    sMenuText     = QT_TR_NOOP("&Execute macro");
     sToolTipText  = QT_TR_NOOP("Execute the macro in the editor");
     sWhatsThis    = "Std_DlgMacroExecuteDirect";
     sStatusTip    = QT_TR_NOOP("Execute the macro in the editor");
@@ -146,7 +146,7 @@ StdCmdMacroAttachDebugger::StdCmdMacroAttachDebugger()
   : Command("Std_MacroAttachDebugger")
 {
     sGroup        = "Macro";
-    sMenuText     = QT_TR_NOOP("Attach to remote debugger...");
+    sMenuText     = QT_TR_NOOP("&Attach to remote debugger...");
     sToolTipText  = QT_TR_NOOP("Attach to a remotely running debugger");
     sWhatsThis    = "Std_MacroAttachDebugger";
     sStatusTip    = QT_TR_NOOP("Attach to a remotely running debugger");
@@ -171,7 +171,7 @@ StdCmdMacroStartDebug::StdCmdMacroStartDebug()
   : Command("Std_MacroStartDebug")
 {
     sGroup        = "Macro";
-    sMenuText     = QT_TR_NOOP("Debug macro");
+    sMenuText     = QT_TR_NOOP("&Debug macro");
     sToolTipText  = QT_TR_NOOP("Start debugging of macro");
     sWhatsThis    = "Std_MacroStartDebug";
     sStatusTip    = QT_TR_NOOP("Start debugging of macro");
@@ -201,7 +201,7 @@ StdCmdMacroStopDebug::StdCmdMacroStopDebug()
   : Command("Std_MacroStopDebug")
 {
     sGroup        = "Macro";
-    sMenuText     = QT_TR_NOOP("Stop debugging");
+    sMenuText     = QT_TR_NOOP("&Stop debugging");
     sToolTipText  = QT_TR_NOOP("Stop debugging of macro");
     sWhatsThis    = "Std_MacroStopDebug";
     sStatusTip    = QT_TR_NOOP("Stop debugging of macro");
@@ -228,7 +228,7 @@ StdCmdMacroStepOver::StdCmdMacroStepOver()
   : Command("Std_MacroStepOver")
 {
     sGroup        = "Macro";
-    sMenuText     = QT_TR_NOOP("Step over");
+    sMenuText     = QT_TR_NOOP("Step &over");
     sToolTipText  = QT_TR_NOOP("Step to the next line in this file");
     sWhatsThis    = "Std_MacroStepOver";
     sStatusTip    = QT_TR_NOOP("Step to the next line in this file");
@@ -255,7 +255,7 @@ StdCmdMacroStepInto::StdCmdMacroStepInto()
   : Command("Std_MacroStepInto")
 {
     sGroup        = "Macro";
-    sMenuText     = QT_TR_NOOP("Step into");
+    sMenuText     = QT_TR_NOOP("Step &into");
     sToolTipText  = QT_TR_NOOP("Step to the next line executed");
     sWhatsThis    = "Std_MacroStepInto";
     sStatusTip    = QT_TR_NOOP("Step to the next line executed");
@@ -282,7 +282,7 @@ StdCmdToggleBreakpoint::StdCmdToggleBreakpoint()
   : Command("Std_ToggleBreakpoint")
 {
     sGroup        = "Macro";
-    sMenuText     = QT_TR_NOOP("Toggle breakpoint");
+    sMenuText     = QT_TR_NOOP("Toggle &breakpoint");
     sToolTipText  = QT_TR_NOOP("Add or remove a breakpoint at this position");
     sWhatsThis    = "Std_ToggleBreakpoint";
     sStatusTip    = QT_TR_NOOP("Add or remove a breakpoint at this position");

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -72,7 +72,7 @@ StdCmdWorkbench::StdCmdWorkbench()
   : Command("Std_Workbench")
 {
     sGroup        = "View";
-    sMenuText     = QT_TR_NOOP("Workbench");
+    sMenuText     = QT_TR_NOOP("&Workbench");
     sToolTipText  = QT_TR_NOOP("Switch between workbenches");
     sWhatsThis    = "Std_Workbench";
     sStatusTip    = QT_TR_NOOP("Switch between workbenches");
@@ -137,7 +137,7 @@ StdCmdRecentFiles::StdCmdRecentFiles()
   :Command("Std_RecentFiles")
 {
     sGroup        = "File";
-    sMenuText     = QT_TR_NOOP("Open Recent");
+    sMenuText     = QT_TR_NOOP("Open &Recent");
     sToolTipText  = QT_TR_NOOP("Recent file list");
     sWhatsThis    = "Std_RecentFiles";
     sStatusTip    = QT_TR_NOOP("Recent file list");
@@ -178,7 +178,7 @@ StdCmdRecentMacros::StdCmdRecentMacros()
   :Command("Std_RecentMacros")
 {
     sGroup        = "Macro";
-    sMenuText     = QT_TR_NOOP("Recent macros");
+    sMenuText     = QT_TR_NOOP("&Recent macros");
     sToolTipText  = QT_TR_NOOP("Recent macro list");
     sWhatsThis    = "Std_RecentMacros";
     sStatusTip    = QT_TR_NOOP("Recent macro list");
@@ -378,7 +378,7 @@ StdCmdDlgParameter::StdCmdDlgParameter()
   :Command("Std_DlgParameter")
 {
   sGroup        = "Tools";
-  sMenuText     = QT_TR_NOOP("E&dit parameters ...");
+  sMenuText     = QT_TR_NOOP("E&dit parameters...");
   sToolTipText  = QT_TR_NOOP("Opens a Dialog to edit the parameters");
   sWhatsThis    = "Std_DlgParameter";
   sStatusTip    = QT_TR_NOOP("Opens a Dialog to edit the parameters");
@@ -403,7 +403,7 @@ StdCmdDlgPreferences::StdCmdDlgPreferences()
   :Command("Std_DlgPreferences")
 {
     sGroup        = "Tools";
-    sMenuText     = QT_TR_NOOP("&Preferences ...");
+    sMenuText     = QT_TR_NOOP("Prefere&nces ...");
     sToolTipText  = QT_TR_NOOP("Opens a Dialog to edit the preferences");
     sWhatsThis    = "Std_DlgPreferences";
     sStatusTip    = QT_TR_NOOP("Opens a Dialog to edit the preferences");
@@ -522,7 +522,7 @@ StdCmdOnlineHelp::StdCmdOnlineHelp()
   :Command("Std_OnlineHelp")
 {
     sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("Help");
+    sMenuText     = QT_TR_NOOP("&Help");
     sToolTipText  = QT_TR_NOOP("Opens the Help documentation");
     sWhatsThis    = "Std_OnlineHelp";
     sStatusTip    = sToolTipText;
@@ -574,7 +574,7 @@ StdCmdFreeCADDonation::StdCmdFreeCADDonation()
   :Command("Std_FreeCADDonation")
 {
     sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("Support FreeCAD");
+    sMenuText     = QT_TR_NOOP("Support FreeCA&D");
     sToolTipText  = QT_TR_NOOP("Support FreeCAD development");
     sWhatsThis    = "Std_FreeCADDonation";
     sStatusTip    = sToolTipText;
@@ -601,7 +601,7 @@ StdCmdFreeCADWebsite::StdCmdFreeCADWebsite()
   :Command("Std_FreeCADWebsite")
 {
     sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("FreeCAD Website");
+    sMenuText     = QT_TR_NOOP("FreeCAD W&ebsite");
     sToolTipText  = QT_TR_NOOP("Navigates to the official FreeCAD website");
     sWhatsThis    = "Std_FreeCADWebsite";
     sStatusTip    = sToolTipText;
@@ -629,7 +629,7 @@ StdCmdFreeCADUserHub::StdCmdFreeCADUserHub()
   :Command("Std_FreeCADUserHub")
 {
     sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("User Documentation");
+    sMenuText     = QT_TR_NOOP("&User Documentation");
     sToolTipText  = QT_TR_NOOP("Opens the documentation for users");
     sWhatsThis    = "Std_FreeCADUserHub";
     sStatusTip    = sToolTipText;
@@ -657,7 +657,7 @@ StdCmdFreeCADPowerUserHub::StdCmdFreeCADPowerUserHub()
   :Command("Std_FreeCADPowerUserHub")
 {
     sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("Python Scripting Documentation");
+    sMenuText     = QT_TR_NOOP("&Python Scripting Documentation");
     sToolTipText  = QT_TR_NOOP("Opens the Python Scripting documentation");
     sWhatsThis    = "Std_FreeCADPowerUserHub";
     sStatusTip    = sToolTipText;
@@ -685,7 +685,7 @@ StdCmdFreeCADForum::StdCmdFreeCADForum()
   :Command("Std_FreeCADForum")
 {
     sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("FreeCAD Forum");
+    sMenuText     = QT_TR_NOOP("FreeCAD &Forum");
     sToolTipText  = QT_TR_NOOP("The FreeCAD forum, where you can find help from other users");
     sWhatsThis    = "Std_FreeCADForum";
     sStatusTip    = sToolTipText;
@@ -713,7 +713,7 @@ StdCmdFreeCADFAQ::StdCmdFreeCADFAQ()
   :Command("Std_FreeCADFAQ")
 {
     sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("FreeCAD FAQ");
+    sMenuText     = QT_TR_NOOP("FreeCAD FA&Q");
     sToolTipText  = QT_TR_NOOP("Opens the Frequently Asked Questions");
     sWhatsThis    = "Std_FreeCADFAQ";
     sStatusTip    = sToolTipText;
@@ -766,7 +766,7 @@ StdCmdReportBug::StdCmdReportBug()
   :Command("Std_ReportBug")
 {
     sGroup        = "Help";
-    sMenuText     = QT_TR_NOOP("Report an Issue");
+    sMenuText     = QT_TR_NOOP("Report an &Issue");
     sToolTipText  = QT_TR_NOOP("Report an issue or suggest a new feature");
     sWhatsThis    = "Std_ReportBug";
     sStatusTip    = sToolTipText;
@@ -793,7 +793,7 @@ StdCmdTextDocument::StdCmdTextDocument()
   :Command("Std_TextDocument")
 {
     sGroup        = "Tools";
-    sMenuText     = QT_TR_NOOP("Add text document");
+    sMenuText     = QT_TR_NOOP("Add te&xt document");
     sToolTipText  = QT_TR_NOOP("Add text document to active document");
     sWhatsThis    = "Std_TextDocument";
     sStatusTip    = QT_TR_NOOP("Add text document to active document");
@@ -862,7 +862,7 @@ StdCmdUserEditMode::StdCmdUserEditMode()
   : Command("Std_UserEditMode")
 {
     sGroup        = "Edit";
-    sMenuText     = QT_TR_NOOP("Edit mode");
+    sMenuText     = QT_TR_NOOP("Edit &mode");
     sToolTipText  = QT_TR_NOOP("Defines behavior when editing an object from tree");
     sStatusTip    = QT_TR_NOOP("Defines behavior when editing an object from tree");
     sWhatsThis    = "Std_UserEditMode";
@@ -883,7 +883,7 @@ Gui::Action * StdCmdUserEditMode::createAction()
 
     for (auto const &uem : Gui::Application::Instance->listUserEditModes()) {
         QAction* act = pcAction->addAction(QString());
-        auto modeName = QString::fromStdString(uem.second.first);
+        auto modeName = QString::fromStdString(uem.second.first).remove(QChar::fromLatin1('&'));
         act->setCheckable(true);
         act->setIcon(BitmapFactory().iconFromTheme(qPrintable(QString::fromLatin1("Std_UserEditMode")+modeName)));
         act->setObjectName(QString::fromLatin1("Std_UserEditMode")+modeName);

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -320,7 +320,7 @@ StdCmdFreezeViews::StdCmdFreezeViews()
   : Command("Std_FreezeViews")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Freeze display");
+    sMenuText     = QT_TR_NOOP("F&reeze display");
     sToolTipText  = QT_TR_NOOP("Freezes the current view position");
     sWhatsThis    = "Std_FreezeViews";
     sStatusTip    = QT_TR_NOOP("Freezes the current view position");
@@ -335,15 +335,15 @@ Action * StdCmdFreezeViews::createAction()
     applyCommandData(this->className(), pcAction);
 
     // add the action items
-    saveView = pcAction->addAction(QObject::tr("Save views..."));
+    saveView = pcAction->addAction(QObject::tr("&Save views..."));
     saveView->setWhatsThis(QString::fromLatin1(getWhatsThis()));
-    QAction* loadView = pcAction->addAction(QObject::tr("Load views..."));
+    QAction* loadView = pcAction->addAction(QObject::tr("&Load views..."));
     loadView->setWhatsThis(QString::fromLatin1(getWhatsThis()));
     pcAction->addAction(QString::fromLatin1(""))->setSeparator(true);
-    freezeView = pcAction->addAction(QObject::tr("Freeze view"));
+    freezeView = pcAction->addAction(QObject::tr("F&reeze view"));
     freezeView->setShortcut(QString::fromLatin1(getAccel()));
     freezeView->setWhatsThis(QString::fromLatin1(getWhatsThis()));
-    clearView = pcAction->addAction(QObject::tr("Clear views"));
+    clearView = pcAction->addAction(QObject::tr("&Clear views"));
     clearView->setWhatsThis(QString::fromLatin1(getWhatsThis()));
     separator = pcAction->addAction(QString::fromLatin1(""));
     separator->setSeparator(true);
@@ -568,10 +568,10 @@ void StdCmdFreezeViews::languageChange()
         return;
     auto pcAction = qobject_cast<ActionGroup*>(_pcAction);
     QList<QAction*> acts = pcAction->actions();
-    acts[0]->setText(QObject::tr("Save views..."));
-    acts[1]->setText(QObject::tr("Load views..."));
-    acts[3]->setText(QObject::tr("Freeze view"));
-    acts[4]->setText(QObject::tr("Clear views"));
+    acts[0]->setText(QObject::tr("&Save views..."));
+    acts[1]->setText(QObject::tr("&Load views..."));
+    acts[3]->setText(QObject::tr("F&reeze view"));
+    acts[4]->setText(QObject::tr("&Clear views"));
     int index=1;
     for (QList<QAction*>::Iterator it = acts.begin()+5; it != acts.end(); ++it, index++) {
         if ((*it)->isVisible()) {
@@ -592,7 +592,7 @@ StdCmdToggleClipPlane::StdCmdToggleClipPlane()
   : Command("Std_ToggleClipPlane")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Clipping plane");
+    sMenuText     = QT_TR_NOOP("Clippin&g plane");
     sToolTipText  = QT_TR_NOOP("Toggles clipping plane for active view");
     sWhatsThis    = "Std_ToggleClipPlane";
     sStatusTip    = QT_TR_NOOP("Toggles clipping plane for active view");
@@ -645,7 +645,7 @@ StdCmdDrawStyle::StdCmdDrawStyle()
   : Command("Std_DrawStyle")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Draw style");
+    sMenuText     = QT_TR_NOOP("&Draw style");
     sToolTipText  = QT_TR_NOOP("Change the draw style of the objects");
     sStatusTip    = QT_TR_NOOP("Change the draw style of the objects");
     sWhatsThis    = "Std_DrawStyle";
@@ -725,37 +725,37 @@ void StdCmdDrawStyle::languageChange()
     QList<QAction*> a = pcAction->actions();
 
     a[0]->setText(QCoreApplication::translate(
-        "Std_DrawStyle", "As is"));
+        "Std_DrawStyle", "&1 As is"));
     a[0]->setToolTip(QCoreApplication::translate(
         "Std_DrawStyle", "Normal mode"));
 
     a[1]->setText(QCoreApplication::translate(
-        "Std_DrawStyle", "Points"));
+        "Std_DrawStyle", "&2 Points"));
     a[1]->setToolTip(QCoreApplication::translate(
         "Std_DrawStyle", "Points mode"));
 
     a[2]->setText(QCoreApplication::translate(
-        "Std_DrawStyle", "Wireframe"));
+        "Std_DrawStyle", "&3 Wireframe"));
     a[2]->setToolTip(QCoreApplication::translate(
         "Std_DrawStyle", "Wireframe mode"));
 
     a[3]->setText(QCoreApplication::translate(
-        "Std_DrawStyle", "Hidden line"));
+        "Std_DrawStyle", "&4 Hidden line"));
     a[3]->setToolTip(QCoreApplication::translate(
         "Std_DrawStyle", "Hidden line mode"));
 
     a[4]->setText(QCoreApplication::translate(
-        "Std_DrawStyle", "No shading"));
+        "Std_DrawStyle", "&5 No shading"));
     a[4]->setToolTip(QCoreApplication::translate(
         "Std_DrawStyle", "No shading mode"));
 
     a[5]->setText(QCoreApplication::translate(
-        "Std_DrawStyle", "Shaded"));
+        "Std_DrawStyle", "&6 Shaded"));
     a[5]->setToolTip(QCoreApplication::translate(
         "Std_DrawStyle", "Shaded mode"));
 
     a[6]->setText(QCoreApplication::translate(
-        "Std_DrawStyle", "Flat lines"));
+        "Std_DrawStyle", "&7 Flat lines"));
     a[6]->setToolTip(QCoreApplication::translate(
         "Std_DrawStyle", "Flat lines mode"));
 }
@@ -865,7 +865,7 @@ StdCmdToggleVisibility::StdCmdToggleVisibility()
   : Command("Std_ToggleVisibility")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Toggle visibility");
+    sMenuText     = QT_TR_NOOP("Toggle &visibility");
     sToolTipText  = QT_TR_NOOP("Toggles visibility");
     sStatusTip    = QT_TR_NOOP("Toggles visibility");
     sWhatsThis    = "Std_ToggleVisibility";
@@ -896,7 +896,7 @@ StdCmdToggleTransparency::StdCmdToggleTransparency()
     : Command("Std_ToggleTransparency")
 {
     sGroup = "Standard-View";
-    sMenuText = QT_TR_NOOP("Toggle transparency");
+    sMenuText = QT_TR_NOOP("Toggle transparenc&y");
     static std::string toolTip = std::string("<p>")
         + QT_TR_NOOP("Toggles transparency of the selected objects. You can also fine tune transparency "
             "value in the Appearance taskbox (right click an object in the tree, Appearance).")
@@ -1003,7 +1003,7 @@ StdCmdToggleSelectability::StdCmdToggleSelectability()
   : Command("Std_ToggleSelectability")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Toggle selectability");
+    sMenuText     = QT_TR_NOOP("Toggle se&lectability");
     sToolTipText  = QT_TR_NOOP("Toggles the property of the objects to get selected in the 3D-View");
     sStatusTip    = QT_TR_NOOP("Toggles the property of the objects to get selected in the 3D-View");
     sWhatsThis    = "Std_ToggleSelectability";
@@ -1055,7 +1055,7 @@ StdCmdShowSelection::StdCmdShowSelection()
   : Command("Std_ShowSelection")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Show selection");
+    sMenuText     = QT_TR_NOOP("Sho&w selection");
     sToolTipText  = QT_TR_NOOP("Show all selected objects");
     sStatusTip    = QT_TR_NOOP("Show all selected objects");
     sWhatsThis    = "Std_ShowSelection";
@@ -1083,7 +1083,7 @@ StdCmdHideSelection::StdCmdHideSelection()
   : Command("Std_HideSelection")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Hide selection");
+    sMenuText     = QT_TR_NOOP("&Hide selection");
     sToolTipText  = QT_TR_NOOP("Hide all selected objects");
     sStatusTip    = QT_TR_NOOP("Hide all selected objects");
     sWhatsThis    = "Std_HideSelection";
@@ -1111,7 +1111,7 @@ StdCmdSelectVisibleObjects::StdCmdSelectVisibleObjects()
   : Command("Std_SelectVisibleObjects")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Select visible objects");
+    sMenuText     = QT_TR_NOOP("&Select visible objects");
     sToolTipText  = QT_TR_NOOP("Select visible objects in the active document");
     sStatusTip    = QT_TR_NOOP("Select visible objects in the active document");
     sWhatsThis    = "Std_SelectVisibleObjects";
@@ -1153,7 +1153,7 @@ StdCmdToggleObjects::StdCmdToggleObjects()
   : Command("Std_ToggleObjects")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Toggle all objects");
+    sMenuText     = QT_TR_NOOP("To&ggle all objects");
     sToolTipText  = QT_TR_NOOP("Toggles visibility of all objects in the active document");
     sStatusTip    = QT_TR_NOOP("Toggles visibility of all objects in the active document");
     sWhatsThis    = "Std_ToggleObjects";
@@ -1194,7 +1194,7 @@ StdCmdShowObjects::StdCmdShowObjects()
   : Command("Std_ShowObjects")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Show all objects");
+    sMenuText     = QT_TR_NOOP("Show &all objects");
     sToolTipText  = QT_TR_NOOP("Show all objects in the document");
     sStatusTip    = QT_TR_NOOP("Show all objects in the document");
     sWhatsThis    = "Std_ShowObjects";
@@ -1231,7 +1231,7 @@ StdCmdHideObjects::StdCmdHideObjects()
   : Command("Std_HideObjects")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Hide all objects");
+    sMenuText     = QT_TR_NOOP("Hide all &objects");
     sToolTipText  = QT_TR_NOOP("Hide all objects in the document");
     sStatusTip    = QT_TR_NOOP("Hide all objects in the document");
     sWhatsThis    = "Std_HideObjects";
@@ -1268,7 +1268,7 @@ StdCmdViewHome::StdCmdViewHome()
   : Command("Std_ViewHome")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Home");
+    sMenuText     = QT_TR_NOOP("&Home");
     sToolTipText  = QT_TR_NOOP("Set to default home view");
     sWhatsThis    = "Std_ViewHome";
     sStatusTip    = QT_TR_NOOP("Set to default home view");
@@ -1296,7 +1296,7 @@ StdCmdViewBottom::StdCmdViewBottom()
   : Command("Std_ViewBottom")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Bottom");
+    sMenuText     = QT_TR_NOOP("&5 Bottom");
     sToolTipText  = QT_TR_NOOP("Set to bottom view");
     sWhatsThis    = "Std_ViewBottom";
     sStatusTip    = QT_TR_NOOP("Set to bottom view");
@@ -1320,7 +1320,7 @@ StdCmdViewFront::StdCmdViewFront()
   : Command("Std_ViewFront")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Front");
+    sMenuText     = QT_TR_NOOP("&1 Front");
     sToolTipText  = QT_TR_NOOP("Set to front view");
     sWhatsThis    = "Std_ViewFront";
     sStatusTip    = QT_TR_NOOP("Set to front view");
@@ -1344,7 +1344,7 @@ StdCmdViewLeft::StdCmdViewLeft()
   : Command("Std_ViewLeft")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Left");
+    sMenuText     = QT_TR_NOOP("&6 Left");
     sToolTipText  = QT_TR_NOOP("Set to left view");
     sWhatsThis    = "Std_ViewLeft";
     sStatusTip    = QT_TR_NOOP("Set to left view");
@@ -1368,7 +1368,7 @@ StdCmdViewRear::StdCmdViewRear()
   : Command("Std_ViewRear")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Rear");
+    sMenuText     = QT_TR_NOOP("&4 Rear");
     sToolTipText  = QT_TR_NOOP("Set to rear view");
     sWhatsThis    = "Std_ViewRear";
     sStatusTip    = QT_TR_NOOP("Set to rear view");
@@ -1392,7 +1392,7 @@ StdCmdViewRight::StdCmdViewRight()
   : Command("Std_ViewRight")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Right");
+    sMenuText     = QT_TR_NOOP("&3 Right");
     sToolTipText  = QT_TR_NOOP("Set to right view");
     sWhatsThis    = "Std_ViewRight";
     sStatusTip    = QT_TR_NOOP("Set to right view");
@@ -1416,7 +1416,7 @@ StdCmdViewTop::StdCmdViewTop()
   : Command("Std_ViewTop")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Top");
+    sMenuText     = QT_TR_NOOP("&2 Top");
     sToolTipText  = QT_TR_NOOP("Set to top view");
     sWhatsThis    = "Std_ViewTop";
     sStatusTip    = QT_TR_NOOP("Set to top view");
@@ -1441,7 +1441,7 @@ StdCmdViewIsometric::StdCmdViewIsometric()
   : Command("Std_ViewIsometric")
 {
     sGroup      = "Standard-View";
-    sMenuText   = QT_TR_NOOP("Isometric");
+    sMenuText   = QT_TR_NOOP("&Isometric");
     sToolTipText= QT_TR_NOOP("Set to isometric view");
     sWhatsThis  = "Std_ViewIsometric";
     sStatusTip  = QT_TR_NOOP("Set to isometric view");
@@ -1465,7 +1465,7 @@ StdCmdViewDimetric::StdCmdViewDimetric()
   : Command("Std_ViewDimetric")
 {
     sGroup      = "Standard-View";
-    sMenuText   = QT_TR_NOOP("Dimetric");
+    sMenuText   = QT_TR_NOOP("&Dimetric");
     sToolTipText= QT_TR_NOOP("Set to dimetric view");
     sWhatsThis  = "Std_ViewDimetric";
     sStatusTip  = QT_TR_NOOP("Set to dimetric view");
@@ -1488,7 +1488,7 @@ StdCmdViewTrimetric::StdCmdViewTrimetric()
   : Command("Std_ViewTrimetric")
 {
     sGroup      = "Standard-View";
-    sMenuText   = QT_TR_NOOP("Trimetric");
+    sMenuText   = QT_TR_NOOP("&Trimetric");
     sToolTipText= QT_TR_NOOP("Set to trimetric view");
     sWhatsThis  = "Std_ViewTrimetric";
     sStatusTip  = QT_TR_NOOP("Set to trimetric view");
@@ -1511,7 +1511,7 @@ StdCmdViewRotateLeft::StdCmdViewRotateLeft()
   : Command("Std_ViewRotateLeft")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Rotate Left");
+    sMenuText     = QT_TR_NOOP("Rotate &Left");
     sToolTipText  = QT_TR_NOOP("Rotate the view by 90\xc2\xb0 counter-clockwise");
     sWhatsThis    = "Std_ViewRotateLeft";
     sStatusTip    = QT_TR_NOOP("Rotate the view by 90\xc2\xb0 counter-clockwise");
@@ -1536,7 +1536,7 @@ StdCmdViewRotateRight::StdCmdViewRotateRight()
   : Command("Std_ViewRotateRight")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Rotate Right");
+    sMenuText     = QT_TR_NOOP("Rotate &Right");
     sToolTipText  = QT_TR_NOOP("Rotate the view by 90\xc2\xb0 clockwise");
     sWhatsThis    = "Std_ViewRotateRight";
     sStatusTip    = QT_TR_NOOP("Rotate the view by 90\xc2\xb0 clockwise");
@@ -1561,7 +1561,7 @@ StdCmdViewFitAll::StdCmdViewFitAll()
   : Command("Std_ViewFitAll")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Fit all");
+    sMenuText     = QT_TR_NOOP("&Fit all");
     sToolTipText  = QT_TR_NOOP("Fits the whole content on the screen");
     sWhatsThis    = "Std_ViewFitAll";
     sStatusTip    = QT_TR_NOOP("Fits the whole content on the screen");
@@ -1592,7 +1592,7 @@ StdCmdViewFitSelection::StdCmdViewFitSelection()
   : Command("Std_ViewFitSelection")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Fit selection");
+    sMenuText     = QT_TR_NOOP("Fit &selection");
     sToolTipText  = QT_TR_NOOP("Fits the selected content on the screen");
     sWhatsThis    = "Std_ViewFitSelection";
     sStatusTip    = QT_TR_NOOP("Fits the selected content on the screen");
@@ -1622,7 +1622,7 @@ public:
         : GroupCommand("Std_ViewGroup")
     {
         sGroup = "Standard-View";
-        sMenuText = QT_TR_NOOP("Standard views");
+        sMenuText = QT_TR_NOOP("Standard &views");
         sToolTipText = QT_TR_NOOP("Change to a standard view");
         sStatusTip = QT_TR_NOOP("Change to a standard view");
         sWhatsThis = "Std_ViewGroup";
@@ -1661,7 +1661,7 @@ StdViewDock::StdViewDock()
   : Command("Std_ViewDock")
 {
     sGroup       = "Standard-View";
-    sMenuText    = QT_TR_NOOP("Docked");
+    sMenuText    = QT_TR_NOOP("&Docked");
     sToolTipText = QT_TR_NOOP("Display the active view either in fullscreen, in undocked or docked mode");
     sWhatsThis   = "Std_ViewDock";
     sStatusTip   = QT_TR_NOOP("Display the active view either in fullscreen, in undocked or docked mode");
@@ -1690,7 +1690,7 @@ StdViewUndock::StdViewUndock()
   : Command("Std_ViewUndock")
 {
     sGroup       = "Standard-View";
-    sMenuText    = QT_TR_NOOP("Undocked");
+    sMenuText    = QT_TR_NOOP("&Undocked");
     sToolTipText = QT_TR_NOOP("Display the active view either in fullscreen, in undocked or docked mode");
     sWhatsThis   = "Std_ViewUndock";
     sStatusTip   = QT_TR_NOOP("Display the active view either in fullscreen, in undocked or docked mode");
@@ -1751,7 +1751,7 @@ StdViewFullscreen::StdViewFullscreen()
   : Command("Std_ViewFullscreen")
 {
     sGroup       = "Standard-View";
-    sMenuText    = QT_TR_NOOP("Fullscreen");
+    sMenuText    = QT_TR_NOOP("&Fullscreen");
     sToolTipText = QT_TR_NOOP("Display the active view either in fullscreen, in undocked or docked mode");
     sWhatsThis   = "Std_ViewFullscreen";
     sStatusTip   = QT_TR_NOOP("Display the active view either in fullscreen, in undocked or docked mode");
@@ -1781,7 +1781,7 @@ StdViewDockUndockFullscreen::StdViewDockUndockFullscreen()
   : Command("Std_ViewDockUndockFullscreen")
 {
     sGroup       = "Standard-View";
-    sMenuText    = QT_TR_NOOP("Document window");
+    sMenuText    = QT_TR_NOOP("D&ocument window");
     sToolTipText = QT_TR_NOOP("Display the active view either in fullscreen, in undocked or docked mode");
     sWhatsThis   = "Std_ViewDockUndockFullscreen";
     sStatusTip   = QT_TR_NOOP("Display the active view either in fullscreen, in undocked or docked mode");
@@ -1923,7 +1923,7 @@ StdViewScreenShot::StdViewScreenShot()
   : Command("Std_ViewScreenShot")
 {
     sGroup      = "Standard-View";
-    sMenuText   = QT_TR_NOOP("Save image...");
+    sMenuText   = QT_TR_NOOP("Save &image...");
     sToolTipText= QT_TR_NOOP("Creates a screenshot of the active view");
     sWhatsThis  = "Std_ViewScreenShot";
     sStatusTip  = QT_TR_NOOP("Creates a screenshot of the active view");
@@ -2094,7 +2094,7 @@ StdViewLoadImage::StdViewLoadImage()
   : Command("Std_ViewLoadImage")
 {
     sGroup      = "Standard-View";
-    sMenuText   = QT_TR_NOOP("Load image...");
+    sMenuText   = QT_TR_NOOP("&Load image...");
     sToolTipText= QT_TR_NOOP("Loads an image");
     sWhatsThis  = "Std_ViewLoadImage";
     sStatusTip  = QT_TR_NOOP("Loads an image");
@@ -2169,7 +2169,7 @@ StdCmdToggleNavigation::StdCmdToggleNavigation()
   : Command("Std_ToggleNavigation")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Toggle navigation/Edit mode");
+    sMenuText     = QT_TR_NOOP("Toggle navigation/&Edit mode");
     sToolTipText  = QT_TR_NOOP("Toggle between navigation and edit mode");
     sStatusTip    = QT_TR_NOOP("Toggle between navigation and edit mode");
     sWhatsThis    = "Std_ToggleNavigation";
@@ -2218,7 +2218,7 @@ StdCmdAxisCross::StdCmdAxisCross()
   : Command("Std_AxisCross")
 {
         sGroup        = "Standard-View";
-        sMenuText     = QT_TR_NOOP("Toggle axis cross");
+        sMenuText     = QT_TR_NOOP("Toggle a&xis cross");
         sToolTipText  = QT_TR_NOOP("Turns on or off the axis cross at the origin");
         sStatusTip    = QT_TR_NOOP("Turns on or off the axis cross at the origin");
         sWhatsThis    = "Std_AxisCross";
@@ -2349,7 +2349,7 @@ StdCmdViewIvStereoOff::StdCmdViewIvStereoOff()
   : Command("Std_ViewIvStereoOff")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Stereo Off");
+    sMenuText     = QT_TR_NOOP("Stereo &Off");
     sToolTipText  = QT_TR_NOOP("Switch stereo viewing off");
     sWhatsThis    = "Std_ViewIvStereoOff";
     sStatusTip    = QT_TR_NOOP("Switch stereo viewing off");
@@ -2378,7 +2378,7 @@ StdCmdViewIvStereoRedGreen::StdCmdViewIvStereoRedGreen()
   : Command("Std_ViewIvStereoRedGreen")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Stereo red/cyan");
+    sMenuText     = QT_TR_NOOP("Stereo re&d/cyan");
     sToolTipText  = QT_TR_NOOP("Switch stereo viewing to red/cyan");
     sWhatsThis    = "Std_ViewIvStereoRedGreen";
     sStatusTip    = QT_TR_NOOP("Switch stereo viewing to red/cyan");
@@ -2406,7 +2406,7 @@ StdCmdViewIvStereoQuadBuff::StdCmdViewIvStereoQuadBuff()
   : Command("Std_ViewIvStereoQuadBuff")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Stereo quad buffer");
+    sMenuText     = QT_TR_NOOP("Stereo &quad buffer");
     sToolTipText  = QT_TR_NOOP("Switch stereo viewing to quad buffer");
     sWhatsThis    = "Std_ViewIvStereoQuadBuff";
     sStatusTip    = QT_TR_NOOP("Switch stereo viewing to quad buffer");
@@ -2434,7 +2434,7 @@ StdCmdViewIvStereoInterleavedRows::StdCmdViewIvStereoInterleavedRows()
   : Command("Std_ViewIvStereoInterleavedRows")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Stereo Interleaved Rows");
+    sMenuText     = QT_TR_NOOP("Stereo Interleaved &Rows");
     sToolTipText  = QT_TR_NOOP("Switch stereo viewing to Interleaved Rows");
     sWhatsThis    = "Std_ViewIvStereoInterleavedRows";
     sStatusTip    = QT_TR_NOOP("Switch stereo viewing to Interleaved Rows");
@@ -2462,7 +2462,7 @@ StdCmdViewIvStereoInterleavedColumns::StdCmdViewIvStereoInterleavedColumns()
   : Command("Std_ViewIvStereoInterleavedColumns")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Stereo Interleaved Columns");
+    sMenuText     = QT_TR_NOOP("Stereo Interleaved &Columns");
     sToolTipText  = QT_TR_NOOP("Switch stereo viewing to Interleaved Columns");
     sWhatsThis    = "Std_ViewIvStereoInterleavedColumns";
     sStatusTip    = QT_TR_NOOP("Switch stereo viewing to Interleaved Columns");
@@ -2491,7 +2491,7 @@ StdCmdViewIvIssueCamPos::StdCmdViewIvIssueCamPos()
   : Command("Std_ViewIvIssueCamPos")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Issue camera position");
+    sMenuText     = QT_TR_NOOP("Issue camera &position");
     sToolTipText  = QT_TR_NOOP("Issue the camera position to the console and to a macro, to easily recall this position");
     sWhatsThis    = "Std_ViewIvIssueCamPos";
     sStatusTip    = QT_TR_NOOP("Issue the camera position to the console and to a macro, to easily recall this position");
@@ -2541,7 +2541,7 @@ StdViewZoomIn::StdViewZoomIn()
   : Command("Std_ViewZoomIn")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Zoom In");
+    sMenuText     = QT_TR_NOOP("Zoom &In");
     sToolTipText  = QT_TR_NOOP("Increase the zoom factor by a fixed amount");
     sWhatsThis    = "Std_ViewZoomIn";
     sStatusTip    = QT_TR_NOOP("Increase the zoom factor by a fixed amount");
@@ -2570,7 +2570,7 @@ StdViewZoomOut::StdViewZoomOut()
   : Command("Std_ViewZoomOut")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Zoom Out");
+    sMenuText     = QT_TR_NOOP("Zoom &Out");
     sToolTipText  = QT_TR_NOOP("Decrease the zoom factor by a fixed amount");
     sWhatsThis    = "Std_ViewZoomOut";
     sStatusTip    = QT_TR_NOOP("Decrease the zoom factor by a fixed amount");
@@ -2716,7 +2716,7 @@ StdViewBoxZoom::StdViewBoxZoom()
   : Command("Std_ViewBoxZoom")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Box zoom");
+    sMenuText     = QT_TR_NOOP("&Box zoom");
     sToolTipText  = QT_TR_NOOP("Activate the box zoom tool");
     sWhatsThis    = "Std_ViewBoxZoom";
     sStatusTip    = QT_TR_NOOP("Activate the box zoom tool");
@@ -2750,7 +2750,7 @@ StdBoxSelection::StdBoxSelection()
   : Command("Std_BoxSelection")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Box selection");
+    sMenuText     = QT_TR_NOOP("&Box selection");
     sToolTipText  = QT_TR_NOOP("Activate the box selection tool");
     sWhatsThis    = "Std_BoxSelection";
     sStatusTip    = QT_TR_NOOP("Activate the box selection tool");
@@ -2976,7 +2976,7 @@ StdBoxElementSelection::StdBoxElementSelection()
   : Command("Std_BoxElementSelection")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Box element selection");
+    sMenuText     = QT_TR_NOOP("Bo&x element selection");
     sToolTipText  = QT_TR_NOOP("Box element selection");
     sWhatsThis    = "Std_BoxElementSelection";
     sStatusTip    = QT_TR_NOOP("Box element selection");
@@ -3021,7 +3021,7 @@ StdTreeSelection::StdTreeSelection()
   : Command("Std_TreeSelection")
 {
     sGroup        = "TreeView";
-    sMenuText     = QT_TR_NOOP("Go to selection");
+    sMenuText     = QT_TR_NOOP("&Go to selection");
     sToolTipText  = QT_TR_NOOP("Scroll to first selected item");
     sWhatsThis    = "Std_TreeSelection";
     sStatusTip    = QT_TR_NOOP("Scroll to first selected item");
@@ -3149,7 +3149,7 @@ StdCmdSceneInspector::StdCmdSceneInspector()
 {
     // setting the
     sGroup        = "Tools";
-    sMenuText     = QT_TR_NOOP("Scene inspector...");
+    sMenuText     = QT_TR_NOOP("Scene i&nspector...");
     sToolTipText  = QT_TR_NOOP("Scene inspector");
     sWhatsThis    = "Std_SceneInspector";
     sStatusTip    = QT_TR_NOOP("Scene inspector");
@@ -3182,7 +3182,7 @@ StdCmdTextureMapping::StdCmdTextureMapping()
 {
     // setting the
     sGroup        = "Tools";
-    sMenuText     = QT_TR_NOOP("Texture mapping...");
+    sMenuText     = QT_TR_NOOP("Text&ure mapping...");
     sToolTipText  = QT_TR_NOOP("Texture mapping");
     sWhatsThis    = "Std_TextureMapping";
     sStatusTip    = QT_TR_NOOP("Texture mapping");
@@ -3209,7 +3209,7 @@ StdCmdDemoMode::StdCmdDemoMode()
   : Command("Std_DemoMode")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("View turntable...");
+    sMenuText     = QT_TR_NOOP("View &turntable...");
     sToolTipText  = QT_TR_NOOP("View turntable");
     sWhatsThis    = "Std_DemoMode";
     sStatusTip    = QT_TR_NOOP("View turntable");
@@ -3238,7 +3238,7 @@ StdCmdSelBack::StdCmdSelBack()
   :Command("Std_SelBack")
 {
   sGroup        = "View";
-  sMenuText     = QT_TR_NOOP("Selection back");
+  sMenuText     = QT_TR_NOOP("Selection &back");
   static std::string toolTip = std::string("<p>")
       + QT_TR_NOOP("Restore the previous Tree view selection. "
       "Only works if Tree RecordSelection mode is switched on.")
@@ -3272,7 +3272,7 @@ StdCmdSelForward::StdCmdSelForward()
   :Command("Std_SelForward")
 {
   sGroup        = "View";
-  sMenuText     = QT_TR_NOOP("Selection forward");
+  sMenuText     = QT_TR_NOOP("Selection &forward");
   static std::string toolTip = std::string("<p>")
       + QT_TR_NOOP("Restore the next Tree view selection. "
       "Only works if Tree RecordSelection mode is switched on.")
@@ -3326,7 +3326,7 @@ StdTreeSingleDocument::StdTreeSingleDocument()
   : Command("Std_TreeSingleDocument")
 {
     sGroup       = "TreeView";
-    sMenuText    = QT_TR_NOOP("Single document");
+    sMenuText    = QT_TR_NOOP("&Single document");
     sToolTipText = QT_TR_NOOP("Only display the active document in the tree view");
     sWhatsThis   = "Std_TreeSingleDocument";
     sStatusTip   = QT_TR_NOOP("Only display the active document in the tree view");
@@ -3343,7 +3343,7 @@ StdTreeMultiDocument::StdTreeMultiDocument()
   : Command("Std_TreeMultiDocument")
 {
     sGroup       = "TreeView";
-    sMenuText    = QT_TR_NOOP("Multi document");
+    sMenuText    = QT_TR_NOOP("&Multi document");
     sToolTipText = QT_TR_NOOP("Display all documents in the tree view");
     sWhatsThis   = "Std_TreeMultiDocument";
     sStatusTip   = QT_TR_NOOP("Display all documents in the tree view");
@@ -3360,7 +3360,7 @@ StdTreeCollapseDocument::StdTreeCollapseDocument()
   : Command("Std_TreeCollapseDocument")
 {
     sGroup       = "TreeView";
-    sMenuText    = QT_TR_NOOP("Collapse/Expand");
+    sMenuText    = QT_TR_NOOP("Collapse/E&xpand");
     sToolTipText = QT_TR_NOOP("Expand active document and collapse all others");
     sWhatsThis   = "Std_TreeCollapseDocument";
     sStatusTip   = QT_TR_NOOP("Expand active document and collapse all others");
@@ -3399,7 +3399,7 @@ StdTreeSyncView::StdTreeSyncView()
   : Command("Std_TreeSyncView")
 {
     sGroup       = "TreeView";
-    sMenuText    = QT_TR_NOOP("Sync view");
+    sMenuText    = QT_TR_NOOP("&1 Sync view");
     sToolTipText = QT_TR_NOOP("Auto switch to the 3D view containing the selected item");
     sStatusTip   = sToolTipText;
     sWhatsThis   = "Std_TreeSyncView";
@@ -3417,7 +3417,7 @@ StdTreeSyncSelection::StdTreeSyncSelection()
   : Command("Std_TreeSyncSelection")
 {
     sGroup       = "TreeView";
-    sMenuText    = QT_TR_NOOP("Sync selection");
+    sMenuText    = QT_TR_NOOP("&2 Sync selection");
     sToolTipText = QT_TR_NOOP("Auto expand tree item when the corresponding object is selected in 3D view");
     sStatusTip   = sToolTipText;
     sWhatsThis   = "Std_TreeSyncSelection";
@@ -3435,7 +3435,7 @@ StdTreeSyncPlacement::StdTreeSyncPlacement()
   : Command("Std_TreeSyncPlacement")
 {
     sGroup       = "TreeView";
-    sMenuText    = QT_TR_NOOP("Sync placement");
+    sMenuText    = QT_TR_NOOP("&3 Sync placement");
     sToolTipText = QT_TR_NOOP("Auto adjust placement on drag and drop objects across coordinate systems");
     sStatusTip   = sToolTipText;
     sWhatsThis   = "Std_TreeSyncPlacement";
@@ -3453,7 +3453,7 @@ StdTreePreSelection::StdTreePreSelection()
   : Command("Std_TreePreSelection")
 {
     sGroup       = "TreeView";
-    sMenuText    = QT_TR_NOOP("Pre-selection");
+    sMenuText    = QT_TR_NOOP("&4 Pre-selection");
     sToolTipText = QT_TR_NOOP("Preselect the object in 3D view when hovering the cursor over the tree item");
     sStatusTip   = sToolTipText;
     sWhatsThis   = "Std_TreePreSelection";
@@ -3471,7 +3471,7 @@ StdTreeRecordSelection::StdTreeRecordSelection()
   : Command("Std_TreeRecordSelection")
 {
     sGroup       = "TreeView";
-    sMenuText    = QT_TR_NOOP("Record selection");
+    sMenuText    = QT_TR_NOOP("&5 Record selection");
     sToolTipText = QT_TR_NOOP("Record selection in tree view in order to go back/forward using navigation button");
     sStatusTip   = sToolTipText;
     sWhatsThis   = "Std_TreeRecordSelection";
@@ -3489,7 +3489,7 @@ StdTreeDrag::StdTreeDrag()
   : Command("Std_TreeDrag")
 {
     sGroup       = "TreeView";
-    sMenuText    = QT_TR_NOOP("Initiate dragging");
+    sMenuText    = QT_TR_NOOP("Initiate &dragging");
     sToolTipText = QT_TR_NOOP("Initiate dragging of current selected tree items");
     sStatusTip   = sToolTipText;
     sWhatsThis   = "Std_TreeDrag";
@@ -3609,7 +3609,7 @@ StdCmdDockOverlayAll::StdCmdDockOverlayAll()
   :Command("Std_DockOverlayAll")
 {
   sGroup        = "View";
-  sMenuText     = QT_TR_NOOP("Toggle overlay for all");
+  sMenuText     = QT_TR_NOOP("Toggle overl&ay for all");
   sToolTipText  = QT_TR_NOOP("Toggle overlay mode for all docked windows");
   sWhatsThis    = "Std_DockOverlayAll";
   sStatusTip    = sToolTipText;
@@ -3633,7 +3633,7 @@ StdCmdDockOverlayTransparentAll::StdCmdDockOverlayTransparentAll()
   :Command("Std_DockOverlayTransparentAll")
 {
   sGroup        = "View";
-  sMenuText     = QT_TR_NOOP("Toggle transparent for all");
+  sMenuText     = QT_TR_NOOP("Toggle tra&nsparent for all");
   sToolTipText  = QT_TR_NOOP("Toggle transparent mode for all docked overlay windows.\n"
                              "This makes the docked windows stay transparent at all times.");
   sWhatsThis    = "Std_DockOverlayTransparentAll";
@@ -3658,7 +3658,7 @@ StdCmdDockOverlayToggle::StdCmdDockOverlayToggle()
   :Command("Std_DockOverlayToggle")
 {
   sGroup        = "View";
-  sMenuText     = QT_TR_NOOP("Toggle overlay");
+  sMenuText     = QT_TR_NOOP("Toggle &overlay");
   sToolTipText  = QT_TR_NOOP("Toggle overlay mode for the docked window under the cursor");
   sWhatsThis    = "Std_DockOverlayToggle";
   sStatusTip    = sToolTipText;
@@ -3682,7 +3682,7 @@ StdCmdDockOverlayToggleTransparent::StdCmdDockOverlayToggleTransparent()
   :Command("Std_DockOverlayToggleTransparent")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Toggle transparent mode");
+    sMenuText     = QT_TR_NOOP("Toggle tran&sparent mode");
     sToolTipText  = QT_TR_NOOP("Toggle transparent mode for the docked window under cursor.\n"
                                "This makes the docked window stay transparent at all times.");
     sWhatsThis    = "Std_DockOverlayToggleTransparent";
@@ -3707,7 +3707,7 @@ StdCmdDockOverlayToggleLeft::StdCmdDockOverlayToggleLeft()
   :Command("Std_DockOverlayToggleLeft")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Toggle left");
+    sMenuText     = QT_TR_NOOP("Toggle &left");
     sToolTipText  = QT_TR_NOOP("Show/hide left overlay panel");
     sWhatsThis    = "Std_DockOverlayToggleLeft";
     sStatusTip    = sToolTipText;
@@ -3732,7 +3732,7 @@ StdCmdDockOverlayToggleRight::StdCmdDockOverlayToggleRight()
   :Command("Std_DockOverlayToggleRight")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Toggle right");
+    sMenuText     = QT_TR_NOOP("Toggle &right");
     sToolTipText  = QT_TR_NOOP("Show/hide right overlay panel");
     sWhatsThis    = "Std_DockOverlayToggleRight";
     sStatusTip    = sToolTipText;
@@ -3757,7 +3757,7 @@ StdCmdDockOverlayToggleTop::StdCmdDockOverlayToggleTop()
   :Command("Std_DockOverlayToggleTop")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Toggle top");
+    sMenuText     = QT_TR_NOOP("Toggle &top");
     sToolTipText  = QT_TR_NOOP("Show/hide top overlay panel");
     sWhatsThis    = "Std_DockOverlayToggleTop";
     sStatusTip    = sToolTipText;
@@ -3782,7 +3782,7 @@ StdCmdDockOverlayToggleBottom::StdCmdDockOverlayToggleBottom()
   :Command("Std_DockOverlayToggleBottom")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Toggle bottom");
+    sMenuText     = QT_TR_NOOP("Toggle &bottom");
     sToolTipText  = QT_TR_NOOP("Show/hide bottom overlay panel");
     sWhatsThis    = "Std_DockOverlayToggleBottom";
     sStatusTip    = sToolTipText;
@@ -3807,7 +3807,7 @@ StdCmdDockOverlayMouseTransparent::StdCmdDockOverlayMouseTransparent()
   :Command("Std_DockOverlayMouseTransparent")
 {
   sGroup        = "View";
-  sMenuText     = QT_TR_NOOP("Bypass mouse events in docked overlay windows");
+  sMenuText     = QT_TR_NOOP("Bypass &mouse events in docked overlay windows");
   sToolTipText  = QT_TR_NOOP("Bypass all mouse events in docked overlay windows");
   sWhatsThis    = "Std_DockOverlayMouseTransparent";
   sStatusTip    = sToolTipText;
@@ -3881,7 +3881,7 @@ StdStoreWorkingView::StdStoreWorkingView()
   : Command("Std_StoreWorkingView")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Store working view");
+    sMenuText     = QT_TR_NOOP("St&ore working view");
     sToolTipText  = QT_TR_NOOP("Store a document-specific temporary working view");
     sStatusTip    = QT_TR_NOOP("Store a document-specific temporary working view");
     sWhatsThis    = "Std_StoreWorkingView";
@@ -3911,7 +3911,7 @@ StdRecallWorkingView::StdRecallWorkingView()
   : Command("Std_RecallWorkingView")
 {
     sGroup        = "Standard-View";
-    sMenuText     = QT_TR_NOOP("Recall working view");
+    sMenuText     = QT_TR_NOOP("R&ecall working view");
     sToolTipText  = QT_TR_NOOP("Recall previously stored temporary working view");
     sStatusTip    = QT_TR_NOOP("Recall previously stored temporary working view");
     sWhatsThis    = "Std_RecallWorkingView";
@@ -3943,7 +3943,7 @@ StdCmdAlignToSelection::StdCmdAlignToSelection()
   : Command("Std_AlignToSelection")
 {
     sGroup        = "View";
-    sMenuText     = QT_TR_NOOP("Align to selection");
+    sMenuText     = QT_TR_NOOP("&Align to selection");
     sToolTipText  = QT_TR_NOOP("Align the view with the selection");
     sWhatsThis    = "Std_AlignToSelection";
     sPixmap       = "align-to-selection";

--- a/src/Gui/CommandWindow.cpp
+++ b/src/Gui/CommandWindow.cpp
@@ -109,7 +109,7 @@ StdCmdCloseActiveWindow::StdCmdCloseActiveWindow()
   : Command("Std_CloseActiveWindow")
 {
     sGroup        = "Window";
-    sMenuText     = QT_TR_NOOP("Cl&ose");
+    sMenuText     = QT_TR_NOOP("&Close");
     sToolTipText  = QT_TR_NOOP("Close active window");
     sWhatsThis    = "Std_CloseActiveWindow";
     sStatusTip    = QT_TR_NOOP("Close active window");
@@ -141,7 +141,7 @@ StdCmdCloseAllWindows::StdCmdCloseAllWindows()
   : Command("Std_CloseAllWindows")
 {
     sGroup        = "Window";
-    sMenuText     = QT_TR_NOOP("Close Al&l");
+    sMenuText     = QT_TR_NOOP("Close A&ll");
     sToolTipText  = QT_TR_NOOP("Close all windows");
     sWhatsThis    = "Std_CloseAllWindows";
     sStatusTip    = QT_TR_NOOP("Close all windows");
@@ -169,7 +169,7 @@ StdCmdActivateNextWindow::StdCmdActivateNextWindow()
   : Command("Std_ActivateNextWindow")
 {
     sGroup        = "Window";
-    sMenuText     = QT_TR_NOOP("Ne&xt");
+    sMenuText     = QT_TR_NOOP("&Next");
     sToolTipText  = QT_TR_NOOP("Activate next window");
     sWhatsThis    = "Std_ActivateNextWindow";
     sStatusTip    = QT_TR_NOOP("Activate next window");
@@ -198,7 +198,7 @@ StdCmdActivatePrevWindow::StdCmdActivatePrevWindow()
   : Command("Std_ActivatePrevWindow")
 {
     sGroup        = "Window";
-    sMenuText     = QT_TR_NOOP("Pre&vious");
+    sMenuText     = QT_TR_NOOP("&Previous");
     sToolTipText  = QT_TR_NOOP("Activate previous window");
     sWhatsThis    = "Std_ActivatePrevWindow";
     sStatusTip    = QT_TR_NOOP("Activate previous window");
@@ -278,7 +278,7 @@ StdCmdDockViewMenu::StdCmdDockViewMenu()
   : Command("Std_DockViewMenu")
 {
     sGroup        = "View";
-    sMenuText     = QT_TR_NOOP("Panels");
+    sMenuText     = QT_TR_NOOP("&Panels");
     sToolTipText  = QT_TR_NOOP("List of available dock panels");
     sWhatsThis    = "Std_DockViewMenu";
     sStatusTip    = QT_TR_NOOP("List of available dock panels");
@@ -314,7 +314,7 @@ StdCmdToolBarMenu::StdCmdToolBarMenu()
   : Command("Std_ToolBarMenu")
 {
     sGroup        = "View";
-    sMenuText     = QT_TR_NOOP("Tool&bars");
+    sMenuText     = QT_TR_NOOP("&Toolbars");
     sToolTipText  = QT_TR_NOOP("Toggles this window");
     sWhatsThis    = "Std_ToolBarMenu";
     sStatusTip    = QT_TR_NOOP("Toggles this window");

--- a/src/Gui/DocumentRecovery.cpp
+++ b/src/Gui/DocumentRecovery.cpp
@@ -340,7 +340,7 @@ void DocumentRecovery::accept()
             }
         }
 
-        d->ui.buttonBox->button(QDialogButtonBox::Ok)->setText(tr("Finish"));
+        d->ui.buttonBox->button(QDialogButtonBox::Ok)->setText(tr("&Finish"));
         d->ui.buttonBox->button(QDialogButtonBox::Cancel)->setEnabled(false);
         d->recovered = true;
     }

--- a/src/Gui/OnlineDocumentation.cpp
+++ b/src/Gui/OnlineDocumentation.cpp
@@ -322,7 +322,7 @@ StdCmdPythonHelp::StdCmdPythonHelp()
     , server(nullptr)
 {
     sGroup = "Tools";
-    sMenuText = QT_TR_NOOP("Automatic Python Modules Documentation");
+    sMenuText = QT_TR_NOOP("Automatic Python &Modules Documentation");
     sToolTipText = QT_TR_NOOP("Opens the Python Modules documentation");
     sWhatsThis = "Std_PythonHelp";
     sStatusTip = sToolTipText;

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -536,12 +536,12 @@ std::list<std::string> Workbench::listCommandbars() const
     qApp->translate("Workbench", "Clipboard");
     qApp->translate("Workbench", "Workbench");
     qApp->translate("Workbench", "Structure");
-    qApp->translate("Workbench", "Standard views");
+    qApp->translate("Workbench", "Standard &views");
     qApp->translate("Workbench", "Individual views");
-    qApp->translate("Workbench", "Axonometric");
+    qApp->translate("Workbench", "A&xonometric");
     qApp->translate("Workbench", "&Stereo");
     qApp->translate("Workbench", "&Zoom");
-    qApp->translate("Workbench", "Visibility");
+    qApp->translate("Workbench", "V&isibility");
     qApp->translate("Workbench", "&View");
     qApp->translate("Workbench", "&Tools");
     qApp->translate("Workbench", "&Macro");
@@ -646,14 +646,14 @@ MenuItem* StdWorkbench::setupMenuBar() const
           << "Std_Edit" << "Std_Properties" << "Separator" << "Std_UserEditMode" << "Separator" << "Std_DlgPreferences";
 
     auto axoviews = new MenuItem;
-    axoviews->setCommand("Axonometric");
+    axoviews->setCommand("A&xonometric");
     *axoviews << "Std_ViewIsometric"
               << "Std_ViewDimetric"
               << "Std_ViewTrimetric";
 
     // Standard views
     auto stdviews = new MenuItem;
-    stdviews->setCommand("Standard views");
+    stdviews->setCommand("Standard &views");
     *stdviews << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_AlignToSelection" << axoviews
               << "Separator" << "Std_ViewHome" << "Std_ViewFront" << "Std_ViewTop"
               << "Std_ViewRight" << "Std_ViewRear" << "Std_ViewBottom" << "Std_ViewLeft"
@@ -674,7 +674,7 @@ MenuItem* StdWorkbench::setupMenuBar() const
 
     // Visibility
     auto visu = new MenuItem;
-    visu->setCommand("Visibility");
+    visu->setCommand("V&isibility");
     *visu << "Std_ToggleVisibility" << "Std_ShowSelection" << "Std_HideSelection"
           << "Std_SelectVisibleObjects"
           << "Separator" << "Std_ToggleObjects" << "Std_ShowObjects" << "Std_HideObjects"

--- a/src/Mod/Material/Gui/Command.cpp
+++ b/src/Mod/Material/Gui/Command.cpp
@@ -86,7 +86,7 @@ StdCmdSetAppearance::StdCmdSetAppearance()
     : Command("Std_SetAppearance")
 {
     sGroup = "Standard-View";
-    sMenuText = QT_TR_NOOP("Appearance...");
+    sMenuText = QT_TR_NOOP("&Appearance...");
     sToolTipText = QT_TR_NOOP("Sets the display properties of the selected object");
     sWhatsThis = "Std_SetAppearance";
     sStatusTip = QT_TR_NOOP("Sets the display properties of the selected object");
@@ -115,7 +115,7 @@ StdCmdSetMaterial::StdCmdSetMaterial()
     : Command("Std_SetMaterial")
 {
     sGroup = "Standard-View";
-    sMenuText = QT_TR_NOOP("Material...");
+    sMenuText = QT_TR_NOOP("&Material...");
     sToolTipText = QT_TR_NOOP("Sets the material of the selected object");
     sWhatsThis = "Std_SetMaterial";
     sStatusTip = QT_TR_NOOP("Sets the material of the selected object");

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -2081,7 +2081,7 @@ CmdColorPerFace::CmdColorPerFace()
 {
     sAppModule    = "Part";
     sGroup        = QT_TR_NOOP("Part");
-    sMenuText     = QT_TR_NOOP("Appearance per face");
+    sMenuText     = QT_TR_NOOP("Appearance per &face");
     sToolTipText  = QT_TR_NOOP("Set the appearance of each individual face "
                                "of the selected object.");
     sStatusTip    = sToolTipText;
@@ -2183,7 +2183,7 @@ CmdPartSectionCut::CmdPartSectionCut()
 {
     sAppModule = "Part";
     sGroup = "View";
-    sMenuText = QT_TR_NOOP("Persistent section cut");
+    sMenuText = QT_TR_NOOP("Persiste&nt section cut");
     sToolTipText = QT_TR_NOOP("Creates a persistent section cut of visible part objects");
     sWhatsThis = "Part_SectionCut";
     sStatusTip = sToolTipText;

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -606,7 +606,7 @@ CmdPartDesignDuplicateSelection::CmdPartDesignDuplicateSelection()
 {
     sAppModule      = "PartDesign";
     sGroup          = QT_TR_NOOP("PartDesign");
-    sMenuText       = QT_TR_NOOP("Duplicate selected object");
+    sMenuText       = QT_TR_NOOP("Duplicate selected &object");
     sToolTipText    = QT_TR_NOOP("Duplicates the selected object and adds it to the active body");
     sWhatsThis      = "PartDesign_DuplicateSelection";
     sStatusTip      = sToolTipText;

--- a/src/Mod/Spreadsheet/Gui/Command.cpp
+++ b/src/Mod/Spreadsheet/Gui/Command.cpp
@@ -58,7 +58,7 @@ CmdSpreadsheetMergeCells::CmdSpreadsheetMergeCells()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Merge cells");
+    sMenuText = QT_TR_NOOP("&Merge cells");
     sToolTipText = QT_TR_NOOP("Merge selected cells");
     sWhatsThis = "Spreadsheet_MergeCells";
     sStatusTip = sToolTipText;
@@ -119,7 +119,7 @@ CmdSpreadsheetSplitCell::CmdSpreadsheetSplitCell()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Split cell");
+    sMenuText = QT_TR_NOOP("Sp&lit cell");
     sToolTipText = QT_TR_NOOP("Split previously merged cells");
     sWhatsThis = "Spreadsheet_SplitCell";
     sStatusTip = sToolTipText;
@@ -140,7 +140,7 @@ void CmdSpreadsheetSplitCell::activated(int iMsg)
 
             if (current.isValid()) {
                 std::string address = CellAddress(current.row(), current.column()).toString();
-                Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Split cell"));
+                Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Sp&lit cell"));
                 Gui::Command::doCommand(Gui::Command::Doc,
                                         "App.ActiveDocument.%s.splitCell('%s')",
                                         sheet->getNameInDocument(),
@@ -181,7 +181,7 @@ CmdSpreadsheetImport::CmdSpreadsheetImport()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Import spreadsheet");
+    sMenuText = QT_TR_NOOP("&Import spreadsheet");
     sToolTipText = QT_TR_NOOP("Import CSV file into spreadsheet");
     sWhatsThis = "Spreadsheet_Import";
     sStatusTip = sToolTipText;
@@ -234,7 +234,7 @@ CmdSpreadsheetExport::CmdSpreadsheetExport()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Export spreadsheet");
+    sMenuText = QT_TR_NOOP("&Export spreadsheet");
     sToolTipText = QT_TR_NOOP("Export spreadsheet to CSV file");
     sWhatsThis = "Spreadsheet_Export";
     sStatusTip = sToolTipText;
@@ -280,7 +280,7 @@ CmdSpreadsheetAlignLeft::CmdSpreadsheetAlignLeft()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Align left");
+    sMenuText = QT_TR_NOOP("Align &left");
     sToolTipText = QT_TR_NOOP("Left-align contents of selected cells");
     sWhatsThis = "Spreadsheet_AlignLeft";
     sStatusTip = sToolTipText;
@@ -337,7 +337,7 @@ CmdSpreadsheetAlignCenter::CmdSpreadsheetAlignCenter()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Align center");
+    sMenuText = QT_TR_NOOP("Align &center");
     sToolTipText = QT_TR_NOOP("Center-align contents of selected cells");
     sWhatsThis = "Spreadsheet_AlignCenter";
     sStatusTip = sToolTipText;
@@ -394,7 +394,7 @@ CmdSpreadsheetAlignRight::CmdSpreadsheetAlignRight()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Align right");
+    sMenuText = QT_TR_NOOP("Align &right");
     sToolTipText = QT_TR_NOOP("Right-align contents of selected cells");
     sWhatsThis = "Spreadsheet_AlignRight";
     sStatusTip = sToolTipText;
@@ -451,7 +451,7 @@ CmdSpreadsheetAlignTop::CmdSpreadsheetAlignTop()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Align top");
+    sMenuText = QT_TR_NOOP("Align &top");
     sToolTipText = QT_TR_NOOP("Top-align contents of selected cells");
     sWhatsThis = "Spreadsheet_AlignTop";
     sStatusTip = sToolTipText;
@@ -508,7 +508,7 @@ CmdSpreadsheetAlignBottom::CmdSpreadsheetAlignBottom()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Align bottom");
+    sMenuText = QT_TR_NOOP("Align &bottom");
     sToolTipText = QT_TR_NOOP("Bottom-align contents of selected cells");
     sWhatsThis = "Spreadsheet_AlignBottom";
     sStatusTip = sToolTipText;
@@ -565,7 +565,7 @@ CmdSpreadsheetAlignVCenter::CmdSpreadsheetAlignVCenter()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Vertically center-align");
+    sMenuText = QT_TR_NOOP("&Vertically center-align");
     sToolTipText = QT_TR_NOOP("Vertically center-align contents of selected cells");
     sWhatsThis = "Spreadsheet_AlignVCenter";
     sStatusTip = sToolTipText;
@@ -622,7 +622,7 @@ CmdSpreadsheetStyleBold::CmdSpreadsheetStyleBold()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Bold text");
+    sMenuText = QT_TR_NOOP("&Bold text");
     sToolTipText = QT_TR_NOOP("Set text in selected cells bold");
     sWhatsThis = "Spreadsheet_StyleBold";
     sStatusTip = sToolTipText;
@@ -706,7 +706,7 @@ CmdSpreadsheetStyleItalic::CmdSpreadsheetStyleItalic()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Italic text");
+    sMenuText = QT_TR_NOOP("&Italic text");
     sToolTipText = QT_TR_NOOP("Set text in selected cells italic");
     sWhatsThis = "Spreadsheet_StyleItalic";
     sStatusTip = sToolTipText;
@@ -790,7 +790,7 @@ CmdSpreadsheetStyleUnderline::CmdSpreadsheetStyleUnderline()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Underline text");
+    sMenuText = QT_TR_NOOP("&Underline text");
     sToolTipText = QT_TR_NOOP("Underline text in selected cells");
     sWhatsThis = "Spreadsheet_StyleUnderline";
     sStatusTip = sToolTipText;
@@ -945,7 +945,7 @@ CmdCreateSpreadsheet::CmdCreateSpreadsheet()
 {
     sAppModule = "Spreadsheet";
     sGroup = QT_TR_NOOP("Spreadsheet");
-    sMenuText = QT_TR_NOOP("Create spreadsheet");
+    sMenuText = QT_TR_NOOP("&Create spreadsheet");
     sToolTipText = QT_TR_NOOP("Create a new spreadsheet");
     sWhatsThis = "Spreadsheet_CreateSheet";
     sStatusTip = sToolTipText;

--- a/src/Mod/Start/Gui/Manipulator.cpp
+++ b/src/Mod/Start/Gui/Manipulator.cpp
@@ -45,7 +45,7 @@ CmdStart::CmdStart()
 {
     sAppModule = "Start";
     sGroup = QT_TR_NOOP("Start");
-    sMenuText = QT_TR_NOOP("Start Page");
+    sMenuText = QT_TR_NOOP("&Start Page");
     sToolTipText = QT_TR_NOOP("Displays the Start Page");
     sWhatsThis = "Start_Start";
     sStatusTip = sToolTipText;


### PR DESCRIPTION
I use menu accelerators fairly often, so I find it very frustrating when they are missing, or worse, they don't work due to the same letter being assigned to several commands.

I don't mind making a patch like this fixing lots of them, and more to come... but I worry about the impact of this on UI translations.

Do we have a way to update them so that translations don't break? Or should I just not touch the .cpp files at all and instead fix the accelerators in the English translation files, leaving the mistakes frozen forever in the C++ strings?