### PR TITLE
Gui: Use Coin 4.0.3 fix for orthographic camera clipping

### DIFF
--- a/src/Gui/NavigationAnimation.cpp
+++ b/src/Gui/NavigationAnimation.cpp
@@ -58,7 +58,10 @@ FixedTimeAnimation::FixedTimeAnimation(NavigationStyle* navigation, const SbRota
 
 void FixedTimeAnimation::initialize()
 {
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 403)
     navigation->findBoundingSphere();
+#endif
+
     prevAngle = 0;
     prevTranslation = SbVec3f(0, 0, 0);
 
@@ -135,7 +138,10 @@ SpinningAnimation::SpinningAnimation(NavigationStyle* navigation, const SbVec3f&
 
 void SpinningAnimation::initialize()
 {
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 403)
     navigation->findBoundingSphere();
+#endif
+
     prevAngle = 0;
 
     navigation->setViewing(true);

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -516,12 +516,14 @@ void NavigationStyle::viewAll()
     }
 }
 
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 403)
 void NavigationStyle::findBoundingSphere() {
     // Find a bounding sphere for the scene
     SoGetBoundingBoxAction action(viewer->getSoRenderManager()->getViewportRegion());
     action.apply(viewer->getSceneGraph());
     boundingSphere.circumscribe(action.getBoundingBox());
 }
+#endif
 
 /** Rotate the camera by the given amount, then reposition it so we're still pointing at the same
  * focal point
@@ -554,8 +556,9 @@ void NavigationStyle::reorientCamera(SoCamera* camera, const SbRotation& rotatio
     // Reposition camera so the rotation center stays in the same place
     camera->position = rotationCenter + newRotationCenterDistance;
 
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 403)
     // Fix issue with near clipping in orthogonal view
-     if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {
+    if (camera->getTypeId().isDerivedFrom(SoOrthographicCamera::getClassTypeId())) {
 
          // The center of the bounding sphere in camera coordinate system
          SbVec3f center;
@@ -572,6 +575,7 @@ void NavigationStyle::reorientCamera(SoCamera* camera, const SbRotation& rotatio
          camera->farDistance = 2 * boundingSphere.getRadius();
          camera->focalDistance = camera->focalDistance.getValue() - repositionDistance;
      }
+#endif
 }
 
 void NavigationStyle::panCamera(SoCamera * cam, float aspectratio, const SbPlane & panplane,
@@ -782,7 +786,10 @@ void NavigationStyle::doZoom(SoCamera* camera, float logfactor, const SbVec2f& p
         // Rotation mode is WindowCenter
         if (!rotationCenterMode) {
             viewer->changeRotationCenterPosition(getFocalPoint());
+
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 403)
             findBoundingSphere();
+#endif
         }
     }
 }
@@ -1405,7 +1412,11 @@ void NavigationStyle::setViewingMode(const ViewerMode newmode)
         // first starting a drag operation.
         animator->stop();
         viewer->showRotationCenter(true);
+
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 403)
         findBoundingSphere();
+#endif
+
         this->spinprojector->project(this->lastmouseposition);
         this->interactiveCountInc();
         this->clearLog();

--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -152,7 +152,11 @@ public:
     SoCamera* getCamera() const;
     void setCameraOrientation(const SbRotation& orientation, SbBool moveToCenter = false);
     void translateCamera(const SbVec3f& translation);
+
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 403)
     void findBoundingSphere();
+#endif
+
     void reorientCamera(SoCamera* camera, const SbRotation& rotation);
     void reorientCamera(SoCamera* camera, const SbRotation& rotation, const SbVec3f& rotationCenter);
 
@@ -284,7 +288,9 @@ private:
     float sensitivity;
     SbBool resetcursorpos;
 
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 403)
     SbSphere boundingSphere;
+#endif
 };
 
 /** Sub-classes of this class appear in the preference dialog where users can

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1073,7 +1073,11 @@ void View3DInventorViewer::setEditingViewProvider(Gui::ViewProvider* vp, int Mod
 {
     this->editViewProvider = vp;
     this->editViewProvider->setEditViewer(this, ModNum);
+
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 403)
     this->navigation->findBoundingSphere();
+#endif
+
     addEventCallback(SoEvent::getClassTypeId(), Gui::ViewProvider::eventCallback,this->editViewProvider);
 }
 
@@ -1536,7 +1540,9 @@ void View3DInventorViewer::setSceneGraph(SoNode* root)
         }
     }
 
+#if (COIN_MAJOR_VERSION * 100 + COIN_MINOR_VERSION * 10 + COIN_MICRO_VERSION < 403)
     navigation->findBoundingSphere();
+#endif
 }
 
 void View3DInventorViewer::savePicture(int width, int height, int sample, const QColor& bg, QImage& img) const


### PR DESCRIPTION
This PR replaces #11279 when compiling with Coin 4.0.3+. As of Coin 4.0.3 there is a fix build into Coin for the orthographic camera clipping. This also fixes https://github.com/FreeCAD/FreeCAD/issues/12162#issuecomment-2045927219 and #16223 when compiled with Coin 4.0.3+.