### PR TITLE
Material: Add metal cards with machining model

### DIFF
--- a/src/Mod/Material/CMakeLists.txt
+++ b/src/Mod/Material/CMakeLists.txt
@@ -228,12 +228,19 @@ SET(MachiningLib_Files
     Resources/Materials/Machining/Aluminum-6061.FCMat
     Resources/Materials/Machining/Aluminum-7075.FCMat
     Resources/Materials/Machining/Aluminum-Cast.FCMat
+    Resources/Materials/Machining/AluminumCastAlloy.FCMat
+    Resources/Materials/Machining/AluminumWroughtAlloy.FCMat
+    Resources/Materials/Machining/AusteniticStainlessSteel.FCMat
     Resources/Materials/Machining/Brass-Hard.FCMat
     Resources/Materials/Machining/Brass-Medium.FCMat
     Resources/Materials/Machining/Brass-Soft.FCMat
     Resources/Materials/Machining/CarbonSteel.FCMat
+    Resources/Materials/Machining/GrayCastIron.FCMat
     Resources/Materials/Machining/HardPlastics.FCMat
     Resources/Materials/Machining/Hardwood.FCMat
+    Resources/Materials/Machining/LowAlloySteel.FCMat
+    Resources/Materials/Machining/MalleableCastIron.FCMat
+    Resources/Materials/Machining/MildSteel.FCMat
     Resources/Materials/Machining/SoftPlastics.FCMat
     Resources/Materials/Machining/Softwood.FCMat
     Resources/Materials/Machining/Stainless-303.FCMat

--- a/src/Mod/Material/Resources/Materials/Machining/AluminumCastAlloy.FCMat
+++ b/src/Mod/Material/Resources/Materials/Machining/AluminumCastAlloy.FCMat
@@ -1,37 +1,37 @@
 General:
-  UUID: "32a4d8c1-89a5-4ca8-8d84-d3b6f5468880"
+  UUID: '048ba0ec-1fc4-4e3c-9710-bde305a1503f'
   Author: "Jonas Bähr"
   License: "CC-BY-3.0"
-  Name: "Tool Steel (unhardened)"
+  Name: "Aluminum (Hard Cast Alloy)"
   Description: >-
-    Prototype for normal, unhardened, cold working, tool steels.
-    Surface speeds given for uncoated bits; coated HSS bits can operate 2.3 times faster, carbite 30% faster.
+    Prototype for various high-silicon cast aluminium alloys.
+    Surface speeds given for uncoated bits; coated bits can operate 50% to 70% faster.
     Surface speeds given for roughing with a width of cut less than half the bit's diameter.
-    For finishing with woc <= 0.1 * D bits can operatre 30% to 50% faster.
-    For slotting with woc <= D carbite bits should operate 15% slower.
+    For finishing with woc <= 0.1 * D carbide bits can operatre 2.5 times faster.
+    For slotting with woc <= D HSS bits should operate 25% slower.
     NB: Specific alloys can deviate significantly!
     Source: Tabellenbuch Zerspantechnik, http://www.europa-lehrmittel.de/14733
 Inherits:
-  Steel:
-    UUID: "4b849c55-6b3a-4f75-a055-40c0d0324596"
+  Aluminum:
+    UUID: "d1f317f0-5ffa-4798-8ab3-af2ff0b5182c"
 Models:
   Father:
     UUID: '9cdda8b6-b606-4778-8f13-3934d8668e67'
     Father: "Metal"
   MaterialStandard:
     UUID: '1e2c0088-904a-4537-925f-64064c07d700'
-    KindOfMaterial: "Steel"
+    KindOfMaterial: "Aluminium"
   Machinability:
     UUID: '9d81fcb2-bf81-48e3-bb57-d45ecf380096'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 272
     # uncoated HSS, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedHSS: '15 m/min'
+    SurfaceSpeedHSS: '80 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 274
     # uncoated carbide, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedCarbide: '40 m/min'
+    SurfaceSpeedCarbide: '120 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 215
     # Chip compression correction for milling, 1.2, already applied,
-    # base rake angle transformed from gamma_0=6° (steel, cf. P. 216) to 0°
-    # i.e. 2500 * 1.2 / (1 - 6/100) is 3191.489
-    UnitCuttingForce: '3191 N/mm^2'
+    # base rake angle transformed from gamma_0=12° (aluminium, cf. P. 216) to 0°
+    # i.e. 680 * 1.2 / (1 - 12/100) is 927.273
+    UnitCuttingForce: '927 N/mm^2'
     ChipThicknessExponent: 0.27

--- a/src/Mod/Material/Resources/Materials/Machining/AluminumWroughtAlloy.FCMat
+++ b/src/Mod/Material/Resources/Materials/Machining/AluminumWroughtAlloy.FCMat
@@ -1,37 +1,38 @@
 General:
-  UUID: "32a4d8c1-89a5-4ca8-8d84-d3b6f5468880"
+  UUID: "5528dd01-e009-4e88-8c71-d5e9bbe8f7f3"
   Author: "Jonas Bähr"
   License: "CC-BY-3.0"
-  Name: "Tool Steel (unhardened)"
+  Name: "Aluminum (Soft Wrought Alloy)"
   Description: >-
-    Prototype for normal, unhardened, cold working, tool steels.
-    Surface speeds given for uncoated bits; coated HSS bits can operate 2.3 times faster, carbite 30% faster.
+    Prototype for various easy-to-machine wrought aluminium alloys.
+    Surface speeds given for uncoated bits; coated bits can operate 50% faster.
     Surface speeds given for roughing with a width of cut less than half the bit's diameter.
-    For finishing with woc <= 0.1 * D bits can operatre 30% to 50% faster.
-    For slotting with woc <= D carbite bits should operate 15% slower.
+    The same values can be used for slotting (woc <= D).
+    For finishing with woc <= 0.1 * D carbide bits can operatre 2.2 times faster.
     NB: Specific alloys can deviate significantly!
     Source: Tabellenbuch Zerspantechnik, http://www.europa-lehrmittel.de/14733
 Inherits:
-  Steel:
-    UUID: "4b849c55-6b3a-4f75-a055-40c0d0324596"
+  Aluminum:
+    UUID: "d1f317f0-5ffa-4798-8ab3-af2ff0b5182c"
 Models:
   Father:
     UUID: '9cdda8b6-b606-4778-8f13-3934d8668e67'
     Father: "Metal"
   MaterialStandard:
     UUID: '1e2c0088-904a-4537-925f-64064c07d700'
-    KindOfMaterial: "Steel"
+    KindOfMaterial: "Aluminium"
   Machinability:
     UUID: '9d81fcb2-bf81-48e3-bb57-d45ecf380096'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 272
     # uncoated HSS, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedHSS: '15 m/min'
+    SurfaceSpeedHSS: '120 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 274
     # uncoated carbide, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedCarbide: '40 m/min'
+    # under "favorable condition" 50% higher: 180 * 150% = 270
+    SurfaceSpeedCarbide: '270 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 215
     # Chip compression correction for milling, 1.2, already applied,
-    # base rake angle transformed from gamma_0=6° (steel, cf. P. 216) to 0°
-    # i.e. 2500 * 1.2 / (1 - 6/100) is 3191.489
-    UnitCuttingForce: '3191 N/mm^2'
+    # base rake angle transformed from gamma_0=12° (aluminium, cf. P. 216) to 0°
+    # i.e. 470 * 1.2 / (1 - 12/100) is 641.909
+    UnitCuttingForce: '641 N/mm^2'
     ChipThicknessExponent: 0.27

--- a/src/Mod/Material/Resources/Materials/Machining/AusteniticStainlessSteel.FCMat
+++ b/src/Mod/Material/Resources/Materials/Machining/AusteniticStainlessSteel.FCMat
@@ -1,14 +1,14 @@
 General:
-  UUID: "32a4d8c1-89a5-4ca8-8d84-d3b6f5468880"
+  UUID: "5857838c-56e3-493e-9d89-5896718f0a15"
   Author: "Jonas Bähr"
   License: "CC-BY-3.0"
-  Name: "Tool Steel (unhardened)"
+  Name: "Austenitic Stainless Steel"
   Description: >-
-    Prototype for normal, unhardened, cold working, tool steels.
-    Surface speeds given for uncoated bits; coated HSS bits can operate 2.3 times faster, carbite 30% faster.
+    Prototype for austenitic stainless steels.
+    Surface speeds given for uncoated bits; coated bits can operate 65% to 85% faster.
     Surface speeds given for roughing with a width of cut less than half the bit's diameter.
-    For finishing with woc <= 0.1 * D bits can operatre 30% to 50% faster.
-    For slotting with woc <= D carbite bits should operate 15% slower.
+    The same values can be used for slotting (woc <= D).
+    For finishing with woc <= 0.1 * D surface speeds can be increased by 30% to 50%.
     NB: Specific alloys can deviate significantly!
     Source: Tabellenbuch Zerspantechnik, http://www.europa-lehrmittel.de/14733
 Inherits:
@@ -25,13 +25,13 @@ Models:
     UUID: '9d81fcb2-bf81-48e3-bb57-d45ecf380096'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 272
     # uncoated HSS, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedHSS: '15 m/min'
+    SurfaceSpeedHSS: '12 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 274
     # uncoated carbide, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedCarbide: '40 m/min'
+    SurfaceSpeedCarbide: '45 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 215
     # Chip compression correction for milling, 1.2, already applied,
     # base rake angle transformed from gamma_0=6° (steel, cf. P. 216) to 0°
-    # i.e. 2500 * 1.2 / (1 - 6/100) is 3191.489
-    UnitCuttingForce: '3191 N/mm^2'
-    ChipThicknessExponent: 0.27
+    # i.e. 2000 * 1.2 / (1 - 6/100) is 2553.191
+    UnitCuttingForce: '2553 N/mm^2'
+    ChipThicknessExponent: 0.20

--- a/src/Mod/Material/Resources/Materials/Machining/GrayCastIron.FCMat
+++ b/src/Mod/Material/Resources/Materials/Machining/GrayCastIron.FCMat
@@ -1,14 +1,14 @@
 General:
-  UUID: "32a4d8c1-89a5-4ca8-8d84-d3b6f5468880"
+  UUID: "73b598d1-fa8a-4245-a87f-9f333abfe39c"
   Author: "Jonas Bähr"
   License: "CC-BY-3.0"
-  Name: "Tool Steel (unhardened)"
+  Name: "Gray Cast Iron"
   Description: >-
-    Prototype for normal, unhardened, cold working, tool steels.
-    Surface speeds given for uncoated bits; coated HSS bits can operate 2.3 times faster, carbite 30% faster.
+    Prototype for gray cast iron, GJL.
+    Surface speeds given for uncoated bits; coated bits can operate 2 times faster.
     Surface speeds given for roughing with a width of cut less than half the bit's diameter.
-    For finishing with woc <= 0.1 * D bits can operatre 30% to 50% faster.
-    For slotting with woc <= D carbite bits should operate 15% slower.
+    The same values can be used for slotting (woc = D).
+    For finishing with woc <= 0.1 * D carbide bits can operatre 30% faster.
     NB: Specific alloys can deviate significantly!
     Source: Tabellenbuch Zerspantechnik, http://www.europa-lehrmittel.de/14733
 Inherits:
@@ -20,18 +20,18 @@ Models:
     Father: "Metal"
   MaterialStandard:
     UUID: '1e2c0088-904a-4537-925f-64064c07d700'
-    KindOfMaterial: "Steel"
+    KindOfMaterial: "Cast Iron"
   Machinability:
     UUID: '9d81fcb2-bf81-48e3-bb57-d45ecf380096'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 272
     # uncoated HSS, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedHSS: '15 m/min'
+    SurfaceSpeedHSS: '25 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 274
     # uncoated carbide, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedCarbide: '40 m/min'
+    SurfaceSpeedCarbide: '60 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 215
     # Chip compression correction for milling, 1.2, already applied,
-    # base rake angle transformed from gamma_0=6° (steel, cf. P. 216) to 0°
-    # i.e. 2500 * 1.2 / (1 - 6/100) is 3191.489
-    UnitCuttingForce: '3191 N/mm^2'
-    ChipThicknessExponent: 0.27
+    # base rake angle transformed from gamma_0=2° (cast iron, cf. P. 216) to 0°
+    # i.e. 1050 * 1.2 / (1 - 2/100) is 1285.714
+    UnitCuttingForce: '1286 N/mm^2'
+    ChipThicknessExponent: 0.23

--- a/src/Mod/Material/Resources/Materials/Machining/LowAlloySteel.FCMat
+++ b/src/Mod/Material/Resources/Materials/Machining/LowAlloySteel.FCMat
@@ -1,14 +1,14 @@
 General:
-  UUID: "32a4d8c1-89a5-4ca8-8d84-d3b6f5468880"
+  UUID: "eb695e3f-4d45-4935-9f40-c4dd8966f0a8"
   Author: "Jonas Bähr"
   License: "CC-BY-3.0"
-  Name: "Tool Steel (unhardened)"
+  Name: "Low Alloy Steel"
   Description: >-
-    Prototype for normal, unhardened, cold working, tool steels.
-    Surface speeds given for uncoated bits; coated HSS bits can operate 2.3 times faster, carbite 30% faster.
+    Prototype for low alloy steels.
+    Surface speeds given for uncoated bits; coated bits can operate 1.5 to 2.5 times faster.
     Surface speeds given for roughing with a width of cut less than half the bit's diameter.
-    For finishing with woc <= 0.1 * D bits can operatre 30% to 50% faster.
-    For slotting with woc <= D carbite bits should operate 15% slower.
+    For finishing with woc <= 0.1 * D carbide bits can operatre 20% to 40% faster.
+    For slotting with woc <= D carbide bits should operate 10% to 25% slower.
     NB: Specific alloys can deviate significantly!
     Source: Tabellenbuch Zerspantechnik, http://www.europa-lehrmittel.de/14733
 Inherits:
@@ -25,13 +25,13 @@ Models:
     UUID: '9d81fcb2-bf81-48e3-bb57-d45ecf380096'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 272
     # uncoated HSS, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedHSS: '15 m/min'
+    SurfaceSpeedHSS: '20 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 274
     # uncoated carbide, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedCarbide: '40 m/min'
+    SurfaceSpeedCarbide: '60 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 215
     # Chip compression correction for milling, 1.2, already applied,
     # base rake angle transformed from gamma_0=6° (steel, cf. P. 216) to 0°
-    # i.e. 2500 * 1.2 / (1 - 6/100) is 3191.489
-    UnitCuttingForce: '3191 N/mm^2'
-    ChipThicknessExponent: 0.27
+    # i.e. 2200 * 1.2 / (1 - 6/100) is 2808.511
+    UnitCuttingForce: '2809 N/mm^2'
+    ChipThicknessExponent: 0.24

--- a/src/Mod/Material/Resources/Materials/Machining/MalleableCastIron.FCMat
+++ b/src/Mod/Material/Resources/Materials/Machining/MalleableCastIron.FCMat
@@ -1,14 +1,14 @@
 General:
-  UUID: "32a4d8c1-89a5-4ca8-8d84-d3b6f5468880"
+  UUID: "b5c9fff8-0a37-4a62-b633-81a737744d19"
   Author: "Jonas Bähr"
   License: "CC-BY-3.0"
-  Name: "Tool Steel (unhardened)"
+  Name: "Malleable Cast Iron"
   Description: >-
-    Prototype for normal, unhardened, cold working, tool steels.
-    Surface speeds given for uncoated bits; coated HSS bits can operate 2.3 times faster, carbite 30% faster.
+    Prototype for malleable cast iron, GJM.
+    Surface speeds given for uncoated bits; coated bits can operate 60% to 70% faster.
     Surface speeds given for roughing with a width of cut less than half the bit's diameter.
-    For finishing with woc <= 0.1 * D bits can operatre 30% to 50% faster.
-    For slotting with woc <= D carbite bits should operate 15% slower.
+    The same values can be used for slotting (woc <= D)
+    For finishing with woc <= 0.1 * D bits can operatre 10% to 20% faster.
     NB: Specific alloys can deviate significantly!
     Source: Tabellenbuch Zerspantechnik, http://www.europa-lehrmittel.de/14733
 Inherits:
@@ -20,18 +20,18 @@ Models:
     Father: "Metal"
   MaterialStandard:
     UUID: '1e2c0088-904a-4537-925f-64064c07d700'
-    KindOfMaterial: "Steel"
+    KindOfMaterial: "Cast Iron"
   Machinability:
     UUID: '9d81fcb2-bf81-48e3-bb57-d45ecf380096'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 272
     # uncoated HSS, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedHSS: '15 m/min'
+    SurfaceSpeedHSS: '18 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 274
     # uncoated carbide, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedCarbide: '40 m/min'
+    SurfaceSpeedCarbide: '50 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 215
     # Chip compression correction for milling, 1.2, already applied,
-    # base rake angle transformed from gamma_0=6° (steel, cf. P. 216) to 0°
-    # i.e. 2500 * 1.2 / (1 - 6/100) is 3191.489
-    UnitCuttingForce: '3191 N/mm^2'
-    ChipThicknessExponent: 0.27
+    # base rake angle transformed from gamma_0=2° (cast iron, cf. P. 216) to 0°
+    # i.e. 1500 * 1.2 / (1 - 2/100) is 1836.735
+    UnitCuttingForce: '1837 N/mm^2'
+    ChipThicknessExponent: 0.28

--- a/src/Mod/Material/Resources/Materials/Machining/MildSteel.FCMat
+++ b/src/Mod/Material/Resources/Materials/Machining/MildSteel.FCMat
@@ -1,14 +1,14 @@
 General:
-  UUID: "32a4d8c1-89a5-4ca8-8d84-d3b6f5468880"
+  UUID: "029b8fac-d453-4ff5-ba26-b37a79a33d97"
   Author: "Jonas Bähr"
   License: "CC-BY-3.0"
-  Name: "Tool Steel (unhardened)"
+  Name: "Mild Steel"
   Description: >-
-    Prototype for normal, unhardened, cold working, tool steels.
-    Surface speeds given for uncoated bits; coated HSS bits can operate 2.3 times faster, carbite 30% faster.
+    Prototype for soft unalloyed steels with low carbon content.
+    Surface speeds given for uncoated bits; coated bits can operate 70% to 260% faster.
     Surface speeds given for roughing with a width of cut less than half the bit's diameter.
-    For finishing with woc <= 0.1 * D bits can operatre 30% to 50% faster.
-    For slotting with woc <= D carbite bits should operate 15% slower.
+    For finishing with woc <= 0.1 * D bits can operatre 20% to 40% faster.
+    For slotting with woc <= D carbide bits should operate 15% slower.
     NB: Specific alloys can deviate significantly!
     Source: Tabellenbuch Zerspantechnik, http://www.europa-lehrmittel.de/14733
 Inherits:
@@ -25,13 +25,13 @@ Models:
     UUID: '9d81fcb2-bf81-48e3-bb57-d45ecf380096'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 272
     # uncoated HSS, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedHSS: '15 m/min'
+    SurfaceSpeedHSS: '25 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 274
     # uncoated carbide, contour milling, roughing (woc: < 0.5 D, doc: < 1.5 D)
-    SurfaceSpeedCarbide: '40 m/min'
+    SurfaceSpeedCarbide: '70 m/min'
     # ISBN 978-3-7585-1315-2, 5. Edition 2022, P. 215
     # Chip compression correction for milling, 1.2, already applied,
     # base rake angle transformed from gamma_0=6° (steel, cf. P. 216) to 0°
-    # i.e. 2500 * 1.2 / (1 - 6/100) is 3191.489
-    UnitCuttingForce: '3191 N/mm^2'
-    ChipThicknessExponent: 0.27
+    # i.e. 1800 * 1.2 / (1 - 6/100) is 2297.872
+    UnitCuttingForce: '2298 N/mm^2'
+    ChipThicknessExponent: 0.20


### PR DESCRIPTION
This PR extends @sliptonic's #14460, where the "machinability" model was introduced. There, as sample data, the legacy material cards from the ["feeds and speeds" addon](https://github.com/dubstar-04/FeedsAndSpeeds) were added and (partly) converted to the new format. However, due to copyright concerns, unclear semantics and unknown source of the data, the values required for cutting force calculations have been removed.

This PR adds material cards with complete machining model data for various classes of metals. The data comes from the German standard work ["Tabellenbuch Zerspantechnik"](http://www.europa-lehrmittel.de/14733), ISBN 978-3-7585-1315-2, 5. Edition 2022.
Usage of this data for our purpose is legal as facts are not protected by copyright according to German law. 
A comprehensive summary is published by the German federal ministry of education an research: [“Urheberrecht in der Wissenschaft”](https://www.bmbf.de/SharedDocs/Publikationen/de/bmbf/1/31518_Urheberrecht_in_der_Wissenschaft.pdf?__blob=publicationFile&v=8), Page 32. (There is an [official English translation](https://www.bmbf.de/SharedDocs/Publikationen/de/bmbf/FS/31580_Urheberrecht_in_der_Wissenschaft_en.pdf?__blob=publicationFile&v=5) available, unfortunately not as detailed as the original.)
This view has been confirmed by the licensing department of the publisher. They just kindly asked to give them credit, even though not strictly required by German law — fair enough if you ask me.

In its current state, the PR does not remove the previous data from #14460. I suggest to do so, as I see no point in shipping incomplete data of unknown provenance (at least the debian maintainers are very sensitive on this last point). But I'd like to hear other opinions on this first.

Here is an example of how to use the data to calculate the required cutting forces, spindle speed, power and torque as well as horizontal feed for contour milling:
(to fully integrate this into FC, we need to extend the tool bits with some additional properties, but that's another story)
```py
from math import acos, sqrt
from math import degrees, radians, pi
import Materials;

materialManager = Materials.MaterialManager()
alu = materialManager.getMaterial('5528dd01-e009-4e88-8c71-d5e9bbe8f7f3')
alu.Name
alu.Description

kc11 = FreeCAD.Units.Quantity(alu.PhysicalProperties['UnitCuttingForce']) # why is the property a string, not a Quantity as defined by the model???
h0 = FreeCAD.Units.Quantity('1 mm') # unit chip thickness, per definition 1mm for k_c1.1
mc = float(alu.PhysicalProperties['ChipThicknessExponent']) # why is the property a string, not a float as defined by the model???

ToolRakeAngle = FreeCAD.Units.Quantity('20°')
Kg = 1 - 0.01 * ToolRakeAngle.getValueAs("deg") # correction factor for rake angle

ToolDiameter = FreeCAD.Units.Quantity('6 mm')
D = ToolDiameter

ae = FreeCAD.Units.Quantity('2.5 mm') # width of cut (radial)
ap = FreeCAD.Units.Quantity('5 mm') # depth of cut (axial)

ToolNumberOfFlutes = 3
z = ToolNumberOfFlutes

ToolHelixAngle = FreeCAD.Units.Quantity('35°')

#kapr = radians(90 - ToolHelixAngle.getValueAs("deg")) # this looks wired! to be investigated
kapr = radians(90) # straight milling cutter, i.e. chamfer=90° aka no chamfer

fz = FreeCAD.Units.Quantity('0.03 mm') # feed per tooth

phie = acos(1 - (2 * ae / D)) # engangement angle

#hm = sqrt(ae/D) * fz * sin(kapr) # mean undeformed chip thickness; good approximation for ae << D; 20%-30% too large for ae=D
Sb = D * pi * (phie / (2*pi)) # chip arc length
hm = fz * (ae/Sb) * sin(kapr) # mean undeformed chip thickness using Cavalieri's principle

Kw = 1.2 # correction factor for tool wear: 1 for new sharp tools, 1.2 for used tools, 1.5 for dull tools that need to be replaced

kc = kc11 * (hm/h0)**-mc * Kg * Kw # specific cutting force

Fcz = ap * hm * kc # cutting force per flute

ze = phie * z / (2*pi) # engaged flutes

Fc = Fcz * ze # cutting force

vc = FreeCAD.Units.Quantity(alu.PhysicalProperties['SurfaceSpeedCarbide'])

Pc = Fc * vc # mechanical cutting power

eff = 0.85 # machine efficiency: 
P = Pc / eff # electrical spindle power
P.getValueAs("kW")

Mc = Fc * D / 2 # cutting torque
Mc.getValueAs("Nm")

n = vc / (pi * D) # spindle speed
n.getValueAs("1/min")

vf = n * z * fz # feed rate
vf.getValueAs("mm/min")
```