### PR TITLE
Gui: fix switching back to classic theme

### DIFF
--- a/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
@@ -10,6 +10,7 @@
         </FCParamGroup>
         <FCParamGroup Name="MainWindow">
           <FCText Name="Theme">FreeCAD Classic</FCText>
+          <FCText Name="StyleSheet"></FCText>
           <FCText Name="OverlayActiveStyleSheet">Light Theme + Dark Background.qss</FCText>
         </FCParamGroup>
       </FCParamGroup>

--- a/src/Gui/PreferencePacks/FreeCAD Classic/post.FCMacro
+++ b/src/Gui/PreferencePacks/FreeCAD Classic/post.FCMacro
@@ -210,4 +210,3 @@ navcubePrefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/NaviCube")
 navcubePrefs.RemUnsigned("BaseColor")
 
 mwPrefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/MainWindow")
-mwPrefs.RemString("StyleSheet")


### PR DESCRIPTION
After switching back from the dark theme to the classic theme, the user config entry "StyleSheet" was not reset to the value for the classic theme. This caused the problem that was reported in issue #15890.

dark theme:
`<FCText Name="StyleSheet">FreeCAD Dark.qss</FCText>`

classic theme:
`<FCText Name="StyleSheet"></FCText>`