### PR TITLE
[TD]fix false positives in isCircle (fix #15979)

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.h
+++ b/src/Mod/TechDraw/App/Geometry.h
@@ -450,6 +450,9 @@ class TechDrawExport GeometryUtils
         static bool isLine(TopoDS_Edge occEdge);
         static TopoDS_Edge asLine(TopoDS_Edge occEdge);
 
+        static double edgeLength(TopoDS_Edge occEdge);
+
+
 };
 
 } //end namespace TechDraw


### PR DESCRIPTION
This PR implements a fix for issue #15979.  It implements more rigourous checks in isCircle/getCircleParms
to avoid falsely treating bsplines as circles.