### PR TITLE
BIM: Arch_Survey: Fix concatenate bytes bug

### DIFF
--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -870,7 +870,6 @@ def survey(callback=False):
                                 else:
                                     u = FreeCAD.Units.Quantity(o.Object.Shape.Length,FreeCAD.Units.Length)
                                     t = u.getUserPreferred()[0]
-                                    t = t.encode("utf8")
                                     anno.LabelText = "l " + t
                                     FreeCAD.Console.PrintMessage("Object: " + n + ", Element: Whole, Length: " + t + "\n")
                                     FreeCAD.SurveyObserver.totalLength += u.Value


### PR DESCRIPTION
The line `t = t.encode("utf8")` returns a bytes object which does not make sense in the context of the rest of the code. It is probably a copy-paste error. Removing the line fixes the problem.

To test the bug:
1. open the file attached to this forum post: https://forum.freecad.org/viewtopic.php?t=89012#p770224
2. Make the rectangles visible.
3. Start the Survey command and box select all objects in the 3D view.
