### PR TITLE
PD: Xerces-C++ - Prepare for the latest version (backward compatible)

### DIFF
--- a/src/App/Metadata.cpp
+++ b/src/App/Metadata.cpp
@@ -58,7 +58,12 @@ directly. If you did not intend to use a system-defined macro
 
 using namespace App;
 namespace fs = boost::filesystem;
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+#else
 XERCES_CPP_NAMESPACE_USE
+#endif
 
 namespace MetadataInternal
 {

--- a/src/App/MetadataPyImp.cpp
+++ b/src/App/MetadataPyImp.cpp
@@ -30,7 +30,12 @@
 #include "MetadataPy.cpp"
 
 using namespace Base;
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+#else
 XERCES_CPP_NAMESPACE_USE
+#endif
 
 // Returns a string which represents the object e.g. when printed in Python
 std::string MetadataPy::representation() const

--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -56,7 +56,12 @@
 #include <Base/Stream.h>
 #include <Base/XMLTools.h>
 
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+#else
 XERCES_CPP_NAMESPACE_USE
+#endif
 using namespace App;
 
 namespace {

--- a/src/App/ProjectFile.h
+++ b/src/App/ProjectFile.h
@@ -32,11 +32,17 @@
 #include <string>
 #include <xercesc/util/XercesDefs.hpp>
 
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+namespace XERCES_CPP_NAMESPACE { class DOMNode; class DOMElement; class DOMDocument; }
+#else
 XERCES_CPP_NAMESPACE_BEGIN
 class DOMDocument;
 class DOMElement;
 class DOMNode;
 XERCES_CPP_NAMESPACE_END
+#endif
 
 namespace App
 {

--- a/src/Base/InputSource.cpp
+++ b/src/Base/InputSource.cpp
@@ -35,8 +35,12 @@
 #include "InputSource.h"
 #include "XMLTools.h"
 
-
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+#else
 XERCES_CPP_NAMESPACE_USE
+#endif
 
 using namespace Base;
 using namespace std;

--- a/src/Base/InputSource.h
+++ b/src/Base/InputSource.h
@@ -32,10 +32,18 @@
 #include <FCGlobal.h>
 #endif
 
-
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+namespace XERCES_CPP_NAMESPACE
+{
+class BinInputStream;
+}
+#else
 XERCES_CPP_NAMESPACE_BEGIN
 class BinInputStream;
 XERCES_CPP_NAMESPACE_END
+#endif
 
 namespace Base
 {

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -60,8 +60,12 @@
 
 FC_LOG_LEVEL_INIT("Parameter", true, true)
 
-
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+#else
 XERCES_CPP_NAMESPACE_USE
+#endif
 using namespace Base;
 
 
@@ -76,7 +80,6 @@ using namespace Base;
 // - DOMPrintErrorHandler
 // - XStr
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
 
 class DOMTreeErrorReporter: public ErrorHandler
 {

--- a/src/Base/Parameter.h
+++ b/src/Base/Parameter.h
@@ -65,7 +65,18 @@ using PyObject = struct _object;
 #pragma warning(disable : 4275)
 #endif
 
-
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+namespace XERCES_CPP_NAMESPACE
+{
+class DOMNode;
+class DOMElement;
+class DOMDocument;
+class XMLFormatTarget;
+class InputSource;
+}  // namespace XERCES_CPP_NAMESPACE
+#else
 XERCES_CPP_NAMESPACE_BEGIN
 class DOMNode;
 class DOMElement;
@@ -73,6 +84,7 @@ class DOMDocument;
 class XMLFormatTarget;
 class InputSource;
 XERCES_CPP_NAMESPACE_END
+#endif
 
 class ParameterManager;
 

--- a/src/Base/Reader.cpp
+++ b/src/Base/Reader.cpp
@@ -46,8 +46,12 @@
 #include <zipios++/zipinputstream.h>
 #include <boost/iostreams/filtering_stream.hpp>
 
-
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+#else
 XERCES_CPP_NAMESPACE_USE
+#endif
 
 using namespace std;
 

--- a/src/Base/Reader.h
+++ b/src/Base/Reader.h
@@ -42,11 +42,20 @@ namespace zipios
 {
 class ZipInputStream;
 }
-
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+namespace XERCES_CPP_NAMESPACE
+{
+class DefaultHandler;
+class SAX2XMLReader;
+}  // namespace XERCES_CPP_NAMESPACE
+#else
 XERCES_CPP_NAMESPACE_BEGIN
 class DefaultHandler;
 class SAX2XMLReader;
 XERCES_CPP_NAMESPACE_END
+#endif
 
 namespace Base
 {

--- a/src/Base/XMLTools.cpp
+++ b/src/Base/XMLTools.cpp
@@ -26,7 +26,12 @@
 #include "XMLTools.h"
 
 using namespace Base;
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+#else
 XERCES_CPP_NAMESPACE_USE
+#endif
 
 std::unique_ptr<XMLTranscoder> XMLTools::transcoder;  // NOLINT
 

--- a/src/Base/XMLTools.h
+++ b/src/Base/XMLTools.h
@@ -31,12 +31,22 @@
 
 #include <Base/Exception.h>
 
-
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+namespace XERCES_CPP_NAMESPACE
+{
+class DOMNode;
+class DOMElement;
+class DOMDocument;
+}  // namespace XERCES_CPP_NAMESPACE
+#else
 XERCES_CPP_NAMESPACE_BEGIN
 class DOMNode;
 class DOMElement;
 class DOMDocument;
 XERCES_CPP_NAMESPACE_END
+#endif
 
 // Helper class
 class BaseExport XMLTools

--- a/src/Mod/Mesh/App/Core/IO/Reader3MF.cpp
+++ b/src/Mod/Mesh/App/Core/IO/Reader3MF.cpp
@@ -41,7 +41,12 @@
 
 
 using namespace MeshCore;
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+#else
 XERCES_CPP_NAMESPACE_USE
+#endif
 
 Reader3MF::Reader3MF(std::istream& str)
 {

--- a/src/Mod/Mesh/App/Core/IO/Reader3MF.h
+++ b/src/Mod/Mesh/App/Core/IO/Reader3MF.h
@@ -31,10 +31,20 @@
 #include <unordered_map>
 #include <xercesc/util/XercesDefs.hpp>
 
+#ifndef XERCES_CPP_NAMESPACE_BEGIN
+#define XERCES_CPP_NAMESPACE_QUALIFIER
+using namespace XERCES_CPP_NAMESPACE;
+namespace XERCES_CPP_NAMESPACE
+{
+class DOMDocument;
+class DOMNodeList;
+}  // namespace XERCES_CPP_NAMESPACE
+#else
 XERCES_CPP_NAMESPACE_BEGIN
 class DOMDocument;
 class DOMNodeList;
 XERCES_CPP_NAMESPACE_END
+#endif
 
 namespace MeshCore
 {

--- a/tests/src/App/Metadata.cpp
+++ b/tests/src/App/Metadata.cpp
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 
 #include "App/Metadata.h"
+#include <xercesc/util/PlatformUtils.hpp>
 
 // NOLINTBEGIN(readability-named-parameter)
 
@@ -192,11 +193,11 @@ class MetadataTest: public ::testing::Test
 protected:
     void SetUp() override
     {
-        xercesc_3_2::XMLPlatformUtils::Initialize();
+        XERCES_CPP_NAMESPACE::XMLPlatformUtils::Initialize();
     }
     void TearDown() override
     {
-        xercesc_3_2::XMLPlatformUtils::Terminate();
+        XERCES_CPP_NAMESPACE::XMLPlatformUtils::Terminate();
     }
     std::string GivenSimpleMetadataXMLString()
     {

--- a/tests/src/Base/Reader.cpp
+++ b/tests/src/Base/Reader.cpp
@@ -11,6 +11,7 @@
 #include <array>
 #include <boost/filesystem.hpp>
 #include <fstream>
+#include <xercesc/util/PlatformUtils.hpp>
 
 namespace fs = boost::filesystem;
 
@@ -19,7 +20,7 @@ class ReaderTest: public ::testing::Test
 protected:
     void SetUp() override
     {
-        xercesc_3_2::XMLPlatformUtils::Initialize();
+        XERCES_CPP_NAMESPACE::XMLPlatformUtils::Initialize();
         _tempDir = fs::temp_directory_path();
         std::string filename = "unit_test_Reader.xml";
         _tempFile = _tempDir / filename;


### PR DESCRIPTION
# Goal
The goal of this PR is to be able to manage the current and latest version of Xerces-C++ . Currently, the version required and mostly used by FreeCAD is older from 2 to 4 years than the latest commit in the Xerces-C++ repository (see [Xerces-C++ tags](https://github.com/apache/xerces-c/tags)).

# Description
In order for FreeCAD to continue to use the latest version of Xerces-C++, this PR aims to prepare Xerces-C++ bump version. The bump will be performed in another PR **after** the fixes described in the last line of this PR comment.

It also allows developers like me to use the latest version of Xerces-C++ and compile it in debug mode and then investigate memory leaks, such as described and found in #16316  with Valgrind.

# DEV explanations:
The new version do not contain the following macros:
- `XERCES_CPP_NAMESPACE_BEGIN`
- `XERCES_CPP_NAMESPACE_END`
- `XERCES_CPP_NAMESPACE_USE`
- `XERCES_CPP_NAMESPACE_QUALIFIER`

Now everything is regrouped using only the `XERCES_CPP_NAMESPACE` macro - See the diff [here in the official XERCES-C repo](https://github.com/apache/xerces-c/commit/6d418754009bf0986787b71f97ea7dc84dcfbd65)

Also, there is no more type `xercesc_3_2`  - It has been replace with `using namespace` and `#include`

# Important notice
- Please notice that this code is backward compatible with older versions of Xerces and compile with the most recent one.
- Please notice that **this is NOT a fix** for #16316 , it is a PR to better investigate it (memory leaks)