### PR TITLE
MeasureGui: Auto close task on document deletion

### DIFF
--- a/src/Mod/Measure/Gui/Command.cpp
+++ b/src/Mod/Measure/Gui/Command.cpp
@@ -57,6 +57,7 @@ void StdCmdMeasure::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     Gui::TaskMeasure* task = new Gui::TaskMeasure();
+    task->setDocumentName(this->getDocument()->getName());
     Gui::Control().showDialog(task);
 }
 

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -115,7 +115,7 @@ TaskMeasure::TaskMeasure()
         App::GetApplication().setActiveTransaction("Add Measurement");
     }
 
-
+    setAutoCloseOnDeletedDocument(true);
     // Call invoke method delayed, otherwise the dialog might not be fully initialized
     QTimer::singleShot(0, this, &TaskMeasure::invoke);
 }


### PR DESCRIPTION
Auto close measure task when the document is closed.

Fixes #16424