### PR TITLE
DependencyGraph: Tweak dot flags to prevent overlaped edges

### DIFF
--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -280,7 +280,10 @@ void GraphvizView::updateSvgItem(const App::Document &doc)
     QProcess * dotProc = thread->dotProcess();
     QProcess * flatProc = thread->unflattenProcess();
     QStringList args, flatArgs;
-    args << QLatin1String("-Tsvg");
+    // TODO: Make -Granksep flag value variable depending on number of edges,
+    // the downside is that the value affects all subgraphs
+    args << QLatin1String("-Granksep=2") << QLatin1String("-Goutputorder=edgesfirst")
+         << QLatin1String("-Gsplines=ortho") << QLatin1String("-Tsvg");
     flatArgs << QLatin1String("-c2 -l2");
 
 #ifdef FC_OS_LINUX


### PR DESCRIPTION
- `-Granksep=2` lets increase the separation between groups (nodes), ideally should depend on graph size. **Sometimes a value of 2 is not enough.**
- `-Goutputorder=edgesfirst` lets place the edges first to allocate more space for them
- `-Gsplines=ortho` changes the edges from curves to straight, orthogonal lines

### Example: small assembly

The current `dot` command uses default values, cause of this when you have medium/big projects the lines /edges) that connect the elements (nodes) overlap each other.
A while a go I mentioned some flags in https://github.com/FreeCAD/FreeCAD/issues/10207#issuecomment-1760205932 that works fine which lead us to this PR which is a simplification of that.

The only problem of using flags is that affect the entire graph. A better approach is to add properties in a subgraph basis because with bigger files the generated graph get hugely wide because all subgroups take the default value "left to right", each subgroup adds up. Read below.

![FreeCAD_graphviz](https://github.com/user-attachments/assets/14e4fda7-9baf-4cdd-9b20-2a9415a09c36)

The real benefit comes with bigger graphs.

<details>
  <summary><b>Click here to show/hide an gv file from a bigger example </b></summary>

Compare the output between `dot -Tsvg CoffeeTable.gv -o CoffeeTable.svg` and `dot -Tsvg -Granksep=2 -Goutputorder=edgesfirst -Gsplines=ortho CoffeeTable.gv -o CoffeeTable.svg`

```gv
digraph "" {
graph [
compound=true];
subgraph clusterPart {
graph [
bgcolor="#585ddd50", label="Part&#92;n(Izquierda)", style="rounded,filled"];
subgraph clusterOrigin {
graph [
bgcolor="#a0a8ba50", label=Origin, style="rounded,filled"];
}
subgraph clusterBody001 {
graph [
bgcolor="#7b83f950", label="Body001&#92;n(Madera_500)", style="rounded,filled"];
subgraph clusterOrigin002 {
graph [
bgcolor="#093c5650", label=Origin002, style="rounded,filled"];
}
subgraph clusterOrigin002 {
graph [
bgcolor=none, label=Origin002];
}
}
subgraph clusterBody {
graph [
bgcolor="#c8a2fc50", label="Body&#92;n(Madera_300)", style="rounded,filled"];
subgraph clusterOrigin001 {
graph [
bgcolor="#a21aca50", label=Origin001, style="rounded,filled"];
}
subgraph clusterOrigin001 {
graph [
bgcolor=none, label=Origin001];
}
}
subgraph clusterOrigin {
graph [
bgcolor=none, label=Origin];
41[label="Z_Axis&#92;n(Z-axis)", shape=Mrecord, style=filled];
42[fixedsize=true, height=0, style=invis, width=0];
52[label="XY_Plane&#92;n(XY-plane)", shape=Mrecord, style=filled];
53[label="Y_Axis&#92;n(Y-axis)", shape=Mrecord, style=filled];
55[label="XZ_Plane&#92;n(XZ-plane)", shape=Mrecord, style=filled];
79[label="X_Axis&#92;n(X-axis)", shape=Mrecord, style=filled];
92[label="YZ_Plane&#92;n(YZ-plane)", shape=Mrecord, style=filled];
}
subgraph clusterLink001 {
graph [
bgcolor="#e0e0e0", label="Link001&#92;n(Madera_502)", style="rounded,filled"];
23[fixedsize=true, height=0, style=invis, width=0];
24[fontsize="8pt", label=".LinkPlacement.Base.y", shape=box, style=dashed];
}
subgraph clusterLink {
graph [
bgcolor="#e0e0e0", label="Link&#92;n(Madera_501)", style="rounded,filled"];
48[fixedsize=true, height=0, style=invis, width=0];
49[fontsize="8pt", label=".LinkPlacement.Base.z", shape=box, style=dashed];
}
54[fixedsize=true, height=0, style=invis, width=0];
}
subgraph clusterBody {
graph [
bgcolor="#1e08b450", label="Body&#92;n(Madera_300)", style="rounded,filled"];
subgraph clusterOrigin001 {
graph [
bgcolor=none, label=Origin001];
29[label="YZ_Plane001&#92;n(YZ-plane001)", shape=Mrecord, style=filled];
36[label="XY_Plane001&#92;n(XY-plane001)", shape=Mrecord, style=filled];
38[label="X_Axis001&#92;n(X-axis001)", shape=Mrecord, style=filled];
39[label="XZ_Plane001&#92;n(XZ-plane001)", shape=Mrecord, style=filled];
50[label="Y_Axis001&#92;n(Y-axis001)", shape=Mrecord, style=filled];
60[fixedsize=true, height=0, style=invis, width=0];
61[label="Z_Axis001&#92;n(Z-axis001)", shape=Mrecord, style=filled];
}
subgraph clusterBox {
graph [
bgcolor="#e0e0e0", label=Box, style="rounded,filled"];
43[fixedsize=true, height=0, style=invis, width=0];
44[fontsize="8pt", label=Height, shape=box, style=dashed];
45[fontsize="8pt", label=Length, shape=box, style=dashed];
46[fontsize="8pt", label=Width, shape=box, style=dashed];
}
57[fixedsize=true, height=0, style=invis, width=0];
}
subgraph clusterBody001 {
graph [
bgcolor="#9e463550", label="Body001&#92;n(Madera_500)", style="rounded,filled"];
subgraph clusterOrigin002 {
graph [
bgcolor=none, label=Origin002];
26[label="YZ_Plane002&#92;n(YZ-plane002)", shape=Mrecord, style=filled];
27[label="Z_Axis002&#92;n(Z-axis002)", shape=Mrecord, style=filled];
28[label="Y_Axis002&#92;n(Y-axis002)", shape=Mrecord, style=filled];
30[label="X_Axis002&#92;n(X-axis002)", shape=Mrecord, style=filled];
31[label="XY_Plane002&#92;n(XY-plane002)", shape=Mrecord, style=filled];
32[fixedsize=true, height=0, style=invis, width=0];
86[label="XZ_Plane002&#92;n(XZ-plane002)", shape=Mrecord, style=filled];
}
subgraph clusterBox001 {
graph [
bgcolor="#e0e0e0", label=Box001, style="rounded,filled"];
13[fixedsize=true, height=0, style=invis, width=0];
14[fontsize="8pt", label=Height, shape=box, style=dashed];
15[fontsize="8pt", label=Length, shape=box, style=dashed];
16[fontsize="8pt", label=Width, shape=box, style=dashed];
}
25[fixedsize=true, height=0, style=invis, width=0];
}
subgraph clusterPart001 {
graph [
bgcolor="#08776250", label="Part001&#92;n(Abajo)", style="rounded,filled"];
subgraph clusterOrigin003 {
graph [
bgcolor="#4d9d8350", label=Origin003, style="rounded,filled"];
}
subgraph clusterBody002 {
graph [
bgcolor="#7ac18050", label="Body002&#92;n(Cuerpo)", style="rounded,filled"];
subgraph clusterOrigin004 {
graph [
bgcolor="#e5b72150", label=Origin004, style="rounded,filled"];
}
subgraph clusterOrigin004 {
graph [
bgcolor=none, label=Origin004];
}
}
subgraph clusterOrigin003 {
graph [
bgcolor=none, label=Origin003];
51[label="YZ_Plane003&#92;n(YZ-plane003)", shape=Mrecord, style=filled];
56[label="XY_Plane003&#92;n(XY-plane003)", shape=Mrecord, style=filled];
62[label="XZ_Plane003&#92;n(XZ-plane003)", shape=Mrecord, style=filled];
71[label="X_Axis003&#92;n(X-axis003)", shape=Mrecord, style=filled];
72[label="Y_Axis003&#92;n(Y-axis003)", shape=Mrecord, style=filled];
73[label="Z_Axis003&#92;n(Z-axis003)", shape=Mrecord, style=filled];
97[fixedsize=true, height=0, style=invis, width=0];
}
67[fixedsize=true, height=0, style=invis, width=0];
68[fontsize="8pt", label=".Placement.Base.x", shape=box, style=dashed];
69[fontsize="8pt", label=".Placement.Base.y", shape=box, style=dashed];
70[fontsize="8pt", label=".Placement.Base.z", shape=box, style=dashed];
}
subgraph clusterBody002 {
graph [
bgcolor="#45877050", label="Body002&#92;n(Cuerpo)", style="rounded,filled"];
subgraph clusterOrigin004 {
graph [
bgcolor=none, label=Origin004];
20[label="XY_Plane004&#92;n(XY-plane004)", shape=Mrecord, style=filled];
58[label="Y_Axis004&#92;n(Y-axis004)", shape=Mrecord, style=filled];
75[label="X_Axis004&#92;n(X-axis004)", shape=Mrecord, style=filled];
76[fixedsize=true, height=0, style=invis, width=0];
81[label="Z_Axis004&#92;n(Z-axis004)", shape=Mrecord, style=filled];
82[label="XZ_Plane004&#92;n(XZ-plane004)", shape=Mrecord, style=filled];
85[label="YZ_Plane004&#92;n(YZ-plane004)", shape=Mrecord, style=filled];
}
subgraph clusterBox002 {
graph [
bgcolor="#e0e0e0", label=Box002, style="rounded,filled"];
99[fixedsize=true, height=0, style=invis, width=0];
100[fontsize="8pt", label=Height, shape=box, style=dashed];
101[fontsize="8pt", label=Length, shape=box, style=dashed];
102[fontsize="8pt", label=Width, shape=box, style=dashed];
}
74[fixedsize=true, height=0, style=invis, width=0];
}
subgraph clusterPart002 {
graph [
bgcolor="#aeb6aa50", label="Part002&#92;n(Cristal)", style="rounded,filled"];
subgraph clusterOrigin005 {
graph [
bgcolor="#18fa7c50", label=Origin005, style="rounded,filled"];
}
subgraph clusterBody003 {
graph [
bgcolor="#f97dd450", label="Body003&#92;n(Cuerpo001)", style="rounded,filled"];
subgraph clusterOrigin006 {
graph [
bgcolor="#76e7e350", label=Origin006, style="rounded,filled"];
}
subgraph clusterOrigin006 {
graph [
bgcolor=none, label=Origin006];
}
}
subgraph clusterOrigin005 {
graph [
bgcolor=none, label=Origin005];
40[label="X_Axis005&#92;n(X-axis005)", shape=Mrecord, style=filled];
77[fixedsize=true, height=0, style=invis, width=0];
83[label="Z_Axis005&#92;n(Z-axis005)", shape=Mrecord, style=filled];
93[label="Y_Axis005&#92;n(Y-axis005)", shape=Mrecord, style=filled];
95[label="XY_Plane005&#92;n(XY-plane005)", shape=Mrecord, style=filled];
96[label="XZ_Plane005&#92;n(XZ-plane005)", shape=Mrecord, style=filled];
98[label="YZ_Plane005&#92;n(YZ-plane005)", shape=Mrecord, style=filled];
}
88[fixedsize=true, height=0, style=invis, width=0];
89[fontsize="8pt", label=".Placement.Base.x", shape=box, style=dashed];
90[fontsize="8pt", label=".Placement.Base.y", shape=box, style=dashed];
91[fontsize="8pt", label=".Placement.Base.z", shape=box, style=dashed];
}
subgraph clusterBody003 {
graph [
bgcolor="#4a8eed50", label="Body003&#92;n(Cuerpo001)", style="rounded,filled"];
subgraph clusterOrigin006 {
graph [
bgcolor=none, label=Origin006];
9[label="YZ_Plane006&#92;n(YZ-plane006)", shape=Mrecord, style=filled];
11[label="XZ_Plane006&#92;n(XZ-plane006)", shape=Mrecord, style=filled];
12[label="XY_Plane006&#92;n(XY-plane006)", shape=Mrecord, style=filled];
21[fixedsize=true, height=0, style=invis, width=0];
80[label="Z_Axis006&#92;n(Z-axis006)", shape=Mrecord, style=filled];
87[label="X_Axis006&#92;n(X-axis006)", shape=Mrecord, style=filled];
104[label="Y_Axis006&#92;n(Y-axis006)", shape=Mrecord, style=filled];
}
subgraph clusterBox003 {
graph [
bgcolor="#e0e0e0", label=Box003, style="rounded,filled"];
2[fixedsize=true, height=0, style=invis, width=0];
3[fontsize="8pt", label=Height, shape=box, style=dashed];
4[fontsize="8pt", label=Length, shape=box, style=dashed];
5[fontsize="8pt", label=Width, shape=box, style=dashed];
}
103[fixedsize=true, height=0, style=invis, width=0];
}
subgraph clusterPart003 {
graph [
bgcolor="#802f2e50", label="Part003&#92;n(Coffee table)", style="rounded,filled"];
subgraph clusterOrigin007 {
graph [
bgcolor="#a271b050", label=Origin007, style="rounded,filled"];
}
subgraph clusterOrigin007 {
graph [
bgcolor=none, label=Origin007];
0[label="YZ_Plane007&#92;n(YZ-plane007)", shape=Mrecord, style=filled];
1[label="X_Axis007&#92;n(X-axis007)", shape=Mrecord, style=filled];
10[fixedsize=true, height=0, style=invis, width=0];
37[label="XY_Plane007&#92;n(XY-plane007)", shape=Mrecord, style=filled];
78[label="XZ_Plane007&#92;n(XZ-plane007)", shape=Mrecord, style=filled];
84[label="Z_Axis007&#92;n(Z-axis007)", shape=Mrecord, style=filled];
94[label="Y_Axis007&#92;n(Y-axis007)", shape=Mrecord, style=filled];
}
subgraph clusterLink002 {
graph [
bgcolor="#e0e0e0", label="Link002&#92;n(Derecha)", style="rounded,filled"];
33[fixedsize=true, height=0, style=invis, width=0];
34[fontsize="8pt", label=".Placement.Base.x", shape=box, style=dashed];
}
subgraph clusterLink003 {
graph [
bgcolor="#e0e0e0", label="Link003&#92;n(Arriba)", style="rounded,filled"];
63[fixedsize=true, height=0, style=invis, width=0];
64[fontsize="8pt", label=".Placement.Base.x", shape=box, style=dashed];
65[fontsize="8pt", label=".Placement.Base.y", shape=box, style=dashed];
66[fontsize="8pt", label=".Placement.Base.z", shape=box, style=dashed];
}
59[fixedsize=true, height=0, style=invis, width=0];
}
subgraph clusterSpreadsheet {
graph [
bgcolor="#e0e0e0", label=Spreadsheet, style="rounded,filled"];
6[fontsize="8pt", label=cristal_grosor, shape=box, style=dashed];
7[fontsize="8pt", label=cristal_largo, shape=box, style=dashed];
8[fontsize="8pt", label=cristal_ancho, shape=box, style=dashed];
17[fontsize="8pt", label=l_h, shape=box, style=dashed];
18[fontsize="8pt", label=ancho, shape=box, style=dashed];
19[fontsize="8pt", label=grosor, shape=box, style=dashed];
22[fixedsize=true, height=0, style=invis, width=0];
35[fontsize="8pt", label=l_u, shape=box, style=dashed];
47[fontsize="8pt", label=l_v, shape=box, style=dashed];
}
3 -> 6[arrowsize=0.5, style=dashed];
4 -> 7[arrowsize=0.5, style=dashed];
5 -> 8[arrowsize=0.5, style=dashed];
14 -> 17[arrowsize=0.5, style=dashed];
15 -> 18[arrowsize=0.5, style=dashed];
16 -> 19[arrowsize=0.5, style=dashed];
23 -> 57[lhead=clusterBody, ltail=clusterLink001];
24 -> 19[arrowsize=0.5, style=dashed];
24 -> 17[arrowsize=0.5, style=dashed];
33 -> 54[lhead=clusterPart, ltail=clusterLink002];
34 -> 18[arrowsize=0.5, style=dashed];
34 -> 35[arrowsize=0.5, style=dashed];
44 -> 47[arrowsize=0.5, style=dashed];
45 -> 18[arrowsize=0.5, style=dashed];
46 -> 19[arrowsize=0.5, style=dashed];
48 -> 25[lhead=clusterBody001, ltail=clusterLink];
49 -> 19[arrowsize=0.5, style=dashed];
49 -> 47[arrowsize=0.5, style=dashed];
63 -> 67[lhead=clusterPart001, ltail=clusterLink003];
64 -> 18[arrowsize=0.5, style=dashed];
65 -> 19[arrowsize=0.5, style=dashed];
65 -> 17[arrowsize=0.5, style=dashed];
66 -> 47[arrowsize=0.5, style=dashed];
68 -> 18[arrowsize=0.5, style=dashed];
69 -> 19[arrowsize=0.5, style=dashed];
69 -> 17[arrowsize=0.5, style=dashed];
70 -> 19[arrowsize=0.5, style=dashed];
89 -> 18[arrowsize=0.5, style=dashed];
89 -> 7[arrowsize=0.5, style=dashed];
89 -> 35[arrowsize=0.5, style=dashed];
90 -> 8[arrowsize=0.5, style=dashed];
90 -> 17[arrowsize=0.5, style=dashed];
91 -> 19[arrowsize=0.5, style=dashed];
91 -> 47[arrowsize=0.5, style=dashed];
100 -> 19[arrowsize=0.5, style=dashed];
101 -> 35[arrowsize=0.5, style=dashed];
102 -> 18[arrowsize=0.5, style=dashed];
}
```
</details>

Fix #10207

---

I checked more about GraphViz and found a strategy that could help to enhance the overall aspect ratio.

- For each subgraph you can set the direction of their elements: top to bottom, left to right.
- If you need something more like a grid you need to create invisible relations between some nodes

This small example demonstrates that:
```gv
//  dot -Tsvg ex.gv -o ex.svg

digraph G {
    rankdir=TB; // Main graph flows from left to right
    subgraph clusterA {
        rankdir=LR; // Subgraph flows from top to bottom
        label="Subgraph A";
        A1 -> A2 -> A3 -> A4;
    }
    subgraph clusterB {
        rankdir=LR; // Subgraph flows from top to bottom
        label="Subgraph B";
        B1 -> B2 -> B3 -> B4;
    }
    subgraph clusterC {
        rankdir=LR; // Subgraph flows from top to bottom
        label="Subgraph C";
        C1 -> C2 -> C3 -> C4;
	
        // Invisible edges to enforce the 2x2 grid layout
        { rank=same; C1 -> C2 [style=invis]; }
        { rank=same; C3 -> C4 [style=invis]; }
        C1 -> C3 [style=invis];
        C2 -> C4 [style=invis];
    }
    subgraph clusterD {
        rankdir=LR; // Subgraph flows from top to bottom
        label="Subgraph D";
        D1 -> D2 -> D3 -> D4;
    }
    subgraph clusterE {
        label="Subgraph E";
        E1;
        E2;
        E3;
        E4;
        // Invisible edges to enforce the 2x2 grid layout
        { rank=same; E1 -> E2 [style=invis]; } // force E1 and E2 to be on the same horizontal row. 
        { rank=same; E3 -> E4 [style=invis]; } // force E3 and E4 to be on the same horizontal row. 
	// ensure that the two rows (E1, E2 and E3, E4) are aligned vertically.
        E1 -> E3 [style=invis];
        E2 -> E4 [style=invis]; // really needed?
    }
    A1 -> B1;
    B2 -> C3;
    C4 -> D2;
    D3 -> A4;
}
```

The main layout is left to right but the internal layout of the subgroups is top to bottom but as you can see you can force a grid with invisible links.

![ex](https://github.com/user-attachments/assets/08effbe8-e013-44e8-85ab-bd1818a69625)

One use-case of this is to force a 3x2 grid for Origin groups

```gv
digraph G {
    rankdir=TB; // Main graph flows from left to right
// unformatted raw output from FreeCAD generator
subgraph clusterOrigin {
graph [
bgcolor=none, label=Origin];
41[label="Z_Axis&#92;n(Z-axis)", shape=Mrecord, style=filled];
//42[fixedsize=true, height=0, style=invis, width=0]; // gives error on terminal
52[label="XY_Plane&#92;n(XY-plane)", shape=Mrecord, style=filled];
53[label="Y_Axis&#92;n(Y-axis)", shape=Mrecord, style=filled];
55[label="XZ_Plane&#92;n(XZ-plane)", shape=Mrecord, style=filled];
79[label="X_Axis&#92;n(X-axis)", shape=Mrecord, style=filled];
92[label="YZ_Plane&#92;n(YZ-plane)", shape=Mrecord, style=filled];
}
// attempt to see what changes could be done to enhance the graphs
	subgraph clusterOriginEnhanced {
	graph [
		bgcolor=none, label="Origin enhanced"];
	141[label="Z_Axis&#92;n(Z-axis)", shape=Mrecord, style=filled];
	152[label="XY_Plane&#92;n(XY-plane)", shape=Mrecord, style=filled];
	153[label="Y_Axis&#92;n(Y-axis)", shape=Mrecord, style=filled];
	155[label="XZ_Plane&#92;n(XZ-plane)", shape=Mrecord, style=filled];
	179[label="X_Axis&#92;n(X-axis)", shape=Mrecord, style=filled];
	192[label="YZ_Plane&#92;n(YZ-plane)", shape=Mrecord, style=filled];
        // Invisible edges to enforce the 3x2 grid layout
        { rank=same; 179 -> 152 [style=invis]; }
        { rank=same; 153 -> 155 [style=invis]; }
        { rank=same; 141 -> 192 [style=invis]; }
	// ensure that the 3 rows are aligned vertically.
	179 -> 153 [style=invis];
	153 -> 141 [style=invis];
	}
}
```

Comparison before vs after:

![ex2](https://github.com/user-attachments/assets/e1cd5b54-abfd-469f-9a5e-86f3e5ec7e20)

As seen above it's possible to have more control on the graph using invisible edges. Imagine having 6 bodies with origin: instead of having 36 block wide (caused by Origin groups) you only will have 12.

Could be implemented that when a element with **Internal Name** starting with `Origin` is found the hack above is saved into the graph forcing the 3x2 grid in those Origin groups (subgraphs).


In a more general way you can set an algorithm that when detects a lot of elements it forces a grid of $n\times m$.


Well, that's an idea that could be implemented later. Right now I'm checking some translation stuff, maybe next week can comeback to check this.

This PR is a "just enough".