### PR TITLE
DXF: Change C++ DXF import to ignore type 999 (comment) records

### DIFF
--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2357,26 +2357,29 @@ bool CDxfRead::get_next_record()
         return m_not_eof;
     }
 
-    if ((*m_ifs).eof()) {
-        m_not_eof = false;
-        return false;
-    }
+    do {
+        if ((*m_ifs).eof()) {
+            m_not_eof = false;
+            return false;
+        }
 
-    std::getline(*m_ifs, m_record_data);
-    ++m_line;
-    int temp = 0;
-    if (!ParseValue<int>(this, &temp)) {
-        ImportError("CDxfRead::get_next_record() Failed to get integer record type from '%s'\n",
-                    m_record_data);
-        return false;
-    }
-    m_record_type = (eDXFGroupCode_t)temp;
-    if ((*m_ifs).eof()) {
-        return false;
-    }
+        std::getline(*m_ifs, m_record_data);
+        ++m_line;
+        int temp = 0;
+        if (!ParseValue<int>(this, &temp)) {
+            ImportError("CDxfRead::get_next_record() Failed to get integer record type from '%s'\n",
+                        m_record_data);
+            return false;
+        }
+        m_record_type = (eDXFGroupCode_t)temp;
+        if ((*m_ifs).eof()) {
+            return false;
+        }
 
-    std::getline(*m_ifs, m_record_data);
-    ++m_line;
+        std::getline(*m_ifs, m_record_data);
+        ++m_line;
+    } while (m_record_type == eComment);
+
     // Remove any carriage return at the end of m_str which may occur because of inconsistent
     // handling of LF vs. CRLF line termination.
     auto last = m_record_data.rbegin();

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -211,6 +211,7 @@ enum eDXFGroupCode_t
     eUCSXDirection = 111,
     eUCSYDirection = 112,
     eExtrusionDirection = 210,
+    eComment = 999,
 
     // The following apply to points and directions in text DXF files to identify the three
     // coordinates


### PR DESCRIPTION
Fixes #16131 