### PR TITLE
Add shortcut: Ctrl+,: Preferences

### DIFF
--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -359,6 +359,7 @@ StdCmdDlgPreferences::StdCmdDlgPreferences()
     sStatusTip    = QT_TR_NOOP("Opens a Dialog to edit the preferences");
     sPixmap     = "preferences-system";
     eType         = 0;
+    sAccel        = "Ctrl+,";
 }
 
 Action * StdCmdDlgPreferences::createAction()


### PR DESCRIPTION
FreeCAD doesn't have a shortcut for Preferences.

As far as I know there is no established standard for Preferences. I chose Ctrl+, as that is used by a number of applications, like VS Code, nautilus and gedit.