### PR TITLE
Sketcher/Toponaming: call SketchObject::convertSubName() in Gui selections

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -1677,8 +1677,11 @@ void TaskSketcherElements::onListWidgetElementsItemPressed(QListWidgetItem* it)
             selectVertex(item->isMidPointSelected, item->MidVertex);
         }
 
-        if (!elementSubNames.empty()) {
-            Gui::Selection().addSelections(doc_name.c_str(), obj_name.c_str(), elementSubNames);
+        for (const auto& elementSubName : elementSubNames) {
+            Gui::Selection().addSelection2(
+                doc_name.c_str(),
+                obj_name.c_str(),
+                sketchView->getSketchObject()->convertSubName(elementSubName).c_str());
         }
 
         this->blockSelection(block);

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3875,7 +3875,12 @@ bool ViewProviderSketch::addSelection(const std::string& subNameSuffix, float x,
 bool ViewProviderSketch::addSelection2(const std::string& subNameSuffix, float x, float y, float z)
 {
     return Gui::Selection().addSelection2(
-        editDocName.c_str(), editObjName.c_str(), (editSubName + subNameSuffix).c_str(), x, y, z);
+        editDocName.c_str(),
+        editObjName.c_str(),
+        (editSubName + getSketchObject()->convertSubName(subNameSuffix)).c_str(),
+        x,
+        y,
+        z);
 }
 
 bool ViewProviderSketch::setPreselect(const std::string& subNameSuffix, float x, float y, float z)


### PR DESCRIPTION
related to https://github.com/FreeCAD/FreeCAD/pull/16355#issuecomment-2344246162

This PR should fix some errors that may trigger while selecting Sketcher geometries in Gui.

It is based on the following `#define` from LS3
https://github.com/realthunder/FreeCAD/blob/631044ad5b898b8142cdd54f9f8452ae46c51dd1/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp#L1016