### PR TITLE
BIM: Fix calculation of wall blocks

### DIFF
--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -351,7 +351,7 @@ class _Wall(ArchComponent.Component):
                                                 else:
                                                     cuts2.append(sh)
                                             offset += (obj.BlockLength.Value + obj.Joint.Value)
-                                        offset -= (edge.Length - obj.Joint.Value)
+                                        offset -= edge.Length
 
                             if isinstance(bplates,list):
                                 bplates = bplates[0]


### PR DESCRIPTION
At the corners of the base wire the joint width was wrongly added.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=89504
