### PR TITLE
Draft: Fix max value of Scale multiplier in ui files

### DIFF
--- a/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_SetStyle.ui
@@ -349,6 +349,12 @@
              <string>The annotation scale multiplier is the inverse of the scale set in the
 Annotation scale widget. If the scale is 1:100 the multiplier is 100.</string>
             </property>
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>10000</number>
+            </property>
            </widget>
           </item>
           <item row="4" column="0">

--- a/src/Mod/Draft/Resources/ui/dialog_AnnotationStyleEditor.ui
+++ b/src/Mod/Draft/Resources/ui/dialog_AnnotationStyleEditor.ui
@@ -417,6 +417,12 @@
             <property name="toolTip">
              <string>A multiplier factor that affects the size of texts and markers</string>
             </property>
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>10000</number>
+            </property>
            </widget>
           </item>
           <item row="1" column="0">


### PR DESCRIPTION
Without this max value the spinbox stops at 99.99. The max value is the same as in preferences-drafttexts.ui.
