### PR TITLE
[GUI] Move the Push In and Pull Out buttons to the left side

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsLightSources.ui
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.ui
@@ -179,19 +179,6 @@
           <number>2</number>
          </property>
          <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
           <layout class="QVBoxLayout" name="verticalLayout">
            <item>
             <spacer name="verticalSpacer">
@@ -247,6 +234,19 @@
             </widget>
            </item>
           </layout>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </widget>


### PR DESCRIPTION
Closes #16587.


Perfection is a state in which any change can make only worse. I thought that _Light Sources dialog_ finally reached it, but @FEA-eng has found a way to improve even further. This commit moves the push in and pull out buttons to the left side of the viewport, allowing user to see the axes I deliberately covered before.


The screenshot below shows how the dialog looks now.


<details><summary>Screenshot</summary>



![KUbuntu 24 04 1 64-bit-2024-09-17-22-59-41](https://github.com/user-attachments/assets/f65cf2f9-eb15-457e-946f-96c18eb18c72)



</details>


