### PR TITLE
Toponaming:  Support disabling hashing; getting element history

### DIFF
--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -117,6 +117,8 @@ public:
     PropertyString TipName;
     /// Whether to show hidden items in TreeView
     PropertyBool ShowHidden;
+    /// Whether to use hasher on topological naming
+    PropertyBool UseHasher;
     //@}
 
     /** @name Signals of the document */

--- a/src/Mod/Part/App/PartFeaturePy.xml
+++ b/src/Mod/Part/App/PartFeaturePy.xml
@@ -13,5 +13,20 @@
       <Author Licence="LGPL" Name="Juergen Riegel" EMail="FreeCAD@juergen-riegel.net" />
       <UserDocu>This is the father of all shape object classes</UserDocu>
     </Documentation>
+    <Methode Name="getElementHistory" Const="true" Keyword="true">
+      <Documentation>
+        <UserDocu>
+getElementHistory(name,recursive=True,sameType=False,showName=False) - returns the element mapped name history
+
+name: mapped element name belonging to this shape
+recursive: if True, then track back the history through other objects till the origin
+sameType: if True, then stop trace back when element type changes
+showName: if False, return the owner object, or else return a tuple of object name and label
+
+If not recursive, then return tuple(sourceObject, sourceElementName, [intermediateNames...]),
+otherwise return a list of tuple.
+        </UserDocu>
+      </Documentation>
+    </Methode>
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/Part/App/PartFeaturePyImp.cpp
+++ b/src/Mod/Part/App/PartFeaturePyImp.cpp
@@ -37,6 +37,45 @@ std::string PartFeaturePy::representation() const
     return {"<Part::PartFeature>"};
 }
 
+PyObject *PartFeaturePy::getElementHistory(PyObject *args, PyObject *kwds) {
+    const char *name;
+    PyObject *recursive = Py_True;
+    PyObject *sameType = Py_False;
+    PyObject *showName = Py_False;
+    static char *kwlist[] = {"elementName", "recursive", "sameType", "showName", nullptr};
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|OOO", kwlist, &name, &recursive, &sameType, &showName))
+        return {};
+
+    auto feature = getFeaturePtr();
+    Py::List list;
+    bool showObjName = PyObject_IsTrue(showName);
+    PY_TRY {
+        std::string tmp;
+        for (auto &history: Feature::getElementHistory(feature, name,
+                                                       PyObject_IsTrue(recursive), PyObject_IsTrue(sameType))) {
+            Py::Tuple ret(3);
+            if (history.obj) {
+                if (showObjName) {
+                    ret.setItem(0, Py::TupleN(Py::String(history.obj->getFullName()),
+                                              Py::String(history.obj->Label.getValue())));
+                } else
+                    ret.setItem(0, Py::Object(history.obj->getPyObject(), true));
+            } else
+                ret.setItem(0, Py::Int(history.tag));
+            tmp.clear();
+            ret.setItem(1, Py::String(history.element.appendToBuffer(tmp)));
+            Py::List intermedates;
+            for (auto &h: history.intermediates) {
+                tmp.clear();
+                intermedates.append(Py::String(h.appendToBuffer(tmp)));
+            }
+            ret.setItem(2, intermedates);
+            list.append(ret);
+        }
+        return Py::new_reference_to(list);
+    } PY_CATCH;
+}
+
 PyObject *PartFeaturePy::getCustomAttributes(const char* ) const
 {
     return nullptr;


### PR DESCRIPTION
Missing items to make https://github.com/realthunder/FreeCAD_assembly3/wiki/Topological-Naming-Algorithm#hashing-element-name instructions work in a main executable ( which is very useful)