### PR TITLE
Gui: Workaround for #14350

### DIFF
--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -261,7 +261,23 @@ void PropertyEditor::closeEditor()
     if (editingIndex.isValid()) {
         Base::StateLocker guard(closingEditor);
         bool hasFocus = activeEditor && activeEditor->hasFocus();
+#ifdef Q_OS_MACOS
+        // Brute-force workaround for https://github.com/FreeCAD/FreeCAD/issues/14350
+        int currentIndex = 0;
+        QTabBar *tabBar = nullptr;
+        if (auto mdiArea = Gui::MainWindow::getInstance()->findChild<QMdiArea*>()) {
+            tabBar = mdiArea->findChild<QTabBar*>();
+            if (tabBar) {
+                currentIndex = tabBar->currentIndex();
+            }
+        }
+#endif
         closePersistentEditor(editingIndex);
+#ifdef Q_OS_MACOS
+        if (tabBar) {
+            tabBar->setCurrentIndex(currentIndex);
+        }
+#endif
         editingIndex = QPersistentModelIndex();
         activeEditor = nullptr;
         if(hasFocus)


### PR DESCRIPTION
On macOS, when closing a persistent property editor, Qt switches the MDIView active tab to the first one, regardless of which you are currently editing. This adds a workaround that records the active tab and explicitly sets it after closing the editor. Because there is no redraw in between these events, the switch is not visible.

Fixes #14350 