### PR TITLE
BIM: Fix Welcome dialog wiki links

### DIFF
--- a/src/Mod/BIM/Resources/ui/dialogWelcome.ui
+++ b/src/Mod/BIM/Resources/ui/dialogWelcome.ui
@@ -82,7 +82,7 @@
    <item>
     <widget class="QLabel" name="label_4">
      <property name="text">
-      <string>FreeCAD is a complex application. If this is your first contact with FreeCAD, or you have never worked with 3D or BIM before, you might want to take our &lt;a href=&quot;https://www.freecadweb.org/wiki/BIM_Start_Tutorial&quot;&gt;BIM tutorial&lt;/a&gt; first (Also available under menu &lt;span style=&quot; font-weight:600;&quot;&gt;Help -&amp;gt; BIM Tutorial&lt;/span&gt;).</string>
+      <string>FreeCAD is a complex application. If this is your first contact with FreeCAD, or you have never worked with 3D or BIM before, you might want to take our &lt;a href=&quot;https://wiki.freecad.org/BIM_ingame_tutorial&quot;&gt;BIM tutorial&lt;/a&gt; first (Also available under menu &lt;span style=&quot; font-weight:600;&quot;&gt;Help -&amp;gt; BIM Tutorial&lt;/span&gt;).</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -92,7 +92,7 @@
    <item>
     <widget class="QLabel" name="label_7">
      <property name="text">
-      <string>The BIM workbench also has a &lt;a href=&quot;https://wiki.freecadweb.org/BIM_Workbench&quot;&gt;complete documentation&lt;/a&gt;  available under the Help menu. The &quot;what's this?&quot; button will also open the help page of any tool from the toolbars.</string>
+      <string>The BIM workbench also has a &lt;a href=&quot;https://wiki.freecad.org/BIM_Workbench&quot;&gt;complete documentation&lt;/a&gt;  available under the Help menu. The &quot;what's this?&quot; button will also open the help page of any tool from the toolbars.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>


### PR DESCRIPTION
Old links to www.freecadweb.org, including BIM_Start_Tutorial which no longer exists and I assume should now be BIM_ingame_tutorial.
