### PR TITLE
CI: fix buggy caching

### DIFF
--- a/.github/workflows/actions/linux/generateCacheKey/action.yml
+++ b/.github/workflows/actions/linux/generateCacheKey/action.yml
@@ -28,6 +28,9 @@ inputs:
   compiler:
     description: "Binary name/path of compiler to be used"
     required: true
+  qt_major_version:
+    description: "Major version number of qt to be used"
+    required: true
 outputs:
   cacheKey:
     description: "Cache key with distro and compiler version"
@@ -39,6 +42,6 @@ runs:
     - id: generateCacheKey
       shell: bash -l {0}
       run: |
-        cacheKey=$(lsb_release -ds | tr -d ' ')-$(basename ${{ inputs.compiler }})$(${{ inputs.compiler }} -dumpfullversion -dumpversion)
+        cacheKey=$(lsb_release -ds | tr -d ' ')-$(basename ${{ inputs.compiler }})$(${{ inputs.compiler }} -dumpfullversion -dumpversion)-qt${{ inputs.qt_major_version }}
         echo "Generated cache key : $cacheKey"
         echo "cacheKey=$cacheKey" >> $GITHUB_OUTPUT

--- a/.github/workflows/actions/windows/getCcache/action.yml
+++ b/.github/workflows/actions/windows/getCcache/action.yml
@@ -59,7 +59,7 @@ runs:
       id: getCached
       with:
         path: ${{ inputs.ccachebindir }}
-        key: ccacheforwin
+        key: ccacheforwin-${{ inputs.ccacheversion }}
     - name: Download ccache
       shell: bash
       if: steps.getCached.outputs.cache-hit != 'true'

--- a/.github/workflows/actions/windows/getLibpack/action.yml
+++ b/.github/workflows/actions/windows/getLibpack/action.yml
@@ -59,7 +59,7 @@ runs:
       id: getCached
       with:
         path: ${{ inputs.libpackdir }}
-        key: libpackforwin
+        key: libpackforwin-${{ inputs.libpackname }}
     - name: Download libpack
       shell: bash
       if: steps.getCached.outputs.cache-hit != 'true'

--- a/.github/workflows/sub_buildUbuntu2004.yml
+++ b/.github/workflows/sub_buildUbuntu2004.yml
@@ -152,6 +152,7 @@ jobs:
         uses: ./.github/workflows/actions/linux/generateCacheKey
         with:
           compiler: ${{ env.CXX }}
+          qt_major_version: 5
       - name: Restore Compiler Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/sub_buildUbuntu2204Conda.yml
+++ b/.github/workflows/sub_buildUbuntu2204Conda.yml
@@ -102,6 +102,7 @@ jobs:
         uses: ./.github/workflows/actions/linux/generateCacheKey
         with:
           compiler: ${{ env.CXX }}
+          qt_major_version: 5
       - name: Restore Compiler Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
+++ b/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
@@ -108,15 +108,16 @@ jobs:
         uses: ./.github/workflows/actions/linux/generateCacheKey
         with:
           compiler: ${{ env.CXX }}
+          qt_major_version: 6
       - name: Restore Compiler Cache
         uses: actions/cache@v4
         with:
           save-always: true
           path: ${{ env.CCACHE_DIR }}
-          key: FC-${{ steps.genCacheKey.outputs.cacheKey }}-${{ github.ref }}-${{ github.run_id }}-qt6
+          key: FC-${{ steps.genCacheKey.outputs.cacheKey }}-${{ github.ref }}-${{ github.run_id }}
           restore-keys: |
-            FC-${{ steps.genCacheKey.outputs.cacheKey }}-${{ github.ref }}-qt6-
-            FC-${{ steps.genCacheKey.outputs.cacheKey }}-qt6-
+            FC-${{ steps.genCacheKey.outputs.cacheKey }}-${{ github.ref }}-
+            FC-${{ steps.genCacheKey.outputs.cacheKey }}-
       - name: Print CCache statistics before build, reset stats and print config
         run: |
           ccache -s


### PR DESCRIPTION
ci is often (always?) taking very long because the conda linux qt6 workflow can't find it's compiler cache and the conda linux qt5 sometimes wrongly fetches the qt6 cache which is useless for it. Hopefully this fixes it going forward, since the cache key format is being modified results will not be fully seen until everything is rebased on this