### PR TITLE
Fem: Undo Python object creation by pressing cancel button

### DIFF
--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -570,6 +570,7 @@ SET(FemGuiObjects_SRCS
 
 SET(FemGuiTaskPanels_SRCS
     femtaskpanels/__init__.py
+    femtaskpanels/base_femtaskpanel.py
     femtaskpanels/task_constraint_bodyheatsource.py
     femtaskpanels/task_constraint_centrif.py
     femtaskpanels/task_constraint_currentdensity.py

--- a/src/Mod/Fem/Gui/TaskDlgMeshShapeNetgen.cpp
+++ b/src/Mod/Fem/Gui/TaskDlgMeshShapeNetgen.cpp
@@ -29,7 +29,7 @@
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Gui/Application.h>
-#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 #include <Gui/Document.h>
 #include <Gui/MainWindow.h>
 #include <Gui/WaitCursor.h>
@@ -112,7 +112,9 @@ bool TaskDlgMeshShapeNetgen::accept()
         }
 
         // FemSetNodesObject->Label.setValue(name->name);
-        Gui::Command::doCommand(Gui::Command::Gui, "Gui.activeDocument().resetEdit()");
+        App::Document* doc = FemMeshShapeNetgenObject->getDocument();
+        Gui::cmdAppDocument(doc, "recompute()");
+        Gui::cmdGuiDocument(doc, "resetEdit()");
         Gui::Command::commitCommand();
 
         return true;
@@ -132,7 +134,9 @@ bool TaskDlgMeshShapeNetgen::reject()
     //     //    doc->resetEdit();
     // param->MeshViewProvider->resetHighlightNodes();
     Gui::Command::abortCommand();
-    Gui::Command::doCommand(Gui::Command::Gui, "Gui.activeDocument().resetEdit()");
+    App::Document* doc = FemMeshShapeNetgenObject->getDocument();
+    Gui::cmdGuiDocument(doc, "resetEdit()");
+    Gui::cmdAppDocument(doc, "recompute()");
 
     return true;
 }

--- a/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
@@ -596,11 +596,11 @@ void ViewProviderFemMesh::resetHighlightNodes()
 
 PyObject* ViewProviderFemMesh::getPyObject()
 {
-    if (PythonObject.is(Py::_None())) {
-        // ref counter is set to 1
-        PythonObject = Py::Object(new ViewProviderFemMeshPy(this), true);
+    if (!pyViewObject) {
+        pyViewObject = new ViewProviderFemMeshPy(this);
     }
-    return Py::new_reference_to(PythonObject);
+    pyViewObject->IncRef();
+    return pyViewObject;
 }
 
 void ViewProviderFemMesh::setDisplacementByNodeId(const std::map<long, Base::Vector3d>& NodeDispMap)

--- a/src/Mod/Fem/Gui/ViewProviderFemMesh.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemMesh.h
@@ -145,8 +145,6 @@ private:
     static App::PropertyFloatConstraint::Constraints floatRange;
     static const char* colorModeEnum[];
 
-    Py::Object PythonObject;
-
 protected:
     /// get called by the container whenever a property has been changed
     void onChanged(const App::Property* prop) override;

--- a/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
@@ -240,9 +240,9 @@ void ViewProviderFemPostPipeline::scaleField(vtkDataSet* dset,
 
 PyObject* ViewProviderFemPostPipeline::getPyObject()
 {
-    if (PythonObject.is(Py::_None())) {
-        // ref counter is set to 1
-        PythonObject = Py::Object(new ViewProviderFemPostPipelinePy(this), true);
+    if (!pyViewObject) {
+        pyViewObject = new ViewProviderFemPostPipelinePy(this);
     }
-    return Py::new_reference_to(PythonObject);
+    pyViewObject->IncRef();
+    return pyViewObject;
 }

--- a/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.h
@@ -52,9 +52,6 @@ public:
     void scaleField(vtkDataSet* dset, vtkDataArray* pdata, double FieldFactor);
     PyObject* getPyObject() override;
 
-private:
-    Py::Object PythonObject;
-
 protected:
     void updateFunctionSize();
 };

--- a/src/Mod/Fem/femcommands/commands.py
+++ b/src/Mod/Fem/femcommands/commands.py
@@ -786,9 +786,7 @@ class _MeshGmshFromShape(CommandManager):
         FreeCADGui.doCommand(
             "FreeCADGui.ActiveDocument.setEdit(FreeCAD.ActiveDocument.ActiveObject.Name)"
         )
-        FreeCAD.ActiveDocument.commitTransaction()
         FreeCADGui.Selection.clearSelection()
-        FreeCAD.ActiveDocument.recompute()
 
 
 class _MeshGroup(CommandManager):
@@ -844,7 +842,6 @@ class _MeshNetgenFromShape(CommandManager):
         FreeCADGui.doCommand(
             "FreeCADGui.ActiveDocument.setEdit(FreeCAD.ActiveDocument.ActiveObject.Name)"
         )
-        FreeCAD.ActiveDocument.commitTransaction()
         FreeCADGui.Selection.clearSelection()
         # a recompute immediately starts meshing when task panel is opened, this is not intended
 

--- a/src/Mod/Fem/femcommands/manager.py
+++ b/src/Mod/Fem/femcommands/manager.py
@@ -300,7 +300,6 @@ class CommandManager:
         FreeCADGui.doCommand(
             "FreeCADGui.ActiveDocument.setEdit(FreeCAD.ActiveDocument.ActiveObject.Name)"
         )
-        FreeCAD.ActiveDocument.recompute()
 
     def add_obj_on_gui_noset_edit(self, objtype):
         FreeCAD.ActiveDocument.openTransaction(f"Create Fem{objtype}")
@@ -312,7 +311,6 @@ class CommandManager:
         )
         # FreeCAD.ActiveDocument.commitTransaction()  # solver command class had this line
         # no clear selection is done
-        FreeCAD.ActiveDocument.recompute()
 
     def add_obj_on_gui_expand_noset_edit(self, objtype):
         # like add_obj_on_gui_noset_edit but the parent object
@@ -332,7 +330,6 @@ class CommandManager:
         FreeCADGui.Selection.clearSelection()
         FreeCADGui.doCommand("addedObjDocObj = FreeCAD.ActiveDocument.getObject(addedObj.Name)")
         FreeCADGui.doCommand("FreeCADGui.Selection.addSelection(addedObjDocObj)")
-        FreeCAD.ActiveDocument.recompute()
 
     def add_obj_on_gui_selobj_set_edit(self, objtype):
         FreeCAD.ActiveDocument.openTransaction(f"Create Fem{objtype}")
@@ -345,7 +342,6 @@ class CommandManager:
         FreeCADGui.doCommand(
             "FreeCADGui.ActiveDocument.setEdit(FreeCAD.ActiveDocument.ActiveObject.Name)"
         )
-        FreeCAD.ActiveDocument.recompute()
 
     def add_obj_on_gui_selobj_noset_edit(self, objtype):
         FreeCAD.ActiveDocument.openTransaction(f"Create Fem{objtype}")
@@ -355,7 +351,6 @@ class CommandManager:
             "FreeCAD.ActiveDocument, FreeCAD.ActiveDocument.{})".format(objtype, self.selobj.Name)
         )
         FreeCADGui.Selection.clearSelection()
-        FreeCAD.ActiveDocument.recompute()
 
     def add_obj_on_gui_selobj_expand_noset_edit(self, objtype):
         # like add_obj_on_gui_selobj_noset_edit but the selection is kept
@@ -368,4 +363,3 @@ class CommandManager:
         )
         # expand selobj in tree view
         expandParentObject()
-        FreeCAD.ActiveDocument.recompute()

--- a/src/Mod/Fem/femtaskpanels/base_femtaskpanel.py
+++ b/src/Mod/Fem/femtaskpanels/base_femtaskpanel.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *   Copyright (c) 2024 Mario Passaglia <mpassaglia[at]cbc.uba.ar>         *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+__title__ = "FreeCAD FEM base task panel object"
+__author__ = "Mario Passaglia"
+__url__ = "https://www.freecad.org"
+
+## @package base_femtaskpanel
+#  \ingroup FEM
+#  \brief base object for FEM task panels
+
+
+class _BaseTaskPanel:
+    """
+    Base task panel
+    """
+
+    def __init__(self, obj):
+        self.obj = obj
+
+    def accept(self):
+        gui_doc = self.obj.ViewObject.Document
+        gui_doc.Document.recompute()
+        gui_doc.resetEdit()
+        gui_doc.Document.commitTransaction()
+
+        return True
+
+    def reject(self):
+        gui_doc = self.obj.ViewObject.Document
+        gui_doc.Document.abortTransaction()
+        gui_doc.resetEdit()
+        gui_doc.Document.recompute()
+
+        return True

--- a/src/Mod/Fem/femtaskpanels/task_constraint_bodyheatsource.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_bodyheatsource.py
@@ -37,12 +37,13 @@ import FreeCADGui
 from femguiutils import selection_widgets
 
 from femtools import membertools
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
 
     def __init__(self, obj):
-        self.obj = obj
+        super().__init__(obj)
 
         self.parameter_widget = FreeCADGui.PySideUic.loadUi(
             FreeCAD.getHomePath() + "Mod/Fem/Resources/ui/BodyHeatSource.ui"
@@ -97,8 +98,7 @@ class _TaskPanel:
     def reject(self):
         self.restore_visibility()
         self.selection_widget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
-        return True
+        return super().reject()
 
     def accept(self):
         self.obj.References = self.selection_widget.references
@@ -106,11 +106,9 @@ class _TaskPanel:
         self.obj.TotalPower = self.total_power
         self.obj.Mode = self.mode
 
-        self.obj.Document.recompute()
         self.selection_widget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
         self.restore_visibility()
-        return True
+        return super().accept()
 
     def restore_visibility(self):
         if self._mesh is not None and self._part is not None:

--- a/src/Mod/Fem/femtaskpanels/task_constraint_centrif.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_centrif.py
@@ -36,16 +36,16 @@ import FreeCAD
 import FreeCADGui
 
 from femguiutils import selection_widgets
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The TaskPanel for editing References property of FemConstraintCentrif objects
     """
 
     def __init__(self, obj):
-
-        self.obj = obj
+        super().__init__(obj)
 
         # parameter widget
         self.parameterWidget = FreeCADGui.PySideUic.loadUi(
@@ -139,21 +139,14 @@ class _TaskPanel:
         self.obj.RotationFrequency = self.rotation_frequency
         self.obj.RotationAxis = self.AxisSelectionWidget.references
         self.obj.References = self.BodySelectionWidget.references
-        self.recompute_and_set_back_all()
-        return True
-
-    def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.Document.recompute()
-
         self.AxisSelectionWidget.finish_selection()
         self.BodySelectionWidget.finish_selection()
+        return super().accept()
 
-        doc.resetEdit()
+    def reject(self):
+        self.AxisSelectionWidget.finish_selection()
+        self.BodySelectionWidget.finish_selection()
+        return super().reject()
 
     def init_parameter_widget(self):
         self.rotation_frequency = self.obj.RotationFrequency

--- a/src/Mod/Fem/femtaskpanels/task_constraint_currentdensity.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_currentdensity.py
@@ -35,12 +35,13 @@ import FreeCADGui
 from femguiutils import selection_widgets
 
 from femtools import membertools
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
 
     def __init__(self, obj):
-        self._obj = obj
+        super().__init__(obj)
 
         self._paramWidget = FreeCADGui.PySideUic.loadUi(
             FreeCAD.getHomePath() + "Mod/Fem/Resources/ui/CurrentDensity.ui"
@@ -76,18 +77,15 @@ class _TaskPanel:
     def reject(self):
         self._restoreVisibility()
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
-        return True
+        return super().reject()
 
     def accept(self):
-        if self._obj.References != self._selectionWidget.references:
-            self._obj.References = self._selectionWidget.references
+        if self.obj.References != self._selectionWidget.references:
+            self.obj.References = self._selectionWidget.references
         self._applyWidgetChanges()
-        self._obj.Document.recompute()
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
         self._restoreVisibility()
-        return True
+        return super().accept()
 
     def _restoreVisibility(self):
         if self._mesh is not None and self._part is not None:
@@ -101,37 +99,37 @@ class _TaskPanel:
                 self._part.ViewObject.hide()
 
     def _initParamWidget(self):
-        self._paramWidget.realXQSB.setProperty("value", self._obj.CurrentDensity_re_1)
+        self._paramWidget.realXQSB.setProperty("value", self.obj.CurrentDensity_re_1)
         FreeCADGui.ExpressionBinding(self._paramWidget.realXQSB).bind(
-            self._obj, "CurrentDensity_re_1"
+            self.obj, "CurrentDensity_re_1"
         )
-        self._paramWidget.realYQSB.setProperty("value", self._obj.CurrentDensity_re_2)
+        self._paramWidget.realYQSB.setProperty("value", self.obj.CurrentDensity_re_2)
         FreeCADGui.ExpressionBinding(self._paramWidget.realYQSB).bind(
-            self._obj, "CurrentDensity_re_2"
+            self.obj, "CurrentDensity_re_2"
         )
-        self._paramWidget.realZQSB.setProperty("value", self._obj.CurrentDensity_re_3)
+        self._paramWidget.realZQSB.setProperty("value", self.obj.CurrentDensity_re_3)
         FreeCADGui.ExpressionBinding(self._paramWidget.realZQSB).bind(
-            self._obj, "CurrentDensity_re_3"
+            self.obj, "CurrentDensity_re_3"
         )
-        self._paramWidget.imagXQSB.setProperty("value", self._obj.CurrentDensity_im_1)
+        self._paramWidget.imagXQSB.setProperty("value", self.obj.CurrentDensity_im_1)
         FreeCADGui.ExpressionBinding(self._paramWidget.imagXQSB).bind(
-            self._obj, "CurrentDensity_im_1"
+            self.obj, "CurrentDensity_im_1"
         )
-        self._paramWidget.imagYQSB.setProperty("value", self._obj.CurrentDensity_im_2)
+        self._paramWidget.imagYQSB.setProperty("value", self.obj.CurrentDensity_im_2)
         FreeCADGui.ExpressionBinding(self._paramWidget.imagYQSB).bind(
-            self._obj, "CurrentDensity_im_2"
+            self.obj, "CurrentDensity_im_2"
         )
-        self._paramWidget.imagZQSB.setProperty("value", self._obj.CurrentDensity_im_3)
+        self._paramWidget.imagZQSB.setProperty("value", self.obj.CurrentDensity_im_3)
         FreeCADGui.ExpressionBinding(self._paramWidget.imagZQSB).bind(
-            self._obj, "CurrentDensity_im_3"
+            self.obj, "CurrentDensity_im_3"
         )
 
-        self._paramWidget.reXunspecBox.setChecked(self._obj.CurrentDensity_re_1_Disabled)
-        self._paramWidget.reYunspecBox.setChecked(self._obj.CurrentDensity_re_2_Disabled)
-        self._paramWidget.reZunspecBox.setChecked(self._obj.CurrentDensity_re_3_Disabled)
-        self._paramWidget.imXunspecBox.setChecked(self._obj.CurrentDensity_im_1_Disabled)
-        self._paramWidget.imYunspecBox.setChecked(self._obj.CurrentDensity_im_2_Disabled)
-        self._paramWidget.imZunspecBox.setChecked(self._obj.CurrentDensity_im_3_Disabled)
+        self._paramWidget.reXunspecBox.setChecked(self.obj.CurrentDensity_re_1_Disabled)
+        self._paramWidget.reYunspecBox.setChecked(self.obj.CurrentDensity_re_2_Disabled)
+        self._paramWidget.reZunspecBox.setChecked(self.obj.CurrentDensity_re_3_Disabled)
+        self._paramWidget.imXunspecBox.setChecked(self.obj.CurrentDensity_im_1_Disabled)
+        self._paramWidget.imYunspecBox.setChecked(self.obj.CurrentDensity_im_2_Disabled)
+        self._paramWidget.imZunspecBox.setChecked(self.obj.CurrentDensity_im_3_Disabled)
 
     def _applyCurrentDensityChanges(self, enabledBox, currentDensityQSB):
         enabled = enabledBox.isChecked()
@@ -148,32 +146,32 @@ class _TaskPanel:
 
     def _applyWidgetChanges(self):
         # apply the current densities and their enabled state
-        self._obj.CurrentDensity_re_1_Disabled, self._obj.CurrentDensity_re_1 = (
+        self.obj.CurrentDensity_re_1_Disabled, self.obj.CurrentDensity_re_1 = (
             self._applyCurrentDensityChanges(
                 self._paramWidget.reXunspecBox, self._paramWidget.realXQSB
             )
         )
-        self._obj.CurrentDensity_re_2_Disabled, self._obj.CurrentDensity_re_2 = (
+        self.obj.CurrentDensity_re_2_Disabled, self.obj.CurrentDensity_re_2 = (
             self._applyCurrentDensityChanges(
                 self._paramWidget.reYunspecBox, self._paramWidget.realYQSB
             )
         )
-        self._obj.CurrentDensity_re_3_Disabled, self._obj.CurrentDensity_re_3 = (
+        self.obj.CurrentDensity_re_3_Disabled, self.obj.CurrentDensity_re_3 = (
             self._applyCurrentDensityChanges(
                 self._paramWidget.reZunspecBox, self._paramWidget.realZQSB
             )
         )
-        self._obj.CurrentDensity_im_1_Disabled, self._obj.CurrentDensity_im_1 = (
+        self.obj.CurrentDensity_im_1_Disabled, self.obj.CurrentDensity_im_1 = (
             self._applyCurrentDensityChanges(
                 self._paramWidget.imXunspecBox, self._paramWidget.imagXQSB
             )
         )
-        self._obj.CurrentDensity_im_2_Disabled, self._obj.CurrentDensity_im_2 = (
+        self.obj.CurrentDensity_im_2_Disabled, self.obj.CurrentDensity_im_2 = (
             self._applyCurrentDensityChanges(
                 self._paramWidget.imYunspecBox, self._paramWidget.imagYQSB
             )
         )
-        self._obj.CurrentDensity_im_3_Disabled, self._obj.CurrentDensity_im_3 = (
+        self.obj.CurrentDensity_im_3_Disabled, self.obj.CurrentDensity_im_3 = (
             self._applyCurrentDensityChanges(
                 self._paramWidget.imZunspecBox, self._paramWidget.imagZQSB
             )

--- a/src/Mod/Fem/femtaskpanels/task_constraint_electrostaticpotential.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_electrostaticpotential.py
@@ -38,12 +38,13 @@ import FreeCADGui
 from femguiutils import selection_widgets
 
 from femtools import membertools
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
 
     def __init__(self, obj):
-        self._obj = obj
+        super().__init__(obj)
 
         self._paramWidget = FreeCADGui.PySideUic.loadUi(
             FreeCAD.getHomePath() + "Mod/Fem/Resources/ui/ElectrostaticPotential.ui"
@@ -71,13 +72,13 @@ class _TaskPanel:
 
         # start with vector inputs hidden if no vector is set
         if (
-            self._obj.AV_re_1_Disabled
-            and self._obj.AV_re_2_Disabled
-            and self._obj.AV_re_3_Disabled
-            and self._obj.AV_im_Disabled
-            and self._obj.AV_im_1_Disabled
-            and self._obj.AV_im_2_Disabled
-            and self._obj.AV_im_3_Disabled
+            self.obj.AV_re_1_Disabled
+            and self.obj.AV_re_2_Disabled
+            and self.obj.AV_re_3_Disabled
+            and self.obj.AV_im_Disabled
+            and self.obj.AV_im_1_Disabled
+            and self.obj.AV_im_2_Disabled
+            and self.obj.AV_im_3_Disabled
         ):
             self._vectorField_visibility(False)
             self._paramWidget.vectorFieldBox.setChecked(False)
@@ -100,18 +101,15 @@ class _TaskPanel:
     def reject(self):
         self._restoreVisibility()
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
-        return True
+        return super().reject()
 
     def accept(self):
-        if self._obj.References != self._selectionWidget.references:
-            self._obj.References = self._selectionWidget.references
+        if self.obj.References != self._selectionWidget.references:
+            self.obj.References = self._selectionWidget.references
         self._applyWidgetChanges()
-        self._obj.Document.recompute()
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
         self._restoreVisibility()
-        return True
+        return super().accept()
 
     def _restoreVisibility(self):
         if self._mesh is not None and self._part is not None:
@@ -125,45 +123,45 @@ class _TaskPanel:
                 self._part.ViewObject.hide()
 
     def _initParamWidget(self):
-        self._paramWidget.potentialQSB.setProperty("value", self._obj.Potential)
-        FreeCADGui.ExpressionBinding(self._paramWidget.potentialQSB).bind(self._obj, "Potential")
-        self._paramWidget.potentialBox.setChecked(not self._obj.PotentialEnabled)
+        self._paramWidget.potentialQSB.setProperty("value", self.obj.Potential)
+        FreeCADGui.ExpressionBinding(self._paramWidget.potentialQSB).bind(self.obj, "Potential")
+        self._paramWidget.potentialBox.setChecked(not self.obj.PotentialEnabled)
 
         # the vector potentials
         # realScalarQSB always the same value as potentialQSB
-        self._paramWidget.realScalarQSB.setProperty("value", self._obj.Potential)
-        FreeCADGui.ExpressionBinding(self._paramWidget.realScalarQSB).bind(self._obj, "Potential")
-        self._paramWidget.realXQSB.setProperty("value", self._obj.AV_re_1)
-        FreeCADGui.ExpressionBinding(self._paramWidget.realXQSB).bind(self._obj, "AV_re_1")
-        self._paramWidget.realYQSB.setProperty("value", self._obj.AV_re_2)
-        FreeCADGui.ExpressionBinding(self._paramWidget.realYQSB).bind(self._obj, "AV_re_2")
-        self._paramWidget.realZQSB.setProperty("value", self._obj.AV_re_3)
-        FreeCADGui.ExpressionBinding(self._paramWidget.realZQSB).bind(self._obj, "AV_re_3")
-        self._paramWidget.imagScalarQSB.setProperty("value", self._obj.AV_im)
-        FreeCADGui.ExpressionBinding(self._paramWidget.imagScalarQSB).bind(self._obj, "AV_im")
-        self._paramWidget.imagXQSB.setProperty("value", self._obj.AV_im_1)
-        FreeCADGui.ExpressionBinding(self._paramWidget.imagXQSB).bind(self._obj, "AV_im_1")
-        self._paramWidget.imagYQSB.setProperty("value", self._obj.AV_im_2)
-        FreeCADGui.ExpressionBinding(self._paramWidget.imagYQSB).bind(self._obj, "AV_im_2")
-        self._paramWidget.imagZQSB.setProperty("value", self._obj.AV_im_3)
-        FreeCADGui.ExpressionBinding(self._paramWidget.imagZQSB).bind(self._obj, "AV_im_3")
+        self._paramWidget.realScalarQSB.setProperty("value", self.obj.Potential)
+        FreeCADGui.ExpressionBinding(self._paramWidget.realScalarQSB).bind(self.obj, "Potential")
+        self._paramWidget.realXQSB.setProperty("value", self.obj.AV_re_1)
+        FreeCADGui.ExpressionBinding(self._paramWidget.realXQSB).bind(self.obj, "AV_re_1")
+        self._paramWidget.realYQSB.setProperty("value", self.obj.AV_re_2)
+        FreeCADGui.ExpressionBinding(self._paramWidget.realYQSB).bind(self.obj, "AV_re_2")
+        self._paramWidget.realZQSB.setProperty("value", self.obj.AV_re_3)
+        FreeCADGui.ExpressionBinding(self._paramWidget.realZQSB).bind(self.obj, "AV_re_3")
+        self._paramWidget.imagScalarQSB.setProperty("value", self.obj.AV_im)
+        FreeCADGui.ExpressionBinding(self._paramWidget.imagScalarQSB).bind(self.obj, "AV_im")
+        self._paramWidget.imagXQSB.setProperty("value", self.obj.AV_im_1)
+        FreeCADGui.ExpressionBinding(self._paramWidget.imagXQSB).bind(self.obj, "AV_im_1")
+        self._paramWidget.imagYQSB.setProperty("value", self.obj.AV_im_2)
+        FreeCADGui.ExpressionBinding(self._paramWidget.imagYQSB).bind(self.obj, "AV_im_2")
+        self._paramWidget.imagZQSB.setProperty("value", self.obj.AV_im_3)
+        FreeCADGui.ExpressionBinding(self._paramWidget.imagZQSB).bind(self.obj, "AV_im_3")
 
-        self._paramWidget.reXunspecBox.setChecked(self._obj.AV_re_1_Disabled)
-        self._paramWidget.reYunspecBox.setChecked(self._obj.AV_re_2_Disabled)
-        self._paramWidget.reZunspecBox.setChecked(self._obj.AV_re_3_Disabled)
-        self._paramWidget.imScalarunspecBox.setChecked(self._obj.AV_im_Disabled)
-        self._paramWidget.imXunspecBox.setChecked(self._obj.AV_im_1_Disabled)
-        self._paramWidget.imYunspecBox.setChecked(self._obj.AV_im_2_Disabled)
-        self._paramWidget.imZunspecBox.setChecked(self._obj.AV_im_3_Disabled)
+        self._paramWidget.reXunspecBox.setChecked(self.obj.AV_re_1_Disabled)
+        self._paramWidget.reYunspecBox.setChecked(self.obj.AV_re_2_Disabled)
+        self._paramWidget.reZunspecBox.setChecked(self.obj.AV_re_3_Disabled)
+        self._paramWidget.imScalarunspecBox.setChecked(self.obj.AV_im_Disabled)
+        self._paramWidget.imXunspecBox.setChecked(self.obj.AV_im_1_Disabled)
+        self._paramWidget.imYunspecBox.setChecked(self.obj.AV_im_2_Disabled)
+        self._paramWidget.imZunspecBox.setChecked(self.obj.AV_im_3_Disabled)
 
-        self._paramWidget.potentialConstantBox.setChecked(self._obj.PotentialConstant)
+        self._paramWidget.potentialConstantBox.setChecked(self.obj.PotentialConstant)
 
-        self._paramWidget.electricInfinityBox.setChecked(self._obj.ElectricInfinity)
+        self._paramWidget.electricInfinityBox.setChecked(self.obj.ElectricInfinity)
 
-        self._paramWidget.electricForcecalculationBox.setChecked(self._obj.ElectricForcecalculation)
+        self._paramWidget.electricForcecalculationBox.setChecked(self.obj.ElectricForcecalculation)
 
-        self._paramWidget.capacitanceBodyBox.setChecked(not self._obj.CapacitanceBodyEnabled)
-        self._paramWidget.capacitanceBody_spinBox.setValue(self._obj.CapacitanceBody)
+        self._paramWidget.capacitanceBodyBox.setChecked(not self.obj.CapacitanceBodyEnabled)
+        self._paramWidget.capacitanceBody_spinBox.setValue(self.obj.CapacitanceBody)
         self._paramWidget.capacitanceBody_spinBox.setEnabled(
             not self._paramWidget.capacitanceBodyBox.isChecked()
         )
@@ -183,41 +181,41 @@ class _TaskPanel:
 
     def _applyWidgetChanges(self):
         # apply the voltages and their enabled state
-        self._obj.PotentialEnabled, self._obj.Potential = self._applyPotentialChanges(
+        self.obj.PotentialEnabled, self.obj.Potential = self._applyPotentialChanges(
             self._paramWidget.potentialBox, self._paramWidget.potentialQSB
         )
-        self._obj.AV_re_1_Disabled, self._obj.AV_re_1 = self._applyPotentialChanges(
+        self.obj.AV_re_1_Disabled, self.obj.AV_re_1 = self._applyPotentialChanges(
             self._paramWidget.reXunspecBox, self._paramWidget.realXQSB
         )
-        self._obj.AV_re_2_Disabled, self._obj.AV_re_2 = self._applyPotentialChanges(
+        self.obj.AV_re_2_Disabled, self.obj.AV_re_2 = self._applyPotentialChanges(
             self._paramWidget.reYunspecBox, self._paramWidget.realYQSB
         )
-        self._obj.AV_re_3_Disabled, self._obj.AV_re_3 = self._applyPotentialChanges(
+        self.obj.AV_re_3_Disabled, self.obj.AV_re_3 = self._applyPotentialChanges(
             self._paramWidget.reZunspecBox, self._paramWidget.realZQSB
         )
-        self._obj.AV_im_Disabled, self._obj.AV_im = self._applyPotentialChanges(
+        self.obj.AV_im_Disabled, self.obj.AV_im = self._applyPotentialChanges(
             self._paramWidget.imScalarunspecBox, self._paramWidget.imagScalarQSB
         )
-        self._obj.AV_im_1_Disabled, self._obj.AV_im_1 = self._applyPotentialChanges(
+        self.obj.AV_im_1_Disabled, self.obj.AV_im_1 = self._applyPotentialChanges(
             self._paramWidget.imXunspecBox, self._paramWidget.imagXQSB
         )
-        self._obj.AV_im_2_Disabled, self._obj.AV_im_2 = self._applyPotentialChanges(
+        self.obj.AV_im_2_Disabled, self.obj.AV_im_2 = self._applyPotentialChanges(
             self._paramWidget.imYunspecBox, self._paramWidget.imagYQSB
         )
-        self._obj.AV_im_3_Disabled, self._obj.AV_im_3 = self._applyPotentialChanges(
+        self.obj.AV_im_3_Disabled, self.obj.AV_im_3 = self._applyPotentialChanges(
             self._paramWidget.imZunspecBox, self._paramWidget.imagZQSB
         )
         # because this is an enable the others are disabled, reverse
-        self._obj.PotentialEnabled = not self._obj.PotentialEnabled
+        self.obj.PotentialEnabled = not self.obj.PotentialEnabled
 
-        self._obj.PotentialConstant = self._paramWidget.potentialConstantBox.isChecked()
+        self.obj.PotentialConstant = self._paramWidget.potentialConstantBox.isChecked()
 
-        self._obj.ElectricInfinity = self._paramWidget.electricInfinityBox.isChecked()
+        self.obj.ElectricInfinity = self._paramWidget.electricInfinityBox.isChecked()
 
         calc_is_checked = self._paramWidget.electricForcecalculationBox.isChecked()
-        self._obj.ElectricForcecalculation = calc_is_checked  # two lines because max line length
+        self.obj.ElectricForcecalculation = calc_is_checked  # two lines because max line length
 
-        self._obj.CapacitanceBodyEnabled = not self._paramWidget.capacitanceBodyBox.isChecked()
-        if self._obj.CapacitanceBodyEnabled:
+        self.obj.CapacitanceBodyEnabled = not self._paramWidget.capacitanceBodyBox.isChecked()
+        if self.obj.CapacitanceBodyEnabled:
             self._paramWidget.capacitanceBody_spinBox.setEnabled(True)
-            self._obj.CapacitanceBody = self._paramWidget.capacitanceBody_spinBox.value()
+            self.obj.CapacitanceBody = self._paramWidget.capacitanceBody_spinBox.value()

--- a/src/Mod/Fem/femtaskpanels/task_constraint_flowvelocity.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_flowvelocity.py
@@ -37,12 +37,13 @@ import FreeCADGui
 
 from femguiutils import selection_widgets
 from femtools import membertools
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
 
     def __init__(self, obj):
-        self._obj = obj
+        super().__init__(obj)
 
         self._paramWidget = FreeCADGui.PySideUic.loadUi(
             FreeCAD.getHomePath() + "Mod/Fem/Resources/ui/FlowVelocity.ui"
@@ -154,19 +155,16 @@ class _TaskPanel:
 
     def reject(self):
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
         self._restoreVisibility()
-        return True
+        return super().reject()
 
     def accept(self):
-        if self._obj.References != self._selectionWidget.references:
-            self._obj.References = self._selectionWidget.references
+        if self.obj.References != self._selectionWidget.references:
+            self.obj.References = self._selectionWidget.references
         self._applyWidgetChanges()
-        self._obj.Document.recompute()
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
         self._restoreVisibility()
-        return True
+        return super().accept()
 
     def _restoreVisibility(self):
         if self._mesh is not None and self._part is not None:
@@ -185,25 +183,25 @@ class _TaskPanel:
         self._paramWidget.velocityY.setProperty("unit", unit)
         self._paramWidget.velocityZ.setProperty("unit", unit)
 
-        self._paramWidget.velocityX.setProperty("value", self._obj.VelocityX)
-        FreeCADGui.ExpressionBinding(self._paramWidget.velocityX).bind(self._obj, "VelocityX")
-        self._paramWidget.velocityXBox.setChecked(self._obj.VelocityXUnspecified)
-        self._paramWidget.formulaX.setText(self._obj.VelocityXFormula)
-        self._paramWidget.formulaXCB.setChecked(self._obj.VelocityXHasFormula)
+        self._paramWidget.velocityX.setProperty("value", self.obj.VelocityX)
+        FreeCADGui.ExpressionBinding(self._paramWidget.velocityX).bind(self.obj, "VelocityX")
+        self._paramWidget.velocityXBox.setChecked(self.obj.VelocityXUnspecified)
+        self._paramWidget.formulaX.setText(self.obj.VelocityXFormula)
+        self._paramWidget.formulaXCB.setChecked(self.obj.VelocityXHasFormula)
 
-        self._paramWidget.velocityY.setProperty("value", self._obj.VelocityY)
-        FreeCADGui.ExpressionBinding(self._paramWidget.velocityY).bind(self._obj, "VelocityY")
-        self._paramWidget.velocityYBox.setChecked(self._obj.VelocityYUnspecified)
-        self._paramWidget.formulaY.setText(self._obj.VelocityYFormula)
-        self._paramWidget.formulaYCB.setChecked(self._obj.VelocityYHasFormula)
+        self._paramWidget.velocityY.setProperty("value", self.obj.VelocityY)
+        FreeCADGui.ExpressionBinding(self._paramWidget.velocityY).bind(self.obj, "VelocityY")
+        self._paramWidget.velocityYBox.setChecked(self.obj.VelocityYUnspecified)
+        self._paramWidget.formulaY.setText(self.obj.VelocityYFormula)
+        self._paramWidget.formulaYCB.setChecked(self.obj.VelocityYHasFormula)
 
-        self._paramWidget.velocityZ.setProperty("value", self._obj.VelocityZ)
-        FreeCADGui.ExpressionBinding(self._paramWidget.velocityZ).bind(self._obj, "VelocityZ")
-        self._paramWidget.velocityZBox.setChecked(self._obj.VelocityZUnspecified)
-        self._paramWidget.formulaZ.setText(self._obj.VelocityZFormula)
-        self._paramWidget.formulaZCB.setChecked(self._obj.VelocityZHasFormula)
+        self._paramWidget.velocityZ.setProperty("value", self.obj.VelocityZ)
+        FreeCADGui.ExpressionBinding(self._paramWidget.velocityZ).bind(self.obj, "VelocityZ")
+        self._paramWidget.velocityZBox.setChecked(self.obj.VelocityZUnspecified)
+        self._paramWidget.formulaZ.setText(self.obj.VelocityZFormula)
+        self._paramWidget.formulaZCB.setChecked(self.obj.VelocityZHasFormula)
 
-        self._paramWidget.normalBox.setChecked(self._obj.NormalToBoundary)
+        self._paramWidget.normalBox.setChecked(self.obj.NormalToBoundary)
 
     def _applyVelocityChanges(self, enabledBox, velocityQSB):
         enabled = enabledBox.isChecked()
@@ -220,22 +218,22 @@ class _TaskPanel:
 
     def _applyWidgetChanges(self):
         # apply the velocities and their enabled state
-        self._obj.VelocityXUnspecified, self._obj.VelocityX = self._applyVelocityChanges(
+        self.obj.VelocityXUnspecified, self.obj.VelocityX = self._applyVelocityChanges(
             self._paramWidget.velocityXBox, self._paramWidget.velocityX
         )
-        self._obj.VelocityXHasFormula = self._paramWidget.formulaXCB.isChecked()
-        self._obj.VelocityXFormula = self._paramWidget.formulaX.text()
+        self.obj.VelocityXHasFormula = self._paramWidget.formulaXCB.isChecked()
+        self.obj.VelocityXFormula = self._paramWidget.formulaX.text()
 
-        self._obj.VelocityYUnspecified, self._obj.VelocityY = self._applyVelocityChanges(
+        self.obj.VelocityYUnspecified, self.obj.VelocityY = self._applyVelocityChanges(
             self._paramWidget.velocityYBox, self._paramWidget.velocityY
         )
-        self._obj.VelocityYHasFormula = self._paramWidget.formulaYCB.isChecked()
-        self._obj.VelocityYFormula = self._paramWidget.formulaY.text()
+        self.obj.VelocityYHasFormula = self._paramWidget.formulaYCB.isChecked()
+        self.obj.VelocityYFormula = self._paramWidget.formulaY.text()
 
-        self._obj.VelocityZUnspecified, self._obj.VelocityZ = self._applyVelocityChanges(
+        self.obj.VelocityZUnspecified, self.obj.VelocityZ = self._applyVelocityChanges(
             self._paramWidget.velocityZBox, self._paramWidget.velocityZ
         )
-        self._obj.VelocityZHasFormula = self._paramWidget.formulaZCB.isChecked()
-        self._obj.VelocityZFormula = self._paramWidget.formulaZ.text()
+        self.obj.VelocityZHasFormula = self._paramWidget.formulaZCB.isChecked()
+        self.obj.VelocityZFormula = self._paramWidget.formulaZ.text()
 
-        self._obj.NormalToBoundary = self._paramWidget.normalBox.isChecked()
+        self.obj.NormalToBoundary = self._paramWidget.normalBox.isChecked()

--- a/src/Mod/Fem/femtaskpanels/task_constraint_initialflowvelocity.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_initialflowvelocity.py
@@ -37,12 +37,13 @@ import FreeCADGui
 
 from femguiutils import selection_widgets
 from femtools import membertools
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
 
     def __init__(self, obj):
-        self._obj = obj
+        super().__init__(obj)
 
         self._paramWidget = FreeCADGui.PySideUic.loadUi(
             FreeCAD.getHomePath() + "Mod/Fem/Resources/ui/InitialFlowVelocity.ui"
@@ -154,19 +155,16 @@ class _TaskPanel:
 
     def reject(self):
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
         self._restoreVisibility()
-        return True
+        return super().reject()
 
     def accept(self):
-        if self._obj.References != self._selectionWidget.references:
-            self._obj.References = self._selectionWidget.references
+        if self.obj.References != self._selectionWidget.references:
+            self.obj.References = self._selectionWidget.references
         self._applyWidgetChanges()
-        self._obj.Document.recompute()
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
         self._restoreVisibility()
-        return True
+        return super().accept()
 
     def _restoreVisibility(self):
         if self._mesh is not None and self._part is not None:
@@ -185,23 +183,23 @@ class _TaskPanel:
         self._paramWidget.velocityY.setProperty("unit", unit)
         self._paramWidget.velocityZ.setProperty("unit", unit)
 
-        self._paramWidget.velocityX.setProperty("value", self._obj.VelocityX)
-        FreeCADGui.ExpressionBinding(self._paramWidget.velocityX).bind(self._obj, "VelocityX")
-        self._paramWidget.velocityXBox.setChecked(self._obj.VelocityXUnspecified)
-        self._paramWidget.formulaX.setText(self._obj.VelocityXFormula)
-        self._paramWidget.formulaXCB.setChecked(self._obj.VelocityXHasFormula)
+        self._paramWidget.velocityX.setProperty("value", self.obj.VelocityX)
+        FreeCADGui.ExpressionBinding(self._paramWidget.velocityX).bind(self.obj, "VelocityX")
+        self._paramWidget.velocityXBox.setChecked(self.obj.VelocityXUnspecified)
+        self._paramWidget.formulaX.setText(self.obj.VelocityXFormula)
+        self._paramWidget.formulaXCB.setChecked(self.obj.VelocityXHasFormula)
 
-        self._paramWidget.velocityY.setProperty("value", self._obj.VelocityY)
-        FreeCADGui.ExpressionBinding(self._paramWidget.velocityY).bind(self._obj, "VelocityY")
-        self._paramWidget.velocityYBox.setChecked(self._obj.VelocityYUnspecified)
-        self._paramWidget.formulaY.setText(self._obj.VelocityYFormula)
-        self._paramWidget.formulaYCB.setChecked(self._obj.VelocityYHasFormula)
+        self._paramWidget.velocityY.setProperty("value", self.obj.VelocityY)
+        FreeCADGui.ExpressionBinding(self._paramWidget.velocityY).bind(self.obj, "VelocityY")
+        self._paramWidget.velocityYBox.setChecked(self.obj.VelocityYUnspecified)
+        self._paramWidget.formulaY.setText(self.obj.VelocityYFormula)
+        self._paramWidget.formulaYCB.setChecked(self.obj.VelocityYHasFormula)
 
-        self._paramWidget.velocityZ.setProperty("value", self._obj.VelocityZ)
-        FreeCADGui.ExpressionBinding(self._paramWidget.velocityZ).bind(self._obj, "VelocityZ")
-        self._paramWidget.velocityZBox.setChecked(self._obj.VelocityZUnspecified)
-        self._paramWidget.formulaZ.setText(self._obj.VelocityZFormula)
-        self._paramWidget.formulaZCB.setChecked(self._obj.VelocityZHasFormula)
+        self._paramWidget.velocityZ.setProperty("value", self.obj.VelocityZ)
+        FreeCADGui.ExpressionBinding(self._paramWidget.velocityZ).bind(self.obj, "VelocityZ")
+        self._paramWidget.velocityZBox.setChecked(self.obj.VelocityZUnspecified)
+        self._paramWidget.formulaZ.setText(self.obj.VelocityZFormula)
+        self._paramWidget.formulaZCB.setChecked(self.obj.VelocityZHasFormula)
 
     def _applyVelocityChanges(self, enabledBox, velocityQSB):
         enabled = enabledBox.isChecked()
@@ -218,20 +216,20 @@ class _TaskPanel:
 
     def _applyWidgetChanges(self):
         # apply the velocities and their enabled state
-        self._obj.VelocityXUnspecified, self._obj.VelocityX = self._applyVelocityChanges(
+        self.obj.VelocityXUnspecified, self.obj.VelocityX = self._applyVelocityChanges(
             self._paramWidget.velocityXBox, self._paramWidget.velocityX
         )
-        self._obj.VelocityXHasFormula = self._paramWidget.formulaXCB.isChecked()
-        self._obj.VelocityXFormula = self._paramWidget.formulaX.text()
+        self.obj.VelocityXHasFormula = self._paramWidget.formulaXCB.isChecked()
+        self.obj.VelocityXFormula = self._paramWidget.formulaX.text()
 
-        self._obj.VelocityYUnspecified, self._obj.VelocityY = self._applyVelocityChanges(
+        self.obj.VelocityYUnspecified, self.obj.VelocityY = self._applyVelocityChanges(
             self._paramWidget.velocityYBox, self._paramWidget.velocityY
         )
-        self._obj.VelocityYHasFormula = self._paramWidget.formulaYCB.isChecked()
-        self._obj.VelocityYFormula = self._paramWidget.formulaY.text()
+        self.obj.VelocityYHasFormula = self._paramWidget.formulaYCB.isChecked()
+        self.obj.VelocityYFormula = self._paramWidget.formulaY.text()
 
-        self._obj.VelocityZUnspecified, self._obj.VelocityZ = self._applyVelocityChanges(
+        self.obj.VelocityZUnspecified, self.obj.VelocityZ = self._applyVelocityChanges(
             self._paramWidget.velocityZBox, self._paramWidget.velocityZ
         )
-        self._obj.VelocityZHasFormula = self._paramWidget.formulaZCB.isChecked()
-        self._obj.VelocityZFormula = self._paramWidget.formulaZ.text()
+        self.obj.VelocityZHasFormula = self._paramWidget.formulaZCB.isChecked()
+        self.obj.VelocityZFormula = self._paramWidget.formulaZ.text()

--- a/src/Mod/Fem/femtaskpanels/task_constraint_initialpressure.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_initialpressure.py
@@ -34,12 +34,13 @@ import FreeCADGui
 from femguiutils import selection_widgets
 
 from femtools import membertools
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
 
     def __init__(self, obj):
-        self._obj = obj
+        super().__init__(obj)
 
         self._paramWidget = FreeCADGui.PySideUic.loadUi(
             FreeCAD.getHomePath() + "Mod/Fem/Resources/ui/InitialPressure.ui"
@@ -75,18 +76,15 @@ class _TaskPanel:
     def reject(self):
         self._restoreVisibility()
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
-        return True
+        return super().reject()
 
     def accept(self):
-        if self._obj.References != self._selectionWidget.references:
-            self._obj.References = self._selectionWidget.references
+        if self.obj.References != self._selectionWidget.references:
+            self.obj.References = self._selectionWidget.references
         self._applyWidgetChanges()
-        self._obj.Document.recompute()
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
         self._restoreVisibility()
-        return True
+        return super().accept()
 
     def _restoreVisibility(self):
         if self._mesh is not None and self._part is not None:
@@ -100,8 +98,8 @@ class _TaskPanel:
                 self._part.ViewObject.hide()
 
     def _initParamWidget(self):
-        self._paramWidget.pressureQSB.setProperty("value", self._obj.Pressure)
-        FreeCADGui.ExpressionBinding(self._paramWidget.pressureQSB).bind(self._obj, "Pressure")
+        self._paramWidget.pressureQSB.setProperty("value", self.obj.Pressure)
+        FreeCADGui.ExpressionBinding(self._paramWidget.pressureQSB).bind(self.obj, "Pressure")
 
     def _applyWidgetChanges(self):
         pressure = None
@@ -113,4 +111,4 @@ class _TaskPanel:
                 "Pressure has not been set.\n".format(self._paramWidget.pressureQSB.text())
             )
         if pressure is not None:
-            self._obj.Pressure = pressure
+            self.obj.Pressure = pressure

--- a/src/Mod/Fem/femtaskpanels/task_constraint_magnetization.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_magnetization.py
@@ -35,12 +35,13 @@ import FreeCADGui
 from femguiutils import selection_widgets
 
 from femtools import membertools
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
 
     def __init__(self, obj):
-        self._obj = obj
+        super().__init__(obj)
 
         self._paramWidget = FreeCADGui.PySideUic.loadUi(
             FreeCAD.getHomePath() + "Mod/Fem/Resources/ui/Magnetization.ui"
@@ -76,18 +77,15 @@ class _TaskPanel:
     def reject(self):
         self._restoreVisibility()
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
-        return True
+        return super().reject()
 
     def accept(self):
-        if self._obj.References != self._selectionWidget.references:
-            self._obj.References = self._selectionWidget.references
+        if self.obj.References != self._selectionWidget.references:
+            self.obj.References = self._selectionWidget.references
         self._applyWidgetChanges()
-        self._obj.Document.recompute()
         self._selectionWidget.finish_selection()
-        FreeCADGui.ActiveDocument.resetEdit()
         self._restoreVisibility()
-        return True
+        return super().accept()
 
     def _restoreVisibility(self):
         if self._mesh is not None and self._part is not None:
@@ -101,37 +99,37 @@ class _TaskPanel:
                 self._part.ViewObject.hide()
 
     def _initParamWidget(self):
-        self._paramWidget.realXQSB.setProperty("value", self._obj.Magnetization_re_1)
+        self._paramWidget.realXQSB.setProperty("value", self.obj.Magnetization_re_1)
         FreeCADGui.ExpressionBinding(self._paramWidget.realXQSB).bind(
-            self._obj, "Magnetization_re_1"
+            self.obj, "Magnetization_re_1"
         )
-        self._paramWidget.realYQSB.setProperty("value", self._obj.Magnetization_re_2)
+        self._paramWidget.realYQSB.setProperty("value", self.obj.Magnetization_re_2)
         FreeCADGui.ExpressionBinding(self._paramWidget.realYQSB).bind(
-            self._obj, "Magnetization_re_2"
+            self.obj, "Magnetization_re_2"
         )
-        self._paramWidget.realZQSB.setProperty("value", self._obj.Magnetization_re_3)
+        self._paramWidget.realZQSB.setProperty("value", self.obj.Magnetization_re_3)
         FreeCADGui.ExpressionBinding(self._paramWidget.realZQSB).bind(
-            self._obj, "Magnetization_re_3"
+            self.obj, "Magnetization_re_3"
         )
-        self._paramWidget.imagXQSB.setProperty("value", self._obj.Magnetization_im_1)
+        self._paramWidget.imagXQSB.setProperty("value", self.obj.Magnetization_im_1)
         FreeCADGui.ExpressionBinding(self._paramWidget.imagXQSB).bind(
-            self._obj, "Magnetization_im_1"
+            self.obj, "Magnetization_im_1"
         )
-        self._paramWidget.imagYQSB.setProperty("value", self._obj.Magnetization_im_2)
+        self._paramWidget.imagYQSB.setProperty("value", self.obj.Magnetization_im_2)
         FreeCADGui.ExpressionBinding(self._paramWidget.imagYQSB).bind(
-            self._obj, "Magnetization_im_2"
+            self.obj, "Magnetization_im_2"
         )
-        self._paramWidget.imagZQSB.setProperty("value", self._obj.Magnetization_im_3)
+        self._paramWidget.imagZQSB.setProperty("value", self.obj.Magnetization_im_3)
         FreeCADGui.ExpressionBinding(self._paramWidget.imagZQSB).bind(
-            self._obj, "Magnetization_im_3"
+            self.obj, "Magnetization_im_3"
         )
 
-        self._paramWidget.reXunspecBox.setChecked(self._obj.Magnetization_re_1_Disabled)
-        self._paramWidget.reYunspecBox.setChecked(self._obj.Magnetization_re_2_Disabled)
-        self._paramWidget.reZunspecBox.setChecked(self._obj.Magnetization_re_3_Disabled)
-        self._paramWidget.imXunspecBox.setChecked(self._obj.Magnetization_im_1_Disabled)
-        self._paramWidget.imYunspecBox.setChecked(self._obj.Magnetization_im_2_Disabled)
-        self._paramWidget.imZunspecBox.setChecked(self._obj.Magnetization_im_3_Disabled)
+        self._paramWidget.reXunspecBox.setChecked(self.obj.Magnetization_re_1_Disabled)
+        self._paramWidget.reYunspecBox.setChecked(self.obj.Magnetization_re_2_Disabled)
+        self._paramWidget.reZunspecBox.setChecked(self.obj.Magnetization_re_3_Disabled)
+        self._paramWidget.imXunspecBox.setChecked(self.obj.Magnetization_im_1_Disabled)
+        self._paramWidget.imYunspecBox.setChecked(self.obj.Magnetization_im_2_Disabled)
+        self._paramWidget.imZunspecBox.setChecked(self.obj.Magnetization_im_3_Disabled)
 
     def _applyMagnetizationChanges(self, enabledBox, magnetizationQSB):
         enabled = enabledBox.isChecked()
@@ -148,32 +146,32 @@ class _TaskPanel:
 
     def _applyWidgetChanges(self):
         # apply the magnetizations and their enabled state
-        self._obj.Magnetization_re_1_Disabled, self._obj.Magnetization_re_1 = (
+        self.obj.Magnetization_re_1_Disabled, self.obj.Magnetization_re_1 = (
             self._applyMagnetizationChanges(
                 self._paramWidget.reXunspecBox, self._paramWidget.realXQSB
             )
         )
-        self._obj.Magnetization_re_2_Disabled, self._obj.Magnetization_re_2 = (
+        self.obj.Magnetization_re_2_Disabled, self.obj.Magnetization_re_2 = (
             self._applyMagnetizationChanges(
                 self._paramWidget.reYunspecBox, self._paramWidget.realYQSB
             )
         )
-        self._obj.Magnetization_re_3_Disabled, self._obj.Magnetization_re_3 = (
+        self.obj.Magnetization_re_3_Disabled, self.obj.Magnetization_re_3 = (
             self._applyMagnetizationChanges(
                 self._paramWidget.reZunspecBox, self._paramWidget.realZQSB
             )
         )
-        self._obj.Magnetization_im_1_Disabled, self._obj.Magnetization_im_1 = (
+        self.obj.Magnetization_im_1_Disabled, self.obj.Magnetization_im_1 = (
             self._applyMagnetizationChanges(
                 self._paramWidget.imXunspecBox, self._paramWidget.imagXQSB
             )
         )
-        self._obj.Magnetization_im_2_Disabled, self._obj.Magnetization_im_2 = (
+        self.obj.Magnetization_im_2_Disabled, self.obj.Magnetization_im_2 = (
             self._applyMagnetizationChanges(
                 self._paramWidget.imYunspecBox, self._paramWidget.imagYQSB
             )
         )
-        self._obj.Magnetization_im_3_Disabled, self._obj.Magnetization_im_3 = (
+        self.obj.Magnetization_im_3_Disabled, self.obj.Magnetization_im_3 = (
             self._applyMagnetizationChanges(
                 self._paramWidget.imZunspecBox, self._paramWidget.imagZQSB
             )

--- a/src/Mod/Fem/femtaskpanels/task_constraint_sectionprint.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_sectionprint.py
@@ -36,17 +36,17 @@ import FreeCAD
 import FreeCADGui
 
 from femguiutils import selection_widgets
+from . import base_femtaskpanel
 
 
 # TODO uses the old style Add button, move to the new style. See constraint fixed
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The TaskPanel for editing References property of ConstraintSectionPrint objects
     """
 
     def __init__(self, obj):
-
-        self.obj = obj
+        super().__init__(obj)
 
         # parameter widget
         self.parameterWidget = FreeCADGui.PySideUic.loadUi(
@@ -93,18 +93,12 @@ class _TaskPanel:
 
         self.obj.Variable = self.variable
         self.obj.References = self.selectionWidget.references
-        self.recompute_and_set_back_all()
-        return True
+        self.selectionWidget.finish_selection()
+        return super().accept()
 
     def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.Document.recompute()
         self.selectionWidget.finish_selection()
-        doc.resetEdit()
+        return super().reject()
 
     def init_parameter_widget(self):
         self.variable = self.obj.Variable

--- a/src/Mod/Fem/femtaskpanels/task_constraint_tie.py
+++ b/src/Mod/Fem/femtaskpanels/task_constraint_tie.py
@@ -36,16 +36,16 @@ import FreeCAD
 import FreeCADGui
 
 from femguiutils import selection_widgets
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The TaskPanel for editing References property of FemConstraintTie objects
     """
 
     def __init__(self, obj):
-
-        self.obj = obj
+        super().__init__(obj)
 
         # parameter widget
         self.parameterWidget = FreeCADGui.PySideUic.loadUi(
@@ -94,18 +94,12 @@ class _TaskPanel:
         self.obj.Tolerance = self.tolerance
         self.obj.Adjust = self.adjust
         self.obj.References = self.selectionWidget.references
-        self.recompute_and_set_back_all()
-        return True
+        self.selectionWidget.finish_selection()
+        return super().accept()
 
     def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.Document.recompute()
         self.selectionWidget.finish_selection()
-        doc.resetEdit()
+        return super().reject()
 
     def init_parameter_widget(self):
         self.tolerance = self.obj.Tolerance

--- a/src/Mod/Fem/femtaskpanels/task_element_fluid1D.py
+++ b/src/Mod/Fem/femtaskpanels/task_element_fluid1D.py
@@ -40,16 +40,16 @@ from FreeCAD import Units
 
 from femguiutils import selection_widgets
 from femobjects import element_fluid1D
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The TaskPanel for editing References property of ElementFluid1D objects
     """
 
     def __init__(self, obj):
-
-        self.obj = obj
+        super().__init__(obj)
 
         # parameter widget
         self.parameterWidget = FreeCADGui.PySideUic.loadUi(
@@ -242,18 +242,12 @@ class _TaskPanel:
     def accept(self):
         self.set_fluidsection_props()
         self.obj.References = self.selectionWidget.references
-        self.recompute_and_set_back_all()
-        return True
+        self.selectionWidget.finish_selection()
+        return super().accept()
 
     def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.Document.recompute()
         self.selectionWidget.finish_selection()
-        doc.resetEdit()
+        return super().reject()
 
     def get_fluidsection_props(self):
         self.SectionType = self.obj.SectionType

--- a/src/Mod/Fem/femtaskpanels/task_element_geometry1D.py
+++ b/src/Mod/Fem/femtaskpanels/task_element_geometry1D.py
@@ -36,16 +36,16 @@ import FreeCADGui
 
 from femguiutils import selection_widgets
 from femobjects import element_geometry1D
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The TaskPanel for editing References property of ElementGeometry1D objects
     """
 
     def __init__(self, obj):
-
-        self.obj = obj
+        super().__init__(obj)
 
         # parameter widget
         self.parameterWidget = FreeCADGui.PySideUic.loadUi(
@@ -99,18 +99,12 @@ class _TaskPanel:
     def accept(self):
         self.set_beamsection_props()
         self.obj.References = self.selectionWidget.references
-        self.recompute_and_set_back_all()
-        return True
+        self.selectionWidget.finish_selection()
+        return super().accept()
 
     def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.Document.recompute()
         self.selectionWidget.finish_selection()
-        doc.resetEdit()
+        return super().reject()
 
     def get_beamsection_props(self):
         self.SectionType = self.obj.SectionType

--- a/src/Mod/Fem/femtaskpanels/task_element_geometry2D.py
+++ b/src/Mod/Fem/femtaskpanels/task_element_geometry2D.py
@@ -35,16 +35,16 @@ import FreeCAD
 import FreeCADGui
 
 from femguiutils import selection_widgets
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The TaskPanel for editing References property of ElementGeometry2D objects
     """
 
     def __init__(self, obj):
-
-        self.obj = obj
+        super().__init__(obj)
 
         # parameter widget
         self.parameterWidget = FreeCADGui.PySideUic.loadUi(
@@ -68,18 +68,12 @@ class _TaskPanel:
     def accept(self):
         self.obj.Thickness = self.thickness
         self.obj.References = self.selectionWidget.references
-        self.recompute_and_set_back_all()
-        return True
+        self.selectionWidget.finish_selection()
+        return super().accept()
 
     def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.Document.recompute()
         self.selectionWidget.finish_selection()
-        doc.resetEdit()
+        return super().reject()
 
     def init_parameter_widget(self):
         self.thickness = self.obj.Thickness

--- a/src/Mod/Fem/femtaskpanels/task_element_rotation1D.py
+++ b/src/Mod/Fem/femtaskpanels/task_element_rotation1D.py
@@ -35,16 +35,16 @@ import FreeCAD
 import FreeCADGui
 
 from femguiutils import selection_widgets
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The TaskPanel for editing References property of ElementRotation1D objects
     """
 
     def __init__(self, obj):
-
-        self.obj = obj
+        super().__init__(obj)
 
         # parameter widget
         self.parameterWidget = FreeCADGui.PySideUic.loadUi(
@@ -68,18 +68,12 @@ class _TaskPanel:
 
     def accept(self):
         self.obj.Rotation = self.rotation
-        self.recompute_and_set_back_all()
-        return True
+        self.selectionWidget.finish_selection()
+        return super().accept()
 
     def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.Document.recompute()
         self.selectionWidget.finish_selection()
-        doc.resetEdit()
+        return super().reject()
 
     def rotation_changed(self, base_quantity_value):
         self.rotation = base_quantity_value

--- a/src/Mod/Fem/femtaskpanels/task_material_common.py
+++ b/src/Mod/Fem/femtaskpanels/task_material_common.py
@@ -39,20 +39,17 @@ import FreeCADGui
 from FreeCAD import Units
 
 from femguiutils import selection_widgets
+from . import base_femtaskpanel
 
 
-unicode = str
-
-
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The editmode TaskPanel for FemMaterial objects
     """
 
     def __init__(self, obj):
+        super().__init__(obj)
 
-        FreeCAD.Console.PrintMessage("\n")  # empty line on start task panel
-        self.obj = obj
         self.material = self.obj.Material  # FreeCAD material dictionary of current material
         self.card_path = ""
         self.materials = {}  # { card_path : FreeCAD material dict, ... }
@@ -213,18 +210,12 @@ class _TaskPanel:
                 )
                 FreeCAD.Console.PrintError(error_message)
                 QtGui.QMessageBox.critical(None, "Material data not changed", error_message)
-        self.recompute_and_set_back_all()
-        return True
+        self.selectionWidget.finish_selection()
+        return super().accept()
 
     def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.Document.recompute()
         self.selectionWidget.finish_selection()
-        doc.resetEdit()
+        return super().reject()
 
     def do_not_set_thermal_zeros(self):
         """thermal material parameter are set to 0.0 if not available
@@ -579,11 +570,10 @@ class _TaskPanel:
         if value:
             if not (1 - variation < float(old_value) / value < 1 + variation):
                 material = self.material
-                # unicode() is an alias to str for py3
                 if qUnit != "":
-                    material[matProperty] = unicode(value) + " " + qUnit
+                    material[matProperty] = str(value) + " " + qUnit
                 else:
-                    material[matProperty] = unicode(value)
+                    material[matProperty] = str(value)
                 self.material = material
                 if self.has_transient_mat is False:
                     self.add_transient_material()
@@ -626,7 +616,7 @@ class _TaskPanel:
         elif value == 0:
             # PoissonRatio was set to 0.0 what is possible
             material = self.material
-            material["PoissonRatio"] = unicode(value)
+            material["PoissonRatio"] = str(value)
             self.material = material
             if self.has_transient_mat is False:
                 self.add_transient_material()

--- a/src/Mod/Fem/femtaskpanels/task_material_reinforced.py
+++ b/src/Mod/Fem/femtaskpanels/task_material_reinforced.py
@@ -34,22 +34,16 @@ from PySide import QtGui
 
 import FreeCAD
 import FreeCADGui
+from . import base_femtaskpanel
 
 
-unicode = str
-
-
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The editmode TaskPanel for MaterialReinforced objects
     """
 
-    unicode = str
-
     def __init__(self, obj):
-
-        FreeCAD.Console.PrintMessage("\n")  # empty line on start task panel
-        self.obj = obj
+        super().__init__(obj)
 
         # init matrix and reinforcement material
         self.material_m = self.obj.Material
@@ -174,31 +168,10 @@ class _TaskPanel:
             )
             FreeCAD.Console.PrintError(error_message)
             QtGui.QMessageBox.critical(None, "Material data not changed", error_message)
-        self.recompute_and_set_back_all()
-        return True
+        return super().accept()
 
     def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        guidoc = FreeCADGui.getDocument(self.obj.Document)
-        guidoc.Document.recompute()
-        guidoc.resetEdit()
-        self.output_obj_mat_param()
-
-    def output_obj_mat_param(self):
-        self.print_mat_dict(self.obj.Material)
-        self.print_mat_dict(self.obj.Reinforcement)
-        print("\n")
-
-    def print_mat_dict(self, mat_dict):
-        if "Name" in mat_dict:
-            print("Material: {}".format(mat_dict["Name"]))
-        else:
-            print("Matrix material: no Name")
-        for key in mat_dict:
-            print(f"    {key}: {mat_dict[key]}")
+        return super().reject()
 
     # choose material card ***********************************************************************
     def get_material_card(self, material):

--- a/src/Mod/Fem/femtaskpanels/task_mesh_boundarylayer.py
+++ b/src/Mod/Fem/femtaskpanels/task_mesh_boundarylayer.py
@@ -35,16 +35,16 @@ import FreeCAD
 import FreeCADGui
 
 from femguiutils import selection_widgets
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The TaskPanel for editing References property of MeshBoundaryLayer objects
     """
 
     def __init__(self, obj):
-
-        self.obj = obj
+        super().__init__(obj)
 
         # parameter widget
         self.parameterWidget = FreeCADGui.PySideUic.loadUi(
@@ -80,18 +80,12 @@ class _TaskPanel:
     def accept(self):
         self.set_mesh_boundarylayer_props()
         self.obj.References = self.selectionWidget.references
-        self.recompute_and_set_back_all()
-        return True
+        self.selectionWidget.finish_selection()
+        return super().accept()
 
     def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.Document.recompute()
         self.selectionWidget.finish_selection()
-        doc.resetEdit()
+        return super().reject()
 
     def init_parameter_widget(self):
         self.bl_min_thickness = self.obj.MinimumThickness

--- a/src/Mod/Fem/femtaskpanels/task_mesh_group.py
+++ b/src/Mod/Fem/femtaskpanels/task_mesh_group.py
@@ -35,16 +35,16 @@ import FreeCAD
 import FreeCADGui
 
 from femguiutils import selection_widgets
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The TaskPanel for editing References property of MeshGroup objects
     """
 
     def __init__(self, obj):
-
-        self.obj = obj
+        super().__init__(obj)
 
         # parameter widget
         self.parameterWidget = FreeCADGui.PySideUic.loadUi(
@@ -74,18 +74,12 @@ class _TaskPanel:
     def accept(self):
         self.obj.UseLabel = self.use_label
         self.obj.References = self.selectionWidget.references
-        self.recompute_and_set_back_all()
-        return True
+        self.selectionWidget.finish_selection()
+        return super().accept()
 
     def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.Document.recompute()
         self.selectionWidget.finish_selection()
-        doc.resetEdit()
+        return super().reject()
 
     def init_parameter_widget(self):
         self.use_label = self.obj.UseLabel

--- a/src/Mod/Fem/femtaskpanels/task_mesh_region.py
+++ b/src/Mod/Fem/femtaskpanels/task_mesh_region.py
@@ -35,16 +35,16 @@ import FreeCAD
 import FreeCADGui
 
 from femguiutils import selection_widgets
+from . import base_femtaskpanel
 
 
-class _TaskPanel:
+class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
     """
     The TaskPanel for editing References property of FemMeshRegion objects
     """
 
     def __init__(self, obj):
-
-        self.obj = obj
+        super().__init__(obj)
 
         # parameter widget
         self.parameterWidget = FreeCADGui.PySideUic.loadUi(
@@ -69,18 +69,12 @@ class _TaskPanel:
     def accept(self):
         self.obj.CharacteristicLength = self.elelen
         self.obj.References = self.selectionWidget.references
-        self.recompute_and_set_back_all()
-        return True
+        self.selectionWidget.finish_selection()
+        return super().accept()
 
     def reject(self):
-        self.recompute_and_set_back_all()
-        return True
-
-    def recompute_and_set_back_all(self):
-        doc = FreeCADGui.getDocument(self.obj.Document)
-        doc.Document.recompute()
         self.selectionWidget.finish_selection()
-        doc.resetEdit()
+        return super().reject()
 
     def init_parameter_widget(self):
         self.elelen = self.obj.CharacteristicLength


### PR DESCRIPTION
Currently transactions are only aborted for C++ Constraints objects.

The first commit is to use the `pyViewObject` member of the `Gui::ViewProvider` base class in `getPyObject` methods.
My recollection is that the `Gui::ViewProvider` destructor is responsible for leaving the system in the correct state via the `pyViewObject` member when removing an object, for example when a transaction is aborted.
Using any other member as is currently the case leads to undefined behavior.

With the second commit, the transaction is aborted by pressing the Cancel button to undo the creation of the object.

@FEA-eng 