### PR TITLE
PD: Make PD tests more robust

### DIFF
--- a/src/Mod/PartDesign/PartDesignTests/TestLinearPattern.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestLinearPattern.py
@@ -41,6 +41,7 @@ class TestLinearPattern(unittest.TestCase):
         self.LinearPattern.Direction = (self.Doc.X_Axis,[""])
         self.LinearPattern.Length = 90.0
         self.LinearPattern.Occurrences = 10
+        self.LinearPattern.Refine = True
         self.Body.addObject(self.LinearPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.LinearPattern.Shape.Volume, 1e4)
@@ -69,6 +70,7 @@ class TestLinearPattern(unittest.TestCase):
         self.LinearPattern.Direction = (self.Doc.Y_Axis,[""])
         self.LinearPattern.Length = 90.0
         self.LinearPattern.Occurrences = 10
+        self.LinearPattern.Refine = True
         self.Body.addObject(self.LinearPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.LinearPattern.Shape.Volume, 1e4)
@@ -88,6 +90,7 @@ class TestLinearPattern(unittest.TestCase):
         self.LinearPattern.Direction = (self.Doc.Z_Axis,[""])
         self.LinearPattern.Length = 90.0
         self.LinearPattern.Occurrences = 10
+        self.LinearPattern.Refine = True
         self.Body.addObject(self.LinearPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.LinearPattern.Shape.Volume, 1e4)
@@ -110,6 +113,7 @@ class TestLinearPattern(unittest.TestCase):
         self.LinearPattern.Direction = (self.PadSketch,["N_Axis"])
         self.LinearPattern.Length = 90.0
         self.LinearPattern.Occurrences = 10
+        self.LinearPattern.Refine = True
         self.Body.addObject(self.LinearPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.LinearPattern.Shape.Volume, 1e4)
@@ -132,6 +136,7 @@ class TestLinearPattern(unittest.TestCase):
         self.LinearPattern.Direction = (self.PadSketch,["V_Axis"])
         self.LinearPattern.Length = 90.0
         self.LinearPattern.Occurrences = 10
+        self.LinearPattern.Refine = True
         self.Body.addObject(self.LinearPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.LinearPattern.Shape.Volume, 1e4)
@@ -154,6 +159,7 @@ class TestLinearPattern(unittest.TestCase):
         self.LinearPattern.Direction = (self.PadSketch,["H_Axis"])
         self.LinearPattern.Length = 90.0
         self.LinearPattern.Occurrences = 10
+        self.LinearPattern.Refine = True
         self.Body.addObject(self.LinearPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.LinearPattern.Shape.Volume, 1e4)

--- a/src/Mod/PartDesign/PartDesignTests/TestPolarPattern.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPolarPattern.py
@@ -41,6 +41,7 @@ class TestPolarPattern(unittest.TestCase):
         self.PolarPattern.Axis = (self.Doc.X_Axis,[""])
         self.PolarPattern.Angle = 360
         self.PolarPattern.Occurrences = 4
+        self.PolarPattern.Refine = True
         self.Body.addObject(self.PolarPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.PolarPattern.Shape.Volume, 4000)
@@ -60,6 +61,7 @@ class TestPolarPattern(unittest.TestCase):
         self.PolarPattern.Axis = (self.Doc.Y_Axis,[""])
         self.PolarPattern.Angle = 360
         self.PolarPattern.Occurrences = 4
+        self.PolarPattern.Refine = True
         self.Body.addObject(self.PolarPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.PolarPattern.Shape.Volume, 4000)
@@ -79,6 +81,7 @@ class TestPolarPattern(unittest.TestCase):
         self.PolarPattern.Axis = (self.Doc.Z_Axis,[""])
         self.PolarPattern.Angle = 360
         self.PolarPattern.Occurrences = 4
+        self.PolarPattern.Refine = True
         self.Body.addObject(self.PolarPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.PolarPattern.Shape.Volume, 4000)
@@ -101,6 +104,7 @@ class TestPolarPattern(unittest.TestCase):
         self.PolarPattern.Axis = (self.PadSketch,["N_Axis"])
         self.PolarPattern.Angle = 360
         self.PolarPattern.Occurrences = 4
+        self.PolarPattern.Refine = True
         self.Body.addObject(self.PolarPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.PolarPattern.Shape.Volume, 4000)
@@ -123,6 +127,7 @@ class TestPolarPattern(unittest.TestCase):
         self.PolarPattern.Axis = (self.PadSketch,["V_Axis"])
         self.PolarPattern.Angle = 360
         self.PolarPattern.Occurrences = 4
+        self.PolarPattern.Refine = True
         self.Body.addObject(self.PolarPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.PolarPattern.Shape.Volume, 4000)
@@ -145,6 +150,7 @@ class TestPolarPattern(unittest.TestCase):
         self.PolarPattern.Axis = (self.PadSketch,["H_Axis"])
         self.PolarPattern.Angle = 360
         self.PolarPattern.Occurrences = 4
+        self.PolarPattern.Refine = True
         self.Body.addObject(self.PolarPattern)
         self.Doc.recompute()
         self.assertAlmostEqual(self.PolarPattern.Shape.Volume, 4000)

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -676,6 +676,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         pocket.Length = 5
         pocket.Direction = (0, 0, -1)
         pocket.ReferenceAxis = (sketch, ['N_Axis'])
+        pocket.Refine = True
 
         body.addObject(sketch)
         body.addObject(pocket)


### PR DESCRIPTION
If in the user settings the refinement is switched off several PD tests will fail. This change explicitly sets the Refine property to True to guarantee correct behaviour