### PR TITLE
Material: fix incorrect installation path of gui files

### DIFF
--- a/src/Mod/Material/Gui/CMakeLists.txt
+++ b/src/Mod/Material/Gui/CMakeLists.txt
@@ -172,6 +172,6 @@ fc_copy_sources(MatGui "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Materia
 fc_copy_sources(MatGui "${CMAKE_BINARY_DIR}/Mod/Material" ${Material_Ui_Files})
 
 INSTALL(TARGETS MatGui DESTINATION ${CMAKE_INSTALL_LIBDIR})
-INSTALL(FILES ${MatGuiIcon_SVG} DESTINATION "${CMAKE_INSTALL_DATADIR}/Mod/Material/Resources/icons")
-INSTALL(FILES ${MatGuiImages} DESTINATION "${CMAKE_INSTALL_DATADIR}/Mod/Material/Resources/images")
-INSTALL(FILES ${Material_Ui_Files} DESTINATION "${CMAKE_BINARY_DIR}/Mod/Material/Resources/ui")
+INSTALL(FILES ${MatGuiIcon_SVG} DESTINATION "Mod/Material/Resources/icons")
+INSTALL(FILES ${MatGuiImages} DESTINATION "Mod/Material/Resources/images")
+INSTALL(FILES ${Material_Ui_Files} DESTINATION "Mod/Material/Resources/ui")


### PR DESCRIPTION
see https://github.com/FreeCAD/FreeCAD/pull/15448#discussion_r1685774007

one could also argue that all three should be going to `${CMAKE_INSTALL_DATADIR}`, but in that case the code in `MaterialEditor.py` should be changed to look for them there instead of a relative path.
https://github.com/FreeCAD/FreeCAD/blob/ac3b5b3c747947ef29c71697a2400189c16a87c6/src/Mod/Material/MaterialEditor.py#L68-L72

@davesrocketshop 