### PR TITLE
[Sketcher] Round 1 of refactors

### DIFF
--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -793,6 +793,11 @@ GeomBSplineCurve* GeomCurve::toNurbs(double first, double last) const
     return toBSpline(first, last);
 }
 
+GeomCurve* GeomCurve::createArc([[maybe_unused]] double first, [[maybe_unused]] double last) const
+{
+    return nullptr;
+}
+
 bool GeomCurve::tangent(double u, gp_Dir& dir) const
 {
     Handle(Geom_Curve) curve = Handle(Geom_Curve)::DownCast(handle());
@@ -1378,6 +1383,14 @@ Geometry *GeomBSplineCurve::copy() const
     catch (Standard_Failure& exc) {
         THROWM(Base::CADKernelError, exc.GetMessageString())
     }
+}
+
+GeomCurve* GeomBSplineCurve::createArc(double first, double last) const
+{
+   auto newBsp = static_cast<Part::GeomBSplineCurve*>(this->copy());
+   newBsp->Trim(first, last);
+
+   return newBsp;
 }
 
 int GeomBSplineCurve::countPoles() const
@@ -2270,6 +2283,14 @@ Geometry *GeomTrimmedCurve::copy() const
     return newCurve;
 }
 
+GeomCurve* GeomTrimmedCurve::createArc(double first, double last) const
+{
+    auto newArc = static_cast<Part::GeomTrimmedCurve*>(this->copy());
+    newArc->setRange(first, last);
+
+    return newArc;
+}
+
 // Persistence implementer
 unsigned int GeomTrimmedCurve::getMemSize () const
 {
@@ -2590,6 +2611,14 @@ Geometry *GeomCircle::copy() const
     GeomCircle *newCirc = new GeomCircle(myCurve);
     newCirc->copyNonTag(this);
     return newCirc;
+}
+
+GeomCurve* GeomCircle::createArc(double first, double last) const
+{
+    auto newArc = new GeomArcOfCircle(Handle(Geom_Circle)::DownCast(this->handle()->Copy()));
+    newArc->setRange(first, last, false);
+
+    return newArc;
 }
 
 GeomBSplineCurve* GeomCircle::toNurbs(double first, double last) const
@@ -3028,6 +3057,14 @@ Geometry *GeomEllipse::copy() const
     GeomEllipse *newEllipse = new GeomEllipse(myCurve);
     newEllipse->copyNonTag(this);
     return newEllipse;
+}
+
+GeomCurve* GeomEllipse::createArc(double first, double last) const
+{
+    auto newArc = new GeomArcOfEllipse(Handle(Geom_Ellipse)::DownCast(this->handle()->Copy()));
+    newArc->setRange(first, last, false);
+
+    return newArc;
 }
 
 GeomBSplineCurve* GeomEllipse::toNurbs(double first, double last) const

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -795,7 +795,7 @@ GeomBSplineCurve* GeomCurve::toNurbs(double first, double last) const
 
 GeomCurve* GeomCurve::createArc([[maybe_unused]] double first, [[maybe_unused]] double last) const
 {
-    return nullptr;
+    THROWM(Base::NotImplementedError, "createArc: not implemented for this type of curve");
 }
 
 bool GeomCurve::tangent(double u, gp_Dir& dir) const
@@ -3606,11 +3606,19 @@ void GeomHyperbola::setHandle(const Handle(Geom_Hyperbola)& c)
     myCurve = Handle(Geom_Hyperbola)::DownCast(c->Copy());
 }
 
-Geometry *GeomHyperbola::copy() const
+Geometry* GeomHyperbola::copy() const
 {
     GeomHyperbola *newHyp = new GeomHyperbola(myCurve);
     newHyp->copyNonTag(this);
     return newHyp;
+}
+
+GeomCurve* GeomHyperbola::createArc(double first, double last) const
+{
+    auto newArc = new GeomArcOfHyperbola(Handle(Geom_Hyperbola)::DownCast(this->handle()->Copy()));
+    newArc->setRange(first, last, false);
+
+    return newArc;
 }
 
 GeomBSplineCurve* GeomHyperbola::toNurbs(double first, double last) const
@@ -4056,6 +4064,14 @@ Geometry *GeomParabola::copy() const
     GeomParabola *newPar = new GeomParabola(myCurve);
     newPar->copyNonTag(this);
     return newPar;
+}
+
+GeomCurve* GeomParabola::createArc(double first, double last) const
+{
+    auto newArc = new GeomArcOfParabola(Handle(Geom_Parabola)::DownCast(this->handle()->Copy()));
+    newArc->setRange(first, last, false);
+
+    return newArc;
 }
 
 GeomBSplineCurve* GeomParabola::toNurbs(double first, double last) const

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -212,7 +212,7 @@ public:
     */
     virtual GeomBSplineCurve* toNurbs(double first, double last) const;
     /*!
-     * \brief getArc Generates a curve that is an arc of this curve between given parameters
+     * \brief createArc Generates a curve that is an arc of this curve between given parameters
      * \param first Parameter at start of arc
      * \param last Parameter at end of arc. This may be < `first` for periodic curves.
      * \return the new curve
@@ -653,7 +653,8 @@ public:
     GeomHyperbola();
     explicit GeomHyperbola(const Handle(Geom_Hyperbola)&);
     ~GeomHyperbola() override;
-    Geometry *copy() const override;
+    Geometry* copy() const override;
+    GeomCurve* createArc(double first, double last) const override;
 
     double getMajorRadius() const;
     void setMajorRadius(double Radius);
@@ -717,7 +718,8 @@ public:
     GeomParabola();
     explicit GeomParabola(const Handle(Geom_Parabola)&);
     ~GeomParabola() override;
-    Geometry *copy() const override;
+    Geometry* copy() const override;
+    GeomCurve* createArc(double first, double last) const override;
 
     double getFocal() const;
     void setFocal(double length);

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -209,8 +209,15 @@ public:
       The default implementation does the same as \ref toBSpline.
       In sub-classes this can be reimplemented to create a real
       NURBS curve and not just an approximation.
-     */
+    */
     virtual GeomBSplineCurve* toNurbs(double first, double last) const;
+    /*!
+     * \brief getArc Generates a curve that is an arc of this curve between given parameters
+     * \param first Parameter at start of arc
+     * \param last Parameter at end of arc. This may be < `first` for periodic curves.
+     * \return the new curve
+     */
+    virtual GeomCurve* createArc(double first, double last) const;
     bool tangent(double u, gp_Dir&) const;
     bool tangent(double u, Base::Vector3d& dir) const;
     Base::Vector3d pointAtParameter(double u) const;
@@ -293,6 +300,8 @@ public:
 
     ~GeomBSplineCurve() override;
     Geometry *copy() const override;
+
+    GeomCurve* createArc(double first, double last) const override;
 
    /*!
     * Interpolate a spline passing through the given points without tangency.
@@ -430,6 +439,7 @@ public:
     ~GeomTrimmedCurve() override;
     Geometry *copy() const override;
 
+    GeomCurve* createArc(double first, double last) const override;
     // Persistence implementer ---------------------
     unsigned int getMemSize() const override;
     void Save(Base::Writer &/*writer*/) const override;
@@ -514,6 +524,7 @@ public:
     ~GeomCircle() override;
     Geometry *copy() const override;
 
+    GeomCurve* createArc(double first, double last) const override;
     double getRadius() const;
     void setRadius(double Radius);
 
@@ -575,6 +586,7 @@ public:
     ~GeomEllipse() override;
     Geometry *copy() const override;
 
+    GeomCurve* createArc(double first, double last) const override;
     double getMajorRadius() const;
     void setMajorRadius(double Radius);
     double getMinorRadius() const;

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -2628,13 +2628,12 @@ class TestTopologicalNamingProblem(unittest.TestCase):
 
         self.PadSketch.trim(2, App.Vector(7.337847, -25.000000, 0))
         self.PadSketch.addConstraint(Sketcher.Constraint("Equal", 3, 1))
-        self.PadSketch.addConstraint(Sketcher.Constraint("Horizontal", 5))
-        self.PadSketch.addConstraint(Sketcher.Constraint("Radius", 4, 73.031111))
-        self.PadSketch.setDatum(18, App.Units.Quantity("70.000000 mm"))
-        self.PadSketch.addConstraint(
+        radConstr = self.PadSketch.addConstraint(Sketcher.Constraint("Radius", 4, 73.031111))
+        self.PadSketch.setDatum(radConstr, App.Units.Quantity("70.000000 mm"))
+        distYConstr = self.PadSketch.addConstraint(
             Sketcher.Constraint("DistanceY", 4, 3, -1, 1, 88.867210)
         )
-        self.PadSketch.setDatum(19, App.Units.Quantity("80.000000 mm"))
+        self.PadSketch.setDatum(distYConstr, App.Units.Quantity("80.000000 mm"))
 
         self.Doc.recompute()
         self.assertTrue(self.Sketch001.isValid())

--- a/src/Mod/Sketcher/App/Constraint.cpp
+++ b/src/Mod/Sketcher/App/Constraint.cpp
@@ -239,6 +239,25 @@ void Constraint::substituteIndex(int fromGeoId, int toGeoId)
     }
 }
 
+void Constraint::substituteIndexAndPos(int fromGeoId,
+                                       PointPos fromPosId,
+                                       int toGeoId,
+                                       PointPos toPosId)
+{
+    if (this->First == fromGeoId && this->FirstPos == fromPosId) {
+        this->First = toGeoId;
+        this->FirstPos = toPosId;
+    }
+    if (this->Second == fromGeoId && this->SecondPos == fromPosId) {
+        this->Second = toGeoId;
+        this->SecondPos = toPosId;
+    }
+    if (this->Third == fromGeoId && this->ThirdPos == fromPosId) {
+        this->Third = toGeoId;
+        this->ThirdPos = toPosId;
+    }
+}
+
 std::string Constraint::typeToString(ConstraintType type)
 {
     return type2str[type];

--- a/src/Mod/Sketcher/App/Constraint.h
+++ b/src/Mod/Sketcher/App/Constraint.h
@@ -132,6 +132,21 @@ public:
     /// utility function to swap the index in First/Second/Third of the provided constraint from the
     /// fromGeoId GeoId to toGeoId
     void substituteIndex(int fromGeoId, int toGeoId);
+    /// utility function to swap the index and position in First/Second/Third of the provided
+    /// constraint from {fromGeoId, fromPosId} to {toGeoId, toPosId}.
+    void substituteIndexAndPos(int fromGeoId, PointPos fromPosId, int toGeoId, PointPos toPosId);
+
+    /// utility function to check if `geoId` is one of the geometries
+    bool involvesGeoId(int geoId) const
+    {
+        return First == geoId || Second == geoId || Third == geoId;
+    }
+    /// utility function to check if (`geoId`, `posId`) is one of the points/curves
+    bool involvesGeoIdAndPosId(int geoId, PointPos posId) const
+    {
+        return (First == geoId && FirstPos == posId) || (Second == geoId && SecondPos == posId)
+            || (Third == geoId && ThirdPos == posId);
+    }
 
     std::string typeToString() const
     {

--- a/src/Mod/Sketcher/App/GeometryFacade.cpp
+++ b/src/Mod/Sketcher/App/GeometryFacade.cpp
@@ -68,18 +68,6 @@ std::unique_ptr<GeometryFacade> GeometryFacade::getFacade(const Part::Geometry* 
     // return std::make_unique<GeometryFacade>(geometry);
 }
 
-// std::unique_ptr<const GeometryFacade> GeometryFacade::getFacade(const Part::Geometry* geometry)
-// {
-//     if (geometry) {
-//         return std::unique_ptr<const GeometryFacade>(new GeometryFacade(geometry));
-//     }
-//     else {
-//         return std::unique_ptr<const GeometryFacade>(nullptr);
-//     }
-//     // make_unique has no access to private constructor
-//     // return std::make_unique<const GeometryFacade>(geometry);
-// }
-
 void GeometryFacade::setGeometry(Part::Geometry* geometry)
 {
     Geo = geometry;

--- a/src/Mod/Sketcher/App/GeometryFacade.cpp
+++ b/src/Mod/Sketcher/App/GeometryFacade.cpp
@@ -55,7 +55,8 @@ GeometryFacade::~GeometryFacade()
     }
 }
 
-std::unique_ptr<GeometryFacade> GeometryFacade::getFacade(Part::Geometry* geometry, bool owner)
+std::unique_ptr<GeometryFacade> GeometryFacade::getFacade(const Part::Geometry* geometry,
+                                                          bool owner)
 {
     if (geometry) {
         return std::unique_ptr<GeometryFacade>(new GeometryFacade(geometry, owner));
@@ -67,17 +68,17 @@ std::unique_ptr<GeometryFacade> GeometryFacade::getFacade(Part::Geometry* geomet
     // return std::make_unique<GeometryFacade>(geometry);
 }
 
-std::unique_ptr<const GeometryFacade> GeometryFacade::getFacade(const Part::Geometry* geometry)
-{
-    if (geometry) {
-        return std::unique_ptr<const GeometryFacade>(new GeometryFacade(geometry));
-    }
-    else {
-        return std::unique_ptr<const GeometryFacade>(nullptr);
-    }
-    // make_unique has no access to private constructor
-    // return std::make_unique<const GeometryFacade>(geometry);
-}
+// std::unique_ptr<const GeometryFacade> GeometryFacade::getFacade(const Part::Geometry* geometry)
+// {
+//     if (geometry) {
+//         return std::unique_ptr<const GeometryFacade>(new GeometryFacade(geometry));
+//     }
+//     else {
+//         return std::unique_ptr<const GeometryFacade>(nullptr);
+//     }
+//     // make_unique has no access to private constructor
+//     // return std::make_unique<const GeometryFacade>(geometry);
+// }
 
 void GeometryFacade::setGeometry(Part::Geometry* geometry)
 {
@@ -152,7 +153,7 @@ int GeometryFacade::getId(const Part::Geometry* geometry)
     return gf->getId();
 }
 
-void GeometryFacade::setId(Part::Geometry* geometry, int id)
+void GeometryFacade::setId(const Part::Geometry* geometry, int id)
 {
     auto gf = GeometryFacade::getFacade(geometry);
     gf->setId(id);

--- a/src/Mod/Sketcher/App/GeometryFacade.h
+++ b/src/Mod/Sketcher/App/GeometryFacade.h
@@ -120,7 +120,6 @@ protected:
 public:  // Factory methods
     static std::unique_ptr<GeometryFacade> getFacade(const Part::Geometry* geometry,
                                                      bool owner = false);
-    // static std::unique_ptr<const GeometryFacade> getFacade(const Part::Geometry* geometry);
 
 public:  // Utility methods
     static void ensureSketchGeometryExtension(Part::Geometry* geometry);

--- a/src/Mod/Sketcher/App/GeometryFacade.h
+++ b/src/Mod/Sketcher/App/GeometryFacade.h
@@ -118,8 +118,9 @@ protected:
     friend class GeometryFacadePy;
 
 public:  // Factory methods
-    static std::unique_ptr<GeometryFacade> getFacade(Part::Geometry* geometry, bool owner = false);
-    static std::unique_ptr<const GeometryFacade> getFacade(const Part::Geometry* geometry);
+    static std::unique_ptr<GeometryFacade> getFacade(const Part::Geometry* geometry,
+                                                     bool owner = false);
+    // static std::unique_ptr<const GeometryFacade> getFacade(const Part::Geometry* geometry);
 
 public:  // Utility methods
     static void ensureSketchGeometryExtension(Part::Geometry* geometry);
@@ -132,7 +133,7 @@ public:  // Utility methods
     static void setInternalType(Part::Geometry* geometry, InternalType::InternalType type);
     static bool getBlocked(const Part::Geometry* geometry);
     static int getId(const Part::Geometry* geometry);
-    static void setId(Part::Geometry* geometry, int id);
+    static void setId(const Part::Geometry* geometry, int id);
 
 public:
     // Explicit deletion to show intent (not that it is needed)

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1401,10 +1401,16 @@ Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomPoint *geomPo
 template <>
 Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomLineSegment *lineSeg, PointPos PosId)
 {
-    if (PosId == PointPos::start)
+    switch (PosId) {
+    case PointPos::start: {
         return lineSeg->getStartPoint();
-    else if (PosId == PointPos::end)
+    }
+    case PointPos::end: {
         return lineSeg->getEndPoint();
+    }
+    default:
+        break;
+    }
     return Base::Vector3d();
 }
 
@@ -1429,58 +1435,92 @@ Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomEllipse *elli
 template <>
 Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomArcOfCircle *aoc, PointPos PosId)
 {
-    if (PosId == PointPos::start)
+    switch (PosId) {
+    case PointPos::start: {
         return aoc->getStartPoint(/*emulateCCW=*/true);
-    else if (PosId == PointPos::end)
+    }
+    case PointPos::end: {
         return aoc->getEndPoint(/*emulateCCW=*/true);
-    else if (PosId == PointPos::mid)
+    }
+    case PointPos::mid: {
         return aoc->getCenter();
+    }
+    default:
+        break;
+    }
     return Base::Vector3d();
 }
 
 template <>
 Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomArcOfEllipse *aoe, PointPos PosId)
 {
-    if (PosId == PointPos::start)
+    switch (PosId) {
+    case PointPos::start: {
         return aoe->getStartPoint(/*emulateCCW=*/true);
-    else if (PosId == PointPos::end)
+    }
+    case PointPos::end: {
         return aoe->getEndPoint(/*emulateCCW=*/true);
-    else if (PosId == PointPos::mid)
+    }
+    case PointPos::mid: {
         return aoe->getCenter();
+    }
+    default:
+        break;
+    }
     return Base::Vector3d();
 }
 
 template <>
 Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomArcOfHyperbola *aoh, PointPos PosId)
 {
-    if (PosId == PointPos::start)
+    switch (PosId) {
+    case PointPos::start: {
         return aoh->getStartPoint();
-    else if (PosId == PointPos::end)
+    }
+    case PointPos::end: {
         return aoh->getEndPoint();
-    else if (PosId == PointPos::mid)
+    }
+    case PointPos::mid: {
         return aoh->getCenter();
+    }
+    default:
+        break;
+    }
     return Base::Vector3d();
 }
 
 template <>
 Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomArcOfParabola *aop, PointPos PosId)
 {
-    if (PosId == PointPos::start)
+    switch (PosId) {
+    case PointPos::start: {
         return aop->getStartPoint();
-    else if (PosId == PointPos::end)
+    }
+    case PointPos::end: {
         return aop->getEndPoint();
-    else if (PosId == PointPos::mid)
+    }
+    case PointPos::mid: {
         return aop->getCenter();
+    }
+    default:
+        break;
+    }
     return Base::Vector3d();
 }
 
 template <>
 Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomBSplineCurve *bsp, PointPos PosId)
 {
-    if (PosId == PointPos::start)
+    switch (PosId) {
+    case PointPos::start: {
         return bsp->getStartPoint();
-    else if (PosId == PointPos::end)
+    }
+    case PointPos::end: {
         return bsp->getEndPoint();
+    }
+    default:
+        break;
+    }
     return Base::Vector3d();
 }
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3502,29 +3502,13 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
                                                                     int GeoId1,
                                                                     Base::Vector3d point1,
                                                                     Constraint* constr) {
+        // TODO: Move code currently later in this method (that does as per the following description) here.
         /* It is possible that the trimming entity has both a PointOnObject constraint to the
-         * trimmed entity, and a simple Tangent contstrait to the trimmed entity. In this case we
+         * trimmed entity, and a simple Tangent contstraint to the trimmed entity. In this case we
          * want to change to a single end-to-end tangency, i.e we want to ensure that constrType1 is
          * set to Sketcher::Tangent, that the secondPos1 is captured from the PointOnObject, and
          * also make sure that the PointOnObject constraint is deleted. The below loop ensures this,
          * also in case the ordering of the constraints is first Tangent and then PointOnObject. */
-        // if (!(constr->Type == Sketcher::Tangent
-        //       || constr->Type == Sketcher::Perpendicular)) {
-        //     return;
-        // }
-
-        // if (constr->First == GeoId1 && constr->Second == GeoId) {
-        //     constr->Type = constr->Type;
-        //     if (secondPos == Sketcher::PointPos::none)
-        //         secondPos = constr->FirstPos;
-        //     delete_list.push_back(constrId);
-        // }
-        // else if (constr->First == GeoId && constr->Second == GeoId1) {
-        //     constr->Type = constr->Type;
-        //     if (secondPos == Sketcher::PointPos::none)
-        //         secondPos = constr->SecondPos;
-        //     delete_list.push_back(constrId);
-        // }
     };
 
     // makes an equality constraint between GeoId1 and GeoId2

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -11260,41 +11260,40 @@ bool SketchObject::AutoLockTangencyAndPerpty(Constraint* cstr, bool bForce, bool
                 // no tangency lockdown is implemented for simple tangency. Do nothing.
                 return false;
             }
-            else {
-                Base::Vector3d p = getPoint(geoIdPt, posPt);
 
-                // this piece of code is also present in Sketch.cpp, correct for offset
-                // and to do the autodecision for old sketches.
-                // the difference between the datum value and the actual angle to apply.
-                // (datum=angle+offset)
-                double angleOffset = 0.0;
-                // the desired angle value (and we are to decide if 180* should be added to it)
-                double angleDesire = 0.0;
-                if (cstr->Type == Tangent) {
-                    angleOffset = -M_PI / 2;
-                    angleDesire = 0.0;
-                }
-                if (cstr->Type == Perpendicular) {
-                    angleOffset = 0;
-                    angleDesire = M_PI / 2;
-                }
+            Base::Vector3d p = getPoint(geoIdPt, posPt);
 
-                double angleErr = calculateAngleViaPoint(geoId1, geoId2, p.x, p.y) - angleDesire;
-
-                // bring angleErr to -pi..pi
-                if (angleErr > M_PI)
-                    angleErr -= M_PI * 2;
-                if (angleErr < -M_PI)
-                    angleErr += M_PI * 2;
-
-                // the autodetector
-                if (fabs(angleErr) > M_PI / 2)
-                    angleDesire += M_PI;
-
-                // external tangency. The angle stored is offset by Pi/2 so that a value of 0.0 is
-                // invalid and treated as "undecided".
-                cstr->setValue(angleDesire + angleOffset);
+            // this piece of code is also present in Sketch.cpp, correct for offset
+            // and to do the autodecision for old sketches.
+            // the difference between the datum value and the actual angle to apply.
+            // (datum=angle+offset)
+            double angleOffset = 0.0;
+            // the desired angle value (and we are to decide if 180* should be added to it)
+            double angleDesire = 0.0;
+            if (cstr->Type == Tangent) {
+                angleOffset = -M_PI / 2;
+                angleDesire = 0.0;
             }
+            if (cstr->Type == Perpendicular) {
+                angleOffset = 0;
+                angleDesire = M_PI / 2;
+            }
+
+            double angleErr = calculateAngleViaPoint(geoId1, geoId2, p.x, p.y) - angleDesire;
+
+            // bring angleErr to -pi..pi
+            if (angleErr > M_PI)
+                angleErr -= M_PI * 2;
+            if (angleErr < -M_PI)
+                angleErr += M_PI * 2;
+
+            // the autodetector
+            if (fabs(angleErr) > M_PI / 2)
+                angleDesire += M_PI;
+
+            // external tangency. The angle stored is offset by Pi/2 so that a value of 0.0 is
+            // invalid and treated as "undecided".
+            cstr->setValue(angleDesire + angleOffset);
         }
     }
     catch (Base::Exception& e) {

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3446,18 +3446,18 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
         return ((point1 - point2).Length() < 500 * Precision::Confusion()) ;
     };
 
-    auto isPointAtPosition =
-        [this, &arePointsWithinPrecision](int GeoId1, PointPos pos1, Base::Vector3d point) {
-            Base::Vector3d pp = getPoint(GeoId1, pos1);
+    auto isPointAtPosition = [this, &arePointsWithinPrecision]
+        (int GeoId1, PointPos pos1, Base::Vector3d point) {
+        Base::Vector3d pp = getPoint(GeoId1, pos1);
 
-            return arePointsWithinPrecision(point, pp);
-        };
+        return arePointsWithinPrecision(point, pp);
+    };
 
     // Checks whether preexisting constraints must be converted to new constraints.
     // Preexisting point on object constraints get converted to coincidents, unless an end-to-end
     // tangency is more relevant. returns by reference:
-    //      - The type of constraint that should be used to constraint GeoId1 and GeoId
-    //      - The element of GeoId1 to which the constraint should be applied.
+    //     - The type of constraint that should be used to constraint GeoId1 and GeoId
+    //     - The element of GeoId1 to which the constraint should be applied.
     auto transformPreexistingConstraint = [this, isPointAtPosition](int GeoId,
                                                                     int GeoId1,
                                                                     Base::Vector3d point1,
@@ -3529,11 +3529,9 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
     int GeoId1 = GeoEnum::GeoUndef, GeoId2 = GeoEnum::GeoUndef;
     Base::Vector3d point1, point2;
 
-    // Remove B-splines' internal geometry beforehand so GeoId1 and GeoId2 do not change
-    if (geo->is<Part::GeomBSplineCurve>()) {
-        deleteUnusedInternalGeometryAndUpdateGeoId(GeoId);
-        geo = getGeometry(GeoId);
-    }
+    // Remove internal geometry beforehand so GeoId1 and GeoId2 do not change
+    deleteUnusedInternalGeometryAndUpdateGeoId(GeoId);
+    geo = getGeometry(GeoId);
 
     // Using SketchObject wrapper, as Part2DObject version returns GeoId = -1 when intersection not
     // found, which is wrong for a GeoId (axis). seekTrimPoints returns:
@@ -3562,10 +3560,10 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
     double lastParam = static_cast<const Part::GeomCurve*>(geo)->getLastParameter();
     double pointParam, point1Param, point2Param;
     if (!getIntersectionParameters(
-            geo, point, pointParam, point1, point1Param, point2, point2Param))
+            geo, point, pointParam, point1, point1Param, point2, point2Param)) {
         return -1;
+    }
 
-    bool ok = false;
     bool startPointRemains = false;
     bool endPointRemains = false;
     std::vector<std::pair<double, double> > paramsOfNewGeos;
@@ -3574,121 +3572,29 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
     std::vector<const Part::Geometry*> newGeosAsConsts;
     bool oldGeoIsConstruction = GeometryFacade::getConstruction(static_cast<const Part::GeomCurve*>(geo));
 
-    auto setUpNewGeoLimitsFromNonPeriodic =
-        [&]() {
-            if (GeoId1 != GeoEnum::GeoUndef) {
-                startPointRemains = true;
-                paramsOfNewGeos.emplace_back(firstParam, point1Param);
-            }
-            if (GeoId2 != GeoEnum::GeoUndef) {
-                endPointRemains = true;
-                paramsOfNewGeos.emplace_back(point2Param, lastParam);
-            }
-        };
-
-    auto setUpNewGeoLimitsFromPeriodic =
-        [&]() {
-            startPointRemains = false;
-            endPointRemains = false;
-            if (GeoId1 != GeoEnum::GeoUndef && GeoId2 != GeoEnum::GeoUndef) {
-                paramsOfNewGeos.emplace_back(point2Param, point1Param);
-            }
-        };
-
-    auto createArcGeos = [&](const Part::GeomTrimmedCurve* curve) {
-        for (auto& [u1, u2] : paramsOfNewGeos) {
-            auto newArc = std::unique_ptr<Part::GeomTrimmedCurve>(
-                static_cast<Part::GeomTrimmedCurve*>(curve->copy()));
-            newArc->setRange(u1, u2);
-            newGeos.push_back(newArc.release());
+    if (isClosedCurve(geo)) {
+        startPointRemains = false;
+        endPointRemains = false;
+        if (GeoId1 != GeoEnum::GeoUndef && GeoId2 != GeoEnum::GeoUndef) {
+            paramsOfNewGeos.emplace_back(point2Param, point1Param);
         }
-
-        return true;
-    };
-
-    auto createArcGeosForCircle = [&](const Part::GeomCircle* curve) {
-        for (auto& [u1, u2] : paramsOfNewGeos) {
-            auto newArc = std::make_unique<Part::GeomArcOfCircle>(
-                Handle(Geom_Circle)::DownCast(curve->handle()->Copy()));
-            newArc->setRange(u1, u2, false);
-            newGeos.push_back(newArc.release());
-            // int newId(GeoEnum::GeoUndef);
-            // newId = addGeometry(std::move(newArc));
-            // if (newId < 0) {
-            //     return false;
-            // }
-            // newIds.push_back(newId);
-            // setConstruction(newId, GeometryFacade::getConstruction(curve));
-            // exposeInternalGeometry(newId);
-        }
-
-        return true;
-    };
-
-    auto createArcGeosForEllipse = [&](const Part::GeomEllipse* curve) {
-        for (auto& [u1, u2] : paramsOfNewGeos) {
-            auto newArc = std::make_unique<Part::GeomArcOfEllipse>(
-                Handle(Geom_Ellipse)::DownCast(curve->handle()->Copy()));
-            newArc->setRange(u1, u2, false);
-            newGeos.push_back(newArc.release());
-        }
-
-        return true;
-    };
-
-    auto createArcGeosForBSplineCurve = [&](const Part::GeomBSplineCurve* curve) {
-        for (auto& [u1, u2] : paramsOfNewGeos) {
-            auto newBsp = std::unique_ptr<Part::GeomBSplineCurve>(
-                static_cast<Part::GeomBSplineCurve*>(curve->copy()));
-            newBsp->Trim(u1, u2);
-            newGeos.push_back(newBsp.release());
-        }
-
-        return true;
-    };
-
-    if (geo->is<Part::GeomLineSegment>()) {
-        setUpNewGeoLimitsFromNonPeriodic();
-
-        ok = createArcGeos(static_cast<const Part::GeomTrimmedCurve*>(geo));
     }
-    else if (geo->is<Part::GeomCircle>()) {
-        setUpNewGeoLimitsFromPeriodic();
-
-        ok = createArcGeosForCircle(static_cast<const Part::GeomCircle*>(geo));
-    }
-    else if (geo->is<Part::GeomEllipse>()) {
-        setUpNewGeoLimitsFromPeriodic();
-
-        ok = createArcGeosForEllipse(static_cast<const Part::GeomEllipse*>(geo));
-    }
-    else if (geo->is<Part::GeomArcOfCircle>()) {
-        setUpNewGeoLimitsFromNonPeriodic();
-
-        ok = createArcGeos(static_cast<const Part::GeomTrimmedCurve*>(geo));
-    }
-    else if (geo->isDerivedFrom<Part::GeomArcOfConic>()) {
-        setUpNewGeoLimitsFromNonPeriodic();
-
-        ok = createArcGeos(static_cast<const Part::GeomTrimmedCurve*>(geo));
-    }
-    else if (geo->is<Part::GeomBSplineCurve>()) {
-        const Part::GeomBSplineCurve* bsp = static_cast<const Part::GeomBSplineCurve*>(geo);
-
-        // what to do for periodic b-splines?
-        if (bsp->isPeriodic()) {
-            setUpNewGeoLimitsFromPeriodic();
+    else {
+        if (GeoId1 != GeoEnum::GeoUndef) {
+            startPointRemains = true;
+            paramsOfNewGeos.emplace_back(firstParam, point1Param);
         }
-        else {
-            setUpNewGeoLimitsFromNonPeriodic();
+        if (GeoId2 != GeoEnum::GeoUndef) {
+            endPointRemains = true;
+            paramsOfNewGeos.emplace_back(point2Param, lastParam);
         }
-
-        ok = createArcGeosForBSplineCurve(bsp);
     }
 
-    if (!ok) {
-        delGeometries(newIds);
-        return -1;
+    for (auto& [u1, u2] : paramsOfNewGeos) {
+        auto newGeo = static_cast<const Part::GeomCurve*>(geo)->createArc(u1, u2);
+        assert(newGeo);
+        newGeos.push_back(newGeo);
+        newGeosAsConsts.push_back(newGeo);
     }
 
     switch (newGeos.size()) {
@@ -3713,16 +3619,15 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
     }
     }
 
-    for (auto& newGeo : newGeos) {
-        newGeosAsConsts.push_back(newGeo);
-    }
-
     // Now that we have the new curves, change constraints as needed
     // Some are covered with `deriveConstraintsForPieces`, others are specific to trim
     // FIXME: We are using non-smart pointers since that's what's needed in `addConstraints`.
     std::vector<Constraint*> newConstraints;
 
-    // A geoId we expect to never exist during this operation. We use it because newIds.front() is supposed to be `GeoId`, but we will delete constraints on it down the line, even if we will need it later. As a result, note that this will cause some malformed constraints until they are transferred back.
+    // A geoId we expect to never exist during this operation (but still not `GeoEnum::GeoUndef`).
+    // We use it because newIds.front() is supposed to be `GeoId`, but we will delete constraints
+    // on it down the line, even if we may need it later.
+    // Note that this will cause some malformed constraints until they are transferred back.
     int nonexistentGeoId = getHighestCurveIndex() + newIds.size();
     newIds.front() = nonexistentGeoId;
 
@@ -3760,79 +3665,94 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
 
     const auto& allConstraints = this->Constraints.getValues();
 
-    bool isGeoId1CoincidentOnPoint1 = false;
-    bool isGeoId2CoincidentOnPoint2 = false;
+    bool isPoint1ConstrainedOnGeoId1 = false;
+    bool isPoint2ConstrainedOnGeoId2 = false;
 
     // Workaround to avoid https://github.com/FreeCAD/FreeCAD/issues/15484.
     // We will delete its internal geometry first and then replace GeoId with one of the curves.
     // Of course, this will change `newIds`, and that's why we offset them.
-    std::vector<int> geoIdsToBeDeleted;
+    std::set< int, std::greater<> > geoIdsToBeDeleted;
     // geoIdsToBeDeleted.push_back(GeoId);
-    if (hasInternalGeometry(geo)) {
-        for (const auto& oldConstrId: idsOfOldConstraints) {
-            if (allConstraints[oldConstrId]->Type == InternalAlignment) {
-                geoIdsToBeDeleted.push_back(allConstraints[oldConstrId]->First);
-            }
-        }
-
-        // NOTE: Assuming no duplication here.
-        // If there are redundants for some pathological reason, use std::unique.
-        std::sort(geoIdsToBeDeleted.begin(), geoIdsToBeDeleted.end(), std::greater<>());
-
-        // keep constraints on internal geometries so they are deleted
-        // when the old curve is deleted
-    }
 
     for (const auto& oldConstrId: idsOfOldConstraints) {
+        // trim-specific changes first
         const Constraint* con = allConstraints[oldConstrId];
-        bool newConstraintCreated = deriveConstraintsForPieces(GeoId, newIds, newGeosAsConsts, con, newConstraints);
-        // trim-specific changes once general changes are done
+        bool constraintWasModified = false;
         switch (con->Type) {
         case PointOnObject: {
-            if (!newConstraintCreated) {
-                break;
-            }
-            Constraint* newConstr = newConstraints.back();
             // we might want to transform this (and the new point-on-object constraints) into a coincidence
-            if (newConstr->Second == newIds.front() &&
-                isPointAtPosition(newConstr->First, newConstr->FirstPos, point1)) {
+            if (con->First == GeoId1 && con->Second == GeoId
+                && isPointAtPosition(con->First, con->FirstPos, point1)) {
                 // This concerns the start portion of the trim
+                Constraint* newConstr = con->copy();
                 newConstr->Type = Sketcher::Coincident;
+                newConstr->Second = newIds.front();
                 newConstr->SecondPos = PointPos::end;
-                if (newConstr->First == GeoId1) {
-                    isGeoId1CoincidentOnPoint1 = true;
-                }
+                newConstraints.push_back(newConstr);
+                isPoint1ConstrainedOnGeoId1 = true;
+                constraintWasModified = true;
             }
-            if (newConstr->Second == newIds.back() &&
-                isPointAtPosition(newConstr->First, newConstr->FirstPos, point2)) {
+            else if (con->First == GeoId2 && con->Second == GeoId
+                     && isPointAtPosition(con->First, con->FirstPos, point2)) {
                 // This concerns the end portion of the trim
+                Constraint* newConstr = con->copy();
                 newConstr->Type = Sketcher::Coincident;
+                newConstr->Second = newIds.back();
                 newConstr->SecondPos = PointPos::start;
-                if (newConstr->First == GeoId2) {
-                    isGeoId2CoincidentOnPoint2 = true;
-                }
+                newConstraints.push_back(newConstr);
+                isPoint2ConstrainedOnGeoId2 = true;
+                constraintWasModified = true;
             }
             break;
         }
         case Tangent:
         case Perpendicular: {
-            // TODO Tangent may have to be turned into endpoint-to-endpoint
-            // we might want to transform this into a coincidence
-            if (!newConstraintCreated) {
-                break;
+            // These may have to be turned into endpoint-to-endpoint or endpoint-to-edge
+            // TODO: could there be tangent/perpendicular constraints not involving the trim that are modified below?
+            if (con->involvesGeoId(GeoId1) && con->involvesGeoIdAndPosId(GeoId, PointPos::none)) {
+                Constraint* newConstr = con->copy();
+                newConstr->substituteIndexAndPos(GeoId, PointPos::none, newIds.front(), PointPos::end);
+                newConstraints.push_back(newConstr);
+                isPoint1ConstrainedOnGeoId1 = true;
+                constraintWasModified = true;
             }
+            if (con->involvesGeoId(GeoId2) && con->involvesGeoIdAndPosId(GeoId, PointPos::none)) {
+                Constraint* newConstr = con->copy();
+                newConstr->substituteIndexAndPos(GeoId, PointPos::none, newIds.back(), PointPos::start);
+                newConstraints.push_back(newConstr);
+                isPoint2ConstrainedOnGeoId2 = true;
+                constraintWasModified = true;
+            }
+            if (constraintWasModified) {
+                // make sure the first position is a point
+                if (newConstraints.back()->FirstPos == PointPos::none) {
+                    std::swap(newConstraints.back()->First, newConstraints.back()->Second);
+                    std::swap(newConstraints.back()->FirstPos, newConstraints.back()->SecondPos);
+                }
+                // there is no need for the third point if it exists
+                newConstraints.back()->Third = GeoEnum::GeoUndef;
+                newConstraints.back()->ThirdPos = PointPos::none;
+            }
+            break;
+        }
+        case InternalAlignment: {
+            geoIdsToBeDeleted.insert(con->First);
             break;
         }
         default:
             break;
         }
+        if (!constraintWasModified) {
+            deriveConstraintsForPieces(GeoId, newIds, newGeosAsConsts, con, newConstraints);
+        }
     }
 
     // Add point-on-object/coincidence constraints with the newly exposed points.
-    // This will need to account for the constraints that were already converted to coincident or end-to-end tangency/perpendicularity.
+    // This will need to account for the constraints that were already converted
+    // to coincident or end-to-end tangency/perpendicularity.
     // TODO: Tangent/perpendicular not yet covered
 
-    if (GeoId1 != GeoEnum::GeoUndef && !isGeoId1CoincidentOnPoint1) {
+    if (GeoId1 != GeoEnum::GeoUndef && !isPoint1ConstrainedOnGeoId1) {
         Constraint* newConstr = new Constraint();
         newConstr->First = newIds.front();
         newConstr->FirstPos = PointPos::end;
@@ -3853,7 +3773,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
         newConstraints.push_back(newConstr);
     }
 
-    if (GeoId2 != GeoEnum::GeoUndef && !isGeoId2CoincidentOnPoint2) {
+    if (GeoId2 != GeoEnum::GeoUndef && !isPoint2ConstrainedOnGeoId2) {
         Constraint* newConstr = new Constraint();
         newConstr->First = newIds.back();
         newConstr->FirstPos = PointPos::start;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3580,8 +3580,9 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
         return 0;
     }
 
-    double firstParam = static_cast<const Part::GeomCurve*>(geo)->getFirstParameter();
-    double lastParam = static_cast<const Part::GeomCurve*>(geo)->getLastParameter();
+    const auto* geoAsCurve = static_cast<const Part::GeomCurve*>(geo);
+    double firstParam = geoAsCurve->getFirstParameter();
+    double lastParam = geoAsCurve->getLastParameter();
     double pointParam, point1Param, point2Param;
     if (!getIntersectionParameters(
             geo, point, pointParam, point1, point1Param, point2, point2Param)) {
@@ -3594,7 +3595,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
     std::vector<int> newIds;
     std::vector<Part::Geometry*> newGeos;
     std::vector<const Part::Geometry*> newGeosAsConsts;
-    bool oldGeoIsConstruction = GeometryFacade::getConstruction(static_cast<const Part::GeomCurve*>(geo));
+    bool oldGeoIsConstruction = GeometryFacade::getConstruction(geoAsCurve);
 
     if (isClosedCurve(geo)) {
         startPointRemains = false;
@@ -3615,7 +3616,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
     }
 
     for (auto& [u1, u2] : paramsOfNewGeos) {
-        auto newGeo = static_cast<const Part::GeomCurve*>(geo)->createArc(u1, u2);
+        auto newGeo = geoAsCurve->createArc(u1, u2);
         assert(newGeo);
         newGeos.push_back(newGeo);
         newGeosAsConsts.push_back(newGeo);

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1389,68 +1389,128 @@ int SketchObject::movePoint(int GeoId, PointPos PosId, const Base::Vector3d& toP
     return lastSolverStatus;
 }
 
+template <>
+Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomPoint *geomPoint, PointPos PosId)
+{
+    if (PosId == PointPos::start || PosId == PointPos::mid || PosId == PointPos::end)
+        return geomPoint->getPoint();
+    return Base::Vector3d();
+}
+
+template <>
+Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomLineSegment *lineSeg, PointPos PosId)
+{
+    if (PosId == PointPos::start)
+        return lineSeg->getStartPoint();
+    else if (PosId == PointPos::end)
+        return lineSeg->getEndPoint();
+    return Base::Vector3d();
+}
+
+template <>
+Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomCircle *circle, PointPos PosId)
+{
+    auto pt = circle->getCenter();
+    if(PosId != PointPos::mid)
+        pt.x += circle->getRadius();
+    return pt;
+}
+
+template <>
+Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomEllipse *ellipse, PointPos PosId)
+{
+    auto pt = ellipse->getCenter();
+    if(PosId != PointPos::mid)
+        pt += ellipse->getMajorAxisDir()*ellipse->getMajorRadius();
+    return pt;
+}
+
+template <>
+Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomArcOfCircle *aoc, PointPos PosId)
+{
+    if (PosId == PointPos::start)
+        return aoc->getStartPoint(/*emulateCCW=*/true);
+    else if (PosId == PointPos::end)
+        return aoc->getEndPoint(/*emulateCCW=*/true);
+    else if (PosId == PointPos::mid)
+        return aoc->getCenter();
+    return Base::Vector3d();
+}
+
+template <>
+Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomArcOfEllipse *aoe, PointPos PosId)
+{
+    if (PosId == PointPos::start)
+        return aoe->getStartPoint(/*emulateCCW=*/true);
+    else if (PosId == PointPos::end)
+        return aoe->getEndPoint(/*emulateCCW=*/true);
+    else if (PosId == PointPos::mid)
+        return aoe->getCenter();
+    return Base::Vector3d();
+}
+
+template <>
+Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomArcOfHyperbola *aoh, PointPos PosId)
+{
+    if (PosId == PointPos::start)
+        return aoh->getStartPoint();
+    else if (PosId == PointPos::end)
+        return aoh->getEndPoint();
+    else if (PosId == PointPos::mid)
+        return aoh->getCenter();
+    return Base::Vector3d();
+}
+
+template <>
+Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomArcOfParabola *aop, PointPos PosId)
+{
+    if (PosId == PointPos::start)
+        return aop->getStartPoint();
+    else if (PosId == PointPos::end)
+        return aop->getEndPoint();
+    else if (PosId == PointPos::mid)
+        return aop->getCenter();
+    return Base::Vector3d();
+}
+
+template <>
+Base::Vector3d SketchObject::getPointForGeometry<>(const Part::GeomBSplineCurve *bsp, PointPos PosId)
+{
+    if (PosId == PointPos::start)
+        return bsp->getStartPoint();
+    else if (PosId == PointPos::end)
+        return bsp->getEndPoint();
+    return Base::Vector3d();
+}
+
 Base::Vector3d SketchObject::getPoint(const Part::Geometry *geo, PointPos PosId)
 {
     if (geo->is<Part::GeomPoint>()) {
-        const Part::GeomPoint *p = static_cast<const Part::GeomPoint*>(geo);
-        if (PosId == PointPos::start || PosId == PointPos::mid || PosId == PointPos::end)
-            return p->getPoint();
-    } else if (geo->is<Part::GeomLineSegment>()) {
-        const Part::GeomLineSegment *lineSeg = static_cast<const Part::GeomLineSegment*>(geo);
-        if (PosId == PointPos::start)
-            return lineSeg->getStartPoint();
-        else if (PosId == PointPos::end)
-            return lineSeg->getEndPoint();
-    } else if (geo->is<Part::GeomCircle>()) {
-        const Part::GeomCircle *circle = static_cast<const Part::GeomCircle*>(geo);
-        auto pt = circle->getCenter();
-        if(PosId != PointPos::mid)
-             pt.x += circle->getRadius();
-        return pt;
-    } else if (geo->is<Part::GeomEllipse>()) {
-        const Part::GeomEllipse *ellipse = static_cast<const Part::GeomEllipse*>(geo);
-        auto pt = ellipse->getCenter();
-        if(PosId != PointPos::mid)
-            pt += ellipse->getMajorAxisDir()*ellipse->getMajorRadius();
-        return pt;
-    } else if (geo->is<Part::GeomArcOfCircle>()) {
-        const Part::GeomArcOfCircle *aoc = static_cast<const Part::GeomArcOfCircle*>(geo);
-        if (PosId == PointPos::start)
-            return aoc->getStartPoint(/*emulateCCW=*/true);
-        else if (PosId == PointPos::end)
-            return aoc->getEndPoint(/*emulateCCW=*/true);
-        else if (PosId == PointPos::mid)
-            return aoc->getCenter();
-    } else if (geo->is<Part::GeomArcOfEllipse>()) {
-        const Part::GeomArcOfEllipse *aoc = static_cast<const Part::GeomArcOfEllipse*>(geo);
-        if (PosId == PointPos::start)
-            return aoc->getStartPoint(/*emulateCCW=*/true);
-        else if (PosId == PointPos::end)
-            return aoc->getEndPoint(/*emulateCCW=*/true);
-        else if (PosId == PointPos::mid)
-            return aoc->getCenter();
-    } else if (geo->is<Part::GeomArcOfHyperbola>()) {
-        const Part::GeomArcOfHyperbola *aoh = static_cast<const Part::GeomArcOfHyperbola*>(geo);
-        if (PosId == PointPos::start)
-            return aoh->getStartPoint();
-        else if (PosId == PointPos::end)
-            return aoh->getEndPoint();
-        else if (PosId == PointPos::mid)
-            return aoh->getCenter();
-    } else if (geo->is<Part::GeomArcOfParabola>()) {
-        const Part::GeomArcOfParabola *aop = static_cast<const Part::GeomArcOfParabola*>(geo);
-        if (PosId == PointPos::start)
-            return aop->getStartPoint();
-        else if (PosId == PointPos::end)
-            return aop->getEndPoint();
-        else if (PosId == PointPos::mid)
-            return aop->getCenter();
-    } else if (geo->is<Part::GeomBSplineCurve>()) {
-        const Part::GeomBSplineCurve *bsp = static_cast<const Part::GeomBSplineCurve*>(geo);
-        if (PosId == PointPos::start)
-            return bsp->getStartPoint();
-        else if (PosId == PointPos::end)
-            return bsp->getEndPoint();
+        return getPointForGeometry<Part::GeomPoint>(static_cast<const Part::GeomPoint*>(geo), PosId);
+    }
+    else if (geo->is<Part::GeomLineSegment>()) {
+        return getPointForGeometry<Part::GeomLineSegment>(static_cast<const Part::GeomLineSegment*>(geo), PosId);
+    }
+    else if (geo->is<Part::GeomCircle>()) {
+        return getPointForGeometry<Part::GeomCircle>(static_cast<const Part::GeomCircle*>(geo), PosId);
+    }
+    else if (geo->is<Part::GeomEllipse>()) {
+        return getPointForGeometry<Part::GeomEllipse>(static_cast<const Part::GeomEllipse*>(geo), PosId);
+    }
+    else if (geo->is<Part::GeomArcOfCircle>()) {
+        return getPointForGeometry<Part::GeomArcOfCircle>(static_cast<const Part::GeomArcOfCircle*>(geo), PosId);
+    }
+    else if (geo->is<Part::GeomArcOfEllipse>()) {
+        return getPointForGeometry<Part::GeomArcOfEllipse>(static_cast<const Part::GeomArcOfEllipse*>(geo), PosId);
+    }
+    else if (geo->is<Part::GeomArcOfHyperbola>()) {
+        return getPointForGeometry<Part::GeomArcOfHyperbola>(static_cast<const Part::GeomArcOfHyperbola*>(geo), PosId);
+    }
+    else if (geo->is<Part::GeomArcOfParabola>()) {
+        return getPointForGeometry<Part::GeomArcOfParabola>(static_cast<const Part::GeomArcOfParabola*>(geo), PosId);
+    }
+    else if (geo->is<Part::GeomBSplineCurve>()) {
+        return getPointForGeometry<Part::GeomBSplineCurve>(static_cast<const Part::GeomBSplineCurve*>(geo), PosId);
     }
     return Base::Vector3d();
 }

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -410,7 +410,8 @@ public:
     /// the constraint that will replace the given one (which is to be deleted). NOTE: Currently
     /// assuming all constraints on the end points of the old curve have been transferred or
     /// destroyed
-    void deriveConstraintsForPieces(const int oldId,
+    /// Returns whether or not new constraint(s) was/were added.
+    bool deriveConstraintsForPieces(const int oldId,
                                     const std::vector<int> newIds,
                                     const Constraint* con,
                                     std::vector<Constraint*>& newConstraints);
@@ -455,6 +456,7 @@ public:
                 double perpscale = 1.0);
 
     int removeAxesAlignment(const std::vector<int>& geoIdList);
+    static bool isClosedCurve(const Part::Geometry* geo);
     static bool hasInternalGeometry(const Part::Geometry* geo);
     /// Exposes all internal geometry of an object supporting internal geometry
     /*!

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -461,6 +461,14 @@ public:
      */
     int deleteUnusedInternalGeometry(int GeoId, bool delgeoid = false);
     /*!
+     \brief Same as `deleteUnusedInternalGeometry`, but changes `GeoId` to the new Id of the
+     geometry, or to `GeoEnum::GeoUndef` if the geometry is deleted as well. \param GeoId - the
+     geometry having the internal geometry to delete \param delgeoid - if true in addition to the
+     unused internal geometry also deletes the GeoId geometry \retval int - returns -1 on error,
+     otherwise the number of deleted elements
+     */
+    int deleteUnusedInternalGeometryAndUpdateGeoId(int& GeoId, bool delgeoid = false);
+    /*!
      \brief Approximates the given geometry with a B-spline
      \param GeoId - the geometry to approximate
      \param delgeoid - if true in addition to the unused internal geometry also deletes the GeoId

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -218,6 +218,9 @@ public:
     /// Sync frozen external geometries
     int syncGeometry(const std::vector<int>& geoIds);
 
+    template<typename returnType>
+    returnType performActionByGeomType(const Part::Geometry* geo);
+
     /** returns a pointer to a given Geometry index, possible indexes are:
      *  id>=0 for user defined geometries,
      *  id==-1 for the horizontal sketch axis,
@@ -357,6 +360,11 @@ public:
     /// retrieves the coordinates of a point
     static Base::Vector3d getPoint(const Part::Geometry* geo, PointPos PosId);
     Base::Vector3d getPoint(int GeoId, PointPos PosId) const;
+    template<class geomType>
+    static Base::Vector3d getPointForGeometry(const geomType* geo, PointPos PosId)
+    {
+        return Base::Vector3d();
+    }
 
     /// toggle geometry to draft line
     int toggleConstruction(int GeoId);

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -412,9 +412,16 @@ public:
     /// destroyed
     /// Returns whether or not new constraint(s) was/were added.
     bool deriveConstraintsForPieces(const int oldId,
-                                    const std::vector<int> newIds,
+                                    const std::vector<int>& newIds,
                                     const Constraint* con,
                                     std::vector<Constraint*>& newConstraints);
+    // Explicitly giving `newGeos` for cases where they are not yet added
+    bool deriveConstraintsForPieces(const int oldId,
+                                    const std::vector<int>& newIds,
+                                    const std::vector<const Part::Geometry*>& newGeo,
+                                    const Constraint* con,
+                                    std::vector<Constraint*>& newConstraints);
+
     /// split a curve
     int split(int geoId, const Base::Vector3d& point);
     /*!
@@ -892,7 +899,7 @@ protected:
     supportedGeometry(const std::vector<Part::Geometry*>& geoList) const;
 
     void updateGeoHistory();
-    void generateId(Part::Geometry* geo);
+    void generateId(const Part::Geometry* geo);
 
     /*!
      \brief Transfer constraints on lines being filleted.
@@ -963,6 +970,11 @@ protected:
                      Sketcher::PointPos secondPos = Sketcher::PointPos::none,
                      int thirdGeoId = GeoEnum::GeoUndef,
                      Sketcher::PointPos thirdPos = Sketcher::PointPos::none);
+
+    std::unique_ptr<Constraint> getConstraintAfterDeletingGeo(const Constraint* constr,
+                                                              const int deletedGeoId) const;
+
+    void changeConstraintAfterDeletingGeo(Constraint* constr, const int deletedGeoId) const;
 
 private:
     /// Flag to allow external geometry from other bodies than the one this sketch belongs to

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -447,6 +447,7 @@ public:
                 double perpscale = 1.0);
 
     int removeAxesAlignment(const std::vector<int>& geoIdList);
+    static bool hasInternalGeometry(const Part::Geometry* geo);
     /// Exposes all internal geometry of an object supporting internal geometry
     /*!
      * \return -1 on error

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -406,6 +406,14 @@ public:
     int trim(int geoId, const Base::Vector3d& point);
     /// extend a curve
     int extend(int geoId, double increment, PointPos endPoint);
+    /// Once smaller pieces have been created from a larger curve (by split or trim, say), derive
+    /// the constraint that will replace the given one (which is to be deleted). NOTE: Currently
+    /// assuming all constraints on the end points of the old curve have been transferred or
+    /// destroyed
+    void deriveConstraintsForPieces(const int oldId,
+                                    const std::vector<int> newIds,
+                                    const Constraint* con,
+                                    std::vector<Constraint*>& newConstraints);
     /// split a curve
     int split(int geoId, const Base::Vector3d& point);
     /*!

--- a/tests/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObject.cpp
@@ -111,6 +111,13 @@ int countConstraintsOfType(const Sketcher::SketchObject* obj, const Sketcher::Co
     return result;
 }
 
+// Get point at the parameter after scaling the range to [0, 1].
+Base::Vector3d getPointAtNormalizedParameter(const Part::GeomCurve& curve, double param)
+{
+    return curve.pointAtParameter(curve.getFirstParameter()
+                                  + (curve.getLastParameter() - curve.getFirstParameter()) * param);
+}
+
 // TODO: How to set up B-splines here?
 // It's not straightforward to change everything from a "default" one.
 
@@ -724,12 +731,8 @@ TEST_F(SketchObjectTest, testTrimLineSegmentEnd)
     Part::GeomLineSegment lineSeg;
     setupLineSegment(lineSeg);
     // TODO: create curves intersecting at the right spots
-    Base::Vector3d trimPoint(lineSeg.pointAtParameter(
-        lineSeg.getFirstParameter()
-        + (lineSeg.getLastParameter() - lineSeg.getFirstParameter()) * 0.2));
-    Base::Vector3d p1(lineSeg.pointAtParameter(
-        lineSeg.getFirstParameter()
-        + (lineSeg.getLastParameter() - lineSeg.getFirstParameter()) * 0.5));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(lineSeg, 0.2));
+    Base::Vector3d p1(getPointAtNormalizedParameter(lineSeg, 0.5));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
@@ -754,19 +757,13 @@ TEST_F(SketchObjectTest, testTrimLineSegmentMid)
     Part::GeomLineSegment lineSeg;
     setupLineSegment(lineSeg);
     // TODO: create curves intersecting at the right spots
-    Base::Vector3d trimPoint(lineSeg.pointAtParameter(
-        lineSeg.getFirstParameter()
-        + (lineSeg.getLastParameter() - lineSeg.getFirstParameter()) * 0.5));
-    Base::Vector3d p1(lineSeg.pointAtParameter(
-        lineSeg.getFirstParameter()
-        + (lineSeg.getLastParameter() - lineSeg.getFirstParameter()) * 0.3));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(lineSeg, 0.5));
+    Base::Vector3d p1(getPointAtNormalizedParameter(lineSeg, 0.3));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
     getObject()->addGeometry(&lineSegCut1);
-    Base::Vector3d p3(lineSeg.pointAtParameter(
-        lineSeg.getFirstParameter()
-        + (lineSeg.getLastParameter() - lineSeg.getFirstParameter()) * 0.7));
+    Base::Vector3d p3(getPointAtNormalizedParameter(lineSeg, 0.7));
     Base::Vector3d p4(p3.x + 0.1, p3.y - 0.1, p3.z);
     // to ensure that this line clearly intersects the curve, not just have a point on object
     // without explicit constraint
@@ -799,12 +796,8 @@ TEST_F(SketchObjectTest, testTrimCircleEnd)
     Part::GeomCircle circle;
     setupCircle(circle);
     // TODO: create curves intersecting at the right spots
-    Base::Vector3d trimPoint(
-        circle.pointAtParameter(circle.getFirstParameter()
-                                + (circle.getLastParameter() - circle.getFirstParameter()) * 0.2));
-    Base::Vector3d p1(
-        circle.pointAtParameter(circle.getFirstParameter()
-                                + (circle.getLastParameter() - circle.getFirstParameter()) * 0.5));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(circle, 0.2));
+    Base::Vector3d p1(getPointAtNormalizedParameter(circle, 0.5));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
@@ -826,19 +819,13 @@ TEST_F(SketchObjectTest, testTrimCircleMid)
     Part::GeomCircle circle;
     setupCircle(circle);
     // TODO: create curves intersecting at the right spots
-    Base::Vector3d trimPoint(
-        circle.pointAtParameter(circle.getFirstParameter()
-                                + (circle.getLastParameter() - circle.getFirstParameter()) * 0.5));
-    Base::Vector3d p1(
-        circle.pointAtParameter(circle.getFirstParameter()
-                                + (circle.getLastParameter() - circle.getFirstParameter()) * 0.3));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(circle, 0.5));
+    Base::Vector3d p1(getPointAtNormalizedParameter(circle, 0.3));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
     getObject()->addGeometry(&lineSegCut1);
-    Base::Vector3d p3(
-        circle.pointAtParameter(circle.getFirstParameter()
-                                + (circle.getLastParameter() - circle.getFirstParameter()) * 0.7));
+    Base::Vector3d p3(getPointAtNormalizedParameter(circle, 0.7));
     Base::Vector3d p4(p3.x + 0.1, p3.y + 0.1, p3.z);
     // to ensure that this line clearly intersects the curve, not just have a point on object
     // without explicit constraint
@@ -874,12 +861,8 @@ TEST_F(SketchObjectTest, testTrimArcOfCircleEnd)
     Part::GeomArcOfCircle arcOfCircle;
     setupArcOfCircle(arcOfCircle);
     // TODO: create curves intersecting at the right spots
-    Base::Vector3d trimPoint(arcOfCircle.pointAtParameter(
-        arcOfCircle.getFirstParameter()
-        + (arcOfCircle.getLastParameter() - arcOfCircle.getFirstParameter()) * 0.2));
-    Base::Vector3d p1(arcOfCircle.pointAtParameter(
-        arcOfCircle.getFirstParameter()
-        + (arcOfCircle.getLastParameter() - arcOfCircle.getFirstParameter()) * 0.5));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(arcOfCircle, 0.2));
+    Base::Vector3d p1(getPointAtNormalizedParameter(arcOfCircle, 0.5));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
@@ -903,19 +886,13 @@ TEST_F(SketchObjectTest, testTrimArcOfCircleMid)
     Part::GeomArcOfCircle arcOfCircle;
     setupArcOfCircle(arcOfCircle);
     // TODO: create curves intersecting at the right spots
-    Base::Vector3d trimPoint(arcOfCircle.pointAtParameter(
-        arcOfCircle.getFirstParameter()
-        + (arcOfCircle.getLastParameter() - arcOfCircle.getFirstParameter()) * 0.5));
-    Base::Vector3d p1(arcOfCircle.pointAtParameter(
-        arcOfCircle.getFirstParameter()
-        + (arcOfCircle.getLastParameter() - arcOfCircle.getFirstParameter()) * 0.3));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(arcOfCircle, 0.5));
+    Base::Vector3d p1(getPointAtNormalizedParameter(arcOfCircle, 0.3));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
     getObject()->addGeometry(&lineSegCut1);
-    Base::Vector3d p3(arcOfCircle.pointAtParameter(
-        arcOfCircle.getFirstParameter()
-        + (arcOfCircle.getLastParameter() - arcOfCircle.getFirstParameter()) * 0.7));
+    Base::Vector3d p3(getPointAtNormalizedParameter(arcOfCircle, 0.7));
     Base::Vector3d p4(p3.x + 0.1, p3.y + 0.1, p3.z);
     // to ensure that this line clearly intersects the curve, not just have a point on object
     // without explicit constraint
@@ -949,12 +926,8 @@ TEST_F(SketchObjectTest, testTrimEllipseEnd)
     Part::GeomEllipse ellipse;
     setupEllipse(ellipse);
     // TODO: create curves intersecting at the right spots
-    Base::Vector3d trimPoint(ellipse.pointAtParameter(
-        ellipse.getFirstParameter()
-        + (ellipse.getLastParameter() - ellipse.getFirstParameter()) * 0.2));
-    Base::Vector3d p1(ellipse.pointAtParameter(
-        ellipse.getFirstParameter()
-        + (ellipse.getLastParameter() - ellipse.getFirstParameter()) * 0.5));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(ellipse, 0.2));
+    Base::Vector3d p1(getPointAtNormalizedParameter(ellipse, 0.5));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
@@ -981,19 +954,13 @@ TEST_F(SketchObjectTest, testTrimEllipseMid)
     Part::GeomEllipse ellipse;
     setupEllipse(ellipse);
     // TODO: create curves intersecting at the right spots
-    Base::Vector3d trimPoint(ellipse.pointAtParameter(
-        ellipse.getFirstParameter()
-        + (ellipse.getLastParameter() - ellipse.getFirstParameter()) * 0.5));
-    Base::Vector3d p1(ellipse.pointAtParameter(
-        ellipse.getFirstParameter()
-        + (ellipse.getLastParameter() - ellipse.getFirstParameter()) * 0.3));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(ellipse, 0.5));
+    Base::Vector3d p1(getPointAtNormalizedParameter(ellipse, 0.3));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
     getObject()->addGeometry(&lineSegCut1);
-    Base::Vector3d p3(ellipse.pointAtParameter(
-        ellipse.getFirstParameter()
-        + (ellipse.getLastParameter() - ellipse.getFirstParameter()) * 0.7));
+    Base::Vector3d p3(getPointAtNormalizedParameter(ellipse, 0.7));
     Base::Vector3d p4(p3.x + 0.1, p3.y + 0.1, p3.z);
     // to ensure that this line clearly intersects the curve, not just have a point on object
     // without explicit constraint
@@ -1035,12 +1002,8 @@ TEST_F(SketchObjectTest, testTrimPeriodicBSplineEnd)
     auto periodicBSpline = createTypicalPeriodicBSpline();
     assert(periodicBSpline);
     // TODO: create curves intersecting at the right spots
-    Base::Vector3d trimPoint(periodicBSpline->pointAtParameter(
-        periodicBSpline->getFirstParameter()
-        + (periodicBSpline->getLastParameter() - periodicBSpline->getFirstParameter()) * 0.2));
-    Base::Vector3d p1(periodicBSpline->pointAtParameter(
-        periodicBSpline->getFirstParameter()
-        + (periodicBSpline->getLastParameter() - periodicBSpline->getFirstParameter()) * 0.5));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(*periodicBSpline, 0.2));
+    Base::Vector3d p1(getPointAtNormalizedParameter(*periodicBSpline, 0.5));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
@@ -1065,19 +1028,13 @@ TEST_F(SketchObjectTest, testTrimPeriodicBSplineMid)
     auto periodicBSpline = createTypicalPeriodicBSpline();
     assert(periodicBSpline);
     // TODO: create curves intersecting at the right spots
-    Base::Vector3d trimPoint(periodicBSpline->pointAtParameter(
-        periodicBSpline->getFirstParameter()
-        + (periodicBSpline->getLastParameter() - periodicBSpline->getFirstParameter()) * 0.5));
-    Base::Vector3d p1(periodicBSpline->pointAtParameter(
-        periodicBSpline->getFirstParameter()
-        + (periodicBSpline->getLastParameter() - periodicBSpline->getFirstParameter()) * 0.3));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(*periodicBSpline, 0.5));
+    Base::Vector3d p1(getPointAtNormalizedParameter(*periodicBSpline, 0.3));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
     getObject()->addGeometry(&lineSegCut1);
-    Base::Vector3d p3(periodicBSpline->pointAtParameter(
-        periodicBSpline->getFirstParameter()
-        + (periodicBSpline->getLastParameter() - periodicBSpline->getFirstParameter()) * 0.7));
+    Base::Vector3d p3(getPointAtNormalizedParameter(*periodicBSpline, 0.7));
     Base::Vector3d p4(p3.x + 0.1, p3.y + 0.1, p3.z);
     // to ensure that this line clearly intersects the curve, not just have a point on object
     // without explicit constraint
@@ -1117,14 +1074,8 @@ TEST_F(SketchObjectTest, testTrimNonPeriodicBSplineEnd)
     auto nonPeriodicBSpline = createTypicalNonPeriodicBSpline();
     assert(nonPeriodicBSpline);
     // create curves intersecting at the right spots
-    Base::Vector3d trimPoint(nonPeriodicBSpline->pointAtParameter(
-        nonPeriodicBSpline->getFirstParameter()
-        + (nonPeriodicBSpline->getLastParameter() - nonPeriodicBSpline->getFirstParameter())
-            * 0.2));
-    Base::Vector3d p1(nonPeriodicBSpline->pointAtParameter(
-        nonPeriodicBSpline->getFirstParameter()
-        + (nonPeriodicBSpline->getLastParameter() - nonPeriodicBSpline->getFirstParameter())
-            * 0.5));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(*nonPeriodicBSpline, 0.2));
+    Base::Vector3d p1(getPointAtNormalizedParameter(*nonPeriodicBSpline, 0.5));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
@@ -1153,22 +1104,13 @@ TEST_F(SketchObjectTest, testTrimNonPeriodicBSplineMid)
     auto nonPeriodicBSpline = createTypicalNonPeriodicBSpline();
     assert(nonPeriodicBSpline);
     // TODO: create curves intersecting at the right spots
-    Base::Vector3d trimPoint(nonPeriodicBSpline->pointAtParameter(
-        nonPeriodicBSpline->getFirstParameter()
-        + (nonPeriodicBSpline->getLastParameter() - nonPeriodicBSpline->getFirstParameter())
-            * 0.5));
-    Base::Vector3d p1(nonPeriodicBSpline->pointAtParameter(
-        nonPeriodicBSpline->getFirstParameter()
-        + (nonPeriodicBSpline->getLastParameter() - nonPeriodicBSpline->getFirstParameter())
-            * 0.3));
+    Base::Vector3d trimPoint(getPointAtNormalizedParameter(*nonPeriodicBSpline, 0.5));
+    Base::Vector3d p1(getPointAtNormalizedParameter(*nonPeriodicBSpline, 0.3));
     Base::Vector3d p2(p1.x + 0.1, p1.y + 0.1, p1.z);
     Part::GeomLineSegment lineSegCut1;
     lineSegCut1.setPoints(p1, p2);
     getObject()->addGeometry(&lineSegCut1);
-    Base::Vector3d p3(nonPeriodicBSpline->pointAtParameter(
-        nonPeriodicBSpline->getFirstParameter()
-        + (nonPeriodicBSpline->getLastParameter() - nonPeriodicBSpline->getFirstParameter())
-            * 0.7));
+    Base::Vector3d p3(getPointAtNormalizedParameter(*nonPeriodicBSpline, 0.7));
     Base::Vector3d p4(p3.x + 0.1, p3.y + 0.1, p3.z);
     // to ensure that this line clearly intersects the curve, not just have a point on object
     // without explicit constraint

--- a/tests/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObject.cpp
@@ -161,6 +161,298 @@ TEST_F(SketchObjectTest, testGeoIdFromShapeTypeRootPoint)
     EXPECT_EQ(posId, Sketcher::PointPos::start);
 }
 
+TEST_F(SketchObjectTest, testGetPointFromGeomPoint)
+{
+    // Arrange
+    Base::Vector3d coords(1.0, 2.0, 0.0);
+    Part::GeomPoint point(coords);
+
+    // Act
+    auto ptStart = Sketcher::SketchObject::getPoint(&point, Sketcher::PointPos::start);
+    auto ptMid = Sketcher::SketchObject::getPoint(&point, Sketcher::PointPos::mid);
+    auto ptEnd = Sketcher::SketchObject::getPoint(&point, Sketcher::PointPos::end);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptNone = Sketcher::SketchObject::getPoint(&point, Sketcher::PointPos::none);
+
+    // Assert
+    EXPECT_DOUBLE_EQ(ptStart[0], 1.0);
+    EXPECT_DOUBLE_EQ(ptStart[1], 2.0);
+    EXPECT_DOUBLE_EQ(ptMid[0], 1.0);
+    EXPECT_DOUBLE_EQ(ptMid[1], 2.0);
+    EXPECT_DOUBLE_EQ(ptEnd[0], 1.0);
+    EXPECT_DOUBLE_EQ(ptEnd[1], 2.0);
+}
+
+TEST_F(SketchObjectTest, testGetPointFromGeomLineSegment)
+{
+    // Arrange
+    Base::Vector3d coords1(1.0, 2.0, 0.0);
+    Base::Vector3d coords2(3.0, 4.0, 0.0);
+    Part::GeomLineSegment lineSeg;
+    lineSeg.setPoints(coords1, coords2);
+
+    // Act
+    auto ptStart = Sketcher::SketchObject::getPoint(&lineSeg, Sketcher::PointPos::start);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptMid = Sketcher::SketchObject::getPoint(&lineSeg, Sketcher::PointPos::mid);
+    auto ptEnd = Sketcher::SketchObject::getPoint(&lineSeg, Sketcher::PointPos::end);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptNone = Sketcher::SketchObject::getPoint(&lineSeg, Sketcher::PointPos::none);
+
+    // Assert
+    EXPECT_DOUBLE_EQ(ptStart[0], 1.0);
+    EXPECT_DOUBLE_EQ(ptStart[1], 2.0);
+    EXPECT_DOUBLE_EQ(ptEnd[0], 3.0);
+    EXPECT_DOUBLE_EQ(ptEnd[1], 4.0);
+}
+
+TEST_F(SketchObjectTest, testGetPointFromGeomCircle)
+{
+    // Arrange
+    Base::Vector3d coordsCenter(1.0, 2.0, 0.0);
+    double radius = 3.0;
+    Part::GeomCircle circle;
+    circle.setCenter(coordsCenter);
+    circle.setRadius(radius);
+
+    // Act
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptStart = Sketcher::SketchObject::getPoint(&circle, Sketcher::PointPos::start);
+    auto ptMid = Sketcher::SketchObject::getPoint(&circle, Sketcher::PointPos::mid);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptEnd = Sketcher::SketchObject::getPoint(&circle, Sketcher::PointPos::end);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptNone = Sketcher::SketchObject::getPoint(&circle, Sketcher::PointPos::none);
+
+    // Assert
+    // NOTE: Presently, start/end points of a circle are defined as the point on circle right of the
+    // the center
+    EXPECT_DOUBLE_EQ(ptStart[0], 1.0 + radius);
+    EXPECT_DOUBLE_EQ(ptStart[1], 2.0);
+    EXPECT_DOUBLE_EQ(ptEnd[0], 1.0 + radius);
+    EXPECT_DOUBLE_EQ(ptEnd[1], 2.0);
+    EXPECT_DOUBLE_EQ(ptMid[0], 1.0);
+    EXPECT_DOUBLE_EQ(ptMid[1], 2.0);
+}
+
+TEST_F(SketchObjectTest, testGetPointFromGeomEllipse)
+{
+    // Arrange
+    Base::Vector3d coordsCenter(1.0, 2.0, 0.0);
+    double majorRadius = 4.0;
+    double minorRadius = 3.0;
+    Part::GeomEllipse ellipse;
+    ellipse.setCenter(coordsCenter);
+    ellipse.setMajorRadius(majorRadius);
+    ellipse.setMinorRadius(minorRadius);
+
+    // Act
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptStart = Sketcher::SketchObject::getPoint(&ellipse, Sketcher::PointPos::start);
+    auto ptMid = Sketcher::SketchObject::getPoint(&ellipse, Sketcher::PointPos::mid);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptEnd = Sketcher::SketchObject::getPoint(&ellipse, Sketcher::PointPos::end);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptNone = Sketcher::SketchObject::getPoint(&ellipse, Sketcher::PointPos::none);
+
+    // Assert
+    // NOTE: Presently, start/end points of an ellipse are defined as the point on the major axis in
+    // it's "positive" direction
+    EXPECT_DOUBLE_EQ(ptStart[0], 1.0 + majorRadius);
+    EXPECT_DOUBLE_EQ(ptStart[1], 2.0);
+    EXPECT_DOUBLE_EQ(ptEnd[0], 1.0 + majorRadius);
+    EXPECT_DOUBLE_EQ(ptEnd[1], 2.0);
+    EXPECT_DOUBLE_EQ(ptMid[0], 1.0);
+    EXPECT_DOUBLE_EQ(ptMid[1], 2.0);
+}
+
+TEST_F(SketchObjectTest, testGetPointFromGeomArcOfCircle)
+{
+    // Arrange
+    Base::Vector3d coordsCenter(1.0, 2.0, 0.0);
+    double radius = 3.0, startParam = M_PI / 3, endParam = M_PI * 1.5;
+    Part::GeomArcOfCircle arcOfCircle;
+    arcOfCircle.setCenter(coordsCenter);
+    arcOfCircle.setRadius(radius);
+    arcOfCircle.setRange(startParam, endParam, true);
+
+    // Act
+    auto ptStart = Sketcher::SketchObject::getPoint(&arcOfCircle, Sketcher::PointPos::start);
+    auto ptMid = Sketcher::SketchObject::getPoint(&arcOfCircle, Sketcher::PointPos::mid);
+    auto ptEnd = Sketcher::SketchObject::getPoint(&arcOfCircle, Sketcher::PointPos::end);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptNone = Sketcher::SketchObject::getPoint(&arcOfCircle, Sketcher::PointPos::none);
+
+    // Assert
+    // NOTE: parameters for arc of circle are CCW angles from positive x-axis
+    EXPECT_DOUBLE_EQ(ptStart[0], 1.0 + cos(startParam) * radius);
+    EXPECT_DOUBLE_EQ(ptStart[1], 2.0 + sin(startParam) * radius);
+    EXPECT_DOUBLE_EQ(ptEnd[0], 1.0 + cos(endParam) * radius);
+    EXPECT_DOUBLE_EQ(ptEnd[1], 2.0 + sin(endParam) * radius);
+    EXPECT_DOUBLE_EQ(ptMid[0], 1.0);
+    EXPECT_DOUBLE_EQ(ptMid[1], 2.0);
+}
+
+TEST_F(SketchObjectTest, testGetPointFromGeomArcOfEllipse)
+{
+    // Arrange
+    Base::Vector3d coordsCenter(1.0, 2.0, 0.0);
+    double majorRadius = 4.0;
+    double minorRadius = 3.0;
+    double startParam = M_PI / 3, endParam = M_PI * 1.5;
+    Part::GeomArcOfEllipse arcOfEllipse;
+    arcOfEllipse.setCenter(coordsCenter);
+    arcOfEllipse.setMajorRadius(majorRadius);
+    arcOfEllipse.setMinorRadius(minorRadius);
+    arcOfEllipse.setRange(startParam, endParam, true);
+
+    // Act
+    auto ptStart = Sketcher::SketchObject::getPoint(&arcOfEllipse, Sketcher::PointPos::start);
+    auto ptMid = Sketcher::SketchObject::getPoint(&arcOfEllipse, Sketcher::PointPos::mid);
+    auto ptEnd = Sketcher::SketchObject::getPoint(&arcOfEllipse, Sketcher::PointPos::end);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptNone = Sketcher::SketchObject::getPoint(&arcOfEllipse, Sketcher::PointPos::none);
+
+    // Assert
+    // NOTE: parameters for arc of ellipse are CCW angles from positive x-axis
+    EXPECT_DOUBLE_EQ(ptStart[0], 1.0 + cos(startParam) * majorRadius);
+    EXPECT_DOUBLE_EQ(ptStart[1], 2.0 + sin(startParam) * minorRadius);
+    EXPECT_DOUBLE_EQ(ptEnd[0], 1.0 + cos(endParam) * majorRadius);
+    EXPECT_DOUBLE_EQ(ptEnd[1], 2.0 + sin(endParam) * minorRadius);
+    EXPECT_DOUBLE_EQ(ptMid[0], 1.0);
+    EXPECT_DOUBLE_EQ(ptMid[1], 2.0);
+}
+
+TEST_F(SketchObjectTest, testGetPointFromGeomArcOfHyperbola)
+{
+    // Arrange
+    Base::Vector3d coordsCenter(1.0, 2.0, 0.0);
+    double majorRadius = 4.0;
+    double minorRadius = 3.0;
+    double startParam = M_PI / 3, endParam = M_PI * 1.5;
+    Part::GeomArcOfHyperbola arcOfHyperbola;
+    arcOfHyperbola.setCenter(coordsCenter);
+    arcOfHyperbola.setMajorRadius(majorRadius);
+    arcOfHyperbola.setMinorRadius(minorRadius);
+    arcOfHyperbola.setRange(startParam, endParam, true);
+
+    // Act
+    auto ptStart = Sketcher::SketchObject::getPoint(&arcOfHyperbola, Sketcher::PointPos::start);
+    auto ptMid = Sketcher::SketchObject::getPoint(&arcOfHyperbola, Sketcher::PointPos::mid);
+    auto ptEnd = Sketcher::SketchObject::getPoint(&arcOfHyperbola, Sketcher::PointPos::end);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptNone = Sketcher::SketchObject::getPoint(&arcOfHyperbola, Sketcher::PointPos::none);
+
+    // Assert
+    // FIXME: Figure out how this is defined
+    // EXPECT_DOUBLE_EQ(ptStart[0], 1.0);
+    // EXPECT_DOUBLE_EQ(ptStart[1], 2.0);
+    // EXPECT_DOUBLE_EQ(ptEnd[0], 1.0);
+    // EXPECT_DOUBLE_EQ(ptEnd[1], 2.0);
+    EXPECT_DOUBLE_EQ(ptMid[0], 1.0);
+    EXPECT_DOUBLE_EQ(ptMid[1], 2.0);
+}
+
+TEST_F(SketchObjectTest, testGetPointFromGeomArcOfParabola)
+{
+    // Arrange
+    Base::Vector3d coordsCenter(1.0, 2.0, 0.0);
+    double focal = 3.0;
+    double startParam = M_PI / 3, endParam = M_PI * 1.5;
+    Part::GeomArcOfParabola arcOfParabola;
+    arcOfParabola.setCenter(coordsCenter);
+    arcOfParabola.setFocal(focal);
+    arcOfParabola.setRange(startParam, endParam, true);
+
+    // Act
+    auto ptStart = Sketcher::SketchObject::getPoint(&arcOfParabola, Sketcher::PointPos::start);
+    auto ptMid = Sketcher::SketchObject::getPoint(&arcOfParabola, Sketcher::PointPos::mid);
+    auto ptEnd = Sketcher::SketchObject::getPoint(&arcOfParabola, Sketcher::PointPos::end);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptNone = Sketcher::SketchObject::getPoint(&arcOfParabola, Sketcher::PointPos::none);
+
+    // Assert
+    // FIXME: Figure out how this is defined
+    // EXPECT_DOUBLE_EQ(ptStart[0], 1.0);
+    // EXPECT_DOUBLE_EQ(ptStart[1], 2.0);
+    // EXPECT_DOUBLE_EQ(ptEnd[0], 1.0);
+    // EXPECT_DOUBLE_EQ(ptEnd[1], 2.0);
+    EXPECT_DOUBLE_EQ(ptMid[0], 1.0);
+    EXPECT_DOUBLE_EQ(ptMid[1], 2.0);
+}
+
+TEST_F(SketchObjectTest, testGetPointFromGeomBSplineCurveNonPeriodic)
+{
+    // Arrange
+    int degree = 3;
+    std::vector<Base::Vector3d> poles;
+    poles.emplace_back(1, 0, 0);
+    poles.emplace_back(1, 1, 0);
+    poles.emplace_back(1, 0.5, 0);
+    poles.emplace_back(0, 1, 0);
+    poles.emplace_back(0, 0, 0);
+    std::vector<double> weights(5, 1.0);
+    std::vector<double> knotsNonPeriodic = {0.0, 1.0, 2.0};
+    std::vector<int> multiplicitiesNonPeriodic = {degree + 1, 1, degree + 1};
+    Part::GeomBSplineCurve nonPeriodicBSpline(poles,
+                                              weights,
+                                              knotsNonPeriodic,
+                                              multiplicitiesNonPeriodic,
+                                              degree,
+                                              false);
+
+    // Act
+    auto ptStart = Sketcher::SketchObject::getPoint(&nonPeriodicBSpline, Sketcher::PointPos::start);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptMid = Sketcher::SketchObject::getPoint(&nonPeriodicBSpline, Sketcher::PointPos::mid);
+    auto ptEnd = Sketcher::SketchObject::getPoint(&nonPeriodicBSpline, Sketcher::PointPos::end);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptNone = Sketcher::SketchObject::getPoint(&nonPeriodicBSpline, Sketcher::PointPos::none);
+
+    // Assert
+    EXPECT_DOUBLE_EQ(ptStart[0], poles.front()[0]);
+    EXPECT_DOUBLE_EQ(ptStart[1], poles.front()[1]);
+    EXPECT_DOUBLE_EQ(ptEnd[0], poles.back()[0]);
+    EXPECT_DOUBLE_EQ(ptEnd[1], poles.back()[1]);
+}
+
+TEST_F(SketchObjectTest, testGetPointFromGeomBSplineCurvePeriodic)
+{
+    // Arrange
+    int degree = 3;
+    std::vector<Base::Vector3d> poles;
+    poles.emplace_back(1, 0, 0);
+    poles.emplace_back(1, 1, 0);
+    poles.emplace_back(1, 0.5, 0);
+    poles.emplace_back(0, 1, 0);
+    poles.emplace_back(0, 0, 0);
+    std::vector<double> weights(5, 1.0);
+    std::vector<double> knotsPeriodic = {0.0, 0.3, 1.0, 1.5, 1.8, 2.0};
+    std::vector<int> multiplicitiesPeriodic(6, 1);
+    Part::GeomBSplineCurve periodicBSpline(poles,
+                                           weights,
+                                           knotsPeriodic,
+                                           multiplicitiesPeriodic,
+                                           degree,
+                                           true);
+
+    // Act
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptStart = Sketcher::SketchObject::getPoint(&periodicBSpline, Sketcher::PointPos::start);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptMid = Sketcher::SketchObject::getPoint(&periodicBSpline, Sketcher::PointPos::mid);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptEnd = Sketcher::SketchObject::getPoint(&periodicBSpline, Sketcher::PointPos::end);
+    // TODO: Maybe we want this to give an error instead of some default value
+    auto ptNone = Sketcher::SketchObject::getPoint(&periodicBSpline, Sketcher::PointPos::none);
+
+    // Assert
+    // With non-trivial values for weights, knots, mults, etc, getting the coordinates is
+    // non-trivial as well. This is the best we can do.
+    EXPECT_DOUBLE_EQ(ptStart[0], ptEnd[0]);
+    EXPECT_DOUBLE_EQ(ptStart[1], ptEnd[1]);
+}
+
 TEST_F(SketchObjectTest, testReverseAngleConstraintToSupplementaryExpressionNoUnits1)
 {
     std::string expr = Sketcher::SketchObject::reverseAngleConstraintExpression("180 - 60");


### PR DESCRIPTION
Done as [a grant by the FPA](https://github.com/FreeCAD/FPA-grant-proposals/issues/6).

Adds some tests for `split` and `trim` functions in `SketchObject`, and refactors them. Plenty of changes are still needed after this, especially in `trim`: not all necessary tests are added, and the cognitive complexity is only reduced from 233 to 92. However, the many corner cases and constraint combinations in `trim` make this a significantly difficult task. The method has been almost completely rewritten, so this needs thorough testing.