### PR TITLE
[Backport] App: Return root object placement if target and root object are the same in getGlobalPlacement

### DIFF
--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -295,6 +295,8 @@ Base::Placement GeoFeature::getGlobalPlacement(App::DocumentObject* targetObj,
     App::Document* doc = rootObj->getDocument();
     Base::Placement plc = getPlacementFromProp(rootObj, "Placement");
 
+    if (targetObj == rootObj) return plc;
+
     for (auto& name : names) {
         App::DocumentObject* obj = doc->getObject(name.c_str());
         if (!obj) {


### PR DESCRIPTION
@chennes forgot to cherry pick this commit from #15262.

(cherry picked from commit 8db7191084352cc83e908b3819cec3612058ccd2)