### PR TITLE
DXF: Remove O(n^2) time on DXF import with the legacy importer

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -2741,7 +2741,7 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
 
     # Move layer contents to layers
     for (l, contents) in layerObjects.items():
-        l.Group = contents
+        l.Group += contents
 
     # Make blocks, if any
     if dxfMakeBlocks:

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -1927,11 +1927,24 @@ def addObject(shape, name="Shape", layer=None):
     if layer:
         lay = locateLayer(layer)
         # For old style layers, which are just groups
-        if hasattr(lay, "addObject"):
-            lay.addObject(newob)
+        if hasattr(lay, "Group"):
+            pass
         # For new Draft Layers
-        elif hasattr(lay, "Proxy") and hasattr(lay.Proxy, "addObject"):
-            lay.Proxy.addObject(lay, newob)
+        elif hasattr(lay, "Proxy") and hasattr(lay.Proxy, "Group"):
+            lay = lay.Proxy
+        else:
+            lay = None
+
+        if lay != None:
+            if lay not in layerObjects:
+                l = []
+                layerObjects[lay] = l
+            else:
+                l = layerObjects[lay]
+            l.append(newob)
+            
+
+
     formatObject(newob)
     return newob
 
@@ -2227,6 +2240,8 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
     badobjects = []
     global layerBlocks
     layerBlocks = {}
+    global layerObjects
+    layerObjects = {}
     sketch = None
     shapes = []
 
@@ -2723,6 +2738,10 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
                     if gui:
                         formatObject(newob, insert)
             num += 1
+
+    # Move layer contents to layers
+    for (l, contents) in layerObjects.items():
+        l.Group = contents
 
     # Make blocks, if any
     if dxfMakeBlocks:


### PR DESCRIPTION
Accumulates the contents of each layer in a local Python list, then at the end assigns all the objects at once into the layer. This avoids a very slow process of traversing the objects so far and (re-)updating their properties each time a new object is added. Fixes #16604
Also see #15732 for more analysis on the same problem in the C++ DXF importer.