### PR TITLE
Toponaming: make sure TopoShapes have Hashers

### DIFF
--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -296,6 +296,16 @@ ComplexGeoData::getElementMappedNames(const IndexedName& element, bool needUnmap
     return {std::make_pair(MappedName(element), ElementIDRefs())};
 }
 
+ElementMapPtr ComplexGeoData::resetElementMap(ElementMapPtr elementMap)
+{
+    _elementMap.swap(elementMap);
+    // We expect that if the ComplexGeoData ( TopoShape ) has a hasher, then its elementMap will
+    // have the same one.  Make sure that happens.
+    if ( _elementMap && ! _elementMap->hasher )
+        _elementMap->hasher = Hasher;
+    return elementMap;
+}
+
 std::vector<MappedElement> ComplexGeoData::getElementMap() const
 {
     flushElementMap();

--- a/src/App/ComplexGeoData.h
+++ b/src/App/ComplexGeoData.h
@@ -316,11 +316,7 @@ public:
      *
      * @return Returns the existing element map.
      */
-    virtual ElementMapPtr resetElementMap(ElementMapPtr elementMap = ElementMapPtr())
-    {
-        _elementMap.swap(elementMap);
-        return elementMap;
-    }
+    virtual ElementMapPtr resetElementMap(ElementMapPtr elementMap = ElementMapPtr());
 
     /// Get the entire element map
     std::vector<MappedElement> getElementMap() const;

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1075,7 +1075,6 @@ std::pair<bool,int> Document::addStringHasher(const StringHasherRef & hasher) co
 
 StringHasherRef Document::getStringHasher(int idx) const {
     if(idx<0) {
-            return d->Hasher;
         return d->Hasher;
     }
     StringHasherRef hasher;

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -39,13 +39,13 @@ class TestTopologicalNamingProblem(unittest.TestCase):
 
     def setUp(self):
         """ Create a document for each test in the test suite """
-        self.Doc = App.newDocument("PartDesignTestTNP."+self._testMethodName)
+        self.Doc = App.newDocument("PartDesignTestTNP." + self._testMethodName)
 
     def countFacesEdgesVertexes(self, map):
         faces = [name for name in map.keys() if name.startswith("Face")]
         edges = [name for name in map.keys() if name.startswith("Edge")]
         vertexes = [name for name in map.keys() if name.startswith("Vertex")]
-        return ( len(faces), len(edges), len(vertexes) )
+        return (len(faces), len(edges), len(vertexes))
 
     def testPadsOnBaseObject(self):
         """ Simple TNP test case
@@ -110,9 +110,9 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         self.assertTrue(self.Pad1.isValid())
 
         if self.Body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
-            self.assertFalse(self.Pad2.isValid())   # TNP problem is present without ElementMaps
+            self.assertFalse(self.Pad2.isValid())  # TNP problem is present without ElementMaps
         else:
-            self.assertTrue(self.Pad2.isValid())    # TNP problem is not present with ElementMaps
+            self.assertTrue(self.Pad2.isValid())  # TNP problem is not present with ElementMaps
 
     def testPartDesignElementMapSketch(self):
         """ Test that creating a sketch results in a correct element map.  """
@@ -130,11 +130,11 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         edges = [name for name in reverseMap.keys() if name.startswith("Edge")]
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         # Assert
-        self.assertEqual(sketch.Shape.ElementMapSize,12)
-        self.assertEqual(len(reverseMap),8)
-        self.assertEqual(len(reverseFaces),0)
-        self.assertEqual(len(edges),4)
-        self.assertEqual(len(vertexes),4)
+        self.assertEqual(sketch.Shape.ElementMapSize, 12)
+        self.assertEqual(len(reverseMap), 8)
+        self.assertEqual(len(reverseFaces), 0)
+        self.assertEqual(len(edges), 4)
+        self.assertEqual(len(vertexes), 4)
 
     def testPartDesignElementMapPad(self):
         """ Test that padding a sketch results in a correct element map.  Note that comprehensive testing
@@ -157,11 +157,11 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         edges = [name for name in reverseMap.keys() if name.startswith("Edge")]
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         # Assert
-        self.assertEqual(pad.Shape.ElementMapSize,30)   # 4 duplicated Vertexes in here
-        self.assertEqual(len(reverseMap),26)
-        self.assertEqual(len(faces),6)
-        self.assertEqual(len(edges),12)
-        self.assertEqual(len(vertexes),8)
+        self.assertEqual(pad.Shape.ElementMapSize, 30)  # 4 duplicated Vertexes in here
+        self.assertEqual(len(reverseMap), 26)
+        self.assertEqual(len(faces), 6)
+        self.assertEqual(len(edges), 12)
+        self.assertEqual(len(vertexes), 8)
 
     def testPartDesignElementMapBox(self):
         # Arrange
@@ -200,10 +200,10 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 8)
-        self.assertEqual(len(reverseMap),8)
-        self.assertEqual(len(faces),3)
-        self.assertEqual(len(edges),3)
-        self.assertEqual(len(vertexes),2)
+        self.assertEqual(len(reverseMap), 8)
+        self.assertEqual(len(faces), 3)
+        self.assertEqual(len(edges), 3)
+        self.assertEqual(len(vertexes), 2)
 
     def testPartDesignElementMapSphere(self):
         # Arrange
@@ -225,10 +225,10 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 6)
-        self.assertEqual(len(reverseMap),6)
-        self.assertEqual(len(faces),1)
-        self.assertEqual(len(edges),3)
-        self.assertEqual(len(vertexes),2)
+        self.assertEqual(len(reverseMap), 6)
+        self.assertEqual(len(faces), 1)
+        self.assertEqual(len(edges), 3)
+        self.assertEqual(len(vertexes), 2)
 
     def testPartDesignElementMapCone(self):
         # Arrange
@@ -250,10 +250,10 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 8)
-        self.assertEqual(len(reverseMap),8)
-        self.assertEqual(len(faces),3)
-        self.assertEqual(len(edges),3)
-        self.assertEqual(len(vertexes),2)
+        self.assertEqual(len(reverseMap), 8)
+        self.assertEqual(len(faces), 3)
+        self.assertEqual(len(edges), 3)
+        self.assertEqual(len(vertexes), 2)
 
     def testPartDesignElementMapEllipsoid(self):
         # Arrange
@@ -275,10 +275,10 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 6)
-        self.assertEqual(len(reverseMap),6)
-        self.assertEqual(len(faces),1)
-        self.assertEqual(len(edges),3)
-        self.assertEqual(len(vertexes),2)
+        self.assertEqual(len(reverseMap), 6)
+        self.assertEqual(len(faces), 1)
+        self.assertEqual(len(edges), 3)
+        self.assertEqual(len(vertexes), 2)
 
     def testPartDesignElementMapTorus(self):
         # Arrange
@@ -300,10 +300,10 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 4)
-        self.assertEqual(len(reverseMap),4)
-        self.assertEqual(len(faces),1)
-        self.assertEqual(len(edges),2)
-        self.assertEqual(len(vertexes),1)
+        self.assertEqual(len(reverseMap), 4)
+        self.assertEqual(len(faces), 1)
+        self.assertEqual(len(edges), 2)
+        self.assertEqual(len(vertexes), 1)
 
     def testPartDesignElementMapPrism(self):
         # Arrange
@@ -325,10 +325,10 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 38)
-        self.assertEqual(len(reverseMap),38)
-        self.assertEqual(len(faces),8)
-        self.assertEqual(len(edges),18)
-        self.assertEqual(len(vertexes),12)
+        self.assertEqual(len(reverseMap), 38)
+        self.assertEqual(len(faces), 8)
+        self.assertEqual(len(edges), 18)
+        self.assertEqual(len(vertexes), 12)
 
     def testPartDesignElementMapWedge(self):
         # Arrange
@@ -350,10 +350,10 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 26)
-        self.assertEqual(len(reverseMap),26)
-        self.assertEqual(len(faces),6)
-        self.assertEqual(len(edges),12)
-        self.assertEqual(len(vertexes),8)
+        self.assertEqual(len(reverseMap), 26)
+        self.assertEqual(len(faces), 6)
+        self.assertEqual(len(edges), 12)
+        self.assertEqual(len(vertexes), 8)
 
         # body.BaseFeature = box
 
@@ -522,14 +522,15 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         body.addObject(sketch)
         body.addObject(pad)
         self.Doc.recompute()
-       # Assert
+        # Assert
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 30)
-        self.assertEqual(body.Shape.ElementMapSize,30)
-        self.assertEqual(sketch.Shape.ElementMapSize,12)
-        self.assertEqual(pad.Shape.ElementMapSize,30)
-        self.assertNotEqual(pad.Shape.ElementReverseMap['Vertex1'],"Vertex1")   # NewName, not OldName
-        self.assertEqual(self.countFacesEdgesVertexes(pad.Shape.ElementReverseMap),(6,12,8))
+        self.assertEqual(body.Shape.ElementMapSize, 30)
+        self.assertEqual(sketch.Shape.ElementMapSize, 12)
+        self.assertEqual(pad.Shape.ElementMapSize, 30)
+        self.assertNotEqual(pad.Shape.ElementReverseMap['Vertex1'],
+                            "Vertex1")  # NewName, not OldName
+        self.assertEqual(self.countFacesEdgesVertexes(pad.Shape.ElementReverseMap), (6, 12, 8))
 
         # Todo: Offer a way to turn on hashing and check that with a # starting
         #  Pad -> Extrusion -> makes compounds and does booleans, thus the resulting newName element maps
@@ -539,22 +540,23 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # Arrange
         body = self.Doc.addObject('PartDesign::Body', 'Body')
         sketch = self.Doc.addObject('Sketcher::SketchObject', 'Sketch')
-        TestSketcherApp.CreateRectangleSketch(sketch, (1, 1), (2, 2))   # (pt), (w,l)
+        TestSketcherApp.CreateRectangleSketch(sketch, (1, 1), (2, 2))  # (pt), (w,l)
         if body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
             return
         # Act
         revolution = self.Doc.addObject('PartDesign::Revolution', 'Revolution')
-        revolution.ReferenceAxis = (self.Doc.getObject('Sketch'),['V_Axis'])
+        revolution.ReferenceAxis = (self.Doc.getObject('Sketch'), ['V_Axis'])
         revolution.Profile = sketch
         body.addObject(sketch)
         body.addObject(revolution)
         self.Doc.recompute()
         # Assert
         self.assertEqual(len(body.Shape.childShapes()), 1)
-        self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 14 )
-        self.assertEqual(revolution.Shape.ElementMapSize, 14 )
-        self.assertEqual(self.countFacesEdgesVertexes(revolution.Shape.ElementReverseMap),(4,6,4))
-        volume = ( math.pi * 3 * 3 - math.pi * 1 * 1 ) * 2   # 50.26548245743668
+        self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 14)
+        self.assertEqual(revolution.Shape.ElementMapSize, 14)
+        self.assertEqual(self.countFacesEdgesVertexes(revolution.Shape.ElementReverseMap),
+                         (4, 6, 4))
+        volume = (math.pi * 3 * 3 - math.pi * 1 * 1) * 2  # 50.26548245743668
         self.assertAlmostEqual(revolution.Shape.Volume, volume)
 
     def testPartDesignElementMapLoft(self):
@@ -582,9 +584,9 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # 4 vertexes are quad dups for 12 more.  26 + 4 + 12 = 42
         self.assertEqual(body.Shape.ElementMapSize, 42)
         revMap = body.Shape.ElementReverseMap
-        self.assertNotEqual(loft.Shape.ElementReverseMap['Vertex1'],"Vertex1")
-        self.assertNotEqual(revMap['Vertex1'],"Vertex1")
-        self.assertEqual(self.countFacesEdgesVertexes(loft.Shape.ElementReverseMap),(6,12,8))
+        self.assertNotEqual(loft.Shape.ElementReverseMap['Vertex1'], "Vertex1")
+        self.assertNotEqual(revMap['Vertex1'], "Vertex1")
+        self.assertEqual(self.countFacesEdgesVertexes(loft.Shape.ElementReverseMap), (6, 12, 8))
         volume = 7.0
         self.assertAlmostEqual(loft.Shape.Volume, volume)
 
@@ -597,7 +599,8 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         sketch2.AttachmentSupport = (self.Doc.getObject("XZ_Plane"), [''])
         sketch2.addGeometry(Part.LineSegment(App.Vector(0, 0, 0),
                                              App.Vector(0, 1, 0)))
-        sketch2.Placement=App.Placement(App.Vector(0,0,0),App.Rotation(App.Vector(1.00,0.00,0.00),90.00))
+        sketch2.Placement = App.Placement(App.Vector(0, 0, 0),
+                                          App.Rotation(App.Vector(1.00, 0.00, 0.00), 90.00))
         # Need to set sketch2 placement?
         if body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
             return
@@ -610,26 +613,26 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         body.addObject(pipe)
         self.Doc.recompute()
         # Assert
-        self.assertAlmostEqual(body.Shape.Volume,1)
-        self.assertAlmostEqual(body.Shape.BoundBox.XMin,0)
-        self.assertAlmostEqual(body.Shape.BoundBox.YMin,0)
-        self.assertAlmostEqual(body.Shape.BoundBox.ZMin,0)
-        self.assertAlmostEqual(body.Shape.BoundBox.XMax,1)
-        self.assertAlmostEqual(body.Shape.BoundBox.YMax,1)
-        self.assertAlmostEqual(body.Shape.BoundBox.ZMax,1)
+        self.assertAlmostEqual(body.Shape.Volume, 1)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMin, 0)
+        self.assertAlmostEqual(body.Shape.BoundBox.YMin, 0)
+        self.assertAlmostEqual(body.Shape.BoundBox.ZMin, 0)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMax, 1)
+        self.assertAlmostEqual(body.Shape.BoundBox.YMax, 1)
+        self.assertAlmostEqual(body.Shape.BoundBox.ZMax, 1)
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 26)
         revMap = body.Shape.childShapes()[0].ElementReverseMap
         # TODO: This is a child of the body and not the actual Pipe.
         #   1: is that okay and normal, or should the pipe have an element map
         #   2: Should these be newNames and not oldNames?
-        self.assertEqual(revMap['Vertex1'],"Vertex1")
-        self.assertEqual(revMap['Vertex8'],"Vertex8")
-        self.assertEqual(revMap['Edge1'],"Edge1")
-        self.assertEqual(revMap['Edge12'],"Edge12")
-        self.assertEqual(revMap['Face1'],"Face1")
-        self.assertEqual(revMap['Face6'],"Face6")
-        self.assertEqual(self.countFacesEdgesVertexes(revMap),(6,12,8))
+        self.assertEqual(revMap['Vertex1'], "Vertex1")
+        self.assertEqual(revMap['Vertex8'], "Vertex8")
+        self.assertEqual(revMap['Edge1'], "Edge1")
+        self.assertEqual(revMap['Edge12'], "Edge12")
+        self.assertEqual(revMap['Face1'], "Face1")
+        self.assertEqual(revMap['Face6'], "Face6")
+        self.assertEqual(self.countFacesEdgesVertexes(revMap), (6, 12, 8))
 
     def testPartDesignElementMapHelix(self):
         # Arrange
@@ -641,7 +644,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # Act
         helix = self.Doc.addObject('PartDesign::AdditiveHelix', 'Helix')
         helix.Profile = sketch
-        helix.ReferenceAxis = (self.Doc.getObject('Sketch'),['V_Axis'])
+        helix.ReferenceAxis = (self.Doc.getObject('Sketch'), ['V_Axis'])
         body.addObject(sketch)
         body.addObject(helix)
         self.Doc.recompute()
@@ -649,7 +652,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertGreaterEqual(body.Shape.childShapes()[0].ElementMapSize, 26)
         revMap = body.Shape.childShapes()[0].ElementReverseMap
-        self.assertEqual(self.countFacesEdgesVertexes(revMap),(6,12,8))
+        self.assertEqual(self.countFacesEdgesVertexes(revMap), (6, 12, 8))
         volume = 9.424696540407776  # TODO:  math formula to calc this.
         self.assertAlmostEqual(helix.Shape.Volume, volume)
 
@@ -668,7 +671,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         pocket = self.Doc.addObject('PartDesign::Pocket', 'Pocket')
         pocket.Profile = sketch
         pocket.Length = 5
-        pocket.Direction = ( 0,0,-1)
+        pocket.Direction = (0, 0, -1)
         pocket.ReferenceAxis = (sketch, ['N_Axis'])
 
         body.addObject(sketch)
@@ -677,11 +680,12 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # Assert
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 55)
-        self.assertEqual(body.Shape.ElementMapSize,55)
-        self.assertEqual(sketch.Shape.ElementMapSize,12)
-        self.assertEqual(pocket.Shape.ElementMapSize,55)
-        self.assertNotEqual(pocket.Shape.ElementReverseMap['Vertex1'],"Vertex1")   # NewName, not OldName
-        self.assertEqual(self.countFacesEdgesVertexes(pocket.Shape.ElementReverseMap),(11,24,16))
+        self.assertEqual(body.Shape.ElementMapSize, 55)
+        self.assertEqual(sketch.Shape.ElementMapSize, 12)
+        self.assertEqual(pocket.Shape.ElementMapSize, 55)
+        self.assertNotEqual(pocket.Shape.ElementReverseMap['Vertex1'],
+                            "Vertex1")  # NewName, not OldName
+        self.assertEqual(self.countFacesEdgesVertexes(pocket.Shape.ElementReverseMap), (11, 24, 16))
         volume = 1000 - 5 * 1 * 1
         self.assertAlmostEqual(pocket.Shape.Volume, volume)
 
@@ -706,11 +710,11 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # Assert
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 32)
-        self.assertEqual(body.Shape.ElementMapSize,32)
-        self.assertEqual(sketch.Shape.ElementMapSize,2)
-        self.assertEqual(hole.Shape.ElementMapSize,32)
+        self.assertEqual(body.Shape.ElementMapSize, 32)
+        self.assertEqual(sketch.Shape.ElementMapSize, 2)
+        self.assertEqual(hole.Shape.ElementMapSize, 32)
         # self.assertNotEqual(hole.Shape.ElementReverseMap['Vertex1'],"Vertex1")   # NewName, not OldName
-        self.assertEqual(self.countFacesEdgesVertexes(hole.Shape.ElementReverseMap),(7,15,10))
+        self.assertEqual(self.countFacesEdgesVertexes(hole.Shape.ElementReverseMap), (7, 15, 10))
         volume = 1000 - 10 * math.pi * 3 * 3
         self.assertAlmostEqual(hole.Shape.Volume, volume)
 
@@ -732,8 +736,8 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         if body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
             return
         # Assert
-        revMap = groove.Shape.ElementReverseMap # body.Shape.childShapes()[0].ElementReverseMap
-        self.assertEqual(self.countFacesEdgesVertexes(revMap),(5,9,6))
+        revMap = groove.Shape.ElementReverseMap  # body.Shape.childShapes()[0].ElementReverseMap
+        self.assertEqual(self.countFacesEdgesVertexes(revMap), (5, 9, 6))
         volume = 785.3981633974482  # TODO:  math formula to calc this.  Maybe make a sketch as the Profile.
         self.assertAlmostEqual(groove.Shape.Volume, volume)
 
@@ -758,8 +762,8 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         if body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
             return
         # Assert
-        revMap = loft.Shape.ElementReverseMap # body.Shape.childShapes()[0].ElementReverseMap
-        self.assertEqual(self.countFacesEdgesVertexes(revMap),(11,24,16))
+        revMap = loft.Shape.ElementReverseMap  # body.Shape.childShapes()[0].ElementReverseMap
+        self.assertEqual(self.countFacesEdgesVertexes(revMap), (11, 24, 16))
         volume = 993  # TODO:  math formula to calc this.
         self.assertAlmostEqual(loft.Shape.Volume, volume)
 
@@ -774,7 +778,8 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         sketch2.AttachmentSupport = (self.Doc.getObject("XZ_Plane"), [''])
         sketch2.addGeometry(Part.LineSegment(App.Vector(0, 0, 0),
                                              App.Vector(0, 1, 0)))
-        sketch2.Placement=App.Placement(App.Vector(0,0,0),App.Rotation(App.Vector(1.00,0.00,0.00),90.00))
+        sketch2.Placement = App.Placement(App.Vector(0, 0, 0),
+                                          App.Rotation(App.Vector(1.00, 0.00, 0.00), 90.00))
         # Need to set sketch2 placement?
         if body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
             return
@@ -787,26 +792,26 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         body.addObject(pipe)
         self.Doc.recompute()
         # Assert
-        self.assertAlmostEqual(body.Shape.Volume,999)
-        self.assertAlmostEqual(body.Shape.BoundBox.XMin,0)
-        self.assertAlmostEqual(body.Shape.BoundBox.YMin,0)
-        self.assertAlmostEqual(body.Shape.BoundBox.ZMin,0)
-        self.assertAlmostEqual(body.Shape.BoundBox.XMax,10)
-        self.assertAlmostEqual(body.Shape.BoundBox.YMax,10)
-        self.assertAlmostEqual(body.Shape.BoundBox.ZMax,10)
+        self.assertAlmostEqual(body.Shape.Volume, 999)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMin, 0)
+        self.assertAlmostEqual(body.Shape.BoundBox.YMin, 0)
+        self.assertAlmostEqual(body.Shape.BoundBox.ZMin, 0)
+        self.assertAlmostEqual(body.Shape.BoundBox.XMax, 10)
+        self.assertAlmostEqual(body.Shape.BoundBox.YMax, 10)
+        self.assertAlmostEqual(body.Shape.BoundBox.ZMax, 10)
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 44)
         revMap = body.Shape.childShapes()[0].ElementReverseMap
         # TODO: This is a child of the body and not the actual Pipe.
         #   1: is that okay and normal, or should the pipe have an element map
         #   2: Should these be newNames and not oldNames?
-        self.assertEqual(revMap['Vertex1'],"Vertex1")
-        self.assertEqual(revMap['Vertex8'],"Vertex8")
-        self.assertEqual(revMap['Edge1'],"Edge1")
-        self.assertEqual(revMap['Edge12'],"Edge12")
-        self.assertEqual(revMap['Face1'],"Face1")
-        self.assertEqual(revMap['Face6'],"Face6")
-        self.assertEqual(self.countFacesEdgesVertexes(revMap),(9,21,14))
+        self.assertEqual(revMap['Vertex1'], "Vertex1")
+        self.assertEqual(revMap['Vertex8'], "Vertex8")
+        self.assertEqual(revMap['Edge1'], "Edge1")
+        self.assertEqual(revMap['Edge12'], "Edge12")
+        self.assertEqual(revMap['Face1'], "Face1")
+        self.assertEqual(revMap['Face6'], "Face6")
+        self.assertEqual(self.countFacesEdgesVertexes(revMap), (9, 21, 14))
 
     def testPartDesignElementMapSubHelix(self):
         # Arrange
@@ -820,7 +825,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # Act
         helix = self.Doc.addObject('PartDesign::SubtractiveHelix', 'SubHelix')
         helix.Profile = sketch
-        helix.ReferenceAxis = (self.Doc.getObject('Sketch'),['V_Axis'])
+        helix.ReferenceAxis = (self.Doc.getObject('Sketch'), ['V_Axis'])
         body.addObject(sketch)
         body.addObject(helix)
         self.Doc.recompute()
@@ -828,7 +833,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 50)
         revMap = body.Shape.childShapes()[0].ElementReverseMap
-        self.assertEqual(self.countFacesEdgesVertexes(revMap),(10,24,16))
+        self.assertEqual(self.countFacesEdgesVertexes(revMap), (10, 24, 16))
         volume = 991.3606270276762  # TODO:  math formula to calc this.
         self.assertAlmostEqual(helix.Shape.Volume, volume)
 
@@ -837,7 +842,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # Arrange
         body = self.Doc.addObject('PartDesign::Body', 'Body')
         box = self.Doc.addObject('PartDesign::AdditiveBox', 'Box')
-        if body.Shape.ElementMapVersion == "":   # Skip without element maps.
+        if body.Shape.ElementMapVersion == "":  # Skip without element maps.
             return
         chamfer = self.Doc.addObject('PartDesign::Chamfer', 'Chamfer')
         chamfer.Base = (box, ['Edge1',
@@ -865,32 +870,32 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 98)
-        self.assertEqual(len(reverseMap),98)
-        self.assertEqual(len(faces),26) # 6 Faces become 26 ( +8 + 2*6 )
-        self.assertEqual(len(edges),48) # 12 Edges become 48
-        self.assertEqual(len(vertexes),24) # 8 Vertices become 24
+        self.assertEqual(len(reverseMap), 98)
+        self.assertEqual(len(faces), 26)  # 6 Faces become 26 ( +8 + 2*6 )
+        self.assertEqual(len(edges), 48)  # 12 Edges become 48
+        self.assertEqual(len(vertexes), 24)  # 8 Vertices become 24
 
     def testPartDesignElementMapFillet(self):
         """ Test Fillet ( and  FeatureDressup )"""
         # Arrange
         body = self.Doc.addObject('PartDesign::Body', 'Body')
         box = self.Doc.addObject('PartDesign::AdditiveBox', 'Box')
-        if body.Shape.ElementMapVersion == "":   # Skip without element maps.
+        if body.Shape.ElementMapVersion == "":  # Skip without element maps.
             return
         fillet = self.Doc.addObject('PartDesign::Fillet', 'Fillet')
         fillet.Base = (box, ['Edge1',
-                              'Edge2',
-                              'Edge3',
-                              'Edge4',
-                              'Edge5',
-                              'Edge6',
-                              'Edge7',
-                              'Edge8',
-                              'Edge9',
-                              'Edge10',
-                              'Edge11',
-                              'Edge12',
-                              ])
+                             'Edge2',
+                             'Edge3',
+                             'Edge4',
+                             'Edge5',
+                             'Edge6',
+                             'Edge7',
+                             'Edge8',
+                             'Edge9',
+                             'Edge10',
+                             'Edge11',
+                             'Edge12',
+                             ])
         # Act / Assert
         body.addObject(box)
         body.addObject(fillet)
@@ -901,16 +906,16 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 106)
-        self.assertEqual(len(reverseMap),106)
-        self.assertEqual(len(faces),26) # 6 Faces become 26 ( +8 + 2*6 )
-        self.assertEqual(len(edges),56) # 12 Edges become 56  Why?
-        self.assertEqual(len(vertexes),24) # 8 Vertices become 24
+        self.assertEqual(len(reverseMap), 106)
+        self.assertEqual(len(faces), 26)  # 6 Faces become 26 ( +8 + 2*6 )
+        self.assertEqual(len(edges), 56)  # 12 Edges become 56  Why?
+        self.assertEqual(len(vertexes), 24)  # 8 Vertices become 24
 
     def testPartDesignElementMapTransform(self):
         # Arrange
         body = self.Doc.addObject('PartDesign::Body', 'Body')
         box = self.Doc.addObject('PartDesign::AdditiveBox', 'Box')
-        if body.Shape.ElementMapVersion == "":   # Skip without element maps.
+        if body.Shape.ElementMapVersion == "":  # Skip without element maps.
             return
         multitransform = self.Doc.addObject('PartDesign::MultiTransform', 'MultiTransform')
         scaled = self.Doc.addObject('PartDesign::Scaled', 'Scaled')
@@ -933,7 +938,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         body = self.Doc.addObject('PartDesign::Body', 'Body')
         box = self.Doc.addObject('PartDesign::AdditiveBox', 'Box')
         shapebinder = self.Doc.addObject('PartDesign::ShapeBinder', 'ShapeBinder')
-        if body.Shape.ElementMapVersion == "":   # Skip without element maps.
+        if body.Shape.ElementMapVersion == "":  # Skip without element maps.
             return
         # Act / Assert
         body.addObject(box)
@@ -948,12 +953,12 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         body = self.Doc.addObject('PartDesign::Body', 'Body')
         box = self.Doc.addObject('PartDesign::AdditiveBox', 'Box')
         subshapebinder = self.Doc.addObject('PartDesign::SubShapeBinder', 'SubShapeBinder')
-        if body.Shape.ElementMapVersion == "":   # Skip without element maps.
+        if body.Shape.ElementMapVersion == "":  # Skip without element maps.
             return
         # Act / Assert
         body.addObject(box)
         body.addObject(subshapebinder)
-        subshapebinder.Support = [ (box, ["Face1"]) ]
+        subshapebinder.Support = [(box, ["Face1"])]
         self.assertEqual(len(body.Shape.childShapes()), 0)
         self.Doc.recompute()
         self.assertEqual(len(body.Shape.childShapes()), 1)
@@ -1010,25 +1015,25 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         pad.Length = 10
         doc.recompute()
 
-        sketch001 = body.newObject('Sketcher::SketchObject','Sketch001')
+        sketch001 = body.newObject('Sketcher::SketchObject', 'Sketch001')
         sketch001 = doc.Sketch001
-        sketch001.AttachmentSupport = (doc.getObject('Pad'),['Face6',])
+        sketch001.AttachmentSupport = (doc.getObject('Pad'), ['Face6', ])
         sketch001.MapMode = 'FlatFace'
         App.ActiveDocument.recompute()
 
         geoList = []
         geoList.append(Part.Circle(App.Vector(15.093666, 13.036922, 0.000000),
                                    App.Vector(0.000000, 0.000000, 1.000000), 5.000000))
-        sketch001.addGeometry(geoList,False)
+        sketch001.addGeometry(geoList, False)
         del geoList
-        sketch001.addConstraint(Sketcher.Constraint('Radius',0,5.000000))
+        sketch001.addConstraint(Sketcher.Constraint('Radius', 0, 5.000000))
         doc.recompute()
 
-        pad001 = body.newObject('PartDesign::Pad','Pad001')
+        pad001 = body.newObject('PartDesign::Pad', 'Pad001')
         pad001.Profile = doc.getObject('Sketch001')
         pad001.Length = 10
         App.ActiveDocument.recompute()
-        pad001.ReferenceAxis = (doc.getObject('Sketch001'),['N_Axis'])
+        pad001.ReferenceAxis = (doc.getObject('Sketch001'), ['N_Axis'])
         sketch001.Visibility = False
         App.ActiveDocument.recompute()
         pad001.Length = 10.000000
@@ -1057,7 +1062,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
                                         App.Vector(4.869811, 22.837425, 0.000000)))
         geoList.append(Part.LineSegment(App.Vector(4.869811, 22.837425, 0.000000),
                                         App.Vector(2.510468, 22.837425, 0.000000)))
-        padSketch.addGeometry(geoList,False)
+        padSketch.addGeometry(geoList, False)
         del geoList
 
         constraintList = []
@@ -1075,12 +1080,12 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # Assert
         if body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
             return
-        self.assertEqual(body.Shape.BoundBox.XMin,0)
-        self.assertEqual(body.Shape.BoundBox.YMin,0)
-        self.assertEqual(body.Shape.BoundBox.ZMin,0)
-        self.assertEqual(body.Shape.BoundBox.XMax,31.37)
-        self.assertEqual(body.Shape.BoundBox.YMax,25.2)
-        self.assertEqual(body.Shape.BoundBox.ZMax,20)
+        self.assertEqual(body.Shape.BoundBox.XMin, 0)
+        self.assertEqual(body.Shape.BoundBox.YMin, 0)
+        self.assertEqual(body.Shape.BoundBox.ZMin, 0)
+        self.assertEqual(body.Shape.BoundBox.XMax, 31.37)
+        self.assertEqual(body.Shape.BoundBox.YMax, 25.2)
+        self.assertEqual(body.Shape.BoundBox.ZMax, 20)
 
     def testApplyFillet(self):
         # Arrange
@@ -1097,23 +1102,23 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         pad.Length = 10
         doc.recompute()
 
-        sketch001 = body.newObject('Sketcher::SketchObject','Sketch001')
-        sketch001.AttachmentSupport = (doc.getObject('Pad'),['Face6',])
+        sketch001 = body.newObject('Sketcher::SketchObject', 'Sketch001')
+        sketch001.AttachmentSupport = (doc.getObject('Pad'), ['Face6', ])
         sketch001.MapMode = 'FlatFace'
 
         geoList = []
         geoList.append(Part.Circle(App.Vector(15.093666, 13.036922, 0.000000),
                                    App.Vector(0.000000, 0.000000, 1.000000), 5.000000))
-        sketch001.addGeometry(geoList,False)
+        sketch001.addGeometry(geoList, False)
         del geoList
-        sketch001.addConstraint(Sketcher.Constraint('Radius',0,5.000000))
+        sketch001.addConstraint(Sketcher.Constraint('Radius', 0, 5.000000))
         doc.recompute()
 
-        pad001 = body.newObject('PartDesign::Pad','Pad001')
+        pad001 = body.newObject('PartDesign::Pad', 'Pad001')
         pad001.Profile = doc.getObject('Sketch001')
         pad001.Length = 10
         App.ActiveDocument.recompute()
-        pad001.ReferenceAxis = (doc.getObject('Sketch001'),['N_Axis'])
+        pad001.ReferenceAxis = (doc.getObject('Sketch001'), ['N_Axis'])
         sketch001.Visibility = False
         App.ActiveDocument.recompute()
 
@@ -1135,22 +1140,22 @@ class TestTopologicalNamingProblem(unittest.TestCase):
 
         area1 = pad.Shape.Area
         # Act
-        doc.getObject('Sketch').fillet(2,3,
-                                            App.Vector(6.673934,25.000000,0),
-                                            App.Vector(0.000000,21.980343,0),
-                                            4.740471,True,True,False)
+        doc.getObject('Sketch').fillet(2, 3,
+                                       App.Vector(6.673934, 25.000000, 0),
+                                       App.Vector(0.000000, 21.980343, 0),
+                                       4.740471, True, True, False)
         doc.recompute()
         area2 = pad.Shape.Area
 
         # Assert
         if body.Shape.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
             return
-        self.assertEqual(body.Shape.BoundBox.XMin,0)
-        self.assertEqual(body.Shape.BoundBox.YMin,0)
-        self.assertEqual(body.Shape.BoundBox.ZMin,0)
-        self.assertEqual(body.Shape.BoundBox.XMax,31.37)
-        self.assertAlmostEqual(body.Shape.BoundBox.YMax,25.2)
-        self.assertEqual(body.Shape.BoundBox.ZMax,20)
+        self.assertEqual(body.Shape.BoundBox.XMin, 0)
+        self.assertEqual(body.Shape.BoundBox.YMin, 0)
+        self.assertEqual(body.Shape.BoundBox.ZMin, 0)
+        self.assertEqual(body.Shape.BoundBox.XMax, 31.37)
+        self.assertAlmostEqual(body.Shape.BoundBox.YMax, 25.2)
+        self.assertEqual(body.Shape.BoundBox.ZMax, 20)
         self.assertNotEqual(area1, area2)
 
     def testShapeBinder(self):
@@ -1469,8 +1474,8 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         x1, x2, y1, y2 = 10 / math.sqrt(2) - math.sqrt(2), 10 / math.sqrt(2) + math.sqrt(2), 6, 11
         geoList = []
         geoList.append(
-            Part.LineSegment(App.Vector(x1, y1, 0.0 ),
-                             App.Vector(x1, y2, 0.0 )))
+            Part.LineSegment(App.Vector(x1, y1, 0.0),
+                             App.Vector(x1, y2, 0.0)))
         geoList.append(
             Part.LineSegment(App.Vector(x1, y2, 0.0),
                              App.Vector(x2, y2, 0.0)))
@@ -1499,7 +1504,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         pocket = self.Doc.addObject('PartDesign::Pocket', 'Pocket')
         pocket.Type = "Length"
         pocket.Length = 3
-        pocket.Direction = App.Vector(-0.710000000,0.7100000000, 0.0000000000)
+        pocket.Direction = App.Vector(-0.710000000, 0.7100000000, 0.0000000000)
         pocket.Profile = doc.Sketch
         body.addObject(pocket)
         self.Doc.recompute()
@@ -1511,7 +1516,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         self.Doc.recompute()
         volume4 = body.Shape.Volume
         # Assert
-        if body.Shape.ElementMapVersion == "":   # Skip without element maps.
+        if body.Shape.ElementMapVersion == "":  # Skip without element maps.
             return
         reverseMap = body.Shape.childShapes()[0].ElementReverseMap
         faces = [name for name in reverseMap.keys() if name.startswith("Face")]
@@ -1519,16 +1524,16 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 62)
-        self.assertEqual(len(reverseMap),62)
-        self.assertEqual(len(faces),12)
-        self.assertEqual(len(edges),30)
-        self.assertEqual(len(vertexes),20)
+        self.assertEqual(len(reverseMap), 62)
+        self.assertEqual(len(faces), 12)
+        self.assertEqual(len(edges), 30)
+        self.assertEqual(len(vertexes), 20)
         boxVolume = 10 * 10 * 10
         chamferVolume = 1 * 1 * 0.5 * 10
         # cut area is rectangle with sqrt(2) as one side minus 2 isosceles right triangles
-        cutArea = (2 * math.sqrt(2)) * 3 - ((math.sqrt(2)/2 * math.sqrt(2)/2)/2)*2
-        cutVolume = cutArea * 4 # height is 4  ( 11-6 with a limit of 10 from the box )
-        self.assertAlmostEqual(volume1, boxVolume )
+        cutArea = (2 * math.sqrt(2)) * 3 - ((math.sqrt(2) / 2 * math.sqrt(2) / 2) / 2) * 2
+        cutVolume = cutArea * 4  # height is 4  ( 11-6 with a limit of 10 from the box )
+        self.assertAlmostEqual(volume1, boxVolume)
         self.assertAlmostEqual(volume2, boxVolume - 3 * chamferVolume)
         self.assertAlmostEqual(volume3, boxVolume - 3 * chamferVolume - cutVolume, 4)
         self.assertAlmostEqual(volume4, boxVolume - 2 * chamferVolume - cutVolume, 4)
@@ -1545,9 +1550,9 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         fillet = self.Doc.addObject('PartDesign::Fillet', 'Fillet')
         fillet.Refine = True
         fillet.Base = (box, ['Edge1',
-                              'Edge5',
-                              'Edge7',
-                              ])
+                             'Edge5',
+                             'Edge7',
+                             ])
         # fillet.Size = 1
         body.addObject(fillet)
         self.Doc.recompute()
@@ -1558,11 +1563,11 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         doc.Sketch.MapMode = 'FlatFace'
         doc.recompute()
 
-        x1, x2, y1, y2 = 4,6 , 6, 11
+        x1, x2, y1, y2 = 4, 6, 6, 11
         geoList = []
         geoList.append(
-            Part.LineSegment(App.Vector(x1, y1, 0.0 ),
-                             App.Vector(x1, y2, 0.0 )))
+            Part.LineSegment(App.Vector(x1, y1, 0.0),
+                             App.Vector(x1, y2, 0.0)))
         geoList.append(
             Part.LineSegment(App.Vector(x1, y2, 0.0),
                              App.Vector(x2, y2, 0.0)))
@@ -1592,7 +1597,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         pocket.Refine = True
         pocket.Type = "Length"
         pocket.Length = 3
-        pocket.Direction = App.Vector(-0.710000000,0.7100000000, 0.0000000000)
+        pocket.Direction = App.Vector(-0.710000000, 0.7100000000, 0.0000000000)
         pocket.Profile = doc.Sketch
         # pocket.Reversed = False
         body.addObject(pocket)
@@ -1600,12 +1605,12 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         volume3 = body.Shape.Volume
         # Change the filleted edges, potentially triggering TNP
         fillet.Base = (box, ['Edge5',
-                              'Edge7',
-                              ])
+                             'Edge7',
+                             ])
         self.Doc.recompute()
         volume4 = body.Shape.Volume
         # Assert
-        if body.Shape.ElementMapVersion == "":   # Skip without element maps.
+        if body.Shape.ElementMapVersion == "":  # Skip without element maps.
             return
         reverseMap = body.Shape.childShapes()[0].ElementReverseMap
         faces = [name for name in reverseMap.keys() if name.startswith("Face")]
@@ -1613,15 +1618,15 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         vertexes = [name for name in reverseMap.keys() if name.startswith("Vertex")]
         self.assertEqual(len(body.Shape.childShapes()), 1)
         self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 64)
-        self.assertEqual(len(reverseMap),62)
-        self.assertEqual(len(faces),12)
-        self.assertEqual(len(edges),30)
-        self.assertEqual(len(vertexes),20)
+        self.assertEqual(len(reverseMap), 62)
+        self.assertEqual(len(faces), 12)
+        self.assertEqual(len(edges), 30)
+        self.assertEqual(len(vertexes), 20)
         boxVolume = 10 * 10 * 10
         # Full prism minus the rounded triangle prism.
-        filletVolume = 1 * 1 * 10 - 1 * 1 * math.pi / 4 * 10 #0.5 * 10
+        filletVolume = 1 * 1 * 10 - 1 * 1 * math.pi / 4 * 10  # 0.5 * 10
         cutVolume = 24
-        self.assertAlmostEqual(volume1, boxVolume )
+        self.assertAlmostEqual(volume1, boxVolume)
         self.assertAlmostEqual(volume2, boxVolume - 3 * filletVolume)
         self.assertAlmostEqual(volume3, boxVolume - 3 * filletVolume - cutVolume, 4)
         self.assertAlmostEqual(volume4, boxVolume - 2 * filletVolume - cutVolume, 4)
@@ -1662,33 +1667,42 @@ class TestTopologicalNamingProblem(unittest.TestCase):
     def testPD_TNPSketchPadTouching(self):
         """ Prove that a sketch with touching wires works correctly"""
         doc = App.ActiveDocument
-        App.activeDocument().addObject('PartDesign::Body','Body')
-        doc.Body.newObject('Sketcher::SketchObject','Sketch')
-        doc.Sketch.AttachmentSupport = (doc.XY_Plane,[''])
+        App.activeDocument().addObject('PartDesign::Body', 'Body')
+        doc.Body.newObject('Sketcher::SketchObject', 'Sketch')
+        doc.Sketch.AttachmentSupport = (doc.XY_Plane, [''])
         doc.Sketch.MapMode = 'FlatFace'
         radius = 20
         geoList = []
-        geoList.append(Part.Circle(App.Vector(-20, 20, 0.000000), App.Vector(0.000000, 0.000000, 1.000000), radius))
-        doc.Sketch.addGeometry(geoList,False)
+        geoList.append(
+            Part.Circle(App.Vector(-20, 20, 0.000000), App.Vector(0.000000, 0.000000, 1.000000),
+                        radius))
+        doc.Sketch.addGeometry(geoList, False)
         geoList = []
-        geoList.append(Part.Circle(App.Vector(20, 20, 0.000000), App.Vector(0.000000, 0.000000, 1.000000), radius))
-        doc.Sketch.addGeometry(geoList,False)
+        geoList.append(
+            Part.Circle(App.Vector(20, 20, 0.000000), App.Vector(0.000000, 0.000000, 1.000000),
+                        radius))
+        doc.Sketch.addGeometry(geoList, False)
         geoList = []
-        geoList.append(Part.Circle(App.Vector(20, -20, 0.000000), App.Vector(0.000000, 0.000000, 1.000000), radius))
-        doc.Sketch.addGeometry(geoList,False)
+        geoList.append(
+            Part.Circle(App.Vector(20, -20, 0.000000), App.Vector(0.000000, 0.000000, 1.000000),
+                        radius))
+        doc.Sketch.addGeometry(geoList, False)
         geoList = []
-        geoList.append(Part.Circle(App.Vector(-20,-20, 0.000000), App.Vector(0.000000, 0.000000, 1.000000), radius))
-        doc.Sketch.addGeometry(geoList,False)
+        geoList.append(
+            Part.Circle(App.Vector(-20, -20, 0.000000), App.Vector(0.000000, 0.000000, 1.000000),
+                        radius))
+        doc.Sketch.addGeometry(geoList, False)
         del geoList
         doc.recompute()
-        doc.Body.newObject('PartDesign::Pad','Pad')
-        doc.Pad.Profile = (doc.Sketch, ['',])
+        doc.Body.newObject('PartDesign::Pad', 'Pad')
+        doc.Pad.Profile = (doc.Sketch, ['', ])
         doc.Pad.Length = 10
-        doc.Pad.ReferenceAxis = (doc.Sketch,['N_Axis'])
+        doc.Pad.ReferenceAxis = (doc.Sketch, ['N_Axis'])
         doc.Sketch.Visibility = False
         doc.recompute()
-        expected_volume = math.pi * radius * radius * 10 * 4 # Volume of 4 padded circles
+        expected_volume = math.pi * radius * radius * 10 * 4  # Volume of 4 padded circles
         # self.assertAlmostEqual(doc.Body.Shape.Volume, expected_volume ) # TODO ENABLE THIS ASSERTION WHEN IT PASSES
+
     #   # Add additional code to attach another sketch, then change the original sketch and check TNP
 
     # TODO ENABLE THIS TEST IF CODE IS WRITTEN TO SUPPORT SKETCHES WITH OVERLAPS.
@@ -1730,16 +1744,16 @@ class TestTopologicalNamingProblem(unittest.TestCase):
     def testPD_TNPSketchPadSketchMove(self):
         """ Prove that a sketch attached to a padded sketch shape does not have a problem when the initial sketch has geometry move"""
         doc = App.ActiveDocument
-        App.activeDocument().addObject('PartDesign::Body','Body')
-        doc.Body.newObject('Sketcher::SketchObject','Sketch')
-        doc.Sketch.AttachmentSupport = (doc.XY_Plane,[''])
+        App.activeDocument().addObject('PartDesign::Body', 'Body')
+        doc.Body.newObject('Sketcher::SketchObject', 'Sketch')
+        doc.Sketch.AttachmentSupport = (doc.XY_Plane, [''])
         doc.Sketch.MapMode = 'FlatFace'
         geoList = []
-        geoList.append(Part.LineSegment(App.Vector(0,0,0),App.Vector(40,0,0)))
-        geoList.append(Part.LineSegment(App.Vector(40,0,0),App.Vector(40,20,0)))
-        geoList.append(Part.LineSegment(App.Vector(40,20,0),App.Vector(0,20,0)))
-        geoList.append(Part.LineSegment(App.Vector(0,20,0),App.Vector(0,0,0)))
-        doc.Sketch.addGeometry(geoList,False)
+        geoList.append(Part.LineSegment(App.Vector(0, 0, 0), App.Vector(40, 0, 0)))
+        geoList.append(Part.LineSegment(App.Vector(40, 0, 0), App.Vector(40, 20, 0)))
+        geoList.append(Part.LineSegment(App.Vector(40, 20, 0), App.Vector(0, 20, 0)))
+        geoList.append(Part.LineSegment(App.Vector(0, 20, 0), App.Vector(0, 0, 0)))
+        doc.Sketch.addGeometry(geoList, False)
         constraintList = []
         constraintList.append(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
         constraintList.append(Sketcher.Constraint('Coincident', 1, 2, 2, 1))
@@ -1751,10 +1765,10 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         constraintList.append(Sketcher.Constraint('Vertical', 3))
         doc.Sketch.addConstraint(constraintList)
         doc.recompute()
-        doc.Body.newObject('PartDesign::Pad','Pad')
-        doc.Pad.Profile = (doc.Sketch, ['',])
+        doc.Body.newObject('PartDesign::Pad', 'Pad')
+        doc.Pad.Profile = (doc.Sketch, ['', ])
         doc.Pad.Length = 10
-        doc.Pad.ReferenceAxis = (doc.Sketch,['N_Axis'])
+        doc.Pad.ReferenceAxis = (doc.Sketch, ['N_Axis'])
         doc.Sketch.Visibility = False
         doc.Pad.Length = 10.000000
         doc.Pad.TaperAngle = 0.000000
@@ -1769,15 +1783,15 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         doc.Pad.Offset = 0
         doc.recompute()
         doc.Sketch.Visibility = False
-        doc.Body.newObject('Sketcher::SketchObject','Sketch001')
-        doc.Sketch001.AttachmentSupport = (doc.Pad,['Face6',])
+        doc.Body.newObject('Sketcher::SketchObject', 'Sketch001')
+        doc.Sketch001.AttachmentSupport = (doc.Pad, ['Face6', ])
         doc.Sketch001.MapMode = 'FlatFace'
         geoList = []
-        geoList.append(Part.LineSegment(App.Vector(5,5,0),App.Vector(5,10,0)))
-        geoList.append(Part.LineSegment(App.Vector(5,10,0),App.Vector(25,10,0)))
-        geoList.append(Part.LineSegment(App.Vector(25,10,0),App.Vector(25,5,0)))
-        geoList.append(Part.LineSegment(App.Vector(25,5,0),App.Vector(5,5,0)))
-        doc.Sketch001.addGeometry(geoList,False)
+        geoList.append(Part.LineSegment(App.Vector(5, 5, 0), App.Vector(5, 10, 0)))
+        geoList.append(Part.LineSegment(App.Vector(5, 10, 0), App.Vector(25, 10, 0)))
+        geoList.append(Part.LineSegment(App.Vector(25, 10, 0), App.Vector(25, 5, 0)))
+        geoList.append(Part.LineSegment(App.Vector(25, 5, 0), App.Vector(5, 5, 0)))
+        doc.Sketch001.addGeometry(geoList, False)
         del geoList
         constraintList = []
         constraintList.append(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
@@ -1790,10 +1804,10 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         constraintList.append(Sketcher.Constraint('Horizontal', 3))
         doc.Sketch001.addConstraint(constraintList)
         doc.recompute()
-        doc.Body.newObject('PartDesign::Pad','Pad001')
-        doc.Pad001.Profile = (doc.Sketch001, ['',])
+        doc.Body.newObject('PartDesign::Pad', 'Pad001')
+        doc.Pad001.Profile = (doc.Sketch001, ['', ])
         doc.Pad001.Length = 10
-        doc.Pad001.ReferenceAxis = (doc.Sketch001,['N_Axis'])
+        doc.Pad001.ReferenceAxis = (doc.Sketch001, ['N_Axis'])
         doc.Sketch001.Visibility = False
         doc.Pad001.Length = 10.000000
         doc.Pad001.TaperAngle = 0.000000
@@ -1809,33 +1823,35 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         doc.recompute()
         doc.Pad.Visibility = False
         doc.Sketch001.Visibility = False
-        doc.Sketch.movePoint(3,0,App.Vector(-5,0,0),1)
-        doc.Sketch.movePoint(0,0,App.Vector(0.000000,-5,0),1)
-        doc.Sketch.movePoint(1,0,App.Vector(-5,0.000000,0),1)
-        doc.Sketch.movePoint(2,0,App.Vector(-0,-5,0),1)
+        doc.Sketch.movePoint(3, 0, App.Vector(-5, 0, 0), 1)
+        doc.Sketch.movePoint(0, 0, App.Vector(0.000000, -5, 0), 1)
+        doc.Sketch.movePoint(1, 0, App.Vector(-5, 0.000000, 0), 1)
+        doc.Sketch.movePoint(2, 0, App.Vector(-0, -5, 0), 1)
         doc.recompute()
         # If Sketch001 is still at the right start point, we are good.
         self.assertTrue(doc.Sketch001.AttachmentOffset.Matrix == App.Matrix())
         matrix1 = App.Matrix()
-        matrix1.A34 = 10    # Z offset by 10.
+        matrix1.A34 = 10  # Z offset by 10.
         self.assertTrue(doc.Sketch001.Placement.Matrix == matrix1)
 
     def testPD_TNPSketchPadSketchDelete(self):
         """ Prove that a sketch attached to a padded sketch shape does not have a problem when the initial sketch has geometry deleted"""
         doc = App.ActiveDocument
-        App.activeDocument().addObject('PartDesign::Body','Body')
-        doc.Body.newObject('Sketcher::SketchObject','Sketch')
-        doc.Sketch.AttachmentSupport = (doc.XY_Plane,[''])
+        App.activeDocument().addObject('PartDesign::Body', 'Body')
+        doc.Body.newObject('Sketcher::SketchObject', 'Sketch')
+        doc.Sketch.AttachmentSupport = (doc.XY_Plane, [''])
         doc.Sketch.MapMode = 'FlatFace'
         import ProfileLib.RegularPolygon
-        ProfileLib.RegularPolygon.makeRegularPolygon(doc.Sketch,6,App.Vector(0.000000,0.000000,0),App.Vector(24,12,0),False)
+        ProfileLib.RegularPolygon.makeRegularPolygon(doc.Sketch, 6,
+                                                     App.Vector(0.000000, 0.000000, 0),
+                                                     App.Vector(24, 12, 0), False)
         doc.Sketch.addConstraint(Sketcher.Constraint('Coincident', 6, 3, -1, 1))
-        doc.Sketch.addConstraint(Sketcher.Constraint('PointOnObject',0,2,-2))
+        doc.Sketch.addConstraint(Sketcher.Constraint('PointOnObject', 0, 2, -2))
         doc.recompute()
-        doc.Body.newObject('PartDesign::Pad','Pad')
-        doc.Pad.Profile = (doc.Sketch, ['',])
+        doc.Body.newObject('PartDesign::Pad', 'Pad')
+        doc.Pad.Profile = (doc.Sketch, ['', ])
         doc.Pad.Length = 10
-        doc.Pad.ReferenceAxis = (doc.Sketch,['N_Axis'])
+        doc.Pad.ReferenceAxis = (doc.Sketch, ['N_Axis'])
         doc.Sketch.Visibility = False
         doc.Pad.Length = 10.000000
         doc.Pad.TaperAngle = 0.000000
@@ -1850,15 +1866,15 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         doc.Pad.Offset = 0
         doc.recompute()
         doc.Sketch.Visibility = False
-        doc.Body.newObject('Sketcher::SketchObject','Sketch001')
-        doc.Sketch001.AttachmentSupport = (doc.Pad,['Face8',])
+        doc.Body.newObject('Sketcher::SketchObject', 'Sketch001')
+        doc.Sketch001.AttachmentSupport = (doc.Pad, ['Face8', ])
         doc.Sketch001.MapMode = 'FlatFace'
         geoList = []
-        geoList.append(Part.LineSegment(App.Vector(-5, 5, 0.000000),App.Vector(-5, -5, 0.000000)))
-        geoList.append(Part.LineSegment(App.Vector(-5, -5, 0.000000),App.Vector(5, -5, 0.000000)))
-        geoList.append(Part.LineSegment(App.Vector(5, -5, 0.000000),App.Vector(5, 5, 0.000000)))
-        geoList.append(Part.LineSegment(App.Vector(5, 5, 0.000000),App.Vector(-5, 5, 0.000000)))
-        doc.Sketch001.addGeometry(geoList,False)
+        geoList.append(Part.LineSegment(App.Vector(-5, 5, 0.000000), App.Vector(-5, -5, 0.000000)))
+        geoList.append(Part.LineSegment(App.Vector(-5, -5, 0.000000), App.Vector(5, -5, 0.000000)))
+        geoList.append(Part.LineSegment(App.Vector(5, -5, 0.000000), App.Vector(5, 5, 0.000000)))
+        geoList.append(Part.LineSegment(App.Vector(5, 5, 0.000000), App.Vector(-5, 5, 0.000000)))
+        doc.Sketch001.addGeometry(geoList, False)
         del geoList
         constraintList = []
         constraintList.append(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
@@ -1872,10 +1888,10 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         doc.Sketch001.addConstraint(constraintList)
         constraintList = []
         doc.recompute()
-        doc.Body.newObject('PartDesign::Pad','Pad001')
-        doc.Pad001.Profile = (doc.Sketch001, ['',])
+        doc.Body.newObject('PartDesign::Pad', 'Pad001')
+        doc.Pad001.Profile = (doc.Sketch001, ['', ])
         doc.Pad001.Length = 10
-        doc.Pad001.ReferenceAxis = (doc.Sketch001,['N_Axis'])
+        doc.Pad001.ReferenceAxis = (doc.Sketch001, ['N_Axis'])
         doc.Sketch001.Visibility = False
         doc.Pad001.Length = 10.000000
         doc.Pad001.TaperAngle = 0.000000
@@ -1892,13 +1908,13 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         doc.Pad.Visibility = False
         doc.Sketch001.Visibility = False
         doc.Sketch.delGeometries([4])
-        doc.Sketch.addConstraint(Sketcher.Constraint('Coincident',3,2,4,1))
+        doc.Sketch.addConstraint(Sketcher.Constraint('Coincident', 3, 2, 4, 1))
         doc.Sketch.delConstraint(12)
         doc.recompute()
         # If Sketch001 is still at the right start point, we are good.
         self.assertTrue(doc.Sketch001.AttachmentOffset.Matrix == App.Matrix())
         matrix1 = App.Matrix()
-        matrix1.A34 = 10    # Z offset by 10
+        matrix1.A34 = 10  # Z offset by 10
         self.assertTrue(doc.Sketch001.Placement.Matrix == matrix1)
 
     def testPD_TNPSketchPadSketchConstructionChange(self):
@@ -1956,11 +1972,12 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # Act
         App.Gui.Selection.addSelection("", extrude.Name, "Face2")
         # Assert
-        self.assertEqual(len(App.Gui.Selection.getSelectionEx("", 0)[0].SubElementNames),1)
+        self.assertEqual(len(App.Gui.Selection.getSelectionEx("", 0)[0].SubElementNames), 1)
         if extrude.ElementMapVersion == "":  # Should be '4' as of Mar 2023.
-            self.assertEqual(App.Gui.Selection.getSelectionEx("", 0)[0].SubElementNames[0],"Face2")
+            self.assertEqual(App.Gui.Selection.getSelectionEx("", 0)[0].SubElementNames[0], "Face2")
         else:
-            self.assertEqual(App.Gui.Selection.getSelectionEx("", 0)[0].SubElementNames[0][-8:],",F.Face2")
+            self.assertEqual(App.Gui.Selection.getSelectionEx("", 0)[0].SubElementNames[0][-8:],
+                             ",F.Face2")
 
     def testGetElementFunctionality(self):
         # Arrange
@@ -1978,7 +1995,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
             return
         map = pad.Shape.ElementMap
         # Assert
-        self.assertGreater(pad.Shape.ElementMapSize,0)
+        self.assertGreater(pad.Shape.ElementMapSize, 0)
         for tnpName in map.keys():
             element1 = pad.Shape.getElement(tnpName)
             element2 = pad.Shape.getElement(map[tnpName])
@@ -1993,7 +2010,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # Act
         self.Doc.saveAs(filename)
         App.closeDocument(filename)
-        self.Doc = App.openDocument(filename+".FCStd")
+        self.Doc = App.openDocument(filename + ".FCStd")
         self.Doc.recompute()
         # Assert
         self.assertEqual(self.Doc.Sketch.Shape.ElementMapSize, 18)
@@ -2001,25 +2018,25 @@ class TestTopologicalNamingProblem(unittest.TestCase):
     def testBodySubShapeBinderElementMap(self):
         # Arrange
         doc = App.ActiveDocument
-        doc.addObject("Part::Box","Box")
+        doc.addObject("Part::Box", "Box")
         doc.ActiveObject.Label = "Cube"
-        doc.addObject("Part::Box","Box")
+        doc.addObject("Part::Box", "Box")
         doc.ActiveObject.Label = "Cube"
-        doc.addObject("Part::MultiFuse","Fusion")
+        doc.addObject("Part::MultiFuse", "Fusion")
         doc.Fusion.Refine = False
-        doc.Fusion.Shapes = [doc.Box, doc.Box001,]
+        doc.Fusion.Shapes = [doc.Box, doc.Box001, ]
         doc.recompute()
         self.assertEqual(doc.Fusion.Shape.ElementMapSize, 26)
 
-        doc.addObject('PartDesign::Body','Body')
+        doc.addObject('PartDesign::Body', 'Body')
         doc.Body.Label = 'Body'
 
-        doc.addObject('PartDesign::Body','Body001')
+        doc.addObject('PartDesign::Body', 'Body001')
         doc.Body001.Label = 'Body001'
 
         # act
         # Set up the subshapebinder version
-        binder = doc.Body.newObject('PartDesign::SubShapeBinder','Binder')
+        binder = doc.Body.newObject('PartDesign::SubShapeBinder', 'Binder')
         binder.Support = [(doc.Fusion, (""))]
         doc.recompute()
 
@@ -2028,48 +2045,55 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         doc.recompute()
 
         # assert
-        self.assertEqual(doc.Body.OutList[1].Shape.ElementMapSize, 26) # subobjects ( subshapebinder here ) should have elementmap
-        self.assertEqual(doc.Body.Shape.ElementMapSize, 0)  # TODO:  This is Sus, although LS3 passes.  Might be because
+        self.assertEqual(doc.Body.OutList[1].Shape.ElementMapSize,
+                         26)  # subobjects ( subshapebinder here ) should have elementmap
+        self.assertEqual(doc.Body.Shape.ElementMapSize,
+                         0)  # TODO:  This is Sus, although LS3 passes.  Might be because
         # SubShapeBinder is different in LS3.
-        self.assertEqual(doc.Body001.BaseFeature.Shape.ElementMapSize, 26) # base feature lookup should have element map
+        self.assertEqual(doc.Body001.BaseFeature.Shape.ElementMapSize,
+                         26)  # base feature lookup should have element map
         self.assertEqual(doc.Body001.Shape.ElementMapSize, 26)  # Body Shape should have element map
-
 
     def testBaseFeatureAttachmentSupport(self):
         # Arrange
         doc = App.ActiveDocument
-        doc.addObject("Part::Box","Box")
+        doc.addObject("Part::Box", "Box")
         doc.ActiveObject.Label = "Cube"
         doc.recompute()
-        doc.addObject("Part::Box","Box")
+        doc.addObject("Part::Box", "Box")
         doc.ActiveObject.Label = "Cube"
-        doc.Box001.Placement=App.Placement(App.Vector(5.00,5.00,5.00),App.Rotation(App.Vector(0.00,0.00,1.00),0.00))
+        doc.Box001.Placement = App.Placement(App.Vector(5.00, 5.00, 5.00),
+                                             App.Rotation(App.Vector(0.00, 0.00, 1.00), 0.00))
         doc.recompute()
 
-        doc.addObject("Part::MultiFuse","Fusion")
+        doc.addObject("Part::MultiFuse", "Fusion")
         doc.Fusion.Refine = False
-        doc.Fusion.Shapes = [doc.Box, doc.Box001,]
+        doc.Fusion.Shapes = [doc.Box, doc.Box001, ]
 
         doc.recompute()
         # doc.Box.Visibility = False
         # doc.Box001.Visibility = False
         # doc.recompute()
 
-        doc.addObject('PartDesign::Body','Body')
+        doc.addObject('PartDesign::Body', 'Body')
         doc.Body.Label = 'Body'
         doc.Body.BaseFeature = App.activeDocument().Fusion
         doc.recompute()
 
-        doc.Body.newObject('Sketcher::SketchObject','Sketch')
+        doc.Body.newObject('Sketcher::SketchObject', 'Sketch')
         doc.Sketch.AttachmentSupport = (doc.getObject('BaseFeature'), ('Face8'))
         doc.Sketch.MapMode = 'FlatFace'
         doc.recompute()
         geoList = []
-        geoList.append(Part.LineSegment(App.Vector(12.0, 13.0, 0.000000),App.Vector(12.0, 11.0, 0.000000)))
-        geoList.append(Part.LineSegment(App.Vector(12.0, 11, 0.000000),App.Vector(14.0, 11.0, 0.000000)))
-        geoList.append(Part.LineSegment(App.Vector(14.0, 11, 0.000000),App.Vector(14.0, 13.0, 0.000000)))
-        geoList.append(Part.LineSegment(App.Vector(14.0, 13.0, 0.000000),App.Vector(12, 13.0, 0.000000)))
-        doc.Sketch.addGeometry(geoList,False)
+        geoList.append(
+            Part.LineSegment(App.Vector(12.0, 13.0, 0.000000), App.Vector(12.0, 11.0, 0.000000)))
+        geoList.append(
+            Part.LineSegment(App.Vector(12.0, 11, 0.000000), App.Vector(14.0, 11.0, 0.000000)))
+        geoList.append(
+            Part.LineSegment(App.Vector(14.0, 11, 0.000000), App.Vector(14.0, 13.0, 0.000000)))
+        geoList.append(
+            Part.LineSegment(App.Vector(14.0, 13.0, 0.000000), App.Vector(12, 13.0, 0.000000)))
+        doc.Sketch.addGeometry(geoList, False)
         del geoList
         constraintList = []
         constraintList.append(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
@@ -2086,14 +2110,14 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         doc.recompute()
 
         # Assert that we have a sketch element map before proceeding
-        self.assertEqual(doc.Sketch.Shape.ElementMapSize,12)
+        self.assertEqual(doc.Sketch.Shape.ElementMapSize, 12)
 
         # Arrange
-        doc.Body.newObject('PartDesign::Pad','Pad')
-        doc.Pad.Profile = (doc.Sketch, ['',])
+        doc.Body.newObject('PartDesign::Pad', 'Pad')
+        doc.Pad.Profile = (doc.Sketch, ['', ])
         doc.Pad.Length = 10
         doc.recompute()
-        doc.Pad.ReferenceAxis = (doc.Sketch,['N_Axis'])
+        doc.Pad.ReferenceAxis = (doc.Sketch, ['N_Axis'])
         doc.Sketch.Visibility = False
         doc.Pad.Length = 10.000000
         doc.Pad.TaperAngle = 0.000000
@@ -2111,16 +2135,18 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         doc.recompute()
 
         # Act
-        doc.Box001.Width='3.00 mm'
-        doc.Box001.Placement=App.Placement(App.Vector(5.00,5.00,5.00),App.Rotation(App.Vector(0.00,0.00,1.00),0.00))
+        doc.Box001.Width = '3.00 mm'
+        doc.Box001.Placement = App.Placement(App.Vector(5.00, 5.00, 5.00),
+                                             App.Rotation(App.Vector(0.00, 0.00, 1.00), 0.00))
         doc.recompute()
         # Assert
-        self.assertEqual(len(doc.Body.Shape.Faces),17)  # Check that the object seems right.
-        self.assertEqual(len(doc.Body.Shape.Edges),42)
-        self.assertEqual(len(doc.Body.Shape.Vertexes),28)
-        self.assertEqual(len(doc.Body.Shape.Shells),1)
-        self.assertEqual(len(doc.Body.Shape.Solids),1)
-        self.assertEqual(doc.Sketch.AttachmentSupport[0][1][0], 'Face9')    # Attachment autochanged from Face8.
+        self.assertEqual(len(doc.Body.Shape.Faces), 17)  # Check that the object seems right.
+        self.assertEqual(len(doc.Body.Shape.Edges), 42)
+        self.assertEqual(len(doc.Body.Shape.Vertexes), 28)
+        self.assertEqual(len(doc.Body.Shape.Shells), 1)
+        self.assertEqual(len(doc.Body.Shape.Solids), 1)
+        self.assertEqual(doc.Sketch.AttachmentSupport[0][1][0],
+                         'Face9')  # Attachment autochanged from Face8.
         # potentially check the .BoundBox ( calc seems off on this, Not applying sketch position to Pad object )
 
     def create_t_sketch(self):
@@ -2584,7 +2610,6 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         #   import TestApp
         #   TestApp.Test("TestPartDesignApp.TestTopologicalNamingProblem.testPadChange_UpToFirst_to_Dimension")
         # to leave the test document(s) around for further examination in an interactive setting.
-        if hasattr(App,"KeepTestDoc") and App.KeepTestDoc:
+        if hasattr(App, "KeepTestDoc") and App.KeepTestDoc:
             return
         App.closeDocument(self.Doc.Name)
-

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -577,15 +577,11 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         self.Doc.recompute()
         # Assert
         self.assertEqual(len(body.Shape.childShapes()), 1)
-        self.assertEqual(body.Shape.childShapes()[0].ElementMapSize, 30)
-        self.assertEqual(loft.Shape.ElementMapSize, 30)
-        revMap = body.Shape.childShapes()[0].ElementReverseMap
-        # 4 vertexes and 4 edges in each of the two sketches = 16.
-        # Loft is a rectangular prism and so 26.
-        # End map is 12 Edge + 6 face + 8 vertexes (with 4 duplicates)
-        # Why only 4 dup vertexes in the map, not 8 and 8 dup edges?
-        # Theory:  only vertexes on the actual profile matter to the mapper.
-        # Has newnames, so we must have done a boolean to attach the ends to the pipe.
+        # 6 face 12 edge 8 vertexes = 26
+        # 4 edges are duplicated (the originals from the sketch loft profile, and then those in the loft)
+        # 4 vertexes are quad dups for 12 more.  26 + 4 + 12 = 42
+        self.assertEqual(body.Shape.ElementMapSize, 42)
+        revMap = body.Shape.ElementReverseMap
         self.assertNotEqual(loft.Shape.ElementReverseMap['Vertex1'],"Vertex1")
         self.assertNotEqual(revMap['Vertex1'],"Vertex1")
         self.assertEqual(self.countFacesEdgesVertexes(loft.Shape.ElementReverseMap),(6,12,8))


### PR DESCRIPTION
Match behavior before ElementMaps refactored out of ComplexGeoData. 