### PR TITLE
Addon Manager: Adjust button reference for Qt6 compatibility

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -432,7 +432,7 @@ class CommandAddonManager(QtCore.QObject):
             ok_btn.setText(translate("AddonsInstaller", "Restart now"))
             cancel_btn.setText(translate("AddonsInstaller", "Restart later"))
             ret = m.exec_()
-            if ret == m.Ok:
+            if ret == QtWidgets.QMessageBox.StandardButton.Ok:
                 # restart FreeCAD after a delay to give time to this dialog to close
                 QtCore.QTimer.singleShot(1000, utils.restart_freecad)
 


### PR DESCRIPTION
The old code worked in Qt5, but Qt6 no longer supports this style of constant reference. The new code will work in Qt5 and Qt6.