### PR TITLE
Fix Qt6 warnings

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2118,8 +2118,7 @@ QPixmap MainWindow::splashImage() const
             y = h - 20;
         }
 
-        QColor color;
-        color.setNamedColor(QString::fromLatin1(tc->second.c_str()));
+        QColor color(QString::fromLatin1(tc->second.c_str()));
         if (color.isValid()) {
             painter.setPen(color);
             painter.setFont(fontExe);
@@ -2129,8 +2128,7 @@ QPixmap MainWindow::splashImage() const
             }
             painter.setFont(fontVer);
             painter.drawText(x + (l + 235), y - 7, version);
-            QColor warningColor;
-            warningColor.setNamedColor(QString::fromLatin1(wc->second.c_str()));
+            QColor warningColor(QString::fromLatin1(wc->second.c_str()));
             if (suffix == QLatin1String("dev") && warningColor.isValid()) {
                 fontVer.setPointSizeF(14.0);
                 painter.setFont(fontVer);

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -162,7 +162,7 @@ public:
         // choose text color
         auto tc = cfg.find("SplashTextColor");
         if (tc != cfg.end()) {
-            QColor col; col.setNamedColor(QString::fromLatin1(tc->second.c_str()));
+            QColor col(QString::fromStdString(tc->second));
             if (col.isValid()) {
                 textColor = col;
             }

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -871,12 +871,20 @@ void AboutDialog::copyToClipboard()
 #endif
     QLocale loc;
     str << "Locale: " << QLocale::languageToString(loc.language()) << "/"
+#if QT_VERSION < QT_VERSION_CHECK(6,6,0)
         << QLocale::countryToString(loc.country())
+#else
+        << QLocale::territoryToString(loc.territory())
+#endif
         << " (" << loc.name() << ")";
     if (loc != QLocale::system()) {
         loc = QLocale::system();
         str << " [ OS: " << QLocale::languageToString(loc.language()) << "/"
+#if QT_VERSION < QT_VERSION_CHECK(6,6,0)
             << QLocale::countryToString(loc.country())
+#else
+            << QLocale::territoryToString(loc.territory())
+#endif
             << " (" << loc.name() << ") ]";
     }
     str << "\n";

--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -308,7 +308,11 @@ void ToolBarGrip::mouseMoveEvent(QMouseEvent *me)
         return;
     }
 
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     QPoint pos = me->globalPos();
+#else
+    QPoint pos = me->globalPosition().toPoint();
+#endif
     QRect rect(toolbar->mapToGlobal(QPoint(0,0)), toolbar->size());
 
     // if mouse did not leave the area of toolbar do not continue with undocking it

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -877,7 +877,7 @@ Py::Object View3DInventorPy::saveImage(const Py::Tuple& args)
     if (colname.compare(QLatin1String("Current"), Qt::CaseInsensitive) == 0)
         bg = QColor(); // assign an invalid color here
     else
-        bg.setNamedColor(colname);
+        bg = QColor(colname);
 
     QImage img;
     getView3DIventorPtr()->getViewer()->savePicture(w, h, s, bg, img);
@@ -926,7 +926,7 @@ Py::Object View3DInventorPy::saveVectorGraphic(const Py::Tuple& args)
     if (colname.compare(QLatin1String("Current"), Qt::CaseInsensitive) == 0)
         bg = getView3DIventorPtr()->getViewer()->backgroundColor();
     else
-        bg.setNamedColor(colname);
+        bg = QColor(colname);
 
     getView3DIventorPtr()->getViewer()->saveGraphic(ps,bg,vo.get());
     out->closeFile();

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -87,7 +87,7 @@ void DlgCAMSimulator::mouseMoveEvent(QMouseEvent* ev)
     modifiers |= (ev->modifiers() & Qt::ControlModifier) != 0 ? MS_KBD_CONTROL : 0;
     modifiers |= (ev->modifiers() & Qt::AltModifier) != 0 ? MS_KBD_ALT : 0;
 
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QPoint pnt = ev->pos();
 #else
     QPoint pnt = ev->position().toPoint();
@@ -97,7 +97,7 @@ void DlgCAMSimulator::mouseMoveEvent(QMouseEvent* ev)
 
 void DlgCAMSimulator::mousePressEvent(QMouseEvent* ev)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QPoint pnt = ev->pos();
 #else
     QPoint pnt = ev->position().toPoint();
@@ -107,7 +107,7 @@ void DlgCAMSimulator::mousePressEvent(QMouseEvent* ev)
 
 void DlgCAMSimulator::mouseReleaseEvent(QMouseEvent* ev)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QPoint pnt = ev->pos();
 #else
     QPoint pnt = ev->position().toPoint();

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -36,7 +36,7 @@ using namespace MillSim;
 namespace CAMSimulator
 {
 
-static const float MouseScrollDelta = 120.0f;
+static const float MouseScrollDelta = 120.0F;
 
 DlgCAMSimulator::DlgCAMSimulator(QWindow* parent)
     : QWindow(parent)
@@ -86,17 +86,33 @@ void DlgCAMSimulator::mouseMoveEvent(QMouseEvent* ev)
     int modifiers = (ev->modifiers() & Qt::ShiftModifier) != 0 ? MS_KBD_SHIFT : 0;
     modifiers |= (ev->modifiers() & Qt::ControlModifier) != 0 ? MS_KBD_CONTROL : 0;
     modifiers |= (ev->modifiers() & Qt::AltModifier) != 0 ? MS_KBD_ALT : 0;
-    mMillSimulator->MouseMove(ev->x(), ev->y(), modifiers);
+
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    QPoint pnt = ev->pos();
+#else
+    QPoint pnt = ev->position().toPoint();
+#endif
+    mMillSimulator->MouseMove(pnt.x(), pnt.y(), modifiers);
 }
 
 void DlgCAMSimulator::mousePressEvent(QMouseEvent* ev)
 {
-    mMillSimulator->MousePress(ev->button(), true, ev->x(), ev->y());
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    QPoint pnt = ev->pos();
+#else
+    QPoint pnt = ev->position().toPoint();
+#endif
+    mMillSimulator->MousePress(ev->button(), true, pnt.x(), pnt.y());
 }
 
 void DlgCAMSimulator::mouseReleaseEvent(QMouseEvent* ev)
 {
-    mMillSimulator->MousePress(ev->button(), false, ev->x(), ev->y());
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    QPoint pnt = ev->pos();
+#else
+    QPoint pnt = ev->position().toPoint();
+#endif
+    mMillSimulator->MousePress(ev->button(), false, pnt.x(), pnt.y());
 }
 
 void DlgCAMSimulator::wheelEvent(QWheelEvent* ev)

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -1159,8 +1159,7 @@ QString SheetTableView::toHtml() const
     boldFont.setBold(true);
     boldFormat.setFont(boldFont);
 
-    QColor bgColor;
-    bgColor.setNamedColor(QLatin1String("#f0f0f0"));
+    QColor bgColor(QLatin1String("#f0f0f0"));
     QTextCharFormat bgFormat;
     bgFormat.setBackground(QBrush(bgColor));
 


### PR DESCRIPTION
* QColor::setNamedColor is deprecated since Qt 6.6
* Several methods of QMouseEvent are deprecated since Qt 6.0
* QLocale::countryToString and QLocale::country() are deprecated since Qt 6.6