### PR TITLE
Sketcher/Gui: check if there's a 3D view while executing ViewProviderSketch::unsetEdit()

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3312,23 +3312,28 @@ void ViewProviderSketch::unsetEdit(int ModNum)
         if (sketchHandler)
             deactivateHandler();
 
-        // Resets the override draw style mode when leaving the sketch edit mode.
-        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-        auto disableShadedView = hGrp->GetBool("DisableShadedView", true);
-        if (disableShadedView) {
-            Gui::Document* doc = Gui::Application::Instance->activeDocument();
-            Gui::MDIView* mdi = doc->getActiveView();
-            Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(mdi)->getViewer();
+        Gui::MDIView* mdi = getInventorView();
 
+        // handle the override draw style mode only if there's a 3D view, otherwise SIGSEGV may
+        // occur as described in https://github.com/FreeCAD/FreeCAD/issues/15918
+        if (mdi) {
+
+            // Resets the override draw style mode when leaving the sketch edit mode.
             ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-            "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
-            auto OverrideMode = hGrp->GetASCII("OverrideMode", "As Is");
+                "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+            auto disableShadedView = hGrp->GetBool("DisableShadedView", true);
+            if (disableShadedView) {
+                Gui::View3DInventorViewer* viewer =
+                    static_cast<Gui::View3DInventor*>(mdi)->getViewer();
 
-            if (viewer)
-            {
-                viewer->updateOverrideMode(OverrideMode);
-                viewer->setOverrideMode(OverrideMode);
+                ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+                    "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+                auto OverrideMode = hGrp->GetASCII("OverrideMode", "As Is");
+
+                if (viewer) {
+                    viewer->updateOverrideMode(OverrideMode);
+                    viewer->setOverrideMode(OverrideMode);
+                }
             }
         }
 


### PR DESCRIPTION
related to #15918

Performs the override draw style code only if there's actually a 3D view