### PR TITLE
Reimplementation of Light source dialog

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
@@ -111,7 +111,7 @@ void DlgSettingsLightSources::dragMotionCallback(void *data, SoDragger *drag)
     setValueSilently(self->ui->z_spnBox, dir[2]);
 }
 
-void DlgSettingsLightSources::createViewer(void)
+void DlgSettingsLightSources::createViewer()
 {
     const QColor default_bg_color {200, 200, 200};
     const SbVec3f default_view_direction {1.0f, 1.0f, -5.0f};

--- a/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
@@ -24,9 +24,6 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-#include <QColor>
-#include <QEvent>
-#include <QGridLayout>
 #include <Inventor/draggers/SoDirectionalLightDragger.h>
 #include <Inventor/events/SoEvent.h>
 #include <Inventor/nodes/SoDirectionalLight.h>
@@ -52,58 +49,79 @@ DlgSettingsLightSources::DlgSettingsLightSources(QWidget* parent)
   , ui(new Ui_DlgSettingsLightSources)
 {
     ui->setupUi(this);
-    setupConnection();
+
+    view = ui->viewer;
+    createViewer();
+
+    QSizePolicy sp {QSizePolicy::Expanding, QSizePolicy::Expanding};
+    sp.setHeightForWidth(true);
+    sp.setHorizontalStretch(1);
+    sp.setVerticalStretch(1);
+    view->setSizePolicy(sp);
 }
 
-DlgSettingsLightSources::~DlgSettingsLightSources()
+static inline
+SbVec3f getDirectionVector(const SbRotation &rotation)
 {
+    SbVec3f dir {0.0f, 0.0f, -1.0f};
+    rotation.multVec(dir, dir);
+    return dir;
 }
 
-void DlgSettingsLightSources::setupConnection()
+static inline
+void setLightDirection(const SbRotation &rotation, Gui::View3DInventorViewer *viewer)
 {
-    connect(ui->checkBoxLight1, &QCheckBox::toggled,
-            this, &DlgSettingsLightSources::toggleLight);
-    connect(ui->sliderIntensity1, &QSlider::valueChanged,
-            this, &DlgSettingsLightSources::lightIntensity);
-    connect(ui->light1Color, &Gui::ColorButton::changed,
-            this, &DlgSettingsLightSources::lightColor);
+    viewer->getHeadlight()->direction = getDirectionVector(rotation);
 }
 
-void DlgSettingsLightSources::showEvent(QShowEvent* event)
+static inline
+void setLightDraggerDirection(const SbRotation &rotation, SoDirectionalLightDragger *light_dragger)
 {
-    Q_UNUSED(event)
-    static bool underConstruction = false;  // Prevent recursion
-    if (!underConstruction && !view) {
-        underConstruction = true;
-        QGroupBox* box = ui->groupBoxLight;
-        QWidget* widget = createViewer(box);
-        auto grid = new QGridLayout(box);
-        grid->addWidget(widget);
+    light_dragger->rotation = rotation;
+}
 
-        loadDirection();
-        underConstruction = false;
-    }
+static inline
+void setValueSilently(QDoubleSpinBox *spn, const float val)
+{
+    Q_ASSERT_X(spn, "setValueSilently", "QDoubleSpinBox has been deleted");
+
+    spn->blockSignals(true);
+    spn->setValue(val);
+    spn->blockSignals(false);
 }
 
 void DlgSettingsLightSources::dragMotionCallback(void *data, SoDragger *drag)
 {
-    auto lightdrag = static_cast<SoDirectionalLightDragger*>(drag);  // NOLINT
+    auto lightdrag = dynamic_cast <SoDirectionalLightDragger *> (drag);
     auto self = static_cast<DlgSettingsLightSources*>(data);
-    SbRotation rotation = lightdrag->rotation.getValue();
-    SbVec3f dir(0, 0, -1);
-    rotation.multVec(dir, dir);
-    self->view->getHeadlight()->direction = dir;
+
+    const SbRotation rotation = lightdrag->rotation.getValue();
+
+    setLightDirection(rotation, self->view);
+
+    setValueSilently(self->ui->q0_spnBox, rotation[0]);
+    setValueSilently(self->ui->q1_spnBox, rotation[1]);
+    setValueSilently(self->ui->q2_spnBox, rotation[2]);
+    setValueSilently(self->ui->q3_spnBox, rotation[3]);
+
+    const SbVec3f dir = getDirectionVector(rotation);
+
+    setValueSilently(self->ui->x_spnBox, dir[0]);
+    setValueSilently(self->ui->y_spnBox, dir[1]);
+    setValueSilently(self->ui->z_spnBox, dir[2]);
 }
 
-QWidget* DlgSettingsLightSources::createViewer(QWidget* parent)
+void DlgSettingsLightSources::createViewer(void)
 {
+    const QColor default_bg_color {200, 200, 200};
+    const SbVec3f default_view_direction {1.0f, 1.0f, -5.0f};
+
     // NOLINTBEGIN
-    view = new Gui::View3DInventorViewer(parent);
     view->setRedirectToSceneGraph(true);
     view->setViewing(true);
     view->setPopupMenuEnabled(false);
 
-    view->setBackgroundColor(QColor(255, 255, 255));
+    view->setBackgroundColor(default_bg_color);
     view->setGradientBackground(Gui::View3DInventorViewer::NoGradient);
     view->setEnabledNaviCube(false);
 
@@ -119,20 +137,11 @@ QWidget* DlgSettingsLightSources::createViewer(QWidget* parent)
     });
 
     view->setCameraType(SoOrthographicCamera::getClassTypeId());
-    view->setViewDirection(SbVec3f(1, 1, -5));
+    view->setViewDirection(default_view_direction);
     view->viewAll();
-    float height = static_cast<SoOrthographicCamera*>(view->getCamera())->height.getValue();
-    static_cast<SoOrthographicCamera*>(view->getCamera())->height.setValue(height / 2.0F);
+    auto cam = dynamic_cast <SoOrthographicCamera *> (view->getCamera());
+    cam->height = cam->height.getValue() * 2.0f;
     // NOLINTEND
-
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    View3DSettings viewSettings(hGrp, view);
-    viewSettings.OnChange(*hGrp,"BackgroundColor");
-
-    const int size = 250;
-    view->resize(size, size);
-
-    return view;
 }
 
 SoDirectionalLightDragger* DlgSettingsLightSources::createDragger()
@@ -172,23 +181,39 @@ void DlgSettingsLightSources::loadSettings()
     ui->checkBoxLight1->onRestore();
     ui->light1Color->onRestore();
     ui->sliderIntensity1->onRestore();
+    loadDirection();
+    lightColor();
+}
+
+void DlgSettingsLightSources::resetSettingsToDefaults()
+{
+    ParameterGrp::handle grp = ui->sliderIntensity1->getWindowParameter();
+
+    grp->SetFloat("HeadlightRotationX", 0.0);
+    grp->SetFloat("HeadlightRotationY", 0.0);
+    grp->SetFloat("HeadlightRotationZ", 0.0);
+    grp->SetFloat("HeadlightRotationW", 1.0);
+
+    grp->SetASCII("HeadlightDirection", "(0.0,0.0,-1.0)");
+
+    PreferencePage::resetSettingsToDefaults();
 }
 
 void DlgSettingsLightSources::saveDirection()
 {
     if (lightDragger) {
+        const SbRotation rotation = lightDragger->rotation.getValue();
+        const SbVec3f dir = getDirectionVector(rotation);
+        const QString headlightDir = QString::fromLatin1("(%1,%2,%3)").arg(dir[0]).arg(dir[1]).arg(dir[2]);
+
         ParameterGrp::handle grp = ui->sliderIntensity1->getWindowParameter();
-        SbRotation rotation = lightDragger->rotation.getValue();
+
         grp->SetFloat("HeadlightRotationX", rotation[0]);
         grp->SetFloat("HeadlightRotationY", rotation[1]);
         grp->SetFloat("HeadlightRotationZ", rotation[2]);
         grp->SetFloat("HeadlightRotationW", rotation[3]);
 
-        SbVec3f dir(0, 0, -1);
-        rotation.multVec(dir, dir);
-
-        QString headlightDir = QString::fromLatin1("(%1,%2,%3)").arg(dir[0]).arg(dir[1]).arg(dir[2]);
-        grp->SetASCII("HeadlightDirection", headlightDir.toLatin1());
+        grp->SetASCII("HeadlightDirection", qPrintable(headlightDir));
     }
 }
 
@@ -196,18 +221,29 @@ void DlgSettingsLightSources::loadDirection()
 {
     ParameterGrp::handle grp = ui->sliderIntensity1->getWindowParameter();
     SbRotation rotation = lightDragger->rotation.getValue();
-    // NOLINTBEGIN
-    float q1 = float(grp->GetFloat("HeadlightRotationX", rotation[0]));
-    float q2 = float(grp->GetFloat("HeadlightRotationY", rotation[1]));
-    float q3 = float(grp->GetFloat("HeadlightRotationZ", rotation[2]));
-    float q4 = float(grp->GetFloat("HeadlightRotationW", rotation[3]));
-    // NOLINTEND
-    rotation.setValue(q1, q2, q3, q4);
-    lightDragger->rotation.setValue(rotation);
 
-    SbVec3f direction(0, 0, -1);
-    rotation.multVec(direction, direction);
-    view->getHeadlight()->direction = direction;
+    auto get_q = [&grp](const char *name, const float def){return static_cast <float> (grp->GetFloat(name, def));};
+
+    const float q0 = get_q("HeadlightRotationX", rotation[0]),
+                q1 = get_q("HeadlightRotationY", rotation[1]),
+                q2 = get_q("HeadlightRotationZ", rotation[2]),
+                q3 = get_q("HeadlightRotationW", rotation[3]);
+
+    rotation.setValue(q0, q1, q2, q3);
+
+    setLightDirection(rotation, ui->viewer);
+    setLightDraggerDirection(rotation, lightDragger);
+
+    setValueSilently(ui->q0_spnBox, rotation[0]);
+    setValueSilently(ui->q1_spnBox, rotation[1]);
+    setValueSilently(ui->q2_spnBox, rotation[2]);
+    setValueSilently(ui->q3_spnBox, rotation[3]);
+
+    const SbVec3f dir = getDirectionVector(rotation);
+
+    setValueSilently(ui->x_spnBox, dir[0]);
+    setValueSilently(ui->y_spnBox, dir[1]);
+    setValueSilently(ui->z_spnBox, dir[2]);
 }
 
 void DlgSettingsLightSources::toggleLight(bool on)
@@ -220,19 +256,17 @@ void DlgSettingsLightSources::toggleLight(bool on)
 void DlgSettingsLightSources::lightIntensity(int value)
 {
     if (view) {
-        float intensity = float(value) / 100.0F;
-        view->getHeadlight()->intensity = intensity;
+        view->getHeadlight()->intensity = static_cast <float> (value) / 100.0f;
     }
 }
 
 void DlgSettingsLightSources::lightColor()
 {
     if (view) {
-        QColor color = ui->light1Color->color();
-        float red = float(color.redF());
-        float green = float(color.greenF());
-        float blue = float(color.blueF());
-        view->getHeadlight()->color = SbColor(red, green, blue);
+        const QColor color = ui->light1Color->color();
+        view->getHeadlight()->color.setValue(color.redF(),
+                                             color.greenF(),
+                                             color.blueF());
     }
 }
 
@@ -242,6 +276,42 @@ void DlgSettingsLightSources::changeEvent(QEvent* event)
         ui->retranslateUi(this);
     }
     PreferencePage::changeEvent(event);
+}
+
+void DlgSettingsLightSources::updateDraggerQS()
+{
+    const float q0 = ui->q0_spnBox->value(),
+                q1 = ui->q1_spnBox->value(),
+                q2 = ui->q2_spnBox->value(),
+                q3 = ui->q3_spnBox->value();
+
+    const SbRotation rotation {q0, q1, q2, q3};
+
+    setLightDirection(rotation, view);
+    setLightDraggerDirection(rotation, lightDragger);
+
+    const SbVec3f dir = getDirectionVector(rotation);
+
+    setValueSilently(ui->x_spnBox, dir[0]);
+    setValueSilently(ui->y_spnBox, dir[1]);
+    setValueSilently(ui->z_spnBox, dir[2]);
+}
+
+void DlgSettingsLightSources::updateDraggerXYZ()
+{
+    const float x = ui->x_spnBox->value(),
+                y = ui->y_spnBox->value(),
+                z = ui->z_spnBox->value();
+
+    const SbRotation rotation {SbVec3f{0.0f, 0.0f, -1.0f}, SbVec3f{x, y, z}};
+
+    setLightDirection(rotation, view);
+    setLightDraggerDirection(rotation, lightDragger);
+
+    setValueSilently(ui->q0_spnBox, rotation[0]);
+    setValueSilently(ui->q1_spnBox, rotation[1]);
+    setValueSilently(ui->q2_spnBox, rotation[2]);
+    setValueSilently(ui->q3_spnBox, rotation[3]);
 }
 
 

--- a/src/Gui/PreferencePages/DlgSettingsLightSources.h
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.h
@@ -27,6 +27,7 @@
 
 #include <Gui/PropertyPage.h>
 #include <memory>
+#include <QPointer>
 
 class SoDragger;
 class SoDirectionalLightDragger;
@@ -47,29 +48,32 @@ class DlgSettingsLightSources : public PreferencePage
 
 public:
     explicit DlgSettingsLightSources(QWidget* parent = nullptr);
-    ~DlgSettingsLightSources() override;
+    ~DlgSettingsLightSources() override = default;
 
     void saveSettings() override;
     void loadSettings() override;
+    void resetSettingsToDefaults() override;
 
-protected:
-    void changeEvent(QEvent* event) override;
-    void showEvent(QShowEvent* event) override;
-
-private:
-    void setupConnection();
+public Q_SLOTS:
+    void updateDraggerQS (void);
+    void updateDraggerXYZ(void);
     void toggleLight(bool on);
     void lightIntensity(int value);
     void lightColor();
+
+protected:
+    void changeEvent(QEvent* event) override;
+
+private:
     void saveDirection();
     void loadDirection();
-    QWidget* createViewer(QWidget* parent);
+    void createViewer(void);
     SoDirectionalLightDragger* createDragger();
     static void dragMotionCallback(void *data, SoDragger *drag);
 
 private:
     std::unique_ptr<Ui_DlgSettingsLightSources> ui;
-    View3DInventorViewer* view = nullptr;
+    QPointer <View3DInventorViewer> view;
     SoDirectionalLightDragger* lightDragger = nullptr;
 };
 

--- a/src/Gui/PreferencePages/DlgSettingsLightSources.h
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.h
@@ -55,8 +55,8 @@ public:
     void resetSettingsToDefaults() override;
 
 public Q_SLOTS:
-    void updateDraggerQS (void);
-    void updateDraggerXYZ(void);
+    void updateDraggerQS ();
+    void updateDraggerXYZ();
     void toggleLight(bool on);
     void lightIntensity(int value);
     void lightColor();
@@ -67,7 +67,7 @@ protected:
 private:
     void saveDirection();
     void loadDirection();
-    void createViewer(void);
+    void createViewer();
     SoDirectionalLightDragger* createDragger();
     static void dragMotionCallback(void *data, SoDragger *drag);
 

--- a/src/Gui/PreferencePages/DlgSettingsLightSources.ui
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.ui
@@ -14,6 +14,19 @@
    <string>Light Sources</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
+   <item row="4" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>428</width>
+       <height>376</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -38,7 +51,7 @@
       </item>
       <item row="0" column="1">
        <widget class="Gui::PrefColorButton" name="light1Color">
-        <property name="color">
+        <property name="color" stdset="0">
          <color>
           <red>255</red>
           <green>255</green>
@@ -102,24 +115,154 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBoxLight">
+    <widget class="QGroupBox" name="groupBoxDirection">
+     <property name="toolTip">
+      <string>Adjust the orientation of the directional light source by dragging the handle with the mouse or use the spin boxes for fine tuning.</string>
+     </property>
      <property name="title">
-      <string>Lights</string>
+      <string>Direction</string>
      </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="2" rowspan="7">
+       <widget class="Gui::View3DInventorViewer" name="viewer" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QDoubleSpinBox" name="z_spnBox">
+        <property name="minimum">
+         <double>-100.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QDoubleSpinBox" name="q0_spnBox">
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="minimum">
+         <double>-100.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QLabel" name="q1_label">
+        <property name="text">
+         <string>q1</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="4">
+       <widget class="QDoubleSpinBox" name="q1_spnBox">
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="minimum">
+         <double>-100.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="z_label">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;z&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QLabel" name="q2_label">
+        <property name="text">
+         <string>q2</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QLabel" name="q3_label">
+        <property name="text">
+         <string>q3</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="x_spnBox">
+        <property name="minimum">
+         <double>-100.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="y_label">
+        <property name="text">
+         <string>y</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="4">
+       <widget class="QDoubleSpinBox" name="q2_spnBox">
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="minimum">
+         <double>-100.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="4">
+       <widget class="QDoubleSpinBox" name="q3_spnBox">
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="minimum">
+         <double>-100.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="y_spnBox">
+        <property name="minimum">
+         <double>-100.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="q0_label">
+        <property name="text">
+         <string>q0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="x_label">
+        <property name="text">
+         <string>x</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
-   </item>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>428</width>
-       <height>376</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>
@@ -144,7 +287,24 @@
    <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
+  <customwidget>
+   <class>Gui::View3DInventorViewer</class>
+   <extends>QWidget</extends>
+   <header>Gui/View3DInventorViewer.h</header>
+  </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>checkBoxLight1</tabstop>
+  <tabstop>light1Color</tabstop>
+  <tabstop>sliderIntensity1</tabstop>
+  <tabstop>x_spnBox</tabstop>
+  <tabstop>y_spnBox</tabstop>
+  <tabstop>z_spnBox</tabstop>
+  <tabstop>q0_spnBox</tabstop>
+  <tabstop>q1_spnBox</tabstop>
+  <tabstop>q2_spnBox</tabstop>
+  <tabstop>q3_spnBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>
@@ -174,8 +334,8 @@
      <y>53</y>
     </hint>
     <hint type="destinationlabel">
-     <x>284</x>
-     <y>53</y>
+     <x>339</x>
+     <y>65</y>
     </hint>
    </hints>
   </connection>
@@ -195,5 +355,169 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>q1_spnBox</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>Gui::Dialog::DlgSettingsLightSources</receiver>
+   <slot>updateDraggerQS(void)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>399</x>
+     <y>168</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>q2_spnBox</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>Gui::Dialog::DlgSettingsLightSources</receiver>
+   <slot>updateDraggerQS(void)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>399</x>
+     <y>200</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>q3_spnBox</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>Gui::Dialog::DlgSettingsLightSources</receiver>
+   <slot>updateDraggerQS(void)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>399</x>
+     <y>232</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>q0_spnBox</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>Gui::Dialog::DlgSettingsLightSources</receiver>
+   <slot>updateDraggerQS(void)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>422</x>
+     <y>128</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>241</x>
+     <y>257</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkBoxLight1</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>Gui::Dialog::DlgSettingsLightSources</receiver>
+   <slot>toggleLight(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>68</x>
+     <y>53</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>241</x>
+     <y>257</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>sliderIntensity1</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>Gui::Dialog::DlgSettingsLightSources</receiver>
+   <slot>lightIntensity(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>404</x>
+     <y>52</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>241</x>
+     <y>257</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>light1Color</sender>
+   <signal>changed(void)</signal>
+   <receiver>Gui::Dialog::DlgSettingsLightSources</receiver>
+   <slot>lightColor(void)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>140</x>
+     <y>53</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>241</x>
+     <y>257</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>x_spnBox</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>Gui::Dialog::DlgSettingsLightSources</receiver>
+   <slot>updateDraggerXYZ(void)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>186</x>
+     <y>141</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>241</x>
+     <y>257</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>y_spnBox</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>Gui::Dialog::DlgSettingsLightSources</receiver>
+   <slot>updateDraggerXYZ(void)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>186</x>
+     <y>173</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>241</x>
+     <y>257</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>z_spnBox</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>Gui::Dialog::DlgSettingsLightSources</receiver>
+   <slot>updateDraggerXYZ(void)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>186</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>241</x>
+     <y>257</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
+ <slots>
+  <slot>updateDraggerQS(void)</slot>
+  <slot>updateDraggerXYZ(void)</slot>
+ </slots>
 </ui>


### PR DESCRIPTION

@maxwxyz, @chennes, this pull request:

- Loads lightning settings when user opens _Preferences_ (yes, the settings were not loaded before this commit). Closes #15793
- Adds spinboxes to adjust the light direction using XYZ and orientation quaternion notations
- Removes the code that is supposed to adjust settings on-the-fly (it does not work anyway. If I make it work (by moving _View3DSettings_ variable into the class), _NaviCube_ shows up every time user presses the _Apply_ button. I could not find a way to make it go away). The code did not work because _View3DSettings_ object was created on the stack; in this case it is deleted after going out of its scope. 



- @adrianinsaval, this commit fixes showing up the dialog twice.

The code has been lightened, rewritten in _Qt_ way, now it is easier to read. Possibly, somebody, who understands _FreeCAD's_ allinternals, can make the viewer be adjusted when user changes settings, but I failed to make _NaviCube_ disappear. Perhaps, for now, this is just simplification of the source code and the UI.

I have tested this commit against Qt 5.15.14 and 6.7.2. The commit does not check if user enters an invalid value, though, I can't find harm in this, it does not seem to influence anything.