### PR TITLE
CI: linter settings update

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,8 @@ concurrency-*,-modernize-use-trailing-return-type, -modernize-use-nodiscard,
 -readability-redundant-access-specifiers,-readability-qualified-auto,
 -cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,
 -readability-convert-member-functions-to-static,-bugprone-easily-swappable-parameters,
--cppcoreguidelines-pro-type-static-cast-downcast'
+-cppcoreguidelines-pro-type-static-cast-downcast,-whitespace-*,-readability-braces-around-statements,
+-readability-braces'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -76,10 +76,6 @@ on:
         default: true
         type: boolean
         required: false
-      cpplintFilters:
-        default: -whitespace-*
-        type: string
-        required: false
       cpplintLineLength:
         default: 120
         type: string
@@ -153,7 +149,7 @@ on:
         type: boolean
         required: false
       clazyChecks:
-        default: level2,no-non-pod-global-static,no-copyable-polymorphic
+        default: level2,no-non-pod-global-static,no-copyable-polymorphic,
         type: string
         required: false
       clazyFailSilent:
@@ -520,7 +516,7 @@ jobs:
           # Run cpplint
           for file in ${{ inputs.changedCppFiles }}
           do
-            cpplint --filter=${{ inputs.cpplintFilters }} --linelength=${{ inputs.cpplintLineLength }} $file &>> ${{ env.logdir }}cpplint.log || true
+            cpplint --linelength=${{ inputs.cpplintLineLength }} $file &>> ${{ env.logdir }}cpplint.log || true
           done
           # If cpplint has run successfully, write the Log to the console with the Problem Matchers
           if [ ${{ env.logdir }}cpplint.log ]

--- a/src/Mod/Sketcher/App/Constraint.cpp
+++ b/src/Mod/Sketcher/App/Constraint.cpp
@@ -1,23 +1,24 @@
-/***************************************************************************
- *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>               *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
  ***************************************************************************/
 
 #include "PreCompiled.h"


### PR DESCRIPTION
The CI's linter should be using our .clang-tidy file, but instead had its own set of "default" settings that I suspect are actually overriding the project settings. This PR is testing that out -- the change to the sketcher file is to trigger the linter on something.