### PR TITLE
GUI: fix initialisation of autoCloseDeletedDocument in TaskDialog

### DIFF
--- a/src/Gui/TaskView/TaskDialog.cpp
+++ b/src/Gui/TaskView/TaskDialog.cpp
@@ -42,6 +42,7 @@ TaskDialog::TaskDialog()
     : QObject(nullptr), pos(North)
     , escapeButton(true)
     , autoCloseTransaction(false)
+    , autoCloseDeletedDocument(false)
 {
 
 }


### PR DESCRIPTION
There is only one derived-class where the value is set, and it is set to true, so I assume false should be the default.

Reported by `valgrind` as not initialized (makes noise during debugin). It also might cause unpredictable behavior, but I did not find any reported issue which might be related.