### PR TITLE
labels.yml: Add 'Packaging/building' label for CMake related changes

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -88,6 +88,12 @@
 - changed-files:
   - any-glob-to-any-file:  ['src/Mod/Test/**/*']
 
+# 'Packaging' related labels
+
+"Packaging/building":
+- changed-files:
+  - any-glob-to-any-file:  ['cMake/**/*']
+
 # 'Topic' related labels
 
 "Topic: Stylesheets":


### PR DESCRIPTION
Any changes to `cMake/` are packaging related and therefore label can be applied.