### PR TITLE
Remove version "v0.21" from the old backup format warning message

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2315,7 +2315,7 @@ void Application::checkForDeprecatedSettings()
                 ->GetBool("UseFCBakExtension", true);
         if (!useFCBakExtension) {
             // TODO: This should be translated
-            Base::Console().Warning("The `.FCStd#` backup format is deprecated as of v0.21 and may "
+            Base::Console().Warning("The `.FCStd#` backup format is deprecated and may "
                                     "be removed in future versions.\n"
                                     "To update, check the 'Preferences->General->Document->Use "
                                     "date and FCBak extension' option.\n");


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/15803
Remove version "v0.21" from the old backup format warning message.

@chennes touches strings but only removes the hardcoded old version info
