### PR TITLE
labels.yml: Add Stylesheets + Differenitate between Mod and Topic labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,6 +2,8 @@
 # source:
 # - any: ['src/**/*', '!src/docs/*']
 
+# 'Mod' related labels
+
 "Mod: Core":
 - changed-files:
   - any-glob-to-any-file: ['src/App/**/*', 'src/Base/**/*', 'src/Gui/**/*']
@@ -85,3 +87,9 @@
 "Mod: Test":
 - changed-files:
   - any-glob-to-any-file:  ['src/Mod/Test/**/*']
+
+# 'Topic' related labels
+
+"Topic: Stylesheets":
+- changed-files:
+  - any-glob-to-any-file:  ['src/Gui/Stylesheets/**/*']


### PR DESCRIPTION
Added the functionality for the labeler to recognize Stylesheet related PRs. Also annotated file to differentiate different types of labels (as opposed to sorting them all alphabetically).