### PR TITLE
Core: change order of Python modules search paths (sys.path)

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -159,7 +159,7 @@ def InitApplications():
     # also add these directories to the sys.path to
     # not change the old behaviour. once we have moved to
     # proper python modules this can eventually be removed.
-    sys.path = [ModDir] + libpaths + [ExtDir] + sys.path
+    sys.path = sys.path + [ModDir] + libpaths + [ExtDir]
 
     # The AddonManager may install additional Python packages in
     # these paths:
@@ -209,7 +209,7 @@ def InitApplications():
                 subdirectory = subdirectory.replace("/",os.path.sep)
                 subdirectory = os.path.join(Dir, subdirectory)
                 #classname = workbench.Classname
-                sys.path.insert(0,subdirectory)
+                sys.path.append(subdirectory)
                 PathExtension.append(subdirectory)
                 RunInitPy(subdirectory)
 
@@ -244,7 +244,7 @@ def InitApplications():
         if Dir not in ['', 'CVS', '__init__.py']:
             if checkIfAddonIsDisabled(Dir):
                 continue
-            sys.path.insert(0,Dir)
+            sys.path.append(Dir)
             PathExtension.append(Dir)
             MetadataFile = os.path.join(Dir, "package.xml")
             if os.path.exists(MetadataFile):


### PR DESCRIPTION
This will change the order in sys.path so that
* internal Workbenches
* external Workbenches (Mod directory)
* and User-Macros

(in this order)
will be appended at the end of sys.path instead of inserting them at the beginning.

For example, if a user has a folder "freecad" or "numpy" containing a "\_\_init\_\_.py" inside the user Mod or User-Macros folder, then this module cannot take precedence anymore over the original modules in FreeCAD/usr/lib/python3.*/site-packages.

related discussion:
https://forum.freecad.org/viewtopic.php?t=90418