### PR TITLE
Gui: Scrolling splash screen

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2295,7 +2295,7 @@ void MainWindow::startSplasher()
         if (hGrp->GetBool("ShowSplasher", true)) {
             d->splashscreen = new SplashScreen(SplashScreen::splashImage());
 
-            if (!hGrp->GetBool("ShowSplasherMessages", false)) {
+            if (!hGrp->GetBool("ShowSplasherMessages", true)) {
                 d->splashscreen->setShowMessages(false);
             }
 

--- a/src/Gui/SplashScreen.cpp
+++ b/src/Gui/SplashScreen.cpp
@@ -27,7 +27,6 @@
 #include <QElapsedTimer>
 #include <QFile>
 #include <QFileInfo>
-#include <QMutex>
 #include <QPainter>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
@@ -59,50 +58,10 @@ public:
     SplashObserver& operator=(const SplashObserver&) = delete;
     SplashObserver& operator=(SplashObserver&&) = delete;
 
-    explicit SplashObserver(QSplashScreen* splasher = nullptr)
+    explicit SplashObserver(SplashScreen* splasher = nullptr)
         : splash(splasher)
-        , alignment(Qt::AlignBottom | Qt::AlignLeft)
-        , textColor(Qt::black)
     {
         Base::Console().attachObserver(this);
-
-        // allow to customize text position and color
-        const std::map<std::string, std::string>& cfg = App::Application::Config();
-        auto al = cfg.find("SplashAlignment");
-        if (al != cfg.end()) {
-            QString alt = QString::fromLatin1(al->second.c_str());
-            int align = 0;
-            if (alt.startsWith(QLatin1String("VCenter"))) {
-                align = Qt::AlignVCenter;
-            }
-            else if (alt.startsWith(QLatin1String("Top"))) {
-                align = Qt::AlignTop;
-            }
-            else {
-                align = Qt::AlignBottom;
-            }
-
-            if (alt.endsWith(QLatin1String("HCenter"))) {
-                align += Qt::AlignHCenter;
-            }
-            else if (alt.endsWith(QLatin1String("Right"))) {
-                align += Qt::AlignRight;
-            }
-            else {
-                align += Qt::AlignLeft;
-            }
-
-            alignment = align;
-        }
-
-        // choose text color
-        auto tc = cfg.find("SplashTextColor");
-        if (tc != cfg.end()) {
-            QColor col(QString::fromStdString(tc->second));
-            if (col.isValid()) {
-                textColor = col;
-            }
-        }
     }
     ~SplashObserver() override
     {
@@ -152,16 +111,11 @@ public:
             }
         }
 
-        splash->showMessage(msg.replace(QLatin1String("\n"), QString()), alignment, textColor);
-        QMutex mutex;
-        QMutexLocker ml(&mutex);
-        QWaitCondition().wait(&mutex, 50);
+        splash->pushMessage(msg.replace(QLatin1String("\n"), QString()));
     }
 
 private:
-    QSplashScreen* splash;
-    int alignment;
-    QColor textColor;
+    SplashScreen* splash;
 };
 
 /**
@@ -229,7 +183,32 @@ static void renderDevBuildWarning(
  */
 SplashScreen::SplashScreen(const QPixmap& pixmap, Qt::WindowFlags f)
     : QSplashScreen(pixmap, f)
+    , textColor(Qt::black)
 {
+    const std::map<std::string, std::string>& cfg = App::Application::Config();
+    auto tc = cfg.find("SplashTextColor");
+    if (tc != cfg.end()) {
+        QColor col(QString::fromStdString(tc->second));
+        if (col.isValid()) {
+            textColor = col;
+        }
+    }
+
+    QFontMetrics fm(font());
+    lineSpacing = fm.lineSpacing();
+    maxY = pixmap.rect().height();
+    lineCount = std::max(3, (maxY * 3 / 10) / lineSpacing);
+    startX = pixmap.rect().width() / 20;
+    startY = maxY / 10;
+
+    // With "Top" alignment the newest message is drawn on top and older ones are pushed down,
+    // otherwise the newest message is drawn at the bottom and older ones are pushed up.
+    auto al = cfg.find("SplashAlignment");
+    if ((al == cfg.end()) || !al->second.starts_with("Top")) {
+        startY = maxY - startY;
+        lineSpacing = -lineSpacing;
+    }
+
     // write the messages to splasher
     messages = new SplashObserver(this);
 }
@@ -283,12 +262,19 @@ void SplashScreen::show()
 }
 
 /**
- * Draws the contents of the splash screen using painter \a painter. The default
- * implementation draws the message passed by message().
+ * Draws the contents of the splash screen using painter.
  */
 void SplashScreen::drawContents(QPainter* painter)
 {
-    QSplashScreen::drawContents(painter);
+    painter->setPen(textColor);
+    int y = startY;
+    for (auto str : lines) {
+        painter->drawText(startX, y, str);
+        y += lineSpacing;
+        if (y < 0 || y > maxY) {
+            break;
+        }
+    }
 }
 
 void SplashScreen::setShowMessages(bool on)
@@ -297,6 +283,15 @@ void SplashScreen::setShowMessages(bool on)
     messages->bMsg = on;
     messages->bLog = on;
     messages->bWrn = on;
+}
+
+void SplashScreen::pushMessage(const QString& msg)
+{
+    lines.push_front(msg);
+    if (lines.size() > lineCount) {
+        lines.pop_back();
+    }
+    repaint();
 }
 
 QPixmap SplashScreen::splashImage()

--- a/src/Gui/SplashScreen.h
+++ b/src/Gui/SplashScreen.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <list>
 #include <QSplashScreen>
 
 namespace Gui
@@ -45,6 +46,7 @@ public:
 
     void show();
     void setShowMessages(bool on);
+    void pushMessage(const QString& msg);
 
     static QPixmap splashImage();
 
@@ -54,6 +56,11 @@ protected:
 
 private:
     SplashObserver* messages;
+    std::list<QString> lines;
+    std::list<QString>::size_type lineCount;
+    int lineSpacing;
+    int startX, startY, maxY;
+    QColor textColor;
 };
 
 }  // namespace Gui

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -224,7 +224,7 @@ int main(int argc, char** argv)
         : "freecadabout";
     App::Application::Config()["StartWorkbench"] = "PartDesignWorkbench";
     // App::Application::Config()["HiddenDockWindow"] = "Property editor";
-    App::Application::Config()["SplashAlignment"] = "Bottom|Left";
+    App::Application::Config()["SplashAlignment"] = "Bottom";
     App::Application::Config()["SplashTextColor"] = "#418FDE";
     App::Application::Config()["SplashWarningColor"] = "#CA333B";
     App::Application::Config()["SplashInfoColor"] = "#000000";


### PR DESCRIPTION
When Splash screen is configured to show startup messages, it does so by showing only one at time and adds 50ms delay each time new one is shown to let user notice it. This approach considerably extends application start-up time, so replace it with scrolling messages.

Please note, that after merging #16071, it is a bit problematic to find single suitable color and placement for the messages, so I'm leaving that to the [Design Group](https://forum.freecad.org/viewtopic.php?t=83692) ;-)

Now, after merging #32363, we are back to single splash image, which makes above problem go away.