### PR TITLE
OverlayManager: fix unititialized hideTab variable

### DIFF
--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -136,7 +136,7 @@ public:
 
     ParameterGrp::handle handle;
     QString activeStyleSheet;
-    bool hideTab;
+    bool hideTab = false;
 
 private:
     QString detectOverlayStyleSheetFileName() const {


### PR DESCRIPTION
The hideTab is of type bool, which is primitive type and is thus unitialized if new instance of the class is created. The exception would be to for static instance of the class, but that is not the case (only the pointer to the instance is static).

It was originaly initialized, but the initialization was removed in 9d5390ed833.

I'm not sure but this variable actually looks unused, mey-be there is somethink missing here, otherwise the code contains dead paths.