### PR TITLE
CMake: conda-macos-* do not search Homebrew for dependencies.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -151,6 +151,10 @@
         },
         "cmakeExecutable": "${sourceDir}/conda/cmake.sh",
         "cacheVariables": {
+          "CMAKE_IGNORE_PREFIX_PATH": {
+            "type": "STRING",
+            "value": "/opt/homebrew;/usr/local/homebrew"
+          },
           "CMAKE_INCLUDE_PATH": {
             "type": "FILEPATH",
             "value": "${sourceDir}/.conda/freecad/include"


### PR DESCRIPTION
For reasons still unknown to me, CMake would search the Homebrew paths of `{/usr/local/homebrew,/opt/homebrew}/{bin,include,lib,...}` for dependencies.  This behavior is undesired as they are often incompatible with the dependencies installed from `conda-forge` resulting in either build-time errors or run-time errors.

Adding these paths to the variable `CMAKE_IGNORE_PREFIX_PATH` instructs CMake to avoid searching them for dependencies and eliminates the concerns about compatibility.