### PR TITLE
CMake: Use RelWithDebInfo for Conda Windows Debug builds.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -276,7 +276,13 @@
         "inherits": [
           "conda-debug",
           "conda-windows"
-        ]
+        ],
+        "cacheVariables": {
+          "CMAKE_BUILD_TYPE": {
+            "type": "STRING",
+            "value": "RelWithDebInfo"
+          }
+        }
       },
       {
         "name": "conda-windows-release",


### PR DESCRIPTION
Python is not provided with debug libraries, so debug builds are not possible. Building as RelWithDebInfo will build debug information for the binary, while using the available release libraries.