### PR TITLE
[Start] Fix ThemeAccentColors not populated...

### DIFF
--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -141,6 +141,11 @@ void ThemeSelectorWidget::themeChanged(Theme newTheme)
             prefPackManager->apply("FreeCAD Light");
             break;
     }
+    ParameterGrp::handle hGrp =
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Themes");
+    hGrp->SetUnsigned("ThemeAccentColor1", 1434171135);
+    hGrp->SetUnsigned("ThemeAccentColor2", 1434171135);
+    hGrp->SetUnsigned("ThemeAccentColor3", 1434171135);
 }
 
 bool ThemeSelectorWidget::eventFilter(QObject* object, QEvent* event)

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -143,9 +143,9 @@ void ThemeSelectorWidget::themeChanged(Theme newTheme)
     }
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Themes");
-    const long nonExistentColor = -1434171135;
-    const long defaultAccentColor = 1434171135;
-    long longAccentColor1 = hGrp->GetUnsigned("ThemeAccentColor1", nonExistentColor);
+    const unsigned long nonExistentColor = -1434171135;
+    const unsigned long defaultAccentColor = 1434171135;
+    unsigned long longAccentColor1 = hGrp->GetUnsigned("ThemeAccentColor1", nonExistentColor);
     if (longAccentColor1 == nonExistentColor) {
         hGrp->SetUnsigned("ThemeAccentColor1", defaultAccentColor);
         hGrp->SetUnsigned("ThemeAccentColor2", defaultAccentColor);

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -143,9 +143,14 @@ void ThemeSelectorWidget::themeChanged(Theme newTheme)
     }
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Themes");
-    hGrp->SetUnsigned("ThemeAccentColor1", 1434171135);
-    hGrp->SetUnsigned("ThemeAccentColor2", 1434171135);
-    hGrp->SetUnsigned("ThemeAccentColor3", 1434171135);
+    auto nonExistentColor = -1;
+    auto defaultAccentColor = 1434171135;
+    auto longAccentColor1 = hGrp->GetUnsigned("ThemeAccentColor1", nonExistentColor);
+    if (longAccentColor1 == nonExistentColor) {
+        hGrp->SetUnsigned("ThemeAccentColor1", 1434171135);
+        hGrp->SetUnsigned("ThemeAccentColor2", 1434171135);
+        hGrp->SetUnsigned("ThemeAccentColor3", 1434171135);
+    }
 }
 
 bool ThemeSelectorWidget::eventFilter(QObject* object, QEvent* event)

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -143,8 +143,8 @@ void ThemeSelectorWidget::themeChanged(Theme newTheme)
     }
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Themes");
-    long nonExistentColor = -1434171135;
-    long defaultAccentColor = 1434171135;
+    const long nonExistentColor = -1434171135;
+    const long defaultAccentColor = 1434171135;
     long longAccentColor1 = hGrp->GetUnsigned("ThemeAccentColor1", nonExistentColor);
     if (longAccentColor1 == nonExistentColor) {
         hGrp->SetUnsigned("ThemeAccentColor1", defaultAccentColor);

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -143,13 +143,13 @@ void ThemeSelectorWidget::themeChanged(Theme newTheme)
     }
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Themes");
-    auto nonExistentColor = -1;
-    auto defaultAccentColor = 1434171135;
-    auto longAccentColor1 = hGrp->GetUnsigned("ThemeAccentColor1", nonExistentColor);
+    long nonExistentColor = -1434171135;
+    long defaultAccentColor = 1434171135;
+    long longAccentColor1 = hGrp->GetUnsigned("ThemeAccentColor1", nonExistentColor);
     if (longAccentColor1 == nonExistentColor) {
-        hGrp->SetUnsigned("ThemeAccentColor1", 1434171135);
-        hGrp->SetUnsigned("ThemeAccentColor2", 1434171135);
-        hGrp->SetUnsigned("ThemeAccentColor3", 1434171135);
+        hGrp->SetUnsigned("ThemeAccentColor1", defaultAccentColor);
+        hGrp->SetUnsigned("ThemeAccentColor2", defaultAccentColor);
+        hGrp->SetUnsigned("ThemeAccentColor3", defaultAccentColor);
     }
 }
 


### PR DESCRIPTION
...on some versions of Qt

In comparison to changing the theme in Preferences>General which always sets the three ThemeAccentColors, the Start>ThemeSelectorWidget does not set the three parameters on some versions of Qt.

![NoThemeAccentColorsfromStart](https://github.com/user-attachments/assets/290f72c2-58d0-4806-ac99-5b5cabca16ff)

This results in the menu hovers, checkboxes etc being all black which in _FreeCAD Light_ means the user doesn't see the text underneath the cursor.