### PR TITLE
[Start] Fix First Selected Theme Settings Being Applied

### DIFF
--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -75,16 +75,19 @@ void ThemeSelectorWidget::setupButtons(QBoxLayout* layout)
         button->setIconSize(iconMap[theme.first].actualSize(QSize(256, 256)));
         if (theme.first == Theme::Classic && styleSheetName.isEmpty()) {
             button->setChecked(true);
+            themeChanged(Theme::Classic);
         }
         else if (theme.first == Theme::Light
                  && styleSheetName.contains(QLatin1String("FreeCAD Light"),
                                             Qt::CaseSensitivity::CaseInsensitive)) {
             button->setChecked(true);
+            themeChanged(Theme::Light);
         }
         else if (theme.first == Theme::Dark
                  && styleSheetName.contains(QLatin1String("FreeCAD Dark"),
                                             Qt::CaseSensitivity::CaseInsensitive)) {
             button->setChecked(true);
+            themeChanged(Theme::Dark);
         }
         connect(button, &QToolButton::clicked, this, [this, theme] {
             themeChanged(theme.first);


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/16425 , if a new user does not click on any theme in the Start First Run widget then the default selected theme's entire settings are not applied, this PR fixes that issue.

Please backport to 1.0