### PR TITLE
Materials: Correct installation paths

### DIFF
--- a/src/Mod/Material/Gui/CMakeLists.txt
+++ b/src/Mod/Material/Gui/CMakeLists.txt
@@ -169,9 +169,9 @@ SET_PYTHON_PREFIX_SUFFIX(MatGui)
 
 fc_copy_sources(MatGui "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Material" ${MatGuiIcon_SVG})
 fc_copy_sources(MatGui "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Material" ${MatGuiImages})
-fc_copy_sources(MatGui "${CMAKE_BINARY_DIR}/Mod/Material" ${Material_Ui_Files})
+fc_copy_sources(MatGui "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Material" ${Material_Ui_Files})
 
 INSTALL(TARGETS MatGui DESTINATION ${CMAKE_INSTALL_LIBDIR})
-INSTALL(FILES ${MatGuiIcon_SVG} DESTINATION "${CMAKE_INSTALL_DATADIR}/Mod/Material/Resources/icons")
-INSTALL(FILES ${MatGuiImages} DESTINATION "${CMAKE_INSTALL_DATADIR}/Mod/Material/Resources/images")
-INSTALL(FILES ${Material_Ui_Files} DESTINATION "${CMAKE_BINARY_DIR}/Mod/Material/Resources/ui")
+INSTALL(FILES ${MatGuiIcon_SVG} DESTINATION "Mod/Material/Resources/icons")
+INSTALL(FILES ${MatGuiImages} DESTINATION "Mod/Material/Resources/images")
+INSTALL(FILES ${Material_Ui_Files} DESTINATION "Mod/Material/Resources/ui")

--- a/src/Mod/Material/Gui/CMakeLists.txt
+++ b/src/Mod/Material/Gui/CMakeLists.txt
@@ -172,6 +172,6 @@ fc_copy_sources(MatGui "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Materia
 fc_copy_sources(MatGui "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Material" ${Material_Ui_Files})
 
 INSTALL(TARGETS MatGui DESTINATION ${CMAKE_INSTALL_LIBDIR})
-INSTALL(FILES ${MatGuiIcon_SVG} DESTINATION "Mod/Material/Resources/icons")
-INSTALL(FILES ${MatGuiImages} DESTINATION "Mod/Material/Resources/images")
+INSTALL(FILES ${MatGuiIcon_SVG} DESTINATION "${CMAKE_INSTALL_DATADIR}/Mod/Material/Resources/icons")
+INSTALL(FILES ${MatGuiImages} DESTINATION "${CMAKE_INSTALL_DATADIR}/Mod/Material/Resources/images")
 INSTALL(FILES ${Material_Ui_Files} DESTINATION "Mod/Material/Resources/ui")

--- a/src/Mod/Material/MaterialEditor.py
+++ b/src/Mod/Material/MaterialEditor.py
@@ -69,7 +69,7 @@ class MaterialEditor:
         self.iconPath = (filePath + "Resources" + os.sep + "icons" + os.sep)
 
         # load the UI file from the same directory as this script
-        self.widget = FreeCADGui.PySideUic.loadUi(filePath + "Resources" + os.sep + "ui" + os.sep + "materials-editor.ui")
+        self.widget = FreeCADGui.PySideUic.loadUi(":/ui/materials-editor.ui")
         # remove unused Help button
         self.widget.setWindowFlags(self.widget.windowFlags()
                                    & ~QtCore.Qt.WindowContextHelpButtonHint)


### PR DESCRIPTION
Correct the installation paths affecting builds on various systems while still maintaining the old material editor required for backwards compatibility