### PR TITLE
[BIM] Add Ifc Profile Manager as the BlenderBIM way

### DIFF
--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -117,6 +117,7 @@ SET(bimcommands_SRCS
     bimcommands/BimIfcElements.py
     bimcommands/BimIfcExplorer.py
     bimcommands/BimIfcProperties.py
+    bimcommands/BimIfcProfiles.py
     bimcommands/BimIfcQuantities.py
     bimcommands/BimImagePlane.py
     bimcommands/BimLayers.py

--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -27,22 +27,22 @@ import FreeCAD
 import FreeCADGui
 import Arch_rc
 
-class BIMWorkbench(Workbench):
 
+class BIMWorkbench(Workbench):
     def __init__(self):
 
         def QT_TRANSLATE_NOOP(context, text):
             return text
 
         bdir = os.path.join(FreeCAD.getResourceDir(), "Mod", "BIM")
-        tt = QT_TRANSLATE_NOOP("BIM","The BIM workbench is used to model buildings")
+        tt = QT_TRANSLATE_NOOP("BIM", "The BIM workbench is used to model buildings")
         self.__class__.MenuText = QT_TRANSLATE_NOOP("BIM", "BIM")
-        self.__class__.ToolTip =  tt
-        self.__class__.Icon = os.path.join(bdir,"Resources", "icons",
-                                                "BIMWorkbench.svg")
+        self.__class__.ToolTip = tt
+        self.__class__.Icon = os.path.join(
+            bdir, "Resources", "icons", "BIMWorkbench.svg"
+        )
 
     def Initialize(self):
-
         # add translations and icon paths
         FreeCADGui.addIconPath(":/icons")
         FreeCADGui.addLanguagePath(":/translations")
@@ -55,7 +55,6 @@ class BIMWorkbench(Workbench):
 
         Log("Loading BIM module... done\n")
         FreeCADGui.updateLocale()
-
 
     def createTools(self):
 
@@ -179,7 +178,15 @@ class BIMWorkbench(Workbench):
         ]
 
         sep = ["Separator"]
-        self.modify = self.modify_gen + sep + self.modify_2d + sep + self.modify_obj + sep + self.modify_3d
+        self.modify = (
+            self.modify_gen
+            + sep
+            + self.modify_2d
+            + sep
+            + self.modify_obj
+            + sep
+            + self.modify_3d
+        )
 
         self.manage = [
             "BIM_Setup",
@@ -189,6 +196,7 @@ class BIMWorkbench(Workbench):
             "BIM_IfcElements",
             "BIM_IfcQuantities",
             "BIM_IfcProperties",
+            "BIM_IfcProfiles",
             "BIM_Classification",
             "BIM_Layers",
             "BIM_Material",
@@ -242,6 +250,7 @@ class BIMWorkbench(Workbench):
         # append BIM snaps
 
         from draftutils import init_tools
+
         self.snapbar = init_tools.get_draft_snap_commands()
         self.snapmenu = self.snapbar + [
             "BIM_SetWPTop",
@@ -254,14 +263,20 @@ class BIMWorkbench(Workbench):
         class BIM_GenericTools:
             def __init__(self, tools):
                 self.tools = tools
+
             def GetCommands(self):
                 return self.tools
+
             def GetResources(self):
                 t = QT_TRANSLATE_NOOP("BIM_GenericTools", "Generic 3D tools")
-                return { "MenuText": t, "ToolTip": t, "Icon": "BIM_Box"}
+                return {"MenuText": t, "ToolTip": t, "Icon": "BIM_Box"}
+
             def IsActive(self):
-                v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+                v = hasattr(
+                    FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph"
+                )
                 return v
+
         FreeCADGui.addCommand("BIM_GenericTools", BIM_GenericTools(self.generictools))
         self.bimtools.append("BIM_GenericTools")
 
@@ -289,7 +304,9 @@ class BIMWorkbench(Workbench):
                     }
 
                 def IsActive(self):
-                    v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
+                    v = hasattr(
+                        FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph"
+                    )
                     return v
 
             FreeCADGui.addCommand("Arch_RebarTools", RebarGroupCommand())
@@ -298,7 +315,7 @@ class BIMWorkbench(Workbench):
             Log("Load Reinforcement Module...done\n")
             if hasattr(RebarTools, "updateLocale"):
                 RebarTools.updateLocale()
-            #self.rebar = RebarTools.RebarCommands + ["Arch_Rebar"]
+            # self.rebar = RebarTools.RebarCommands + ["Arch_Rebar"]
 
         # load Reporting
 
@@ -404,31 +421,31 @@ class BIMWorkbench(Workbench):
 
         # create menus
 
-        t1 =  QT_TRANSLATE_NOOP("Workbench", "&2D Drafting")
-        t2 =  QT_TRANSLATE_NOOP("Workbench", "&3D/BIM")
-        t3 =  QT_TRANSLATE_NOOP("Workbench", "Reinforcement tools")
-        t4 =  QT_TRANSLATE_NOOP("Workbench", "&Annotation")
-        t5 =  QT_TRANSLATE_NOOP("Workbench", "&Snapping")
-        t6 =  QT_TRANSLATE_NOOP("Workbench", "&Modify")
-        t7 =  QT_TRANSLATE_NOOP("Workbench", "&Manage")
-        #t8 =  QT_TRANSLATE_NOOP("Workbench", "&IFC")
-        t9 =  QT_TRANSLATE_NOOP("Workbench", "&Flamingo")
+        t1 = QT_TRANSLATE_NOOP("Workbench", "&2D Drafting")
+        t2 = QT_TRANSLATE_NOOP("Workbench", "&3D/BIM")
+        t3 = QT_TRANSLATE_NOOP("Workbench", "Reinforcement tools")
+        t4 = QT_TRANSLATE_NOOP("Workbench", "&Annotation")
+        t5 = QT_TRANSLATE_NOOP("Workbench", "&Snapping")
+        t6 = QT_TRANSLATE_NOOP("Workbench", "&Modify")
+        t7 = QT_TRANSLATE_NOOP("Workbench", "&Manage")
+        # t8 =  QT_TRANSLATE_NOOP("Workbench", "&IFC")
+        t9 = QT_TRANSLATE_NOOP("Workbench", "&Flamingo")
         t10 = QT_TRANSLATE_NOOP("Workbench", "&Fasteners")
         t11 = QT_TRANSLATE_NOOP("Workbench", "&Utils")
         t12 = QT_TRANSLATE_NOOP("Workbench", "Nudge")
 
-        #self.bimtools_menu = list(self.bimtools)
-        #if "Arch_RebarTools" in self.bimtools_menu:
+        # self.bimtools_menu = list(self.bimtools)
+        # if "Arch_RebarTools" in self.bimtools_menu:
         #    self.bimtools_menu.remove("Arch_RebarTools")
         self.appendMenu(t1, self.draftingtools)
         self.appendMenu(t2, self.bimtools)
-        #if self.rebar:
+        # if self.rebar:
         #    self.appendMenu([t2, t3], self.rebar)
         self.appendMenu(t4, self.annotationtools)
         self.appendMenu(t5, self.snapmenu)
         self.appendMenu(t6, self.modify)
         self.appendMenu(t7, self.manage)
-        #if ifctools:
+        # if ifctools:
         #    self.appendMenu(t8, ifctools)
         if flamingo:
             self.appendMenu(t9, flamingo)
@@ -438,7 +455,6 @@ class BIMWorkbench(Workbench):
         self.appendMenu([t11, t12], nudge)
 
     def loadPreferences(self):
-
         """Set up preferences pages"""
 
         def QT_TRANSLATE_NOOP(context, text):
@@ -453,6 +469,7 @@ class BIMWorkbench(Workbench):
             if hasattr(FreeCADGui.draftToolBar, "loadedPreferences"):
                 return
         from draftutils import params
+
         params._param_observer_start()
         FreeCADGui.addPreferencePage(":/ui/preferences-draft.ui", t2)
         FreeCADGui.addPreferencePage(":/ui/preferences-draftinterface.ui", t2)
@@ -462,7 +479,6 @@ class BIMWorkbench(Workbench):
         FreeCADGui.draftToolBar.loadedPreferences = True
 
     def setupMultipleObjectSelection(self):
-
         import BimSelect
 
         if hasattr(FreeCADGui, "addDocumentObserver") and not hasattr(
@@ -472,7 +488,6 @@ class BIMWorkbench(Workbench):
             FreeCADGui.addDocumentObserver(self.BimSelectObserver)
 
     def Activated(self):
-
         import WorkingPlane
         from DraftGui import todo
         import BimStatus
@@ -538,17 +553,25 @@ class BIMWorkbench(Workbench):
         class BIM_WBManipulator:
             def modifyMenuBar(self):
                 return [
-                    {"insert": "BIM_Examples", "menuItem": "Std_ReportBug", "after": ""},
-                    {"insert": "BIM_Tutorial", "menuItem": "Std_ReportBug", "after": ""},
+                    {
+                        "insert": "BIM_Examples",
+                        "menuItem": "Std_ReportBug",
+                        "after": "",
+                    },
+                    {
+                        "insert": "BIM_Tutorial",
+                        "menuItem": "Std_ReportBug",
+                        "after": "",
+                    },
                     {"insert": "BIM_Help", "menuItem": "Std_ReportBug", "after": ""},
                     {"insert": "BIM_Welcome", "menuItem": "Std_ReportBug", "after": ""},
                 ]
+
         if not hasattr(Gui, "BIM_WBManipulator"):
             Gui.BIM_WBManipulator = BIM_WBManipulator()
         Gui.addWorkbenchManipulator(Gui.BIM_WBManipulator)
 
         Log("BIM workbench activated\n")
-
 
     def Deactivated(self):
 
@@ -590,6 +613,7 @@ class BIMWorkbench(Workbench):
         # Ifc stuff
         try:
             from nativeifc import ifc_status
+
             ifc_status.toggle_lock(False)
         except:
             pass
@@ -602,10 +626,9 @@ class BIMWorkbench(Workbench):
 
         Log("BIM workbench deactivated\n")
 
-
     def ContextMenu(self, recipient):
-
         import DraftTools
+
         translate = FreeCAD.Qt.translate
 
         if recipient == "Tree":
@@ -669,8 +692,11 @@ FreeCADGui.addWorkbench(BIMWorkbench)
 # Preference pages for importing and exporting various file formats
 # are independent of the loading of the workbench and can be loaded at startup
 
+
 def QT_TRANSLATE_NOOP(context, text):
     return text
+
+
 t = QT_TRANSLATE_NOOP("QObject", "Import-Export")
 FreeCADGui.addPreferencePage(":/ui/preferences-ifc.ui", t)
 FreeCADGui.addPreferencePage(":/ui/preferences-ifc-export.ui", t)

--- a/src/Mod/BIM/Resources/Arch.qrc
+++ b/src/Mod/BIM/Resources/Arch.qrc
@@ -173,8 +173,8 @@
         <file>ui/dialogCreateProject.ui</file>
         <file>ui/dialogCustomProperties.ui</file>
         <file>ui/dialogDiff.ui</file>
-        <file>ui/dialogExport.ui</file>
         <file>ui/dialogEditIfcArbitraryProfile.ui</file>
+        <file>ui/dialogExport.ui</file>
         <file>ui/dialogIfcElements.ui</file>
         <file>ui/dialogIfcProfiles.ui</file>
         <file>ui/dialogIfcProperties.ui</file>

--- a/src/Mod/BIM/Resources/Arch.qrc
+++ b/src/Mod/BIM/Resources/Arch.qrc
@@ -174,7 +174,9 @@
         <file>ui/dialogCustomProperties.ui</file>
         <file>ui/dialogDiff.ui</file>
         <file>ui/dialogExport.ui</file>
+        <file>ui/dialogEditIfcArbitraryProfile.ui</file>
         <file>ui/dialogIfcElements.ui</file>
+        <file>ui/dialogIfcProfiles.ui</file>
         <file>ui/dialogIfcProperties.ui</file>
         <file>ui/dialogIfcPropertiesRedux.ui</file>
         <file>ui/dialogIfcQuantities.ui</file>

--- a/src/Mod/BIM/Resources/ui/dialogEditIfcArbitraryProfile.ui
+++ b/src/Mod/BIM/Resources/ui/dialogEditIfcArbitraryProfile.ui
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>251</width>
+    <height>318</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Profile Shape Editing</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label_ifc_cls">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Profile Class:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="output_ifc_cls"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_name">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Profile Name:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="input_name"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="intro">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Please use View -&gt; Standard Views -&gt; Fit All (Hotkey:  V, F) to view the profile. 
+
+After editing (or redrawing) the required profile shape, please select the object(Draft Wire) and click OK.</string>
+     </property>
+     <property name="scaledContents">
+      <bool>false</bool>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>100</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/BIM/Resources/ui/dialogIfcProfiles.ui
+++ b/src/Mod/BIM/Resources/ui/dialogIfcProfiles.ui
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>652</width>
+    <height>488</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>IFC Profiles Manager</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This dialog lets you manage the IFC Profile with any BIM object in this document. You can Add Edit Delete the profile or you can use Prune to delete all the unused profiles.  Presets is still under developing&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="ifcFileObjName">
+       <property name="text">
+        <string>IFC File Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="ifcFileObj"/>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="5,3">
+     <item>
+      <widget class="QTreeView" name="profileTree"/>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="3,5">
+       <item>
+        <widget class="QLabel" name="profilePreview">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="profileInfoLayout">
+         <property name="leftMargin">
+          <number>5</number>
+         </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="rightMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
+        </layout>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0,0">
+     <item>
+      <widget class="QPushButton" name="buttonAdd">
+       <property name="text">
+        <string>Add</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="buttonEdit">
+       <property name="text">
+        <string>Edit</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="buttonDel">
+       <property name="text">
+        <string>Delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="buttonPrune">
+       <property name="text">
+        <string>Prune</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="buttonPresets">
+       <property name="text">
+        <string>Presets</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>257</x>
+     <y>473</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>325</x>
+     <y>473</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Mod/BIM/bimcommands/BimIfcProfiles.py
+++ b/src/Mod/BIM/bimcommands/BimIfcProfiles.py
@@ -37,7 +37,7 @@ from PySide.QtWidgets import (
     QDialogButtonBox,
     QFormLayout,
 )
-from nativeifc import ifc_tools, ifc_commands
+# from nativeifc import ifc_tools, ifc_commands
 
 
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
@@ -56,6 +56,8 @@ class BIM_IfcProfiles:
         }
 
     def IsActive(self):
+        from nativeifc import ifc_tools, ifc_commands
+
         "Only Activated when have a IfcFile is selected or it open a IfcFile(Lock Mode)"
         project = ifc_commands.get_project()
         if project:
@@ -66,6 +68,7 @@ class BIM_IfcProfiles:
 
     def Activated(self):
         from PySide import QtGui
+        from nativeifc import ifc_commands
 
         # load the form and set the tree model up
         self.form = FreeCADGui.PySideUic.loadUi(":/ui/dialogIfcProfiles.ui")
@@ -207,6 +210,7 @@ class BIM_IfcProfiles:
 
     def update_arbitrary_profile(self):
         import ifcopenshell
+        from nativeifc import ifc_tools
 
         selections = FreeCADGui.Selection.getSelection()
         if not bool(selections):
@@ -243,6 +247,8 @@ class BIM_IfcProfiles:
         self.form.show()
 
     def delete_profile(self):
+        from nativeifc import ifc_tools
+
         sel_profile_index = self.form.profileTree.currentIndex().row()
 
         if sel_profile_index is None:  # No selection made
@@ -268,6 +274,8 @@ class BIM_IfcProfiles:
         self.update()
 
     def prune_profile(self):
+        from nativeifc import ifc_tools
+
         reply = QMessageBox.information(
             None,
             "Confirm",
@@ -363,6 +371,8 @@ class AddNewProfileDialog(QDialog):
         self.adjustSize()
 
     def add_profile(self):
+        from nativeifc import ifc_tools
+
         scaling = ifc_tools.get_scale(self.ifc_file)
         self.prop_editors = {}
         for prop_name, editor in self.prop_sliders:
@@ -477,6 +487,7 @@ class EditProfileDialog(QDialog):
 
     # signals
     def update_props(self):
+        from nativeifc import ifc_tools
         from ifcopenshell.util.doc import get_entity_doc
 
         clear_layout(self.prop_layout)
@@ -512,6 +523,8 @@ class EditProfileDialog(QDialog):
         self.adjustSize()
 
     def edit_profile(self):
+        from nativeifc import ifc_tools
+
         self.prop_editors = {}
         for prop_name, editor in self.prop_sliders:
             prop_value = editor.get_value()
@@ -638,6 +651,7 @@ def clear_layout(layout):
 def display_arbitrary_closed_profile(profile):
     import Draft
     import ifcopenshell
+    from nativeifc import ifc_tools
 
     ifc_file = profile.file
     edit_doc_name = "EditProfile"

--- a/src/Mod/BIM/bimcommands/BimIfcProfiles.py
+++ b/src/Mod/BIM/bimcommands/BimIfcProfiles.py
@@ -26,7 +26,6 @@
 
 import FreeCAD
 import FreeCADGui
-import ifcopenshell
 from PySide.QtWidgets import (
     QDialog,
     QVBoxLayout,
@@ -122,6 +121,7 @@ class BIM_IfcProfiles:
 
     def updateProfileInfo(self):
         from PySide import QtGui
+        import ifcopenshell
 
         # update thumbnail
         sel_profile_index = self.form.profileTree.currentIndex().row()
@@ -206,6 +206,8 @@ class BIM_IfcProfiles:
             self.edit_ab_dialog.form.buttonBox.rejected.connect(self.show)
 
     def update_arbitrary_profile(self):
+        import ifcopenshell
+
         selections = FreeCADGui.Selection.getSelection()
         if not bool(selections):
             QMessageBox.warning(None, "Error", "Please select one profile shape")
@@ -291,6 +293,7 @@ class AddNewProfileDialog(QDialog):
         super().__init__()
 
         from PySide import QtCore
+        import ifcopenshell
         from ifcopenshell.util.doc import get_entity_doc
 
         self.ifc_file = ifc_file
@@ -437,6 +440,7 @@ class EditArbitraryProfile:
 class EditProfileDialog(QDialog):
     def __init__(self, ifc_file, profile):
         super().__init__()
+        import ifcopenshell
 
         self.ifc_file = ifc_file
         self.profile = profile
@@ -519,7 +523,7 @@ class EditProfileDialog(QDialog):
         attributes["ProfileName"] = self.name_input.text()
         attributes["ProfileType"] = "AREA"
 
-        ifcopenshell.api.run(
+        ifc_tools.api_run(
             "profile.edit_profile",
             self.ifc_file,
             profile=self.profile,
@@ -566,10 +570,9 @@ class HyperlinkLabel(QLabel):
 
 
 # general function
-def draw_image_for_ifc_profile(
-    draw, profile: ifcopenshell.entity_instance, size: float
-):
+def draw_image_for_ifc_profile(draw, profile, size: float):
     """generates image based on `profile` using `PIL.ImageDraw`"""
+    import ifcopenshell
 
     settings = ifcopenshell.geom.settings()
     # ifcopenshell ver 0.7
@@ -634,6 +637,7 @@ def clear_layout(layout):
 # dealing profile shape
 def display_arbitrary_closed_profile(profile):
     import Draft
+    import ifcopenshell
 
     ifc_file = profile.file
     edit_doc_name = "EditProfile"

--- a/src/Mod/BIM/bimcommands/BimIfcProfiles.py
+++ b/src/Mod/BIM/bimcommands/BimIfcProfiles.py
@@ -1,0 +1,716 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2018 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+"""This module contains FreeCAD commands for the BIM workbench"""
+
+import FreeCAD
+import FreeCADGui
+import ifcopenshell
+from PySide.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QMessageBox,
+    QWidget,
+    QLineEdit,
+    QLabel,
+    QComboBox,
+    QDialogButtonBox,
+    QFormLayout,
+)
+from nativeifc import ifc_tools, ifc_commands
+
+
+QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
+translate = FreeCAD.Qt.translate
+
+
+class BIM_IfcProfiles:
+    def GetResources(self):
+        return {
+            "Pixmap": "Arch_Profile",
+            "MenuText": QT_TRANSLATE_NOOP("BIM_IfcProfiles", "Manage IFC profiles..."),
+            "ToolTip": QT_TRANSLATE_NOOP(
+                "BIM_IfcProfiles",
+                "Manage the IFC profiles in your IFC objects",
+            ),
+        }
+
+    def IsActive(self):
+        "Only Activated when have a IfcFile is selected or it open a IfcFile(Lock Mode)"
+        project = ifc_commands.get_project()
+        if project:
+            self.ifc_file = ifc_tools.get_ifcfile(project)
+            return True
+        else:
+            return False
+
+    def Activated(self):
+        from PySide import QtGui
+
+        # load the form and set the tree model up
+        self.form = FreeCADGui.PySideUic.loadUi(":/ui/dialogIfcProfiles.ui")
+        # self.form.setWindowIcon(QtGui.QIcon(":/icons/BIM_IfcElements.svg"))
+        self.form.ifcFileObj.addItem(ifc_commands.get_project().Label)
+        # tree model
+        self.model = QtGui.QStandardItemModel()
+        self.form.profileTree.setModel(self.model)
+        self.form.profileTree.setUniformRowHeights(True)
+        self.form.profileTree.setItemDelegate(QtGui.QStyledItemDelegate())
+        # connect signals
+        self.form.profileTree.selectionModel().selectionChanged.connect(
+            self.updateProfileInfo
+        )
+        self.form.buttonAdd.clicked.connect(self.add_new_profile)
+        self.form.buttonEdit.clicked.connect(self.edit_profile)
+        self.form.buttonDel.clicked.connect(self.delete_profile)
+        self.form.buttonPrune.clicked.connect(self.prune_profile)
+        # center the dialog over FreeCAD window
+        mw = FreeCADGui.getMainWindow()
+        self.form.move(
+            mw.frameGeometry().topLeft()
+            + mw.rect().center()
+            - self.form.rect().center()
+        )
+
+        self.update()
+        self.form.show()
+
+        return
+
+    def update(self):
+        from PySide import QtGui
+
+        self.form.profileTree.reset()
+        self.model.clear()
+        self.model.setHorizontalHeaderLabels(
+            [
+                translate("BIM", "Profile Name"),
+                translate("BIM", "IfcProfileDef"),
+            ]
+        )
+        self.profiles = self.ifc_file.by_type("IfcProfileDef")
+        for profile in self.profiles:
+            self.model.appendRow(
+                [
+                    QtGui.QStandardItem(profile.ProfileName),
+                    QtGui.QStandardItem(profile.is_a()),
+                ]
+            )
+        self.form.profilePreview.clear()
+        clear_layout(self.form.profileInfoLayout)
+
+    def updateProfileInfo(self):
+        from PySide import QtGui
+
+        # update thumbnail
+        sel_profile_index = self.form.profileTree.currentIndex().row()
+        profile = self.profiles[sel_profile_index]
+        profile_thumbnail = QtGui.QPixmap(
+            self.generate_thumbnail_for_active_profile(profile)
+        )
+        self.form.profilePreview.setPixmap(profile_thumbnail)
+
+        # update Display Info
+        clear_layout(self.form.profileInfoLayout)
+        self.schema_ver = self.ifc_file.schema
+        self.schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(self.schema_ver)
+        props = get_profile_props(self.schema, profile.is_a())
+        attributes = profile.get_info()
+        self.name_label = QLabel("Profile Name:")
+        self.name_prop = QLabel(attributes.get("ProfileName"))
+        self.class_label = QLabel("IfcProfileDef:")
+        self.class_prop = QLabel(profile.is_a())
+        self.form.profileInfoLayout.addRow(self.name_label, self.name_prop)
+        self.form.profileInfoLayout.addRow(self.class_label, self.class_prop)
+        for prop in props:
+            attri_value = attributes.get(prop.name())
+            if attri_value is None:
+                attri_value = "None"
+            else:
+                if "Slope" not in prop.name():
+                    attri_value /= ifc_tools.get_scale(self.ifc_file)
+            self.form.profileInfoLayout.addRow(
+                QLabel(f"{prop.name()}:"), QLabel(str(attri_value))
+            )
+
+    def generate_thumbnail_for_active_profile(self, profile):
+        from PIL import Image, ImageDraw, ImageQt
+
+        # generate image
+        size = 128
+        img = Image.new("RGBA", (size, size))
+        draw = ImageDraw.Draw(img)
+        draw_image_for_ifc_profile(draw, profile, size)
+        preview_img = ImageQt.toqpixmap(img)
+        return preview_img
+
+    def add_new_profile(self):
+        dialog = AddNewProfileDialog(self.ifc_file)
+        if dialog.exec():
+            self.ifc_file = dialog.add_profile()
+            self.update()
+
+    def edit_profile(self):
+        sel_profile_index = self.form.profileTree.currentIndex().row()
+        if sel_profile_index is None:  # No selection made
+            QMessageBox.warning(self, "Warning!", "No profile selected!")
+            return
+        self.profile = self.profiles[sel_profile_index]
+        if self.profile.is_a("IfcParameterizedProfileDef"):
+            dialog = EditProfileDialog(self.ifc_file, self.profile)
+            if dialog.exec():
+                self.ifc_file = dialog.edit_profile()
+                self.update()
+        else:  # IfcArbitraryClosedProfileDef and maybe add with voids after
+            self.form.close()
+            active_doc = FreeCAD.ActiveDocument
+            profile_shape = display_arbitrary_closed_profile(self.profile)
+
+            # view obj selecion
+            FreeCAD.setActiveDocument("EditProfile")
+            FreeCADGui.Selection.clearSelection()
+            FreeCADGui.Selection.addSelection(profile_shape)
+            FreeCAD.ActiveDocument.recompute()
+            FreeCADGui.SendMsgToActiveView("ViewSelection")
+
+            self.edit_ab_dialog = EditArbitraryProfile(self.profile, active_doc.Name)
+
+            # Connect signals and slots
+            self.edit_ab_dialog.form.buttonBox.accepted.connect(
+                self.update_arbitrary_profile
+            )
+            self.edit_ab_dialog.form.buttonBox.rejected.connect(
+                self.edit_ab_dialog.reject
+            )
+            self.edit_ab_dialog.form.buttonBox.rejected.connect(self.show)
+
+    def update_arbitrary_profile(self):
+        selections = FreeCADGui.Selection.getSelection()
+        if not bool(selections):
+            QMessageBox.warning(None, "Error", "Please select one profile shape")
+        else:
+            profile_shape = selections[0]
+
+            scaling = ifc_tools.get_scale(self.ifc_file)
+
+            points = []
+            for pts in profile_shape.Shape.OuterWire.Vertexes:
+                points.append((pts.Point.x * scaling, pts.Point.y * scaling))
+            points.append(points[0])  # close shape
+            print(points)
+            old_profile = self.profile
+            new_profile = ifc_tools.api_run(
+                "profile.add_arbitrary_profile",
+                self.ifc_file,
+                profile=points,
+                name=self.edit_ab_dialog.form.input_name.text(),
+            )
+            for inverse in self.ifc_file.get_inverse(old_profile):
+                ifcopenshell.util.element.replace_attribute(
+                    inverse, old_profile, new_profile
+                )
+            ifcopenshell.util.element.remove_deep2(self.ifc_file, old_profile)
+            print("Update Profile:", new_profile)
+
+            self.edit_ab_dialog.finish()
+            self.update()
+            self.show()
+
+    def show(self):
+        self.form.show()
+
+    def delete_profile(self):
+        sel_profile_index = self.form.profileTree.currentIndex().row()
+
+        if sel_profile_index is None:  # No selection made
+            QMessageBox.warning(self, "Warning!", "No profile selected!")
+            return
+
+        profile = self.profiles[sel_profile_index]
+        relation_obj_num = self.ifc_file.get_total_inverses(profile)
+
+        if relation_obj_num:
+            reply = QMessageBox.warning(
+                None,
+                "Warning!",
+                f"Profile {profile.ProfileName} has {relation_obj_num} inverse relationship(s) in project, still want to delete it?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if reply != QMessageBox.Yes:
+                return
+
+        print("Delete IfcProfile", profile)
+        ifc_tools.api_run("profile.remove_profile", self.ifc_file, profile=profile)
+        self.update()
+
+    def prune_profile(self):
+        reply = QMessageBox.information(
+            None,
+            "Confirm",
+            "Are you sure you want to continue deleting all unused profiles?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if reply == QMessageBox.Yes:
+            pruned_profiles = 0
+            for profile in self.profiles:
+                if self.ifc_file.get_total_inverses(profile) > 0:
+                    continue
+                ifc_tools.api_run(
+                    "profile.remove_profile", self.ifc_file, profile=profile
+                )
+                pruned_profiles += 1
+            print(f"{pruned_profiles} profiles were deleted.")
+            self.update()
+
+
+class AddNewProfileDialog(QDialog):
+    def __init__(self, ifc_file):
+        super().__init__()
+
+        from PySide import QtCore
+        from ifcopenshell.util.doc import get_entity_doc
+
+        self.ifc_file = ifc_file
+        self.schema_ver = ifc_file.schema
+        self.schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(self.schema_ver)
+
+        profile_classes = get_profile_classes(self.schema)
+        self.setWindowTitle("Add New Profile")
+        self.layout = QVBoxLayout()
+        self.prop_layout = QVBoxLayout()
+        self.class_label = QLabel("Profile Class:")
+        self.sel_profile_class = QComboBox()
+        self.sel_profile_class.addItems(profile_classes)
+        for index, p_cls in enumerate(profile_classes):
+            self.sel_profile_class.setItemData(
+                index,
+                get_entity_doc(self.schema_ver, p_cls)["description"],
+                QtCore.Qt.ToolTipRole,
+            )
+        self.sel_profile_class.currentIndexChanged.connect(self.update_props)
+        self.name_label = QLabel("Profile Name:")
+        self.name_input = QLineEdit()
+
+        self.layout.addWidget(self.class_label)
+        self.layout.addWidget(self.sel_profile_class)
+        self.layout.addWidget(self.name_label)
+        self.layout.addWidget(self.name_input)
+
+        self.layout.addLayout(self.prop_layout)
+
+        self.button_box = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+
+        self.layout.addWidget(self.button_box)
+        self.setLayout(self.layout)
+        self.update_props()
+        self.adjustSize()
+
+    # signals
+    def update_props(self):
+        from ifcopenshell.util.doc import get_entity_doc
+
+        clear_layout(self.prop_layout)
+        self.p_cls = self.sel_profile_class.currentText()
+        # display spec url
+        spec_url = get_entity_doc(self.schema_ver, self.p_cls)["spec_url"]
+        linkTemplate = "<a href={0}>{1}</a>"
+        self.p_cls_label = HyperlinkLabel()
+        self.p_cls_label.setText(
+            linkTemplate.format(spec_url, f"Property of {self.p_cls}: Click Me")
+        )
+        self.unit_label = QLabel("Length Unit: mm")
+        self.unit_label.setStyleSheet("font-size: 12px")
+        self.prop_layout.addWidget(self.p_cls_label)
+        self.prop_layout.addWidget(self.unit_label)
+
+        props = get_profile_props(self.schema, self.p_cls)
+        self.prop_sliders = []
+        for prop in props:
+            editor = PropEditor(prop.name())
+            self.prop_layout.addWidget(editor)
+            self.prop_sliders.append((prop.name(), editor))
+
+        self.adjustSize()
+
+    def add_profile(self):
+        scaling = ifc_tools.get_scale(self.ifc_file)
+        self.prop_editors = {}
+        for prop_name, editor in self.prop_sliders:
+            prop_value = editor.get_value()
+            if prop_value != 0:
+                if "Slope" not in prop_name:
+                    prop_value *= scaling
+                self.prop_editors[prop_name] = prop_value
+
+        attributes = self.prop_editors
+        attributes["ProfileName"] = self.name_input.text()
+        attributes["ProfileType"] = "AREA"
+
+        if self.p_cls == "IfcArbitraryClosedProfileDef":
+            # 500 is mm in FreeCAD , scaling turn to IfcUnit(Length)
+            points = [
+                (-500 * scaling, -500 * scaling),
+                (500 * scaling, -500 * scaling),
+                (500 * scaling, 500 * scaling),
+                (-500 * scaling, 500 * scaling),
+                (-500 * scaling, -500 * scaling),
+            ]
+            profile = ifc_tools.api_run(
+                "profile.add_arbitrary_profile",
+                self.ifc_file,
+                profile=points,
+                name=self.name_input.text(),
+            )
+        else:
+            profile = ifc_tools.api_run(
+                "profile.add_parameterized_profile",
+                self.ifc_file,
+                ifc_class=self.p_cls,
+            )
+            ifc_tools.api_run(
+                "profile.edit_profile",
+                self.ifc_file,
+                profile=profile,
+                attributes=attributes,
+            )
+        print("Add New IfcProfile", profile)
+        return self.ifc_file
+
+
+class EditArbitraryProfile:
+    def __init__(self, profile, active_doc_name):
+        from PySide import QtCore
+
+        # set ui
+        self.form = FreeCADGui.PySideUic.loadUi(":/ui/dialogEditIfcArbitraryProfile.ui")
+        # Set the window to stay on top
+        self.form.setWindowFlag(QtCore.Qt.WindowStaysOnTopHint, True)
+
+        self.form.output_ifc_cls.addItem("IfcArbitraryClosedProfileDef")
+        self.form.input_name.setText(profile.ProfileName)
+        self.ifc_file = profile.file
+        self.doc_name = active_doc_name
+        self.form.show()
+
+    def reject(self):
+        print("Cancel Edit Profile")
+        self.finish()
+
+    def finish(self):
+        try:
+            edit_doc = FreeCAD.getDocument("EditProfile")
+        except NameError:
+            edit_doc = FreeCAD.ActiveDocument
+        FreeCAD.closeDocument(edit_doc.Name)
+        FreeCAD.setActiveDocument(self.doc_name)
+        FreeCADGui.activateWorkbench("BIMWorkbench")
+        self.form.close()
+
+
+class EditProfileDialog(QDialog):
+    def __init__(self, ifc_file, profile):
+        super().__init__()
+
+        self.ifc_file = ifc_file
+        self.profile = profile
+        self.schema_ver = ifc_file.schema
+        self.schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(self.schema_ver)
+
+        self.setWindowTitle("Edit Profile")
+        self.layout = QVBoxLayout()
+        self.prop_layout = QVBoxLayout()
+        self.class_label = QLabel("Profile Class:")
+        self.sel_profile_class = QComboBox()
+        self.sel_profile_class.addItem(self.profile.is_a())
+        self.name_label = QLabel("Profile Name:")
+        self.name_input = QLineEdit()
+        self.name_input.setText(self.profile.ProfileName)
+
+        self.layout.addWidget(self.class_label)
+        self.layout.addWidget(self.sel_profile_class)
+        self.layout.addWidget(self.name_label)
+        self.layout.addWidget(self.name_input)
+
+        self.update_props()
+        self.layout.addLayout(self.prop_layout)
+
+        self.button_box = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+
+        self.layout.addWidget(self.button_box)
+        self.setLayout(self.layout)
+        self.adjustSize()
+
+    # signals
+    def update_props(self):
+        from ifcopenshell.util.doc import get_entity_doc
+
+        clear_layout(self.prop_layout)
+        self.p_cls = self.sel_profile_class.currentText()
+
+        # display spec url
+        spec_url = get_entity_doc(self.schema_ver, self.p_cls)["spec_url"]
+        linkTemplate = "<a href={0}>{1}</a>"
+        self.p_cls_label = HyperlinkLabel()
+        self.p_cls_label.setText(
+            linkTemplate.format(spec_url, f"Property of {self.p_cls}: Click Me")
+        )
+        self.unit_label = QLabel("Length Unit: mm")
+        self.unit_label.setStyleSheet("font-size: 12px")
+
+        self.prop_layout.addWidget(self.p_cls_label)
+        self.prop_layout.addWidget(self.unit_label)
+
+        props = get_profile_props(self.schema, self.p_cls)
+        self.prop_sliders = []
+        attributes = self.profile.get_info()
+        for prop in props:
+            editor = PropEditor(prop.name())
+            attri_value = attributes.get(prop.name())
+            if attri_value is None:
+                attri_value = 0
+            if "Slope" not in prop.name():
+                attri_value /= ifc_tools.get_scale(self.ifc_file)
+            editor.set_value(attri_value)
+            self.prop_layout.addWidget(editor)
+            self.prop_sliders.append((prop.name(), editor))
+
+        self.adjustSize()
+
+    def edit_profile(self):
+        self.prop_editors = {}
+        for prop_name, editor in self.prop_sliders:
+            prop_value = editor.get_value()
+            if prop_value != 0:
+                if "Slope" not in prop_name:
+                    prop_value *= ifc_tools.get_scale(self.ifc_file)
+                self.prop_editors[prop_name] = prop_value
+        attributes = self.prop_editors
+        attributes["ProfileName"] = self.name_input.text()
+        attributes["ProfileType"] = "AREA"
+
+        ifcopenshell.api.run(
+            "profile.edit_profile",
+            self.ifc_file,
+            profile=self.profile,
+            attributes=attributes,
+        )
+        print("Update IfcProfile:", self.profile)
+
+        return self.ifc_file
+
+
+class PropEditor(QWidget):
+    def __init__(self, prop_name):
+        super().__init__()
+        from PySide.QtCore import Qt
+
+        self.layout = QFormLayout()
+
+        self.label = QLabel(f"{prop_name}:")
+        self.label.setFixedWidth(200)
+        self.line_edit = QLineEdit()
+        self.line_edit.setFixedWidth(80)  # Set a fixed width for the line edit
+        self.line_edit.setAlignment(Qt.AlignRight)
+        self.layout.addRow(self.label, self.line_edit)
+        self.setLayout(self.layout)
+        self.set_value(0)  # default value = 0
+
+    def get_value(self):
+        try:
+            value = float(self.line_edit.text())
+            return value
+        except ValueError:
+            QMessageBox.warning(None, "Error", "Accept only Number")
+            return
+
+    def set_value(self, value):
+        self.line_edit.setText(str(value))
+
+
+class HyperlinkLabel(QLabel):
+    def __init__(self):
+        super().__init__()
+        self.setStyleSheet("font-size: 12px")
+        self.setOpenExternalLinks(True)
+
+
+# general function
+def draw_image_for_ifc_profile(
+    draw, profile: ifcopenshell.entity_instance, size: float
+):
+    """generates image based on `profile` using `PIL.ImageDraw`"""
+
+    settings = ifcopenshell.geom.settings()
+    # ifcopenshell ver 0.7
+    settings.set(settings.INCLUDE_CURVES, True)
+    # ifcopenshell ver 0.8
+    # settings.set("dimensionality", ifcopenshell.ifcopenshell_wrapper.CURVES_SURFACES_AND_SOLIDS)
+    shape = ifcopenshell.geom.create_shape(settings, profile)
+    verts = shape.verts
+    edges = shape.edges
+
+    grouped_verts = [[verts[i], verts[i + 1]] for i in range(0, len(verts), 3)]
+    grouped_edges = [[edges[i], edges[i + 1]] for i in range(0, len(edges), 2)]
+
+    max_x = max([v[0] for v in grouped_verts])
+    min_x = min([v[0] for v in grouped_verts])
+    max_y = max([v[1] for v in grouped_verts])
+    min_y = min([v[1] for v in grouped_verts])
+
+    dim_x = max_x - min_x
+    dim_y = max_y - min_y
+    max_dim = max([dim_x, dim_y])
+    scale = 100 / max_dim
+
+    for vert in grouped_verts:
+        vert[0] = round(scale * (vert[0] - min_x)) + ((size / 2) - scale * (dim_x / 2))
+        vert[1] = round(scale * (vert[1] - min_y)) + ((size / 2) - scale * (dim_y / 2))
+
+    for e in grouped_edges:
+        draw.line(
+            (tuple(grouped_verts[e[0]]), tuple(grouped_verts[e[1]])),
+            fill="black",
+            width=2,
+        )
+
+    return draw
+
+
+def get_profile_classes(schema):
+    classes = ["IfcArbitraryClosedProfileDef"]
+    queue = ["IfcParameterizedProfileDef"]
+    while queue:
+        item = queue.pop()
+        subtypes = [s.name() for s in schema.declaration_by_name(item).subtypes()]
+        classes.extend(subtypes)
+        queue.extend(subtypes)
+    return [c for c in sorted(classes)]
+
+
+def get_profile_props(schema, p_cls):
+    props = schema.declaration_by_name(p_cls).all_attributes()
+    return props[3:]
+
+
+def clear_layout(layout):
+    while layout.count():
+        item = layout.takeAt(0)
+        widget = item.widget()
+        if widget is not None:
+            widget.deleteLater()
+
+
+# dealing profile shape
+def display_arbitrary_closed_profile(profile):
+    import Draft
+
+    ifc_file = profile.file
+    edit_doc_name = "EditProfile"
+    FreeCAD.newDocument(edit_doc_name)
+    FreeCAD.setActiveDocument(edit_doc_name)
+    FreeCAD.DraftWorkingPlane.setTop()
+    FreeCADGui.activateWorkbench("DraftWorkbench")
+    FreeCADGui.ActiveDocument.ActiveView.viewTop()
+
+    scaling = 1 / ifc_tools.get_scale(ifc_file)  # FreeCAD use mm  IFC use SI Meter
+    settings = ifcopenshell.geom.settings()
+    settings.set(settings.INCLUDE_CURVES, True)
+    shape = ifcopenshell.geom.create_shape(settings, profile)
+    verts = shape.verts
+    edges = shape.edges
+
+    grouped_verts = [[verts[i], verts[i + 1]] for i in range(0, len(verts), 3)]
+    grouped_edges = [[edges[i], edges[i + 1]] for i in range(0, len(edges), 2)]
+
+    node_order = get_ordered_path_nodes(grouped_edges)
+    verts_in_order = []
+    for order in node_order:
+        v = grouped_verts[order]
+        vector = FreeCAD.Vector(v[0], v[1], 0).multiply(scaling)
+        verts_in_order.append(vector)
+
+    profile_shape = Draft.make_wire(verts_in_order, closed=True)
+    profile_shape.Label = "ProfileShape"
+    # profile_shape.MakeFace = False
+    FreeCAD.ActiveDocument.recompute()
+
+    return profile_shape
+
+
+def build_adjacency_list(segments):
+    adjacency_list = {}
+
+    for segment in segments:
+        start, end = segment
+        if start not in adjacency_list:
+            adjacency_list[start] = []
+        if end not in adjacency_list:
+            adjacency_list[end] = []
+        adjacency_list[start].append(end)
+        adjacency_list[end].append(start)
+
+    return adjacency_list
+
+
+def find_ordered_path(segments):
+    adjacency_list = build_adjacency_list(segments)
+    visited = set()
+    ordered_path = []
+
+    def dfs(node):
+        visited.add(node)
+        ordered_path.append(node)
+        for neighbor in sorted(adjacency_list[node]):  # Sort for deterministic order
+            if neighbor not in visited:
+                dfs(neighbor)
+
+    start_node = segments[0][0]  # Start from the first segment's start point
+    dfs(start_node)
+
+    # Convert ordered_path to segment pairs
+    ordered_segments = []
+    for i in range(len(ordered_path) - 1):
+        ordered_segments.append([ordered_path[i], ordered_path[i + 1]])
+
+    return ordered_segments
+
+
+def get_ordered_path_nodes(segments):
+    ordered_segments = find_ordered_path(segments)
+    ordered_nodes = [s[0] for s in ordered_segments]
+    ordered_nodes.append(ordered_segments[-1][-1])
+    return ordered_nodes
+
+
+FreeCADGui.addCommand("BIM_IfcProfiles", BIM_IfcProfiles())


### PR DESCRIPTION
trying to add the IfcProfile ability like blenderbim do
so I made this manager to manage the IfcProfileDef in IfcFile
to activate it, must select the Ifc Object

###  Show All the IfcProfile in the IfcFile and have its thumbnail preview and  info
![image](https://github.com/user-attachments/assets/84105514-6100-436d-8dc5-3db0626659ac)

### Create And Edit Parameterized Profile
![image](https://github.com/user-attachments/assets/0a53e472-cef8-4df7-9208-861a51ba25f1)
![image](https://github.com/user-attachments/assets/4087acb6-5903-4c40-b20d-835e36fff3d8)

### Create And Edit ArbitraryClosed Profile
when edit it, FreeCAD will switch to Draft WB using the Draft Wire Tool to edit the profile shape
![image](https://github.com/user-attachments/assets/f0a7872f-4551-46d0-8e9c-082d2373671b)

### Delete Profile
will have a warning dialog if you want to delete a profile have inverse relationships
![image](https://github.com/user-attachments/assets/420d5dd3-c404-476b-9428-28c96b48976f)

### Prune Profile
allow you to delete all the unused profile
![image](https://github.com/user-attachments/assets/ebbf7d06-8c78-44a9-97d1-52f697cacfef)
 

###  What's Next
1. adding support with IfcArbitraryProfileDefWithVoids  (add inner curve)
2. create the presets loader dialog to make it easy to create the profile (maybe can using the Arch Profile preset or using it as base and transfer to new preset structure)  
3. maybe can add a import shape function to make it create obj in FreeCAD like ArchProfile do (in IFC Unlock Mode),  and now because have Parameterized way to create profile shape, so it will be easy to create new shape not in the preset.
4. now the IfcProfile still have no connection with other function yet, trying to build a Type Tool next, to combine Material and profile shape etc. and use it to building things as the base. 
