### PR TITLE
Spreadsheet: Add variable in translation string to handle multiple noun forms

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -139,7 +139,7 @@ SheetTableView::SheetTableView(QWidget* parent)
             auto insert = menu.addAction(tr("Insert %n non-contiguous rows", "", selection.size()));
             connect(insert, &QAction::triggered, this, &SheetTableView::insertRows);
         }
-        auto remove = menu.addAction(tr("Remove row(s)", "", selection.size()));
+        auto remove = menu.addAction(tr("Remove %n row(s)", "", selection.size()));
         connect(remove, &QAction::triggered, this, &SheetTableView::removeRows);
         menu.exec(verticalHeader()->mapToGlobal(point));
     });
@@ -169,7 +169,7 @@ SheetTableView::SheetTableView(QWidget* parent)
                 menu.addAction(tr("Insert %n non-contiguous columns", "", selection.size()));
             connect(insert, &QAction::triggered, this, &SheetTableView::insertColumns);
         }
-        auto remove = menu.addAction(tr("Remove column(s)", "", selection.size()));
+        auto remove = menu.addAction(tr("Remove %n column(s)", "", selection.size()));
         connect(remove, &QAction::triggered, this, &SheetTableView::removeColumns);
         menu.exec(horizontalHeader()->mapToGlobal(point));
     });


### PR DESCRIPTION
Post 1.0: Translations needs to be added for this new string. 

---

Number dependent forms are supported, but we need a variable in the string for it to work.

Adding a variable makes it possible to use the form "Remove column" when the variable == 1 and "Remove columns" otherwise. This removes the need for "(s)" suffixes in the ui.

This is already supported for the other strings in the context menus for headers in spreadsheet.

For more information about forms: https://doc.qt.io/qt-6/i18n-plural-rules.html
The crowdin entries can be found here: https://crowdin.com/editor/freecad/27907/en-en?view=comfortable&filter=basic&value=3#q=(s)