### PR TITLE
CMake: Fix loading of materials-editor.ui for Mod/Material

### DIFF
--- a/src/Mod/Material/Gui/CMakeLists.txt
+++ b/src/Mod/Material/Gui/CMakeLists.txt
@@ -154,11 +154,7 @@ SET(MatGuiImages
     Resources/images/default_image.png
 )
 
-SET(Material_Ui_Files
-    Resources/ui/materials-editor.ui
-)
-
-add_library(MatGui SHARED ${MatGui_SRCS} ${MatGuiIcon_SVG} ${MatGuiImages} ${Material_Ui_Files})
+add_library(MatGui SHARED ${MatGui_SRCS} ${MatGuiIcon_SVG} ${MatGuiImages})
 target_link_libraries(MatGui ${MatGui_LIBS})
 if (FREECAD_WARN_ERROR)
     target_compile_warn_error(MatGui)
@@ -169,9 +165,7 @@ SET_PYTHON_PREFIX_SUFFIX(MatGui)
 
 fc_copy_sources(MatGui "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Material" ${MatGuiIcon_SVG})
 fc_copy_sources(MatGui "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Material" ${MatGuiImages})
-fc_copy_sources(MatGui "${CMAKE_BINARY_DIR}/Mod/Material" ${Material_Ui_Files})
 
 INSTALL(TARGETS MatGui DESTINATION ${CMAKE_INSTALL_LIBDIR})
 INSTALL(FILES ${MatGuiIcon_SVG} DESTINATION "${CMAKE_INSTALL_DATADIR}/Mod/Material/Resources/icons")
 INSTALL(FILES ${MatGuiImages} DESTINATION "${CMAKE_INSTALL_DATADIR}/Mod/Material/Resources/images")
-INSTALL(FILES ${Material_Ui_Files} DESTINATION "${CMAKE_BINARY_DIR}/Mod/Material/Resources/ui")

--- a/src/Mod/Material/MaterialEditor.py
+++ b/src/Mod/Material/MaterialEditor.py
@@ -68,8 +68,7 @@ class MaterialEditor:
         filePath = os.path.dirname(__file__) + os.sep
         self.iconPath = (filePath + "Resources" + os.sep + "icons" + os.sep)
 
-        # load the UI file from the same directory as this script
-        self.widget = FreeCADGui.PySideUic.loadUi(filePath + "Resources" + os.sep + "ui" + os.sep + "materials-editor.ui")
+        self.widget = FreeCADGui.PySideUic.loadUi(":/ui/materials-editor.ui")
         # remove unused Help button
         self.widget.setWindowFlags(self.widget.windowFlags()
                                    & ~QtCore.Qt.WindowContextHelpButtonHint)


### PR DESCRIPTION
The materials-editor.ui is part of Material.qrc, so the file can be loaded from the resource file. After this change it is no longer necessary to install the file explicitly, so the install is removed.

This as a sideeffect fixes the issue with installation process for some distributions #15571 (and #15713 )

## Testing

Manually tested, the Material editor GUI displays and works after this change.

It also obsoletes pull requests #16069 #15565 #15714 