### PR TITLE
fix(PD): threadtype combobox too small for metric fine

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -67,7 +67,7 @@
        <item>
         <widget class="QComboBox" name="ThreadSize">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>


### PR DESCRIPTION
The hole ui currently has an issue with the dropdown being too small, this fixes it.
i cherry-picked this from my current work at #15744
Current:
![Screenshot_20240814_115631](https://github.com/user-attachments/assets/bc26f97c-e0e1-4a4d-852d-9e96436b4c7a)
Fix:
![Screenshot_20240814_161808](https://github.com/user-attachments/assets/a427ad2e-ff60-46e2-9656-2571a8bc9c33)
