### PR TITLE
Filter out infinite objects from Part Loft and Sweep

### DIFF
--- a/src/Mod/Part/Gui/TaskLoft.cpp
+++ b/src/Mod/Part/Gui/TaskLoft.cpp
@@ -137,10 +137,11 @@ void LoftWidget::findShapes()
             }
         }
 
-        if (shape.ShapeType() == TopAbs_FACE ||
+        if (!shape.Infinite() && 
+            (shape.ShapeType() == TopAbs_FACE ||
             shape.ShapeType() == TopAbs_WIRE ||
             shape.ShapeType() == TopAbs_EDGE ||
-            shape.ShapeType() == TopAbs_VERTEX) {
+            shape.ShapeType() == TopAbs_VERTEX)) {
             QString label = QString::fromUtf8(obj->Label.getValue());
             QString name = QString::fromLatin1(obj->getNameInDocument());
             QTreeWidgetItem* child = new QTreeWidgetItem();

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -199,10 +199,11 @@ void SweepWidget::findShapes()
             }
         }
 
-        if (shape.ShapeType() == TopAbs_FACE ||
+        if (!shape.Infinite() && 
+            (shape.ShapeType() == TopAbs_FACE ||
             shape.ShapeType() == TopAbs_WIRE ||
             shape.ShapeType() == TopAbs_EDGE ||
-            shape.ShapeType() == TopAbs_VERTEX) {
+            shape.ShapeType() == TopAbs_VERTEX)) {
             QString label = QString::fromUtf8(obj->Label.getValue());
             QString name = QString::fromLatin1(obj->getNameInDocument());
 


### PR DESCRIPTION
Fixes #16572 

Part Workbench's Sweep and Loft options were erroneously including Std_Part planes and axes in the list. The TopoDS_Shape class has an Infinite() method, and I check to make sure that's not set before including an object.