### PR TITLE
[Draft] Fix error exiting FreeCAD half way through creating a line

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -126,7 +126,7 @@ class Tracker:
 
         So it doesn't obscure the other objects.
         """
-        if self.switch:
+        if hasattr(Draft.get3DView(), "getSceneGraph") and self.switch:
             sg = Draft.get3DView().getSceneGraph()
             sg.removeChild(self.switch)
             sg.addChild(self.switch)
@@ -136,7 +136,7 @@ class Tracker:
 
         So it obscures the other objects.
         """
-        if self.switch:
+        if hasattr(Draft.get3DView(), "getSceneGraph") and self.switch:
             sg = Draft.get3DView().getSceneGraph()
             sg.removeChild(self.switch)
             sg.insertChild(self.switch, 0)


### PR DESCRIPTION
In the process of testing PR15745 I triggered an attribute error (which had absolutely nothing to do with that PR) and this PR is to fix it.

Original error:

```
Traceback (most recent call last):
  File "/home/john/freecad-main-build781/Mod/Draft/InitGui.py", line 165, in Deactivated
    FreeCADGui.draftToolBar.Deactivated()
  File "/home/john/freecad-main-build781/Mod/Draft/DraftGui.py", line 1631, in Deactivated
    FreeCAD.activeDraftCommand.finish()
  File "/home/john/freecad-main-build781/Mod/Draft/draftguitools/gui_lines.py", line 194, in finish
    super().finish()
  File "/home/john/freecad-main-build781/Mod/Draft/draftguitools/gui_base_original.py", line 176, in finish
    self.wp._restore()
  File "/home/john/freecad-main-build781/Mod/Draft/WorkingPlane.py", line 1228, in _restore
    self._update_all(_hist_add=False)
  File "/home/john/freecad-main-build781/Mod/Draft/WorkingPlane.py", line 1687, in _update_all
    self._update_grid()
  File "/home/john/freecad-main-build781/Mod/Draft/WorkingPlane.py", line 1725, in _update_grid
    FreeCADGui.Snapper.restack()  # Required??
  File "/home/john/freecad-main-build781/Mod/Draft/draftguitools/gui_snapper.py", line 1210, in restack
    self.grid.lowerTracker()
  File "/home/john/freecad-main-build781/Mod/Draft/draftguitools/gui_trackers.py", line 130, in lowerTracker
    sg = Draft.get3DView().getSceneGraph()
AttributeError: 'NoneType' object has no attribute 'getSceneGraph'
```
