### PR TITLE
Spreadsheet XLSX import: Fix bug causing xls import failing for some operators

### DIFF
--- a/src/Mod/Spreadsheet/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/CMakeLists.txt
@@ -8,6 +8,7 @@ set(Spreadsheet_Scripts
     Init.py
     TestSpreadsheet.py
     importXLSX.py
+    test_importXLSX.py
 )
 
 if(BUILD_GUI)

--- a/src/Mod/Spreadsheet/importXLSX.py
+++ b/src/Mod/Spreadsheet/importXLSX.py
@@ -225,7 +225,7 @@ class FormulaTranslator(object):
             else:
                 # print('There is a branch. look up: ', theExpr[1])
                 if (lenExpr > 1) and (theExpr[1] in treeDict[branch]):
-                    branch = treeDict[branch][theExpr[0]]
+                    branch = treeDict[branch][theExpr[1]]
                     if branch is None:
                         keyToken = True
                     else:

--- a/src/Mod/Spreadsheet/test_importXLSX.py
+++ b/src/Mod/Spreadsheet/test_importXLSX.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock
 
 from importXLSX import FormulaTranslator, getText, handleStrings, open
 
+
 class TestFormulaTranslator(unittest.TestCase):
     def test_translate_expressions(self):
         # With
@@ -82,7 +83,7 @@ class TestFormulaTranslator(unittest.TestCase):
         formulas_and_expressions = [
             (
                 "IF(a<b+c,0.1+SIN(0.5),0.3+MAX(COS(0.2),SIN(0.1)))",
-                "(a<b+c?0.1+sin(1rad*(0.5)):0.3+max(cos(1rad*(0.2)),sin(1rad*(0.1))))"
+                "(a<b+c?0.1+sin(1rad*(0.5)):0.3+max(cos(1rad*(0.2)),sin(1rad*(0.1))))",
             ),
         ]
 

--- a/src/Mod/Spreadsheet/test_importXLSX.py
+++ b/src/Mod/Spreadsheet/test_importXLSX.py
@@ -1,0 +1,97 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from importXLSX import FormulaTranslator, getText, handleStrings, open
+
+class TestFormulaTranslator(unittest.TestCase):
+    def test_translate_expressions(self):
+        # With
+        formulas_and_expressions = [
+            ("1=2", "1==2"),
+            ("a<b", "a<b"),
+            ("a>b", "a>b"),
+            ("1<>2", "1!=2"),
+            ("a>=b", "a>=b"),
+            ("a<=b", "a<=b"),
+            ("a!b", "a.b"),
+            ("a+b", "a+b"),
+            ("a-b", "a-b"),
+            ("a*b", "a*b"),
+            ("a/b", "a/b"),
+            ("a^b", "a^b"),
+            ("c*(a+b)", "c*(a+b)"),
+            ("IF(a=b, c, d)", "(a==b? c: d)"),
+            ("ABS(a)", "abs(a)"),
+            ("ACOS(a)", "pi/180deg*acos(a)"),
+            ("ASIN(a)", "pi/180deg*asin(a)"),
+            ("ATAN(a)", "pi/180deg*atan(a)"),
+            ("ATAN2(a)", "pi/180deg*atan2(a)"),
+            ("COS(a)", "cos(1rad*(a))"),
+            ("COSH(a)", "cosh(1rad*(a))"),
+            ("EXP(a)", "exp(a)"),
+            ("LOG(n)", "log(n)"),
+            ("LOG10(n)", "log10(n)"),
+            ("MOD(n,d)", "mod(n,d)"),
+            ("POWER(n,p)", "pow(n,p)"),
+            ("SIN(a)", "sin(1rad*(a))"),
+            ("SINH(a)", "sinh(1rad*(a))"),
+            ("SQRT(a)", "sqrt(a)"),
+            ("TAN(a)", "tan(1rad*(a))"),
+            ("TANH(a)", "tanh(1rad*(a))"),
+            ("AVERAGE(a,b,c)", "average(a,b,c)"),
+            ("COUNT(a,b,c)", "count(a,b,c)"),
+            ("MAX(a,b,c)", "max(a,b,c)"),
+            ("MIN(a,b,c)", "min(a,b,c)"),
+            ("STDEVA(a,b,c)", "stddev(a,b,c)"),
+            ("SUM(a,b,c)", "sum(a,b,c)"),
+            ("PI", "pi"),
+            ("_xlfn.CEILING.MATH(a)", "ceil(a)"),
+            ("_xlfn.FLOOR.MATH(a)", "floor(a)"),
+        ]
+
+        # When
+        result = []
+        for formula, _ in formulas_and_expressions:
+            translator = FormulaTranslator()
+            result.append(translator.translateForm(formula))
+
+        # Then
+        expected = [f"={expression}" for _, expression in formulas_and_expressions]
+        self.assertListEqual(expected, result)
+
+    def test_translate_multi_character_branching_operators(self):
+        # With
+        formulas_and_expressions = [
+            ("1<>2", "1!=2"),
+            ("a>=b", "a>=b"),
+            ("a<=b", "a<=b"),
+        ]
+
+        # When
+        result = []
+        for formula, _ in formulas_and_expressions:
+            translator = FormulaTranslator()
+            result.append(translator.translateForm(formula))
+
+        # Then
+        expected = [f"={expression}" for _, expression in formulas_and_expressions]
+        self.assertListEqual(expected, result)
+
+    def test_translate_nested_expression(self):
+        # With
+        formulas_and_expressions = [
+            (
+                "IF(a<b+c,0.1+SIN(0.5),0.3+MAX(COS(0.2),SIN(0.1)))",
+                "(a<b+c?0.1+sin(1rad*(0.5)):0.3+max(cos(1rad*(0.2)),sin(1rad*(0.1))))"
+            ),
+        ]
+
+        # When
+        result = []
+        for formula, _ in formulas_and_expressions:
+            translator = FormulaTranslator()
+            result.append(translator.translateForm(formula))
+
+        # Then
+        expected = [f"={expression}" for _, expression in formulas_and_expressions]
+        self.assertListEqual(expected, result)


### PR DESCRIPTION
The operators `<>`, `<=`, and `>=` excel formulas causes xlsx import to fail.

The issue can be tested on the current version with the generated xlsx file created with the following code (needs to install openpyxl for it to work):
```python
import openpyxl
wb = openpyxl.Workbook()
ws = wb.active
ws['A1'] = "=IF(1<>2,1,0)"
wb.save("testcase.xlsx")
print("testcase.xlsx created successfully")
```

Traceback:
```
Traceback (most recent call last):
  File "<string>", line 5, in <module>
  File "/Users/nauck/projects/freecad/build-debug/Mod/Spreadsheet/importXLSX.py", line 434, in open
    handleWorkSheet(myDom, theSheet, stringList)
  File "/Users/nauck/projects/freecad/build-debug/Mod/Spreadsheet/importXLSX.py", line 319, in handleWorkSheet
    handleCells(row.getElementsByTagName("c"), actSheet, strList)
  File "/Users/nauck/projects/freecad/build-debug/Mod/Spreadsheet/importXLSX.py", line 351, in handleCells
    actCellSheet.set(ref, fTrans.translateForm(theFormula))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nauck/projects/freecad/build-debug/Mod/Spreadsheet/importXLSX.py", line 171, in translateForm
    self.getNextToken(actExpr)
  File "/Users/nauck/projects/freecad/build-debug/Mod/Spreadsheet/importXLSX.py", line 214, in getNextToken
    self.getNextToken(theExpr)
  File "/Users/nauck/projects/freecad/build-debug/Mod/Spreadsheet/importXLSX.py", line 202, in getNextToken
    self.getNextToken(theExpr)
  File "/Users/nauck/projects/freecad/build-debug/Mod/Spreadsheet/importXLSX.py", line 206, in getNextToken
    if not self.isKey(theExpr):
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/nauck/projects/freecad/build-debug/Mod/Spreadsheet/importXLSX.py", line 228, in isKey
    branch = treeDict[branch][theExpr[0]]
             ~~~~~~~~~~~~~~~~^^^^^^^^^^^^
<class 'KeyError'>: ('<',)
```


The issue can also be tested by running the new test `test_translate_expressions` as it will fail without the fix.

Two tests has been created to verify that all operators works after the fix.