### PR TITLE
[TechDraw] Fix uncentered balloon label

### DIFF
--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -218,6 +218,28 @@ QPointF QGCustomText::tightBoundingAdjust() const
     return QPointF(tight.x()-original.x(), tight.y()-original.y());
 }
 
+// TODO: when setting position, it doesn't take into account the tight bounding rect
+// Meaning top left corner has distance to pos(0, 0)
+// Here is a sketch for a fix
+// Note that the position adjustment will have to carried out every time the font changes
+// void QGCustomText::setPos(const QPointF &pos) {
+//     if(tightBounding) {
+//         QGraphicsTextItem::setPos(pos.x() - tightBoundingAdjust().x(), pos.y() - tightBoundingAdjust().y());
+//         return;
+//     }
+//     QGraphicsTextItem::setPos(pos);
+// }
+
+// void QGCustomText::setPos(qreal x, qreal y) {
+//     setPos(QPointF(x, y));
+// }
+
+// QPointF QGCustomText::pos() const
+// {
+//     // Native Qt pos function doesn't take into account the tight bounding rect
+//     return boundingRect().topLeft();
+// }
+
 QColor QGCustomText::getNormalColor()    //preference!
 {
     return PreferencesGui::normalQColor();

--- a/src/Mod/TechDraw/Gui/QGCustomText.h
+++ b/src/Mod/TechDraw/Gui/QGCustomText.h
@@ -52,6 +52,9 @@ public:
     QRectF boundingRect() const override;
     QRectF tightBoundingRect() const;
     QPointF tightBoundingAdjust() const;
+    // void setPos(const QPointF &pos);
+    // void setPos(qreal x, qreal y);
+    // QPointF pos() const;
 
     void setHighlighted(bool state);
     virtual void setPrettyNormal();

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -80,14 +80,15 @@ public:
     void setLabelCenter();
     Base::Vector3d getLabelCenter() const;
     void setPosFromCenter(const double& xCenter, const double& yCenter);
-    double X() const
+
+    double getCenterX() const
     {
-        return posX;
+        return mapToParent(m_labelText->boundingRect().center()).x();
     }
-    double Y() const
+    double getCenterY() const
     {
-        return posY;
-    }//minus posY?
+        return mapToParent(m_labelText->boundingRect().center()).y();
+    }
 
     void setFont(QFont font);
     QFont getFont()
@@ -114,6 +115,7 @@ public:
 
     void setDimText(QGCustomText* newText)
     {
+        newText->setTightBounding(true);
         m_labelText = newText;
     }
     bool getVerticalSep() const
@@ -132,6 +134,7 @@ public:
     {
         seps = newSeps;
     }
+    QGCustomText* m_labelText;
 
 Q_SIGNALS:
     void dragging(bool state);
@@ -153,11 +156,8 @@ private:
     bool verticalSep;
     std::vector<int> seps;
 
-    QGCustomText* m_labelText;
     QColor m_colNormal;
 
-    double posX;
-    double posY;
     bool m_ctrl;
     bool m_drag;
 };


### PR DESCRIPTION
I got annoyed by the off-centered balloon label.

Before
![Screenshot from 2024-09-03 22-47-35](https://github.com/user-attachments/assets/113b3bb4-de44-46e2-bbd6-72df10ba1545)


After
![Screenshot from 2024-09-04 13-13-06](https://github.com/user-attachments/assets/cbf6e3c5-4638-41d2-ba15-917795d7ce90)

TODO: massively simplify balloon logic. Way overcomplicated.