### PR TITLE
fix splashscreen for single image

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2029,8 +2029,10 @@ QPixmap MainWindow::splashImage() const
     int splash_count = pixmaps.count()/2 - 1;
 
     // set a random splash path
-    int random = rand() % splash_count;
-    splash_path += std::to_string(random);
+    if (splash_count) {
+        int random = rand() % splash_count;
+        splash_path += std::to_string(random);
+    }
 
     // if no image was found try the config
     if (splash_image.isNull()) {

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2021,20 +2021,8 @@ QPixmap MainWindow::splashImage() const
     if (fi.isFile() && fi.exists())
         splash_image.load(fi.filePath(), "PNG");
 
-    // determine the count of splashes
-    std::string splash_path = App::Application::Config()["SplashScreen"];
-    QStringList pixmaps = Gui::BitmapFactory().findIconFiles().filter(QString::fromStdString(splash_path));
-    // divide by 2 since there's two sets (normal and 2x)
-    // minus 1 to ignore the default splash that isn't numbered
-    int splash_count = pixmaps.count()/2 - 1;
-
-    // set a random splash path
-    if (splash_count) {
-        int random = rand() % splash_count;
-        splash_path += std::to_string(random);
-    }
-
     // if no image was found try the config
+    std::string splash_path = App::Application::Config()["SplashScreen"];    
     if (splash_image.isNull()) {
         QString path = QString::fromUtf8(splash_path.c_str());
         if (QDir(path).isRelative()) {
@@ -2048,6 +2036,17 @@ QPixmap MainWindow::splashImage() const
     // now try the icon paths
     float pixelRatio (1.0);
     if (splash_image.isNull()) {
+        // determine the count of splashes
+        QStringList pixmaps = Gui::BitmapFactory().findIconFiles().filter(QString::fromStdString(splash_path));
+        // divide by 2 since there's two sets (normal and 2x)
+        // minus 1 to ignore the default splash that isn't numbered
+        int splash_count = pixmaps.count()/2 - 1;
+
+        // set a random splash path
+        if (splash_count) {
+            int random = rand() % splash_count;
+            splash_path += std::to_string(random);
+        }
         if (qApp->devicePixelRatio() > 1.0) {
             // For HiDPI screens, we have a double-resolution version of the splash image
             splash_path += "_2x";

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2022,7 +2022,7 @@ QPixmap MainWindow::splashImage() const
         splash_image.load(fi.filePath(), "PNG");
 
     // if no image was found try the config
-    std::string splash_path = App::Application::Config()["SplashScreen"];    
+    std::string splash_path = App::Application::Config()["SplashScreen"];
     if (splash_image.isNull()) {
         QString path = QString::fromUtf8(splash_path.c_str());
         if (QDir(path).isRelative()) {
@@ -2043,7 +2043,7 @@ QPixmap MainWindow::splashImage() const
         int splash_count = pixmaps.count()/2 - 1;
 
         // set a random splash path
-        if (splash_count) {
+        if (splash_count > 0) {
             int random = rand() % splash_count;
             splash_path += std::to_string(random);
         }


### PR DESCRIPTION
freecad couldn't launch if only one splashscreen image is available as can be the case when the branding system is used