### PR TITLE
[Cam Simulator][1.0] Limit anti alias samples for better compatibility. 

### DIFF
--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -24,6 +24,7 @@
 
 #include "DlgCAMSimulator.h"
 #include "MillSimulation.h"
+#include "Gui/View3DInventorViewer.h"
 #include <Mod/Part/App/BRepMesh.h>
 #include <QDateTime>
 #include <QSurfaceFormat>
@@ -295,7 +296,9 @@ DlgCAMSimulator* DlgCAMSimulator::GetInstance()
         QSurfaceFormat format;
         format.setVersion(4, 1);                         // Request OpenGL 4.1 - for MacOS
         format.setProfile(QSurfaceFormat::CoreProfile);  // Use the core profile = for MacOS
-        format.setSamples(4);
+        int samples = Gui::View3DInventorViewer::getNumSamples();
+        if (samples > 1)
+            format.setSamples(samples);
         format.setSwapInterval(2);
         format.setDepthBufferSize(24);
         format.setStencilBufferSize(8);

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -297,8 +297,9 @@ DlgCAMSimulator* DlgCAMSimulator::GetInstance()
         format.setVersion(4, 1);                         // Request OpenGL 4.1 - for MacOS
         format.setProfile(QSurfaceFormat::CoreProfile);  // Use the core profile = for MacOS
         int samples = Gui::View3DInventorViewer::getNumSamples();
-        if (samples > 1)
+        if (samples > 1) {
             format.setSamples(samples);
+        }
         format.setSwapInterval(2);
         format.setDepthBufferSize(24);
         format.setStencilBufferSize(8);

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -295,7 +295,7 @@ DlgCAMSimulator* DlgCAMSimulator::GetInstance()
         QSurfaceFormat format;
         format.setVersion(4, 1);                         // Request OpenGL 4.1 - for MacOS
         format.setProfile(QSurfaceFormat::CoreProfile);  // Use the core profile = for MacOS
-        format.setSamples(16);
+        format.setSamples(4);
         format.setSwapInterval(2);
         format.setDepthBufferSize(24);
         format.setStencilBufferSize(8);


### PR DESCRIPTION
Probably solves: [This problem](https://forum.freecad.org/viewtopic.php?p=778342#p778342)
Might also solve Wayland problem, issue #15665 

EDIT: instead of hard coded number of samples,  Anti Alias samples is now taken from Display preferences.

