### PR TITLE
Add options to disable addons

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2225,6 +2225,7 @@ void parseProgramOptions(int ac, char ** av, const string& exe, variables_map& v
     ("run-open,r", value<string>()->implicit_value(""),"Run a given test case (use 0 (zero) to run all tests). If no argument is provided then return list of all available tests.  Keeps UI open after test(s) complete.")
     ("module-path,M", value< vector<string> >()->composing(),"Additional module paths")
     ("python-path,P", value< vector<string> >()->composing(),"Additional python paths")
+    ("disable-addon", value< vector<string> >()->composing(),"Disable a given addon.")
     ("single-instance", "Allow to run a single instance of the application")
     ("pass", value< vector<string> >()->multitoken(), "Ignores the following arguments and pass them through to be used by a script")
     ;
@@ -2403,6 +2404,16 @@ void processProgramOptions(const variables_map& vm, std::map<std::string,std::st
         vector<string> Paths = vm["python-path"].as< vector<string> >();
         for (const auto & It : Paths)
             Base::Interpreter().addPythonPath(It.c_str());
+    }
+
+    if (vm.count("disable-addon")) {
+        auto Addons = vm["disable-addon"].as< vector<string> >();
+        string temp;
+        for (const auto & It : Addons) {
+            temp += It + ";";
+        }
+        temp.erase(temp.end()-1);
+        mConfig["DisabledAddons"] = temp;
     }
 
     if (vm.count("input-file")) {

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -106,6 +106,7 @@ def InitApplications():
     MacroMod = os.path.realpath(MacroDir+"/Mod")
     SystemWideMacroDir = FreeCAD.getHomePath()+'Macro'
     SystemWideMacroDir = os.path.realpath(SystemWideMacroDir)
+    DisabledAddons = FreeCAD.ConfigGet("DisabledAddons").split(";")
 
     #print FreeCAD.getHomePath()
     if os.path.isdir(FreeCAD.getHomePath()+'src\\Tools'):
@@ -218,11 +219,30 @@ def InitApplications():
         except Exception as exc:
             Err(str(exc))
 
+    def checkIfAddonIsDisabled(Dir):
+        Name = os.path.basename(Dir)
+
+        if Name in DisabledAddons:
+            Msg(f'NOTICE: Addon "{Name}" disabled by presence of "--disable-addon {Name}" argument\n')
+            return True
+
+        stopFileName = "ALL_ADDONS_DISABLED"
+        stopFile = os.path.join(Dir, os.path.pardir, stopFileName)
+        if os.path.exists(stopFile):
+            Msg(f'NOTICE: Addon "{Dir}" disabled by presence of {stopFileName} stopfile\n')
+            return True
+
+        stopFileName = "ADDON_DISABLED"
+        stopFile = os.path.join(Dir, stopFileName)
+        if os.path.exists(stopFile):
+            Msg(f'NOTICE: Addon "{Dir}" disabled by presence of {stopFileName} stopfile\n')
+            return True
+
+        return False
+
     for Dir in ModDict.values():
-        if ((Dir != '') & (Dir != 'CVS') & (Dir != '__init__.py')):
-            stopFile = os.path.join(Dir, "ADDON_DISABLED")
-            if os.path.exists(stopFile):
-                Msg(f'NOTICE: Addon "{Dir}" disabled by presence of ADDON_DISABLED stopfile\n')
+        if Dir not in ['', 'CVS', '__init__.py']:
+            if checkIfAddonIsDisabled(Dir):
                 continue
             sys.path.insert(0,Dir)
             PathExtension.append(Dir)

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -192,11 +192,31 @@ def InitApplications():
         except Exception as exc:
             Err(str(exc))
 
+    def checkIfAddonIsDisabled(Dir):
+        DisabledAddons = FreeCAD.ConfigGet("DisabledAddons").split(";")
+        Name = os.path.basename(Dir)
+
+        if Name in DisabledAddons:
+            Msg(f'NOTICE: Addon "{Name}" disabled by presence of "--disable-addon {Name}" argument\n')
+            return True
+
+        stopFileName = "ALL_ADDONS_DISABLED"
+        stopFile = os.path.join(Dir, os.path.pardir, stopFileName)
+        if os.path.exists(stopFile):
+            Msg(f'NOTICE: Addon "{Dir}" disabled by presence of {stopFileName} stopfile\n')
+            return True
+
+        stopFileName = "ADDON_DISABLED"
+        stopFile = os.path.join(Dir, stopFileName)
+        if os.path.exists(stopFile):
+            Msg(f'NOTICE: Addon "{Dir}" disabled by presence of {stopFileName} stopfile\n')
+            return True
+
+        return False
+
     for Dir in ModDirs:
-        if (Dir != '') & (Dir != 'CVS') & (Dir != '__init__.py'):
-            stopFile = os.path.join(Dir, "ADDON_DISABLED")
-            if os.path.exists(stopFile):
-                Msg(f'NOTICE: Addon "{Dir}" disabled by presence of ADDON_DISABLED stopfile\n')
+        if Dir not in ['', 'CVS', '__init__.py']:
+            if checkIfAddonIsDisabled(Dir):
                 continue
             MetadataFile = os.path.join(Dir, "package.xml")
             if os.path.exists(MetadataFile):


### PR DESCRIPTION
Closes https://github.com/FreeCAD/FreeCAD/issues/15710

As discussed in issue linked above, there's a need to easily disable addons for debugging.

This pull requests adds two possibilities to disable addons:
 * By adding a command line argument `--disable-addon <addon>`
 * And by creating a `ALL_ADDONS_DISABLED` file in the mod root of the addons to disable

The first one works in the same way as creating a stop file "DISABLE_ADDON", but from the command line. 
The second one expands on how stop files works, by allowing a whole parent directory to be stopped from loading.

Cavets:
 * There are quite a lot of code duplication in the python files before the changegs, so I followed the same pattern. I've contained the bulk of the changes in a function (in both files) to make it easier to maintain or refactor later. If you want this changed, please point me to where to place the function which can be safely imported in both places.