### PR TITLE
Gui: Do not show overlay panels in Start

### DIFF
--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -516,6 +516,8 @@ bool GraphvizView::onHasMsg(const char* pMsg) const
         return true;
     else if (strcmp("PrintPdf",pMsg) == 0)
         return true;
+    else if (strcmp("AllowsOverlayOnHover", pMsg) == 0)
+        return true;
     return false;
 }
 

--- a/src/Gui/ImageView.cpp
+++ b/src/Gui/ImageView.cpp
@@ -370,6 +370,9 @@ bool ImageView::onHasMsg(const char* pMsg) const
     if (strcmp("PrintPdf", pMsg) == 0) {
         return true;
     }
+    else if (strcmp("AllowsOverlayOnHover", pMsg) == 0) {
+        return true;
+    }
 
     return false;
 }

--- a/src/Gui/SplitView3DInventor.cpp
+++ b/src/Gui/SplitView3DInventor.cpp
@@ -235,6 +235,9 @@ bool AbstractSplitView::onHasMsg(const char* pMsg) const
     else if (strcmp("ViewAxo",pMsg) == 0) {
         return true;
     }
+    else if (strcmp("AllowsOverlayOnHover", pMsg) == 0) {
+        return true;
+    }
     return false;
 }
 

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -524,6 +524,9 @@ bool View3DInventor::onHasMsg(const char* pMsg) const
     if (strcmp("ZoomOut", pMsg) == 0) {
         return true;
     }
+    if (strcmp("AllowsOverlayOnHover", pMsg) == 0) {
+        return true;
+    }
 
     return false;
 }

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -461,6 +461,9 @@ bool DrawingView::onHasMsg(const char* pMsg) const
     else if (strcmp("PrintPdf", pMsg) == 0) {
         return true;
     }
+    else if (strcmp("AllowsOverlayOnHover", pMsg) == 0) {
+        return true;
+    }
     return false;
 }
 

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -244,6 +244,9 @@ bool SheetView::onHasMsg(const char* pMsg) const
     if (strcmp(pMsg, "PrintPdf") == 0) {
         return true;
     }
+    else if (strcmp("AllowsOverlayOnHover", pMsg) == 0) {
+        return true;
+    }
 
     return false;
 }

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -392,6 +392,15 @@ void StartView::newArchFile() const
     postStart(PostStartBehavior::doNotSwitchWorkbench);
 }
 
+bool StartView::onHasMsg(const char* pMsg) const
+{
+    if (strcmp("AllowsOverlayOnHover", pMsg) == 0) {
+        return false;
+    }
+
+    return MDIView::onHasMsg(pMsg);
+}
+
 void StartView::postStart(PostStartBehavior behavior) const
 {
     auto hGrp = App::GetApplication().GetParameterGroupByPath(

--- a/src/Mod/Start/Gui/StartView.h
+++ b/src/Mod/Start/Gui/StartView.h
@@ -70,6 +70,8 @@ public:
     void newDraftFile() const;
     void newArchFile() const;
 
+    bool onHasMsg(const char* pMsg) const override;
+
 public:
     enum class PostStartBehavior
     {

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -232,6 +232,9 @@ bool MDIViewPage::onHasMsg(const char* pMsg) const
     if (strcmp("ViewFit", pMsg) == 0) {
         return true;
     }
+    else if (strcmp("AllowsOverlayOnHover", pMsg) == 0) {
+        return true;
+    }
     else if (strcmp("CanPan",pMsg) == 0) {
         return true;
     }


### PR DESCRIPTION
This ensures that overlay panels cannot be shown in the Start page which created ugly artifacts:
![image](https://github.com/user-attachments/assets/ba70cb8a-d85f-47bb-9464-ae9580c312b7)
