### PR TITLE
[MeasureGui] Store measure type as local variable

### DIFF
--- a/src/Mod/Measure/Gui/TaskMeasure.h
+++ b/src/Mod/Measure/Gui/TaskMeasure.h
@@ -72,7 +72,6 @@ private:
 
     App::Document* _mDocument = nullptr;
     Gui::Document* _mGuiDocument = nullptr;
-    App::MeasureType* _mMeasureType = nullptr;
     Measure::MeasureBase* _mMeasureObject = nullptr;
     Gui::ViewProviderDocumentObject* _mViewObject = nullptr;
 


### PR DESCRIPTION
This solves #16565 which was introduced in #15122 where the local measureType variable was moved to a class member. 

With this PR the measure type is stored locally again and the measurement label is retrieved from the mode dropdown when saving the measurement.

Fixes #16565