### PR TITLE
Gui: Ensure minimum size of preferences dialog

### DIFF
--- a/src/Gui/DlgPreferencesImp.cpp
+++ b/src/Gui/DlgPreferencesImp.cpp
@@ -761,10 +761,10 @@ void DlgPreferencesImp::showEvent(QShowEvent* ev)
     auto screen = windowHandle()->screen();
     auto availableSize = screen->availableSize();
 
-    // leave at least 100 px of height so preferences window does not take
+    // leave some portion of height so preferences window does not take
     // entire screen height. User will still be able to resize the window,
     // but it should never start too tall.
-    auto maxStartHeight = availableSize.height() - 100;
+    auto maxStartHeight = availableSize.height() - minVerticalEmptySpace;
 
     if (height() > maxStartHeight) {
         auto heightDifference = availableSize.height() - maxStartHeight;
@@ -783,8 +783,8 @@ void DlgPreferencesImp::expandToMinimumDialogWidth()
     auto availableSize = screen->availableSize();
 
     int mw = minimumDialogWidth(minimumPageWidth());
-    // expand dialog to minimum size required but do not use more than 80% of screen real estate
-    resize(std::min(int(0.8 * availableSize.width()), mw), height());
+    // expand dialog to minimum size required but do not use more than specified width portion
+    resize(std::min(int(maxScreenWidthCoveragePercent * availableSize.width()), mw), height());
 }
 
 void DlgPreferencesImp::onPageSelected(const QModelIndex& index)

--- a/src/Gui/DlgPreferencesImp.cpp
+++ b/src/Gui/DlgPreferencesImp.cpp
@@ -782,11 +782,9 @@ void DlgPreferencesImp::expandToMinimumDialogWidth()
     auto screen = windowHandle()->screen();
     auto availableSize = screen->availableSize();
 
-    // if the expanded dialog occupies less than 50% of the screen
     int mw = minimumDialogWidth(minimumPageWidth());
-    if (availableSize.width() > 2 * mw) {
-        resize(mw, height());
-    }
+    // expand dialog to minimum size required but do not use more than 80% of screen real estate
+    resize(std::min(int(0.8 * availableSize.width()), mw), height());
 }
 
 void DlgPreferencesImp::onPageSelected(const QModelIndex& index)

--- a/src/Gui/DlgPreferencesImp.h
+++ b/src/Gui/DlgPreferencesImp.h
@@ -130,6 +130,9 @@ class GuiExport DlgPreferencesImp : public QDialog
 {
     Q_OBJECT
 
+    static constexpr double maxScreenWidthCoveragePercent = 0.8; // maximum % of screen width taken by the dialog
+    static constexpr int minVerticalEmptySpace = 100;            // px of vertical space to leave
+
 public:
     static void addPage(const std::string& className, const std::string& group);
     static void removePage(const std::string& className, const std::string& group);


### PR DESCRIPTION
This will ensure that the width of preferences dialog is resized to fit all pages properly but not take more than 80% of screen.