### PR TITLE
Gui: Use FreeCAD Theme only for FreeCAD stuff

### DIFF
--- a/src/Gui/BitmapFactory.h
+++ b/src/Gui/BitmapFactory.h
@@ -75,6 +75,10 @@ public:
      * If no such icon is found in the current theme fallback is returned instead.
      */
     QIcon iconFromTheme(const char* name, const QIcon& fallback = QIcon());
+    /** Returns the QIcon corresponding to name in the default (FreeCAD's) icon theme.
+     * If no such icon is found in the current theme fallback is returned instead.
+     */
+    QIcon iconFromDefaultTheme(const char* name, const QIcon& fallback = QIcon());
     /// Retrieves a pixmap by name
     QPixmap pixmap(const char* name) const;
     /** Retrieves a pixmap by name and size created by an
@@ -150,6 +154,7 @@ public:
 private:
     bool loadPixmap(const QString& path, QPixmap&) const;
     void restoreCustomPaths();
+    void configureUseIconTheme();
 
     static BitmapFactoryInst* _pcSingleton;
     BitmapFactoryInst();

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -178,13 +178,8 @@ void StartupProcess::setThemePaths()
         QIcon::setThemeSearchPaths(searchPaths);
     }
 
-    // KDE file dialog needs icons from the desktop theme
-    QIcon::setFallbackThemeName(QIcon::themeName());
-
     std::string name = hTheme->GetASCII("Name");
-    if (name.empty()) {
-        QIcon::setThemeName(QLatin1String("FreeCAD-default"));
-    } else {
+    if (!name.empty()) {
         QIcon::setThemeName(QString::fromLatin1(name.c_str()));
     }
 }


### PR DESCRIPTION
This should fix the issue with FreeCAD icons leaking to system dialogs. Icons loaded with BitmapFactory (almost all) will respect the new user parameter `UseIconTheme` under `BaseApp/Preferences/Bitmaps/Theme` group. Setting this parameter to true will force Qt to use icons from icon theme - by default the system one. Icon theme can be overriden via `Name` parameter. The default is false so FreeCAD will use the default icons. It does not touch Qt icon theme mechanisms so system dialogs, buttons etc should still use the icons from system theme.

Fixes: https://github.com/FreeCAD/FreeCAD/issues/16020