### PR TITLE
[TechDraw] Add box selection

### DIFF
--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -26,6 +26,7 @@
 #include <QDomDocument>
 #include <QFile>
 #include <QGraphicsSceneEvent>
+#include <QKeyEvent>
 #include <QPainter>
 #include <QSvgGenerator>
 #include <QTemporaryFile>
@@ -63,11 +64,14 @@
 #include <Mod/TechDraw/App/Preferences.h>
 
 #include "QGIDrawingTemplate.h"
+#include "QGIEdge.h"
+#include "QGIFace.h"
 #include "QGILeaderLine.h"
 #include "QGIProjGroup.h"
 #include "QGIRichAnno.h"
 #include "QGISVGTemplate.h"
 #include "QGITemplate.h"
+#include "QGIVertex.h"
 #include "QGIViewAnnotation.h"
 #include "QGIViewBalloon.h"
 #include "QGIViewClip.h"
@@ -1261,5 +1265,59 @@ QColor QGSPage::getBackgroundColor()
     return fcColor.asValue<QColor>();
 }
 
+void QGSPage::handleRubberBandSelection()
+{
+    if(!isVKeyPressed && !isFKeyPressed && !isEKeyPressed) {
+        return;  // No filtering keys active
+    }
+
+    QList<QGraphicsItem*> items = selectedItems();
+    QList<QGraphicsItem*>::iterator i;
+    for (i = items.begin(); i != items.end(); ++i) {
+        if(isVKeyPressed && dynamic_cast<QGIVertex*>(*i)) {
+            continue;
+        }
+        else if(isFKeyPressed && dynamic_cast<QGIFace*>(*i)) {
+            continue;
+        }
+        else if(isEKeyPressed && dynamic_cast<QGIEdge*>(*i)) {
+            continue;
+        }
+        (*i)->setSelected(false);
+    }
+}
+
+void QGSPage::keyPressEvent(QKeyEvent* keyEvent) {
+    if(keyEvent->isAutoRepeat()) {
+        return;
+    }
+    if(keyEvent->key() == Qt::Key_E) {
+        isEKeyPressed = true;
+    }
+    if(keyEvent->key() == Qt::Key_F) {
+        isFKeyPressed = true;
+    }
+    if(keyEvent->key() == Qt::Key_V) {
+        isVKeyPressed = true;
+    }
+    QGraphicsScene::keyPressEvent(keyEvent);
+}
+
+
+void QGSPage::keyReleaseEvent(QKeyEvent* keyEvent) {
+    if(keyEvent->isAutoRepeat()) {
+        return;
+    }
+    if(keyEvent->key() == Qt::Key_E) {
+        isEKeyPressed = false;
+    }
+    if(keyEvent->key() == Qt::Key_F) {
+        isFKeyPressed = false;
+    }
+    if(keyEvent->key() == Qt::Key_V) {
+        isVKeyPressed = false;
+    }
+    QGraphicsScene::keyReleaseEvent(keyEvent);
+}
 
 #include <Mod/TechDraw/Gui/moc_QGSPage.cpp>

--- a/src/Mod/TechDraw/Gui/QGSPage.h
+++ b/src/Mod/TechDraw/Gui/QGSPage.h
@@ -152,9 +152,12 @@ public:
 
     static bool itemClearsSelection(int itemTypeIn);
     static Qt::KeyboardModifiers cleanModifierList(Qt::KeyboardModifiers mods);
+    void handleRubberBandSelection();
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+    void keyPressEvent(QKeyEvent* keyEvent) override;
+    void keyReleaseEvent(QKeyEvent* keyEvent) override;
 
     QColor getBackgroundColor();
     bool orphanExists(const char* viewName, const std::vector<App::DocumentObject*>& list);
@@ -162,6 +165,9 @@ protected:
 private:
     QGITemplate* pageTemplate;
     ViewProviderPage* m_vpPage;
+    bool isEKeyPressed = false;
+    bool isVKeyPressed = false;
+    bool isFKeyPressed = false;
 
     bool m_exportingSvg{false};
     bool m_exportingPdf{false};

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -212,6 +212,11 @@ QGVPage::QGVPage(ViewProviderPage* vpPage, QGSPage* scenePage, QWidget* parent)
     initNavigationStyle();
 
     createStandardCursors(devicePixelRatio());
+
+    // Let's not use this signal, as it's called BEFORE it's own selection sequence is run
+    // QObject::connect(this, &QGraphicsView::rubberBandChanged, m_scene, &QGSPage::handleRubberBandSelection);
+
+    setFocusPolicy(Qt::StrongFocus);
 }
 
 QGVPage::~QGVPage()
@@ -447,9 +452,7 @@ void QGVPage::keyPressEvent(QKeyEvent* event)
     else {
         m_navStyle->handleKeyPressEvent(event);
     }
-    if (!event->isAccepted()) {
-        QGraphicsView::keyPressEvent(event);
-    }
+    QGraphicsView::keyPressEvent(event);
 }
 
 void QGVPage::keyReleaseEvent(QKeyEvent* event)
@@ -460,9 +463,7 @@ void QGVPage::keyReleaseEvent(QKeyEvent* event)
     else {
         m_navStyle->handleKeyReleaseEvent(event);
     }
-    if (!event->isAccepted()) {
-        QGraphicsView::keyReleaseEvent(event);
-    }
+    QGraphicsView::keyReleaseEvent(event);
 }
 
 void QGVPage::focusOutEvent(QFocusEvent* event)
@@ -513,6 +514,16 @@ void QGVPage::leaveEvent(QEvent* event)
 
 void QGVPage::mousePressEvent(QMouseEvent* event)
 {
+    // For box selection
+    if (event->button() == Qt::LeftButton && event->modifiers() == Qt::ShiftModifier) {
+        setDragMode(QGraphicsView::RubberBandDrag);
+        QGraphicsView::mousePressEvent(event);
+        return;
+    }
+    else {
+        setDragMode(QGraphicsView::NoDrag);
+    }
+
     if (toolHandler && (event->button() != Qt::MiddleButton)) {
         toolHandler->mousePressEvent(event);
     }
@@ -529,6 +540,11 @@ void QGVPage::mouseMoveEvent(QMouseEvent* event)
     }
     m_navStyle->handleMouseMoveEvent(event);
     QGraphicsView::mouseMoveEvent(event);
+
+    // If box selection ongoing
+    if(event->buttons() == Qt::LeftButton && dragMode() == QGraphicsView::RubberBandDrag) {
+        m_scene->handleRubberBandSelection();
+    }
 }
 
 void QGVPage::mouseReleaseEvent(QMouseEvent* event)


### PR DESCRIPTION
Hold shift and left mouse button to start box selection.
Additionally, hold E to only select edges
Additionally, hold F to only select faces
Additionally, hold V to get an error, because the key has already been mapped to do dimensions. Perhaps dimension shortcut should just be V and not Shift + V?

Fixes #7039

You're welcome.