### PR TITLE
Set correct measurement utility colors for Classic theme.

### DIFF
--- a/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
@@ -7,6 +7,13 @@
           <FCParamGroup Name="Start">
             <FCBool Name="FileCardUseStyleSheet" Value="0"/>
           </FCParamGroup>
+          <FCParamGroup Name="Measure">
+            <FCParamGroup Name="Appearance">
+              <FCUInt Name="DefaultTextColor" Value="4177132287"/>
+              <FCUInt Name="DefaultLineColor" Value="4177132287"/>
+              <FCUInt Name="DefaultTextBackgroundColor" Value="556083711"/>
+            </FCParamGroup>
+          </FCParamGroup>
         </FCParamGroup>
         <FCParamGroup Name="MainWindow">
           <FCText Name="Theme">FreeCAD Classic</FCText>


### PR DESCRIPTION
Resolves https://github.com/FreeCAD/FreeCAD/issues/14410 by defining default colors for the measurement utility. This is a very simple change/correction.