### PR TITLE
Added a filename sample extension in Std_Export function

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -470,6 +470,10 @@ void StdCmdExport::activated(int iMsg)
                 if (!lastExportFile.suffix().isEmpty())
                     defaultFilename += QLatin1String(".") + lastExportFile.suffix();
             }
+            //Append sample extension if there is no last extension to avoid FileDialog::getSaveFileName() cutting the actual filename
+            else {
+                defaultFilename += QLatin1String(".xxx");
+            }
             filenameWasGenerated = true;
         }
     }


### PR DESCRIPTION
This avoids FileDialog::getSaveFileName() abbreviating the actual filename if no extension is given. Now exporting for the first and the second time results in the same behaviour.

This problem was described in #15203.