### PR TITLE
Fem: Fix mesh export to vtk formats

### DIFF
--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -1647,6 +1647,11 @@ void FemMesh::read(const char* FileName)
     }
 }
 
+void FemMesh::writeVTK(const std::string& fileName, bool highest) const
+{
+    FemVTKTools::writeVTKMesh(fileName.c_str(), this, highest);
+}
+
 void FemMesh::writeABAQUS(const std::string& Filename,
                           int elemParam,
                           bool groupParam,
@@ -2272,19 +2277,14 @@ void FemMesh::write(const char* FileName) const
     }
     else if (File.hasExtension("inp")) {
         Base::Console().Log("FEM mesh object will be exported to inp format.\n");
-        // get Abaqus inp prefs
-        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-            "User parameter:BaseApp/Preferences/Mod/Fem/Abaqus");
-        int elemParam = hGrp->GetInt("AbaqusElementChoice", 1);
-        bool groupParam = hGrp->GetBool("AbaqusWriteGroups", false);
         // write ABAQUS Output
-        writeABAQUS(File.filePath(), elemParam, groupParam);
+        writeABAQUS(File.filePath(), 1, false);
     }
 #ifdef FC_USE_VTK
     else if (File.hasExtension({"vtk", "vtu"})) {
         Base::Console().Log("FEM mesh object will be exported to either vtk or vtu format.\n");
         // write unstructure mesh to VTK format *.vtk and *.vtu
-        FemVTKTools::writeVTKMesh(File.filePath().c_str(), this);
+        writeVTK(File.filePath().c_str());
     }
 #endif
     else if (File.hasExtension("z88")) {

--- a/src/Mod/Fem/App/FemMesh.h
+++ b/src/Mod/Fem/App/FemMesh.h
@@ -210,6 +210,7 @@ public:
                      ABAQUS_VolumeVariant volVariant = ABAQUS_VolumeVariant::Standard,
                      ABAQUS_FaceVariant faceVariant = ABAQUS_FaceVariant::Shell,
                      ABAQUS_EdgeVariant edgeVariant = ABAQUS_EdgeVariant::Beam) const;
+    void writeVTK(const std::string& FileName, bool highest = true) const;
     void writeZ88(const std::string& FileName) const;
 
 private:

--- a/src/Mod/Fem/App/FemVTKTools.h
+++ b/src/Mod/Fem/App/FemVTKTools.h
@@ -42,9 +42,11 @@ public:
     // data
     static void importVTKMesh(vtkSmartPointer<vtkDataSet> grid, FemMesh* mesh, float scale = 1.0);
 
-    // extract data from FreCAD FEM mesh and fill a vtkUnstructuredGrid instance with that data
+    // extract data from FreCAD FEM mesh and fill a vtkUnstructuredGrid instance with that data. Set
+    // `highest` to false to export all elements levels.
     static void exportVTKMesh(const FemMesh* mesh,
                               vtkSmartPointer<vtkUnstructuredGrid> grid,
+                              bool highest = true,
                               float scale = 1.0);
 
     // extract data from vtkUnstructuredGrid object and fill a FreeCAD FEM result object with that
@@ -61,7 +63,7 @@ public:
     static FemMesh* readVTKMesh(const char* filename, FemMesh* mesh);
 
     // FemMesh write to vtkUnstructuredGrid data file
-    static void writeVTKMesh(const char* Filename, const FemMesh* mesh);
+    static void writeVTKMesh(const char* Filename, const FemMesh* mesh, bool highest = true);
 
     // FemResult (activeObject or created if res= NULL) read from vtkUnstructuredGrid dataset file
     static App::DocumentObject* readResult(const char* Filename,

--- a/src/Mod/Fem/Gui/DlgSettingsFemInOutVtk.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemInOutVtk.ui
@@ -84,6 +84,41 @@ exported from FreeCAD.</string>
     </widget>
    </item>
    <item row="1" column="0">
+    <widget class="QGroupBox" name="gb_export">
+     <property name="title">
+      <string>Export</string>
+     </property>
+     <layout class="QGridLayout" name="gl_export">
+      <item row="0" column="0">
+       <widget class="QLabel" name="lbl_export_level">
+        <property name="text">
+         <string>Mesh elements to export</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefComboBox" name="cb_export_level">
+        <property name="toolTip">
+         <string>Mesh element level to export</string>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>MeshExportLevel</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Fem/InOutVtk</cstring>
+        </property>
+        <property name="prefType" stdset="0">
+         <string></string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Mod/Fem/Gui/DlgSettingsFemInOutVtkImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemInOutVtkImp.cpp
@@ -51,6 +51,7 @@ void DlgSettingsFemInOutVtkImp::saveSettings()
     hGrp->SetInt("ImportObject", ui->comboBoxVtkImportObject->currentIndex());
 
     ui->comboBoxVtkImportObject->onSave();
+    ui->cb_export_level->onSave();
 }
 
 void DlgSettingsFemInOutVtkImp::loadSettings()
@@ -64,6 +65,9 @@ void DlgSettingsFemInOutVtkImp::loadSettings()
     if (index > -1) {
         ui->comboBoxVtkImportObject->setCurrentIndex(index);
     }
+
+    populateExportLevel();
+    ui->cb_export_level->onRestore();
 }
 
 /**
@@ -79,6 +83,21 @@ void DlgSettingsFemInOutVtkImp::changeEvent(QEvent* e)
     else {
         QWidget::changeEvent(e);
     }
+}
+
+void DlgSettingsFemInOutVtkImp::populateExportLevel() const
+{
+    std::list<std::string> values = {"All", "Highest"};
+
+    for (const auto& val : values) {
+        ui->cb_export_level->addItem(QString::fromStdString(val));
+    }
+
+    auto hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Fem/InOutVtk");
+    std::string current = hGrp->GetASCII("MeshExportLevel", "Highest");
+    int index = ui->cb_export_level->findText(QString::fromStdString(current));
+    ui->cb_export_level->setCurrentIndex(index);
 }
 
 #include "moc_DlgSettingsFemInOutVtkImp.cpp"

--- a/src/Mod/Fem/Gui/DlgSettingsFemInOutVtkImp.h
+++ b/src/Mod/Fem/Gui/DlgSettingsFemInOutVtkImp.h
@@ -48,6 +48,7 @@ protected:
     void changeEvent(QEvent* e) override;
 
 private:
+    void populateExportLevel() const;
     std::unique_ptr<Ui_DlgSettingsFemInOutVtk> ui;
 };
 


### PR DESCRIPTION
If a Fem mesh is exported to vtk file formats, only the highest dimensional elements will be exported.
For example:
Create a Fem mesh containing edge, face and volume elements.
Export the object to .vtu mesh format.
Import the object back as a Fem mesh -> Edge and face elements are lost.

@FEA-eng 