### PR TITLE
Spreadsheet: Double click separator/handle to resize column to content

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.cpp
@@ -92,14 +92,6 @@ void SpreadsheetDelegate::onEditorFinishedWithKey(int key, Qt::KeyboardModifiers
     Q_EMIT finishedWithKey(key, modifiers);
 }
 
-QSize SpreadsheetDelegate::sizeHint(const QStyleOptionViewItem& option,
-                                    const QModelIndex& index) const
-{
-    Q_UNUSED(option);
-    Q_UNUSED(index);
-    return {};
-}
-
 static inline void drawBorder(QPainter* painter,
                               const QStyleOptionViewItem& option,
                               unsigned flags,

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.h
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetDelegate.h
@@ -47,8 +47,6 @@ public:
     void setModelData(QWidget* editor,
                       QAbstractItemModel* model,
                       const QModelIndex& index) const override;
-
-    QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override;
     void paint(QPainter* painter,
                const QStyleOptionViewItem& option,
                const QModelIndex& index) const override;


### PR DESCRIPTION
Qt handles resize to content on double clicking the separator in the header, by default. However this does not work in FreeCAD.

The reason why this doesn't work is due to the method `QStyledItemDelegate::sizeHint(...)` is overloaded to return an empty `QSize` in the class `SpreadsheetDelegate`. By returning a zero size, the cell sizes doesn't increase when double clicking the separator.

This can be tracked all the way back to the [initial commit of the spreadsheet module](https://github.com/FreeCAD/FreeCAD/commit/383ffa6e157f136128a390d82abcacc255102d79#diff-1d69e1ee7f42eff95fffdf9a5c7c8d18412254ccb4f5e71273387d7501923791R75).

There are no comments on why this was done, if this method was a place holder, meant to fix a bug somewhere or if the behavior was unwanted at the time.

I'm treating this as a bug due to:
* The behavior is really common in various spreadsheet programs
* It is supported by default on Qt
* There's no comments nor any documentation that the default behavior is unwanted.

Manual testing has been performed after the change and:

* Scaling by double clicking separator in header works
* Sizes are correctly stored in sheet when resizing to content