### PR TITLE
CAM: remove path to non-existing .qrc file from PathEdit.ui

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -1602,7 +1602,6 @@ Default: &quot;5mm&quot;</string>
  </tabstops>
  <resources>
   <include location="../../../../../Gui/Icons/resource.qrc"/>
-  <include location="../../../../Material/Resources/Material.qrc"/>
   <include location="../../../../Material/Gui/Resources/Material.qrc"/>
   <include location="../Path.qrc"/>
  </resources>


### PR DESCRIPTION
Opening the file in QtCreator reports the file cannot be found.

It looks like leftover. Path was added in e755fc1a5a2978b835f069c096748345ad983576, but not the file. The file with the same name exists on `.../Gui/...` path, looks like messed file rename ??

During my testing the dialog opens and shows at least some icons. I never used `CAM` module, pls can someone help me test if this does not break anythink?