### PR TITLE
Transfer dialog for recompute on older files and disable warning

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1475,6 +1475,7 @@ Document::readObjects(Base::XMLReader& reader)
 
 void Document::addRecomputeObject(DocumentObject *obj) {
     if(testStatus(Status::Restoring) && obj) {
+        setStatus(Status::RecomputeOnRestore, true);
         d->touchedObjs.insert(obj);
         obj->touch();
     }

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -77,7 +77,7 @@ public:
         RestoreError = 10,
         LinkStampChanged = 11, // Indicates during restore time if any linked document's time stamp has changed
         IgnoreErrorOnRecompute = 12, // Don't report errors if the recompute failed
-        RecomputeOnRestore = 13, // Mark pending recompute on restore for migration purpose
+        RecomputeOnRestore = 13, // Mark pending recompute on restore for migration purposes
     };
 
     /** @name Properties */

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -77,6 +77,7 @@ public:
         RestoreError = 10,
         LinkStampChanged = 11, // Indicates during restore time if any linked document's time stamp has changed
         IgnoreErrorOnRecompute = 12, // Don't report errors if the recompute failed
+        RecomputeOnRestore = 13, // Mark pending recompute on restore for migration purpose
     };
 
     /** @name Properties */

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -379,6 +379,40 @@ Application::Application(bool GUIenabled)
         App::GetApplication().signalShowHidden.connect(
             std::bind(&Gui::Application::slotShowHidden, this, sp::_1));
         // NOLINTEND
+        App::GetApplication().signalFinishOpenDocument.connect([]() {
+            std::vector<App::Document*> docs;
+            for(auto doc : App::GetApplication().getDocuments()) {
+                if(doc->testStatus(App::Document::RecomputeOnRestore)) {
+                    docs.push_back(doc);
+                    doc->setStatus(App::Document::RecomputeOnRestore, false);
+                }
+            }
+            if(docs.empty() || !App::DocumentParams::getWarnRecomputeOnRestore())
+                return;
+            WaitCursor wc;
+            wc.restoreCursor();
+            auto res = QMessageBox::warning(getMainWindow(), QObject::tr("Recompution required"),
+                QObject::tr("Some document(s) require recomputation for migration purpose. "
+                            "It is highly recommended to perform a recomputation before "
+                            "any modification to avoid compatibility problem.\n\n"
+                            "Do you want to recompute now?"),
+                QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
+            if(res != QMessageBox::Yes)
+                return;
+            bool hasError = false;
+            for(auto doc : App::Document::getDependentDocuments(docs,true)) {
+                try {
+                    doc->recompute({},false,&hasError);
+                } catch (Base::Exception &e) {
+                    e.ReportException();
+                    hasError = true;
+                }
+            }
+            if(hasError)
+                QMessageBox::critical(getMainWindow(), QObject::tr("Recompute error"),
+                        QObject::tr("Failed to recompute some document(s).\n"
+                                    "Please check report view for more details."));
+        });
 
         // install the last active language
         ParameterGrp::handle hPGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp");

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -131,6 +131,8 @@ public:
     boost::signals2::signal<void ()> signalRefreshWorkbenches;
     /// signal on show hidden items
     boost::signals2::signal<void (const Gui::Document&)> signalShowHidden;
+    /// signal on document open complete
+    boost::signals2::signal<void (const Gui::Document&)> signalFinishRestoreDocument;
     /// signal on activating view
     boost::signals2::signal<void (const Gui::MDIView*)> signalActivateView;
     /// signal on entering in edit mode
@@ -151,6 +153,7 @@ protected:
     void slotRenameDocument(const App::Document&);
     void slotActiveDocument(const App::Document&);
     void slotShowHidden(const App::Document&);
+    void slotFinishRestoreDocument(const App::Document&);
     void slotNewObject(const ViewProvider&);
     void slotDeletedObject(const ViewProvider&);
     void slotChangedObject(const ViewProvider&, const App::Property& Prop);

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -131,7 +131,7 @@ public:
     boost::signals2::signal<void ()> signalRefreshWorkbenches;
     /// signal on show hidden items
     boost::signals2::signal<void (const Gui::Document&)> signalShowHidden;
-    /// signal on document open complete
+    /// signal on document restore complete
     boost::signals2::signal<void (const Gui::Document&)> signalFinishRestoreDocument;
     /// signal on activating view
     boost::signals2::signal<void (const Gui::MDIView*)> signalActivateView;

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -117,6 +117,7 @@ struct DocumentP
     Connection connectStartLoadDocument;
     Connection connectFinishLoadDocument;
     Connection connectShowHidden;
+    Connection connectFinishRestoreDocument;
     Connection connectFinishRestoreObject;
     Connection connectExportObjects;
     Connection connectImportObjects;
@@ -184,7 +185,6 @@ Document::Document(App::Document* pcDocument,Application * app)
         (std::bind(&Gui::Document::slotFinishRestoreDocument, this, sp::_1));
     d->connectShowHidden = App::GetApplication().signalShowHidden.connect
         (std::bind(&Gui::Document::slotShowHidden, this, sp::_1));
-
     d->connectChangePropertyEditor = pcDocument->signalChangePropertyEditor.connect
         (std::bind(&Gui::Document::slotChangePropertyEditor, this, sp::_1, sp::_2));
     d->connectChangeDocument = d->_pcDocument->signalChanged.connect // use the same slot function

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -185,6 +185,7 @@ Document::Document(App::Document* pcDocument,Application * app)
         (std::bind(&Gui::Document::slotFinishRestoreDocument, this, sp::_1));
     d->connectShowHidden = App::GetApplication().signalShowHidden.connect
         (std::bind(&Gui::Document::slotShowHidden, this, sp::_1));
+
     d->connectChangePropertyEditor = pcDocument->signalChangePropertyEditor.connect
         (std::bind(&Gui::Document::slotChangePropertyEditor, this, sp::_1, sp::_2));
     d->connectChangeDocument = d->_pcDocument->signalChanged.connect // use the same slot function

--- a/src/Mod/CAM/Tests/TestCAMSanity.py
+++ b/src/Mod/CAM/Tests/TestCAMSanity.py
@@ -42,7 +42,9 @@ from Tests.PathTestUtils import PathTestBase
 class TestCAMSanity(PathTestBase):
     @classmethod
     def setUpClass(cls):
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
         cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/Tests/boxtest.fcstd")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
         cls.job = cls.doc.getObject("Job")
 
     @classmethod

--- a/src/Mod/CAM/Tests/TestPathAdaptive.py
+++ b/src/Mod/CAM/Tests/TestPathAdaptive.py
@@ -52,7 +52,9 @@ class TestPathAdaptive(PathTestBase):
     def initClass(cls):
         # Open existing FreeCAD document with test geometry
         cls.needsInit = False
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
         cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "Mod/CAM/Tests/test_adaptive.fcstd")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
         # Create Job object, adding geometry objects from file opened above
         cls.job = PathJob.Create("Job", [cls.doc.Fusion], None)

--- a/src/Mod/CAM/Tests/TestPathDrillable.py
+++ b/src/Mod/CAM/Tests/TestPathDrillable.py
@@ -35,7 +35,9 @@ else:
 
 class TestPathDrillable(PathTestUtils.PathTestBase):
     def setUp(self):
+        App.ConfigSet("SuppressRecomputeRequiredDialog", "True")
         self.doc = App.open(App.getHomePath() + "/Mod/CAM/Tests/Drilling_1.FCStd")
+        App.ConfigSet("SuppressRecomputeRequiredDialog", "")
         self.obj = self.doc.getObject("Pocket011")
 
     def tearDown(self):

--- a/src/Mod/CAM/Tests/TestPathOpUtil.py
+++ b/src/Mod/CAM/Tests/TestPathOpUtil.py
@@ -84,7 +84,9 @@ def wireMarkers(wire):
 class TestPathOpUtil(PathTestUtils.PathTestBase):
     @classmethod
     def setUpClass(cls):
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
         cls.doc = FreeCAD.openDocument(DOC)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     @classmethod
     def tearDownClass(cls):

--- a/src/Mod/CAM/Tests/TestPathPost.py
+++ b/src/Mod/CAM/Tests/TestPathPost.py
@@ -86,6 +86,8 @@ class TestFileNameGenerator(unittest.TestCase):
         # cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/Tests/boxtest.fcstd")
         # cls.job = cls.doc.getObject("Job")
 
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
+
         cls.testfile = FreeCAD.getHomePath() + "Mod/CAM/Tests/test_filenaming.fcstd"
         cls.testfilepath, cls.testfilename = os.path.split(cls.testfile)
         cls.testfilename, cls.ext = os.path.splitext(cls.testfilename)
@@ -98,6 +100,7 @@ class TestFileNameGenerator(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     # def test010(self):
     #     self.job.PostProcessorOutputFile = ""
@@ -272,12 +275,14 @@ class TestFileNameGenerator(unittest.TestCase):
 class TestResolvingPostProcessorName(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
         cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/Tests/boxtest.fcstd")
         cls.job = cls.doc.getObject("Job")
 
     @classmethod
     def tearDownClass(cls):
         FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     def setUp(self):
         pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
@@ -327,12 +332,14 @@ class TestPostProcessorFactory(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
         cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/Tests/boxtest.fcstd")
         cls.job = cls.doc.getObject("Job")
 
     @classmethod
     def tearDownClass(cls):
         FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     def setUp(self):
         pass
@@ -359,12 +366,14 @@ class TestPostProcessorClass(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
         cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "/Mod/CAM/Tests/boxtest.fcstd")
         cls.job = cls.doc.getObject("Job")
 
     @classmethod
     def tearDownClass(cls):
         FreeCAD.closeDocument(cls.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     def setUp(self):
         pass
@@ -603,8 +612,10 @@ class TestBuildPostList(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
         cls.testfile = FreeCAD.getHomePath() + "Mod/CAM/Tests/test_filenaming.fcstd"
         cls.doc = FreeCAD.open(cls.testfile)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
         cls.job = cls.doc.getObjectsByLabel("MainJob")[0]
 
     @classmethod

--- a/src/Mod/CAM/Tests/TestPathProfile.py
+++ b/src/Mod/CAM/Tests/TestPathProfile.py
@@ -54,7 +54,9 @@ class TestPathProfile(PathTestBase):
     def initClass(cls):
         # Open existing FreeCAD document with test geometry
         cls.needsInit = False
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
         cls.doc = FreeCAD.open(FreeCAD.getHomePath() + "Mod/CAM/Tests/test_profile.fcstd")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
         # Create Job object, adding geometry objects from file opened above
         cls.job = PathJob.Create("Job", [cls.doc.Body], None)

--- a/src/Mod/CAM/Tests/TestPathToolController.py
+++ b/src/Mod/CAM/Tests/TestPathToolController.py
@@ -31,9 +31,11 @@ from Tests.PathTestUtils import PathTestBase
 class TestPathToolController(PathTestBase):
     def setUp(self):
         self.doc = FreeCAD.newDocument("TestPathToolController")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
 
     def tearDown(self):
         FreeCAD.closeDocument(self.doc.Name)
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
 
     def createTool(self, name="t1", diameter=1.75):
         attrs = {

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -389,10 +389,10 @@ void PropertyPartShape::Restore(Base::XMLReader &reader)
             }
         }
     } else if(owner && !owner->getDocument()->testStatus(App::Document::PartialDoc)) {
-        // Toponaming 09/2024:  Original code has a whole infrastructure of document parameters we aren't bring in:
+        // Toponaming 09/2024:  Original code has an infrastructure for document parameters we aren't bringing in:
         // if(App::DocumentParams::getWarnRecomputeOnRestore()) {
-        // However, this warning appears on all files without element maps, and is now superceded by a user dialog
-        // after loading that is triggered by any addRecomputeObject()
+        // However, this warning appeared on all files without element maps, and is now superseded by a user dialog
+        // after loading that is triggered by any call to addRecomputeObject()
         // FC_WARN("Pending recompute for generating element map: " << owner->getFullName());
         owner->getDocument()->addRecomputeObject(owner);
     }

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -389,11 +389,12 @@ void PropertyPartShape::Restore(Base::XMLReader &reader)
             }
         }
     } else if(owner && !owner->getDocument()->testStatus(App::Document::PartialDoc)) {
+        // Toponaming 09/2024:  Original code has a whole infrastructure of document parameters we aren't bring in:
         // if(App::DocumentParams::getWarnRecomputeOnRestore()) {
-        if( true ) {
-            FC_WARN("Pending recompute for generating element map: " << owner->getFullName());
-            owner->getDocument()->addRecomputeObject(owner);
-        }
+        // However, this warning appears on all files without element maps, and is now superceded by a user dialog
+        // after loading that is triggered by any addRecomputeObject()
+        // FC_WARN("Pending recompute for generating element map: " << owner->getFullName());
+        owner->getDocument()->addRecomputeObject(owner);
     }
 
     if (!shape.isNull() || !_Shape.isNull()) {

--- a/src/Mod/PartDesign/PartDesignTests/TestInvoluteGear.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestInvoluteGear.py
@@ -34,8 +34,10 @@ FIXTURE_PATH = pathlib.Path(__file__).parent / "Fixtures"
 class TestInvoluteGear(unittest.TestCase):
     def setUp(self):
         self.Doc = FreeCAD.newDocument("PartDesignTestInvoluteGear")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
 
     def tearDown(self):
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
         FreeCAD.closeDocument(self.Doc.Name)
 
     def testDefaultGearProfile(self):

--- a/src/Mod/PartDesign/PartDesignTests/TestMultiTransform.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestMultiTransform.py
@@ -29,6 +29,7 @@ App = FreeCAD
 class TestMultiTransform(unittest.TestCase):
     def setUp(self):
         self.Doc = FreeCAD.newDocument("PartDesignTestMultiTransform")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "True")
 
     def testMultiTransform(self):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
@@ -132,5 +133,6 @@ class TestMultiTransform(unittest.TestCase):
     def tearDown(self):
         #closing doc
         FreeCAD.closeDocument("PartDesignTestMultiTransform")
+        FreeCAD.ConfigSet("SuppressRecomputeRequiredDialog", "")
         #print ("omit closing document for debugging")
 


### PR DESCRIPTION
This should eliminate the huge number of recompute warnings on older files without element maps.

It is a UI change, so a decision on whether to 1.0 or 1.1 this needs to be made.  If we do decide on 1.0 I expect the most stringent possible review, and to have to adjust to the results.  Please question everything.