### PR TITLE
Fix FreeCAD Classic cfg file to explicitly reassign theme defaults.

### DIFF
--- a/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
@@ -1,16 +1,302 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <FCParameters>
   <FCParamGroup Name="Root">
     <FCParamGroup Name="BaseApp">
       <FCParamGroup Name="Preferences">
+        <FCParamGroup Name="Themes">
+          <FCUInt Name="ThemeAccentColor1" Value="1434171135"/>
+          <FCUInt Name="ThemeAccentColor2" Value="1434171135"/>
+          <FCUInt Name="ThemeAccentColor3" Value="1434171135"/>
+        </FCParamGroup>
+        <FCParamGroup Name="View">
+          <FCUInt Name="HighlightColor" Value="3789624575"/>
+          <FCUInt Name="SelectionColor" Value="481107199"/>
+          <FCUInt Name="AxisLetterColor" Value="255"/>
+          <FCUInt Name="RotationCenterColor" Value="4278190131"/>
+          <FCText Name="NewDocumentCameraOrientation">Trimetric</FCText>
+          <FCUInt Name="BackgroundColor" Value="336897023"/>
+          <FCUInt Name="BackgroundColor2" Value="859006463"/>
+          <FCUInt Name="BackgroundColor3" Value="2543299327"/>
+          <FCUInt Name="BackgroundColor4" Value="1869583359"/>
+          <FCBool Name="Simple" Value="0"/>
+          <FCBool Name="Gradient" Value="1"/>
+          <FCBool Name="RadialGradient" Value="0"/>
+          <FCBool Name="UseBackgroundColorMid" Value="0"/>
+          <FCUInt Name="CbLabelColor" Value="4294967295"/>
+          <FCUInt Name="DefaultShapeColor" Value="3435980543"/>
+          <FCUInt Name="DefaultAmbientColor" Value="1431655935"/>
+          <FCUInt Name="DefaultEmissiveColor" Value="255"/>
+          <FCUInt Name="DefaultSpecularColor" Value="2290649343"/>
+          <FCBool Name="RandomColor" Value="0"/>
+          <FCUInt Name="DefaultShapeLineColor" Value="421075455"/>
+          <FCInt Name="DefaultShapeLineWidth" Value="2"/>
+          <FCUInt Name="DefaultShapeVertexColor" Value="421075455"/>
+          <FCInt Name="DefaultShapePointSize" Value="2"/>
+          <FCUInt Name="BoundingBoxColor" Value="4294967295"/>
+          <FCFloat Name="BoundingBoxFontSize" Value="10.000000000000"/>
+          <FCUInt Name="AnnotationTextColor" Value="4294967295"/>
+          <FCUInt Name="SketchEdgeColor" Value="4294967295"/>
+          <FCUInt Name="SketchVertexColor" Value="4294967295"/>
+          <FCUInt Name="EditedEdgeColor" Value="4294967295"/>
+          <FCUInt Name="ConstructionColor" Value="746455039"/>
+          <FCUInt Name="ExternalColor" Value="3425924095"/>
+          <FCUInt Name="InvalidSketchColor" Value="4285333759"/>
+          <FCUInt Name="FullyConstrainedColor" Value="16711935"/>
+          <FCUInt Name="InternalAlignedGeoColor" Value="2998042623"/>
+          <FCUInt Name="FullyConstraintElementColor" Value="2161156351"/>
+          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2410282495"/>
+          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="3739142399"/>
+          <FCUInt Name="ConstrainedIcoColor" Value="4280680703"/>
+          <FCUInt Name="NonDrivingConstrDimColor" Value="2555903"/>
+          <FCUInt Name="ConstrainedDimColor" Value="4280680703"/>
+          <FCUInt Name="ExprBasedConstrDimColor" Value="4286523135"/>
+          <FCUInt Name="DeactivatedConstrDimColor" Value="2139062271"/>
+          <FCUInt Name="CursorTextColor" Value="65535"/>
+          <FCUInt Name="CursorCrosshairColor" Value="4294967295"/>
+          <FCUInt Name="CreateLineColor" Value="2139062271"/>
+        </FCParamGroup>
+        <FCParamGroup Name="Editor">
+          <FCUInt Name="Text" Value="809320704"/>
+          <FCUInt Name="Bookmark" Value="16776960"/>
+          <FCUInt Name="Breakpoint" Value="4278190080"/>
+          <FCUInt Name="Keyword" Value="65280"/>
+          <FCUInt Name="Comment" Value="11141120"/>
+          <FCUInt Name="Block comment" Value="2694882304"/>
+          <FCUInt Name="Number" Value="65280"/>
+          <FCUInt Name="String" Value="4278190080"/>
+          <FCUInt Name="Character" Value="4278190080"/>
+          <FCUInt Name="Class name" Value="4289331200"/>
+          <FCUInt Name="Define name" Value="4289331200"/>
+          <FCUInt Name="Operator" Value="2694882304"/>
+          <FCUInt Name="Python output" Value="2863300352"/>
+          <FCUInt Name="Python error" Value="4278190080"/>
+          <FCUInt Name="Current line highlight" Value="3772833792"/>
+          <FCInt Name="FontSize" Value="10"/>
+        </FCParamGroup>
+        <FCParamGroup Name="OutputWindow">
+          <FCUInt Name="colorText" Value="809320959"/>
+          <FCUInt Name="colorLogging" Value="65535"/>
+          <FCUInt Name="colorWarning" Value="4289331455"/>
+          <FCUInt Name="colorError" Value="4278190335"/>
+        </FCParamGroup>
         <FCParamGroup Name="Mod">
           <FCParamGroup Name="Start">
             <FCBool Name="FileCardUseStyleSheet" Value="0"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Arch">
+            <FCUInt Name="ColorHelpers" Value="674321151"/>
+            <FCUInt Name="WallColor" Value="3604403967"/>
+            <FCUInt Name="StructureColor" Value="2527705855"/>
+            <FCUInt Name="RebarColor" Value="3111475967"/>
+            <FCUInt Name="WindowGlassColor" Value="1572326399"/>
+            <FCUInt Name="PanelColor" Value="3416289279"/>
+            <FCUInt Name="defaultSpaceColor" Value="4280090879"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Measure">
+            <FCParamGroup Name="Appearance">
+              <FCInt Name="DefaultFontSize" Value="18"/>
+              <FCUInt Name="DefaultTextColor" Value="4294967295"/>
+              <FCUInt Name="DefaultLineColor" Value="4294967295"/>
+              <FCUInt Name="DefaultTextBackgroundColor" Value="255"/>
+            </FCParamGroup>
+          </FCParamGroup>
+          <FCParamGroup Name="TechDraw">
+            <FCParamGroup Name="Decorations">
+              <FCUInt Name="SectionColor" Value="255"/>
+              <FCUInt Name="CenterColor" Value="255"/>
+              <FCUInt Name="VertexColor" Value="255"/>
+              <FCUInt Name="HighlightColor" Value="255"/>
+            </FCParamGroup>
+            <FCParamGroup Name="Colors">
+              <FCUInt Name="Hatch" Value="255"/>
+              <FCUInt Name="Background" Value="3553874943"/>
+              <FCUInt Name="PreSelectColor" Value="4294902015"/>
+              <FCUInt Name="HiddenColor" Value="255"/>
+              <FCUInt Name="SelectColor" Value="16711935"/>
+              <FCUInt Name="NormalColor" Value="255"/>
+              <FCUInt Name="CutSurfaceColor" Value="3553874943"/>
+              <FCUInt Name="GeomHatch" Value="255"/>
+              <FCUInt Name="FaceColor" Value="4294967295"/>
+              <FCBool Name="ClearFace" Value="0"/>
+              <FCUInt Name="gridColor" Value="255"/>
+              <FCUInt Name="PageColor" Value="4294967295"/>
+              <FCBool Name="LightOnDark" Value="0"/>
+              <FCBool Name="Monochrome" Value="0"/>
+              <FCUInt Name="LightTextColor" Value="4294967295"/>
+              <FCUInt Name="TemplateUnderlineColor" Value="65535"/>
+            </FCParamGroup>
+            <FCParamGroup Name="Dimensions">
+              <FCBool Name="UseGlobalDecimals" Value="1"/>
+              <FCFloat Name="FontSize" Value="10.000000000000"/>
+              <FCInt Name="dimsymbol" Value="3"/>
+              <FCFloat Name="ArrowSize" Value="0.800000000000"/>
+              <FCInt Name="StandardAndStyle" Value="0"/>
+              <FCBool Name="ShowUnits" Value="0"/>
+              <FCInt Name="AltDecimals" Value="2"/>
+              <FCFloat Name="TolSizeAdjust" Value="0.800000000000"/>
+              <FCText Name="DiameterSymbol">⌀</FCText>
+              <FCInt Name="ArrowStyle" Value="0"/>
+              <FCText Name="formatSpec">%.2w</FCText>
+              <FCFloat Name="GapISO" Value="0.000000000000"/>
+              <FCFloat Name="GapASME" Value="0.000000000000"/>
+              <FCFloat Name="LineSpacingFactorISO" Value="2.000000000000"/>
+              <FCFloat Name="BalloonKink" Value="5.000000000000"/>
+              <FCUInt Name="Color" Value="255"/>
+              <FCBool Name="AutoCorrectRefs" Value="1"/>
+            </FCParamGroup>
+            <FCParamGroup Name="Markups">
+              <FCUInt Name="Color" Value="255"/>
+            </FCParamGroup>
+            <FCParamGroup Name="Labels">
+              <FCText Name="LabelFont">Sans</FCText>
+              <FCFloat Name="LabelSize" Value="5.000000000000"/>
+            </FCParamGroup>
+            <FCParamGroup Name="Rez"/>
+            <FCParamGroup Name="Files">
+              <FCText Name="TemplateFile"></FCText>
+              <FCText Name="TemplateDir"></FCText>
+              <FCText Name="FileHatch"></FCText>
+              <FCText Name="LineGroupFile"></FCText>
+              <FCText Name="WeldingDir"></FCText>
+              <FCText Name="DirSymbol"></FCText>
+            </FCParamGroup>
+            <FCParamGroup Name="Standards">
+              <FCInt Name="LineStandard" Value="1"/>
+              <FCInt Name="SectionLineStandard" Value="0"/>
+            </FCParamGroup>
+            <FCParamGroup Name="dimensioning">
+              <FCBool Name="SingleDimensioningTool" Value="1"/>
+              <FCBool Name="SeparatedDimensioningTools" Value="0"/>
+              <FCBool Name="DimensioningDiameter" Value="1"/>
+              <FCBool Name="DimensioningRadius" Value="1"/>
+            </FCParamGroup>
+            <FCParamGroup Name="General">
+              <FCBool Name="GlobalUpdateDrawings" Value="1"/>
+              <FCBool Name="AllowPageOverride" Value="1"/>
+              <FCBool Name="KeepPagesUpToDate" Value="1"/>
+              <FCBool Name="AutoDist" Value="1"/>
+              <FCInt Name="ProjectionAngle" Value="0"/>
+              <FCBool Name="showGrid" Value="0"/>
+              <FCFloat Name="gridSpacing" Value="10.000000000000"/>
+              <FCBool Name="multiSelection" Value="0"/>
+              <FCBool Name="UseCameraDirection" Value="0"/>
+              <FCBool Name="AlwaysShowLabel" Value="0"/>
+              <FCFloat Name="DefaultScale" Value="1.000000000000"/>
+              <FCInt Name="DefaultScaleType" Value="0"/>
+              <FCFloat Name="DefaultViewScale" Value="1.000000000000"/>
+              <FCFloat Name="VertexScale" Value="5.000000000000"/>
+              <FCFloat Name="TemplateDotSize" Value="3.000000000000"/>
+              <FCInt Name="EdgeCapStyle" Value="0"/>
+              <FCBool Name="ShowDetailMatting" Value="1"/>
+              <FCBool Name="ShowDetailHighlight" Value="1"/>
+              <FCBool Name="HandleFaces" Value="1"/>
+              <FCBool Name="ShowSectionEdges" Value="1"/>
+              <FCBool Name="SectionFuseFirst" Value="0"/>
+              <FCFloat Name="EdgeFuzz" Value="10.000000000000"/>
+              <FCFloat Name="MarkFuzz" Value="5.000000000000"/>
+              <FCBool Name="ReportProgress" Value="0"/>
+              <FCBool Name="NewFaceFinder" Value="1"/>
+              <FCInt Name="ScrubCount" Value="1"/>
+            </FCParamGroup>
+            <FCParamGroup Name="PAT">
+              <FCText Name="FilePattern"></FCText>
+              <FCText Name="NamePattern">Diamond</FCText>
+              <FCInt Name="MaxSeg" Value="10000"/>
+            </FCParamGroup>
+            <FCParamGroup Name="LeaderLine">
+              <FCBool Name="AutoHorizontal" Value="1"/>
+            </FCParamGroup>
+            <FCParamGroup Name="HLR">
+              <FCBool Name="SeamViz" Value="0"/>
+              <FCBool Name="SmoothViz" Value="1"/>
+              <FCBool Name="HardViz" Value="1"/>
+              <FCBool Name="UsePolygon" Value="0"/>
+              <FCBool Name="IsoViz" Value="0"/>
+              <FCBool Name="SmoothHid" Value="0"/>
+              <FCBool Name="SeamHid" Value="0"/>
+              <FCBool Name="IsoHid" Value="0"/>
+              <FCInt Name="IsoCount" Value="0"/>
+              <FCBool Name="HardHid" Value="0"/>
+            </FCParamGroup>
+            <FCParamGroup Name="debug">
+              <FCBool Name="debugSection" Value="0"/>
+              <FCBool Name="debugDetail" Value="0"/>
+              <FCBool Name="allowCrazyEdge" Value="0"/>
+            </FCParamGroup>
+          </FCParamGroup>
+          <FCParamGroup Name="CAM">
+            <FCUInt Name="DefaultNormalPathColor" Value="11141375"/>
+            <FCUInt Name="DefaultRapidPathColor" Value="2852126975"/>
+            <FCInt Name="DefaultPathLineWidth" Value="1"/>
+            <FCUInt Name="DefaultPathMarkerColor" Value="1442775295"/>
+            <FCUInt Name="DefaultProbePathColor" Value="4294903295"/>
+            <FCUInt Name="DefaultHighlightPathColor" Value="4286382335"/>
+            <FCUInt Name="DefaultBBoxSelectionColor" Value="3372220415"/>
+            <FCUInt Name="DefaultBBoxNormalColor" Value="4294967295"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Draft">
+            <FCUInt Name="color" Value="3435980288"/>
+            <FCUInt Name="constructioncolor" Value="746455039"/>
+            <FCUInt Name="DefaultTextColor" Value="255"/>
+            <FCText Name="svgDashedLine">3,1</FCText>
+            <FCText Name="svgDashdotLine">3,1,0.2,1</FCText>
+            <FCText Name="svgDottedLine">0.5,1</FCText>
+            <FCFloat Name="HatchPatternSize" Value="0.030000000000"/>
+            <FCInt Name="gridTransparency" Value="0"/>
+            <FCUInt Name="gridColor" Value="842157055"/>
+            <FCUInt Name="snapcolor" Value="4289396735"/>
+            <FCInt Name="DefaultAnnoLineWidth" Value="2"/>
+            <FCUInt Name="DefaultAnnoLineColor" Value="255"/>
+          </FCParamGroup>
+          <FCParamGroup Name="OpenSCAD">
+            <FCInt Name="useMaxFN" Value="16"/>
+            <FCInt Name="exportConvexity" Value="10"/>
+            <FCFloat Name="exportFa" Value="12.000000000000"/>
+            <FCFloat Name="exportFs" Value="2.000000000000"/>
+            <FCFloat Name="meshdeflection" Value="0.000000000000"/>
+            <FCText Name="openscadexecutable"></FCText>
+            <FCText Name="transferdirectory"></FCText>
+            <FCInt Name="transfermechanism" Value="0"/>
+            <FCBool Name="printVerbose" Value="0"/>
+            <FCBool Name="useViewProviderTree" Value="0"/>
+            <FCBool Name="useMultmatrixFeature" Value="0"/>
+          </FCParamGroup>
+          <FCParamGroup Name="Sketcher">
+            <FCParamGroup Name="Snap"/>
+            <FCParamGroup Name="General">
+              <FCUInt Name="GridLineColor" Value="2998055679"/>
+              <FCUInt Name="GridDivLineColor" Value="2998055679"/>
+              <FCInt Name="GridLineWidth" Value="1"/>
+              <FCInt Name="GridDivLineWidth" Value="2"/>
+            </FCParamGroup>
+            <FCParamGroup Name="View">
+              <FCInt Name="EdgeWidth" Value="2"/>
+              <FCInt Name="ConstructionWidth" Value="2"/>
+              <FCInt Name="InternalWidth" Value="2"/>
+              <FCInt Name="ExternalWidth" Value="2"/>
+              <FCInt Name="EdgePattern" Value="65535"/>
+              <FCInt Name="ConstructionPattern" Value="64764"/>
+              <FCInt Name="InternalPattern" Value="64764"/>
+              <FCInt Name="ExternalPattern" Value="58596"/>
+            </FCParamGroup>
+          </FCParamGroup>
+          <FCParamGroup Name="Mesh">
+            <FCUInt Name="MeshColor" Value="3435973887"/>
+            <FCUInt Name="LineColor" Value="255"/>
+            <FCUInt Name="BackfaceColor" Value="3435973887"/>
           </FCParamGroup>
         </FCParamGroup>
         <FCParamGroup Name="MainWindow">
           <FCText Name="Theme">FreeCAD Classic</FCText>
           <FCText Name="OverlayActiveStyleSheet">Light Theme + Dark Background.qss</FCText>
+          <FCText Name="StyleSheet"/>
+        </FCParamGroup>
+        <FCParamGroup Name="TreeView">
+          <FCUInt Name="TreeEditColor" Value="1588208639"/>
+          <FCUInt Name="TreeActiveColor" Value="1016200447"/>
+        </FCParamGroup>
+        <FCParamGroup Name="NaviCube">
+          <FCUInt Name="BaseColor" Value="3806916480"/>
+          <FCInt Name="InactiveOpacity" Value="50"/>
         </FCParamGroup>
       </FCParamGroup>
     </FCParamGroup>

--- a/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
@@ -81,6 +81,10 @@
         <FCParamGroup Name="Mod">
           <FCParamGroup Name="Start">
             <FCBool Name="FileCardUseStyleSheet" Value="0"/>
+            <FCInt Name="FileThumbnailIconsSize" Value="128"/>
+            <FCUInt Name="FileThumbnailBorderColor" Value="1654713087"/>
+            <FCUInt Name="FileThumbnailBackgroundColor" Value="3554532863"/>
+            <FCUInt Name="FileThumbnailSelectionColor" Value="648178175"/>
           </FCParamGroup>
           <FCParamGroup Name="Arch">
             <FCUInt Name="ColorHelpers" Value="674321151"/>

--- a/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Classic/FreeCAD Classic.cfg
@@ -125,16 +125,15 @@
               <FCUInt Name="TemplateUnderlineColor" Value="65535"/>
             </FCParamGroup>
             <FCParamGroup Name="Dimensions">
-              <FCBool Name="UseGlobalDecimals" Value="1"/>
-              <FCFloat Name="FontSize" Value="10.000000000000"/>
-              <FCInt Name="dimsymbol" Value="3"/>
-              <FCFloat Name="ArrowSize" Value="0.800000000000"/>
               <FCInt Name="StandardAndStyle" Value="0"/>
+              <FCBool Name="UseGlobalDecimals" Value="1"/>
               <FCBool Name="ShowUnits" Value="0"/>
               <FCInt Name="AltDecimals" Value="2"/>
+              <FCFloat Name="FontSize" Value="5.000000000000"/>
               <FCFloat Name="TolSizeAdjust" Value="0.800000000000"/>
               <FCText Name="DiameterSymbol">⌀</FCText>
               <FCInt Name="ArrowStyle" Value="0"/>
+              <FCFloat Name="ArrowSize" Value="3.500000000000"/>
               <FCText Name="formatSpec">%.2w</FCText>
               <FCFloat Name="GapISO" Value="0.000000000000"/>
               <FCFloat Name="GapASME" Value="0.000000000000"/>
@@ -147,7 +146,7 @@
               <FCUInt Name="Color" Value="255"/>
             </FCParamGroup>
             <FCParamGroup Name="Labels">
-              <FCText Name="LabelFont">Sans</FCText>
+              <FCText Name="LabelFont">osifont</FCText>
               <FCFloat Name="LabelSize" Value="5.000000000000"/>
             </FCParamGroup>
             <FCParamGroup Name="Rez"/>


### PR DESCRIPTION
This replaces the current config file applied when setting FreeCAD to classic. It was discussed that resolving the config file by clearing out settings in order to regain the Classic (default) appearance was cumbersome. This creates 'Classic' as a true theme, and the hard coded values become failsafes in the event of some unexpected error. It will make future adjustments to the Classic theme easier through modification of this config file instead of digging through code to find and modify scattered values.