### PR TITLE
FEM: Fix UseNonCcxIterationParam preference property type

### DIFF
--- a/src/Mod/Fem/femcommands/commands.py
+++ b/src/Mod/Fem/femcommands/commands.py
@@ -954,7 +954,7 @@ class _SolverCalculixContextManager:
         )
         FreeCADGui.doCommand(
             "{}.IterationsControlParameterTimeUse = {}".format(
-                self.cli_name, ccx_prefs.GetInt("UseNonCcxIterationParam", False)
+                self.cli_name, ccx_prefs.GetBool("UseNonCcxIterationParam", False)
             )
         )
         FreeCADGui.doCommand(


### PR DESCRIPTION
The _UseNonCcxIterationParam_ property is mistakenly treated as Int when reading its value from Preferences (thus, the value can't be read) while the actual type should be Bool.

@marioalexis84 FYI