### PR TITLE
CI: Linter error tweaks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,10 @@
 Checks:          'clang-diagnostic-*,clang-analyzer-*,boost-*,bugprone-*,
 performance-*,readability-*,portability-*,modernize-*,cppcoreguidelines-*,google-explicit-constructor,
 concurrency-*,-modernize-use-trailing-return-type, -modernize-use-nodiscard,
--readability-redundant-access-specifiers,-readability-qualified-auto'
+-readability-redundant-access-specifiers,-readability-qualified-auto,
+-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,
+-readability-convert-member-functions-to-static,-bugprone-easily-swappable-parameters,
+-cppcoreguidelines-pro-type-static-cast-downcast'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -77,7 +77,7 @@ on:
         type: boolean
         required: false
       cpplintFilters:
-        default: -build/c++17,-build/header_guard,-build/include,-build/include_alpha,-build/include_order,-build/include_subdir,-build/include_what_you_use,-build/namespaces,-legal/copyright,-readability/braces,-readability-braces-around-statements,-readability/casting,-readability/namespace,-readability/todo,-runtime/indentation_namespace,-runtime/int,-runtime/references,-whitespace/blank_line,-whitespace/braces,-whitespace/comma,-whitespace/comments,-whitespace/end_of_line,-whitespace/indent,-whitespace/line_length,-whitespace/newline,-whitespace/operators,-whitespace/parens,-whitespace/semicolon,-whitespace/tab,-whitespace/todo
+        default: -whitespace-*
         type: string
         required: false
       cpplintLineLength:
@@ -153,7 +153,7 @@ on:
         type: boolean
         required: false
       clazyChecks:
-        default: level1
+        default: level2,no-non-pod-global-static,no-copyable-polymorphic
         type: string
         required: false
       clazyFailSilent:
@@ -169,7 +169,7 @@ on:
         type: string
         required: false
       QT6Branch: # branch to check for QT6 Porting
-        default: master
+        default: main
         type: string
         required: false
       clazyQT6FailSilent:

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1,23 +1,24 @@
-/***************************************************************************
- *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>               *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
  ***************************************************************************/
 
 #include "PreCompiled.h"


### PR DESCRIPTION
As discussed at the last developer meeting, some of the current default linter warnings are wrong or misleading. This PR silences some of the major culprits in an attempt to make the CI lint run more useful (e.g. we don't develop the bad habit of just ignoring the linter because it's noisy).

The Sketcher file edit is just to demonstrate and exercise the linter, and can be dropped from the final merge if desired.