### PR TITLE
[BIM]  fix Material TaskPanel Load Preset not working bug

### DIFF
--- a/src/Mod/BIM/ArchMaterial.py
+++ b/src/Mod/BIM/ArchMaterial.py
@@ -515,6 +515,7 @@ class _ArchMaterialTaskPanel:
 
     def chooseMat(self, card):
         "sets self.material from a card"
+        card = self.form.comboBox_MaterialsInDir.currentText()
         if card in self.cards:
             import importFCMat
             self.material = importFCMat.read(self.cards[card])


### PR DESCRIPTION
in last commit   
when rewrite  
`QtCore.QObject.connect(self.form.comboBox_MaterialsInDir, QtCore.SIGNAL("currentIndexChanged(QString)"), self.chooseMat)`
to
`self.form.comboBox_MaterialsInDir.currentIndexChanged.connect(self.chooseMat)`

it supposed to return the material name at first
but after fix,  only return the comboBox Index

so need to add one more line to catch the materail name in seleted comboBox 
to continue load the material from cards