### PR TITLE
cMake: ensure the Shiboken target exists before using it

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
+++ b/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
@@ -38,7 +38,7 @@ macro(SetupShibokenAndPyside)
             find_package(Shiboken${SHIBOKEN_MAJOR_VERSION} QUIET)
         endif()
 
-        if(SHIBOKEN_MAJOR_VERSION EQUAL 6)
+        if(TARGET Shiboken6::libshiboken AND SHIBOKEN_MAJOR_VERSION EQUAL 6)
             set_target_properties(Shiboken6::libshiboken PROPERTIES INTERFACE_COMPILE_DEFINITIONS "NDEBUG")
         endif()
     endif()


### PR DESCRIPTION
The target used in the original version of the clause does not exist when using the LibPack, but the setting is also irrelevant because the LibPack has already prevented Shiboken from setting the limited API.