### PR TITLE
[planegcs] Fix error gradient check in `ConstraintTangentCircumf`

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -1624,10 +1624,10 @@ double ConstraintTangentCircumf::grad(double* param)
         }
         else {
             if (param == r1()) {
-                deriv += 2 * (*r1() + *r2());
+                deriv += -2 * (*r1() + *r2());
             }
             if (param == r2()) {
-                deriv += 2 * (*r1() + *r2());
+                deriv += -2 * (*r1() + *r2());
             }
         }
     }


### PR DESCRIPTION
Ghost of #14736 fixes.