### PR TITLE
BIM: fix BIM_Setup license issue

### DIFF
--- a/src/Mod/BIM/bimcommands/BimSetup.py
+++ b/src/Mod/BIM/bimcommands/BimSetup.py
@@ -528,7 +528,10 @@ class BIM_Setup:
             lic = FreeCAD.ParamGet(
                 "User parameter:BaseApp/Preferences/Document"
             ).GetInt("prefLicenseType", 0)
-            lic = [0, 1, 2, 1, 3, 4, 1, 0, 0, 0][
+            lic = [0,
+                   1, 2, 1, 3, 4, 1,
+                   1, 2, 1, 3, 4, 1,
+                   0, 0, 0, 0, 0, 0][
                 lic
             ]  # less choices in our simplified dialog
             newdoc = FreeCAD.ParamGet(


### PR DESCRIPTION
FreeCAD currently has 19 standard licenses. BIM_Setup could only handle the first 10.

Forum post:
https://forum.freecad.org/viewtopic.php?p=781578#p781535
