### PR TITLE
Core: Import STEP: Cancel button does not cancel

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -427,6 +427,10 @@ void Application::setupPythonException(PyObject* module)
     Base::PyExc_FC_PropertyError = PyErr_NewException("Base.PropertyError", PyExc_AttributeError, nullptr);
     Py_INCREF(Base::PyExc_FC_PropertyError);
     PyModule_AddObject(module, "PropertyError", Base::PyExc_FC_PropertyError);
+
+    Base::PyExc_FC_AbortIOException = PyErr_NewException("Base.PyExc_FC_AbortIOException", PyExc_BaseException, nullptr);
+    Py_INCREF(Base::PyExc_FC_AbortIOException);
+    PyModule_AddObject(module, "AbortIOException", Base::PyExc_FC_AbortIOException);
 }
 // clang-format on
 

--- a/src/Base/PyObjectBase.cpp
+++ b/src/Base/PyObjectBase.cpp
@@ -49,6 +49,7 @@ PyObject* Base::PyExc_FC_ExpressionError = nullptr;
 PyObject* Base::PyExc_FC_ParserError = nullptr;
 PyObject* Base::PyExc_FC_CADKernelError = nullptr;
 PyObject* Base::PyExc_FC_PropertyError = nullptr;
+PyObject* Base::PyExc_FC_AbortIOException = nullptr;
 
 typedef struct {            //NOLINT
     PyObject_HEAD

--- a/src/Base/PyObjectBase.h
+++ b/src/Base/PyObjectBase.h
@@ -431,6 +431,7 @@ BaseExport extern PyObject* PyExc_FC_ExpressionError;
 BaseExport extern PyObject* PyExc_FC_ParserError;
 BaseExport extern PyObject* PyExc_FC_CADKernelError;
 BaseExport extern PyObject* PyExc_FC_PropertyError;
+BaseExport extern PyObject* PyExc_FC_AbortIOException;
 
 /** Exception handling for python callback functions
  * Is a convenience macro to manage the exception handling of python callback

--- a/src/Ext/freecad/CMakeLists.txt
+++ b/src/Ext/freecad/CMakeLists.txt
@@ -28,6 +28,7 @@ configure_file(__init__.py.template ${NAMESPACE_INIT})
 
 set(EXT_FILES
     freecad_doc.py
+    module_io.py
     part.py
     partdesign.py
     project_utility.py

--- a/src/Ext/freecad/module_io.py
+++ b/src/Ext/freecad/module_io.py
@@ -1,0 +1,13 @@
+def OpenInsertObject(importerModule, objectPath, importMethod, docName = ""):
+    try:
+        importArgs = []
+        importKwargs = {}
+
+        if docName:
+            importArgs.append(docName)
+        if hasattr(importerModule, "importOptions"):
+            importKwargs["options"] = importerModule.importOptions(objectPath)
+
+        getattr(importerModule, importMethod)(objectPath, *importArgs, **importKwargs)
+    except PyExc_FC_AbortIOException:
+        pass

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -617,9 +617,8 @@ try:
         importKwargs["options"] = %2.importOptions(u"%3")
 
     %2.%4(u"%3", *importArgs, **importKwargs)
-except RuntimeError as e:
-    if not e.message.lower() == "user cancelled import":
-        raise
+except PyExc_FC_AbortIOException:
+    pass
 )raw")
     .arg(QString::fromUtf8(DocName))
     .arg(QString::fromUtf8(Module))

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -140,7 +140,8 @@ private:
                     options.setItem("expandCompound", Py::Boolean(stepSettings.expandCompound));
                     options.setItem("mode", Py::Long(stepSettings.mode));
                     options.setItem("codePage", Py::Long(stepSettings.codePage));
-                } else {
+                }
+                else {
                     throw Py::Exception();
                 }
             }

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -129,22 +129,20 @@ private:
         if (file.hasExtension({"stp", "step"})) {
             PartGui::TaskImportStep dlg(Gui::getMainWindow());
             if (dlg.showDialog()) {
-                if (dlg.exec()) {
-                    auto stepSettings = dlg.getSettings();
-                    options.setItem("merge", Py::Boolean(stepSettings.merge));
-                    options.setItem("useLinkGroup", Py::Boolean(stepSettings.useLinkGroup));
-                    options.setItem("useBaseName", Py::Boolean(stepSettings.useBaseName));
-                    options.setItem("importHidden", Py::Boolean(stepSettings.importHidden));
-                    options.setItem("reduceObjects", Py::Boolean(stepSettings.reduceObjects));
-                    options.setItem("showProgress", Py::Boolean(stepSettings.showProgress));
-                    options.setItem("expandCompound", Py::Boolean(stepSettings.expandCompound));
-                    options.setItem("mode", Py::Long(stepSettings.mode));
-                    options.setItem("codePage", Py::Long(stepSettings.codePage));
-                }
-                else {
-                    throw Py::Exception();
+                if (!dlg.exec()) {
+                    throw Py::RuntimeError("User cancelled import");
                 }
             }
+            auto stepSettings = dlg.getSettings();
+            options.setItem("merge", Py::Boolean(stepSettings.merge));
+            options.setItem("useLinkGroup", Py::Boolean(stepSettings.useLinkGroup));
+            options.setItem("useBaseName", Py::Boolean(stepSettings.useBaseName));
+            options.setItem("importHidden", Py::Boolean(stepSettings.importHidden));
+            options.setItem("reduceObjects", Py::Boolean(stepSettings.reduceObjects));
+            options.setItem("showProgress", Py::Boolean(stepSettings.showProgress));
+            options.setItem("expandCompound", Py::Boolean(stepSettings.expandCompound));
+            options.setItem("mode", Py::Long(stepSettings.mode));
+            options.setItem("codePage", Py::Long(stepSettings.codePage));
         }
         return options;
     }

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -130,7 +130,7 @@ private:
             PartGui::TaskImportStep dlg(Gui::getMainWindow());
             if (dlg.showDialog()) {
                 if (!dlg.exec()) {
-                    throw Py::RuntimeError("User cancelled import");
+                    throw Py::Exception(Base::PyExc_FC_AbortIOException, "User cancelled import");
                 }
             }
             auto stepSettings = dlg.getSettings();

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -128,17 +128,21 @@ private:
         Base::FileInfo file(name8bit.c_str());
         if (file.hasExtension({"stp", "step"})) {
             PartGui::TaskImportStep dlg(Gui::getMainWindow());
-            if (!dlg.showDialog() || dlg.exec()) {
-                auto stepSettings = dlg.getSettings();
-                options.setItem("merge", Py::Boolean(stepSettings.merge));
-                options.setItem("useLinkGroup", Py::Boolean(stepSettings.useLinkGroup));
-                options.setItem("useBaseName", Py::Boolean(stepSettings.useBaseName));
-                options.setItem("importHidden", Py::Boolean(stepSettings.importHidden));
-                options.setItem("reduceObjects", Py::Boolean(stepSettings.reduceObjects));
-                options.setItem("showProgress", Py::Boolean(stepSettings.showProgress));
-                options.setItem("expandCompound", Py::Boolean(stepSettings.expandCompound));
-                options.setItem("mode", Py::Long(stepSettings.mode));
-                options.setItem("codePage", Py::Long(stepSettings.codePage));
+            if (dlg.showDialog()) {
+                if (dlg.exec()) {
+                    auto stepSettings = dlg.getSettings();
+                    options.setItem("merge", Py::Boolean(stepSettings.merge));
+                    options.setItem("useLinkGroup", Py::Boolean(stepSettings.useLinkGroup));
+                    options.setItem("useBaseName", Py::Boolean(stepSettings.useBaseName));
+                    options.setItem("importHidden", Py::Boolean(stepSettings.importHidden));
+                    options.setItem("reduceObjects", Py::Boolean(stepSettings.reduceObjects));
+                    options.setItem("showProgress", Py::Boolean(stepSettings.showProgress));
+                    options.setItem("expandCompound", Py::Boolean(stepSettings.expandCompound));
+                    options.setItem("mode", Py::Long(stepSettings.mode));
+                    options.setItem("codePage", Py::Long(stepSettings.codePage));
+                } else {
+                    throw Py::Exception();
+                }
             }
         }
         return options;


### PR DESCRIPTION
Fix for #16282 "Core: Import STEP: Cancel button does not cancel".

This is achieved by throwing a python exception when the STEP options dialog is cancelled (`dlg.exec()` returns 0).