### PR TITLE
[Gui] Add DPI information to about clipboard info

### DIFF
--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -881,6 +881,7 @@ void AboutDialog::copyToClipboard()
     }
     str << "\n";
 
+    // Add Stylesheet/Theme/Qtstyle information
     std::string styleSheet = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("StyleSheet");
     std::string theme = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("Theme");
     std::string style = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("QtStyle");
@@ -889,6 +890,13 @@ void AboutDialog::copyToClipboard()
         << QString::fromStdString(styleSheet) << "/"
         << QString::fromStdString(theme) << "/"
         << QString::fromStdString(style) << "\n";
+
+    // Add DPI information
+    str << "Logical/physical DPI: "
+        << screen()->logicalDotsPerInch()
+        << "/"
+        << screen()->physicalDotsPerInch()
+        << "\n";
 
     // Add installed module information:
     auto modDir = fs::path(App::Application::getUserAppDataDir()) / "Mod";


### PR DESCRIPTION
```
OS: Ubuntu 23.04 (ubuntu:GNOME/ubuntu)
Word size of FreeCAD: 64-bit
Version: 1.0.0RC1.38657 (Git)
Build type: Debug
Branch: dpiAboutInfo
Hash: 1115f77fcf6c7b4307de00a63f27608ecd3aa38f
Python 3.11.4, Qt 5.15.8, Coin 4.0.0, Vtk 9.1.0, OCC 7.6.3
Locale: English/United States (en_US)
Stylesheet/Theme/QtStyle: Behave-dark.qss/FreeCAD Dark/Fusion
Logical/physical DPI: 96/81.5973
```