### PR TITLE
[CAM]  Fixes for multiple errors in CAM system that give red ink in the console

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/PreferencesJob.py
+++ b/src/Mod/CAM/Path/Main/Gui/PreferencesJob.py
@@ -23,7 +23,7 @@
 import FreeCAD
 import Path
 import Path.Main.Stock as PathStock
-from Path.Post.Processor import PostProcessor
+from Path.Post.Processor import PostProcessor, PostProcessorFactory
 import json
 
 from FreeCAD import Units
@@ -330,7 +330,7 @@ class JobPreferencesPage:
 
     def getPostProcessor(self, name):
         if not name in self.processor:
-            processor = PostProcessor.load(name)
+            processor = PostProcessorFactory.get_post_processor(None, name)
             self.processor[name] = processor
             return processor
         return self.processor[name]

--- a/src/Mod/CAM/Path/Main/Stock.py
+++ b/src/Mod/CAM/Path/Main/Stock.py
@@ -172,12 +172,6 @@ class StockFromBase(Stock):
                 "Extra allowance from part bound box in positive Z direction",
             ),
         )
-        obj.addProperty(
-            "App::PropertyLink",
-            "Material",
-            "Component",
-            QT_TRANSLATE_NOOP("App::Property", "A material for this object"),
-        )
 
         obj.Base = base
         obj.ExtXneg = 1.0

--- a/src/Mod/CAM/Path/Tool/Gui/BitLibrary.py
+++ b/src/Mod/CAM/Path/Tool/Gui/BitLibrary.py
@@ -909,7 +909,6 @@ class ToolBitLibrary(object):
                 )
                 self.path = path
                 self.librarySave()
-                self.updateToolbar()
 
     def libararySaveLinuxCNC(self, path):
         # linuxcnc line template


### PR DESCRIPTION
Various bug fixes for bughunt issues reported to Ondsel.

1) The migration of CAM to use the new material system left behind some logic that created an old dedicated stock material property.

This commit removes that property

2) a dead function call in the tool library system