### PR TITLE
[BIM] Separate profile name from label number

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -477,7 +477,7 @@ def makeProfile(profile=[0,'REC','REC100x100','R',100,100]):
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
-    obj = FreeCAD.ActiveDocument.addObject("Part::Part2DObjectPython",profile[2])
+    obj = FreeCAD.ActiveDocument.addObject("Part::Part2DObjectPython", "Profile")
     obj.Label = profile[2] + "_"
     if profile[3]=="C":
         ArchProfile._ProfileC(obj, profile)

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -478,7 +478,7 @@ def makeProfile(profile=[0,'REC','REC100x100','R',100,100]):
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
     obj = FreeCAD.ActiveDocument.addObject("Part::Part2DObjectPython",profile[2])
-    obj.Label = profile[2]
+    obj.Label = profile[2] + "_"
     if profile[3]=="C":
         ArchProfile._ProfileC(obj, profile)
     elif profile[3]=="H":


### PR DESCRIPTION
Fixes: #16286

This PR simply appends an underscore (`_`) at the end of the profile name's label. This means that the numerical sequence when adding multiple structures with a profile will be:

1. `$PROFILE`_ (e.g. 22x100_)
1. `$PROFILE`_ (e.g. 22x100_001)
1. `$PROFILE`_ (e.g. 22x100_002)

![image](https://github.com/user-attachments/assets/5790fba0-c549-46cb-a531-a0c90a7b204d)

1. Notice that the first profile will only have an underscore suffix. The expectation here might be to either have no underscore, or (for more consistency) to start the sequence with the `_000` suffix. However, the assumption (to be corrected if wrong) is that adding the increasing numerical suffix to multiple identically-named labels is done outside of the BIM module, in FreeCAD's core. This PR seeks to fix the original bug in the least intrusive way (without changing the core), even if not perfect.
2. Notice that to avoid the (numerical) internal name of the profile to be modified by the core, it has been changed explicitly to "Profile". This naming is chosen to be generic on purpose, which better fits the use case of a user changing the underlying profile. In that case, the internal name would still apply and would not be fixed to the first profile used on creation.

