### PR TITLE
Fix crash when using box selection with Arch Survey (issue #15981)

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2925,7 +2925,8 @@ static void doSelect(void* ud, SoEventCallback * cb)
             Gui::Selection().clearSelection(doc->getName());
         }
 
-        for(auto obj : doc->getObjects()) {
+        const std::vector<App::DocumentObject*> objects = doc->getObjects();
+        for(auto obj : objects) {
             if(App::GeoFeatureGroupExtension::getGroupOfObject(obj))
                 continue;
 


### PR DESCRIPTION
Fix for https://github.com/FreeCAD/FreeCAD/issues/15981.

doSelect() loops over document's object vector.  It can happen that, within the loop, Gui::Selection().addSelection() gets called and that ends up calling App::Document::addObject() which pushes an object to the vector that the loop is traversing.  If the vector is full, its storage is reallocated and this means that later iterations of the loop are using invalid iterators. Thus, one ends up with a bogus obj pointer and there will be a crash within getGroupOfObject().  The problem was observed when using Arch Survey.