### PR TITLE
TechDraw: fix dimension being active at wrong times.

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -87,6 +87,13 @@ using DimensionType = TechDraw::DrawViewDimension::DimensionType;
 bool _checkSelection(Gui::Command* cmd, unsigned maxObjs = 2);
 bool _checkDrawViewPart(Gui::Command* cmd);
 
+bool isDimCmdActive(Gui::Command* cmd)
+{
+    bool havePage = DrawGuiUtil::needPage(cmd);
+    bool haveView = DrawGuiUtil::needView(cmd);
+    return (havePage && haveView);
+}
+
 
 void execDistance(Gui::Command* cmd);
 void execDistanceX(Gui::Command* cmd);
@@ -1424,9 +1431,7 @@ void CmdTechDrawDimension::activated(int iMsg)
 
 bool CmdTechDrawDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 
@@ -1479,9 +1484,7 @@ public:
 
     bool isActive() override
     {
-        bool havePage = DrawGuiUtil::needPage(this);
-        bool haveView = DrawGuiUtil::needView(this);
-        return (havePage && haveView);
+        return isDimCmdActive(this);
     }
 };
 
@@ -1519,9 +1522,7 @@ void CmdTechDrawRadiusDimension::activated(int iMsg)
 
 bool CmdTechDrawRadiusDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 void execRadius(Gui::Command* cmd)
@@ -1569,9 +1570,7 @@ void CmdTechDrawDiameterDimension::activated(int iMsg)
 
 bool CmdTechDrawDiameterDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 void execDiameter(Gui::Command* cmd)
@@ -1619,9 +1618,7 @@ void CmdTechDrawLengthDimension::activated(int iMsg)
 
 bool CmdTechDrawLengthDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 void execDistance(Gui::Command* cmd)
@@ -1669,9 +1666,7 @@ void CmdTechDrawHorizontalDimension::activated(int iMsg)
 
 bool CmdTechDrawHorizontalDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 void execDistanceX(Gui::Command* cmd)
@@ -1719,9 +1714,7 @@ void CmdTechDrawVerticalDimension::activated(int iMsg)
 
 bool CmdTechDrawVerticalDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 void execDistanceY(Gui::Command* cmd)
@@ -1768,9 +1761,7 @@ void CmdTechDrawAngleDimension::activated(int iMsg)
 
 bool CmdTechDrawAngleDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 void execAngle(Gui::Command* cmd)
@@ -1817,9 +1808,7 @@ void CmdTechDraw3PtAngleDimension::activated(int iMsg)
 
 bool CmdTechDraw3PtAngleDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 void execAngle3Pt(Gui::Command* cmd)
@@ -1866,9 +1855,7 @@ void CmdTechDrawAreaDimension::activated(int iMsg)
 
 bool CmdTechDrawAreaDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 void execArea(Gui::Command* cmd)
@@ -2057,9 +2044,7 @@ void CmdTechDrawExtentGroup::languageChange()
 
 bool CmdTechDrawExtentGroup::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this, false);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 //===========================================================================
@@ -2097,9 +2082,7 @@ void CmdTechDrawHorizontalExtentDimension::activated(int iMsg)
 
 bool CmdTechDrawHorizontalExtentDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this, false);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 void execExtent(Gui::Command* cmd, const std::string& dimType)
@@ -2211,9 +2194,7 @@ void CmdTechDrawVerticalExtentDimension::activated(int iMsg)
 
 bool CmdTechDrawVerticalExtentDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this, false);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 //===========================================================================
@@ -2367,9 +2348,7 @@ void CmdTechDrawLandmarkDimension::activated(int iMsg)
 
 bool CmdTechDrawLandmarkDimension::isActive()
 {
-    bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this);
-    return (havePage && haveView);
+    return isDimCmdActive(this);
 }
 
 //------------------------------------------------------------------------------

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -1407,7 +1407,6 @@ CmdTechDrawDimension::CmdTechDrawDimension()
     sStatusTip = sToolTipText;
     sPixmap = "TechDraw_Dimension";
     sAccel = "D";
-    eType = ForEdit;
 }
 
 void CmdTechDrawDimension::activated(int iMsg)
@@ -1445,7 +1444,6 @@ public:
         sToolTipText = QT_TR_NOOP("Dimension tools.");
         sWhatsThis = "TechDraw_CompDimensionTools";
         sStatusTip = sToolTipText;
-        eType = ForEdit;
 
         setCheckable(false);
         setRememberLast(false);
@@ -1478,6 +1476,13 @@ public:
     }
 
     const char* className() const override { return "CmdTechDrawCompDimensionTools"; }
+
+    bool isActive() override
+    {
+        bool havePage = DrawGuiUtil::needPage(this);
+        bool haveView = DrawGuiUtil::needView(this);
+        return (havePage && haveView);
+    }
 };
 
 //===========================================================================

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -313,8 +313,8 @@ void TaskProjGroup::turnViewToProjGroup()
     viewPart->X.setValue(0.0);
     viewPart->Y.setValue(0.0);
     viewPart->ScaleType.setValue("Custom");
-    viewPart->Scale.setStatus(App::Property::Hidden, true);
     viewPart->ScaleType.setStatus(App::Property::Hidden, true);
+    viewPart->Scale.setStatus(App::Property::Hidden, true);
     viewPart->Label.setValue("Front");
 
     multiView->addView(viewPart);
@@ -325,7 +325,7 @@ void TaskProjGroup::turnViewToProjGroup()
     viewPart->LockPosition.setStatus(App::Property::ReadOnly, true); //Front should stay locked.
     viewPart->LockPosition.purgeTouched();
 
-    multiView->requestPaint();//make sure the group object is on the Gui page
+    m_page->requestPaint();
     view = multiView;
 
     updateUi();
@@ -336,14 +336,11 @@ void TaskProjGroup::turnProjGroupToView()
     TechDraw::DrawViewPart* viewPart = multiView->getAnchor();
     viewPart->Scale.setValue(multiView->Scale.getValue());
     viewPart->ScaleType.setValue(multiView->ScaleType.getValue());
-    viewPart->Scale.setStatus(App::Property::Hidden, true);
-    viewPart->ScaleType.setStatus(App::Property::Hidden, true);
-    viewPart->Scale.purgeTouched();
-    viewPart->ScaleType.purgeTouched();
+    viewPart->Scale.setStatus(App::Property::Hidden, false);
+    viewPart->ScaleType.setStatus(App::Property::Hidden, false);
     viewPart->Label.setValue("View");
     viewPart->LockPosition.setValue(false);
     viewPart->LockPosition.setStatus(App::Property::ReadOnly, false);
-    viewPart->LockPosition.purgeTouched();
     viewPart->X.setValue(multiView->X.getValue());
     viewPart->Y.setValue(multiView->Y.getValue());
     m_page->addView(viewPart);


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/15764

Also fix : 
- Dimension disappear when view is upgraded to proj group. (described in https://github.com/FreeCAD/FreeCAD/issues/15765)
- Scale and ScaleType were no re-appearing when downgrade from group to view