### PR TITLE
Gui: Fix path to QRC file in PreferencePages UI file

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsCacheDirectory.ui
+++ b/src/Gui/PreferencePages/DlgSettingsCacheDirectory.ui
@@ -48,7 +48,7 @@
            </sizepolicy>
           </property>
           <property name="icon">
-           <iconset resource="Icons/resource.qrc">
+           <iconset resource="../Icons/resource.qrc">
             <normaloff>:/icons/document-open.svg</normaloff>:/icons/document-open.svg</iconset>
           </property>
          </widget>
@@ -198,7 +198,7 @@
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <resources>
-  <include location="Icons/resource.qrc"/>
+  <include location="../Icons/resource.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
QtCreator, when the file is opened, reports reference to .qrc filewhich does not exists. It looks like a missing piece from ccb9d7faeb.