### PR TITLE
[Gui] Add style, theme and qtstyle info to clipboard about info

### DIFF
--- a/src/Doc/CONTRIBUTORS
+++ b/src/Doc/CONTRIBUTORS
@@ -18,6 +18,7 @@ Bartlomiej Niemiec
 Bas Ruigrok (Rexbas)
 bejant
 Benjamin Alterauge
+Benjamin Bræstrup Sayoc
 Bernd Hahnebach
 bgbsww
 blobfish (tanderson69)

--- a/src/Gui/PreferencePacks/FreeCAD Classic/post.FCMacro
+++ b/src/Gui/PreferencePacks/FreeCAD Classic/post.FCMacro
@@ -4,5 +4,5 @@ import FreeCAD
 editorPrefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Editor")
 editorPrefs.RemInt("Text")
 
-appPrefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/General")
+appPrefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/MainWindow")
 appPrefs.RemString("QtStyle")

--- a/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
@@ -4,9 +4,6 @@
   <FCParamGroup Name="Root">
     <FCParamGroup Name="BaseApp">
       <FCParamGroup Name="Preferences">
-        <FCParamGroup Name="General">
-          <FCText Name="QtStyle">Fusion</FCText>
-        </FCParamGroup>
         <FCParamGroup Name="Themes">
           <FCUInt Name="ThemeAccentColor1" Value="1252392959"/>
           <FCUInt Name="ThemeAccentColor2" Value="3027763199"/>
@@ -179,6 +176,7 @@
           <FCInt Name="FontSize" Value="11"/>
         </FCParamGroup>
         <FCParamGroup Name="MainWindow">
+          <FCText Name="QtStyle">Fusion</FCText>
           <FCBool Name="TiledBackground" Value="0"/>
           <FCText Name="Theme">FreeCAD Dark</FCText>
           <FCText Name="StyleSheet">FreeCAD Dark.qss</FCText>

--- a/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
@@ -3,9 +3,6 @@
   <FCParamGroup Name="Root">
     <FCParamGroup Name="BaseApp">
       <FCParamGroup Name="Preferences">
-        <FCParamGroup Name="General">
-          <FCText Name="QtStyle">Fusion</FCText>
-        </FCParamGroup>
         <FCParamGroup Name="Themes">
           <FCUInt Name="ThemeAccentColor1" Value="1252392959"/>
           <FCUInt Name="ThemeAccentColor2" Value="3027763199"/>
@@ -209,6 +206,7 @@
           <FCUInt Name="BaseColor" Value="3505127423"/>
         </FCParamGroup>
         <FCParamGroup Name="MainWindow">
+          <FCText Name="QtStyle">Fusion</FCText>
           <FCText Name="Theme">FreeCAD Light</FCText>
           <FCText Name="StyleSheet">FreeCAD Light.qss</FCText>
           <FCText Name="OverlayActiveStyleSheet">Light Theme + Light Background.qss</FCText>

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -881,6 +881,15 @@ void AboutDialog::copyToClipboard()
     }
     str << "\n";
 
+    std::string styleSheet = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("StyleSheet");
+    std::string theme = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("Theme");
+    std::string style = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("QtStyle");
+
+    str << "Stylesheet/Theme/QtStyle: "
+        << QString::fromStdString(styleSheet) << "/"
+        << QString::fromStdString(theme) << "/"
+        << QString::fromStdString(style) << "\n";
+
     // Add installed module information:
     auto modDir = fs::path(App::Application::getUserAppDataDir()) / "Mod";
     bool firstMod = true;

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -304,7 +304,7 @@ void StartupPostProcess::setCursorFlashing()
 
 void StartupPostProcess::setQtStyle()
 {
-    ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");
+    ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("MainWindow");
     auto qtStyle = hGrp->GetASCII("QtStyle");
     QApplication::setStyle(QString::fromStdString(qtStyle));
 }


### PR DESCRIPTION
Fixes #16272

```
Stylesheet/Theme/QtStyle: Behave-dark.qss/FreeCAD Classic/Fusion
```

For testing, you might have to manually copy the changed preference packs