### PR TITLE
[GUI] Enable zooming with a mouse wheel in Python console

### DIFF
--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -1045,6 +1045,17 @@ void PythonConsole::mouseReleaseEvent( QMouseEvent *e )
     TextEdit::mouseReleaseEvent( e );
 }
 
+void PythonConsole::wheelEvent(QWheelEvent *e)
+{
+    if (e->modifiers() & Qt::ControlModifier) {
+            float delta = e->angleDelta().y() / 120.f;
+            zoomInF(delta);
+            return;
+        }
+
+    TextEdit::wheelEvent(e);
+}
+
 /**
  * Drops the event \a e and writes the right Python command.
  */

--- a/src/Gui/PythonConsole.h
+++ b/src/Gui/PythonConsole.h
@@ -136,6 +136,8 @@ protected:
     void changeEvent    ( QEvent            * e ) override;
     void mouseReleaseEvent( QMouseEvent     * e ) override;
 
+    void wheelEvent(QWheelEvent *e) override;
+
     void overrideCursor(const QString& txt);
 
     /** Pops up the context menu with some extensions */


### PR DESCRIPTION
Closes #13861.


When _QPlainTextEdit_ object is not set to be read-only, zooming with a mouse wheel is disabled.[^1] Fortunately, one can implement zoom using the same snippet.[^2]



I have tested this commit on _KUbuntu 22.04.4_.




[^1]: https://doc.qt.io/qt-6/qplaintextedit.html#read-only-key-bindings
[^2]: https://github.com/qt/qtbase/blob/987c6d2d75429444f866bd17ccc24227198b090f/src/widgets/widgets/qplaintextedit.cpp#L2326-L2338