### PR TITLE
BIM: fix invalid converesion of button to int

### DIFF
--- a/src/Mod/BIM/bimcommands/BimLibrary.py
+++ b/src/Mod/BIM/bimcommands/BimLibrary.py
@@ -536,7 +536,7 @@ class BIM_Library_TaskPanel:
 
         from PySide import QtGui
 
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def reject(self):
 

--- a/src/Mod/BIM/bimcommands/BimPreflight.py
+++ b/src/Mod/BIM/bimcommands/BimPreflight.py
@@ -158,7 +158,7 @@ class BIM_Preflight_TaskPanel:
     def getStandardButtons(self):
         from PySide import QtCore, QtGui
 
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def reject(self):
         from PySide import QtCore, QtGui

--- a/src/Mod/BIM/bimcommands/BimWindows.py
+++ b/src/Mod/BIM/bimcommands/BimWindows.py
@@ -71,7 +71,7 @@ class BIM_Windows_TaskPanel:
     def getStandardButtons(self):
         from PySide import QtGui
 
-        return int(QtGui.QDialogButtonBox.Close)
+        return QtGui.QDialogButtonBox.Close
 
     def reject(self):
         FreeCADGui.Control.closeDialog()


### PR DESCRIPTION
As of 73cb5bafe0, the click on the respective buttons in BIM panel causes the error mentioned bellow. After applying the patch it the dialogs open as expected.

`<class 'TypeError'>: int() argument must be a string, a bytes-like object or a real number, not 'StandardButton'`

* OS: Arch Linux
* Python: 3.12.5