### PR TITLE
Sketcher/Toponaming: import SketchObject::checkSubName() from LS3

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -11350,26 +11350,74 @@ Data::IndexedName SketchObject::checkSubName(const char *subname) const{
 
     bio::stream<bio::array_source> iss(mappedSubname+1, std::strlen(mappedSubname+1));
     int id = -1;
-    switch(mappedSubname[0]) {
-    case '\0': // check length != 0
+    bool valid = false;
+    switch (mappedSubname[0]) {
+        case '\0':  // check length != 0
+            break;
+
+        case 'g':  // = geometry
+        case 'e':  // = external geometry
+            if (iss >> id) {
+                valid = true;
+            }
+            break;
+
+        // for RootPoint, H_Axis, V_Axis
+        default: {
+            const char* dot = strchr(mappedSubname, '.');
+            if (dot) {
+                mappedSubname = dot + 1;
+            }
+            return Data::IndexedName(mappedSubname, types, false);
+        }
+    }
+
+    if (!valid) {
         FC_ERR("invalid subname " << subname);
-        break;
+        // return sub;
+        return Data::IndexedName();
+    }
 
-    case 'g': // = geometry
-    case 'e': // = external geometry
-        if(!(iss>>id))
-            FC_ERR("invalid subname " << subname);
-        break;
-
-    // for RootPoint, H_Axis, V_Axis
-    default: {
-        const char *dot = strchr(mappedSubname,'.');
-        if(dot)
-            mappedSubname = dot+1;
-        return Data::IndexedName(mappedSubname, types, false);
-    }}
-
-    // TNP July '24: omitted code related to external and internal sketcher stuff implemented in LS3
+    int geoId;
+    const Part::Geometry* geo = 0;
+    switch (mappedSubname[0]) {
+        case 'g': {
+            auto it = geoMap.find(id);
+            if (it != geoMap.end()) {
+                geoId = it->second;
+                geo = getGeometry(geoId);
+            }
+            break;
+        }
+        case 'e': {
+            auto it = externalGeoMap.find(id);
+            if (it != externalGeoMap.end()) {
+                geoId = -it->second - 1;
+                geo = getGeometry(geoId);
+            }
+            break;
+        }
+    }
+    if (geo && GeometryFacade::getId(geo) == id) {
+        char sep;
+        int posId = static_cast<int>(PointPos::none);
+        if ((iss >> sep >> posId) && sep == 'v') {
+            int idx = getVertexIndexGeoPos(geoId, static_cast<PointPos>(posId));
+            if (idx < 0) {
+                FC_ERR("invalid subname " << subname);
+                // return sub;
+                return Data::IndexedName();
+            }
+            return Data::IndexedName::fromConst("Vertex", idx + 1);
+        }
+        else if (geoId >= 0) {
+            return Data::IndexedName::fromConst("Edge", geoId + 1);
+        }
+        else {
+            return Data::IndexedName::fromConst("ExternalEdge", -geoId - 2);
+        }
+    }
+    FC_ERR("cannot find subname " << subname);
 
     return Data::IndexedName();
 }

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -11374,7 +11374,6 @@ Data::IndexedName SketchObject::checkSubName(const char *subname) const{
 
     if (!valid) {
         FC_ERR("invalid subname " << subname);
-        // return sub;
         return Data::IndexedName();
     }
 
@@ -11405,7 +11404,6 @@ Data::IndexedName SketchObject::checkSubName(const char *subname) const{
             int idx = getVertexIndexGeoPos(geoId, static_cast<PointPos>(posId));
             if (idx < 0) {
                 FC_ERR("invalid subname " << subname);
-                // return sub;
                 return Data::IndexedName();
             }
             return Data::IndexedName::fromConst("Vertex", idx + 1);

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -1452,6 +1452,7 @@ void TaskSketcherElements::onSelectionChanged(const Gui::SelectionChanges& msg)
                                     static_cast<ElementItem*>(ui->listWidgetElements->item(i));
                                 if (item->ElementNbr == ElementId) {
                                     item->isLineSelected = select;
+                                    modified_item = item;
                                     break;
                                 }
                             }


### PR DESCRIPTION
related to https://github.com/FreeCAD/FreeCAD/issues/13177#issuecomment-2307792664

the imported code restores the synchronization of the selection of external edges between the 3D view and the Task Panel

as for https://github.com/FreeCAD/FreeCAD/issues/16422#issuecomment-2344255862, this PR fixes #16422