### PR TITLE
Add text to readme and the issue template to record macros for bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml
@@ -1,12 +1,12 @@
 name: Report a Problem
 description: Have you found something that does not work well, is too hard to do or is missing altogether? Please create a Problem Report.
-labels: ["needs triage"]
+labels: ["Status: Needs triage"]
 body:
   - type: checkboxes
     id: existing_issue
     attributes:
       label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the problem you encountered.
+      description: Please [search](https://github.com/FreeCAD/FreeCAD/issues) to see if a similar issue already exists for the problem you encountered.
       options:
       - label: I have searched the existing issues
         required: true
@@ -14,7 +14,7 @@ body:
     id: description
     attributes:
       label: Problem description
-      description: Describe the problem and how it impacts user experience, workflow, maintainability or speed of the code. If the problem appears to be a bug with the current functionality, provide as test case or recipe that reproduces the error.
+      description: Describe the problem and how it impacts user experience, workflow, maintainability or speed of the code. If the problem appears to be a bug with the current functionality, provide as test case or recipe that reproduces the error. Ideally record a macro and share it it.
       placeholder: Description of the problem
     validations:
       required: true
@@ -33,14 +33,13 @@ body:
       options:
         - Addon Manager
         - Assembly
-        - BIM/Arch
-        - CAM/Path
+        - BIM
+        - CAM
         - Core
         - Draft
         - Expressions
         - FEM
         - File formats
-        - GCS
         - Mesh
         - OpenSCAD
         - Part
@@ -48,7 +47,7 @@ body:
         - Project Tools & Websites
         - Sketcher
         - Spreadsheet
-        - Techdraw
+        - TechDraw
         - Other (specify in description)
   - type: textarea
     id: anything_else
@@ -57,6 +56,7 @@ body:
       description: |
         Links? References? Anything that will give us more context about the issue you are encountering!
         If there is a discussion about the problem on the forum, provide link(s) here.
+        You can upload or copy your macro here to speed up the diagnosis and debugging.
 
         Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in. To attach a FCStd file, ZIP it first (GitHub won't recognize the extension otherwise).
     validations:
@@ -65,7 +65,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/FreeCAD/FreeCAD/blob/master/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/FreeCAD/FreeCAD/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/PROBLEM_REPORT.yml
@@ -14,7 +14,7 @@ body:
     id: description
     attributes:
       label: Problem description
-      description: Describe the problem and how it impacts user experience, workflow, maintainability or speed of the code. If the problem appears to be a bug with the current functionality, provide as test case or recipe that reproduces the error. Ideally record a macro and share it it.
+      description: Describe the problem and how it impacts user experience, workflow, maintainability or speed of the code. If the problem appears to be a bug with the current functionality, provide as test case or recipe that reproduces the error. Ideally record a macro and attach it.
       placeholder: Description of the problem
     validations:
       required: true

--- a/README.md
+++ b/README.md
@@ -78,18 +78,19 @@ Reporting Issues
 
 To report an issue please:
 
-- First post to forum to verify the issue; 
-- Link forum thread to bug tracker ticket and vice-a-versa; 
-- Use the most updated stable or development versions of FreeCAD; 
-- Post version info from eg. `Help > About FreeCAD > Copy to clipboard`; 
+- First post to forum to verify the issue and search the existing [issues](https://github.com/FreeCAD/FreeCAD/issues) for potential duplicates; 
+- Use the most updated stable or [development versions](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) of FreeCAD; 
+- Post version info from e.g. `Help > About FreeCAD > Copy to clipboard`; 
+- Start recording a macro `Macro > Macro recording...` and repeat all steps. Stop recording after the issue occurs and upload the saved macro or copy the macro code in the issue.
 - Post a Step-By-Step explanation on how to recreate the issue; 
-- Upload an example file to demonstrate problem. 
+- Upload an example file (FCStd as ZIP file) to demonstrate the problem. 
+- Link forum thread to GitHub issue and vice-a-versa; 
 
 For more detail see:
 
 - [Bug Tracker](https://github.com/FreeCAD/FreeCAD/issues)
 - [Reporting Issues and Requesting Features](https://github.com/FreeCAD/FreeCAD/issues/new/choose)
-- [Contributing](https://github.com/FreeCAD/FreeCAD/blob/master/CONTRIBUTING.md)
+- [Contributing](https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md)
 - [Help Forum](https://forum.freecad.org/viewforum.php?f=3)
 - [Developers Handbook](https://freecad.github.io/DevelopersHandbook/)
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ Reporting Issues
 
 To report an issue please:
 
-- First post to forum to verify the issue and search the existing [issues](https://github.com/FreeCAD/FreeCAD/issues) for potential duplicates; 
+- Consider posting to the [Forum](https://forum.freecad.org), [Discord](https://discord.com/invite/F4hdxzYZfc) channel, or [Reddit](https://www.reddit.com/r/FreeCAD) to verify the issue; 
+- Search the existing [issues](https://github.com/FreeCAD/FreeCAD/issues) for potential duplicates; 
 - Use the most updated stable or [development versions](https://github.com/FreeCAD/FreeCAD-Bundle/releases/tag/weekly-builds) of FreeCAD; 
 - Post version info from e.g. `Help > About FreeCAD > Copy to clipboard`; 
-- Start recording a macro `Macro > Macro recording...` and repeat all steps. Stop recording after the issue occurs and upload the saved macro or copy the macro code in the issue.
+- Start recording a macro `Macro > Macro recording...` and repeat all steps. Stop recording after the issue occurs and upload the saved macro or copy the macro code in the issue; 
 - Post a Step-By-Step explanation on how to recreate the issue; 
-- Upload an example file (FCStd as ZIP file) to demonstrate the problem. 
-- Link forum thread to GitHub issue and vice-a-versa; 
+- Upload an example file (FCStd as ZIP file) to demonstrate the problem; 
 
 For more detail see:
 


### PR DESCRIPTION
While trying to narrow down TNP @bgbsww mentioned that is would be very helpful if users could record a macro when recreating issues.
This PR adds text to readme and the issue template that the user should record a macro when recreating the issue and sharing this macro in the issue.
Also, updated old links from master branch to main in the readme and issue template.