### PR TITLE
Gui: Fix issue with missing icons in sketcher

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -538,18 +538,12 @@ bool ActionGroup::doesRememberLast() const
 
 QAction* ActionGroup::addAction(QAction* action)
 {
-    int index = groupAction()->actions().size();
-    action = groupAction()->addAction(action);
-    action->setData(QVariant(index));
-    return action;
+    return groupAction()->addAction(action);
 }
 
 QAction* ActionGroup::addAction(const QString& text)
 {
-    int index = groupAction()->actions().size();
-    QAction* action = groupAction()->addAction(text);
-    action->setData(QVariant(index));
-    return action;
+    return groupAction()->addAction(text);
 }
 
 QList<QAction*> ActionGroup::actions() const
@@ -559,8 +553,9 @@ QList<QAction*> ActionGroup::actions() const
 
 int ActionGroup::checkedAction() const
 {
-    QAction* checked = groupAction()->checkedAction();
-    return checked ? checked->data().toInt() : -1;
+    auto checked = groupAction()->checkedAction();
+    
+    return actions().indexOf(checked);
 }
 
 void ActionGroup::setCheckedAction(int index)


### PR DESCRIPTION
This boiled down to conflict of using `data` attribute of the QAction in ActionGroup and ToolBarManager. I reworked ActionGroup here to not use the data attribute but this is not a proper solution - but it should be working well enough.

Proper solution would be to leave the data for the specific usecases (like index) and store the command name in some other place. It would however require us to subclass the QAction which is not something that should be done so late in the release cycle.

More information here: https://github.com/FreeCAD/FreeCAD/issues/13243#issuecomment-2295016166

Fixes: #13243 