### PR TITLE
[PartDesign]: Sort sketches in Attach sketch tool alphabetically

### DIFF
--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -605,6 +605,9 @@ void CmdSketcherMapSketch::activated(int iMsg)
 
             return;
         }
+        std::sort(sketches.begin(), sketches.end(), [](const auto &a, const auto &b) {
+            return QString::fromUtf8(a->Label.getValue()) < QString::fromUtf8(b->Label.getValue());
+        });
 
         bool ok;
         QStringList items;


### PR DESCRIPTION
Now the order of sketches in sketch attaching tool is defined by when they were added into the list of documents. (no particular order) Sorting them alphabetically makes IMHO much easier to find a sketch by user, compared to current state, especially in large and complex projects with lot of sketches. Of cuser thix expects the user use sensible names for the sketches.

I have used plain `strcmp` which will not produce best results for non-ASCII characters. Hint to use better comparison function is wellcomed. I have avoided conversion to QString or more complex design for a start intentionally.