### PR TITLE
Add Ctrl+{B,I,U} to Spreadsheet; remap File/Import

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -190,7 +190,7 @@ StdCmdImport::StdCmdImport()
     sWhatsThis    = "Std_Import";
     sStatusTip    = QT_TR_NOOP("Import a file in the active document");
     sPixmap       = "Std_Import";
-    sAccel        = "Ctrl+I";
+    sAccel        = "Ctrl+Shift+I";
 }
 
 void StdCmdImport::activated(int iMsg)

--- a/src/Mod/Spreadsheet/Gui/Command.cpp
+++ b/src/Mod/Spreadsheet/Gui/Command.cpp
@@ -627,6 +627,7 @@ CmdSpreadsheetStyleBold::CmdSpreadsheetStyleBold()
     sWhatsThis = "Spreadsheet_StyleBold";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetStyleBold";
+    sAccel = "Ctrl+B";
 }
 
 void CmdSpreadsheetStyleBold::activated(int iMsg)
@@ -710,6 +711,7 @@ CmdSpreadsheetStyleItalic::CmdSpreadsheetStyleItalic()
     sWhatsThis = "Spreadsheet_StyleItalic";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetStyleItalic";
+    sAccel = "Ctrl+I";
 }
 
 void CmdSpreadsheetStyleItalic::activated(int iMsg)
@@ -793,6 +795,7 @@ CmdSpreadsheetStyleUnderline::CmdSpreadsheetStyleUnderline()
     sWhatsThis = "Spreadsheet_StyleUnderline";
     sStatusTip = sToolTipText;
     sPixmap = "SpreadsheetStyleUnderline";
+    sAccel = "Ctrl+U";
 }
 
 void CmdSpreadsheetStyleUnderline::activated(int iMsg)


### PR DESCRIPTION
Adds hotkeys for Bold, Italic and Underline in Spreadsheet.

Ctrl+I was taken by File/Import... This patch remaps that to Ctrl+Shift+I.