### PR TITLE
Assembly: Fix bug where double-clicking on a joint would unselect edge

### DIFF
--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.h
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.h
@@ -170,6 +170,7 @@ public:
 
     bool canDragObjectIn3d(App::DocumentObject* obj) const;
     bool getSelectedObjectsWithinAssembly(bool addPreselection = true, bool onlySolids = false);
+    App::DocumentObject* getSelectedJoint();
 
     /// Get the python wrapper for that ViewProvider
     PyObject* getPyObject() override;


### PR DESCRIPTION
 Fix bug where double-clicking on a joint would unselect the underlying edge.
Fix https://github.com/FreeCAD/FreeCAD/issues/15718