### PR TITLE
Sketcher: initialize geometry history limit variable

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -156,6 +156,7 @@ SketchObject::SketchObject()
                       (App::PropertyType)(App::Prop_None),
                       "Tolerance for fitting arcs of projected external geometry");
     geoLastId = 0;
+    geoHistoryLevel = 0;
 
     ADD_PROPERTY(InternalShape,
                  (Part::TopoShape()));

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -156,7 +156,7 @@ SketchObject::SketchObject()
                       (App::PropertyType)(App::Prop_None),
                       "Tolerance for fitting arcs of projected external geometry");
     geoLastId = 0;
-    geoHistoryLevel = 0;
+    geoHistoryLevel = 1;
 
     ADD_PROPERTY(InternalShape,
                  (Part::TopoShape()));


### PR DESCRIPTION
The variable seems to be uninitialized, valgrind complais about it.

The `git grep geoHistoryLevel` and the code ispection suggest it is never set. If initialized to zero, most of the related code is never used, which can point to the fact there is either another bug or part of the code is dead.

The variable was introduced in 42bf92ad12.

The initialization to 0 ensures stable, predictable behavior, @realthunder might have a suggestion what is going on here?

