### PR TITLE
Issue16068

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -2813,10 +2813,11 @@ def open(filename):
         FreeCAD.setActiveDocument(doc.Name)
         try:
             import ImportGui
-            ImportGui.readDXF(filename)
         except Exception:
             import Import
             Import.readDXF(filename)
+        else:
+            ImportGui.readDXF(filename)
         Draft.convert_draft_texts() # convert annotations to Draft texts
         doc.recompute()
 
@@ -2855,10 +2856,11 @@ def insert(filename, docname):
     else:
         try:
             import ImportGui
-            ImportGui.readDXF(filename)
         except Exception:
             import Import
             Import.readDXF(filename)
+        else:
+            ImportGui.readDXF(filename)
         Draft.convert_draft_texts() # convert annotations to Draft texts
         doc.recompute()
 

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -655,7 +655,7 @@ ImpExpDxfRead::MakeLayer(const std::string& name, ColorIndex_t color, std::strin
         auto result = new Layer(name, color, std::move(lineType), layer);
         if (result->DraftLayerView != nullptr) {
             PyObject_SetAttrString(result->DraftLayerView, "OverrideLineColorChildren", Py_False);
-            PyObject_SetAttrString(result->DraftLayerView, "OverrideShapeColorChildren", Py_False);
+            PyObject_SetAttrString(result->DraftLayerView, "OverrideShapeAppearanceChildren", Py_False);
         }
 
         // We make our own layer class even if we could not make a layer. MoveToLayer will ignore

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -103,7 +103,7 @@ bool ImpExpDxfRead::ReadEntitiesSection()
         // TODO: We do end-to-end joining or complete merging as selected by the options.
         for (auto& shapeSet : ShapesToCombine) {
             m_entityAttributes = shapeSet.first;
-            CombineShapes(shapeSet.second, "Compound");
+            CombineShapes(shapeSet.second, m_entityAttributes.m_Layer == nullptr ? "Compound" : m_entityAttributes.m_Layer->Name.c_str());
         }
     }
     else {

--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -628,7 +628,7 @@ ImpExpDxfRead::MakeLayer(const std::string& name, ColorIndex_t color, std::strin
         App::Color appColor = ObjectColor(color);
         PyObject* draftModule = nullptr;
         PyObject* layer = nullptr;
-        draftModule = PyImport_ImportModule("Draft");
+        draftModule = getDraftModule();
         if (draftModule != nullptr) {
             // After the colours, I also want to pass the draw_style, but there is an intervening
             // line-width parameter. It is easier to just pass that parameter's default value than
@@ -651,7 +651,6 @@ ImpExpDxfRead::MakeLayer(const std::string& name, ColorIndex_t color, std::strin
                                                          appColor.b,
                                                          2.0,
                                                          "Solid");
-            Py_DECREF(draftModule);
         }
         auto result = new Layer(name, color, std::move(lineType), layer);
         if (result->DraftLayerView != nullptr) {

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -122,7 +122,11 @@ protected:
     PyObject* getDraftModule()
     {
         if (DraftModule == nullptr) {
+            static int times = 0;
             DraftModule = PyImport_ImportModule("Draft");
+            if (DraftModule == nullptr && times++ == 0) {
+                ImportError("Unable to locate \"Draft\" module");
+            }
         }
         return DraftModule;
     }

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2910,7 +2910,11 @@ bool CDxfRead::ReadEntitiesSection()
                     return false;
                 }
             }
+            catch (const Base::Exception& e) {
+                e.ReportException();
+            }
             catch (...) {
+                ImportError("CDxfRead::ReadEntity raised unknown exception\n");
             }
         }
         else {

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -686,12 +686,12 @@ protected:
     // notification popup "Log" goes to a log somewhere and not to the screen/user at all
 
     template<typename... args>
-    void ImportError(const char* format, args&&... argValues) const
+    static void ImportError(const char* format, args&&... argValues)
     {
         Base::ConsoleSingleton::Instance().Warning(format, std::forward<args>(argValues)...);
     }
     template<typename... args>
-    void ImportObservation(const char* format, args&&... argValues) const
+    static void ImportObservation(const char* format, args&&... argValues)
     {
         Base::ConsoleSingleton::Instance().Message(format, std::forward<args>(argValues)...);
     }

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include <Base/Interpreter.h>
 #include <Base/Matrix.h>
 #include <Base/Vector3D.h>
 #include <Base/Console.h>
@@ -922,5 +923,25 @@ public:
         return m_entityAttributes.m_LineType[0] == 'h' || m_entityAttributes.m_LineType[0] == 'H';
     }
     static App::Color ObjectColor(ColorIndex_t colorIndex);  // as rgba value
+
+#ifdef DEBUG
+protected:
+    static PyObject* PyObject_GetAttrString(PyObject* o, const char* attr_name)
+    {
+        PyObject* result = ::PyObject_GetAttrString(o, attr_name);
+        if (result == nullptr) {
+            ImportError("Unable to get Attribute '%s'\n", attr_name);
+            PyErr_Clear();
+        }
+        return result;
+    }
+    static void PyObject_SetAttrString(PyObject* o, const char* attr_name, PyObject* v)
+    {
+        if (::PyObject_SetAttrString(o, attr_name, v) != 0) {
+            ImportError("Unable to set Attribute '%s'\n", attr_name);
+            PyErr_Clear();
+        }
+    }
+#endif
 };
 #endif


### PR DESCRIPTION
This PR addresses DXF import behaviour reported in #13597 and #16068, specifically the fact that the importer only imports the first layer of the DXF file, or if "Use layers" is not selected, the first entity in the drawing is lost, and the fact that a generic name is used for the grouped objects created by the "Group layers into blocks" option.

1. It gives the compound objects created by the "Merge layers into blocks" names based on the layer name they are contained in rather than generic "Compound". This only occurs if "Use layers" is also selected; otherwise objects from several DXF layers may be merged into a single compound so applying a layer name would be misleading.
2. It improves error handling in the importer a bit, in particular displaying information about thrown exceptions even if the "ignore errors" flag is set. The improved error handling would have revealed the problem causing both Issues much earlier in use testing.
3. It reduces the number of times an import is requested for the `Draft` module, originally once per layer, now once for the entire import.
4. It corrects the reference to a Layer property that was renamed by a previous commit. The incorrect property name resulted in a Python exception state which propagated for a while eventually acting as a booby-trap causing a later module import to fail.

Fixes #13597
Fixes #16068