### PR TITLE
Correct element map support in Revolution

### DIFF
--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -1106,7 +1106,8 @@ public:
 
     /** Make revolved shell around a basis shape
      *
-     * @param base: the basis shape
+     * @param base: the basis shape (solid)
+     * @param profile: the shape to be revolved
      * @param axis: the revolving axis
      * @param face_maker: optional type name of the the maker used to make a
      *                    face from basis shape
@@ -1120,6 +1121,7 @@ public:
      * @return Return the generated new shape. The TopoShape itself is not modified.
      */
     TopoShape& makeElementRevolution(const TopoShape& _base,
+                                     const TopoDS_Shape& profile,
                                      const gp_Ax1& axis,
                                      const TopoDS_Face& supportface,
                                      const TopoDS_Face& uptoface,
@@ -1143,6 +1145,7 @@ public:
      * @return Return the generated new shape. The TopoShape itself is not modified.
      */
     TopoShape& makeElementRevolution(const gp_Ax1& axis,
+                                     const TopoDS_Shape& profile,
                                      const TopoDS_Face& supportface,
                                      const TopoDS_Face& uptoface,
                                      const char* face_maker = nullptr,
@@ -1151,6 +1154,7 @@ public:
                                      const char* op = nullptr) const
     {
         return TopoShape(0, Hasher).makeElementRevolution(*this,
+                                                          profile,
                                                           axis,
                                                           supportface,
                                                           uptoface,

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -97,6 +97,7 @@
 #include "Geometry.h"
 #include "BRepOffsetAPI_MakeOffsetFix.h"
 #include "Base/Tools.h"
+#include "Base/BoundBox.h"
 
 #include <App/ElementMap.h>
 #include <App/ElementNamingUtils.h>
@@ -4471,6 +4472,7 @@ TopoShape& TopoShape::makeElementRevolve(const TopoShape& _base,
 }
 
 TopoShape& TopoShape::makeElementRevolution(const TopoShape& _base,
+                                            const TopoDS_Shape& profile,
                                             const gp_Ax1& axis,
                                             const TopoDS_Face& supportface,
                                             const TopoDS_Face& uptoface,
@@ -4482,7 +4484,9 @@ TopoShape& TopoShape::makeElementRevolution(const TopoShape& _base,
     if (!op) {
         op = Part::OpCodes::Revolve;
     }
-
+    if (Mode == RevolMode::None) {
+        Mode = RevolMode::FuseWithBase;
+    }
     TopoShape base(_base);
     if (base.isNull()) {
         FC_THROWM(NullShapeException, "Null shape");
@@ -4495,8 +4499,8 @@ TopoShape& TopoShape::makeElementRevolution(const TopoShape& _base,
     }
 
     BRepFeat_MakeRevol mkRevol;
-    for (TopExp_Explorer xp(base.getShape(), TopAbs_FACE); xp.More(); xp.Next()) {
-        mkRevol.Init(_base.getShape(),
+    for (TopExp_Explorer xp(profile, TopAbs_FACE); xp.More(); xp.Next()) {
+        mkRevol.Init(base.getShape(),
                      xp.Current(),
                      supportface,
                      axis,
@@ -4507,9 +4511,6 @@ TopoShape& TopoShape::makeElementRevolution(const TopoShape& _base,
             throw Base::RuntimeError("Revolution: Up to face: Could not revolve the sketch!");
         }
         base = mkRevol.Shape();
-        if (Mode == RevolMode::None) {
-            Mode = RevolMode::FuseWithBase;
-        }
     }
     return makeElementShape(mkRevol, base, op);
 }

--- a/src/Mod/PartDesign/App/FeatureRevolution.h
+++ b/src/Mod/PartDesign/App/FeatureRevolution.h
@@ -96,7 +96,7 @@ protected:
      * Generates a revolution of the input sketchshape and stores it in the given \a revol.
      */
     void generateRevolution(TopoShape& revol,
-                            const TopoDS_Shape& sketchshape,
+                            const TopoShape& sketchshape,
                             const gp_Ax1& ax1,
                             const double angle,
                             const double angle2,
@@ -108,8 +108,8 @@ protected:
      * Generates a revolution of the input \a profileshape.
      * It will be a stand-alone solid created with BRepFeat_MakeRevol.
      */
-    void generateRevolution(TopoDS_Shape& revol,
-                            const TopoDS_Shape& baseshape,
+    void generateRevolution(TopoShape& revol,
+                            const TopoShape& baseshape,
                             const TopoDS_Shape& profileshape,
                             const TopoDS_Face& supportface,
                             const TopoDS_Face& uptoface,


### PR DESCRIPTION
Make element maps refer to history correctly; test for it.