### PR TITLE
Draft: Fix regression with display of SVG patterns

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -263,7 +263,7 @@ class ViewProviderDraft(object):
         draw style, shape color, transparency, and others.
 
         This method  updates the texture and pattern if
-        the properties `TextureImage`, `Pattern`, `DiffuseColor`,
+        the properties `TextureImage`, `Pattern`, `ShapeAppearance`,
         and `PatternSize` change.
 
         Parameters
@@ -275,7 +275,7 @@ class ViewProviderDraft(object):
             Name of the property that was modified.
         """
         # treatment of patterns and image textures
-        if prop in ("TextureImage", "Pattern", "DiffuseColor"):
+        if prop in ("TextureImage", "Pattern", "ShapeAppearance"):
             if hasattr(self.Object, "Shape"):
                 if self.Object.Shape.Faces:
                     path = None


### PR DESCRIPTION
In V0.22 SVG patterns are not displayed when a file is reopend.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=90128
