### PR TITLE
Gui: Fix orthographic camera standard views in an empty scene

### DIFF
--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -569,7 +569,7 @@ void NavigationStyle::reorientCamera(SoCamera* camera, const SbRotation& rotatio
          float repositionDistance = -center.getValue()[2] - boundingSphere.getRadius();
          camera->position = camera->position.getValue() + repositionDistance * dir;
          camera->nearDistance = 0;
-         camera->farDistance = 2 * boundingSphere.getRadius();
+         camera->farDistance = 2 * boundingSphere.getRadius() + 1;
          camera->focalDistance = camera->focalDistance.getValue() - repositionDistance;
      }
 }


### PR DESCRIPTION
This fixes #16223 when using Coin versions before 4.0.3.