### PR TITLE
 Gui: Fix issues with icons in sketcher elements panel

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.ui
@@ -128,6 +128,12 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="iconSize">
+      <size>
+       <width>24</width>
+       <height>24</height>
+      </size>
+     </property>
      <property name="modelColumn">
       <number>0</number>
      </property>

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
@@ -102,6 +102,12 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="iconSize">
+      <size>
+       <width>24</width>
+       <height>24</height>
+      </size>
+     </property>
      <property name="modelColumn">
       <number>0</number>
      </property>


### PR DESCRIPTION
This should fix issues described in #12265. 

For strange icon scaling I forced 24px icon size - this should ensure that icons have proper sizing. I however could not reproduce the issue in any way on my setup so it is blind fix. We need someone to test if it does indeed work.

For the issue with dimmed out icons I made them opaque unless the (pre)selection is partial. That way normally icons are fully opaque and only when hovered or something is selected they become semi-transparent.

Before:
![image](https://github.com/user-attachments/assets/740cddbb-72e1-446a-9964-bded58f3cbb4)

After:
![image](https://github.com/user-attachments/assets/65f3b1da-7526-4b52-adf9-ddc26190e340)

Fixes: #12265 