### PR TITLE
Help: Don't open 404 documentation pages

### DIFF
--- a/src/Mod/Help/Help.py
+++ b/src/Mod/Help/Help.py
@@ -54,6 +54,9 @@ Defaults are to open the wiki in the desktop browser
 """
 
 import os
+import re
+import urllib.request
+import urllib.error
 import FreeCAD
 
 
@@ -101,7 +104,7 @@ def show(page, view=None, conv=None):
     """
 
     page = underscore_page(page)
-    location = get_location(page)
+    location, _pagename = get_location(page)
     FreeCAD.Console.PrintLog("Help: opening " + location + "\n")
     if not location:
         FreeCAD.Console.PrintError(LOCTXT + "\n")
@@ -109,7 +112,10 @@ def show(page, view=None, conv=None):
     md = get_contents(location)
     html = convert(md, conv)
     baseurl = get_uri(location)
-    pagename = os.path.basename(page.replace("_", " ").replace(".md", ""))
+    if _pagename != "":
+        pagename = _pagename
+    else:
+        pagename = os.path.basename(page.replace("_", " ").replace(".md", ""))
     title = translate("Help", "Help") + ": " + pagename
     if FreeCAD.GuiUp:
         if PREFS.GetBool("optionTab", False) and get_qtwebwidgets():
@@ -150,6 +156,27 @@ def get_uri(location):
     return baseurl
 
 
+def location_url(url_localized: str, url_english: str) -> tuple:
+    """
+    Returns localized documentation url and page name, if they exist,
+    otherwise defaults to english version.
+    """
+    try:
+        req = urllib.request.Request(url_localized)
+        with urllib.request.urlopen(req) as response:
+            html = response.read().decode("utf-8")
+            if re.search(r"https://wiki.freecad.org", url_localized):
+                pagename_match = re.search(r"<title>(.*?) - .*?</title>", html)
+            else:
+                pagename_match = re.search(r"Name/.*?:\s*(.+)", html)
+            if pagename_match is not None:
+                return (url_localized, pagename_match.group(1))
+            else:
+                return (url_localized, "")
+    except urllib.error.HTTPError as e:
+        return (url_english, "")
+
+
 def get_location(page):
     """retrieves the location (online or offline) of a given page"""
 
@@ -166,24 +193,33 @@ def get_location(page):
     page = page.replace("wiki/", "")
     page = page.split("#")[0]
     suffix = PREFS.GetString("Suffix", "")
+    pagename = ""
     if suffix:
         if not suffix.startswith("/"):
             suffix = "/" + suffix
     if PREFS.GetBool("optionWiki", True):  # default
-        location = WIKI_URL + "/" + page + suffix
+        location, pagename = location_url(WIKI_URL + "/" + page + suffix, WIKI_URL + "/" + page)
     elif PREFS.GetBool("optionMarkdown", False):
         if PREFS.GetBool("optionBrowser", False):
             location = MD_RENDERED_URL
         else:
             location = MD_RAW_URL
         if suffix:
-            location += "/" + MD_TRANSLATIONS_FOLDER + suffix
-        location += "/" + page + ".md"
+            location, pagename = location_url(
+                location + "/" + MD_TRANSLATIONS_FOLDER + suffix + "/" + page + ".md",
+                location + "/" + page + ".md",
+            )
+        else:
+            location += "/" + page + ".md"
     elif PREFS.GetBool("optionGithub", False):
         location = MD_RENDERED_URL
         if suffix:
-            location += "/" + MD_TRANSLATIONS_FOLDER + suffix
-        location += "/" + page + ".md"
+            location, pagename = location_url(
+                location + "/" + MD_TRANSLATIONS_FOLDER + suffix + "/" + page + ".md",
+                location + "/" + page + ".md",
+            )
+        else:
+            location += "/" + page + ".md"
     elif PREFS.GetBool("optionCustom", False):
         location = PREFS.GetString("Location", "")
         if not location:
@@ -195,7 +231,7 @@ def get_location(page):
                 "wiki",
             )
         location = os.path.join(location, page + ".md")
-    return location
+    return (location, pagename)
 
 
 def show_browser(url):


### PR DESCRIPTION
Unfortunately, not all documentation is translated. When using `What's this?` command it can be showed nonexistent webpages that don't redirect/have link to the English version of the documentation.

Instead of presenting to the user 404 code error pages is preferable to show the documentation on English.

Status codes 200 and 404 are assumed as requests response.