### PR TITLE
Gui: fix size of ComboBox in Preferences/Navigtion

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsNavigation.ui
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.ui
@@ -145,6 +145,7 @@
         <property name="maximumSize">
          <size>
           <width>240</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="toolTip">


### PR DESCRIPTION
Thix fixes visual artifact in the Preferences/Navigation/Navigation cube/Font name dialog. The default value for this field is 0 (at least for some Qt versions), which does not make sense, because the element would be invisible.

Also the element is actually invisible when editing the UI file in QtCreator.

Using the default "max" value set for other fields"