### PR TITLE
GUI: Fix tree visibility click issue

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1677,10 +1677,6 @@ void TreeWidget::keyPressEvent(QKeyEvent* event)
 
 void TreeWidget::mousePressEvent(QMouseEvent* event)
 {
-    QTreeWidget::mousePressEvent(event);
-
-    // Handle the visibility icon after the normal event processing to not interfere with
-    // the selection logic.
     if (isVisibilityIconEnabled()) {
         QTreeWidgetItem* item = itemAt(event->pos());
         if (item && item->type() == TreeWidget::ObjectType && event->button() == Qt::LeftButton) {
@@ -1728,12 +1724,11 @@ void TreeWidget::mousePressEvent(QMouseEvent* event)
                     visible = obj->Visibility.getValue();
                     obj->Visibility.setValue(!visible);
                 }
-
-                event->setAccepted(true);
-                return;
             }
         }
     }
+
+    QTreeWidget::mousePressEvent(event);
 }
 
 void TreeWidget::mouseDoubleClickEvent(QMouseEvent* event)


### PR DESCRIPTION
The tree can change shape during handling the mousePressEvent() event, because some part of the tree can be (un)folded. This might lead to shift of the three (up or down). The position of items in tree change relatively to the position of mouse (which stays in place). If the visibility click is handled after mousePressEvent, the shift in position can lead to cursor beeing over visibility icon and the click is handled like if the visibility icon vas clicked, which is unexpected.

Handling the visibility click first fixes this. The setAccepted(true), was removed, it is left to the subroutine to set it.

Fixes #16463 

NOTE: I have no idea what the issues mentioned in the removed comment were, do they relate to the removed return and setAccepted?