### PR TITLE
Measure: Fix crash when removing referenced element

### DIFF
--- a/src/Mod/Measure/App/MeasureArea.cpp
+++ b/src/Mod/Measure/App/MeasureArea.cpp
@@ -96,12 +96,6 @@ void MeasureArea::parseSelection(const App::MeasureSelection& selection)
 
 App::DocumentObjectExecReturn* MeasureArea::execute()
 {
-    recalculateArea();
-    return DocumentObject::StdReturn;
-}
-
-void MeasureArea::recalculateArea()
-{
     const std::vector<App::DocumentObject*>& objects = Elements.getValues();
     const std::vector<std::string>& subElements = Elements.getSubValues();
 
@@ -113,14 +107,16 @@ void MeasureArea::recalculateArea()
 
         auto info = getMeasureInfo(subject);
         if (!info || !info->valid) {
-            continue;
+            return new App::DocumentObjectExecReturn("Cannot calculate area");
         }
         auto areaInfo = std::dynamic_pointer_cast<Part::MeasureAreaInfo>(info);
         result += areaInfo->area;
     }
 
     Area.setValue(result);
+    return DocumentObject::StdReturn;
 }
+
 
 void MeasureArea::onChanged(const App::Property* prop)
 {
@@ -129,7 +125,8 @@ void MeasureArea::onChanged(const App::Property* prop)
     }
 
     if (prop == &Elements) {
-        recalculateArea();
+        auto ret = recompute();
+        delete ret;
     }
 
     MeasureBase::onChanged(prop);

--- a/src/Mod/Measure/App/MeasureArea.h
+++ b/src/Mod/Measure/App/MeasureArea.h
@@ -53,7 +53,6 @@ public:
     App::PropertyArea Area;
 
     App::DocumentObjectExecReturn* execute() override;
-    void recalculateArea();
 
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Measure/App/MeasureBase.h
+++ b/src/Mod/Measure/App/MeasureBase.h
@@ -116,6 +116,10 @@ public:
 
         // Resolve App::Link
         App::DocumentObject* sub = subObjT.getSubObject();
+        if (!sub) {
+            return nullptr;
+        }
+
         if (sub->isDerivedFrom<App::Link>()) {
             auto link = static_cast<App::Link*>(sub);
             sub = link->getLinkedObject(true);

--- a/src/Mod/Measure/App/MeasureLength.cpp
+++ b/src/Mod/Measure/App/MeasureLength.cpp
@@ -98,12 +98,6 @@ void MeasureLength::parseSelection(const App::MeasureSelection& selection)
 
 App::DocumentObjectExecReturn* MeasureLength::execute()
 {
-    recalculateLength();
-    return DocumentObject::StdReturn;
-}
-
-void MeasureLength::recalculateLength()
-{
     const std::vector<App::DocumentObject*>& objects = Elements.getValues();
     const std::vector<std::string>& subElements = Elements.getSubValues();
 
@@ -115,7 +109,7 @@ void MeasureLength::recalculateLength()
         App::SubObjectT subject {objects.at(i), subElements.at(i).c_str()};
         auto info = getMeasureInfo(subject);
         if (!info || !info->valid) {
-            continue;
+            return new App::DocumentObjectExecReturn("Cannot calculate length");
         }
 
         auto lengthInfo = std::dynamic_pointer_cast<Part::MeasureLengthInfo>(info);
@@ -123,7 +117,9 @@ void MeasureLength::recalculateLength()
     }
 
     Length.setValue(result);
+    return DocumentObject::StdReturn;
 }
+
 
 void MeasureLength::onChanged(const App::Property* prop)
 {
@@ -132,7 +128,8 @@ void MeasureLength::onChanged(const App::Property* prop)
     }
 
     if (prop == &Elements) {
-        recalculateLength();
+        auto ret = recompute();
+        delete ret;
     }
 
     MeasureBase::onChanged(prop);

--- a/src/Mod/Measure/App/MeasureLength.h
+++ b/src/Mod/Measure/App/MeasureLength.h
@@ -50,7 +50,6 @@ public:
     App::PropertyDistance Length;
 
     App::DocumentObjectExecReturn* execute() override;
-    void recalculateLength();
 
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Measure/App/MeasurePosition.cpp
+++ b/src/Mod/Measure/App/MeasurePosition.cpp
@@ -93,12 +93,6 @@ void MeasurePosition::parseSelection(const App::MeasureSelection& selection)
 
 App::DocumentObjectExecReturn* MeasurePosition::execute()
 {
-    recalculatePosition();
-    return DocumentObject::StdReturn;
-}
-
-void MeasurePosition::recalculatePosition()
-{
     const App::DocumentObject* object = Element.getValue();
     const std::vector<std::string>& subElements = Element.getSubValues();
 
@@ -106,12 +100,14 @@ void MeasurePosition::recalculatePosition()
     auto info = getMeasureInfo(subject);
 
     if (!info || !info->valid) {
-        return;
+        return new App::DocumentObjectExecReturn("Cannot calculate position");
     }
 
     auto positionInfo = std::dynamic_pointer_cast<Part::MeasurePositionInfo>(info);
     Position.setValue(positionInfo->position);
+    return DocumentObject::StdReturn;
 }
+
 
 void MeasurePosition::onChanged(const App::Property* prop)
 {
@@ -120,7 +116,8 @@ void MeasurePosition::onChanged(const App::Property* prop)
     }
 
     if (prop == &Element) {
-        recalculatePosition();
+        auto ret = recompute();
+        delete ret;
     }
     DocumentObject::onChanged(prop);
 }

--- a/src/Mod/Measure/App/MeasurePosition.h
+++ b/src/Mod/Measure/App/MeasurePosition.h
@@ -54,7 +54,6 @@ public:
     App::PropertyPosition Position;
 
     App::DocumentObjectExecReturn* execute() override;
-    void recalculatePosition();
 
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Measure/App/MeasureRadius.cpp
+++ b/src/Mod/Measure/App/MeasureRadius.cpp
@@ -119,15 +119,15 @@ void MeasureRadius::parseSelection(const App::MeasureSelection& selection)
 
 App::DocumentObjectExecReturn* MeasureRadius::execute()
 {
-    recalculateRadius();
+    auto info = getMeasureInfoFirst();
+    if (!info || !info->valid) {
+        return new App::DocumentObjectExecReturn("Cannot calculate radius");
+    }
+
+    Radius.setValue(info->radius);
     return DocumentObject::StdReturn;
 }
 
-
-void MeasureRadius::recalculateRadius()
-{
-    Radius.setValue(getMeasureInfoFirst()->radius);
-}
 
 void MeasureRadius::onChanged(const App::Property* prop)
 {
@@ -136,7 +136,8 @@ void MeasureRadius::onChanged(const App::Property* prop)
     }
 
     if (prop == &Element) {
-        recalculateRadius();
+        auto ret = recompute();
+        delete ret;
     }
 
     MeasureBase::onChanged(prop);

--- a/src/Mod/Measure/App/MeasureRadius.h
+++ b/src/Mod/Measure/App/MeasureRadius.h
@@ -58,8 +58,6 @@ public:
         return "MeasureGui::ViewProviderMeasureRadius";
     }
 
-    void recalculateRadius();
-
     static bool isValidSelection(const App::MeasureSelection& selection);
     static bool isPrioritizedSelection(const App::MeasureSelection& selection);
     void parseSelection(const App::MeasureSelection& selection) override;


### PR DESCRIPTION
This fixes the crash when a referenced element of a measurement is deleted as described in #16183.
Also the "recompute***" methods are removed so that errors can be returned from the execute method.