### PR TITLE
DXF importer (Python): allow importing dimensions

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -64,6 +64,7 @@ import WorkingPlane
 from FreeCAD import Vector
 from FreeCAD import Console as FCC
 from Draft import LinearDimension
+from draftobjects.dimension import _Dimension
 from draftutils import params
 from draftutils import utils
 from builtins import open as pyopen
@@ -2596,7 +2597,10 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
                         elif angle in [90, 270]:
                             p2 = vec([x2, y3, z2])
                     newob = doc.addObject("App::FeaturePython", "Dimension")
-                    lay.addObject(newob)
+                    if hasattr(lay, "addObject"):
+                        lay.addObject(newob)
+                    elif hasattr(lay, "Proxy") and hasattr(lay.Proxy, "addObject"):
+                        lay.Proxy.addObject(lay, newob)
                     _Dimension(newob)
                     if gui:
                         from Draft import _ViewProviderDimension


### PR DESCRIPTION
Fixes #16435. With this change, the legacy DXF importer can now import dimensions.

Notes:
1. <strike>As far as I can tell, the layer class does not have an `addObject()` method, or at least I did not find any documentation. I added the check nevertheless, as it was done in other places of the module. It would be great to have confirmation from a maintainer if it's needed.</strike> Update: I think I can answer myself the question, thanks to a comment in the code: `For old style layers, which are just groups `. So the check for `addObject()` is necessary for backwards compatibility, if I understand it correctly.
2. There are other entities in the file that call `lay.addObject(newobj)` and will fail as well without this fix. I prefer to keep the scope limited to the dimensions bug fix. I can address those in a separate PR.