### PR TITLE
fix(PD): initialization of thread class and fit

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -81,6 +81,8 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
         ui->ThreadSize->addItem(tr(it.c_str()));
     }
     ui->ThreadSize->setCurrentIndex(pcHole->ThreadSize.getValue());
+    ui->ThreadSize->setEnabled(!pcHole->Threaded.getValue() && pcHole->ThreadType.getValue() != 0L);
+
     ui->ThreadClass->clear();
     cursor = pcHole->ThreadClass.getEnumVector();
     for (const auto& it : cursor) {
@@ -91,7 +93,7 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole* HoleView, QWidget* pare
     ui->ThreadClass->setEnabled(pcHole->Threaded.getValue());
     ui->ThreadFit->setCurrentIndex(pcHole->ThreadFit.getValue());
     // Fit is only enabled (sensible) if not threaded
-    ui->ThreadFit->setEnabled(!pcHole->Threaded.getValue());
+    ui->ThreadFit->setEnabled(!pcHole->Threaded.getValue() && pcHole->ThreadType.getValue() != 0L);
     ui->Diameter->setMinimum(pcHole->Diameter.getMinimum());
     ui->Diameter->setValue(pcHole->Diameter.getValue());
     // Diameter is only enabled if ThreadType is None


### PR DESCRIPTION
another  small fix to the ui
current behaviour lets thread size and fit enabled when creating a new hole:
![Screenshot_20240913_154340](https://github.com/user-attachments/assets/fb8a8186-b803-46c1-b571-e35716c74cd5)

This shouldn't be enabled when the profile is None, so it should be like this on initialization:
![Screenshot_20240913_160000](https://github.com/user-attachments/assets/77c732e7-315d-4449-a939-60b8412f6722)

To further confirm that is the expected behaviour you can select a thread profile and then select back none and you will see that both combo-boxes will be disabled now, further confirming that it's an initialization issue