### PR TITLE
Revert "CI: Disable Windows conda due to mamba bug."

### DIFF
--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -75,12 +75,11 @@ jobs:
     with:
       artifactBasename: Windows-${{ github.run_id }}
 
-  ## Disable until the following issue is resolved: https://github.com/mamba-org/mamba/issues/3292
-  # Windows_Conda:
-  #   needs: [Prepare]
-  #   uses: ./.github/workflows/sub_buildWindowsConda.yml
-  #   with:
-  #     artifactBasename: Windows_Conda-${{ github.run_id }}
+  Windows_Conda:
+    needs: [Prepare]
+    uses: ./.github/workflows/sub_buildWindowsConda.yml
+    with:
+      artifactBasename: Windows_Conda-${{ github.run_id }}
 
   Lint:
     needs: [Prepare]
@@ -99,7 +98,7 @@ jobs:
         Ubuntu_20-04,
         Ubuntu_22-04_Conda,
         Windows,
-        # Windows_Conda,
+        Windows_Conda,
         Lint
       ]
     if: always()


### PR DESCRIPTION
This reverts commit 77167d81670c73892e01b94b65ebc5d76b278a21.