### PR TITLE
Assembly: Flexible sub-assemblies.

### DIFF
--- a/src/Mod/Assembly/App/AppAssembly.cpp
+++ b/src/Mod/Assembly/App/AppAssembly.cpp
@@ -28,6 +28,7 @@
 #include <Base/PyObjectBase.h>
 
 #include "AssemblyObject.h"
+#include "AssemblyLink.h"
 #include "BomObject.h"
 #include "BomGroup.h"
 #include "JointGroup.h"
@@ -61,6 +62,7 @@ PyMOD_INIT_FUNC(AssemblyApp)
     // This function is responsible for adding inherited slots from a type's base class.
 
     Assembly::AssemblyObject ::init();
+    Assembly::AssemblyLink ::init();
     Assembly::BomObject ::init();
 
     Assembly::BomGroup ::init();

--- a/src/Mod/Assembly/App/AssemblyLink.cpp
+++ b/src/Mod/Assembly/App/AssemblyLink.cpp
@@ -1,0 +1,582 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+#include <cmath>
+#include <vector>
+#endif
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObjectGroup.h>
+#include <App/FeaturePythonPyImp.h>
+#include <App/Link.h>
+#include <App/PropertyPythonObject.h>
+#include <Base/Console.h>
+#include <Base/Placement.h>
+#include <Base/Rotation.h>
+#include <Base/Tools.h>
+#include <Base/Interpreter.h>
+
+#include <Mod/Part/App/PartFeature.h>
+#include <Mod/Part/App/TopoShape.h>
+#include <Mod/PartDesign/App/Body.h>
+#include <Mod/Part/App/DatumFeature.h>
+
+#include "AssemblyObject.h"
+#include "JointGroup.h"
+
+#include "AssemblyLink.h"
+#include "AssemblyLinkPy.h"
+
+namespace PartApp = Part;
+
+using namespace Assembly;
+
+// ================================ Assembly Object ============================
+
+PROPERTY_SOURCE(Assembly::AssemblyLink, App::Part)
+
+AssemblyLink::AssemblyLink()
+{
+    ADD_PROPERTY_TYPE(Rigid,
+                      (true),
+                      "General",
+                      (App::PropertyType)(App::Prop_None),
+                      "If the sub-assembly is set to Rigid, it will act "
+                      "as a rigid body. Else its joints will be taken into account.");
+
+    ADD_PROPERTY_TYPE(LinkedObject,
+                      (nullptr),
+                      "General",
+                      (App::PropertyType)(App::Prop_None),
+                      "The linked assembly.");
+}
+
+AssemblyLink::~AssemblyLink() = default;
+
+PyObject* AssemblyLink::getPyObject()
+{
+    if (PythonObject.is(Py::_None())) {
+        // ref counter is set to 1
+        PythonObject = Py::Object(new AssemblyLinkPy(this), true);
+    }
+    return Py::new_reference_to(PythonObject);
+}
+
+App::DocumentObjectExecReturn* AssemblyLink::execute()
+{
+    updateContents();
+
+    return App::Part::execute();
+}
+
+void AssemblyLink::onChanged(const App::Property* prop)
+{
+    if (App::GetApplication().isRestoring()) {
+        App::Part::onChanged(prop);
+        return;
+    }
+
+    if (prop == &Rigid) {
+        Base::Placement movePlc;
+
+        if (Rigid.getValue()) {
+            // movePlc needs to be computed before updateContents.
+            if (!objLinkMap.empty()) {
+                auto firstElement = *objLinkMap.begin();
+
+                App::DocumentObject* obj = firstElement.first;
+                App::DocumentObject* link = firstElement.second;
+                auto* prop =
+                    dynamic_cast<App::PropertyPlacement*>(obj->getPropertyByName("Placement"));
+                auto* prop2 =
+                    dynamic_cast<App::PropertyPlacement*>(link->getPropertyByName("Placement"));
+                if (prop && prop2) {
+                    movePlc = prop2->getValue() * prop->getValue().inverse();
+                }
+            }
+        }
+
+        updateContents();
+
+        auto* propPlc = dynamic_cast<App::PropertyPlacement*>(getPropertyByName("Placement"));
+        if (!propPlc) {
+            return;
+        }
+
+        if (!Rigid.getValue()) {
+            // when the assemblyLink becomes flexible, we need to make sure its placement is
+            // identity or it's going to mess up moving parts placement within.
+            Base::Placement plc = propPlc->getValue();
+            if (!plc.isIdentity()) {
+                propPlc->setValue(Base::Placement());
+
+                // We need to apply the placement of the assembly link to the children or they will
+                // move.
+                std::vector<App::DocumentObject*> group = Group.getValues();
+                for (auto* obj : group) {
+                    if (!obj->isDerivedFrom<App::Part>() && !obj->isDerivedFrom<PartApp::Feature>()
+                        && !obj->isDerivedFrom<App::Link>()) {
+                        continue;
+                    }
+
+                    auto* prop =
+                        dynamic_cast<App::PropertyPlacement*>(obj->getPropertyByName("Placement"));
+                    if (prop) {
+                        prop->setValue(plc * prop->getValue());
+                    }
+                }
+
+                AssemblyObject::redrawJointPlacements(getJoints());
+            }
+        }
+        else {
+            // For the assemblylink not to move to origin, we need to update its placement.
+            if (!movePlc.isIdentity()) {
+                propPlc->setValue(movePlc);
+            }
+        }
+
+        return;
+    }
+    App::Part::onChanged(prop);
+}
+
+void AssemblyLink::updateContents()
+{
+    synchronizeComponents();
+
+    if (isRigid()) {
+        ensureNoJointGroup();
+    }
+    else {
+        synchronizeJoints();
+    }
+
+    purgeTouched();
+}
+
+void AssemblyLink::synchronizeComponents()
+{
+    App::Document* doc = getDocument();
+
+    AssemblyObject* assembly = getLinkedAssembly();
+    if (!assembly) {
+        return;
+    }
+
+    objLinkMap.clear();
+
+    std::vector<App::DocumentObject*> assemblyGroup = assembly->Group.getValues();
+    std::vector<App::DocumentObject*> assemblyLinkGroup = Group.getValues();
+
+    // We check if a component needs to be added to the AssemblyLink
+    for (auto* obj : assemblyGroup) {
+        if (!obj->isDerivedFrom<App::Part>() && !obj->isDerivedFrom<PartApp::Feature>()
+            && !obj->isDerivedFrom<App::Link>()) {
+            continue;
+        }
+
+        // Note, the user can have nested sub-assemblies.
+        // In which case we need to add an AssemblyLink and not a Link.
+        App::DocumentObject* link = nullptr;
+        bool found = false;
+        for (auto* obj2 : assemblyLinkGroup) {
+            App::DocumentObject* linkedObj;
+
+            auto* subAsmLink = dynamic_cast<AssemblyLink*>(obj2);
+            auto* link2 = dynamic_cast<App::Link*>(obj2);
+            if (subAsmLink) {
+                linkedObj = subAsmLink->getLinkedObject2(false);  // not recursive
+            }
+            else if (link2) {
+                linkedObj = link2->getLinkedObject(false);  // not recursive
+            }
+            else {
+                // We consider only Links and AssemblyLinks in the AssemblyLink.
+                continue;
+            }
+
+
+            if (linkedObj == obj) {
+                found = true;
+                link = obj2;
+                break;
+            }
+        }
+        if (!found) {
+            // Add a link or a AssemblyLink to it in the AssemblyLink.
+            if (obj->isDerivedFrom<AssemblyLink>()) {
+                auto* asmLink = static_cast<AssemblyLink*>(obj);
+                auto* subAsmLink = new AssemblyLink();
+                doc->addObject(subAsmLink, obj->getNameInDocument());
+                subAsmLink->LinkedObject.setValue(obj);
+                subAsmLink->Rigid.setValue(asmLink->Rigid.getValue());
+                subAsmLink->Label.setValue(obj->Label.getValue());
+                addObject(subAsmLink);
+                link = subAsmLink;
+            }
+            else {
+                auto* appLink = new App::Link();
+                doc->addObject(appLink, obj->getNameInDocument());
+                appLink->LinkedObject.setValue(obj);
+                appLink->Label.setValue(obj->Label.getValue());
+                addObject(appLink);
+                link = appLink;
+            }
+        }
+
+        objLinkMap[obj] = link;
+        // If the assemblyLink is rigid, then we keep the placement synchronized.
+        if (isRigid()) {
+            auto* plcProp =
+                dynamic_cast<App::PropertyPlacement*>(obj->getPropertyByName("Placement"));
+            auto* plcProp2 =
+                dynamic_cast<App::PropertyPlacement*>(link->getPropertyByName("Placement"));
+            if (plcProp && plcProp2) {
+                if (!plcProp->getValue().isSame(plcProp2->getValue())) {
+                    plcProp2->setValue(plcProp->getValue());
+                }
+            }
+        }
+    }
+
+    // We check if a component needs to be removed from the AssemblyLink
+    for (auto* link : assemblyLinkGroup) {
+        // We don't need to update assemblyLinkGroup after the addition since we're not removing
+        // something we just added.
+
+        if (objLinkMap.find(link) != objLinkMap.end()) {
+            doc->removeObject(link->getNameInDocument());
+        }
+
+        /*if (!link->isDerivedFrom<App::Link>() && !link->isDerivedFrom<AssemblyLink>()) {
+            // AssemblyLink should contain only Links or assembly links.
+            continue;
+        }
+
+        auto* linkedObj = link->getLinkedObject(false);  // not recursive
+
+        bool found = false;
+        for (auto* obj2 : assemblyGroup) {
+            if (obj2 == linkedObj) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            doc->removeObject(link->getNameInDocument());
+        }*/
+    }
+}
+
+namespace
+{
+template<typename T>
+void copyPropertyIfDifferent(App::DocumentObject* source,
+                             App::DocumentObject* target,
+                             const char* propertyName)
+{
+    auto sourceProp = dynamic_cast<T*>(source->getPropertyByName(propertyName));
+    auto targetProp = dynamic_cast<T*>(target->getPropertyByName(propertyName));
+    if (sourceProp && targetProp && sourceProp->getValue() != targetProp->getValue()) {
+        targetProp->setValue(sourceProp->getValue());
+    }
+}
+
+std::string removeUpToName(const std::string& sub, const std::string& name)
+{
+    size_t pos = sub.find(name);
+    if (pos != std::string::npos) {
+        // Move the position to the character after the found substring and the following '.'
+        pos += name.length() + 1;
+        if (pos < sub.length()) {
+            return sub.substr(pos);
+        }
+    }
+    // If s2 is not found in s1, return the original string
+    return sub;
+}
+
+std::string
+replaceLastOccurrence(const std::string& str, const std::string& oldStr, const std::string& newStr)
+{
+    size_t pos = str.rfind(oldStr);
+    if (pos != std::string::npos) {
+        std::string result = str;
+        result.replace(pos, oldStr.length(), newStr);
+        return result;
+    }
+    return str;
+}
+};  // namespace
+
+void AssemblyLink::synchronizeJoints()
+{
+    App::Document* doc = getDocument();
+    AssemblyObject* assembly = getLinkedAssembly();
+    if (!assembly) {
+        return;
+    }
+
+    JointGroup* jGroup = ensureJointGroup();
+
+    std::vector<App::DocumentObject*> assemblyJoints =
+        assembly->getJoints(assembly->isTouched(), false, false);
+    std::vector<App::DocumentObject*> assemblyLinkJoints = getJoints();
+
+    // We delete the excess of joints if any
+    for (size_t i = assemblyJoints.size(); i < assemblyLinkJoints.size(); ++i) {
+        doc->removeObject(assemblyLinkJoints[i]->getNameInDocument());
+    }
+
+    // We make sure the joints match.
+    for (size_t i = 0; i < assemblyJoints.size(); ++i) {
+        App::DocumentObject* joint = assemblyJoints[i];
+        App::DocumentObject* lJoint;
+        if (i < assemblyLinkJoints.size()) {
+            lJoint = assemblyLinkJoints[i];
+        }
+        else {
+            auto ret = doc->copyObject({joint});
+            if (ret.size() != 1) {
+                continue;
+            }
+            lJoint = ret[0];
+            jGroup->addObject(lJoint);
+        }
+
+        // Then we have to check the properties one by one.
+        copyPropertyIfDifferent<App::PropertyBool>(joint, lJoint, "Activated");
+        copyPropertyIfDifferent<App::PropertyFloat>(joint, lJoint, "Distance");
+        copyPropertyIfDifferent<App::PropertyFloat>(joint, lJoint, "Distance2");
+        copyPropertyIfDifferent<App::PropertyEnumeration>(joint, lJoint, "JointType");
+        copyPropertyIfDifferent<App::PropertyPlacement>(joint, lJoint, "Offset1");
+        copyPropertyIfDifferent<App::PropertyPlacement>(joint, lJoint, "Offset2");
+
+        copyPropertyIfDifferent<App::PropertyBool>(joint, lJoint, "Detach1");
+        copyPropertyIfDifferent<App::PropertyBool>(joint, lJoint, "Detach2");
+
+        copyPropertyIfDifferent<App::PropertyFloat>(joint, lJoint, "AngleMax");
+        copyPropertyIfDifferent<App::PropertyFloat>(joint, lJoint, "AngleMin");
+        copyPropertyIfDifferent<App::PropertyFloat>(joint, lJoint, "LengthMax");
+        copyPropertyIfDifferent<App::PropertyFloat>(joint, lJoint, "LengthMin");
+        copyPropertyIfDifferent<App::PropertyBool>(joint, lJoint, "EnableAngleMax");
+        copyPropertyIfDifferent<App::PropertyBool>(joint, lJoint, "EnableAngleMin");
+        copyPropertyIfDifferent<App::PropertyBool>(joint, lJoint, "EnableLengthMax");
+        copyPropertyIfDifferent<App::PropertyBool>(joint, lJoint, "EnableLengthMin");
+
+        // The reference needs to be handled specifically
+        handleJointReference(joint, lJoint, "Reference1");
+        handleJointReference(joint, lJoint, "Reference2");
+    }
+
+    assemblyLinkJoints = getJoints();
+
+    AssemblyObject::recomputeJointPlacements(assemblyLinkJoints);
+
+    for (auto* joint : assemblyLinkJoints) {
+        joint->purgeTouched();
+    }
+}
+
+
+void AssemblyLink::handleJointReference(App::DocumentObject* joint,
+                                        App::DocumentObject* lJoint,
+                                        const char* refName)
+{
+    AssemblyObject* assembly = getLinkedAssembly();
+
+    auto prop1 = dynamic_cast<App::PropertyXLinkSubHidden*>(joint->getPropertyByName(refName));
+    auto prop2 = dynamic_cast<App::PropertyXLinkSubHidden*>(lJoint->getPropertyByName(refName));
+    if (!prop1 || !prop2) {
+        return;
+    }
+
+    App::DocumentObject* obj1 = nullptr;
+    App::DocumentObject* obj2 = prop2->getValue();
+    std::vector<std::string> subs1 = prop1->getSubValues();
+    std::vector<std::string> subs2 = prop2->getSubValues();
+    if (subs1.empty()) {
+        return;
+    }
+
+    // Example :
+    // Obj1 = docA-Asm1 Subs1 = ["part1.body.pad.face0", "part1.body.pad.vertex1"]
+    // Obj1 = docA-Part Subs1 = ["Asm1.part1.body.pad.face0", "Asm1.part1.body.pad.vertex1"] // some
+    // user may put the assembly inside a part... should become : Obj2 = docB-Asm2 Subs2 =
+    // ["Asm1Link.part1.linkTobody.pad.face0", "Asm1Link.part1.linkTobody.pad.vertex1"] Obj2 =
+    // docB-Part Sub2 = ["Asm2.Asm1Link.part1.linkTobody.pad.face0",
+    // "Asm2.Asm1Link.part1.linkTobody.pad.vertex1"]
+
+    std::string asmLink = getNameInDocument();
+    for (auto& sub : subs1) {
+        // First let's remove 'Asm1' name and everything before if any.
+        sub = removeUpToName(sub, assembly->getNameInDocument());
+        // Then we add the assembly link name.
+        sub = asmLink + "." + sub;
+        // Then the question is, is there more to prepend? Because the parent assembly may have some
+        // parents So we check assemblyLink parents and prepend necessary parents.
+        bool first = true;
+        std::vector<App::DocumentObject*> inList = getInList();
+        int limit = 0;
+        while (!inList.empty() && limit < 20) {
+            ++limit;
+            bool found = false;
+            for (auto* obj : inList) {
+                if (obj->isDerivedFrom<App::Part>()) {
+                    found = true;
+                    if (first) {
+                        first = false;
+                    }
+                    else {
+                        std::string obj1Name = obj1->getNameInDocument();
+                        sub = obj1Name + "." + sub;
+                    }
+                    obj1 = obj;
+                    break;
+                }
+            }
+            if (found) {
+                inList = obj1->getInList();
+            }
+            else {
+                inList = {};
+            }
+        }
+
+        // Lastly we need to replace the object name by its link name.
+        auto* obj = AssemblyObject::getObjFromRef(prop1);
+        auto* link = objLinkMap[obj];
+        if (!obj || !link) {
+            return;
+        }
+        std::string objName = obj->getNameInDocument();
+        std::string linkName = link->getNameInDocument();
+        sub = replaceLastOccurrence(sub, objName, linkName);
+    }
+    // Now obj1 and the subs1 are what should be in obj2 and subs2 if the joint did not changed
+    if (obj1 != obj2) {
+        prop2->setValue(obj1);
+    }
+    bool changed = false;
+    for (size_t i = 0; i < subs1.size(); ++i) {
+        if (i >= subs2.size() || subs1[i] != subs2[i]) {
+            changed = true;
+            break;
+        }
+    }
+    if (changed) {
+        prop2->setSubValues(std::move(subs1));
+    }
+}
+
+void AssemblyLink::ensureNoJointGroup()
+{
+    // Make sure there is no joint group
+    JointGroup* jGroup = AssemblyObject::getJointGroup(this);
+    if (jGroup) {
+        // If there is a joint group, we delete it and its content.
+        jGroup->removeObjectsFromDocument();
+        getDocument()->removeObject(jGroup->getNameInDocument());
+    }
+}
+JointGroup* AssemblyLink::ensureJointGroup()
+{
+    // Make sure there is a jointGroup
+    JointGroup* jGroup = AssemblyObject::getJointGroup(this);
+    if (!jGroup) {
+        jGroup = new JointGroup();
+        getDocument()->addObject(jGroup, tr("Joints").toStdString().c_str());
+
+        // we want to add jgroup at the start, so we don't use
+        // addObject(jGroup);
+        std::vector<DocumentObject*> grp = Group.getValues();
+        grp.insert(grp.begin(), jGroup);
+        Group.setValues(grp);
+    }
+    return jGroup;
+}
+
+App::DocumentObject* AssemblyLink::getLinkedObject2(bool recursive) const
+{
+    auto* obj = LinkedObject.getValue();
+    auto* assembly = dynamic_cast<AssemblyObject*>(obj);
+    if (assembly) {
+        return assembly;
+    }
+    else {
+        auto* assemblyLink = dynamic_cast<AssemblyLink*>(obj);
+        if (assemblyLink) {
+            if (recursive) {
+                return assemblyLink->getLinkedObject2(recursive);
+            }
+            else {
+                return assemblyLink;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+AssemblyObject* AssemblyLink::getLinkedAssembly() const
+{
+    return dynamic_cast<AssemblyObject*>(getLinkedObject2());
+}
+
+AssemblyObject* AssemblyLink::getParentAssembly() const
+{
+    std::vector<App::DocumentObject*> inList = getInList();
+    for (auto* obj : inList) {
+        auto* assembly = dynamic_cast<AssemblyObject*>(obj);
+        if (assembly) {
+            return assembly;
+        }
+    }
+
+    return nullptr;
+}
+
+bool AssemblyLink::isRigid()
+{
+    auto* prop = dynamic_cast<App::PropertyBool*>(getPropertyByName("Rigid"));
+    if (!prop) {
+        return true;
+    }
+
+    return prop->getValue();
+}
+
+std::vector<App::DocumentObject*> AssemblyLink::getJoints()
+{
+    JointGroup* jointGroup = AssemblyObject::getJointGroup(this);
+
+    if (!jointGroup) {
+        return {};
+    }
+
+    return jointGroup->getJoints();
+}

--- a/src/Mod/Assembly/App/AssemblyLink.h
+++ b/src/Mod/Assembly/App/AssemblyLink.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 /****************************************************************************
  *                                                                          *
- *   Copyright (c) 2023 Ondsel <development@ondsel.com>                     *
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
  *                                                                          *
  *   This file is part of FreeCAD.                                          *
  *                                                                          *
@@ -22,39 +22,75 @@
  ***************************************************************************/
 
 
-#ifndef ASSEMBLY_JointGroup_H
-#define ASSEMBLY_JointGroup_H
+#ifndef ASSEMBLY_AssemblyLink_H
+#define ASSEMBLY_AssemblyLink_H
+
+#include <unordered_map>
 
 #include <Mod/Assembly/AssemblyGlobal.h>
 
-#include <App/DocumentObjectGroup.h>
+#include <App/FeaturePython.h>
+#include <App/Part.h>
 #include <App/PropertyLinks.h>
 
 
 namespace Assembly
 {
+class AssemblyObject;
+class JointGroup;
 
-class AssemblyExport JointGroup: public App::DocumentObjectGroup
+class AssemblyExport AssemblyLink: public App::Part
 {
-    PROPERTY_HEADER_WITH_OVERRIDE(Assembly::JointGroup);
+    PROPERTY_HEADER_WITH_OVERRIDE(Assembly::AssemblyLink);
 
 public:
-    JointGroup();
-    ~JointGroup() override;
+    AssemblyLink();
+    ~AssemblyLink() override;
 
     PyObject* getPyObject() override;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override
     {
-        return "AssemblyGui::ViewProviderJointGroup";
+        return "AssemblyGui::ViewProviderAssemblyLink";
     }
 
+    App::DocumentObjectExecReturn* execute() override;
+
+    // The linked assembly is the AssemblyObject that this AssemblyLink pseudo-links to recursively.
+    AssemblyObject* getLinkedAssembly() const;
+    // The parent assembly is the main assembly in which the linked assembly is contained
+    AssemblyObject* getParentAssembly() const;
+
+    // Overriding DocumentObject::getLinkedObject is giving bugs
+    // This function returns the linked object, either an AssemblyObject or an AssemblyLink
+    App::DocumentObject* getLinkedObject2(bool recurse = true) const;
+
+    bool isRigid();
+
+    void updateContents();
+
+    void synchronizeComponents();
+    void synchronizeJoints();
+    void handleJointReference(App::DocumentObject* joint,
+                              App::DocumentObject* lJoint,
+                              const char* refName);
+    void ensureNoJointGroup();
+    JointGroup* ensureJointGroup();
     std::vector<App::DocumentObject*> getJoints();
+
+    App::PropertyXLink LinkedObject;
+    App::PropertyBool Rigid;
+
+    std::unordered_map<App::DocumentObject*, App::DocumentObject*> objLinkMap;
+
+protected:
+    /// get called by the container whenever a property has been changed
+    void onChanged(const App::Property* prop) override;
 };
 
 
 }  // namespace Assembly
 
 
-#endif  // ASSEMBLY_JointGroup_H
+#endif  // ASSEMBLY_AssemblyLink_H

--- a/src/Mod/Assembly/App/AssemblyLinkPy.xml
+++ b/src/Mod/Assembly/App/AssemblyLinkPy.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
+  <PythonExport
+      Father="PartPy"
+      Name="AssemblyLinkPy"
+      Twin="AssemblyLink"
+      TwinPointer="AssemblyLink"
+      Include="Mod/Assembly/App/AssemblyLink.h"
+      Namespace="Assembly"
+      FatherInclude="App/PartPy.h"
+      FatherNamespace="App">
+    <Documentation>
+      <Author Licence="LGPL" Name="Ondsel" EMail="development@ondsel.com" />
+      <UserDocu>This class handles document objects in Assembly</UserDocu>
+    </Documentation>
+
+    <CustomAttributes />
+  </PythonExport>
+</GenerateModel>

--- a/src/Mod/Assembly/App/AssemblyLinkPyImp.cpp
+++ b/src/Mod/Assembly/App/AssemblyLinkPyImp.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 /****************************************************************************
  *                                                                          *
- *   Copyright (c) 2023 Ondsel <development@ondsel.com>                     *
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
  *                                                                          *
  *   This file is part of FreeCAD.                                          *
  *                                                                          *
@@ -21,51 +21,27 @@
  *                                                                          *
  ***************************************************************************/
 
+
 #include "PreCompiled.h"
 
-#include <Base/Console.h>
-#include <Base/Interpreter.h>
-#include <Base/PyObjectBase.h>
+// inclusion of the generated files (generated out of AssemblyLink.xml)
+#include "AssemblyLinkPy.h"
+#include "AssemblyLinkPy.cpp"
 
-#include "ViewProviderAssembly.h"
-#include "ViewProviderAssemblyLink.h"
-#include "ViewProviderBom.h"
-#include "ViewProviderBomGroup.h"
-#include "ViewProviderJointGroup.h"
-#include "ViewProviderViewGroup.h"
+using namespace Assembly;
 
-
-namespace AssemblyGui
+// returns a string which represents the object e.g. when printed in python
+std::string AssemblyLinkPy::representation() const
 {
-extern PyObject* initModule();
+    return {"<Assembly link>"};
 }
 
-/* Python entry */
-PyMOD_INIT_FUNC(AssemblyGui)
+PyObject* AssemblyLinkPy::getCustomAttributes(const char* /*attr*/) const
 {
-    // load dependent module
-    try {
-        Base::Interpreter().runString("import SpreadsheetGui");
-    }
-    catch (const Base::Exception& e) {
-        PyErr_SetString(PyExc_ImportError, e.what());
-        PyMOD_Return(nullptr);
-    }
+    return nullptr;
+}
 
-    PyObject* mod = AssemblyGui::initModule();
-    Base::Console().Log("Loading AssemblyGui module... done\n");
-
-
-    // NOTE: To finish the initialization of our own type objects we must
-    // call PyType_Ready, otherwise we run into a segmentation fault, later on.
-    // This function is responsible for adding inherited slots from a type's base class.
-
-    AssemblyGui::ViewProviderAssembly::init();
-    AssemblyGui::ViewProviderAssemblyLink::init();
-    AssemblyGui::ViewProviderBom::init();
-    AssemblyGui::ViewProviderBomGroup::init();
-    AssemblyGui::ViewProviderJointGroup::init();
-    AssemblyGui::ViewProviderViewGroup::init();
-
-    PyMOD_Return(mod);
+int AssemblyLinkPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0;
 }

--- a/src/Mod/Assembly/App/AssemblyObject.h
+++ b/src/Mod/Assembly/App/AssemblyObject.h
@@ -59,6 +59,7 @@ class Rotation;
 namespace Assembly
 {
 
+class AssemblyLink;
 class JointGroup;
 class ViewGroup;
 
@@ -241,7 +242,7 @@ public:
     double getObjMass(App::DocumentObject* obj);
     void setObjMasses(std::vector<std::pair<App::DocumentObject*, double>> objectMasses);
 
-    std::vector<AssemblyObject*> getSubAssemblies();
+    std::vector<AssemblyLink*> getSubAssemblies();
     void updateGroundedJointsPlacements();
 
 private:

--- a/src/Mod/Assembly/App/CMakeLists.txt
+++ b/src/Mod/Assembly/App/CMakeLists.txt
@@ -19,6 +19,7 @@ set(Assembly_LIBS
 )
 
 generate_from_xml(AssemblyObjectPy)
+generate_from_xml(AssemblyLinkPy)
 generate_from_xml(BomObjectPy)
 generate_from_xml(BomGroupPy)
 generate_from_xml(JointGroupPy)
@@ -27,6 +28,8 @@ generate_from_xml(ViewGroupPy)
 SET(Python_SRCS
     AssemblyObjectPy.xml
     AssemblyObjectPyImp.cpp
+    AssemblyLinkPy.xml
+    AssemblyLinkPyImp.cpp
     BomObjectPy.xml
     BomObjectPyImp.cpp
     BomGroupPy.xml
@@ -49,6 +52,8 @@ SOURCE_GROUP("Module" FILES ${Module_SRCS})
 SET(Assembly_SRCS
     AssemblyObject.cpp
     AssemblyObject.h
+    AssemblyLink.cpp
+    AssemblyLink.h
     BomObject.cpp
     BomObject.h
     BomGroup.cpp

--- a/src/Mod/Assembly/App/JointGroup.cpp
+++ b/src/Mod/Assembly/App/JointGroup.cpp
@@ -53,3 +53,31 @@ PyObject* JointGroup::getPyObject()
     }
     return Py::new_reference_to(PythonObject);
 }
+
+
+std::vector<App::DocumentObject*> JointGroup::getJoints()
+{
+    std::vector<App::DocumentObject*> joints = {};
+
+    Base::PyGILStateLocker lock;
+    for (auto joint : getObjects()) {
+        if (!joint) {
+            continue;
+        }
+
+        auto* prop = dynamic_cast<App::PropertyBool*>(joint->getPropertyByName("Activated"));
+        if (!prop || !prop->getValue()) {
+            // Filter grounded joints and deactivated joints.
+            continue;
+        }
+
+        auto proxy = dynamic_cast<App::PropertyPythonObject*>(joint->getPropertyByName("Proxy"));
+        if (proxy) {
+            if (proxy->getValue().hasAttr("setJointConnectors")) {
+                joints.push_back(joint);
+            }
+        }
+    }
+
+    return joints;
+}

--- a/src/Mod/Assembly/CMakeLists.txt
+++ b/src/Mod/Assembly/CMakeLists.txt
@@ -17,6 +17,7 @@ set(Assembly_Scripts
     JointObject.py
     Preferences.py
     AssemblyImport.py
+    SoSwitchMarker.py
     UtilsAssembly.py
 )
 

--- a/src/Mod/Assembly/CommandInsertLink.py
+++ b/src/Mod/Assembly/CommandInsertLink.py
@@ -98,6 +98,7 @@ class TaskAssemblyInsertLink(QtCore.QObject):
 
         pref = Preferences.preferences()
         self.form.CheckBox_ShowOnlyParts.setChecked(pref.GetBool("InsertShowOnlyParts", False))
+        self.form.CheckBox_RigidSubAsm.setChecked(pref.GetBool("InsertRigidSubAssemblies", True))
 
         # Actions
         self.form.openFileButton.clicked.connect(self.openFiles)
@@ -165,6 +166,7 @@ class TaskAssemblyInsertLink(QtCore.QObject):
     def deactivated(self):
         pref = Preferences.preferences()
         pref.SetBool("InsertShowOnlyParts", self.form.CheckBox_ShowOnlyParts.isChecked())
+        pref.SetBool("InsertRigidSubAssemblies", self.form.CheckBox_RigidSubAsm.isChecked())
         Gui.Selection.clearSelection()
 
     def buildPartList(self):
@@ -353,7 +355,16 @@ class TaskAssemblyInsertLink(QtCore.QObject):
                 print(selectedPart.Document.Name)
                 documentItem.setText(0, f"{newDocName}.FCStd")"""
 
-        addedObject = self.assembly.newObject("App::Link", selectedPart.Label)
+        if selectedPart.isDerivedFrom("Assembly::AssemblyObject"):
+            objType = "Assembly::AssemblyLink"
+        else:
+            objType = "App::Link"
+
+        addedObject = self.assembly.newObject(objType, selectedPart.Label)
+
+        if selectedPart.isDerivedFrom("Assembly::AssemblyObject"):
+            addedObject.Rigid = self.form.CheckBox_RigidSubAsm.isChecked()
+
         # set placement of the added object to the center of the screen.
         view = Gui.activeView()
         x, y = view.getSize()

--- a/src/Mod/Assembly/Gui/CMakeLists.txt
+++ b/src/Mod/Assembly/Gui/CMakeLists.txt
@@ -40,6 +40,8 @@ SET(AssemblyGui_SRCS_Module
     PreCompiled.h
     ViewProviderAssembly.cpp
     ViewProviderAssembly.h
+    ViewProviderAssemblyLink.cpp
+    ViewProviderAssemblyLink.h
     ViewProviderBom.cpp
     ViewProviderBom.h
     ViewProviderBomGroup.cpp

--- a/src/Mod/Assembly/Gui/Resources/Assembly.qrc
+++ b/src/Mod/Assembly/Gui/Resources/Assembly.qrc
@@ -1,5 +1,7 @@
 <RCC>
     <qresource prefix="/">
+        <file>icons/Assembly_AssemblyLink.svg</file>
+        <file>icons/Assembly_AssemblyLinkRigid.svg</file>
         <file>icons/Assembly_InsertLink.svg</file>
         <file>icons/preferences-assembly.svg</file>
         <file>icons/Assembly_ToggleGrounded.svg</file>

--- a/src/Mod/Assembly/Gui/Resources/icons/Assembly_AssemblyLink.svg
+++ b/src/Mod/Assembly/Gui/Resources/icons/Assembly_AssemblyLink.svg
@@ -1,0 +1,359 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="64"
+   height="64"
+   version="1.1"
+   viewBox="0 0 64 64"
+   id="svg96"
+   sodipodi:docname="Assembly_AssemblyLink.svg"
+   inkscape:version="1.1-beta1 (77e7b44db3, 2021-03-28)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="1571"
+     id="namedview98"
+     showgrid="false"
+     inkscape:zoom="10.429825"
+     inkscape:cx="-15.388561"
+     inkscape:cy="38.303615"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg96"
+     inkscape:pagecheckerboard="0" />
+  <defs
+     id="defs26">
+    <linearGradient
+       id="linearGradient4383">
+      <stop
+         stop-color="#3465a4"
+         offset="0"
+         id="stop2" />
+      <stop
+         stop-color="#729fcf"
+         offset="1"
+         id="stop4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4389"
+       x1="20.244"
+       x2="17.244"
+       y1="37.588"
+       y2="27.588"
+       gradientTransform="translate(-1.2435,-2.5881)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3774" />
+    <linearGradient
+       id="linearGradient4399"
+       x1="48.714"
+       x2="44.714"
+       y1="45.586"
+       y2="34.586"
+       gradientTransform="translate(1.2856,1.4142)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#c4a000"
+         offset="0"
+         id="stop8" />
+      <stop
+         stop-color="#edd400"
+         offset="1"
+         id="stop10" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient69042"
+       x1="48.714"
+       x2="44.714"
+       y1="45.586"
+       y2="34.586"
+       gradientTransform="translate(-12.714,-17.586)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3774" />
+    <linearGradient
+       id="linearGradient69056"
+       x1="27.244"
+       x2="22.244"
+       y1="54.588"
+       y2="40.588"
+       gradientTransform="translate(-1.2435,-2.5881)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#c4a000"
+         offset="0"
+         id="stop14" />
+      <stop
+         stop-color="#fce94f"
+         offset="1"
+         id="stop16" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient69709"
+       x1="20.244"
+       x2="17.244"
+       y1="37.588"
+       y2="27.588"
+       gradientTransform="matrix(1,-0.026667,0,1,21.696,-5.3735)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4383" />
+    <linearGradient
+       id="linearGradient69717"
+       x1="50.714"
+       x2="48.714"
+       y1="25.586"
+       y2="20.586"
+       gradientTransform="translate(1.2256,1.0356)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4383" />
+    <linearGradient
+       id="linearGradient3774">
+      <stop
+         stop-color="#4e9a06"
+         offset="0"
+         id="stop21" />
+      <stop
+         stop-color="#8ae234"
+         offset="1"
+         id="stop23" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient69056"
+       id="linearGradient920"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-41.2435,-2.5881)"
+       x1="20.243999"
+       y1="37.588001"
+       x2="17.243999"
+       y2="27.587999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4399"
+       id="linearGradient922"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-52.714,-17.586)"
+       x1="48.714001"
+       y1="45.585999"
+       x2="44.714001"
+       y2="34.585999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4383"
+       id="linearGradient5137"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.06404665,0.06060973,-0.05836811,-0.06167792,58.951461,44.497067)"
+       x1="288.11227"
+       y1="358.15811"
+       x2="372.52457"
+       y2="7.5416322" />
+  </defs>
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Path-Stock</dc:title>
+        <dc:date>2015-07-04</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Path/Gui/Resources/icons/Path-Stock.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g40"
+     style="stroke-width:2">
+    <path
+       d="M 9,49 V 35 l 28,10 v 14 z"
+       id="path30"
+       style="fill:url(#linearGradient69056);stroke:#302b00;stroke-linejoin:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 37,59 V 45 L 55,28 v 13 z"
+       id="path32"
+       style="fill:url(#linearGradient4399);stroke:#302b00;stroke-linejoin:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 11.008,47.606 11,37.9997 l 24,8 0.0081,10.185 z"
+       id="path34"
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#fce94f" />
+    <path
+       d="M 39.005,54.168 39,45.9998 l 14,-13 0.0021,7.1768 z"
+       id="path36"
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#edd400" />
+    <path
+       d="M 23,40 42,23 55,28 37,45 Z"
+       id="path38"
+       inkscape:connector-curvature="0"
+       style="fill:#fce94f;stroke:#302b00;stroke-linejoin:round" />
+  </g>
+  <path
+     d="m 31,33.5 -0.02739,-14.214 12.967,4.3352 v 14.5 z"
+     id="path54"
+     style="fill:url(#linearGradient69709);stroke:#0b1521;stroke-width:2;stroke-linejoin:round"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 32.927,32.029 0.04731,-10.141 8.9272,3.29 0.0781,10.042 z"
+     id="path56"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#729fcf;stroke-width:2" />
+  <path
+     d="m 43.94,38.121 v -14.5 l 11,-9 L 55,28 Z"
+     id="path58"
+     style="fill:url(#linearGradient69717);stroke:#0b1521;stroke-width:2;stroke-linejoin:round"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 45.94,33.621 v -9 l 7,-6 -0.0122,8.5816 z"
+     id="path60"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#729fcf;stroke-width:2" />
+  <path
+     d="M 30.973,19.286 42,9.9998 l 12.94,4.6214 -11,9 z"
+     id="path62"
+     inkscape:connector-curvature="0"
+     style="fill:#729fcf;stroke:#0b1521;stroke-width:2;stroke-linejoin:round" />
+  <g
+     display="none"
+     fill="#ef2929"
+     fill-rule="evenodd"
+     opacity=".588"
+     stroke="#ef2929"
+     stroke-width="1px"
+     id="g94">
+    <path
+       d="m9 35v14"
+       id="path66" />
+    <path
+       d="m9 35 28 10"
+       id="path68" />
+    <path
+       d="m55 28v13"
+       id="path70" />
+    <path
+       d="m37 45 18-17"
+       id="path72" />
+    <path
+       d="m23 40v-14"
+       id="path74" />
+    <path
+       d="m29 5 13 5"
+       id="path76" />
+    <path
+       d="m23 26 19-16"
+       id="path78" />
+    <path
+       d="m19 13 10-8"
+       id="path80" />
+    <path
+       d="m55 15-9 8"
+       id="path82" />
+    <path
+       d="m42 23v-13"
+       id="path84" />
+    <path
+       d="m42 23 14 5"
+       id="path86" />
+    <path
+       d="m23 40 19-17"
+       id="path88" />
+    <path
+       d="m23 10h19"
+       id="path90" />
+    <path
+       d="m34 17v13"
+       id="path92" />
+  </g>
+  <g
+     id="g963"
+     transform="translate(40)">
+    <g
+       style="stroke:#172a04;stroke-width:2;stroke-linejoin:round"
+       transform="translate(-40)"
+       id="g48">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient4389)"
+         id="path42"
+         d="M 9,35 V 21 l 14,5 v 14 z" />
+      <path
+         style="fill:#8ae234"
+         inkscape:connector-curvature="0"
+         id="path44"
+         d="M 9,21 28.585,5.209 42,10.0001 l -19,16 z" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient69042)"
+         id="path46"
+         d="M 23,40 V 26 l 7.9726,-6.7138 0.02739,13.714 z" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient920);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linejoin:round"
+       id="path912"
+       d="M -31,35 V 21 l 14,5 v 14 z" />
+    <path
+       style="fill:#fce94f;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linejoin:round;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       id="path914"
+       d="M -31,21 -11.415,5.209 2,10.0001 l -19,16 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient922);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linejoin:round"
+       id="path916"
+       d="M -17,40 V 26 l 7.9726,-6.7138 0.02739,13.714 z" />
+    <path
+       d="m -15,36 v -9 l 4,-3.5 v 9 z"
+       id="path50"
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-opacity:1" />
+    <path
+       d="m -29.049,33.746 0.08695,-9.9796 9.9568,3.5229 -0.02105,9.9613 z"
+       id="path52"
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-opacity:1" />
+  </g>
+  <path
+     style="fill:#729fcf;fill-opacity:1;stroke:#0d0324;stroke-width:2.50001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     d="m 18.550108,61.250258 c 4.43586,0.09701 9.3144,-2.061146 14.63593,-6.473945 l 4.366056,4.613637 c 0.466586,0.493045 1.032066,0.614262 1.696497,0.364061 0.688282,-0.273708 1.03751,-0.759469 1.046541,-1.457925 l 0.829845,-17.875538 c 0.02034,-0.442612 -0.113848,-0.816106 -0.402643,-1.121278 -0.288877,-0.305258 -0.654413,-0.459727 -1.097237,-0.463654 L 21.730784,38.67955 c -0.43091,-0.01509 -0.810445,0.132693 -1.139626,0.44421 -0.146238,0.13839 -0.270757,0.311878 -0.373763,0.520542 -0.286407,0.649612 -0.197016,1.220796 0.269803,1.714086 l 4.182842,4.420033 c -2.106982,1.704541 -4.028902,2.939225 -5.766508,3.704646 C 17.166435,50.247864 15.5136,50.58264 13.94446,50.487485 10.294918,50.269492 6.5105477,47.564813 2.590594,42.37255 2.3256949,42.044414 1.9970894,41.977185 1.6033706,42.171819 1.555488,42.19447 1.4954292,42.240793 1.4222792,42.310017 1.1785117,42.540703 1.1024481,42.801809 1.1935459,43.093848 l 0.3009105,1.050389 c 0.1406611,0.49012 0.3966392,1.255013 0.7679046,2.294449 0.3718022,1.03956 0.7729408,2.0504 1.2052819,3.032319 0.4320256,0.98161 0.9640333,2.013571 1.5954771,3.096096 0.6319676,1.082684 1.2697067,1.96431 1.9139206,2.645055 3.7328644,3.944539 7.5904954,5.956866 11.5730674,6.038102 z"
+     id="path4228" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path5135"
+     d="m 37.47401,54.811209 c 0.201583,-4.340442 0.475225,-8.67263 0.597055,-13.023013 -4.453213,0.0073 -8.917572,-0.154929 -13.368156,-0.109742 1.429429,1.514929 2.85263,3.035869 4.298909,4.534782 -3.450946,2.882394 -7.068808,5.854247 -11.601125,6.953052 -3.213878,0.803162 -6.755015,-0.104883 -9.7492117,-1.775153 2.0784758,3.078757 5.1294937,5.738765 8.7325997,6.609146 3.330465,0.796917 6.641047,-0.274127 9.409199,-1.815831 2.32694,-1.19094 4.197153,-3.034433 6.463169,-4.311377 1.479192,-0.372261 3.025339,0.624738 3.916918,1.8634 0.434637,0.47459 0.854667,0.974381 1.282337,1.461779 0.0061,-0.129026 0.01224,-0.258064 0.01835,-0.38709 z"
+     style="fill:url(#linearGradient5137);fill-opacity:1.0;stroke:none;stroke-width:5.89736;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/src/Mod/Assembly/Gui/Resources/icons/Assembly_AssemblyLinkRigid.svg
+++ b/src/Mod/Assembly/Gui/Resources/icons/Assembly_AssemblyLinkRigid.svg
@@ -1,0 +1,354 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="64"
+   height="64"
+   version="1.1"
+   viewBox="0 0 64 64"
+   id="svg96"
+   sodipodi:docname="Assembly_AssemblyLinkRigid.svg"
+   inkscape:version="1.1-beta1 (77e7b44db3, 2021-03-28)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="1571"
+     id="namedview98"
+     showgrid="false"
+     inkscape:zoom="7.375"
+     inkscape:cx="-66.644068"
+     inkscape:cy="61.627119"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg96"
+     inkscape:pagecheckerboard="0" />
+  <defs
+     id="defs26">
+    <linearGradient
+       id="linearGradient4383">
+      <stop
+         stop-color="#3465a4"
+         offset="0"
+         id="stop2" />
+      <stop
+         stop-color="#729fcf"
+         offset="1"
+         id="stop4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4389"
+       x1="20.244"
+       x2="17.244"
+       y1="37.588"
+       y2="27.588"
+       gradientTransform="translate(-1.2435,-2.5881)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3774" />
+    <linearGradient
+       id="linearGradient4399"
+       x1="48.714"
+       x2="44.714"
+       y1="45.586"
+       y2="34.586"
+       gradientTransform="translate(1.2856,1.4142)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#c4a000"
+         offset="0"
+         id="stop8" />
+      <stop
+         stop-color="#edd400"
+         offset="1"
+         id="stop10" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient69042"
+       x1="48.714"
+       x2="44.714"
+       y1="45.586"
+       y2="34.586"
+       gradientTransform="translate(-12.714,-17.586)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3774" />
+    <linearGradient
+       id="linearGradient69056"
+       x1="27.244"
+       x2="22.244"
+       y1="54.588"
+       y2="40.588"
+       gradientTransform="translate(-1.2435,-2.5881)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#c4a000"
+         offset="0"
+         id="stop14" />
+      <stop
+         stop-color="#fce94f"
+         offset="1"
+         id="stop16" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient69709"
+       x1="20.243999"
+       x2="17.243999"
+       y1="37.588001"
+       y2="27.587999"
+       gradientTransform="matrix(1,-0.026667,0,1,21.696,-5.3735)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3774" />
+    <linearGradient
+       id="linearGradient69717"
+       x1="50.714001"
+       x2="48.714001"
+       y1="25.586"
+       y2="20.586"
+       gradientTransform="translate(1.2256,1.0356)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3774" />
+    <linearGradient
+       id="linearGradient3774">
+      <stop
+         stop-color="#4e9a06"
+         offset="0"
+         id="stop21" />
+      <stop
+         stop-color="#8ae234"
+         offset="1"
+         id="stop23" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient69056"
+       id="linearGradient920"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.2435,-2.5881)"
+       x1="20.243999"
+       y1="37.588001"
+       x2="17.243999"
+       y2="27.587999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4399"
+       id="linearGradient922"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-12.714,-17.586)"
+       x1="48.714001"
+       y1="45.585999"
+       x2="44.714001"
+       y2="34.585999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4383"
+       id="linearGradient5137"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.06404665,0.06060973,-0.05836811,-0.06167792,58.951461,44.497067)"
+       x1="288.11227"
+       y1="358.15811"
+       x2="372.52457"
+       y2="7.5416322" />
+  </defs>
+  <metadata
+     id="metadata28">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Path-Stock</dc:title>
+        <dc:date>2015-07-04</dc:date>
+        <dc:relation>https://www.freecad.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Path/Gui/Resources/icons/Path-Stock.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g40"
+     style="stroke-width:2">
+    <path
+       d="M 9,49 V 35 l 28,10 v 14 z"
+       id="path30"
+       style="fill:url(#linearGradient69056);stroke:#302b00;stroke-linejoin:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 37,59 V 45 L 55,28 v 13 z"
+       id="path32"
+       style="fill:url(#linearGradient4399);stroke:#302b00;stroke-linejoin:round"
+       inkscape:connector-curvature="0" />
+    <path
+       d="M 11.008,47.606 11,37.9997 l 24,8 0.0081,10.185 z"
+       id="path34"
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#fce94f" />
+    <path
+       d="M 39.005,54.168 39,45.9998 l 14,-13 0.0021,7.1768 z"
+       id="path36"
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#edd400" />
+    <path
+       d="M 23,40 42,23 55,28 37,45 Z"
+       id="path38"
+       inkscape:connector-curvature="0"
+       style="fill:#fce94f;stroke:#302b00;stroke-linejoin:round" />
+  </g>
+  <path
+     d="m 31,33.5 -0.02739,-14.214 12.967,4.3352 v 14.5 z"
+     id="path54"
+     style="fill:url(#linearGradient69709);stroke:#0b1521;stroke-width:2;stroke-linejoin:round;fill-opacity:1.0"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 32.927,32.029 0.04731,-10.141 8.9272,3.29 0.0781,10.042 z"
+     id="path56"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#fce94f;stroke-width:2;stroke-opacity:1" />
+  <path
+     d="m 43.94,38.121 v -14.5 l 11,-9 L 55,28 Z"
+     id="path58"
+     style="fill:url(#linearGradient69717);stroke:#0b1521;stroke-width:2;stroke-linejoin:round;fill-opacity:1.0"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 45.94,33.621 v -9 l 7,-6 -0.0122,8.5816 z"
+     id="path60"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#fce94f;stroke-width:2;stroke-opacity:1" />
+  <path
+     d="M 30.973,19.286 42,9.9998 l 12.94,4.6214 -11,9 z"
+     id="path62"
+     inkscape:connector-curvature="0"
+     style="fill:#fce94f;stroke:#0b1521;stroke-width:2;stroke-linejoin:round;fill-opacity:1" />
+  <g
+     display="none"
+     fill="#ef2929"
+     fill-rule="evenodd"
+     opacity=".588"
+     stroke="#ef2929"
+     stroke-width="1px"
+     id="g94">
+    <path
+       d="m9 35v14"
+       id="path66" />
+    <path
+       d="m9 35 28 10"
+       id="path68" />
+    <path
+       d="m55 28v13"
+       id="path70" />
+    <path
+       d="m37 45 18-17"
+       id="path72" />
+    <path
+       d="m23 40v-14"
+       id="path74" />
+    <path
+       d="m29 5 13 5"
+       id="path76" />
+    <path
+       d="m23 26 19-16"
+       id="path78" />
+    <path
+       d="m19 13 10-8"
+       id="path80" />
+    <path
+       d="m55 15-9 8"
+       id="path82" />
+    <path
+       d="m42 23v-13"
+       id="path84" />
+    <path
+       d="m42 23 14 5"
+       id="path86" />
+    <path
+       d="m23 40 19-17"
+       id="path88" />
+    <path
+       d="m23 10h19"
+       id="path90" />
+    <path
+       d="m34 17v13"
+       id="path92" />
+  </g>
+  <g
+     style="stroke:#172a04;stroke-width:2;stroke-linejoin:round"
+     id="g48">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient4389)"
+       id="path42"
+       d="M 9,35 V 21 l 14,5 v 14 z" />
+    <path
+       style="fill:#8ae234"
+       inkscape:connector-curvature="0"
+       id="path44"
+       d="M 9,21 28.585,5.209 42,10.0001 l -19,16 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient69042)"
+       id="path46"
+       d="M 23,40 V 26 l 7.9726,-6.7138 0.02739,13.714 z" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient920);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linejoin:round"
+     id="path912"
+     d="M 9,35 V 21 l 14,5 v 14 z" />
+  <path
+     style="fill:#fce94f;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linejoin:round;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     id="path914"
+     d="M 9,21 28.585,5.209 42,10.0001 l -19,16 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient922);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linejoin:round"
+     id="path916"
+     d="M 23,40 V 26 l 7.9726,-6.7138 0.02739,13.714 z" />
+  <path
+     d="m 25,36 v -9 l 4,-3.5 v 9 z"
+     id="path50"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#fce94f;stroke-width:2;stroke-opacity:1" />
+  <path
+     d="m 10.951,33.746 0.08695,-9.9796 9.9568,3.5229 -0.02105,9.9613 z"
+     id="path52"
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:#fce94f;stroke-width:2;stroke-opacity:1" />
+  <path
+     style="fill:#729fcf;fill-opacity:1;stroke:#0d0324;stroke-width:2.50001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     d="m 18.550108,61.250258 c 4.43586,0.09701 9.3144,-2.061146 14.63593,-6.473945 l 4.366056,4.613637 c 0.466586,0.493045 1.032066,0.614262 1.696497,0.364061 0.688282,-0.273708 1.03751,-0.759469 1.046541,-1.457925 l 0.829845,-17.875538 c 0.02034,-0.442612 -0.113848,-0.816106 -0.402643,-1.121278 -0.288877,-0.305258 -0.654413,-0.459727 -1.097237,-0.463654 L 21.730784,38.67955 c -0.43091,-0.01509 -0.810445,0.132693 -1.139626,0.44421 -0.146238,0.13839 -0.270757,0.311878 -0.373763,0.520542 -0.286407,0.649612 -0.197016,1.220796 0.269803,1.714086 l 4.182842,4.420033 c -2.106982,1.704541 -4.028902,2.939225 -5.766508,3.704646 C 17.166435,50.247864 15.5136,50.58264 13.94446,50.487485 10.294918,50.269492 6.5105477,47.564813 2.590594,42.37255 2.3256949,42.044414 1.9970894,41.977185 1.6033706,42.171819 1.555488,42.19447 1.4954292,42.240793 1.4222792,42.310017 1.1785117,42.540703 1.1024481,42.801809 1.1935459,43.093848 l 0.3009105,1.050389 c 0.1406611,0.49012 0.3966392,1.255013 0.7679046,2.294449 0.3718022,1.03956 0.7729408,2.0504 1.2052819,3.032319 0.4320256,0.98161 0.9640333,2.013571 1.5954771,3.096096 0.6319676,1.082684 1.2697067,1.96431 1.9139206,2.645055 3.7328644,3.944539 7.5904954,5.956866 11.5730674,6.038102 z"
+     id="path4228" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path5135"
+     d="m 37.47401,54.811209 c 0.201583,-4.340442 0.475225,-8.67263 0.597055,-13.023013 -4.453213,0.0073 -8.917572,-0.154929 -13.368156,-0.109742 1.429429,1.514929 2.85263,3.035869 4.298909,4.534782 -3.450946,2.882394 -7.068808,5.854247 -11.601125,6.953052 -3.213878,0.803162 -6.755015,-0.104883 -9.7492117,-1.775153 2.0784758,3.078757 5.1294937,5.738765 8.7325997,6.609146 3.330465,0.796917 6.641047,-0.274127 9.409199,-1.815831 2.32694,-1.19094 4.197153,-3.034433 6.463169,-4.311377 1.479192,-0.372261 3.025339,0.624738 3.916918,1.8634 0.434637,0.47459 0.854667,0.974381 1.282337,1.461779 0.0061,-0.129026 0.01224,-0.258064 0.01835,-0.38709 z"
+     style="fill:url(#linearGradient5137);fill-opacity:1.0;stroke:none;stroke-width:5.89736;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/src/Mod/Assembly/Gui/Resources/panels/TaskAssemblyCreateJoint.ui
+++ b/src/Mod/Assembly/Gui/Resources/panels/TaskAssemblyCreateJoint.ui
@@ -82,52 +82,121 @@
     </layout>
    </item>
    <item row="4" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="hLayout">
-     <item>
-      <widget class="QLabel" name="offsetLabel">
-       <property name="text">
-        <string>Offset</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="Gui::QuantitySpinBox" name="offsetSpinbox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="unit" stdset="0">
-        <string notr="true">mm</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="hLayoutRotation">
-     <item>
-      <widget class="QLabel" name="rotationLabel">
-       <property name="text">
-        <string>Rotation</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="Gui::QuantitySpinBox" name="rotationSpinbox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="unit" stdset="0">
-        <string notr="true">deg</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    <widget class="QGroupBox" name="groupBox_offsets">
+     <property name="title">
+      <string>Attachement offsets</string>
+     </property>
+     <layout class="QVBoxLayout" name="layout_offset_group">
+      <item>
+       <widget class="QTabWidget" name="offsetTabs">
+        <widget class="QWidget" name="tabSimple">
+         <attribute name="title">
+          <string>Simple</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="layout_tabSimple">
+          <item>
+           <layout class="QHBoxLayout" name="hLayout">
+            <item>
+             <widget class="QLabel" name="offsetLabel">
+              <property name="text">
+               <string>Offset</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Gui::QuantitySpinBox" name="offsetSpinbox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="unit" stdset="0">
+               <string notr="true">mm</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="hLayoutRotation">
+            <item>
+             <widget class="QLabel" name="rotationLabel">
+              <property name="text">
+               <string>Rotation</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Gui::QuantitySpinBox" name="rotationSpinbox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="unit" stdset="0">
+               <string notr="true">deg</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="tabAdvanced">
+         <attribute name="title">
+          <string>Advanced</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="layout_tabAdvanced">
+          <item>
+           <layout class="QHBoxLayout" name="hLayoutOffset1">
+            <item>
+             <widget class="QLabel" name="offset1Label">
+              <property name="text">
+               <string>Offset1</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="offset1Button">
+              <property name="toolTip">
+               <string>By clicking this button, you can set the attachement offset of the first marker (coordinate system) of the joint.</string>
+              </property>
+              <property name="text">
+               <string></string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="hLayoutOffset2">
+            <item>
+             <widget class="QLabel" name="offset2Label">
+              <property name="text">
+               <string>Offset2</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="offset2Button">
+              <property name="toolTip">
+               <string>By clicking this button, you can set the attachement offset of the second marker (coordinate system) of the joint.</string>
+              </property>
+              <property name="text">
+               <string></string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item row="6" column="0">
     <widget class="QToolButton" name="PushButtonReverse">

--- a/src/Mod/Assembly/Gui/Resources/panels/TaskAssemblyInsertLink.ui
+++ b/src/Mod/Assembly/Gui/Resources/panels/TaskAssemblyInsertLink.ui
@@ -68,6 +68,28 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="0">
+    <widget class="Gui::PrefCheckBox" name="CheckBox_RigidSubAsm">
+     <property name="toolTip">
+      <string>If checked, the inserted sub-assemblies will not be flexible.
+Rigid means that the sub-assembly will be considered as a solid.
+Flexible means that the sub-assembly joints will be taken into account in the main assembly.
+You can change this property of sub-assemblies at any time by right clicking them.</string>
+     </property>
+     <property name="text">
+      <string>Rigid sub-assemblies</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="prefEntry" stdset="0">
+      <cstring>InsertRigidSubAssemblies</cstring>
+     </property>
+     <property name="prefPath" stdset="0">
+      <cstring>Mod/Assembly</cstring>
+     </property>
+    </widget>
+   </item>
    </layout>
  </widget>
  <customwidgets>

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -63,6 +63,7 @@
 #include <Mod/Assembly/App/AssemblyUtils.h>
 #include <Mod/Assembly/App/JointGroup.h>
 #include <Mod/Assembly/App/ViewGroup.h>
+#include <Mod/Assembly/App/BomGroup.h>
 #include <Mod/PartDesign/App/Body.h>
 
 #include "ViewProviderAssembly.h"
@@ -1024,7 +1025,7 @@ bool ViewProviderAssembly::onDelete(const std::vector<std::string>& subNames)
     for (auto obj : getObject()->getOutList()) {
         if (obj->getTypeId() == Assembly::JointGroup::getClassTypeId()
             || obj->getTypeId() == Assembly::ViewGroup::getClassTypeId()
-            /* || obj->getTypeId() == Assembly::BomGroup::getClassTypeId()*/) {
+            || obj->getTypeId() == Assembly::BomGroup::getClassTypeId()) {
 
             // Delete the group content first.
             Gui::Command::doCommand(Gui::Command::Doc,

--- a/src/Mod/Assembly/Gui/ViewProviderAssemblyLink.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssemblyLink.cpp
@@ -1,0 +1,150 @@
+﻿// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#include <QAction>
+#include <QMenu>
+#include <vector>
+#include <sstream>
+#include <iostream>
+#endif
+
+#include <App/Link.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/Part.h>
+
+#include <Gui/ActionFunction.h>
+#include <Gui/Application.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/CommandT.h>
+#include <Gui/MainWindow.h>
+
+#include <Mod/Assembly/App/AssemblyObject.h>
+#include <Mod/Assembly/App/AssemblyLink.h>
+
+#include "ViewProviderAssembly.h"
+#include "ViewProviderAssemblyLink.h"
+
+
+using namespace Assembly;
+using namespace AssemblyGui;
+
+
+PROPERTY_SOURCE(AssemblyGui::ViewProviderAssemblyLink, Gui::ViewProviderPart)
+
+ViewProviderAssemblyLink::ViewProviderAssemblyLink()
+{}
+
+ViewProviderAssemblyLink::~ViewProviderAssemblyLink() = default;
+
+QIcon ViewProviderAssemblyLink::getIcon() const
+{
+    auto* assembly = dynamic_cast<Assembly::AssemblyLink*>(getObject());
+    if (assembly->isRigid()) {
+        return Gui::BitmapFactory().pixmap("Assembly_AssemblyLinkRigid.svg");
+    }
+    else {
+        return Gui::BitmapFactory().pixmap("Assembly_AssemblyLink.svg");
+    }
+}
+
+bool ViewProviderAssemblyLink::setEdit(int mode)
+{
+    auto* assemblyLink = dynamic_cast<Assembly::AssemblyLink*>(getObject());
+
+    if (!assemblyLink->isRigid() && mode == (int)ViewProvider::Transform) {
+        Base::Console().UserTranslatedNotification(
+            "Flexible sub-assemblies cannot be transformed.");
+        return true;
+    }
+
+    return ViewProviderPart::setEdit(mode);
+}
+
+bool ViewProviderAssemblyLink::doubleClicked()
+{
+    auto* link = dynamic_cast<AssemblyLink*>(getObject());
+
+    if (!link) {
+        return true;
+    }
+    auto* assembly = link->getLinkedAssembly();
+
+    auto* vpa =
+        dynamic_cast<ViewProviderAssembly*>(Gui::Application::Instance->getViewProvider(assembly));
+    if (!vpa) {
+        return true;
+    }
+
+    return vpa->doubleClicked();
+}
+
+bool ViewProviderAssemblyLink::onDelete(const std::vector<std::string>& subNames)
+{
+    Q_UNUSED(subNames)
+
+    Base::Console().Warning("onDelete\n");
+
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            "App.getDocument(\"%s\").getObject(\"%s\").removeObjectsFromDocument()",
+                            getObject()->getDocument()->getName(),
+                            getObject()->getNameInDocument());
+
+    // getObject()->purgeTouched();
+
+    return ViewProviderPart::onDelete(subNames);
+}
+
+void ViewProviderAssemblyLink::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
+{
+    auto func = new Gui::ActionFunction(menu);
+    QAction* act;
+    auto* assemblyLink = dynamic_cast<Assembly::AssemblyLink*>(getObject());
+    if (assemblyLink->isRigid()) {
+        act = menu->addAction(QObject::tr("Turn flexible"));
+        act->setToolTip(QObject::tr(
+            "Your sub-assembly is currently rigid. This will make it flexible instead."));
+    }
+    else {
+        act = menu->addAction(QObject::tr("Turn rigid"));
+        act->setToolTip(QObject::tr(
+            "Your sub-assembly is currently flexible. This will make it rigid instead."));
+    }
+
+    func->trigger(act, [this]() {
+        auto* assemblyLink = dynamic_cast<Assembly::AssemblyLink*>(getObject());
+        Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Toggle Rigid"));
+        Gui::cmdAppObjectArgs(assemblyLink,
+                              "Rigid = %s",
+                              assemblyLink->Rigid.getValue() ? "False" : "True");
+
+        Gui::Command::commitCommand();
+        Gui::Selection().clearSelection();
+    });
+
+    Q_UNUSED(receiver)
+    Q_UNUSED(member)
+}

--- a/src/Mod/Assembly/Gui/ViewProviderJointGroup.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderJointGroup.cpp
@@ -47,10 +47,3 @@ QIcon ViewProviderJointGroup::getIcon() const
 {
     return Gui::BitmapFactory().pixmap("Assembly_JointGroup.svg");
 }
-
-// Make the joint group impossible to delete.
-bool ViewProviderJointGroup::onDelete(const std::vector<std::string>& subNames)
-{
-    Q_UNUSED(subNames);
-    return false;
-}

--- a/src/Mod/Assembly/Gui/ViewProviderJointGroup.h
+++ b/src/Mod/Assembly/Gui/ViewProviderJointGroup.h
@@ -57,7 +57,11 @@ public:
         return false;
     };
 
-    bool onDelete(const std::vector<std::string>& subNames) override;
+    // Make the joint group impossible to delete.
+    bool onDelete(const std::vector<std::string>&) override
+    {
+        return false;
+    };
 
     // protected:
     /// get called by the container whenever a property has been changed

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -40,6 +40,8 @@ from pivy import coin
 import UtilsAssembly
 import Preferences
 
+from SoSwitchMarker import SoSwitchMarker
+
 translate = App.Qt.translate
 
 TranslatedJointTypes = [
@@ -792,133 +794,17 @@ class ViewProviderJoint:
 
     def attach(self, vobj):
         """Setup the scene sub-graph of the view provider, this method is mandatory"""
-        self.axis_thickness = 3
-        self.scaleFactor = 20
-
-        view_params = App.ParamGet("User parameter:BaseApp/Preferences/View")
-        param_x_axis_color = view_params.GetUnsigned("AxisXColor", 0xCC333300)
-        param_y_axis_color = view_params.GetUnsigned("AxisYColor", 0x33CC3300)
-        param_z_axis_color = view_params.GetUnsigned("AxisZColor", 0x3333CC00)
-
-        self.x_axis_so_color = coin.SoBaseColor()
-        self.x_axis_so_color.rgb.setValue(UtilsAssembly.color_from_unsigned(param_x_axis_color))
-        self.y_axis_so_color = coin.SoBaseColor()
-        self.y_axis_so_color.rgb.setValue(UtilsAssembly.color_from_unsigned(param_y_axis_color))
-        self.z_axis_so_color = coin.SoBaseColor()
-        self.z_axis_so_color.rgb.setValue(UtilsAssembly.color_from_unsigned(param_z_axis_color))
-
         self.app_obj = vobj.Object
-        app_doc = self.app_obj.Document
-        self.gui_doc = Gui.getDocument(app_doc)
 
-        self.transform1 = coin.SoTransform()
-        self.transform2 = coin.SoTransform()
-        self.transform3 = coin.SoTransform()
-
-        self.draw_style = coin.SoDrawStyle()
-        self.draw_style.style = coin.SoDrawStyle.LINES
-        self.draw_style.lineWidth = self.axis_thickness
-
-        self.switch_JCS1 = self.JCS_sep(self.transform1)
-        self.switch_JCS2 = self.JCS_sep(self.transform2)
-        self.switch_JCS_preview = self.JCS_sep(self.transform3)
-
-        self.pick = coin.SoPickStyle()
-        self.setPickableState(True)
+        self.switch_JCS1 = SoSwitchMarker(vobj)
+        self.switch_JCS2 = SoSwitchMarker(vobj)
+        self.switch_JCS_preview = SoSwitchMarker(vobj)
 
         self.display_mode = coin.SoType.fromName("SoFCSelection").createInstance()
-        self.display_mode.addChild(self.pick)
         self.display_mode.addChild(self.switch_JCS1)
         self.display_mode.addChild(self.switch_JCS2)
         self.display_mode.addChild(self.switch_JCS_preview)
         vobj.addDisplayMode(self.display_mode, "Wireframe")
-
-    def JCS_sep(self, soTransform):
-        JCS = coin.SoAnnotation()
-        JCS.addChild(soTransform)
-
-        base_plane_sep = self.plane_sep(0.4, 15)
-        X_axis_sep = self.line_sep([0.5, 0, 0], [1, 0, 0], self.x_axis_so_color)
-        Y_axis_sep = self.line_sep([0, 0.5, 0], [0, 1, 0], self.y_axis_so_color)
-        Z_axis_sep = self.line_sep([0, 0, 0], [0, 0, 1], self.z_axis_so_color)
-
-        JCS.addChild(base_plane_sep)
-        JCS.addChild(X_axis_sep)
-        JCS.addChild(Y_axis_sep)
-        JCS.addChild(Z_axis_sep)
-
-        switch_JCS = coin.SoSwitch()
-        switch_JCS.addChild(JCS)
-        switch_JCS.whichChild = coin.SO_SWITCH_NONE
-
-        return switch_JCS
-
-    def line_sep(self, startPoint, endPoint, soColor):
-        line = coin.SoLineSet()
-        line.numVertices.setValue(2)
-        coords = coin.SoCoordinate3()
-        coords.point.setValues(0, [startPoint, endPoint])
-
-        axis_sep = coin.SoAnnotation()
-        axis_sep.addChild(self.draw_style)
-        axis_sep.addChild(soColor)
-        axis_sep.addChild(coords)
-        axis_sep.addChild(line)
-
-        scale = coin.SoType.fromName("SoShapeScale").createInstance()
-        scale.setPart("shape", axis_sep)
-        scale.scaleFactor = self.scaleFactor
-
-        return scale
-
-    def plane_sep(self, size, num_vertices):
-        coords = coin.SoCoordinate3()
-
-        for i in range(num_vertices):
-            angle = float(i) / num_vertices * 2.0 * math.pi
-            x = math.cos(angle) * size
-            y = math.sin(angle) * size
-            coords.point.set1Value(i, x, y, 0)
-
-        face = coin.SoFaceSet()
-        face.numVertices.setValue(num_vertices)
-
-        transform = coin.SoTransform()
-        transform.translation.setValue(0, 0, 0)
-
-        draw_style = coin.SoDrawStyle()
-        draw_style.style = coin.SoDrawStyle.FILLED
-
-        material = coin.SoMaterial()
-        material.diffuseColor.setValue([0.5, 0.5, 0.5])
-        material.ambientColor.setValue([0.5, 0.5, 0.5])
-        material.specularColor.setValue([0.5, 0.5, 0.5])
-        material.emissiveColor.setValue([0.5, 0.5, 0.5])
-        material.transparency.setValue(0.3)
-
-        face_sep = coin.SoAnnotation()
-        face_sep.addChild(transform)
-        face_sep.addChild(draw_style)
-        face_sep.addChild(material)
-        face_sep.addChild(coords)
-        face_sep.addChild(face)
-
-        scale = coin.SoType.fromName("SoShapeScale").createInstance()
-        scale.setPart("shape", face_sep)
-        scale.scaleFactor = self.scaleFactor
-
-        return scale
-
-    def set_JCS_placement(self, soTransform, placement, ref):
-        # change plc to be relative to the origin of the document.
-        global_plc = UtilsAssembly.getGlobalPlacement(ref)
-        placement = global_plc * placement
-
-        t = placement.Base
-        soTransform.translation.setValue(t.x, t.y, t.z)
-
-        r = placement.Rotation.Q
-        soTransform.rotation.setValue(r[0], r[1], r[2], r[3])
 
     def updateData(self, joint, prop):
         """If a property of the handled feature has changed we have the chance to handle this here"""
@@ -928,7 +814,7 @@ class ViewProviderJoint:
                 plc = joint.Placement1
                 self.switch_JCS1.whichChild = coin.SO_SWITCH_ALL
 
-                self.set_JCS_placement(self.transform1, plc, joint.Reference1)
+                self.switch_JCS1.set_marker_placement(plc, joint.Reference1)
             else:
                 self.switch_JCS1.whichChild = coin.SO_SWITCH_NONE
 
@@ -937,23 +823,22 @@ class ViewProviderJoint:
                 plc = joint.Placement2
                 self.switch_JCS2.whichChild = coin.SO_SWITCH_ALL
 
-                self.set_JCS_placement(self.transform2, plc, joint.Reference2)
+                self.switch_JCS2.set_marker_placement(plc, joint.Reference2)
             else:
                 self.switch_JCS2.whichChild = coin.SO_SWITCH_NONE
 
     def showPreviewJCS(self, visible, placement=None, ref=None):
         if visible:
             self.switch_JCS_preview.whichChild = coin.SO_SWITCH_ALL
-            self.set_JCS_placement(self.transform3, placement, ref)
+            self.switch_JCS_preview.set_marker_placement(placement, ref)
         else:
             self.switch_JCS_preview.whichChild = coin.SO_SWITCH_NONE
 
     def setPickableState(self, state: bool):
         """Set JCS selectable or unselectable in 3D view"""
-        if not state:
-            self.pick.style.setValue(coin.SoPickStyle.UNPICKABLE)
-        else:
-            self.pick.style.setValue(coin.SoPickStyle.SHAPE_ON_TOP)
+        self.switch_JCS1.setPickableState(state)
+        self.switch_JCS2.setPickableState(state)
+        self.switch_JCS_preview.setPickableState(state)
 
     def getDisplayModes(self, obj):
         """Return a list of display modes."""
@@ -968,15 +853,10 @@ class ViewProviderJoint:
     def onChanged(self, vp, prop):
         """Here we can do something when a single property got changed"""
         # App.Console.PrintMessage("Change property: " + str(prop) + "\n")
-        if prop == "color_X_axis":
-            c = vp.getPropertyByName("color_X_axis")
-            self.x_axis_so_color.rgb.setValue(c[0], c[1], c[2])
-        if prop == "color_Y_axis":
-            c = vp.getPropertyByName("color_Y_axis")
-            self.x_axis_so_color.rgb.setValue(c[0], c[1], c[2])
-        if prop == "color_Z_axis":
-            c = vp.getPropertyByName("color_Z_axis")
-            self.x_axis_so_color.rgb.setValue(c[0], c[1], c[2])
+        if prop == "color_X_axis" or prop == "color_Y_axis" or prop == "color_Z_axis":
+            self.switch_JCS1.onChanged(vp, prop)
+            self.switch_JCS2.onChanged(vp, prop)
+            self.switch_JCS_preview.onChanged(vp, prop)
 
     def getIcon(self):
         if self.app_obj.JointType == "Fixed":
@@ -1033,7 +913,10 @@ class ViewProviderJoint:
             self.gui_doc.setEdit(assembly)
 
         panel = TaskAssemblyCreateJoint(0, vobj.Object)
-        Gui.Control.showDialog(panel)
+        dialog = Gui.Control.showDialog(panel)
+        if dialog is not None:
+            dialog.setAutoCloseOnTransactionChange(True)
+            dialog.setDocumentName(App.ActiveDocument.Name)
 
         return True
 
@@ -1377,7 +1260,7 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
             # before handleInitialSelection tries to solve.
             self.handleInitialSelection()
 
-        self.setJointsPickableState(False)
+        UtilsAssembly.setJointsPickableState(self.doc, False)
 
         Gui.Selection.addSelectionGate(
             MakeJointSelGate(self, self.assembly), Gui.Selection.ResolveMode.NoResolve
@@ -1438,7 +1321,7 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
         Gui.Selection.clearSelection()
         self.view.removeEventCallback("SoLocation2Event", self.callbackMove)
         self.view.removeEventCallback("SoKeyboardEvent", self.callbackKey)
-        self.setJointsPickableState(True)
+        UtilsAssembly.setJointsPickableState(self.doc, True)
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
 
@@ -1783,7 +1666,7 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
 
         # newPos = self.view.getPoint(*info["Position"]) is not OK: it's not pos on the object but on the focal plane
         newPos = App.Vector(cursor_info["x"], cursor_info["y"], cursor_info["z"])
-        vertex_name = UtilsAssembly.findElementClosestVertex(self.assembly, ref, newPos)
+        vertex_name = UtilsAssembly.findElementClosestVertex(ref, newPos)
 
         ref = UtilsAssembly.addVertexToReference(ref, vertex_name)
 
@@ -1857,7 +1740,7 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
         # Selection is acceptable so add it
 
         mousePos = App.Vector(mousePos[0], mousePos[1], mousePos[2])
-        vertex_name = UtilsAssembly.findElementClosestVertex(self.assembly, ref, mousePos)
+        vertex_name = UtilsAssembly.findElementClosestVertex(ref, mousePos)
 
         # add the vertex name to the reference
         ref = UtilsAssembly.addVertexToReference(ref, vertex_name)
@@ -1895,15 +1778,3 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
     def clearSelection(self, doc_name):
         self.refs.clear()
         self.updateJoint()
-
-    def setJointsPickableState(self, state: bool):
-        """Make all joints in assembly selectable (True) or unselectable (False) in 3D view"""
-        if self.activeType == "Assembly":
-            jointGroup = UtilsAssembly.getJointGroup(self.assembly)
-            for joint in jointGroup.Group:
-                if hasattr(joint, "JointType"):
-                    joint.ViewObject.Proxy.setPickableState(state)
-        else:
-            for obj in self.assembly.OutList:
-                if obj.TypeId == "App::FeaturePython" and hasattr(obj, "JointType"):
-                    obj.ViewObject.Proxy.setPickableState(state)

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -1288,6 +1288,7 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
 
         global activeTask
         activeTask = self
+        self.blockOffsetRotation = False
 
         self.assembly = UtilsAssembly.activeAssembly()
         if not self.assembly:
@@ -1324,7 +1325,8 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
         self.form.distanceSpinbox2.valueChanged.connect(self.onDistance2Changed)
         self.form.offsetSpinbox.valueChanged.connect(self.onOffsetChanged)
         self.form.rotationSpinbox.valueChanged.connect(self.onRotationChanged)
-        self.form.PushButtonReverse.clicked.connect(self.onReverseClicked)
+        self.form.offset1Button.clicked.connect(self.onOffset1Clicked)
+        self.form.offset2Button.clicked.connect(self.onOffset2Clicked)
 
         self.form.limitCheckbox1.stateChanged.connect(self.adaptUi)
         self.form.limitCheckbox2.stateChanged.connect(self.adaptUi)
@@ -1337,6 +1339,8 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
 
         self.form.reverseRotCheckbox.setChecked(self.jType == "Gears")
         self.form.reverseRotCheckbox.stateChanged.connect(self.reverseRotToggled)
+
+        self.form.offsetTabs.currentChanged.connect(self.on_offset_tab_changed)
 
         if jointObj:
             Gui.Selection.clearSelection()
@@ -1502,9 +1506,15 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
         self.joint.Distance2 = self.form.distanceSpinbox2.property("rawValue")
 
     def onOffsetChanged(self, quantity):
+        if self.blockOffsetRotation:
+            return
+
         self.joint.Offset2.Base = App.Vector(0, 0, self.form.offsetSpinbox.property("rawValue"))
 
     def onRotationChanged(self, quantity):
+        if self.blockOffsetRotation:
+            return
+
         yaw = self.form.rotationSpinbox.property("rawValue")
         ypr = self.joint.Offset2.Rotation.getYawPitchRoll()
         self.joint.Offset2.Rotation.setYawPitchRoll(yaw, ypr[1], ypr[2])
@@ -1644,6 +1654,34 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
 
         else:
             self.form.groupBox_limits.hide()
+
+        self.updateOffsetWidgets()
+
+    def updateOffsetWidgets(self):
+        # Makes sure the values in both the simplified and advanced tabs are sync.
+        pos = self.joint.Offset1.Base
+        self.form.offset1Button.setText(f"({pos.x}, {pos.y}, {pos.z})")
+
+        pos = self.joint.Offset2.Base
+        self.form.offset2Button.setText(f"({pos.x}, {pos.y}, {pos.z})")
+
+        self.blockOffsetRotation = True
+        self.form.offsetSpinbox.setProperty("rawValue", pos.z)
+        self.form.rotationSpinbox.setProperty(
+            "rawValue", self.joint.Offset2.Rotation.getYawPitchRoll()[0]
+        )
+        self.blockOffsetRotation = False
+
+    def on_offset_tab_changed(self):
+        self.updateOffsetWidgets()
+
+    def onOffset1Clicked(self):
+        UtilsAssembly.openEditingPlacementDialog(self.joint, "Offset1")
+        self.updateOffsetWidgets()
+
+    def onOffset2Clicked(self):
+        UtilsAssembly.openEditingPlacementDialog(self.joint, "Offset2")
+        self.updateOffsetWidgets()
 
     def updateTaskboxFromJoint(self):
         self.refs = []

--- a/src/Mod/Assembly/SoSwitchMarker.py
+++ b/src/Mod/Assembly/SoSwitchMarker.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# /**************************************************************************
+#                                                                           *
+#    Copyright (c) 2024 Ondsel <development@ondsel.com>                     *
+#                                                                           *
+#    This file is part of FreeCAD.                                          *
+#                                                                           *
+#    FreeCAD is free software: you can redistribute it and/or modify it     *
+#    under the terms of the GNU Lesser General Public License as            *
+#    published by the Free Software Foundation, either version 2.1 of the   *
+#    License, or (at your option) any later version.                        *
+#                                                                           *
+#    FreeCAD is distributed in the hope that it will be useful, but         *
+#    WITHOUT ANY WARRANTY; without even the implied warranty of             *
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+#    Lesser General Public License for more details.                        *
+#                                                                           *
+#    You should have received a copy of the GNU Lesser General Public       *
+#    License along with FreeCAD. If not, see                                *
+#    <https://www.gnu.org/licenses/>.                                       *
+#                                                                           *
+# **************************************************************************/
+
+import math
+
+import FreeCAD as App
+
+
+if App.GuiUp:
+    import FreeCADGui as Gui
+
+__title__ = "Assembly Marker Inventor object"
+__author__ = "Ondsel"
+__url__ = "https://www.freecad.org"
+
+from pivy import coin
+import UtilsAssembly
+import Preferences
+
+
+class SoSwitchMarker(coin.SoSwitch):
+    def __init__(self, vobj):
+        super().__init__()  # Initialize the SoSwitch base class
+
+        self.axis_thickness = 3
+        self.scaleFactor = 20
+
+        view_params = App.ParamGet("User parameter:BaseApp/Preferences/View")
+        param_x_axis_color = view_params.GetUnsigned("AxisXColor", 0xCC333300)
+        param_y_axis_color = view_params.GetUnsigned("AxisYColor", 0x33CC3300)
+        param_z_axis_color = view_params.GetUnsigned("AxisZColor", 0x3333CC00)
+
+        self.x_axis_so_color = coin.SoBaseColor()
+        self.x_axis_so_color.rgb.setValue(UtilsAssembly.color_from_unsigned(param_x_axis_color))
+        self.y_axis_so_color = coin.SoBaseColor()
+        self.y_axis_so_color.rgb.setValue(UtilsAssembly.color_from_unsigned(param_y_axis_color))
+        self.z_axis_so_color = coin.SoBaseColor()
+        self.z_axis_so_color.rgb.setValue(UtilsAssembly.color_from_unsigned(param_z_axis_color))
+
+        self.app_obj = vobj.Object
+        app_doc = self.app_obj.Document
+        self.gui_doc = Gui.getDocument(app_doc)
+
+        self.transform = coin.SoTransform()
+
+        self.draw_style = coin.SoDrawStyle()
+        self.draw_style.style = coin.SoDrawStyle.LINES
+        self.draw_style.lineWidth = self.axis_thickness
+
+        self.pick = coin.SoPickStyle()
+        self.setPickableState(True)
+
+        JCS = coin.SoAnnotation()
+        JCS.addChild(self.transform)
+        JCS.addChild(self.pick)
+
+        base_plane_sep = self.plane_sep(0.4, 15)
+        X_axis_sep = self.line_sep([0.5, 0, 0], [1, 0, 0], self.x_axis_so_color)
+        Y_axis_sep = self.line_sep([0, 0.5, 0], [0, 1, 0], self.y_axis_so_color)
+        Z_axis_sep = self.line_sep([0, 0, 0], [0, 0, 1], self.z_axis_so_color)
+
+        JCS.addChild(base_plane_sep)
+        JCS.addChild(X_axis_sep)
+        JCS.addChild(Y_axis_sep)
+        JCS.addChild(Z_axis_sep)
+
+        switch_JCS = coin.SoSwitch()
+        self.addChild(JCS)
+        self.whichChild = coin.SO_SWITCH_NONE
+
+    def line_sep(self, startPoint, endPoint, soColor):
+        line = coin.SoLineSet()
+        line.numVertices.setValue(2)
+        coords = coin.SoCoordinate3()
+        coords.point.setValues(0, [startPoint, endPoint])
+
+        axis_sep = coin.SoAnnotation()
+        axis_sep.addChild(self.draw_style)
+        axis_sep.addChild(soColor)
+        axis_sep.addChild(coords)
+        axis_sep.addChild(line)
+
+        scale = coin.SoType.fromName("SoShapeScale").createInstance()
+        scale.setPart("shape", axis_sep)
+        scale.scaleFactor = self.scaleFactor
+
+        return scale
+
+    def plane_sep(self, size, num_vertices):
+        coords = coin.SoCoordinate3()
+
+        for i in range(num_vertices):
+            angle = float(i) / num_vertices * 2.0 * math.pi
+            x = math.cos(angle) * size
+            y = math.sin(angle) * size
+            coords.point.set1Value(i, x, y, 0)
+
+        face = coin.SoFaceSet()
+        face.numVertices.setValue(num_vertices)
+
+        transform = coin.SoTransform()
+        transform.translation.setValue(0, 0, 0)
+
+        draw_style = coin.SoDrawStyle()
+        draw_style.style = coin.SoDrawStyle.FILLED
+
+        material = coin.SoMaterial()
+        material.diffuseColor.setValue([0.5, 0.5, 0.5])
+        material.ambientColor.setValue([0.5, 0.5, 0.5])
+        material.specularColor.setValue([0.5, 0.5, 0.5])
+        material.emissiveColor.setValue([0.5, 0.5, 0.5])
+        material.transparency.setValue(0.3)
+
+        face_sep = coin.SoAnnotation()
+        face_sep.addChild(transform)
+        face_sep.addChild(draw_style)
+        face_sep.addChild(material)
+        face_sep.addChild(coords)
+        face_sep.addChild(face)
+
+        scale = coin.SoType.fromName("SoShapeScale").createInstance()
+        scale.setPart("shape", face_sep)
+        scale.scaleFactor = self.scaleFactor
+
+        return scale
+
+    def set_marker_placement(self, placement, ref):
+        # change plc to be relative to the origin of the document.
+        global_plc = UtilsAssembly.getGlobalPlacement(ref)
+        placement = global_plc * placement
+
+        t = placement.Base
+        self.transform.translation.setValue(t.x, t.y, t.z)
+
+        r = placement.Rotation.Q
+        self.transform.rotation.setValue(r[0], r[1], r[2], r[3])
+
+    def setPickableState(self, state: bool):
+        """Set JCS selectable or unselectable in 3D view"""
+        if not state:
+            self.pick.style.setValue(coin.SoPickStyle.UNPICKABLE)
+        else:
+            self.pick.style.setValue(coin.SoPickStyle.SHAPE_ON_TOP)
+
+    def show_marker(self, visible, placement=None, ref=None):
+        if visible:
+            self.whichChild = coin.SO_SWITCH_ALL
+            self.set_marker_placement(placement, ref)
+        else:
+            self.whichChild = coin.SO_SWITCH_NONE
+
+    def onChanged(self, vp, prop):
+        if prop == "color_X_axis":
+            c = vp.getPropertyByName("color_X_axis")
+            self.x_axis_so_color.rgb.setValue(c[0], c[1], c[2])
+        if prop == "color_Y_axis":
+            c = vp.getPropertyByName("color_Y_axis")
+            self.y_axis_so_color.rgb.setValue(c[0], c[1], c[2])
+        if prop == "color_Z_axis":
+            c = vp.getPropertyByName("color_Z_axis")
+            self.z_axis_so_color.rgb.setValue(c[0], c[1], c[2])

--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -28,12 +28,10 @@ import Part
 
 if App.GuiUp:
     import FreeCADGui as Gui
-
-import PySide.QtCore as QtCore
-import PySide.QtGui as QtGui
+    from PySide import QtCore, QtGui, QtWidgets
 
 
-# translate = App.Qt.translate
+translate = App.Qt.translate
 
 __title__ = "Assembly utilitary functions"
 __author__ = "Ondsel"
@@ -752,6 +750,21 @@ def findCylindersIntersection(obj, surface, edge, elt_index):
                 if res:
                     return App.Vector(res[0].X, res[0].Y, res[0].Z)
     return surface.Center
+
+
+def openEditingPlacementDialog(obj, propName):
+    task_placement = Gui.TaskPlacement()
+    dialog = task_placement.form
+
+    # Connect to the placement property
+    task_placement.setPlacement(getattr(obj, propName))
+    task_placement.setSelection([obj])
+    task_placement.setPropertyName(propName)
+    task_placement.bindObject()
+    task_placement.setIgnoreTransactions(True)
+
+    dialog.findChild(QtWidgets.QPushButton, "selectedVertex").hide()
+    dialog.exec_()
 
 
 def applyOffsetToPlacement(plc, offset):

--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -356,7 +356,7 @@ def extract_type_and_number(element_name):
         return None, None
 
 
-def findElementClosestVertex(assembly, ref, mousePos):
+def findElementClosestVertex(ref, mousePos):
     element_name = getElementName(ref[1][0])
     if element_name == "":
         return ""
@@ -767,6 +767,21 @@ def openEditingPlacementDialog(obj, propName):
     dialog.exec_()
 
 
+def setPickableState(obj, state: bool):
+    vobj = obj.ViewObject
+    if hasattr(vobj, "Proxy"):
+        proxy = vobj.Proxy
+        if hasattr(proxy, "setPickableState"):
+            proxy.setPickableState(state)
+
+
+def setJointsPickableState(doc, state: bool):
+    """Make all joints in document selectable (True) or unselectable (False) in 3D view"""
+    for obj in doc.Objects:
+        if obj.TypeId == "App::FeaturePython" and hasattr(obj, "JointType"):
+            setPickableState(obj, state)
+
+
 def applyOffsetToPlacement(plc, offset):
     plc.Base = plc.Base + plc.Rotation.multVec(offset)
     return plc
@@ -797,6 +812,23 @@ def arePlacementZParallel(plc1, plc2):
     zAxis1 = plc1.Rotation.multVec(App.Vector(0, 0, 1))
     zAxis2 = plc2.Rotation.multVec(App.Vector(0, 0, 1))
     return zAxis1.cross(zAxis2).Length < 1e-06
+
+
+def removeTNPFromSubname(doc_name, obj_name, sub_name):
+    rootObj = App.getDocument(doc_name).getObject(obj_name)
+    resolved = rootObj.resolveSubElement(sub_name)
+    element_name_TNP = resolved[1]
+    element_name = resolved[2]
+
+    # Preprocess the sub_name to remove the TNP string
+    # We do this because after we need to add the vertex_name as well.
+    # And the names will be resolved anyway after.
+    if len(element_name_TNP.split(".")) == 2:
+        names = sub_name.split(".")
+        names.pop(-2)  # remove the TNP string
+        sub_name = ".".join(names)
+
+    return sub_name
 
 
 """

--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -1112,6 +1112,10 @@ def getMovingPart(assembly, ref):
         if obj.TypeId == "App::DocumentObjectGroup":
             continue  # we ignore groups.
 
+        # We ignore dynamic sub-assemblies.
+        if obj.isDerivedFrom("Assembly::AssemblyLink") and obj.Rigid == False:
+            continue
+
         # If it is a LinkGroup then we skip it
         if isLinkGroup(obj):
             continue


### PR DESCRIPTION
This introduce 'AssemblyLink' document object. These are not deriving from App::Link, but in fact deriving from App::Part.
Instead of linking to an assembly like a link would do, it is populating itself with links to the various components. Enabling to have different component placements between each instance of AssemblyLink.


Fix https://github.com/FreeCAD/FreeCAD/issues/15208
Fix https://github.com/FreeCAD/FreeCAD/issues/16436

builds on top of https://github.com/FreeCAD/FreeCAD/pull/16317 so that one needs to merge first.