### PR TITLE
(lint)  fix  header warnigs into  Application.cpp

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -23,7 +23,7 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-#include <boost/interprocess/sync/file_lock.hpp>
+
 #include <QCloseEvent>
 #include <QDir>
 #include <QFileInfo>

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -23,6 +23,7 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
+#include <boost/interprocess/sync/file_lock.hpp>
 #include <QCloseEvent>
 #include <QDir>
 #include <QFileInfo>
@@ -36,7 +37,6 @@
 #include <QTextStream>
 #include <QTimer>
 #include <QWindow>
-#include <boost/interprocess/sync/file_lock.hpp>
 #include <Inventor/errors/SoDebugError.h>
 #include <Inventor/errors/SoError.h>
 #endif
@@ -52,7 +52,6 @@
 #include <Base/Parameter.h>
 #include <Base/Stream.h>
 #include <Base/Tools.h>
-
 #include <Base/UnitsApi.h>
 
 #include <Language/Translator.h>

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -23,9 +23,6 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-#include <boost/interprocess/sync/file_lock.hpp>
-#include <Inventor/errors/SoDebugError.h>
-#include <Inventor/errors/SoError.h>
 #include <QCloseEvent>
 #include <QDir>
 #include <QFileInfo>
@@ -39,6 +36,9 @@
 #include <QTextStream>
 #include <QTimer>
 #include <QWindow>
+#include <boost/interprocess/sync/file_lock.hpp>
+#include <Inventor/errors/SoDebugError.h>
+#include <Inventor/errors/SoError.h>
 #endif
 
 #include <QLoggingCategory>


### PR DESCRIPTION
fix lint warning: "Found C system header after other header"