### PR TITLE
Main: simplify banner

### DIFF
--- a/src/Main/MainCmd.cpp
+++ b/src/Main/MainCmd.cpp
@@ -51,17 +51,8 @@ using App::Application;
 using Base::Console;
 
 const char sBanner[] =
-    "(c) Juergen Riegel, Werner Mayer, Yorik van Havre and others 2001-2024\n"
-    "FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.\n"
-    "FreeCAD wouldn't be possible without FreeCAD community.\n"
-    "  #####                 ####  ###   ####  \n"
-    "  #                    #      # #   #   # \n"
-    "  #     ##  #### ####  #     #   #  #   # \n"
-    "  ####  # # #  # #  #  #     #####  #   # \n"
-    "  #     #   #### ####  #    #     # #   # \n"
-    "  #     #   #    #     #    #     # #   #  ##  ##  ##\n"
-    "  #     #   #### ####   ### #     # ####   ##  ##  ##\n\n";
-
+    "(C) 2001-2024 FreeCAD contributors\n"
+    "FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.\n\n";
 
 int main(int argc, char** argv)
 {

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -61,16 +61,8 @@
 void PrintInitHelp();
 
 const char sBanner[] =
-    "\xc2\xa9 Juergen Riegel, Werner Mayer, Yorik van Havre and others 2001-2024\n"
-    "FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.\n"
-    "FreeCAD wouldn't be possible without FreeCAD community.\n"
-    "  #####                 ####  ###   ####  \n"
-    "  #                    #      # #   #   # \n"
-    "  #     ##  #### ####  #     #   #  #   # \n"
-    "  ####  # # #  # #  #  #     #####  #   # \n"
-    "  #     #   #### ####  #    #     # #   # \n"
-    "  #     #   #    #     #    #     # #   #  ##  ##  ##\n"
-    "  #     #   #### ####   ### #     # ####   ##  ##  ##\n\n";
+    "(C) 2001-2024 FreeCAD contributors\n"
+    "FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.\n\n";
 
 #if defined(_MSC_VER)
 void InitMiniDumpWriter(const std::string&);


### PR DESCRIPTION
FreeCAD advertizes itself too noisy way which brings no usefull infomation. Unify banner for commandline and GUI application and drop unicode '(C)' character.

Most users, at least those who start FreeCAD from their desktop do not see it anyway. Those, who start commandline version are probably more interested in usefull output and those extra 7 lines of a FreeCAD banner are no help here.
Developers running FreeCAD during debugging do not even need to see copyright notice...

Those, who wishes more fancy stuff, could still do so via branding and pick something from [ascii art](https://forum.freecad.org/viewtopic.php?t=6602) forum thread. This way different kinds of official builds can be differentiated.