### PR TITLE
CAM: Fixes #15637 Attributes are ignored when using ToolBitFactory() Creat…

### DIFF
--- a/src/Mod/CAM/Path/Tool/Bit.py
+++ b/src/Mod/CAM/Path/Tool/Bit.py
@@ -486,6 +486,9 @@ class ToolBitFactory(object):
         params = attrs["parameter"]
         for prop in params:
             PathUtil.setProperty(obj, prop, params[prop])
+        attributes = attrs["attribute"]
+        for att in attributes:
+            PathUtil.setProperty(obj, att, attributes[att])
         obj.Proxy._updateBitShape(obj)
         obj.Proxy.unloadBitBody(obj)
         return obj


### PR DESCRIPTION
Extend  ToolBitFactory() Create to also add any ToolBit Attributes{}, as well as the already included Shape and Properties{}