### PR TITLE
Gui: Correct repeated extension

### DIFF
--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -196,7 +196,7 @@ QString FileDialog::getSaveFileName (QWidget * parent, const QString & caption, 
         }
 
         QRegularExpression rx;
-        rx.setPattern(QLatin1String(R"(\s(\(\*\.\w{1,})\W)"));
+        rx.setPattern(QLatin1String(R"(\s\((\*\.\w{1,})\W)"));
         QStringList possibleSuffixes;
         getPossibleSuffixes(possibleSuffixes, rx, filterToSearch);
         auto match = rx.match(*filterToSearch);
@@ -207,7 +207,8 @@ QString FileDialog::getSaveFileName (QWidget * parent, const QString & caption, 
             int offsetStart = 3;
             int offsetEnd = 4;
             QString suffix = filterToSearch->mid(index + offsetStart, length - offsetEnd);
-            if (fi.suffix().isEmpty() || !possibleSuffixes.contains(fi.suffix())) {
+            QString fiSuffix = QLatin1String("*.") + fi.suffix();  // To match with possibleSuffixes
+            if (fi.suffix().isEmpty() || !possibleSuffixes.contains(fiSuffix)) {
                 dirName += suffix;
             }
         }


### PR DESCRIPTION
Fixes #15908 -- the list of possible suffixes was including the "(" in the first suffix, which would then never match with anything, and when checking the list later, the `FileInfo::suffix()` does not include the "*.", so would again never match anything.