### PR TITLE
[Part] [Post 1.0] Preferences > Shape view > Maximum angle deflection warn user...

### DIFF
--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
@@ -42,15 +42,27 @@ using namespace PartGui;
  *  name 'name' and widget flags set to 'f'
  */
 DlgSettings3DViewPart::DlgSettings3DViewPart(QWidget* parent)
-  : PreferencePage(parent), ui(new Ui_DlgSettings3DViewPart), checkValue(false)
+    : PreferencePage(parent)
+    , ui(new Ui_DlgSettings3DViewPart)
+    , checkValue(false)
 {
     ui->setupUi(this);
-    connect(ui->maxDeviation, qOverload<double>(&QDoubleSpinBox::valueChanged),
-            this, &DlgSettings3DViewPart::onMaxDeviationValueChanged);
-    ParameterGrp::handle hPart = App::GetApplication().GetParameterGroupByPath
-        ("User parameter:BaseApp/Preferences/Mod/Part");
-    double lowerLimit = hPart->GetFloat("MinimumDeviation", ui->maxDeviation->minimum());
-    ui->maxDeviation->setMinimum(lowerLimit);
+    connect(ui->maxDeviation,
+            qOverload<double>(&QDoubleSpinBox::valueChanged),
+            this,
+            &DlgSettings3DViewPart::onMaxDeviationValueChanged);
+    connect(ui->maxAngularDeflection,
+            qOverload<double>(&QDoubleSpinBox::valueChanged),
+            this,
+            &DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged);
+    ParameterGrp::handle hPart = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Part");
+    const double minDeviationlowerLimit = hPart->GetFloat(
+        "MinimumDeviation", ui->maxDeviation->minimum());
+    ui->maxDeviation->setMinimum(minDeviationlowerLimit);
+    const double minAngleDeflectionlowerLimit = hPart->GetFloat(
+        "MinimumDeviation", ui->maxAngularDeflection->minimum());
+    ui->maxAngularDeflection->setMinimum(minAngleDeflectionlowerLimit);
 }
 
 /**
@@ -58,15 +70,35 @@ DlgSettings3DViewPart::DlgSettings3DViewPart(QWidget* parent)
  */
 DlgSettings3DViewPart::~DlgSettings3DViewPart() = default;
 
-void DlgSettings3DViewPart::onMaxDeviationValueChanged(double v)
+void DlgSettings3DViewPart::onMaxDeviationValueChanged(double vMaxDev)
 {
-    if (!this->isVisible())
+    if (!this->isVisible()) {
         return;
-    if (v < 0.01 && !checkValue) {
+    }
+    const double maxDevMinThreshold = 0.01;
+    if (vMaxDev < maxDevMinThreshold && !checkValue) {
         checkValue = true;
-        QMessageBox::warning(this, tr("Deviation"),
+        QMessageBox::warning(
+            this,
+            tr("Deviation"),
             tr("Setting a too small deviation causes the tessellation to take longer"
-               "and thus freezes or slows down the GUI."));
+               " and thus freezes or slows down the GUI."));
+    }
+}
+
+void DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged(double vMaxAngle)
+{
+    if (!this->isVisible()) {
+        return;
+    }
+    const double vMaxAngleMinThreshold = 2.0;
+    if (vMaxAngle < vMaxAngleMinThreshold && !checkValue) {
+        checkValue = true;
+        QMessageBox::warning(
+            this,
+            tr("Angle Deflection"),
+            tr("Setting a too small angle deviation causes the tessellation to take longer"
+               " and thus freezes or slows down the GUI."));
     }
 }
 
@@ -79,13 +111,13 @@ void DlgSettings3DViewPart::saveSettings()
     std::vector<App::Document*> docs = App::GetApplication().getDocuments();
     for (auto it : docs) {
         Gui::Document* doc = Gui::Application::Instance->getDocument(it);
-        std::vector<Gui::ViewProvider*> views = doc->getViewProvidersOfType(ViewProviderPart::getClassTypeId());
+        std::vector<Gui::ViewProvider*> views =
+            doc->getViewProvidersOfType(ViewProviderPart::getClassTypeId());
         for (auto view : views) {
             static_cast<ViewProviderPart*>(view)->reload();
         }
     }
 }
-
 void DlgSettings3DViewPart::loadSettings()
 {
     ui->maxDeviation->onRestore();

--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
@@ -91,6 +91,11 @@ void DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged(double vMaxAngle)
     if (!this->isVisible()) {
         return;
     }
+    /**
+     *  The lower threshold of 2.0 was determined by testing
+     *  as laid out in the table as per comment hyperlink:
+     *  https://github.com/FreeCAD/FreeCAD/issues/15951#issuecomment-2304308163
+     */
     const double vMaxAngleMinThreshold = 2.0;
     if (vMaxAngle < vMaxAngleMinThreshold && !checkValue) {
         checkValue = true;

--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.h
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.h
@@ -49,6 +49,7 @@ protected:
 
 private:
     void onMaxDeviationValueChanged(double);
+    void onMaxAngularDeflectionValueChanged(double);
 
 private:
     std::unique_ptr<Ui_DlgSettings3DViewPart> ui;


### PR DESCRIPTION
...if they attempt to set below 2 degrees. Following an issue where a user had set their Max Angle Deflection to 1 degree https://github.com/FreeCAD/FreeCAD/issues/15951#issuecomment-2303242619 it seemed appropriate to implement the same warning that had been previously implemented for the lower threshold of Maximum Deviation.

To see what the implications of performance degradation below 2 degrees, see test table in https://github.com/FreeCAD/FreeCAD/issues/15951#issuecomment-2304308163
