### PR TITLE
Materials: UI updates for transparency

### DIFF
--- a/src/Gui/DlgMaterialProperties.ui
+++ b/src/Gui/DlgMaterialProperties.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>292</width>
-    <height>247</height>
+    <height>296</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -41,62 +41,17 @@
       <property name="spacing">
        <number>6</number>
       </property>
-      <item row="4" column="0" colspan="2">
-       <layout class="QHBoxLayout">
-        <property name="spacing">
-         <number>6</number>
-        </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QLabel" name="textLabel4">
-          <property name="text">
-           <string>Shininess:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>81</width>
-            <height>31</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="shininess">
-          <property name="suffix">
-           <string notr="true">%</string>
-          </property>
-          <property name="singleStep">
-           <number>5</number>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="textLabel1">
         <property name="text">
          <string>Diffuse color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="textLabel4">
+        <property name="text">
+         <string>Shininess:</string>
         </property>
        </widget>
       </item>
@@ -105,26 +60,15 @@
         <property name="text">
          <string/>
         </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="Gui::ColorButton" name="emissiveColor">
-        <property name="text">
-         <string/>
+        <property name="allowTransparency">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="textLabel3">
+      <item row="6" column="0">
+       <widget class="QPushButton" name="buttonReset">
         <property name="text">
-         <string>Specular color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="Gui::ColorButton" name="diffuseColor">
-        <property name="text">
-         <string/>
+         <string>Reset</string>
         </property>
        </widget>
       </item>
@@ -135,10 +79,66 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="1">
+       <widget class="QSpinBox" name="shininess">
+        <property name="minimumSize">
+         <size>
+          <width>122</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="suffix">
+         <string notr="true">%</string>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="singleStep">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::ColorButton" name="emissiveColor">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="allowTransparency">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="textLabel3">
+        <property name="text">
+         <string>Specular color:</string>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="1">
        <widget class="Gui::ColorButton" name="specularColor">
         <property name="text">
          <string/>
+        </property>
+        <property name="allowTransparency">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QPushButton" name="buttonDefault">
+        <property name="text">
+         <string>Default</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::ColorButton" name="diffuseColor">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="allowTransparency">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -150,16 +150,25 @@
        </widget>
       </item>
       <item row="5" column="0">
-       <widget class="QPushButton" name="buttonReset">
+       <widget class="QLabel" name="label_2">
         <property name="text">
-         <string>Reset</string>
+         <string>Transparency:</string>
         </property>
        </widget>
       </item>
       <item row="5" column="1">
-       <widget class="QPushButton" name="buttonDefault">
-        <property name="text">
-         <string>Default</string>
+       <widget class="QSpinBox" name="transparency">
+        <property name="minimumSize">
+         <size>
+          <width>122</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="suffix">
+         <string>%</string>
+        </property>
+        <property name="maximum">
+         <number>100</number>
         </property>
        </widget>
       </item>
@@ -188,7 +197,6 @@
   <tabstop>diffuseColor</tabstop>
   <tabstop>emissiveColor</tabstop>
   <tabstop>specularColor</tabstop>
-  <tabstop>shininess</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/Gui/DlgMaterialPropertiesImp.cpp
+++ b/src/Gui/DlgMaterialPropertiesImp.cpp
@@ -62,6 +62,8 @@ void DlgMaterialPropertiesImp::setupConnections()
             this, &DlgMaterialPropertiesImp::onSpecularColorChanged);
     connect(ui->shininess, qOverload<int>(&QSpinBox::valueChanged),
             this, &DlgMaterialPropertiesImp::onShininessValueChanged);
+    connect(ui->transparency, qOverload<int>(&QSpinBox::valueChanged),
+            this, &DlgMaterialPropertiesImp::onTransparencyValueChanged);
     connect(ui->buttonReset, &QPushButton::clicked,
             this, &DlgMaterialPropertiesImp::onButtonReset);
     connect(ui->buttonDefault, &QPushButton::clicked,
@@ -131,6 +133,14 @@ void DlgMaterialPropertiesImp::onShininessValueChanged(int sh)
 }
 
 /**
+ * Sets the current transparency.
+ */
+void DlgMaterialPropertiesImp::onTransparencyValueChanged(int sh)
+{
+    customMaterial.transparency = (float)sh / 100.0F;
+}
+
+/**
  * Reset the colors to the Coin3D defaults
  */
 void DlgMaterialPropertiesImp::onButtonReset()
@@ -159,6 +169,9 @@ void DlgMaterialPropertiesImp::setButtonColors(const App::Material& mat)
     ui->shininess->blockSignals(true);
     ui->shininess->setValue((int)(100.0F * (mat.shininess + 0.001F)));
     ui->shininess->blockSignals(false);
+    ui->transparency->blockSignals(true);
+    ui->transparency->setValue((int)(100.0F * (mat.transparency + 0.001F)));
+    ui->transparency->blockSignals(false);
 }
 
 #include "moc_DlgMaterialPropertiesImp.cpp"

--- a/src/Gui/DlgMaterialPropertiesImp.h
+++ b/src/Gui/DlgMaterialPropertiesImp.h
@@ -63,6 +63,7 @@ private:
     void onEmissiveColorChanged();
     void onSpecularColorChanged();
     void onShininessValueChanged(int);
+    void onTransparencyValueChanged(int);
     void onButtonReset();
     void onButtonDefault();
     void setButtonColors(const App::Material& mat);

--- a/src/Mod/Material/Gui/DlgInspectAppearance.cpp
+++ b/src/Mod/Material/Gui/DlgInspectAppearance.cpp
@@ -242,6 +242,16 @@ QWidget* DlgInspectAppearance::makeAppearanceTab(const App::Material& material)
 
     grid->addWidget(labelShininess, row, 0);
     grid->addWidget(editShininess, row, 1);
+    row += 1;
+
+    auto* labelTransparency = new QLabel();
+    labelTransparency->setText(tr("Transparency"));
+    auto* editTransparency = new QLineEdit();
+    editTransparency->setText(QString::number(material.transparency));
+    editTransparency->setEnabled(false);
+
+    grid->addWidget(labelTransparency, row, 0);
+    grid->addWidget(editTransparency, row, 1);
 
     return tab;
 }


### PR DESCRIPTION
Add missing UI elements to support per face transparencies:
- Setting per face transparencies
- show transparency information in the appearance inspector
- expose alpha channel in color selector dialog