### PR TITLE
[Gui] Handle unset style preferences in clipboard about info

### DIFF
--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -881,9 +881,25 @@ void AboutDialog::copyToClipboard()
     }
     str << "\n";
 
+    // Add Stylesheet/Theme/Qtstyle information
     std::string styleSheet = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("StyleSheet");
     std::string theme = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("Theme");
-    std::string style = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("QtStyle");
+
+    #if QT_VERSION >= QT_VERSION_CHECK(6, 1, 0)
+        std::string style = qApp->style()->name().toStdString();
+    #else
+        std::string style = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("QtStyle");
+        if(style.empty()) {
+            style = "Qt default";
+        }
+    #endif
+
+    if(styleSheet.empty()) {
+        styleSheet = "unset";
+    }
+    if(theme.empty()) {
+        theme = "unset";
+    }
 
     str << "Stylesheet/Theme/QtStyle: "
         << QString::fromStdString(styleSheet) << "/"


### PR DESCRIPTION
FIxes #16391

```Stylesheet/Theme/QtStyle: unset/FreeCAD Classic/Qt default```