### PR TITLE
MeasureGui: Fix inital label placement

### DIFF
--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -246,8 +246,15 @@ void TaskMeasure::update() {
     // Fill measure object's properties from selection
     _mMeasureObject->parseSelection(selection);
 
+    // Init the view object
+    Gui::ViewProvider* viewObj = Gui::Application::Instance->getViewProvider(_mMeasureObject);
+    if (viewObj) {
+        static_cast<MeasureGui::ViewProviderMeasureBase*>(viewObj)->positionAnno(_mMeasureObject);
+    }
+
     // Get result
     valueResult->setText(_mMeasureObject->getResultString());
+
 }
 
 void TaskMeasure::close(){

--- a/src/Mod/Measure/Gui/TaskMeasure.h
+++ b/src/Mod/Measure/Gui/TaskMeasure.h
@@ -29,6 +29,7 @@
 #include <App/MeasureManager.h>
 
 #include <Mod/Measure/App/MeasureBase.h>
+#include <Mod/Measure/Gui/ViewProviderMeasureBase.h>
 
 
 #include <Gui/TaskView/TaskDialog.h>

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -300,8 +300,6 @@ void ViewProviderMeasureBase::updateIcon() {
 void ViewProviderMeasureBase::attach(App::DocumentObject *pcObj)
 {
     ViewProviderDocumentObject::attach(pcObj);
-    auto measureObj = static_cast<MeasureBase*>(pcObj);
-    positionAnno(measureObj);
     updateIcon();
 }
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -642,8 +642,8 @@ Base::Vector3d ViewProviderMeasure::getBasePosition(){
     return placement.getPosition();
 }
 
-
 Base::Vector3d ViewProviderMeasure::getTextPosition(){
+    // Return the initial position relative to the base position
     auto basePoint = getBasePosition();
 
     Gui::View3DInventor* view = dynamic_cast<Gui::View3DInventor*>(this->getActiveView());
@@ -652,12 +652,14 @@ Base::Vector3d ViewProviderMeasure::getTextPosition(){
         return Base::Vector3d();
     }
     
-    Gui::View3DInventorViewer* viewer = view->getViewer();    
+    Gui::View3DInventorViewer* viewer = view->getViewer();
 
     // Convert to screenspace, offset and convert back to world space
     SbVec2s screenPos = viewer->getPointOnViewport(SbVec3f(basePoint.x, basePoint.y, basePoint.z));
-    SbVec3f textPos = viewer->getPointOnFocalPlane(screenPos + SbVec2s(30.0, 30.0));
-    return Base::Vector3d(textPos[0], textPos[1], textPos[2]);
+    SbVec3f vec = viewer->getPointOnFocalPlane(screenPos + SbVec2s(30.0, 30.0)); 
+    Base::Vector3d textPos(vec[0], vec[1], vec[2]);
+
+    return textPos - basePoint;
 }
 
 //! called by the system when it is time to display this measure


### PR DESCRIPTION
This solves the problem described in #13808 where the initial placement of simple label measurements was returned globally instead of relative to the root position. Also this PR adds a change to trigger the initial placement explicitly as the attach method (where it is currently triggered) is not the right place.

Fixes #13808