### PR TITLE
Measure: Show delta option also in interactive mode

### DIFF
--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -42,9 +42,14 @@
 
 #include <QFormLayout>
 #include <QPushButton>
+#include <QSettings>
 
 using namespace Gui;
 
+namespace {
+constexpr auto taskMeasureSettingsGroup = "TaskMeasure";
+constexpr auto taskMeasureShowDeltaSettingsName = "ShowDelta";
+}
 
 TaskMeasure::TaskMeasure()
 {
@@ -56,7 +61,12 @@ TaskMeasure::TaskMeasure()
                                               true,
                                               nullptr);
 
+    QSettings settings;
+    settings.beginGroup(QLatin1String(taskMeasureSettingsGroup));
+    delta = settings.value(QLatin1String(taskMeasureShowDeltaSettingsName), true).toBool();
+
     showDelta = new QCheckBox();
+    showDelta->setChecked(delta);
     showDeltaLabel = new QLabel(tr("Show Delta:"));
     connect(showDelta, &QCheckBox::stateChanged, this, &TaskMeasure::showDeltaChanged);
 
@@ -493,6 +503,11 @@ void TaskMeasure::onModeChanged(int index)
 void TaskMeasure::showDeltaChanged(int checkState)
 {
     delta = checkState == Qt::CheckState::Checked;
+
+    QSettings settings;
+    settings.beginGroup(QLatin1String(taskMeasureSettingsGroup));
+    settings.setValue(QLatin1String(taskMeasureShowDeltaSettingsName), delta);
+
     this->update();
 }
 

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -46,10 +46,11 @@
 
 using namespace Gui;
 
-namespace {
+namespace
+{
 constexpr auto taskMeasureSettingsGroup = "TaskMeasure";
 constexpr auto taskMeasureShowDeltaSettingsName = "ShowDelta";
-}
+}  // namespace
 
 TaskMeasure::TaskMeasure()
 {
@@ -488,7 +489,8 @@ bool TaskMeasure::eventFilter(QObject* obj, QEvent* event)
     return TaskDialog::eventFilter(obj, event);
 }
 
-void TaskMeasure::setDeltaPossible(bool possible) {
+void TaskMeasure::setDeltaPossible(bool possible)
+{
     showDelta->setVisible(possible);
     showDeltaLabel->setVisible(possible);
 }

--- a/src/Mod/Measure/Gui/TaskMeasure.h
+++ b/src/Mod/Measure/Gui/TaskMeasure.h
@@ -24,6 +24,7 @@
 #include <QString>
 #include <QComboBox>
 #include <QLineEdit>
+#include <QCheckBox>
 
 #include <App/Application.h>
 #include <App/Document.h>
@@ -77,9 +78,11 @@ private:
 
     QLineEdit* valueResult {nullptr};
     QComboBox* modeSwitch {nullptr};
+    QCheckBox* showDelta {nullptr};
 
     void removeObject();
     void onModeChanged(int index);
+    void showDeltaChanged(int checkState);
     void setModeSilent(App::MeasureType* mode);
     App::MeasureType* getMeasureType();
     void enableAnnotateButton(bool state);
@@ -94,6 +97,9 @@ private:
 
     // Stores if the mode is explicitly set by the user or implicitly through the selection
     bool explicitMode = false;
+
+    // Stores if delta measures shall be shown
+    bool delta = false;
 };
 
 }  // namespace Gui

--- a/src/Mod/Measure/Gui/TaskMeasure.h
+++ b/src/Mod/Measure/Gui/TaskMeasure.h
@@ -79,6 +79,7 @@ private:
     QLineEdit* valueResult {nullptr};
     QComboBox* modeSwitch {nullptr};
     QCheckBox* showDelta {nullptr};
+    QLabel* showDeltaLabel{nullptr};
 
     void removeObject();
     void onModeChanged(int index);
@@ -90,6 +91,7 @@ private:
     Gui::ViewProviderDocumentObject* createViewObject(App::DocumentObject* measureObj);
     void saveObject();
     void ensureGroup(Measure::MeasureBase* measurement);
+    void setDeltaPossible(bool possible);
 
 
     // List of measure types

--- a/src/Mod/Measure/Gui/TaskMeasure.h
+++ b/src/Mod/Measure/Gui/TaskMeasure.h
@@ -79,7 +79,7 @@ private:
     QLineEdit* valueResult {nullptr};
     QComboBox* modeSwitch {nullptr};
     QCheckBox* showDelta {nullptr};
-    QLabel* showDeltaLabel{nullptr};
+    QLabel* showDeltaLabel {nullptr};
 
     void removeObject();
     void onModeChanged(int index);

--- a/src/Mod/Measure/Gui/TaskMeasure.h
+++ b/src/Mod/Measure/Gui/TaskMeasure.h
@@ -101,7 +101,7 @@ private:
     bool explicitMode = false;
 
     // Stores if delta measures shall be shown
-    bool delta = false;
+    bool delta = true;
 };
 
 }  // namespace Gui


### PR DESCRIPTION
When using the measurement currently it is only possible to enable the delta's by saving the measurement and turning the option on.
With this MR the delta option is already available in the TaskMeasure to see the deltas also in the interactive mode (if possible). The delta option is stored in the  measurement so when saving the measurement, the option is also applied


https://github.com/user-attachments/assets/21bf0048-59ce-4ae4-921a-a290f924f6a0

