### PR TITLE
CAM Catch other exceptions with Camotics on import.

### DIFF
--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -164,6 +164,12 @@ class CAMWorkbench(Workbench):
                     toolcmdlist.append("CAM_Camotics")
             except (FileNotFoundError, ModuleNotFoundError):
                 pass
+            except subprocess.CalledProcessError as e:
+                print(f"Failed to execute camotics command: {e}")
+            except ValueError as ve:
+                print(f"Version error: {ve}")
+            except Exception as ex:
+                print(f"An unexpected error occurred: {ex}")
 
             try:
                 try:


### PR DESCRIPTION
Fixes #16533
Attempting to import camotics in the appimage raises an InvalidVersion error which we weren't testing for.

This version catches other exceptions and should fail more gracefully.