### PR TITLE
MacOS: Modify OS detection macro

### DIFF
--- a/src/Gui/Assistant.cpp
+++ b/src/Gui/Assistant.cpp
@@ -80,7 +80,7 @@ bool Assistant::startAssistant()
         QString app;
         app = QDir::toNativeSeparators(QString::fromStdString
             (App::Application::getHomePath()) + QLatin1String("bin/"));
-#elif defined(Q_OS_APPLE)
+#elif defined(Q_OS_MACOS)
         QString app = QCoreApplication::applicationDirPath() + QDir::separator();
 #else
 #if QT_VERSION < QT_VERSION_CHECK(6,0,0)

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -1264,7 +1264,7 @@ void PythonConsole::runSourceFromMimeData(const QString& source)
 #elif defined(Q_OS_WIN32)
     // Need to convert CRLF to LF
     text.replace(QLatin1String("\r\n"), QLatin1String("\n"));
-#elif defined(Q_OS_APPLE)
+#elif defined(Q_OS_MACOS)
     //need to convert CR to LF
     text.replace(QLatin1Char('\r'), QLatin1Char('\n'));
 #endif

--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -96,7 +96,7 @@ TDragger::TDragger()
 {
     SO_KIT_CONSTRUCTOR(TDragger);
 
-#if defined(Q_OS_APPLE)
+#if defined(Q_OS_MACOS)
     this->ref();
 #endif
 
@@ -400,7 +400,7 @@ void TPlanarDragger::initClass()
 TPlanarDragger::TPlanarDragger()
 {
     SO_KIT_CONSTRUCTOR(TPlanarDragger);
-#if defined(Q_OS_APPLE)
+#if defined(Q_OS_MACOS)
     this->ref();
 #endif
 
@@ -698,7 +698,7 @@ void RDragger::initClass()
 RDragger::RDragger()
 {
     SO_KIT_CONSTRUCTOR(RDragger);
-#if defined(Q_OS_APPLE)
+#if defined(Q_OS_MACOS)
     this->ref();
 #endif
 

--- a/src/Gui/ToolHandler.cpp
+++ b/src/Gui/ToolHandler.cpp
@@ -123,7 +123,7 @@ void ToolHandler::setSvgCursor(const QString& cursorName,
     qreal defaultCursorSize = isRatioOne ? 64 : 32;
     qreal hotX = x;
     qreal hotY = y;
-#if !defined(Q_OS_WIN32) && !defined(Q_OS_APPLE)
+#if !defined(Q_OS_WIN32) && !defined(Q_OS_MACOS)
     if (qGuiApp->platformName() == QLatin1String("xcb")) {
         hotX *= pRatio;
         hotY *= pRatio;
@@ -157,7 +157,7 @@ void ToolHandler::setCursor(const QPixmap& p, int x, int y, bool autoScale)
             p1.setDevicePixelRatio(pRatio);
             qreal hotX = x;
             qreal hotY = y;
-#if !defined(Q_OS_WIN32) && !defined(Q_OS_APPLE)
+#if !defined(Q_OS_WIN32) && !defined(Q_OS_MACOS)
             if (qGuiApp->platformName() == QLatin1String("xcb")) {
                 hotX *= pRatio;
                 hotY *= pRatio;


### PR DESCRIPTION
Attempt to fix #15904 -- maybe on the Conda build system the macros are defined differently?

ETA: tested with a local Conda build and this does solve the transform problem.