### PR TITLE
Remove xpmMap from BitmapFactory

### DIFF
--- a/src/Gui/BitmapFactory.cpp
+++ b/src/Gui/BitmapFactory.cpp
@@ -52,7 +52,6 @@ namespace Gui {
 class BitmapFactoryInstP
 {
 public:
-    QMap<std::string, const char**> xpmMap;
     QMap<std::string, QPixmap> xpmCache;
 };
 }
@@ -152,11 +151,6 @@ QStringList BitmapFactoryInst::findIconFiles() const
     return files;
 }
 
-void BitmapFactoryInst::addXPM(const char* name, const char** pXPM)
-{
-    d->xpmMap[name] = pXPM;
-}
-
 void BitmapFactoryInst::addPixmapToCache(const char* name, const QPixmap& icon)
 {
     d->xpmCache[name] = icon;
@@ -216,16 +210,11 @@ QPixmap BitmapFactoryInst::pixmap(const char* name) const
     if (it != d->xpmCache.end())
         return it.value();
 
-    // now try to find it in the built-in XPM
     QPixmap icon;
-    QMap<std::string,const char**>::Iterator It = d->xpmMap.find(name);
-    if (It != d->xpmMap.end())
-        icon = QPixmap(It.value());
 
     // Try whether an absolute path is given
     QString fn = QString::fromUtf8(name);
-    if (icon.isNull())
-        loadPixmap(fn, icon);
+    loadPixmap(fn, icon);
 
     // try to find it in the 'icons' search paths
     if (icon.isNull()) {
@@ -333,8 +322,6 @@ QPixmap BitmapFactoryInst::pixmapFromSvg(const QByteArray& originalContents, con
 QStringList BitmapFactoryInst::pixmapNames() const
 {
     QStringList names;
-    for (QMap<std::string,const char**>::Iterator It = d->xpmMap.begin(); It != d->xpmMap.end(); ++It)
-        names << QString::fromUtf8(It.key().c_str());
     for (QMap<std::string, QPixmap>::Iterator It = d->xpmCache.begin(); It != d->xpmCache.end(); ++It) {
         QString item = QString::fromUtf8(It.key().c_str());
         if (!names.contains(item))

--- a/src/Gui/BitmapFactory.h
+++ b/src/Gui/BitmapFactory.h
@@ -66,8 +66,6 @@ public:
     /// Returns the absolute file names of icons found in the given search paths
     QStringList findIconFiles() const;
     /// Adds a build in XPM pixmap under a given name
-    void addXPM(const char* name, const char** pXPM);
-    /// Adds a build in XPM pixmap under a given name
     void addPixmapToCache(const char* name, const QPixmap& icon);
     /// Checks whether the pixmap is already registered.
     bool findPixmapInCache(const char* name, QPixmap& icon) const;


### PR DESCRIPTION
No longer used since:
6ca8b2daae ("update hardcoded XPMs to .svg files. Updated .svg icons for clarity.", 2024-03-23)