### PR TITLE
add BOPFeatures to BOPTools __init__.py

### DIFF
--- a/src/Mod/Part/BOPTools/__init__.py
+++ b/src/Mod/Part/BOPTools/__init__.py
@@ -30,6 +30,7 @@ BOP-like operations"""
 #  \ingroup PART
 
 __all__ = [
+"BOPFeatures",
 "GeneralFuseResult",
 "JoinAPI",
 "JoinFeatures",
@@ -41,6 +42,7 @@ __all__ = [
 
 def importAll():
     "importAll(): imports all modules of BOPTools package"
+    from . import BOPFeatures
     from . import GeneralFuseResult
     from . import JoinAPI
     from . import JoinFeatures


### PR DESCRIPTION
BOPFeatures was not being imported, since it was missing in the BOPTools' __init__.py . All BOPTools modules were being imported except this one.

BOPFeatures has been included in the __init__.py file, as it can be seen in the linked commit.