### PR TITLE
Gui: Hide splashscreen after fully loaded only

### DIFF
--- a/src/Gui/Splashscreen.h
+++ b/src/Gui/Splashscreen.h
@@ -41,7 +41,7 @@ class SplashScreen : public QSplashScreen
     Q_OBJECT
 
 public:
-    explicit SplashScreen(  const QPixmap & pixmap = QPixmap ( ), Qt::WindowFlags f = Qt::WindowFlags() );
+    explicit SplashScreen(  const QPixmap & pixmap = QPixmap ( ), Qt::WindowFlags f = Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
     ~SplashScreen() override;
 
     void setShowMessages(bool on);

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -231,6 +231,7 @@ void StartupPostProcess::execute()
     showMainWindow();
     activateWorkbench();
     checkParameters();
+    hideSplashScreen();
 }
 
 void StartupPostProcess::setWindowTitle()
@@ -444,12 +445,9 @@ void StartupPostProcess::showMainWindow()
         Base::Console().Error("Error in FreeCADGuiInit.py: %s\n", e.what());
         mainWindow->stopSplasher();
         throw;
-
     }
 
-    // stop splash screen and set immediately the active window that may be of interest
-    // for scripts using Python binding for Qt
-    mainWindow->stopSplasher();
+    // immediately the active window that may be of interest for scripts using Python binding for Qt
     mainWindow->activateWindow();
 }
 
@@ -560,4 +558,10 @@ void StartupPostProcess::checkParameters()
         Base::Console().Warning("User parameter file couldn't be opened.\n"
                                 "Continue with an empty configuration that won't be saved.\n");
     }
+}
+
+void StartupPostProcess::hideSplashScreen()
+{
+    // this must be done as last step to ensure that splash screen hides when everything is loaded
+    mainWindow->stopSplasher();
 }

--- a/src/Gui/StartupProcess.h
+++ b/src/Gui/StartupProcess.h
@@ -76,6 +76,7 @@ private:
     void showMainWindow();
     void activateWorkbench();
     void checkParameters();
+    void hideSplashScreen();
 
 private:
     bool loadFromPythonModule = false;


### PR DESCRIPTION
This ensures that SplashScreen stays on top of other windows (especially the main one) and that it is hidden after all workbenches are properly loaded. 

Fixes: #16264 
Fixes: #16161