### PR TITLE
Fix incorrect Compound merge tip

### DIFF
--- a/src/Mod/Import/Resources/ui/preferences-import.ui
+++ b/src/Mod/Import/Resources/ui/preferences-import.ui
@@ -83,7 +83,7 @@
    <item>
     <widget class="Gui::PrefCheckBox" name="checkBox">
      <property name="toolTip">
-      <string>If this is checked, no Compound merge will be done during file reading (slower but higher details).</string>
+      <string>If this is checked, Compound merge will be done during file reading (slower but higher details).</string>
      </property>
      <property name="text">
       <string>Enable STEP Compound merge</string>

--- a/src/Mod/Part/Gui/DlgImportStep.ui
+++ b/src/Mod/Part/Gui/DlgImportStep.ui
@@ -23,7 +23,7 @@
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxMergeCompound">
         <property name="toolTip">
-         <string>If checked, no Compound merge will be done
+         <string>If checked, Compound merge will be done
 during file reading (slower but higher details).</string>
         </property>
         <property name="text">


### PR DESCRIPTION
If checked, no Compound merge will be done --> If checked, Compound merge will be done

Fixes #16126

Might be good to have it for 1.0 since the tooltip here is really misleading as it suggests the opposite of what it should.