### PR TITLE
Assembly: Fix joints not being deleted when component removed.

### DIFF
--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -575,7 +575,7 @@ std::vector<App::DocumentObject*> AssemblyObject::getJointsOfObj(App::DocumentOb
         App::DocumentObject* obj1 = getObjFromRef(joint, "Reference1");
         App::DocumentObject* obj2 = getObjFromRef(joint, "Reference2");
         if (obj == obj1 || obj == obj2) {
-            jointsOf.push_back(obj);
+            jointsOf.push_back(joint);
         }
     }
 

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -962,21 +962,40 @@ bool ViewProviderAssembly::canDelete(App::DocumentObject* obj) const
     bool res = ViewProviderPart::canDelete(obj);
     if (res) {
         // If a component is deleted, then we delete the joints as well.
-        for (auto parent : obj->getInList()) {
+        auto* assemblyPart = static_cast<AssemblyObject*>(getObject());
+
+        std::vector<App::DocumentObject*> objToDel;
+
+        // List its joints
+        std::vector<App::DocumentObject*> joints = assemblyPart->getJointsOfObj(obj);
+        for (auto* joint : joints) {
+            objToDel.push_back(joint);
+        }
+        joints = assemblyPart->getJointsOfPart(obj);
+        for (auto* joint : joints) {
+            if (std::find(objToDel.begin(), objToDel.end(), joint) == objToDel.end()) {
+                objToDel.push_back(joint);
+            }
+        }
+
+        // List its grounded joints
+        std::vector<App::DocumentObject*> inList = obj->getInList();
+        for (auto* parent : inList) {
             if (!parent) {
                 continue;
             }
 
-            auto* prop =
-                dynamic_cast<App::PropertyBool*>(parent->getPropertyByName("EnableLimits"));
-            auto* prop2 =
-                dynamic_cast<App::PropertyLink*>(parent->getPropertyByName("ObjectToGround"));
-            if (prop || prop2) {
-                Gui::Command::doCommand(Gui::Command::Doc,
-                                        "App.getDocument(\"%s\").removeObject(\"%s\")",
-                                        parent->getDocument()->getName(),
-                                        parent->getNameInDocument());
+            if (dynamic_cast<App::PropertyLink*>(parent->getPropertyByName("ObjectToGround"))) {
+                objToDel.push_back(parent);
             }
+        }
+
+        // Deletes them.
+        for (auto* joint : objToDel) {
+            Gui::Command::doCommand(Gui::Command::Doc,
+                                    "App.getDocument(\"%s\").removeObject(\"%s\")",
+                                    joint->getDocument()->getName(),
+                                    joint->getNameInDocument());
         }
     }
 


### PR DESCRIPTION
Make sure that when a components is deleted its joints are too.

This is a regression reported in https://github.com/Ondsel-Development/FreeCAD/issues/127

Fix https://github.com/Ondsel-Development/FreeCAD/issues/127