### PR TITLE
Base: fix XMLReader non-closing character stream

### DIFF
--- a/src/Base/Reader.cpp
+++ b/src/Base/Reader.cpp
@@ -181,6 +181,8 @@ bool Base::XMLReader::read()
 void Base::XMLReader::readElement(const char* ElementName)
 {
     bool ok {};
+
+    endCharStream();
     int currentLevel = Level;
     std::string currentName = LocalName;
     do {
@@ -248,6 +250,8 @@ bool Base::XMLReader::isEndOfDocument() const
 
 void Base::XMLReader::readEndElement(const char* ElementName, int level)
 {
+    endCharStream();
+
     // if we are already at the end of the current element
     if ((ReadType == EndElement || ReadType == StartEndElement) && ElementName
         && LocalName == ElementName && (level < 0 || level == Level)) {


### PR DESCRIPTION
The patch auto closes opened character stream when reaching the end or start of an element. Failing to do that may trigger `Recursive character stream` exception in `XMLReader::beginCharStream()` when opening a new stream.