### PR TITLE
FIX: empty filename in CAM workbench saves to the current project folder

### DIFF
--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -292,6 +292,7 @@ SET(Tests_SRCS
     Tests/boxtest1.fcstd
     Tests/Drilling_1.FCStd
     Tests/drill_test1.FCStd
+    Tests/FilePathTestUtils.py
     Tests/PathTestUtils.py
     Tests/test_adaptive.fcstd
     Tests/test_profile.fcstd

--- a/src/Mod/CAM/Path/Post/Command.py
+++ b/src/Mod/CAM/Path/Post/Command.py
@@ -137,6 +137,7 @@ class CommandPathPost:
                 Path.Log.debug(filename)
                 with open(filename, "w") as f:
                     f.write(gcode)
+            else: return
 
         elif policy == "Append Unique ID on conflict":
             while os.path.isfile(filename):
@@ -157,12 +158,15 @@ class CommandPathPost:
                     Path.Log.debug(filename)
                     with open(filename, "w") as f:
                         f.write(gcode)
+                else: return
             else:
                 with open(filename, "w") as f:
                     f.write(gcode)
+
         else:  # Overwrite
             with open(filename, "w") as f:
                 f.write(gcode)
+
         FreeCAD.Console.PrintMessage(f"File written to {filename}\n")
 
     def Activated(self):

--- a/src/Mod/CAM/Path/Post/Utils.py
+++ b/src/Mod/CAM/Path/Post/Utils.py
@@ -91,7 +91,7 @@ class FilenameGenerator:
             outputpath, _ = os.path.split(FreeCAD.ActiveDocument.getFileName())
 
         if not outputpath:
-            outputpath = os.getcwd() ## TODO: This should be avoided as it would give the Freecad executable's path
+            outputpath = os.getcwd() ## TODO: This should be avoided as it gives the Freecad executable's path in some systems (e.g. Windows)
 
         if not ext:
             ext = ".nc"

--- a/src/Mod/CAM/Path/Post/Utils.py
+++ b/src/Mod/CAM/Path/Post/Utils.py
@@ -88,7 +88,10 @@ class FilenameGenerator:
             filename = FreeCAD.ActiveDocument.Label
 
         if not outputpath:
-            outputpath = os.getcwd()
+            outputpath, _ = os.path.split(FreeCAD.ActiveDocument.getFileName())
+
+        if not outputpath:
+            outputpath = os.getcwd() ## TODO: This should be avoided as it would give the Freecad executable's path
 
         if not ext:
             ext = ".nc"

--- a/src/Mod/CAM/Tests/FilePathTestUtils.py
+++ b/src/Mod/CAM/Tests/FilePathTestUtils.py
@@ -1,0 +1,8 @@
+
+
+import os
+from unittest import TestCase
+
+
+def assertFilePathsEqual(self: TestCase, path1: os.PathLike, path2: os.PathLike):
+    self.assertEqual(os.path.realpath(path1), os.path.realpath(path2))

--- a/src/Mod/CAM/Tests/TestPathPost.py
+++ b/src/Mod/CAM/Tests/TestPathPost.py
@@ -33,12 +33,13 @@ import difflib
 import os
 import unittest
 
+from .FilePathTestUtils import assertFilePathsEqual
+
 PathCommand.LOG_MODULE = Path.Log.thisModule()
 Path.Log.setLevel(Path.Log.Level.INFO, PathCommand.LOG_MODULE)
 
 
 class TestFileNameGenerator(unittest.TestCase):
-
     """
     String substitution allows the following:
     %D ... directory of the active document
@@ -147,8 +148,8 @@ class TestFileNameGenerator(unittest.TestCase):
         # subpart, objs = outlist[0]
 
         # filename = PathPost.resolveFileName(self.job, subpart, 0)
-        #self.assertEqual(filename, os.path.normpath(f"{self.testfilename}.nc"))
-        self.assertEqual(filename, os.path.join(os.getcwd(), f"{self.testfilename}.nc"))
+        # self.assertEqual(filename, os.path.normpath(f"{self.testfilename}.nc"))
+        assertFilePathsEqual( self, filename, os.path.join(self.testfilepath, f"{self.testfilename}.nc"))
 
     def test010(self):
         # Substitute current file path
@@ -163,10 +164,7 @@ class TestFileNameGenerator(unittest.TestCase):
         filename = next(filename_generator)
 
         print(os.path.normpath(filename))
-        self.assertEqual(
-            filename,
-            os.path.normpath(f"{self.testfilepath}/testfile.nc"),
-        )
+        assertFilePathsEqual(self, filename, f"{self.testfilepath}/testfile.nc")
 
     def test015(self):
         # Test basic string substitution without splitting
@@ -185,9 +183,7 @@ class TestFileNameGenerator(unittest.TestCase):
         filename = next(filename_generator)
 
         # filename = PathPost.resolveFileName(self.job, subpart, 0)
-        self.assertEqual(
-            os.path.normpath(filename), os.path.normpath("~/Desktop/MainJob.nc")
-        )
+        assertFilePathsEqual(self, filename, "~/Desktop/MainJob.nc")
 
     def test020(self):
         teststring = "%d.nc"
@@ -200,9 +196,9 @@ class TestFileNameGenerator(unittest.TestCase):
         filename_generator = generator.generate_filenames()
         filename = next(filename_generator)
 
-        expected = os.path.join(os.getcwd(), f"{self.testfilename}.nc")
+        expected = os.path.join(self.testfilepath, f"{self.testfilename}.nc")
 
-        self.assertEqual(filename, expected ) #f"{self.testfilename}.nc")
+        assertFilePathsEqual(self, filename, expected)
 
     def test030(self):
         teststring = "%M/outfile.nc"
@@ -215,7 +211,7 @@ class TestFileNameGenerator(unittest.TestCase):
         filename_generator = generator.generate_filenames()
         filename = next(filename_generator)
 
-        self.assertEqual(filename, os.path.normpath(f"{self.macro}outfile.nc"))
+        assertFilePathsEqual(self, filename, f"{self.macro}outfile.nc")
 
     def test040(self):
         # unused substitution strings should be ignored
@@ -229,10 +225,7 @@ class TestFileNameGenerator(unittest.TestCase):
         filename_generator = generator.generate_filenames()
         filename = next(filename_generator)
 
-        self.assertEqual(
-            filename,
-            os.path.normpath(f"{self.testfilename}/testdoc.nc"),
-        )
+        assertFilePathsEqual(self, filename, f"{self.testfilename}/testdoc.nc")
 
     def test045(self):
         """Testing the sequence number substitution"""
@@ -243,7 +236,7 @@ class TestFileNameGenerator(unittest.TestCase):
         ]
         for expected_filename in expected_filenames:
             filename = next(filename_generator)
-            self.assertEqual(filename, os.path.normpath(expected_filename))
+            assertFilePathsEqual(self, filename, expected_filename)
 
     def test046(self):
         """Testing the sequence number substitution"""
@@ -251,10 +244,12 @@ class TestFileNameGenerator(unittest.TestCase):
         self.job.PostProcessorOutputFile = teststring
         generator = PostUtils.FilenameGenerator(job=self.job)
         filename_generator = generator.generate_filenames()
-        expected_filenames = [os.path.join( os.getcwd(), f"{i}-test_filenaming.nc") for i in range(5)]
+        expected_filenames = [
+            os.path.join(self.testfilepath, f"{i}-test_filenaming.nc") for i in range(5)
+        ]
         for expected_filename in expected_filenames:
             filename = next(filename_generator)
-            self.assertEqual(filename, os.path.normpath(expected_filename))
+            assertFilePathsEqual(self, filename, expected_filename)
 
     def test050(self):
         # explicitly using the sequence number should include it where indicated.
@@ -268,7 +263,9 @@ class TestFileNameGenerator(unittest.TestCase):
         filename_generator = generator.generate_filenames()
         filename = next(filename_generator)
 
-        self.assertEqual(filename, os.path.join(os.getcwd(), "0-test_filenaming.nc"))
+        assertFilePathsEqual(
+            self, filename, os.path.join(self.testfilepath, "0-test_filenaming.nc")
+        )
 
     def test060(self):
         """Test subpart naming"""
@@ -283,7 +280,7 @@ class TestFileNameGenerator(unittest.TestCase):
         filename_generator = generator.generate_filenames()
         filename = next(filename_generator)
 
-        self.assertEqual(filename, os.path.normpath(f"{self.macro}outfile-Tool.nc"))
+        assertFilePathsEqual(self, filename, f"{self.macro}outfile-Tool.nc")
 
 
 class TestResolvingPostProcessorName(unittest.TestCase):


### PR DESCRIPTION
Previously, if the user didn't set a default gcode path, the file was saved to getcwd. Now, it attempts to take the active document's path first.

I would like suggestions about what the standard behaviour should we use, but in general, this needed to be fixed as in Windows at least, it was saving to the same `freecad.exe` folder!