### PR TITLE
Fem: Disconnect slot when destroying Constraint object

### DIFF
--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -118,7 +118,10 @@ Constraint::Constraint()
     App::SuppressibleExtension::initExtension(this);
 }
 
-Constraint::~Constraint() = default;
+Constraint::~Constraint()
+{
+    connDocChangedObject.disconnect();
+}
 
 App::DocumentObjectExecReturn* Constraint::execute()
 {


### PR DESCRIPTION
`slotChangedObject` must be disconnected if the constraint is destroyed, for example in a transaction process.

```
App.ActiveDocument.openTransaction()
App.ActiveDocument.addObject("Fem::Constraint")
App.ActiveDocument.abortTransaction() # here the constraint is destroyed

App.ActiveDocument.openTransaction()
App.ActiveDocument.addObject("Fem::FemPostPipeline")
App.ActiveDocument.abortTransaction() # posible crash or exception raised since the slot is still connected.
```