### PR TITLE
Gui: Drop showLic AboutDialog parameter

### DIFF
--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -266,11 +266,7 @@ AboutDialogFactory::~AboutDialogFactory() = default;
 
 QDialog *AboutDialogFactory::create(QWidget *parent) const
 {
-#ifdef _USE_3DCONNEXION_SDK
-    return new AboutDialog(true, parent);
-#else
-    return new AboutDialog(false, parent);
-#endif
+    return new AboutDialog(parent);
 }
 
 const AboutDialogFactory *AboutDialogFactory::defaultFactory()
@@ -298,11 +294,9 @@ void AboutDialogFactory::setDefaultFactory(AboutDialogFactory *f)
  *
  *  The dialog will be modal.
  */
-AboutDialog::AboutDialog(bool showLic, QWidget* parent)
+AboutDialog::AboutDialog(QWidget* parent)
   : QDialog(parent), ui(new Ui_AboutApplication)
 {
-    Q_UNUSED(showLic);
-
     setModal(true);
     ui->setupUi(this);
     connect(ui->copyButton, &QPushButton::clicked,

--- a/src/Gui/Splashscreen.h
+++ b/src/Gui/Splashscreen.h
@@ -97,7 +97,7 @@ class GuiExport AboutDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit AboutDialog(bool showLic, QWidget* parent = nullptr);
+    explicit AboutDialog(QWidget* parent = nullptr);
     ~AboutDialog() override;
 
 protected:


### PR DESCRIPTION
Since 4ba04178ff44 ("Extended About dialog with credits and license tabs") (8 years ago) the showLic parameter is unused. Drop it.