### PR TITLE
Remove icon ThemeSearchPaths option on Linux

### DIFF
--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -163,23 +163,13 @@ void StartupProcess::registerEventType()
 
 void StartupProcess::setThemePaths()
 {
-    ParameterGrp::handle hTheme = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Bitmaps/Theme");
 #if !defined(Q_OS_LINUX)
     QIcon::setThemeSearchPaths(QIcon::themeSearchPaths()
                             << QString::fromLatin1(":/icons/FreeCAD-default"));
-    QIcon::setThemeName(QLatin1String("FreeCAD-default"));
-#else
-    // Option to opt-in into using a Linux desktop icon theme.
-    // https://forum.freecad.org/viewtopic.php?f=4&t=35624
-    bool themePaths = hTheme->GetBool("ThemeSearchPaths", false);
-    if (!themePaths) {
-        QStringList searchPaths;
-        searchPaths.prepend(QString::fromUtf8(":/icons"));
-        QIcon::setThemeSearchPaths(searchPaths);
-        QIcon::setThemeName(QLatin1String("FreeCAD-default"));
-    }
 #endif
+
+    ParameterGrp::handle hTheme = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Bitmaps/Theme");
 
     std::string searchpath = hTheme->GetASCII("SearchPath");
     if (!searchpath.empty()) {
@@ -189,7 +179,9 @@ void StartupProcess::setThemePaths()
     }
 
     std::string name = hTheme->GetASCII("Name");
-    if (!name.empty()) {
+    if (name.empty()) {
+        QIcon::setThemeName(QLatin1String("FreeCAD-default"));
+    } else {
         QIcon::setThemeName(QString::fromLatin1(name.c_str()));
     }
 }

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -178,6 +178,9 @@ void StartupProcess::setThemePaths()
         QIcon::setThemeSearchPaths(searchPaths);
     }
 
+    // KDE file dialog needs icons from the desktop theme
+    QIcon::setFallbackThemeName(QIcon::themeName());
+
     std::string name = hTheme->GetASCII("Name");
     if (name.empty()) {
         QIcon::setThemeName(QLatin1String("FreeCAD-default"));


### PR DESCRIPTION
ThemeSearchPaths option was originally introduced in: c420de0f9b ("Option to opt-out from using a Linux desktop icon theme.", 2020-01-26)

It was set on by default in:
dc6456caf9 ("Gui: Use FreeCAD supplied icons on Linux by default", 2024-06-26)

The key effect of the option is to select the FreeCAD-default icon theme. The code also unnecessarily resets QIcon::themeSearchPaths, ":\icons" is always included in the default search paths [1], when when using QAdwaitaDecorations causes window frame control icons not to be displayed:

  (qt.qpa.qadwaitadecorations) Failed to find an svg icon for  "window-close-symbolic.svg"
  (qt.qpa.qadwaitadecorations) Failed to find an svg icon for  "window-minimize-symbolic.svg"
  (qt.qpa.qadwaitadecorations) Failed to find an svg icon for  "window-maximize-symbolic.svg"
  (qt.qpa.qadwaitadecorations) Failed to find an svg icon for  "window-restore-symbolic.svg"

A different default icon theme can still be chosen with the Name option.

[1] https://doc.qt.io/qt-6/qicon.html#themeSearchPaths

---

I only spotted this because I am using https://github.com/FedoraQt/QAdwaitaDecorations to make Qt applications fit in better on GNOME but I think there is a general opportunity to simplify things here.
