### PR TITLE
Fem: Use regex to search gmsh groups items and fix physical group item id

### DIFF
--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -28,6 +28,7 @@ __url__ = "https://www.freecad.org"
 #  @{
 
 import os
+import re
 import subprocess
 
 import FreeCAD
@@ -644,44 +645,39 @@ class GmshTools:
             Console.PrintMessage(f"  {self.bl_setting_list}\n")
 
     def write_groups(self, geo):
+        # find shape type and index from group elements and isolate them from possible prefix
+        # for example: "PartObject.Solid2" -> shape: Solid, index: 2
+        # we use the element index of FreeCAD which starts with 1 (example: "Face1"),
+        # same as Gmsh. For unit test we need them to have a fixed order
+        reg_exp = re.compile(r"(?:.*\.)?(?P<shape>Solid|Face|Edge|Vertex)(?P<index>\d+)$")
+
         if self.group_elements:
             # print("  We are going to have to find elements to make mesh groups for.")
             geo.write("// group data\n")
-            # we use the element name of FreeCAD which starts
-            # with 1 (example: "Face1"), same as Gmsh
-            # for unit test we need them to have a fixed order
             for group in sorted(self.group_elements):
                 gdata = self.group_elements[group]
-                # print(gdata)
-                # geo.write("// " + group + "\n")
-                ele_nr = ""
-                if gdata[0].startswith("Solid"):
-                    physical_type = "Volume"
-                    for ele in gdata:
-                        ele_nr += ele.lstrip("Solid") + ", "
-                elif gdata[0].startswith("Face"):
-                    physical_type = "Surface"
-                    for ele in gdata:
-                        ele_nr += ele.lstrip("Face") + ", "
-                elif gdata[0].startswith("Edge"):
-                    physical_type = "Line"
-                    for ele in gdata:
-                        ele_nr += ele.lstrip("Edge") + ", "
-                elif gdata[0].startswith("Vertex"):
-                    physical_type = "Point"
-                    for ele in gdata:
-                        ele_nr += ele.lstrip("Vertex") + ", "
-                if ele_nr:
-                    ele_nr = ele_nr.rstrip(", ")
-                    # print(ele_nr)
-                    curly_br_s = "{"
-                    curly_br_e = "}"
-                    # explicit use double quotes in geo file
-                    geo.write(
-                        'Physical {}("{}") = {}{}{};\n'.format(
-                            physical_type, group, curly_br_s, ele_nr, curly_br_e
-                        )
-                    )
+                ele = {"Volume": [], "Surface": [], "Line": [], "Point": []}
+
+                for i in gdata:
+                    m = reg_exp.match(i)
+                    if m:
+                        shape = m.group("shape")
+                        index = str(m.group("index"))
+                        if shape == "Solid":
+                            ele["Volume"].append(index)
+                        elif shape == "Face":
+                            ele["Surface"].append(index)
+                        elif shape == "Edge":
+                            ele["Line"].append(index)
+                        elif shape == "Vertex":
+                            ele["Point"].append(index)
+
+                for phys in ele:
+                    if ele[phys]:
+                        name = group + "_{}".format(phys)
+                        items = "{" + ", ".join(ele[phys]) + "}"
+                        geo.write('Physical {}("{}") = {};\n'.format(phys, name, items))
+
             geo.write("\n")
 
     def write_boundary_layer(self, geo):

--- a/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
+++ b/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
@@ -7,10 +7,10 @@ General.NumThreads = X;
 Merge "tmp0TVZbM.brep";
 
 // group data
-Physical Surface("Face1") = {1};
-Physical Surface("Face2") = {2};
-Physical Surface("Face6") = {6};
-Physical Volume("Solid1") = {1};
+Physical Surface("Face1_Surface") = {1};
+Physical Surface("Face2_Surface") = {2};
+Physical Surface("Face6_Surface") = {6};
+Physical Volume("Solid1_Volume") = {1};
 
 // Characteristic Length
 // no boundary layer settings for this mesh


### PR DESCRIPTION
Currently, if a mesh group has different element types, the physical group is not created, for example:
Create a Part cube.
Create a Fem analysis, a Gmsh mesh object and a Fem mesh group.
Add two different element types from the Part cube to the group, for example an edge and a face.
Try to mesh -> Error reported as the `.geo` file generated has incorrect items id in the physical group.
Generated shape2mesh.geo file:
```
// group data
Physical Line("MeshGroup") = {6, Face3};
```


This bug is now fixed.
Since each physical group expect to have a unique element type, the physical group is spli based on the element types it contains and one group is created per element type.
Generated shape2mesh.geo file:
```
// group data
Physical Surface("MeshGroup_Surface") = {3};
Physical Line("MeshGroup_Line") = {6};
```

@FEA-eng 
