### PR TITLE
Core: Fix duplicated extensions (see #16299)

### DIFF
--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -89,8 +89,7 @@ private:
     bool hasSuffix(const QString&) const;
     static QList<QUrl> fetchSidebarUrls();
     static QString workingDirectory;
-    static void getPossibleSuffixes(QStringList& possibleSuffixes, const QRegularExpression& rx,
-                                    const QString* suffixDescriptions);
+    static void getSuffixesDescription(QStringList& suffixes, const QString* suffixDescriptions);
 };
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
This PR aims to resolve #16299, while taking into account https://github.com/FreeCAD/FreeCAD/issues/15908 and https://github.com/FreeCAD/FreeCAD/issues/15203 as well.

It simplifies the code and the regression happened because the regex was not clear to me initially and later also not to @chennes (I believe). I initially assumed the regex was meant to match all the suffixes in the description and probably @chennes took over this assumption because my code used it as such. However, I now understand that the regex was only meant to match the first extension in the list to add this first extension when an extension was missing. 

Because of https://github.com/FreeCAD/FreeCAD/issues/15203, the current code extracts the suffixes from `filterSearch` and uses that to determine whether fileInfo has an extension that matches. If not, it concatenates the first suffix from the list of filter suffixes.

Going forward, I would advise to document regexes carefully as I have now done in `getSuffixesDescription()`. 

Closes #16299