### PR TITLE
Sketcher: clean-up geometry history configuation

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -127,7 +127,7 @@ FC_LOG_LEVEL_INIT("Sketch", true, true)
 
 PROPERTY_SOURCE(Sketcher::SketchObject, Part::Part2DObject)
 
-SketchObject::SketchObject()
+SketchObject::SketchObject() : geoLastId(0)
 {
     ADD_PROPERTY_TYPE(
         Geometry, (nullptr), "Sketch", (App::PropertyType)(App::Prop_None), "Sketch geometry");
@@ -164,9 +164,6 @@ SketchObject::SketchObject()
                       "Sketch",
                       (App::PropertyType)(App::Prop_None),
                       "Tolerance for fitting arcs of projected external geometry");
-    geoLastId = 0;
-    geoHistoryLevel = 1;
-
     ADD_PROPERTY(InternalShape,
                  (Part::TopoShape()));
     ADD_PROPERTY_TYPE(MakeInternals,

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -1062,7 +1062,8 @@ private:
     // mapping from Geometry[*].Id to index of Geometry
     std::map<long, int> geoMap;
 
-    int geoHistoryLevel;
+    // keep geoHistoryLevel and the code who ise it for easier porting of stuff from LS3 branch
+    const int geoHistoryLevel = 1;
     std::vector<long> geoIdHistory;
     long geoLastId;
 


### PR DESCRIPTION
Keep code almost 1:1 with LS3 branch, just ensure the variable is initialized and code is documented

Follow-up for #16337 