### PR TITLE
Fem: Import/export 1D elements from mesh to vtk - fixes #15541

### DIFF
--- a/src/Mod/Fem/App/PreCompiled.h
+++ b/src/Mod/Fem/App/PreCompiled.h
@@ -163,12 +163,14 @@
 #include <vtkHexahedron.h>
 #include <vtkIdList.h>
 #include <vtkImageData.h>
+#include <vtkLine.h>
 #include <vtkMultiBlockDataSet.h>
 #include <vtkMultiPieceDataSet.h>
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 #include <vtkPyramid.h>
 #include <vtkQuad.h>
+#include <vtkQuadraticEdge.h>
 #include <vtkQuadraticHexahedron.h>
 #include <vtkQuadraticPyramid.h>
 #include <vtkQuadraticQuad.h>


### PR DESCRIPTION
Fixes #15541

@FEA-eng now is possible export Fem mesh 1D elements to vtk and import the vtk file as Fem mesh.