### PR TITLE
BIM: size fix and clean-up for wellcome window

### DIFF
--- a/src/Mod/BIM/bimcommands/BimWelcome.py
+++ b/src/Mod/BIM/bimcommands/BimWelcome.py
@@ -43,7 +43,6 @@ class BIM_Welcome:
     def Activated(self):
         from PySide import QtCore, QtGui
 
-        # load dialog
         self.form = FreeCADGui.PySideUic.loadUi(":ui/dialogWelcome.ui")
 
         # handle the tutorial links

--- a/src/Mod/BIM/bimcommands/BimWelcome.py
+++ b/src/Mod/BIM/bimcommands/BimWelcome.py
@@ -53,6 +53,8 @@ class BIM_Welcome:
         self.form.label_4.linkActivated.connect(self.handleLink)
         self.form.label_7.linkActivated.connect(self.handleLink)
 
+        self.form.adjustSize()
+
         # center the dialog over FreeCAD window
         mw = FreeCADGui.getMainWindow()
         self.form.move(

--- a/src/Mod/BIM/bimcommands/BimWelcome.py
+++ b/src/Mod/BIM/bimcommands/BimWelcome.py
@@ -46,9 +46,6 @@ class BIM_Welcome:
         # load dialog
         self.form = FreeCADGui.PySideUic.loadUi(":ui/dialogWelcome.ui")
 
-        # set the title image
-        self.form.image.setPixmap(QtGui.QPixmap(":/icons/banner.png"))
-
         # handle the tutorial links
         self.form.label_4.linkActivated.connect(self.handleLink)
         self.form.label_7.linkActivated.connect(self.handleLink)


### PR DESCRIPTION
The actual optimal size of the window depends on many details, like UI style, system fonts, OS etc ... so lets auto-resize the window to fit the content before display.

I have also removed the setting of title image, seems to be redundat, because is already set in the UI file @yorikvanhavre any particular reason why this was set, can this break anythink?