### PR TITLE
Fem: Minor change to MeshGmsh task panel and renaming mesh properties group

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/MeshGmsh.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MeshGmsh.ui
@@ -23,7 +23,7 @@
       </size>
      </property>
      <property name="title">
-      <string>FEM Mesh Parameters</string>
+      <string>Mesh Parameters</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_9">
       <item>
@@ -34,7 +34,7 @@
         <item row="1" column="0">
          <widget class="QLabel" name="l_dimension">
           <property name="text">
-           <string>Element dimension:</string>
+           <string>Element Dimension:</string>
           </property>
          </widget>
         </item>
@@ -44,7 +44,7 @@
         <item row="3" column="0">
          <widget class="QLabel" name="l_max">
           <property name="text">
-           <string>Max element size (0.0 = Auto):</string>
+           <string>Maximum Size:</string>
           </property>
          </widget>
         </item>
@@ -52,6 +52,9 @@
          <widget class="Gui::QuantitySpinBox" name="qsb_max_size">
           <property name="enabled">
            <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>Use 0.0 to set size automatically</string>
           </property>
           <property name="unit" stdset="0">
            <string notr="true">mm</string>
@@ -85,7 +88,7 @@
         <item row="4" column="0">
          <widget class="QLabel" name="l_min">
           <property name="text">
-           <string>Min element size (0.0 = Auto):</string>
+           <string>Minimum Size:</string>
           </property>
          </widget>
         </item>
@@ -93,6 +96,9 @@
          <widget class="Gui::QuantitySpinBox" name="qsb_min_size">
           <property name="enabled">
            <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>Use 0.0 to set size automatically</string>
           </property>
           <property name="unit" stdset="0">
            <string notr="true">mm</string>
@@ -129,7 +135,7 @@
         <item row="2" column="0">
          <widget class="QLabel" name="I_order">
           <property name="text">
-           <string>Element order:</string>
+           <string>Element Order:</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/Fem/Gui/Resources/ui/MeshNetgen.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MeshNetgen.ui
@@ -44,7 +44,7 @@
         <item row="1" column="0">
          <widget class="QLabel" name="l_max">
           <property name="text">
-           <string>Maximal Size:</string>
+           <string>Maximum Size:</string>
           </property>
          </widget>
         </item>
@@ -85,7 +85,7 @@
         <item row="2" column="0">
          <widget class="QLabel" name="l_min">
           <property name="text">
-           <string>Minimal Size:</string>
+           <string>Minimum Size:</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/Fem/femobjects/mesh_gmsh.py
+++ b/src/Mod/Fem/femobjects/mesh_gmsh.py
@@ -82,7 +82,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyLength",
                 name="CharacteristicLengthMax",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Max mesh element size (0.0 means infinity)",
                 value=0.0,  # will be 1e+22
             )
@@ -91,7 +91,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyLength",
                 name="CharacteristicLengthMin",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Min mesh element size",
                 value=0.0,
             )
@@ -100,7 +100,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyEnumeration",
                 name="ElementDimension",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Dimension of mesh elements ('From Shape': according ShapeType of part to mesh)",
                 value=["From Shape", "1D", "2D", "3D"],
             )
@@ -109,7 +109,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyEnumeration",
                 name="ElementOrder",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Order of mesh elements",
                 value=["1st", "2nd"],
             )
@@ -118,7 +118,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyBool",
                 name="OptimizeStd",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Optimize tetrahedral elements",
                 value=True,
             )
@@ -127,7 +127,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyBool",
                 name="OptimizeNetgen",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Optimize tetra elements by use of Netgen",
                 value=False,
             )
@@ -136,7 +136,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyEnumeration",
                 name="HighOrderOptimize",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Optimization of high order meshes",
                 value=[
                     "None",
@@ -151,7 +151,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyBool",
                 name="RecombineAll",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Apply recombination algorithm to all surfaces",
                 value=False,
             )
@@ -160,7 +160,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyBool",
                 name="Recombine3DAll",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Apply recombination algorithm to all volumes",
                 value=False,
             )
@@ -169,7 +169,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyEnumeration",
                 name="RecombinationAlgorithm",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Recombination algorithm",
                 value=[
                     "Simple",
@@ -183,7 +183,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyBool",
                 name="CoherenceMesh",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Removes all duplicate mesh vertices",
                 value=True,
             )
@@ -192,7 +192,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyFloat",
                 name="GeometryTolerance",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Geometrical Tolerance (0.0 means GMSH std = 1e-08)",
                 value=1e-06,
             )
@@ -201,7 +201,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyBool",
                 name="SecondOrderLinear",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Second order nodes are created by linear interpolation",
                 value=False,
             )
@@ -210,7 +210,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyIntegerConstraint",
                 name="MeshSizeFromCurvature",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Number of elements per 2*pi radians, 0 to deactivate",
                 value=(12, 0, 10000, 1),
             )
@@ -219,7 +219,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyEnumeration",
                 name="Algorithm2D",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Mesh algorithm 2D",
                 value=[
                     "Automatic",
@@ -237,7 +237,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyEnumeration",
                 name="Algorithm3D",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Mesh algorithm 3D",
                 value=[
                     "Automatic",
@@ -254,7 +254,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyBool",
                 name="GroupsOfNodes",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="For each group create not only the elements but the nodes too",
                 value=False,
             )
@@ -263,7 +263,7 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
             _PropHelper(
                 type="App::PropertyEnumeration",
                 name="SubdivisionAlgorithm",
-                group="FEM Gmsh Mesh Params",
+                group="Mesh Parameters",
                 doc="Mesh subdivision algorithm",
                 value=["None", "All Quadrangles", "All Hexahedra", "Barycentric"],
             )
@@ -290,6 +290,9 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
                 prop.handle_change_type(
                     obj, "App::PropertyBool", lambda x: "Optimization" if x else "None"
                 )
+            # Migrate group of properties for old projects
+            if obj.getGroupOfProperty(prop.name) == "FEM Gmsh Mesh Params":
+                obj.setGroupOfProperty(prop.name, "Mesh Parameters")
 
         # migrate old Part property to Shape property
         try:


### PR DESCRIPTION
* Minor changes in MeshGmsh task panel
* Currently if a mesh property is modified without regenerating the mesh, the object is left in a state of inconsistency between the property value and the existing mesh.  The reason behind the name change of the mesh property group is to implement (in the future) a mechanism so that it is reported when one of the mesh properties has been modified, requesting a recomputation of the mesh.

@FEA-eng 