### PR TITLE
[Sketcher] fix: properly transfer constraints on conic's center point when spliting

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -4198,8 +4198,9 @@ int SketchObject::split(int GeoId, const Base::Vector3d& point)
 
                 // TODO: Do we apply constraints on center etc of the conics?
 
-                // transfer constraints from start and end of original
+                // transfer constraints from start, mid and end of original
                 transferConstraints(GeoId, PointPos::start, newId0, PointPos::start, true);
+                transferConstraints(GeoId, PointPos::mid, newId0, PointPos::mid);
                 transferConstraints(GeoId, PointPos::end, newId1, PointPos::end, true);
             });
     }


### PR DESCRIPTION
This fixes #15860

When spliting a sketch curve, constraints on the original curve are transferred to the newly created curve. The original code did not consider the constraints on the center point of an ellipse arc.

Besides what I have done, I wonder whether we should add the same code to the following `else` code block. It seems that there will be no such thing with a center point other than circles and ellipses. But maybe there is no harm in having a fallback?

---

Just to add: This is my first contribution to FreeCAD. I have expreience in developing other parametric modeling softwares, but I'm not familiar with FreeCAD. Please let me know if you have any suggestions.