### PR TITLE
Sketcher: Fix copy paste errors

### DIFF
--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -65,85 +65,105 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyObject* oNumArg5;
     int any_index;
 
-    // ConstraintType, GeoIndex
-    if (PyArg_ParseTuple(args, "si", &ConstraintType, &FirstIndex)) {
+    PyObject* activated;
+    PyObject* driving;
+
+    Sketcher::Constraint* cstr = this->getConstraintPtr();
+
+    auto handleSi = [&]() -> bool {
         if (strcmp("Horizontal", ConstraintType) == 0) {
-            this->getConstraintPtr()->Type = Horizontal;
-            this->getConstraintPtr()->First = FirstIndex;
-            return 0;
+            cstr->Type = Horizontal;
         }
         else if (strcmp("Vertical", ConstraintType) == 0) {
-            this->getConstraintPtr()->Type = Vertical;
-            this->getConstraintPtr()->First = FirstIndex;
-            return 0;
+            cstr->Type = Vertical;
         }
         else if (strcmp("Block", ConstraintType) == 0) {
-            this->getConstraintPtr()->Type = Block;
-            this->getConstraintPtr()->First = FirstIndex;
+            cstr->Type = Block;
+        }
+        else {
+            return false;
+        }
+        cstr->First = FirstIndex;
+        return true;
+    };
+
+    // ConstraintType, GeoIndex
+    if (PyArg_ParseTuple(args, "si", &ConstraintType, &FirstIndex)) {
+        if (handleSi()) {
             return 0;
         }
     }
     PyErr_Clear();
 
-    if (PyArg_ParseTuple(args, "siO", &ConstraintType, &FirstIndex, &index_or_value)) {
+    // ConstraintType, GeoIndex, activated
+    if (PyArg_ParseTuple(args, "siO", &ConstraintType, &FirstIndex, &activated)) {
+        if (PyBool_Check(activated)) {
+            if (handleSi()) {
+                cstr->isActive = PyObject_IsTrue(activated);
+                return 0;
+            }
+        }
+    }
+    PyErr_Clear();
+
+
+    auto handleSiO = [&]() -> bool {
         // ConstraintType, GeoIndex1, GeoIndex2
         if (PyLong_Check(index_or_value)) {
             SecondIndex = PyLong_AsLong(index_or_value);
             bool valid = false;
             if (strcmp("Tangent", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Tangent;
+                cstr->Type = Tangent;
                 valid = true;
             }
             else if (strcmp("Parallel", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Parallel;
+                cstr->Type = Parallel;
                 valid = true;
             }
             else if (strcmp("Perpendicular", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Perpendicular;
+                cstr->Type = Perpendicular;
                 valid = true;
             }
             else if (strcmp("Equal", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Equal;
+                cstr->Type = Equal;
                 valid = true;
             }
             else if (strstr(ConstraintType, "InternalAlignment")) {
-                this->getConstraintPtr()->Type = InternalAlignment;
+                cstr->Type = InternalAlignment;
 
                 valid = true;
                 if (strstr(ConstraintType, "EllipseMajorDiameter")) {
-                    this->getConstraintPtr()->AlignmentType = EllipseMajorDiameter;
+                    cstr->AlignmentType = EllipseMajorDiameter;
                 }
                 else if (strstr(ConstraintType, "EllipseMinorDiameter")) {
-                    this->getConstraintPtr()->AlignmentType = EllipseMinorDiameter;
+                    cstr->AlignmentType = EllipseMinorDiameter;
                 }
                 else if (strstr(ConstraintType, "HyperbolaMajor")) {
-                    this->getConstraintPtr()->AlignmentType = HyperbolaMajor;
+                    cstr->AlignmentType = HyperbolaMajor;
                 }
                 else if (strstr(ConstraintType, "HyperbolaMinor")) {
-                    this->getConstraintPtr()->AlignmentType = HyperbolaMinor;
+                    cstr->AlignmentType = HyperbolaMinor;
                 }
                 else if (strstr(ConstraintType, "ParabolaFocalAxis")) {
-                    this->getConstraintPtr()->AlignmentType = ParabolaFocalAxis;
+                    cstr->AlignmentType = ParabolaFocalAxis;
                 }
                 else {
-                    this->getConstraintPtr()->AlignmentType = Undef;
+                    cstr->AlignmentType = Undef;
                     valid = false;
                 }
             }
 
             if (valid) {
-                this->getConstraintPtr()->First = FirstIndex;
-                this->getConstraintPtr()->Second = SecondIndex;
-                return 0;
+                cstr->First = FirstIndex;
+                cstr->Second = SecondIndex;
+                return true;
             }
         }
         // ConstraintType, GeoIndex, Value
         if (PyNumber_Check(index_or_value)) {  // can be float or int
             Value = PyFloat_AsDouble(index_or_value);
-            bool valid = false;
             if (strcmp("Distance", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Distance;
-                valid = true;
+                cstr->Type = Distance;
             }
             else if (strcmp("Angle", ConstraintType) == 0) {
                 if (PyObject_TypeCheck(index_or_value, &(Base::QuantityPy::Type))) {
@@ -153,92 +173,126 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }
-                this->getConstraintPtr()->Type = Angle;
-                valid = true;
+                cstr->Type = Angle;
             }
             else if (strcmp("DistanceX", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = DistanceX;
-                valid = true;
+                cstr->Type = DistanceX;
             }
             else if (strcmp("DistanceY", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = DistanceY;
-                valid = true;
+                cstr->Type = DistanceY;
             }
             else if (strcmp("Radius", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Radius;
+                cstr->Type = Radius;
                 // set a value that is out of range of result of atan2
                 // this value is handled in ViewProviderSketch
-                this->getConstraintPtr()->LabelPosition = 10;
-                valid = true;
+                cstr->LabelPosition = 10;
             }
             else if (strcmp("Diameter", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Diameter;
+                cstr->Type = Diameter;
                 // set a value that is out of range of result of atan2
                 // this value is handled in ViewProviderSketch
-                this->getConstraintPtr()->LabelPosition = 10;
-                valid = true;
+                cstr->LabelPosition = 10;
             }
             else if (strcmp("Weight", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Weight;
+                cstr->Type = Weight;
                 // set a value that is out of range of result of atan2
                 // this value is handled in ViewProviderSketch
-                this->getConstraintPtr()->LabelPosition = 10;
-                valid = true;
+                cstr->LabelPosition = 10;
             }
-            if (valid) {
-                this->getConstraintPtr()->First = FirstIndex;
-                this->getConstraintPtr()->setValue(Value);
+            else {
+                return false;
+            }
+
+            cstr->First = FirstIndex;
+            cstr->setValue(Value);
+            return true;
+        }
+        return false;
+    };
+
+    if (PyArg_ParseTuple(args, "siO", &ConstraintType, &FirstIndex, &index_or_value)) {
+        if (handleSiO()) {
+            return 0;
+        }
+    }
+    PyErr_Clear();
+
+    if (PyArg_ParseTuple(args, "siOO", &ConstraintType, &FirstIndex, &index_or_value, &activated)) {
+        if (PyBool_Check(activated)) {
+            if (handleSiO()) {
+                cstr->isActive = PyObject_IsTrue(activated);
                 return 0;
             }
         }
     }
     PyErr_Clear();
 
-    if (PyArg_ParseTuple(args, "siiO", &ConstraintType, &FirstIndex, &any_index, &index_or_value)) {
+    if (PyArg_ParseTuple(args,
+                         "siOOO",
+                         &ConstraintType,
+                         &FirstIndex,
+                         &index_or_value,
+                         &activated,
+                         &driving)) {
+        if (PyBool_Check(activated) && PyBool_Check(driving)) {
+            if (handleSiO()) {
+                cstr->isActive = PyObject_IsTrue(activated);
+                if (cstr->isDimensional()) {
+                    cstr->isDriving = PyObject_IsTrue(driving);
+                }
+                return 0;
+            }
+        }
+    }
+    PyErr_Clear();
+
+
+    auto handleSiiO = [&]() -> bool {
         // ConstraintType, GeoIndex1, PosIndex1, GeoIndex2
         if (PyLong_Check(index_or_value)) {
             FirstPos = any_index;
             SecondIndex = PyLong_AsLong(index_or_value);
             bool valid = false;
             if (strcmp("Perpendicular", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Perpendicular;
+                cstr->Type = Perpendicular;
                 valid = true;
             }
             else if (strcmp("Tangent", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Tangent;
+                cstr->Type = Tangent;
                 valid = true;
             }
             else if (strcmp("PointOnObject", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = PointOnObject;
+                cstr->Type = PointOnObject;
                 valid = true;
             }
             else if (strstr(ConstraintType, "InternalAlignment")) {
-                this->getConstraintPtr()->Type = InternalAlignment;
+                cstr->Type = InternalAlignment;
 
                 valid = true;
 
                 if (strstr(ConstraintType, "EllipseFocus1")) {
-                    this->getConstraintPtr()->AlignmentType = EllipseFocus1;
+                    cstr->AlignmentType = EllipseFocus1;
                 }
                 else if (strstr(ConstraintType, "EllipseFocus2")) {
-                    this->getConstraintPtr()->AlignmentType = EllipseFocus2;
+                    cstr->AlignmentType = EllipseFocus2;
                 }
                 else if (strstr(ConstraintType, "HyperbolaFocus")) {
-                    this->getConstraintPtr()->AlignmentType = HyperbolaFocus;
+                    cstr->AlignmentType = HyperbolaFocus;
                 }
                 else if (strstr(ConstraintType, "ParabolaFocus")) {
-                    this->getConstraintPtr()->AlignmentType = ParabolaFocus;
+                    cstr->AlignmentType = ParabolaFocus;
                 }
                 else {
-                    this->getConstraintPtr()->AlignmentType = Undef;
+                    cstr->AlignmentType = Undef;
                     valid = false;
                 }
             }
+
             if (valid) {
-                this->getConstraintPtr()->First = FirstIndex;
-                this->getConstraintPtr()->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
-                this->getConstraintPtr()->Second = SecondIndex;
-                return 0;
+                cstr->First = FirstIndex;
+                cstr->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
+                cstr->Second = SecondIndex;
+                return true;
             }
         }
         // ConstraintType, GeoIndex1, GeoIndex2, Value
@@ -254,131 +308,54 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }
-                this->getConstraintPtr()->Type = Angle;
-                this->getConstraintPtr()->First = FirstIndex;
-                this->getConstraintPtr()->Second = SecondIndex;
-                this->getConstraintPtr()->setValue(Value);
-                return 0;
+                cstr->Type = Angle;
+                cstr->Second = SecondIndex;
             }
             else if (strcmp("Distance", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Distance;
-                this->getConstraintPtr()->First = FirstIndex;
-                this->getConstraintPtr()->Second = SecondIndex;
-                this->getConstraintPtr()->setValue(Value);
-                return 0;
+                cstr->Type = Distance;
+                cstr->Second = SecondIndex;
             }
             else if (strcmp("DistanceX", ConstraintType) == 0) {
                 FirstPos = SecondIndex;
                 SecondIndex = -1;
-                this->getConstraintPtr()->Type = DistanceX;
-                this->getConstraintPtr()->First = FirstIndex;
-                this->getConstraintPtr()->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
-                this->getConstraintPtr()->setValue(Value);
-                return 0;
+                cstr->Type = DistanceX;
+                cstr->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
             }
             else if (strcmp("DistanceY", ConstraintType) == 0) {
                 FirstPos = SecondIndex;
                 SecondIndex = -1;
-                this->getConstraintPtr()->Type = DistanceY;
-                this->getConstraintPtr()->First = FirstIndex;
-                this->getConstraintPtr()->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
-                this->getConstraintPtr()->setValue(Value);
-                return 0;
+                cstr->Type = DistanceY;
+                cstr->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
             }
+            else {
+                return false;
+            }
+
+            cstr->First = FirstIndex;
+            cstr->setValue(Value);
+            return true;
+        }
+        return false;
+    };
+
+
+    if (PyArg_ParseTuple(args, "siiO", &ConstraintType, &FirstIndex, &any_index, &index_or_value)) {
+        if (handleSiiO()) {
+            return 0;
         }
     }
     PyErr_Clear();
 
-    if (PyArg_ParseTuple(args, "siiiO", &ConstraintType, &intArg1, &intArg2, &intArg3, &oNumArg4)) {
-        // Value, ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, PosIndex2
-        if (PyLong_Check(oNumArg4)) {
-            intArg4 = PyLong_AsLong(oNumArg4);
-            bool valid = false;
-            if (strcmp("Coincident", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Coincident;
-                valid = true;
-            }
-            else if (strcmp("Horizontal", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Horizontal;
-                valid = true;
-            }
-            else if (strcmp("Vertical", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Vertical;
-                valid = true;
-            }
-            else if (strcmp("Perpendicular", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Perpendicular;
-                valid = true;
-            }
-            else if (strcmp("Tangent", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Tangent;
-                valid = true;
-            }
-            else if (strcmp("TangentViaPoint", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Tangent;
-                // valid = true;//non-standard assignment
-                this->getConstraintPtr()->First = intArg1;
-                this->getConstraintPtr()->FirstPos = Sketcher::PointPos::none;
-                this->getConstraintPtr()->Second = intArg2;
-                this->getConstraintPtr()->SecondPos = Sketcher::PointPos::none;
-                this->getConstraintPtr()->Third = intArg3;
-                this->getConstraintPtr()->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
-                return 0;
-            }
-            else if (strcmp("PerpendicularViaPoint", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Perpendicular;
-                // valid = true;//non-standard assignment
-                this->getConstraintPtr()->First = intArg1;
-                this->getConstraintPtr()->FirstPos = Sketcher::PointPos::none;
-                this->getConstraintPtr()->Second = intArg2;
-                this->getConstraintPtr()->SecondPos = Sketcher::PointPos::none;
-                this->getConstraintPtr()->Third = intArg3;
-                this->getConstraintPtr()->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
-                return 0;
-            }
-            else if (strstr(ConstraintType,
-                            "InternalAlignment")) {  // InteralAlignment with
-                                                     // InternalElementIndex argument
-                this->getConstraintPtr()->Type = InternalAlignment;
-
-                valid = true;
-
-                if (strstr(ConstraintType, "BSplineControlPoint")) {
-                    this->getConstraintPtr()->AlignmentType = BSplineControlPoint;
-                }
-                else if (strstr(ConstraintType, "BSplineKnotPoint")) {
-                    this->getConstraintPtr()->AlignmentType = BSplineKnotPoint;
-                }
-                else {
-                    this->getConstraintPtr()->AlignmentType = Undef;
-                    valid = false;
-                }
-
-                if (valid) {
-                    this->getConstraintPtr()->First = intArg1;
-                    this->getConstraintPtr()->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                    this->getConstraintPtr()->Second = intArg3;
-                    this->getConstraintPtr()->InternalAlignmentIndex = intArg4;
-                    return 0;
-                }
-            }
-            if (valid) {
-                this->getConstraintPtr()->First = intArg1;
-                this->getConstraintPtr()->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                this->getConstraintPtr()->Second = intArg3;
-                this->getConstraintPtr()->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
-                return 0;
-            }
-        }
-        // ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, Value
-        if (PyNumber_Check(oNumArg4)) {  // can be float or int
-            Value = PyFloat_AsDouble(oNumArg4);
-            if (strcmp("Distance", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Distance;
-                this->getConstraintPtr()->First = intArg1;
-                this->getConstraintPtr()->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                this->getConstraintPtr()->Second = intArg3;
-                this->getConstraintPtr()->setValue(Value);
+    if (PyArg_ParseTuple(args,
+                         "siiOO",
+                         &ConstraintType,
+                         &FirstIndex,
+                         &any_index,
+                         &index_or_value,
+                         &activated)) {
+        if (PyBool_Check(activated)) {
+            if (handleSiiO()) {
+                cstr->isActive = PyObject_IsTrue(activated);
                 return 0;
             }
         }
@@ -386,41 +363,193 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyErr_Clear();
 
     if (PyArg_ParseTuple(args,
-                         "siiiiO",
+                         "siiOOO",
+                         &ConstraintType,
+                         &FirstIndex,
+                         &any_index,
+                         &index_or_value,
+                         &activated,
+                         &driving)) {
+        if (PyBool_Check(activated) && PyBool_Check(driving)) {
+            if (handleSiiO()) {
+                cstr->isActive = PyObject_IsTrue(activated);
+                if (cstr->isDimensional()) {
+                    cstr->isDriving = PyObject_IsTrue(driving);
+                }
+                return 0;
+            }
+        }
+    }
+    PyErr_Clear();
+
+
+    auto handleSiiiO = [&]() -> bool {
+        // Value, ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, PosIndex2
+        if (PyLong_Check(oNumArg4)) {
+            intArg4 = PyLong_AsLong(oNumArg4);
+            bool valid = false;
+            if (strcmp("Coincident", ConstraintType) == 0) {
+                cstr->Type = Coincident;
+                valid = true;
+            }
+            else if (strcmp("Horizontal", ConstraintType) == 0) {
+                cstr->Type = Horizontal;
+                valid = true;
+            }
+            else if (strcmp("Vertical", ConstraintType) == 0) {
+                cstr->Type = Vertical;
+                valid = true;
+            }
+            else if (strcmp("Perpendicular", ConstraintType) == 0) {
+                cstr->Type = Perpendicular;
+                valid = true;
+            }
+            else if (strcmp("Tangent", ConstraintType) == 0) {
+                cstr->Type = Tangent;
+                valid = true;
+            }
+            else if (strcmp("TangentViaPoint", ConstraintType) == 0) {
+                cstr->Type = Tangent;
+                // valid = true;//non-standard assignment
+                cstr->First = intArg1;
+                cstr->FirstPos = Sketcher::PointPos::none;
+                cstr->Second = intArg2;
+                cstr->SecondPos = Sketcher::PointPos::none;
+                cstr->Third = intArg3;
+                cstr->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
+                return true;
+            }
+            else if (strcmp("PerpendicularViaPoint", ConstraintType) == 0) {
+                cstr->Type = Perpendicular;
+                // valid = true;//non-standard assignment
+                cstr->First = intArg1;
+                cstr->FirstPos = Sketcher::PointPos::none;
+                cstr->Second = intArg2;
+                cstr->SecondPos = Sketcher::PointPos::none;
+                cstr->Third = intArg3;
+                cstr->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
+                return true;
+            }
+            else if (strstr(ConstraintType,
+                            "InternalAlignment")) {  // InteralAlignment with
+                                                     // InternalElementIndex argument
+                cstr->Type = InternalAlignment;
+
+                valid = true;
+
+                if (strstr(ConstraintType, "BSplineControlPoint")) {
+                    cstr->AlignmentType = BSplineControlPoint;
+                }
+                else if (strstr(ConstraintType, "BSplineKnotPoint")) {
+                    cstr->AlignmentType = BSplineKnotPoint;
+                }
+                else {
+                    cstr->AlignmentType = Undef;
+                    valid = false;
+                }
+
+                if (valid) {
+                    cstr->First = intArg1;
+                    cstr->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
+                    cstr->Second = intArg3;
+                    cstr->InternalAlignmentIndex = intArg4;
+                    return true;
+                }
+            }
+            if (valid) {
+                cstr->First = intArg1;
+                cstr->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
+                cstr->Second = intArg3;
+                cstr->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
+                return true;
+            }
+        }
+        // ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, Value
+        if (PyNumber_Check(oNumArg4)) {  // can be float or int
+            Value = PyFloat_AsDouble(oNumArg4);
+            if (strcmp("Distance", ConstraintType) == 0) {
+                cstr->Type = Distance;
+                cstr->First = intArg1;
+                cstr->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
+                cstr->Second = intArg3;
+                cstr->setValue(Value);
+                return true;
+            }
+        }
+        return false;
+    };
+
+    if (PyArg_ParseTuple(args, "siiiO", &ConstraintType, &intArg1, &intArg2, &intArg3, &oNumArg4)) {
+        if (handleSiiiO()) {
+            return 0;
+        }
+    }
+    PyErr_Clear();
+
+    if (PyArg_ParseTuple(args,
+                         "siiiOO",
                          &ConstraintType,
                          &intArg1,
                          &intArg2,
                          &intArg3,
-                         &intArg4,
-                         &oNumArg5)) {
+                         &oNumArg4,
+                         &activated)) {
+        if (PyBool_Check(activated)) {
+            if (handleSiiiO()) {
+                cstr->isActive = PyObject_IsTrue(activated);
+                return 0;
+            }
+        }
+    }
+    PyErr_Clear();
+
+    if (PyArg_ParseTuple(args,
+                         "siiiOOO",
+                         &ConstraintType,
+                         &intArg1,
+                         &intArg2,
+                         &intArg3,
+                         &oNumArg4,
+                         &activated,
+                         &driving)) {
+        if (PyBool_Check(activated) && PyBool_Check(driving)) {
+            if (handleSiiiO()) {
+                cstr->isActive = PyObject_IsTrue(activated);
+                if (cstr->isDimensional()) {
+                    cstr->isDriving = PyObject_IsTrue(driving);
+                }
+                return 0;
+            }
+        }
+    }
+    PyErr_Clear();
+
+
+    auto handleSiiiiO = [&]() -> bool {
         // ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, PosIndex2, GeoIndex3
         if (PyLong_Check(oNumArg5)) {
             intArg5 = PyLong_AsLong(oNumArg5);
             if (strcmp("Symmetric", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Symmetric;
-                this->getConstraintPtr()->First = intArg1;
-                this->getConstraintPtr()->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                this->getConstraintPtr()->Second = intArg3;
-                this->getConstraintPtr()->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
-                this->getConstraintPtr()->Third = intArg5;
-                return 0;
+                cstr->Type = Symmetric;
+                cstr->First = intArg1;
+                cstr->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
+                cstr->Second = intArg3;
+                cstr->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
+                cstr->Third = intArg5;
+                return true;
             }
         }
         // ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, PosIndex2, Value
         if (PyNumber_Check(oNumArg5)) {  // can be float or int
             Value = PyFloat_AsDouble(oNumArg5);
-            bool valid = false;
             if (strcmp("Distance", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Distance;
-                valid = true;
+                cstr->Type = Distance;
             }
             else if (strcmp("DistanceX", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = DistanceX;
-                valid = true;
+                cstr->Type = DistanceX;
             }
             else if (strcmp("DistanceY", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = DistanceY;
-                valid = true;
+                cstr->Type = DistanceY;
             }
             else if (strcmp("Angle", ConstraintType) == 0) {
                 if (PyObject_TypeCheck(oNumArg5, &(Base::QuantityPy::Type))) {
@@ -430,8 +559,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }
-                this->getConstraintPtr()->Type = Angle;
-                valid = true;
+                cstr->Type = Angle;
             }
             else if (strcmp("AngleViaPoint", ConstraintType) == 0) {
                 if (PyObject_TypeCheck(oNumArg5, &(Base::QuantityPy::Type))) {
@@ -441,28 +569,116 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }
-                this->getConstraintPtr()->Type = Angle;
+                cstr->Type = Angle;
                 // valid = true;//non-standard assignment
-                this->getConstraintPtr()->First = intArg1;
-                this->getConstraintPtr()->FirstPos = Sketcher::PointPos::none;
-                this->getConstraintPtr()->Second = intArg2;  // let's goof up all the terminology =)
-                this->getConstraintPtr()->SecondPos = Sketcher::PointPos::none;
-                this->getConstraintPtr()->Third = intArg3;
-                this->getConstraintPtr()->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
-                this->getConstraintPtr()->setValue(Value);
-                return 0;
+                cstr->First = intArg1;
+                cstr->FirstPos = Sketcher::PointPos::none;
+                cstr->Second = intArg2;  // let's goof up all the terminology =)
+                cstr->SecondPos = Sketcher::PointPos::none;
+                cstr->Third = intArg3;
+                cstr->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
+                cstr->setValue(Value);
+                return true;
             }
-            if (valid) {
-                this->getConstraintPtr()->First = intArg1;
-                this->getConstraintPtr()->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                this->getConstraintPtr()->Second = intArg3;
-                this->getConstraintPtr()->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
-                this->getConstraintPtr()->setValue(Value);
+            else {
+                return false;
+            }
+
+            cstr->First = intArg1;
+            cstr->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
+            cstr->Second = intArg3;
+            cstr->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
+            cstr->setValue(Value);
+            return true;
+        }
+        return false;
+    };
+
+    if (PyArg_ParseTuple(args,
+                         "siiiiO",
+                         &ConstraintType,
+                         &intArg1,
+                         &intArg2,
+                         &intArg3,
+                         &intArg4,
+                         &oNumArg5)) {
+        if (handleSiiiiO()) {
+            return 0;
+        }
+    }
+    PyErr_Clear();
+
+    if (PyArg_ParseTuple(args,
+                         "siiiiOO",
+                         &ConstraintType,
+                         &intArg1,
+                         &intArg2,
+                         &intArg3,
+                         &intArg4,
+                         &oNumArg5,
+                         &activated)) {
+        if (PyBool_Check(activated)) {
+            if (handleSiiiiO()) {
+                cstr->isActive = PyObject_IsTrue(activated);
                 return 0;
             }
         }
     }
     PyErr_Clear();
+
+    if (PyArg_ParseTuple(args,
+                         "siiiiOOO",
+                         &ConstraintType,
+                         &intArg1,
+                         &intArg2,
+                         &intArg3,
+                         &intArg4,
+                         &oNumArg5,
+                         &activated,
+                         &driving)) {
+        if (PyBool_Check(activated) && PyBool_Check(driving)) {
+            if (handleSiiiiO()) {
+                cstr->isActive = PyObject_IsTrue(activated);
+                if (cstr->isDimensional()) {
+                    cstr->isDriving = PyObject_IsTrue(driving);
+                }
+                return 0;
+            }
+        }
+    }
+    PyErr_Clear();
+
+    auto handleSiiiiiO = [&]() -> bool {
+        if (PyLong_Check(index_or_value)) {
+            ThirdPos = PyLong_AsLong(index_or_value);
+            // ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, PosIndex2, GeoIndex3, PosIndex3
+            if (strcmp("Symmetric", ConstraintType) == 0) {
+                cstr->Type = Symmetric;
+                cstr->First = FirstIndex;
+                cstr->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
+                cstr->Second = SecondIndex;
+                cstr->SecondPos = static_cast<Sketcher::PointPos>(SecondPos);
+                cstr->Third = ThirdIndex;
+                cstr->ThirdPos = static_cast<Sketcher::PointPos>(ThirdPos);
+                return true;
+            }
+        }
+        if (PyNumber_Check(index_or_value)) {  // can be float or int
+            Value = PyFloat_AsDouble(index_or_value);
+            if (strcmp("SnellsLaw", ConstraintType) == 0) {
+                cstr->Type = SnellsLaw;
+                cstr->First = FirstIndex;
+                cstr->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
+                cstr->Second = SecondIndex;
+                cstr->SecondPos = static_cast<Sketcher::PointPos>(SecondPos);
+                cstr->Third = ThirdIndex;
+                cstr->ThirdPos = Sketcher::PointPos::none;
+                cstr->setValue(Value);
+                return true;
+            }
+        }
+        return false;
+    };
 
     if (PyArg_ParseTuple(args,
                          "siiiiiO",
@@ -473,31 +689,48 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                          &SecondPos,
                          &ThirdIndex,
                          &index_or_value)) {
-        if (PyLong_Check(index_or_value)) {
-            ThirdPos = PyLong_AsLong(index_or_value);
-            // ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, PosIndex2, GeoIndex3, PosIndex3
-            if (strcmp("Symmetric", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = Symmetric;
-                this->getConstraintPtr()->First = FirstIndex;
-                this->getConstraintPtr()->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
-                this->getConstraintPtr()->Second = SecondIndex;
-                this->getConstraintPtr()->SecondPos = static_cast<Sketcher::PointPos>(SecondPos);
-                this->getConstraintPtr()->Third = ThirdIndex;
-                this->getConstraintPtr()->ThirdPos = static_cast<Sketcher::PointPos>(ThirdPos);
+        if (handleSiiiiiO()) {
+            return 0;
+        }
+    }
+    PyErr_Clear();
+
+    if (PyArg_ParseTuple(args,
+                         "siiiiiOO",
+                         &ConstraintType,
+                         &FirstIndex,
+                         &FirstPos,
+                         &SecondIndex,
+                         &SecondPos,
+                         &ThirdIndex,
+                         &index_or_value,
+                         &activated)) {
+        if (PyBool_Check(activated)) {
+            if (handleSiiiiiO()) {
+                cstr->isActive = PyObject_IsTrue(activated);
                 return 0;
             }
         }
-        if (PyNumber_Check(index_or_value)) {  // can be float or int
-            Value = PyFloat_AsDouble(index_or_value);
-            if (strcmp("SnellsLaw", ConstraintType) == 0) {
-                this->getConstraintPtr()->Type = SnellsLaw;
-                this->getConstraintPtr()->First = FirstIndex;
-                this->getConstraintPtr()->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
-                this->getConstraintPtr()->Second = SecondIndex;
-                this->getConstraintPtr()->SecondPos = static_cast<Sketcher::PointPos>(SecondPos);
-                this->getConstraintPtr()->Third = ThirdIndex;
-                this->getConstraintPtr()->ThirdPos = Sketcher::PointPos::none;
-                this->getConstraintPtr()->setValue(Value);
+    }
+    PyErr_Clear();
+
+    if (PyArg_ParseTuple(args,
+                         "siiiiiOOO",
+                         &ConstraintType,
+                         &FirstIndex,
+                         &FirstPos,
+                         &SecondIndex,
+                         &SecondPos,
+                         &ThirdIndex,
+                         &index_or_value,
+                         &activated,
+                         &driving)) {
+        if (PyBool_Check(activated) && PyBool_Check(driving)) {
+            if (handleSiiiiiO()) {
+                cstr->isActive = PyObject_IsTrue(activated);
+                if (cstr->isDimensional()) {
+                    cstr->isDriving = PyObject_IsTrue(driving);
+                }
                 return 0;
             }
         }

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -68,22 +68,22 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyObject* activated;
     PyObject* driving;
 
-    Sketcher::Constraint* cstr = this->getConstraintPtr();
+    Sketcher::Constraint* constraint = this->getConstraintPtr();
 
     auto handleSi = [&]() -> bool {
         if (strcmp("Horizontal", ConstraintType) == 0) {
-            cstr->Type = Horizontal;
+            constraint->Type = Horizontal;
         }
         else if (strcmp("Vertical", ConstraintType) == 0) {
-            cstr->Type = Vertical;
+            constraint->Type = Vertical;
         }
         else if (strcmp("Block", ConstraintType) == 0) {
-            cstr->Type = Block;
+            constraint->Type = Block;
         }
         else {
             return false;
         }
-        cstr->First = FirstIndex;
+        constraint->First = FirstIndex;
         return true;
     };
 
@@ -99,7 +99,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     if (PyArg_ParseTuple(args, "siO", &ConstraintType, &FirstIndex, &activated)) {
         if (PyBool_Check(activated)) {
             if (handleSi()) {
-                cstr->isActive = PyObject_IsTrue(activated);
+                constraint->isActive = PyObject_IsTrue(activated);
                 return 0;
             }
         }
@@ -113,49 +113,49 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             SecondIndex = PyLong_AsLong(index_or_value);
             bool valid = false;
             if (strcmp("Tangent", ConstraintType) == 0) {
-                cstr->Type = Tangent;
+                constraint->Type = Tangent;
                 valid = true;
             }
             else if (strcmp("Parallel", ConstraintType) == 0) {
-                cstr->Type = Parallel;
+                constraint->Type = Parallel;
                 valid = true;
             }
             else if (strcmp("Perpendicular", ConstraintType) == 0) {
-                cstr->Type = Perpendicular;
+                constraint->Type = Perpendicular;
                 valid = true;
             }
             else if (strcmp("Equal", ConstraintType) == 0) {
-                cstr->Type = Equal;
+                constraint->Type = Equal;
                 valid = true;
             }
             else if (strstr(ConstraintType, "InternalAlignment")) {
-                cstr->Type = InternalAlignment;
+                constraint->Type = InternalAlignment;
 
                 valid = true;
                 if (strstr(ConstraintType, "EllipseMajorDiameter")) {
-                    cstr->AlignmentType = EllipseMajorDiameter;
+                    constraint->AlignmentType = EllipseMajorDiameter;
                 }
                 else if (strstr(ConstraintType, "EllipseMinorDiameter")) {
-                    cstr->AlignmentType = EllipseMinorDiameter;
+                    constraint->AlignmentType = EllipseMinorDiameter;
                 }
                 else if (strstr(ConstraintType, "HyperbolaMajor")) {
-                    cstr->AlignmentType = HyperbolaMajor;
+                    constraint->AlignmentType = HyperbolaMajor;
                 }
                 else if (strstr(ConstraintType, "HyperbolaMinor")) {
-                    cstr->AlignmentType = HyperbolaMinor;
+                    constraint->AlignmentType = HyperbolaMinor;
                 }
                 else if (strstr(ConstraintType, "ParabolaFocalAxis")) {
-                    cstr->AlignmentType = ParabolaFocalAxis;
+                    constraint->AlignmentType = ParabolaFocalAxis;
                 }
                 else {
-                    cstr->AlignmentType = Undef;
+                    constraint->AlignmentType = Undef;
                     valid = false;
                 }
             }
 
             if (valid) {
-                cstr->First = FirstIndex;
-                cstr->Second = SecondIndex;
+                constraint->First = FirstIndex;
+                constraint->Second = SecondIndex;
                 return true;
             }
         }
@@ -163,7 +163,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         if (PyNumber_Check(index_or_value)) {  // can be float or int
             Value = PyFloat_AsDouble(index_or_value);
             if (strcmp("Distance", ConstraintType) == 0) {
-                cstr->Type = Distance;
+                constraint->Type = Distance;
             }
             else if (strcmp("Angle", ConstraintType) == 0) {
                 if (PyObject_TypeCheck(index_or_value, &(Base::QuantityPy::Type))) {
@@ -173,38 +173,38 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }
-                cstr->Type = Angle;
+                constraint->Type = Angle;
             }
             else if (strcmp("DistanceX", ConstraintType) == 0) {
-                cstr->Type = DistanceX;
+                constraint->Type = DistanceX;
             }
             else if (strcmp("DistanceY", ConstraintType) == 0) {
-                cstr->Type = DistanceY;
+                constraint->Type = DistanceY;
             }
             else if (strcmp("Radius", ConstraintType) == 0) {
-                cstr->Type = Radius;
+                constraint->Type = Radius;
                 // set a value that is out of range of result of atan2
                 // this value is handled in ViewProviderSketch
-                cstr->LabelPosition = 10;
+                constraint->LabelPosition = 10;
             }
             else if (strcmp("Diameter", ConstraintType) == 0) {
-                cstr->Type = Diameter;
+                constraint->Type = Diameter;
                 // set a value that is out of range of result of atan2
                 // this value is handled in ViewProviderSketch
-                cstr->LabelPosition = 10;
+                constraint->LabelPosition = 10;
             }
             else if (strcmp("Weight", ConstraintType) == 0) {
-                cstr->Type = Weight;
+                constraint->Type = Weight;
                 // set a value that is out of range of result of atan2
                 // this value is handled in ViewProviderSketch
-                cstr->LabelPosition = 10;
+                constraint->LabelPosition = 10;
             }
             else {
                 return false;
             }
 
-            cstr->First = FirstIndex;
-            cstr->setValue(Value);
+            constraint->First = FirstIndex;
+            constraint->setValue(Value);
             return true;
         }
         return false;
@@ -220,7 +220,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     if (PyArg_ParseTuple(args, "siOO", &ConstraintType, &FirstIndex, &index_or_value, &activated)) {
         if (PyBool_Check(activated)) {
             if (handleSiO()) {
-                cstr->isActive = PyObject_IsTrue(activated);
+                constraint->isActive = PyObject_IsTrue(activated);
                 return 0;
             }
         }
@@ -236,9 +236,9 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                          &driving)) {
         if (PyBool_Check(activated) && PyBool_Check(driving)) {
             if (handleSiO()) {
-                cstr->isActive = PyObject_IsTrue(activated);
-                if (cstr->isDimensional()) {
-                    cstr->isDriving = PyObject_IsTrue(driving);
+                constraint->isActive = PyObject_IsTrue(activated);
+                if (constraint->isDimensional()) {
+                    constraint->isDriving = PyObject_IsTrue(driving);
                 }
                 return 0;
             }
@@ -254,44 +254,44 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             SecondIndex = PyLong_AsLong(index_or_value);
             bool valid = false;
             if (strcmp("Perpendicular", ConstraintType) == 0) {
-                cstr->Type = Perpendicular;
+                constraint->Type = Perpendicular;
                 valid = true;
             }
             else if (strcmp("Tangent", ConstraintType) == 0) {
-                cstr->Type = Tangent;
+                constraint->Type = Tangent;
                 valid = true;
             }
             else if (strcmp("PointOnObject", ConstraintType) == 0) {
-                cstr->Type = PointOnObject;
+                constraint->Type = PointOnObject;
                 valid = true;
             }
             else if (strstr(ConstraintType, "InternalAlignment")) {
-                cstr->Type = InternalAlignment;
+                constraint->Type = InternalAlignment;
 
                 valid = true;
 
                 if (strstr(ConstraintType, "EllipseFocus1")) {
-                    cstr->AlignmentType = EllipseFocus1;
+                    constraint->AlignmentType = EllipseFocus1;
                 }
                 else if (strstr(ConstraintType, "EllipseFocus2")) {
-                    cstr->AlignmentType = EllipseFocus2;
+                    constraint->AlignmentType = EllipseFocus2;
                 }
                 else if (strstr(ConstraintType, "HyperbolaFocus")) {
-                    cstr->AlignmentType = HyperbolaFocus;
+                    constraint->AlignmentType = HyperbolaFocus;
                 }
                 else if (strstr(ConstraintType, "ParabolaFocus")) {
-                    cstr->AlignmentType = ParabolaFocus;
+                    constraint->AlignmentType = ParabolaFocus;
                 }
                 else {
-                    cstr->AlignmentType = Undef;
+                    constraint->AlignmentType = Undef;
                     valid = false;
                 }
             }
 
             if (valid) {
-                cstr->First = FirstIndex;
-                cstr->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
-                cstr->Second = SecondIndex;
+                constraint->First = FirstIndex;
+                constraint->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->Second = SecondIndex;
                 return true;
             }
         }
@@ -308,31 +308,31 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }
-                cstr->Type = Angle;
-                cstr->Second = SecondIndex;
+                constraint->Type = Angle;
+                constraint->Second = SecondIndex;
             }
             else if (strcmp("Distance", ConstraintType) == 0) {
-                cstr->Type = Distance;
-                cstr->Second = SecondIndex;
+                constraint->Type = Distance;
+                constraint->Second = SecondIndex;
             }
             else if (strcmp("DistanceX", ConstraintType) == 0) {
                 FirstPos = SecondIndex;
                 SecondIndex = -1;
-                cstr->Type = DistanceX;
-                cstr->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->Type = DistanceX;
+                constraint->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
             }
             else if (strcmp("DistanceY", ConstraintType) == 0) {
                 FirstPos = SecondIndex;
                 SecondIndex = -1;
-                cstr->Type = DistanceY;
-                cstr->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->Type = DistanceY;
+                constraint->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
             }
             else {
                 return false;
             }
 
-            cstr->First = FirstIndex;
-            cstr->setValue(Value);
+            constraint->First = FirstIndex;
+            constraint->setValue(Value);
             return true;
         }
         return false;
@@ -355,7 +355,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                          &activated)) {
         if (PyBool_Check(activated)) {
             if (handleSiiO()) {
-                cstr->isActive = PyObject_IsTrue(activated);
+                constraint->isActive = PyObject_IsTrue(activated);
                 return 0;
             }
         }
@@ -372,9 +372,9 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                          &driving)) {
         if (PyBool_Check(activated) && PyBool_Check(driving)) {
             if (handleSiiO()) {
-                cstr->isActive = PyObject_IsTrue(activated);
-                if (cstr->isDimensional()) {
-                    cstr->isDriving = PyObject_IsTrue(driving);
+                constraint->isActive = PyObject_IsTrue(activated);
+                if (constraint->isDimensional()) {
+                    constraint->isDriving = PyObject_IsTrue(driving);
                 }
                 return 0;
             }
@@ -389,78 +389,78 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             intArg4 = PyLong_AsLong(oNumArg4);
             bool valid = false;
             if (strcmp("Coincident", ConstraintType) == 0) {
-                cstr->Type = Coincident;
+                constraint->Type = Coincident;
                 valid = true;
             }
             else if (strcmp("Horizontal", ConstraintType) == 0) {
-                cstr->Type = Horizontal;
+                constraint->Type = Horizontal;
                 valid = true;
             }
             else if (strcmp("Vertical", ConstraintType) == 0) {
-                cstr->Type = Vertical;
+                constraint->Type = Vertical;
                 valid = true;
             }
             else if (strcmp("Perpendicular", ConstraintType) == 0) {
-                cstr->Type = Perpendicular;
+                constraint->Type = Perpendicular;
                 valid = true;
             }
             else if (strcmp("Tangent", ConstraintType) == 0) {
-                cstr->Type = Tangent;
+                constraint->Type = Tangent;
                 valid = true;
             }
             else if (strcmp("TangentViaPoint", ConstraintType) == 0) {
-                cstr->Type = Tangent;
+                constraint->Type = Tangent;
                 // valid = true;//non-standard assignment
-                cstr->First = intArg1;
-                cstr->FirstPos = Sketcher::PointPos::none;
-                cstr->Second = intArg2;
-                cstr->SecondPos = Sketcher::PointPos::none;
-                cstr->Third = intArg3;
-                cstr->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->First = intArg1;
+                constraint->FirstPos = Sketcher::PointPos::none;
+                constraint->Second = intArg2;
+                constraint->SecondPos = Sketcher::PointPos::none;
+                constraint->Third = intArg3;
+                constraint->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
                 return true;
             }
             else if (strcmp("PerpendicularViaPoint", ConstraintType) == 0) {
-                cstr->Type = Perpendicular;
+                constraint->Type = Perpendicular;
                 // valid = true;//non-standard assignment
-                cstr->First = intArg1;
-                cstr->FirstPos = Sketcher::PointPos::none;
-                cstr->Second = intArg2;
-                cstr->SecondPos = Sketcher::PointPos::none;
-                cstr->Third = intArg3;
-                cstr->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->First = intArg1;
+                constraint->FirstPos = Sketcher::PointPos::none;
+                constraint->Second = intArg2;
+                constraint->SecondPos = Sketcher::PointPos::none;
+                constraint->Third = intArg3;
+                constraint->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
                 return true;
             }
             else if (strstr(ConstraintType,
                             "InternalAlignment")) {  // InteralAlignment with
                                                      // InternalElementIndex argument
-                cstr->Type = InternalAlignment;
+                constraint->Type = InternalAlignment;
 
                 valid = true;
 
                 if (strstr(ConstraintType, "BSplineControlPoint")) {
-                    cstr->AlignmentType = BSplineControlPoint;
+                    constraint->AlignmentType = BSplineControlPoint;
                 }
                 else if (strstr(ConstraintType, "BSplineKnotPoint")) {
-                    cstr->AlignmentType = BSplineKnotPoint;
+                    constraint->AlignmentType = BSplineKnotPoint;
                 }
                 else {
-                    cstr->AlignmentType = Undef;
+                    constraint->AlignmentType = Undef;
                     valid = false;
                 }
 
                 if (valid) {
-                    cstr->First = intArg1;
-                    cstr->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                    cstr->Second = intArg3;
-                    cstr->InternalAlignmentIndex = intArg4;
+                    constraint->First = intArg1;
+                    constraint->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
+                    constraint->Second = intArg3;
+                    constraint->InternalAlignmentIndex = intArg4;
                     return true;
                 }
             }
             if (valid) {
-                cstr->First = intArg1;
-                cstr->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                cstr->Second = intArg3;
-                cstr->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->First = intArg1;
+                constraint->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
+                constraint->Second = intArg3;
+                constraint->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
                 return true;
             }
         }
@@ -468,11 +468,11 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         if (PyNumber_Check(oNumArg4)) {  // can be float or int
             Value = PyFloat_AsDouble(oNumArg4);
             if (strcmp("Distance", ConstraintType) == 0) {
-                cstr->Type = Distance;
-                cstr->First = intArg1;
-                cstr->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                cstr->Second = intArg3;
-                cstr->setValue(Value);
+                constraint->Type = Distance;
+                constraint->First = intArg1;
+                constraint->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
+                constraint->Second = intArg3;
+                constraint->setValue(Value);
                 return true;
             }
         }
@@ -496,7 +496,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                          &activated)) {
         if (PyBool_Check(activated)) {
             if (handleSiiiO()) {
-                cstr->isActive = PyObject_IsTrue(activated);
+                constraint->isActive = PyObject_IsTrue(activated);
                 return 0;
             }
         }
@@ -514,9 +514,9 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                          &driving)) {
         if (PyBool_Check(activated) && PyBool_Check(driving)) {
             if (handleSiiiO()) {
-                cstr->isActive = PyObject_IsTrue(activated);
-                if (cstr->isDimensional()) {
-                    cstr->isDriving = PyObject_IsTrue(driving);
+                constraint->isActive = PyObject_IsTrue(activated);
+                if (constraint->isDimensional()) {
+                    constraint->isDriving = PyObject_IsTrue(driving);
                 }
                 return 0;
             }
@@ -530,12 +530,12 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         if (PyLong_Check(oNumArg5)) {
             intArg5 = PyLong_AsLong(oNumArg5);
             if (strcmp("Symmetric", ConstraintType) == 0) {
-                cstr->Type = Symmetric;
-                cstr->First = intArg1;
-                cstr->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                cstr->Second = intArg3;
-                cstr->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
-                cstr->Third = intArg5;
+                constraint->Type = Symmetric;
+                constraint->First = intArg1;
+                constraint->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
+                constraint->Second = intArg3;
+                constraint->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->Third = intArg5;
                 return true;
             }
         }
@@ -543,13 +543,13 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         if (PyNumber_Check(oNumArg5)) {  // can be float or int
             Value = PyFloat_AsDouble(oNumArg5);
             if (strcmp("Distance", ConstraintType) == 0) {
-                cstr->Type = Distance;
+                constraint->Type = Distance;
             }
             else if (strcmp("DistanceX", ConstraintType) == 0) {
-                cstr->Type = DistanceX;
+                constraint->Type = DistanceX;
             }
             else if (strcmp("DistanceY", ConstraintType) == 0) {
-                cstr->Type = DistanceY;
+                constraint->Type = DistanceY;
             }
             else if (strcmp("Angle", ConstraintType) == 0) {
                 if (PyObject_TypeCheck(oNumArg5, &(Base::QuantityPy::Type))) {
@@ -559,7 +559,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }
-                cstr->Type = Angle;
+                constraint->Type = Angle;
             }
             else if (strcmp("AngleViaPoint", ConstraintType) == 0) {
                 if (PyObject_TypeCheck(oNumArg5, &(Base::QuantityPy::Type))) {
@@ -569,26 +569,26 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                         Value = q.getValueAs(Base::Quantity::Radian);
                     }
                 }
-                cstr->Type = Angle;
+                constraint->Type = Angle;
                 // valid = true;//non-standard assignment
-                cstr->First = intArg1;
-                cstr->FirstPos = Sketcher::PointPos::none;
-                cstr->Second = intArg2;  // let's goof up all the terminology =)
-                cstr->SecondPos = Sketcher::PointPos::none;
-                cstr->Third = intArg3;
-                cstr->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
-                cstr->setValue(Value);
+                constraint->First = intArg1;
+                constraint->FirstPos = Sketcher::PointPos::none;
+                constraint->Second = intArg2;  // let's goof up all the terminology =)
+                constraint->SecondPos = Sketcher::PointPos::none;
+                constraint->Third = intArg3;
+                constraint->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->setValue(Value);
                 return true;
             }
             else {
                 return false;
             }
 
-            cstr->First = intArg1;
-            cstr->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-            cstr->Second = intArg3;
-            cstr->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
-            cstr->setValue(Value);
+            constraint->First = intArg1;
+            constraint->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
+            constraint->Second = intArg3;
+            constraint->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
+            constraint->setValue(Value);
             return true;
         }
         return false;
@@ -619,7 +619,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                          &activated)) {
         if (PyBool_Check(activated)) {
             if (handleSiiiiO()) {
-                cstr->isActive = PyObject_IsTrue(activated);
+                constraint->isActive = PyObject_IsTrue(activated);
                 return 0;
             }
         }
@@ -638,9 +638,9 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                          &driving)) {
         if (PyBool_Check(activated) && PyBool_Check(driving)) {
             if (handleSiiiiO()) {
-                cstr->isActive = PyObject_IsTrue(activated);
-                if (cstr->isDimensional()) {
-                    cstr->isDriving = PyObject_IsTrue(driving);
+                constraint->isActive = PyObject_IsTrue(activated);
+                if (constraint->isDimensional()) {
+                    constraint->isDriving = PyObject_IsTrue(driving);
                 }
                 return 0;
             }
@@ -653,27 +653,27 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             ThirdPos = PyLong_AsLong(index_or_value);
             // ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, PosIndex2, GeoIndex3, PosIndex3
             if (strcmp("Symmetric", ConstraintType) == 0) {
-                cstr->Type = Symmetric;
-                cstr->First = FirstIndex;
-                cstr->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
-                cstr->Second = SecondIndex;
-                cstr->SecondPos = static_cast<Sketcher::PointPos>(SecondPos);
-                cstr->Third = ThirdIndex;
-                cstr->ThirdPos = static_cast<Sketcher::PointPos>(ThirdPos);
+                constraint->Type = Symmetric;
+                constraint->First = FirstIndex;
+                constraint->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->Second = SecondIndex;
+                constraint->SecondPos = static_cast<Sketcher::PointPos>(SecondPos);
+                constraint->Third = ThirdIndex;
+                constraint->ThirdPos = static_cast<Sketcher::PointPos>(ThirdPos);
                 return true;
             }
         }
         if (PyNumber_Check(index_or_value)) {  // can be float or int
             Value = PyFloat_AsDouble(index_or_value);
             if (strcmp("SnellsLaw", ConstraintType) == 0) {
-                cstr->Type = SnellsLaw;
-                cstr->First = FirstIndex;
-                cstr->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
-                cstr->Second = SecondIndex;
-                cstr->SecondPos = static_cast<Sketcher::PointPos>(SecondPos);
-                cstr->Third = ThirdIndex;
-                cstr->ThirdPos = Sketcher::PointPos::none;
-                cstr->setValue(Value);
+                constraint->Type = SnellsLaw;
+                constraint->First = FirstIndex;
+                constraint->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->Second = SecondIndex;
+                constraint->SecondPos = static_cast<Sketcher::PointPos>(SecondPos);
+                constraint->Third = ThirdIndex;
+                constraint->ThirdPos = Sketcher::PointPos::none;
+                constraint->setValue(Value);
                 return true;
             }
         }
@@ -707,7 +707,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                          &activated)) {
         if (PyBool_Check(activated)) {
             if (handleSiiiiiO()) {
-                cstr->isActive = PyObject_IsTrue(activated);
+                constraint->isActive = PyObject_IsTrue(activated);
                 return 0;
             }
         }
@@ -727,9 +727,9 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                          &driving)) {
         if (PyBool_Check(activated) && PyBool_Check(driving)) {
             if (handleSiiiiiO()) {
-                cstr->isActive = PyObject_IsTrue(activated);
-                if (cstr->isDimensional()) {
-                    cstr->isDriving = PyObject_IsTrue(driving);
+                constraint->isActive = PyObject_IsTrue(activated);
+                if (constraint->isDimensional()) {
+                    constraint->isDriving = PyObject_IsTrue(driving);
                 }
                 return 0;
             }

--- a/src/Mod/Sketcher/App/PythonConverter.cpp
+++ b/src/Mod/Sketcher/App/PythonConverter.cpp
@@ -675,9 +675,9 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
 
     if (!constraint->isActive || !constraint->isDriving) {
         std::string active = constraint->isActive ? "True" : "False";
-        std::string driving = constraint->isDriving ? "True" : "False";
         resultStr += ", " + active;
         if (constraint->isDimensional()) {
+            std::string driving = constraint->isDriving ? "True" : "False";
             resultStr += ", " + driving;
         }
     }

--- a/src/Mod/Sketcher/App/PythonConverter.cpp
+++ b/src/Mod/Sketcher/App/PythonConverter.cpp
@@ -355,6 +355,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
     std::string geoId2 = (addLastIdVar2 ? "lastGeoId + " : "") + std::to_string(constraint->Second);
     std::string geoId3 = (addLastIdVar3 ? "lastGeoId + " : "") + std::to_string(constraint->Third);
 
+
     static std::map<
         const Sketcher::ConstraintType,
         std::function<
@@ -365,10 +366,9 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 return boost::str(
-                     boost::format("Sketcher.Constraint('Coincident', %s, %i, %s, %i)") % geoId1
-                     % static_cast<int>(constr->FirstPos) % geoId2
-                     % static_cast<int>(constr->SecondPos));
+                 return boost::str(boost::format("Sketcher.Constraint('Coincident', %s, %i, %s, %i")
+                                   % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
+                                   % static_cast<int>(constr->SecondPos));
              }},
             {Sketcher::Horizontal,
              [](const Sketcher::Constraint* constr,
@@ -376,12 +376,12 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
                  if (constr->Second == GeoEnum::GeoUndef) {
-                     return boost::str(boost::format("Sketcher.Constraint('Horizontal', %s)")
+                     return boost::str(boost::format("Sketcher.Constraint('Horizontal', %s")
                                        % geoId1);
                  }
                  else {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('Horizontal', %s, %i, %s, %i)") % geoId1
+                         boost::format("Sketcher.Constraint('Horizontal', %s, %i, %s, %i") % geoId1
                          % static_cast<int>(constr->FirstPos) % geoId2
                          % static_cast<int>(constr->SecondPos));
                  }
@@ -392,12 +392,12 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
                  if (constr->Second == GeoEnum::GeoUndef) {
-                     return boost::str(boost::format("Sketcher.Constraint('Vertical', %s)")
+                     return boost::str(boost::format("Sketcher.Constraint('Vertical', %s")
                                        % geoId1);
                  }
                  else {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('Vertical', %s, %i, %s, %i)") % geoId1
+                         boost::format("Sketcher.Constraint('Vertical', %s, %i, %s, %i") % geoId1
                          % static_cast<int>(constr->FirstPos) % geoId2
                          % static_cast<int>(constr->SecondPos));
                  }
@@ -407,7 +407,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 [[maybe_unused]] std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 return boost::str(boost::format("Sketcher.Constraint('Block', %s)") % geoId1);
+                 return boost::str(boost::format("Sketcher.Constraint('Block', %s") % geoId1);
              }},
             {Sketcher::Tangent,
              [](const Sketcher::Constraint* constr,
@@ -415,16 +415,16 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
                  if (constr->FirstPos == Sketcher::PointPos::none) {
-                     return boost::str(boost::format("Sketcher.Constraint('Tangent', %s, %s)")
+                     return boost::str(boost::format("Sketcher.Constraint('Tangent', %s, %s")
                                        % geoId1 % geoId2);
                  }
                  else if (constr->SecondPos == Sketcher::PointPos::none) {
-                     return boost::str(boost::format("Sketcher.Constraint('Tangent', %s, %i, %s)")
+                     return boost::str(boost::format("Sketcher.Constraint('Tangent', %s, %i, %s")
                                        % geoId1 % static_cast<int>(constr->FirstPos) % geoId2);
                  }
                  else {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('Tangent', %s, %i, %s, %i)") % geoId1
+                         boost::format("Sketcher.Constraint('Tangent', %s, %i, %s, %i") % geoId1
                          % static_cast<int>(constr->FirstPos) % geoId2
                          % static_cast<int>(constr->SecondPos));
                  }
@@ -434,7 +434,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 return boost::str(boost::format("Sketcher.Constraint('Parallel', %s, %s)") % geoId1
+                 return boost::str(boost::format("Sketcher.Constraint('Parallel', %s, %s") % geoId1
                                    % geoId2);
              }},
             {Sketcher::Perpendicular,
@@ -443,17 +443,17 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
                  if (constr->FirstPos == Sketcher::PointPos::none) {
-                     return boost::str(boost::format("Sketcher.Constraint('Perpendicular', %s, %s)")
+                     return boost::str(boost::format("Sketcher.Constraint('Perpendicular', %s, %s")
                                        % geoId1 % geoId2);
                  }
                  else if (constr->SecondPos == Sketcher::PointPos::none) {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('Perpendicular', %s, %i, %s)") % geoId1
+                         boost::format("Sketcher.Constraint('Perpendicular', %s, %i, %s") % geoId1
                          % static_cast<int>(constr->FirstPos) % geoId2);
                  }
                  else {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('Perpendicular', %s, %i, %s, %i)")
+                         boost::format("Sketcher.Constraint('Perpendicular', %s, %i, %s, %i")
                          % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
                          % static_cast<int>(constr->SecondPos));
                  }
@@ -463,7 +463,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 return boost::str(boost::format("Sketcher.Constraint('Equal', %s, %s)") % geoId1
+                 return boost::str(boost::format("Sketcher.Constraint('Equal', %s, %s") % geoId1
                                    % geoId2);
              }},
             {Sketcher::InternalAlignment,
@@ -477,7 +477,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                      || constr->AlignmentType == HyperbolaMinor
                      || constr->AlignmentType == ParabolaFocalAxis) {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('InternalAlignment:%s', %s, %s)")
+                         boost::format("Sketcher.Constraint('InternalAlignment:%s', %s, %s")
                          % constr->internalAlignmentTypeToString() % geoId1 % geoId2);
                  }
                  else if (constr->AlignmentType == EllipseFocus1
@@ -485,21 +485,20 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                           || constr->AlignmentType == HyperbolaFocus
                           || constr->AlignmentType == ParabolaFocus) {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('InternalAlignment:%s', %s, %i, %s)")
+                         boost::format("Sketcher.Constraint('InternalAlignment:%s', %s, %i, %s")
                          % constr->internalAlignmentTypeToString() % geoId1
                          % static_cast<int>(constr->FirstPos) % geoId2);
                  }
                  else if (constr->AlignmentType == BSplineControlPoint) {
                      return boost::str(
-                         boost::format(
-                             "Sketcher.Constraint('InternalAlignment:%s', %s, %i, %s, %i)")
+                         boost::format("Sketcher.Constraint('InternalAlignment:%s', %s, %i, %s, %i")
                          % constr->internalAlignmentTypeToString() % geoId1
                          % static_cast<int>(constr->FirstPos) % geoId2
                          % constr->InternalAlignmentIndex);
                  }
                  else if (constr->AlignmentType == BSplineKnotPoint) {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('InternalAlignment:%s', %s, 1, %s, %i)")
+                         boost::format("Sketcher.Constraint('InternalAlignment:%s', %s, 1, %s, %i")
                          % constr->internalAlignmentTypeToString() % geoId1 % geoId2
                          % constr->InternalAlignmentIndex);
                  }
@@ -513,21 +512,21 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
                  if (constr->Second == GeoEnum::GeoUndef) {
-                     return boost::str(boost::format("Sketcher.Constraint('Distance', %s, %f)")
+                     return boost::str(boost::format("Sketcher.Constraint('Distance', %s, %f")
                                        % geoId1 % constr->getValue());
                  }
                  else if (constr->FirstPos == Sketcher::PointPos::none) {
-                     return boost::str(boost::format("Sketcher.Constraint('Distance', %s, %s, %f)")
+                     return boost::str(boost::format("Sketcher.Constraint('Distance', %s, %s, %f")
                                        % geoId1 % geoId2 % constr->getValue());
                  }
                  else if (constr->SecondPos == Sketcher::PointPos::none) {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('Distance', %s, %i, %s, %f)") % geoId1
+                         boost::format("Sketcher.Constraint('Distance', %s, %i, %s, %f") % geoId1
                          % static_cast<int>(constr->FirstPos) % geoId2 % constr->getValue());
                  }
                  else {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('Distance', %s, %i, %s, %i, %f)")
+                         boost::format("Sketcher.Constraint('Distance', %s, %i, %s, %i, %f")
                          % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
                          % static_cast<int>(constr->SecondPos) % constr->getValue());
                  }
@@ -538,24 +537,24 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId2,
                 std::string& geoId3) {
                  if (constr->Second == GeoEnum::GeoUndef) {
-                     return boost::str(boost::format("Sketcher.Constraint('Angle', %s, %f)")
-                                       % geoId1 % constr->getValue());
+                     return boost::str(boost::format("Sketcher.Constraint('Angle', %s, %f") % geoId1
+                                       % constr->getValue());
                  }
                  else if (constr->Third == GeoEnum::GeoUndef) {
                      if (constr->SecondPos == Sketcher::PointPos::none) {
-                         return boost::str(boost::format("Sketcher.Constraint('Angle', %s, %s, %f)")
+                         return boost::str(boost::format("Sketcher.Constraint('Angle', %s, %s, %f")
                                            % geoId1 % geoId2 % constr->getValue());
                      }
                      else {
                          return boost::str(
-                             boost::format("Sketcher.Constraint('Angle', %s, %i, %s, %i, %f)")
+                             boost::format("Sketcher.Constraint('Angle', %s, %i, %s, %i, %f")
                              % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
                              % static_cast<int>(constr->SecondPos) % constr->getValue());
                      }
                  }
                  else {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('AngleViaPoint', %s, %s, %s, %i, %f)")
+                         boost::format("Sketcher.Constraint('AngleViaPoint', %s, %s, %s, %i, %f")
                          % geoId1 % geoId2 % geoId3 % static_cast<int>(constr->ThirdPos)
                          % constr->getValue());
                  }
@@ -566,17 +565,17 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
                  if (constr->Second == GeoEnum::GeoUndef) {
-                     return boost::str(boost::format("Sketcher.Constraint('DistanceX', %s, %f)")
+                     return boost::str(boost::format("Sketcher.Constraint('DistanceX', %s, %f")
                                        % geoId1 % constr->getValue());
                  }
                  else if (constr->SecondPos == Sketcher::PointPos::none) {
-                     return boost::str(boost::format("Sketcher.Constraint('DistanceX', %s, %i, %f)")
+                     return boost::str(boost::format("Sketcher.Constraint('DistanceX', %s, %i, %f")
                                        % geoId1 % static_cast<int>(constr->FirstPos)
                                        % constr->getValue());
                  }
                  else {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('DistanceX', %s, %i, %s, %i, %f)")
+                         boost::format("Sketcher.Constraint('DistanceX', %s, %i, %s, %i, %f")
                          % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
                          % static_cast<int>(constr->SecondPos) % constr->getValue());
                  }
@@ -587,17 +586,17 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
                  if (constr->Second == GeoEnum::GeoUndef) {
-                     return boost::str(boost::format("Sketcher.Constraint('DistanceY', %s, %f)")
+                     return boost::str(boost::format("Sketcher.Constraint('DistanceY', %s, %f")
                                        % geoId1 % constr->getValue());
                  }
                  else if (constr->SecondPos == Sketcher::PointPos::none) {
-                     return boost::str(boost::format("Sketcher.Constraint('DistanceY', %s, %i, %f)")
+                     return boost::str(boost::format("Sketcher.Constraint('DistanceY', %s, %i, %f")
                                        % geoId1 % static_cast<int>(constr->FirstPos)
                                        % constr->getValue());
                  }
                  else {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('DistanceY', %s, %i, %s, %i, %f)")
+                         boost::format("Sketcher.Constraint('DistanceY', %s, %i, %s, %i, %f")
                          % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
                          % static_cast<int>(constr->SecondPos) % constr->getValue());
                  }
@@ -607,7 +606,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 [[maybe_unused]] std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 return boost::str(boost::format("Sketcher.Constraint('Radius', %s, %f)") % geoId1
+                 return boost::str(boost::format("Sketcher.Constraint('Radius', %s, %f") % geoId1
                                    % constr->getValue());
              }},
             {Sketcher::Diameter,
@@ -615,7 +614,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 [[maybe_unused]] std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 return boost::str(boost::format("Sketcher.Constraint('Diameter', %s, %f)") % geoId1
+                 return boost::str(boost::format("Sketcher.Constraint('Diameter', %s, %f") % geoId1
                                    % constr->getValue());
              }},
             {Sketcher::Weight,
@@ -623,7 +622,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 [[maybe_unused]] std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 return boost::str(boost::format("Sketcher.Constraint('Weight', %s, %f)") % geoId1
+                 return boost::str(boost::format("Sketcher.Constraint('Weight', %s, %f") % geoId1
                                    % constr->getValue());
              }},
             {Sketcher::PointOnObject,
@@ -631,7 +630,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 return boost::str(boost::format("Sketcher.Constraint('PointOnObject', %s, %i, %s)")
+                 return boost::str(boost::format("Sketcher.Constraint('PointOnObject', %s, %i, %s")
                                    % geoId1 % static_cast<int>(constr->FirstPos) % geoId2);
              }},
             {Sketcher::Symmetric,
@@ -641,13 +640,13 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId3) {
                  if (constr->ThirdPos == Sketcher::PointPos::none) {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('Symmetric', %s, %i, %s, %i, %s)")
+                         boost::format("Sketcher.Constraint('Symmetric', %s, %i, %s, %i, %s")
                          % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
                          % static_cast<int>(constr->SecondPos) % geoId3);
                  }
                  else {
                      return boost::str(
-                         boost::format("Sketcher.Constraint('Symmetric', %s, %i, %s, %i, %s, %i)")
+                         boost::format("Sketcher.Constraint('Symmetric', %s, %i, %s, %i, %s, %i")
                          % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
                          % static_cast<int>(constr->SecondPos) % geoId3
                          % static_cast<int>(constr->ThirdPos));
@@ -659,7 +658,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId2,
                 std::string& geoId3) {
                  return boost::str(
-                     boost::format("Sketcher.Constraint('SnellsLaw', %s, %i, %s, %i, %s, %f)")
+                     boost::format("Sketcher.Constraint('SnellsLaw', %s, %i, %s, %i, %s, %f")
                      % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
                      % static_cast<int>(constr->SecondPos) % geoId3 % constr->getValue());
              }},
@@ -672,8 +671,19 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
     }
 
     auto creator = result->second;
+    std::string resultStr = creator(constraint, geoId1, geoId2, geoId3);
 
-    return creator(constraint, geoId1, geoId2, geoId3);
+    if (!constraint->isActive || !constraint->isDriving) {
+        std::string active = constraint->isActive ? "True" : "False";
+        std::string driving = constraint->isDriving ? "True" : "False";
+        resultStr += ", " + active;
+        if (constraint->isDimensional()) {
+            resultStr += ", " + driving;
+        }
+    }
+    resultStr += ")";
+
+    return resultStr;
 }
 
 std::vector<std::string> PythonConverter::multiLine(std::string&& singlestring)

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1549,12 +1549,7 @@ int SketchObject::addGeometry(const std::vector<Part::Geometry*>& geoList,
         Part::Geometry* copy = v->copy();
         generateId(copy);
 
-        if (copy->is<Part::GeomPoint>()) {
-            // creation mode for points is always construction not to
-            // break legacy code
-            GeometryFacade::setConstruction(copy, true);
-        }
-        else if (construction) {
+        if (construction) {
             GeometryFacade::setConstruction(copy, construction);
         }
 
@@ -1588,12 +1583,7 @@ int SketchObject::addGeometry(std::unique_ptr<Part::Geometry> newgeo, bool const
     auto* geoNew = newgeo.release();
     generateId(geoNew);
 
-    if (geoNew->is<Part::GeomPoint>()) {
-        // creation mode for points is always construction not to
-        // break legacy code
-        GeometryFacade::setConstruction(geoNew, true);
-    }
-    else if (construction) {
+    if (construction) {
         GeometryFacade::setConstruction(geoNew, construction);
     }
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -2335,7 +2335,7 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
 
     // Add a vertex to preserve the original intersection of the filleted lines
     Part::GeomPoint* originalCorner = new Part::GeomPoint(getPoint(geoId1, posId1));
-    int originalCornerId = addGeometry(originalCorner);
+    int originalCornerId = addGeometry(originalCorner, true);
     delete originalCorner;
 
     // Constrain the vertex to the two lines

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPoint.h
@@ -85,7 +85,7 @@ private:
                                   editPoint.x,
                                   editPoint.y);
 
-            if (!isConstructionMode()) {
+            if (isConstructionMode()) {
                 Gui::cmdAppObjectArgs(sketchgui->getObject(),
                                       "toggleConstruction(%d)",
                                       getHighestCurveIndex());


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/15771
Fix 2 of the errors described in https://github.com/FreeCAD/FreeCAD/issues/15653

1 - Points being forced to construction when added to sketch (so on copy paste)
For this we simply have to remove a limitation that was here for unknown purpose. Apparantly to ensure legacy code would work (considered legacy 9 years ago).

2 - Driving and activated status of constraints not ported when copy pasted.


