### PR TITLE
Use portable text to set shortcut

### DIFF
--- a/src/Gui/DlgKeyboardImp.cpp
+++ b/src/Gui/DlgKeyboardImp.cpp
@@ -457,10 +457,10 @@ void DlgCustomKeyboardImp::setShortcutOfCurrentAction(const QString& accelText)
     QVariant data = item->data(1, Qt::UserRole);
     QByteArray name = data.toByteArray(); // command name
 
-    QString nativeText;
+    QString portableText;
     if (!accelText.isEmpty()) {
         QKeySequence shortcut = accelText;
-        nativeText = shortcut.toString(QKeySequence::NativeText);
+        portableText = shortcut.toString(QKeySequence::PortableText);
         ui->accelLineEditShortcut->setText(accelText);
         ui->editShortcut->clear();
     }
@@ -468,7 +468,7 @@ void DlgCustomKeyboardImp::setShortcutOfCurrentAction(const QString& accelText)
         ui->accelLineEditShortcut->clear();
         ui->editShortcut->clear();
     }
-    ShortcutManager::instance()->setShortcut(name, nativeText.toLatin1());
+    ShortcutManager::instance()->setShortcut(name, portableText.toLatin1());
 
     ui->buttonAssign->setEnabled(false);
     ui->buttonReset->setEnabled(true);


### PR DESCRIPTION
This should resolve #9639.

At least on macOS, it seems that setting nontrivial shortcuts only works when the shortcut is converted to `PortableText`, rather than `NativeText`.

Before, it was impossible to map, eg, the backspace key or CMD-T to an action. Now this appears to work.

Happy to make any changes to this PR if needed :) 