### PR TITLE
Draft: Fixes error in Draft trackers when not on a 3D view

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -89,7 +89,7 @@ class Tracker:
         ToDo.delay(self._removeSwitch, self.switch)
         self.switch = None
 
-    def getSceneGraph(self):
+    def get_scene_graph(self):
         """Returns the current scenegraph or None if this is not a 3D view
         """
         v = Draft.get3DView()
@@ -104,7 +104,7 @@ class Tracker:
         Must not be called
         from an event handler (or other scene graph traversal).
         """
-        sg = self.getSceneGraph()
+        sg = self.get_scene_graph()
         if not sg:
             return
         if self.ontop:
@@ -118,7 +118,7 @@ class Tracker:
         As with _insertSwitch,
         must not be called during scene graph traversal).
         """
-        sg = self.getSceneGraph()
+        sg = self.get_scene_graph()
         if not sg:
             return
         if sg.findChild(switch) >= 0:
@@ -140,7 +140,7 @@ class Tracker:
         So it doesn't obscure the other objects.
         """
         if self.switch:
-            sg = self.getSceneGraph()
+            sg = self.get_scene_graph()
             if not sg:
                 return
             sg.removeChild(self.switch)
@@ -152,7 +152,7 @@ class Tracker:
         So it obscures the other objects.
         """
         if self.switch:
-            sg = self.getSceneGraph()
+            sg = self.get_scene_graph()
             if not sg:
                 return
             sg.removeChild(self.switch)

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -89,13 +89,24 @@ class Tracker:
         ToDo.delay(self._removeSwitch, self.switch)
         self.switch = None
 
+    def getSceneGraph(self):
+        """Returns the current scenegraph or None if this is not a 3D view
+        """
+        v = Draft.get3DView()
+        if v:
+            return v.getSceneGraph()
+        else:
+            return None
+
     def _insertSwitch(self, switch):
         """Insert self.switch into the scene graph.
 
         Must not be called
         from an event handler (or other scene graph traversal).
         """
-        sg = Draft.get3DView().getSceneGraph()
+        sg = self.getSceneGraph()
+        if not sg:
+            return
         if self.ontop:
             sg.insertChild(switch, 0)
         else:
@@ -107,7 +118,9 @@ class Tracker:
         As with _insertSwitch,
         must not be called during scene graph traversal).
         """
-        sg = Draft.get3DView().getSceneGraph()
+        sg = self.getSceneGraph()
+        if not sg:
+            return
         if sg.findChild(switch) >= 0:
             sg.removeChild(switch)
 
@@ -127,7 +140,9 @@ class Tracker:
         So it doesn't obscure the other objects.
         """
         if self.switch:
-            sg = Draft.get3DView().getSceneGraph()
+            sg = self.getSceneGraph()
+            if not sg:
+                return
             sg.removeChild(self.switch)
             sg.addChild(self.switch)
 
@@ -137,7 +152,9 @@ class Tracker:
         So it obscures the other objects.
         """
         if self.switch:
-            sg = Draft.get3DView().getSceneGraph()
+            sg = self.getSceneGraph()
+            if not sg:
+                return
             sg.removeChild(self.switch)
             sg.insertChild(self.switch, 0)
 


### PR DESCRIPTION
Draft trackers yielded an error when invoked and the current view is not a 3D view.
This might still leave trackers on if user switches views in the middle of a Draft command, but it's of low impact, and it was so already before this PR, only now there is no error message.