### PR TITLE
[Measure] Disable QuickMeasure for TechDraw, Spreadsheet, Part Container and Origin objects

### DIFF
--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -123,6 +123,9 @@ void QuickMeasure::addSelectionToMeasurement()
         std::string vpType = obj->getViewProviderName();
         auto* vp = Gui::Application::Instance->getViewProvider(obj);
         if ((vpType == "SketcherGui::ViewProviderSketch" && vp->isEditing())
+            || vpType.find("Gui::ViewProviderOrigin") != std::string::npos
+            || vpType.find("Gui::ViewProviderPart") != std::string::npos
+            || vpType.find("SpreadsheetGui") != std::string::npos
             || vpType.find("TechDrawGui") != std::string::npos) {
             continue;
         }

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -122,7 +122,8 @@ void QuickMeasure::addSelectionToMeasurement()
 
         std::string vpType = obj->getViewProviderName();
         auto* vp = Gui::Application::Instance->getViewProvider(obj);
-        if (vpType == "SketcherGui::ViewProviderSketch" && vp->isEditing()) {
+        if ((vpType == "SketcherGui::ViewProviderSketch" && vp->isEditing())
+            || vpType.find("TechDrawGui") != std::string::npos) {
             continue;
         }
 


### PR DESCRIPTION
I cannot see the reason for additional processing of objects by QuickMeasure that aren't needed and therefore assist performance.

CC @WandererFan 