### PR TITLE
Horrible hack to work around bug in OCCT7.7.2

### DIFF
--- a/src/Mod/Part/App/PrimitiveFeature.cpp
+++ b/src/Mod/Part/App/PrimitiveFeature.cpp
@@ -652,6 +652,13 @@ App::DocumentObjectExecReturn *Cone::execute()
         return new App::DocumentObjectExecReturn("Radius of cone too small");
     if (Height.getValue() < Precision::Confusion())
         return new App::DocumentObjectExecReturn("Height of cone too small");
+    double angle = Angle.getValue();
+#if OCC_VERSION_HEX == 0x070702
+    // OCCT 7.7.2 will not model a cone with an angle of exactly 360, so we cheat:
+    if ( angle == 360.0) {
+        angle = 359.99;
+    }
+#endif
     try {
         TopoDS_Shape ResultShape;
         if (std::abs(Radius1.getValue() - Radius2.getValue()) < Precision::Confusion()){
@@ -665,7 +672,7 @@ App::DocumentObjectExecReturn *Cone::execute()
             BRepPrimAPI_MakeCone mkCone(Radius1.getValue(),
                                         Radius2.getValue(),
                                         Height.getValue(),
-                                        Angle.getValue()/180.0f*M_PI);
+                                        angle/180.0f*M_PI);
             ResultShape = mkCone.Shape();
         }
         this->Shape.setValue(ResultShape);


### PR DESCRIPTION
Fix #15599.

The failure is actually in cone, and represents a bug in 7.7.2 but not 7.6.3 and not 7.8.x.  Angle values of 360.0 fail completely, 359.9999 and 359.999 partially, and 359.99 results in an ugly fix.

If it isn't clear, I hate this code, but it seems like the pragmatic best choice; the alternative is FreeCADs with 7.7.2 don't work with cones of 360 degrees.  I'm gonna take a bath now. 