### PR TITLE
Fem: Allow only one shape type per mesh group - Partially revert #16076

### DIFF
--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -363,10 +363,7 @@ class GmshTools:
         Console.PrintMessage("  " + self.gmsh_bin + "\n")
 
     def get_group_data(self):
-        # TODO: solids, faces, edges and vertexes don't seem to work together in one group,
-        #       some output message or make them work together
-
-        # mesh group objects
+        # mesh group objects. Only one shape type is expected
         if not self.mesh_obj.MeshGroupList:
             # print("  No mesh group objects.")
             pass
@@ -674,9 +671,8 @@ class GmshTools:
 
                 for phys in ele:
                     if ele[phys]:
-                        name = group + "_{}".format(phys)
                         items = "{" + ", ".join(ele[phys]) + "}"
-                        geo.write('Physical {}("{}") = {};\n'.format(phys, name, items))
+                        geo.write('Physical {}("{}") = {};\n'.format(phys, group, items))
 
             geo.write("\n")
 

--- a/src/Mod/Fem/femtaskpanels/task_mesh_group.py
+++ b/src/Mod/Fem/femtaskpanels/task_mesh_group.py
@@ -64,8 +64,9 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
 
         # geometry selection widget
         # start with Solid in list!
+        # only one shape type is allowed
         self.selectionWidget = selection_widgets.GeometryElementsSelection(
-            obj.References, ["Solid", "Face", "Edge", "Vertex"], True, False
+            obj.References, ["Solid", "Face", "Edge", "Vertex"], False, False
         )
 
         # form made from param and selection widget

--- a/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
+++ b/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
@@ -7,10 +7,10 @@ General.NumThreads = X;
 Merge "tmp0TVZbM.brep";
 
 // group data
-Physical Surface("Face1_Surface") = {1};
-Physical Surface("Face2_Surface") = {2};
-Physical Surface("Face6_Surface") = {6};
-Physical Volume("Solid1_Volume") = {1};
+Physical Surface("Face1") = {1};
+Physical Surface("Face2") = {2};
+Physical Surface("Face6") = {6};
+Physical Volume("Solid1") = {1};
 
 // Characteristic Length
 // no boundary layer settings for this mesh


### PR DESCRIPTION
https://github.com/FreeCAD/FreeCAD/pull/16076 basically breaks Elmer solver due to inconsistent references names between constraints and mesh groups.
Since both `gmsh` and `salome smesh` work with only one element type per group, instead of add a suffix to the group name as is done in #16076, just disallow adding multiple types directly from the GUI in the `MeshGroup` task panel.

@FEA-eng , @chennes 