### PR TITLE
BIM: NativeIFC 2D support

### DIFF
--- a/src/Mod/BIM/ArchAxis.py
+++ b/src/Mod/BIM/ArchAxis.py
@@ -95,15 +95,21 @@ class _Axis:
         pl = obj.Placement
         geoms = []
         dist = 0
-        if obj.Distances and obj.Length.Value:
-            if len(obj.Distances) == len(obj.Angles):
-                for i in range(len(obj.Distances)):
+        distances = [0]
+        angles = [0]
+        if hasattr(obj, "Distances"):
+            distances = obj.Distances
+        if hasattr(obj, "Angles"):
+            angles = obj.Angles
+        if distances and obj.Length.Value:
+            if angles and len(distances) == len(angles):
+                for i in range(len(distances)):
                     if hasattr(obj.Length,"Value"):
                         l = obj.Length.Value
                     else:
                         l = obj.Length
-                    dist += obj.Distances[i]
-                    ang = math.radians(obj.Angles[i])
+                    dist += distances[i]
+                    ang = math.radians(angles[i])
                     p1 = Vector(dist,0,0)
                     p2 = Vector(dist+(l/math.cos(ang))*math.sin(ang),l,0)
                     if hasattr(obj,"Limit") and obj.Limit.Value:
@@ -274,8 +280,29 @@ class _ViewProviderAxis:
                     self.linecoords.point.setValues(verts)
                     self.lineset.coordIndex.setValues(0,len(vset),vset)
                     self.lineset.coordIndex.setNum(len(vset))
-            self.onChanged(obj.ViewObject,"BubbleSize")
-            self.onChanged(obj.ViewObject,"ShowLabel")
+        elif prop in ["Placement", "Length"] and not hasattr(obj, "Distances"):
+            # copy values from FlatLines/Wireframe nodes
+            rn = obj.ViewObject.RootNode
+            if rn.getNumChildren() < 3:
+                return
+            coords = rn.getChild(1)
+            pts = coords.point.getValues()
+            self.linecoords.point.setValues(pts)
+            #self.linecoords.point.setNum(len(pts))
+            sw = rn.getChild(2)
+            if sw.getNumChildren() < 4:
+                return
+            edges = sw.getChild(sw.getNumChildren()-2)
+            if not edges.getNumChildren():
+                return
+            if edges.getChild(0).getNumChildren() < 4:
+                return
+            eset = edges.getChild(0).getChild(3)
+            vset = eset.coordIndex.getValues()
+            self.lineset.coordIndex.setValues(0,len(vset),vset)
+            self.lineset.coordIndex.setNum(len(vset))
+        self.onChanged(obj.ViewObject,"BubbleSize")
+        self.onChanged(obj.ViewObject,"ShowLabel")
 
     def onChanged(self, vobj, prop):
 
@@ -317,7 +344,10 @@ class _ViewProviderAxis:
                                 pos = []
                             else:
                                 pos = [vobj.BubblePosition]
-                        for i in range(len(vobj.Object.Distances)):
+                        n = 0
+                        if hasattr(vobj.Object, "Distances"):
+                            n = len(vobj.Object.Distances)
+                        for i in range(n):
                             for p in pos:
                                 if hasattr(vobj.Object,"Limit") and vobj.Object.Limit.Value:
                                     verts = [vobj.Object.Placement.inverse().multVec(vobj.Object.Shape.Edges[i].Vertexes[0].Point),
@@ -679,7 +709,7 @@ class _AxisTaskPanel:
         'fills the treewidget'
         self.updating = True
         self.tree.clear()
-        if self.obj:
+        if self.obj and hasattr(self.obj, "Distances"):
             for i in range(len(self.obj.Distances)):
                 item = QtGui.QTreeWidgetItem(self.tree)
                 item.setText(0,str(i+1))

--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -843,6 +843,10 @@ class _SectionPlane:
                 # old objects
                 l = obj.ViewObject.DisplaySize.Value
                 h = obj.ViewObject.DisplaySize.Value
+        if not l:
+            l = 1
+        if not h:
+            h = 1
         p = Part.makePlane(l,h,Vector(l/2,-h/2,0),Vector(0,0,-1))
         # make sure the normal direction is pointing outwards, you never know what OCC will decide...
         if p.normalAt(0,0).getAngle(obj.Placement.Rotation.multVec(FreeCAD.Vector(0,0,1))) > 1:
@@ -1018,6 +1022,10 @@ class _ViewProviderSectionPlane:
             if hasattr(vobj,"Transparency"):
                 self.mat2.transparency.setValue(vobj.Transparency/100.0)
         elif prop in ["DisplayLength","DisplayHeight","ArrowSize"]:
+            # for IFC objects: propagate to the object
+            if prop in ["DisplayLength","DisplayHeight"]:
+                if hasattr(vobj.Object.Proxy, "onChanged"):
+                    vobj.Object.Proxy.onChanged(vobj.Object, prop)
             if hasattr(vobj,"DisplayLength") and hasattr(vobj,"DisplayHeight"):
                 ld = vobj.DisplayLength.Value/2
                 hd = vobj.DisplayHeight.Value/2

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -188,6 +188,7 @@ SET(nativeifc_SRCS
     nativeifc/__init__.py
     nativeifc/ifc_openshell.py
     nativeifc/ifc_types.py
+    nativeifc/ifc_export.py
 )
 
 SOURCE_GROUP("" FILES ${Arch_SRCS})

--- a/src/Mod/BIM/bimcommands/BimSectionPlane.py
+++ b/src/Mod/BIM/bimcommands/BimSectionPlane.py
@@ -62,6 +62,12 @@ class Arch_SectionPlane:
         FreeCADGui.doCommand("section = Arch.makeSectionPlane("+ss+")")
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()
+        if len(sel) == 1 and getattr(sel[0], "IfcClass", None) == "IfcProject":
+            # remove the IFC project, otherwise we can't aggregate (circular loop)
+            FreeCADGui.doCommand("section.Objects = []")
+            #FreeCADGui.addModule("nativeifc.ifc_tools")
+            #p = "FreeCAD.ActiveDocument."+sel[0].Name
+            #FreeCADGui.doCommand("nativeifc.ifc_tools.aggregate(section,"+p+")")
 
 
 

--- a/src/Mod/BIM/bimcommands/BimTDView.py
+++ b/src/Mod/BIM/bimcommands/BimTDView.py
@@ -92,6 +92,11 @@ class BIM_TDView:
             page.addView(view)
             if page.Scale:
                 view.Scale = page.Scale
+            if "ShapeMode" in draft.PropertiesList:
+                draft.ShapeMode = "Shape"
+            for child in draft.OutListRecursive:
+                if "ShapeMode" in child.PropertiesList:
+                    child.ShapeMode = "Shape"
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()
 

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -2464,6 +2464,7 @@ def create_annotation(anno, ifcfile, context, history, preferences):
     ovc = None
     zvc = None
     xvc = None
+    reps = []
     repid = "Annotation"
     reptype = "Annotation2D"
     if anno.isDerivedFrom("Part::Feature"):
@@ -2475,7 +2476,6 @@ def create_annotation(anno, ifcfile, context, history, preferences):
             objectType = "AREA"
         else:
             objectType = "LINEWORK"
-        reps = []
         sh = anno.Shape.copy()
         sh.scale(preferences['SCALE_FACTOR']) # to meters
         ehc = []
@@ -2520,24 +2520,13 @@ def create_annotation(anno, ifcfile, context, history, preferences):
         if FreeCAD.GuiUp:
             objectType = "DIMENSION"
             vp = anno.ViewObject.Proxy
-            reps = []
-            sh = Part.makePolygon([vp.p1,vp.p2,vp.p3,vp.p4])
+            if "BBIMDIMS" in preferences and preferences["BBIMDIMS"]:
+                sh = Part.makePolygon([vp.p2,vp.p3])
+            else:
+                sh = Part.makePolygon([vp.p1,vp.p2,vp.p3,vp.p4])
             sh.scale(preferences['SCALE_FACTOR']) # to meters
-            ehc = []
-            curves = []
-            for w in sh.Wires:
-                curves.append(createCurve(ifcfile,w))
-                for e in w.Edges:
-                    ehc.append(e.hashCode())
-            if curves:
-                reps.append(ifcfile.createIfcGeometricCurveSet(curves))
-            curves = []
-            # leftover edges
-            for e in sh.Edges:
-                if e.hashCode() not in ehc:
-                    curves.append(createCurve(ifcfile,e))
-            if curves:
-                reps.append(ifcfile.createIfcGeometricCurveSet(curves))
+            curve = createCurve(ifcfile,sh)
+            reps = [ifcfile.createIfcGeometricCurveSet([curve])]
             # Append text
             l = FreeCAD.Vector(vp.tbase).multiply(preferences['SCALE_FACTOR'])
             zdir = None

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -2443,11 +2443,9 @@ def create_annotation(anno, ifcfile, context, history, preferences):
 
     # uses global ifcbin, curvestyles
     objectType = None
-    xvc = ifcbin.createIfcDirection((1.0,0.0,0.0))
-    zvc = ifcbin.createIfcDirection((0.0,0.0,1.0))
-    ovc = ifcbin.createIfcCartesianPoint((0.0,0.0,0.0))
-    gpl = ifcbin.createIfcAxis2Placement3D(ovc,zvc,xvc)
-    placement = ifcbin.createIfcLocalPlacement(gpl)
+    ovc = None
+    zvc = None
+    xvc = None
     if anno.isDerivedFrom("Part::Feature"):
         if Draft.getType(anno) == "Hatch":
             objectType = "HATCH"
@@ -2477,18 +2475,20 @@ def create_annotation(anno, ifcfile, context, history, preferences):
     elif anno.isDerivedFrom("App::Annotation"):
         objectType = "TEXT"
         l = FreeCAD.Vector(anno.Position).multiply(preferences['SCALE_FACTOR'])
-        pos = ifcbin.createIfcCartesianPoint((l.x,l.y,l.z))
+        pos = ifcbin.createIfcCartesianPoint((0.0,0.0,0.0))
         tpl = ifcbin.createIfcAxis2Placement3D(pos,None,None)
+        ovc = ifcbin.createIfcCartesianPoint((l.x,l.y,l.z))
         s = ";".join(anno.LabelText)
         txt = ifcfile.createIfcTextLiteral(s,tpl,"LEFT")
         reps = [txt]
     elif Draft.getType(anno) in ["DraftText","Text"]:
         objectType = "TEXT"
         l = FreeCAD.Vector(anno.Placement.Base).multiply(preferences['SCALE_FACTOR'])
-        pos = ifcbin.createIfcCartesianPoint((l.x,l.y,l.z))
-        zdir = ifcbin.createIfcDirection(tuple(anno.Placement.Rotation.multVec(FreeCAD.Vector(0,0,1))))
-        xdir = ifcbin.createIfcDirection(tuple(anno.Placement.Rotation.multVec(FreeCAD.Vector(1,0,0))))
-        tpl = ifcbin.createIfcAxis2Placement3D(pos,zdir,xdir)
+        pos = ifcbin.createIfcCartesianPoint((0.0,0.0,0.0))
+        tpl = ifcbin.createIfcAxis2Placement3D(pos,None,None)
+        ovc = ifcbin.createIfcCartesianPoint((l.x,l.y,l.z))
+        zvc = ifcbin.createIfcDirection(tuple(anno.Placement.Rotation.multVec(FreeCAD.Vector(0,0,1))))
+        xvc = ifcbin.createIfcDirection(tuple(anno.Placement.Rotation.multVec(FreeCAD.Vector(1,0,0))))
         alg = "LEFT"
         if FreeCAD.GuiUp and hasattr(anno.ViewObject,"Justification"):
             if anno.ViewObject.Justification == "Right":
@@ -2546,7 +2546,14 @@ def create_annotation(anno, ifcfile, context, history, preferences):
             for rep in reps:
                 isi = ifcfile.createIfcStyledItem(rep,[psa],None)
             break
-
+    if not xvc:
+        xvc = ifcbin.createIfcDirection((1.0,0.0,0.0))
+    if not zvc:
+        zvc = ifcbin.createIfcDirection((0.0,0.0,1.0))
+    if not ovc:
+        ovc = ifcbin.createIfcCartesianPoint((0.0,0.0,0.0))
+    gpl = ifcbin.createIfcAxis2Placement3D(ovc,zvc,xvc)
+    placement = ifcbin.createIfcLocalPlacement(gpl)
     shp = ifcfile.createIfcShapeRepresentation(context,'Annotation','Annotation2D',reps)
     rep = ifcfile.createIfcProductDefinitionShape(None,None,[shp])
     label = anno.Label

--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -2474,6 +2474,29 @@ def create_annotation(anno, ifcfile, context, history, preferences):
             objectType = "LEADER"
         elif anno.Shape.Faces:
             objectType = "AREA"
+        elif Draft.getType(anno) == "Axis":
+            axdata = anno.Proxy.getAxisData(anno)
+            axes = []
+            for ax in axdata:
+                p1 = ifcbin.createIfcCartesianPoint(tuple(FreeCAD.Vector(ax[0]).multiply(preferences['SCALE_FACTOR'])[:2]))
+                p2 = ifcbin.createIfcCartesianPoint(tuple(FreeCAD.Vector(ax[1]).multiply(preferences['SCALE_FACTOR'])[:2]))
+                pol = ifcbin.createIfcPolyline([p1,p2])
+                axis = ifcfile.createIfcGridAxis(ax[2],pol,True)
+                axes.append(axis)
+            if axes:
+                if len(axes) > 1:
+                    xvc =  ifcbin.createIfcDirection((1.0,0.0,0.0))
+                    zvc =  ifcbin.createIfcDirection((0.0,0.0,1.0))
+                    ovc =  ifcbin.createIfcCartesianPoint((0.0,0.0,0.0))
+                    gpl =  ifcbin.createIfcAxis2Placement3D(ovc,zvc,xvc)
+                    plac = ifcbin.createIfcLocalPlacement(gpl)
+                    grid = ifcfile.createIfcGrid(uid,history,name,description,None,plac,None,axes,None,None)
+                    return grid
+                else:
+                    return axes[0]
+            else:
+                print("Unable to handle object",anno.Label)
+                return None
         else:
             objectType = "LINEWORK"
         sh = anno.Shape.copy()

--- a/src/Mod/BIM/importers/importIFCHelper.py
+++ b/src/Mod/BIM/importers/importIFCHelper.py
@@ -872,14 +872,20 @@ def get2DShape(representation,scaling=1000):
                         pts.append(c)
                     return pts
 
-                for s in el.Segments:
-                    if s.is_a("IfcLineIndex"):
-                        result.append(Part.makePolygon(index2points(s)))
-                    elif s.is_a("IfcArcIndex"):
-                        [p1, p2, p3] = index2points(s)
-                        result.append(Part.Arc(p1, p2, p3))
-                    else:
-                        raise RuntimeError("Illegal IfcIndexedPolyCurve segment")
+                if not el.Segments:
+                    # use all points
+                    verts = [FreeCAD.Vector(c[0],c[1],c[2] if len(c) > 2 else 0) for c in coords]
+                    verts = [v.multiply(scaling) for v in verts]
+                    result.append(Part.makePolygon(verts))
+                else:
+                    for s in el.Segments:
+                        if s.is_a("IfcLineIndex"):
+                            result.append(Part.makePolygon(index2points(s)))
+                        elif s.is_a("IfcArcIndex"):
+                            [p1, p2, p3] = index2points(s)
+                            result.append(Part.Arc(p1, p2, p3))
+                        else:
+                            raise RuntimeError("Illegal IfcIndexedPolyCurve segment")
             else:
                 print("getCurveSet: unhandled element: ", el)
 

--- a/src/Mod/BIM/importers/importIFCHelper.py
+++ b/src/Mod/BIM/importers/importIFCHelper.py
@@ -774,8 +774,9 @@ def getVector(entity,scaling=1000):
     return v
 
 
-def get2DShape(representation,scaling=1000):
-    """Returns a shape from a 2D IfcShapeRepresentation"""
+def get2DShape(representation,scaling=1000,notext=False):
+    """Returns a shape from a 2D IfcShapeRepresentation
+    if notext is True, no Draft text is created"""
 
     import Part
     import DraftVecUtils
@@ -885,9 +886,9 @@ def get2DShape(representation,scaling=1000):
                             [p1, p2, p3] = index2points(s)
                             result.append(Part.Arc(p1, p2, p3))
                         else:
-                            raise RuntimeError("Illegal IfcIndexedPolyCurve segment")
+                            raise RuntimeError("Illegal IfcIndexedPolyCurve segment: "+s.is_a())
             else:
-                print("getCurveSet: unhandled element: ", el)
+                print("importIFCHelper.getCurveSet: unhandled element: ", el)
 
         return result
 
@@ -909,6 +910,8 @@ def get2DShape(representation,scaling=1000):
                 else:
                     result = preresult
             elif item.is_a("IfcTextLiteral"):
+                if notext:
+                    continue
                 pl = getPlacement(item.Placement, scaling)
                 if pl:
                     t = Draft.make_text(item.Literal.split(";"), pl)

--- a/src/Mod/BIM/nativeifc/ifc_export.py
+++ b/src/Mod/BIM/nativeifc/ifc_export.py
@@ -139,15 +139,17 @@ def get_dimension(annotation):
         if annotation.ObjectType == "DIMENSION":
             s = ifcopenshell.util.unit.calculate_unit_scale(annotation.file) * 1000
             for rep in annotation.Representation.Representations:
-                shape = importIFCHelper.get2DShape(rep, s)
+                shape = importIFCHelper.get2DShape(rep, s, notext=True)
                 if shape and len(shape) == 1:
                     if len(shape[0].Vertexes) >= 2:
                         # two-point polyline (BBIM)
                         res = [rep, shape[0].Vertexes[0].Point, shape[0].Vertexes[-1].Point]
                         if len(shape[0].Vertexes) > 2:
                             # 4-point polyline (FreeCAD)
-                            res.append(shape[0].Vertexes[0].Point)
+                            res.append(shape[0].Vertexes[1].Point)
                         return res
+                else:
+                    print(annotation,"NOT A DIMENSION")
     return None
 
 

--- a/src/Mod/BIM/nativeifc/ifc_export.py
+++ b/src/Mod/BIM/nativeifc/ifc_export.py
@@ -26,6 +26,7 @@ import ifcopenshell
 
 from importers import exportIFC
 from importers import exportIFCHelper
+from importers import importIFCHelper
 
 from nativeifc import ifc_tools
 
@@ -116,6 +117,17 @@ def is_annotation(obj):
     return False
 
 
+def get_text(annotation):
+    """Determines if an IfcAnnotation contains an IfcTextLiteral.
+    Returns the IfcTextLiteral or None"""
+
+    for rep in annotation.Representation.Representations:
+        for item in rep.Items:
+            if item.is_a("IfcTextLiteral"):
+                return item
+    return None
+
+
 def create_annotation(obj, ifcfile):
     """Adds an IfcAnnotation from the given object to the given IFC file"""
 
@@ -144,3 +156,10 @@ def get_history(ifcfile):
         # IFC4 allows to not write any history
         history = None
     return history
+
+
+def get_placement(ifcelement, ifcfile):
+    """Returns a FreeCAD placement from an IFC placement"""
+
+    s = 0.001 / ifcopenshell.util.unit.calculate_unit_scale(ifcfile)
+    return importIFCHelper.getPlacement(ifcelement, scaling=s)

--- a/src/Mod/BIM/nativeifc/ifc_export.py
+++ b/src/Mod/BIM/nativeifc/ifc_export.py
@@ -234,6 +234,9 @@ def get_dimension(annotation):
             s = ifcopenshell.util.unit.calculate_unit_scale(annotation.file) * 1000
             for rep in annotation.Representation.Representations:
                 shape = importIFCHelper.get2DShape(rep, s, notext=True)
+                pl = get_placement(annotation.ObjectPlacement, scale=s)
+                if pl:
+                    shape[0].Placement = pl
                 if shape and len(shape) == 1:
                     if len(shape[0].Vertexes) >= 2:
                         # two-point polyline (BBIM)

--- a/src/Mod/BIM/nativeifc/ifc_export.py
+++ b/src/Mod/BIM/nativeifc/ifc_export.py
@@ -1,0 +1,146 @@
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2024 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU General Public License (GPL)            *
+# *   as published by the Free Software Foundation; either version 3 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU General Public License for more details.                          *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD
+import Draft
+import ifcopenshell
+
+from importers import exportIFC
+from importers import exportIFCHelper
+
+from nativeifc import ifc_tools
+
+
+def get_export_preferences(ifcfile):
+    """returns a preferences dict for exportIFC"""
+
+    prefs = exportIFC.getPreferences()
+    prefs["SCHEMA"] = ifcfile.wrapped_data.schema_name()
+    s = ifcopenshell.util.unit.calculate_unit_scale(ifcfile)
+    # the above lines yields meter -> file unit scale factor. We need mm
+    prefs["SCALE_FACTOR"] = 0.001 / s
+    context = ifcfile[
+        ifc_tools.get_body_context_ids(ifcfile)[0]
+    ]  # we take the first one (first found subcontext)
+    return prefs, context
+
+
+def create_product(obj, parent, ifcfile, ifcclass=None):
+    """Creates an IFC product out of a FreeCAD object"""
+
+    name = obj.Label
+    description = getattr(obj, "Description", None)
+    if not ifcclass:
+        ifcclass = ifc_tools.get_ifctype(obj)
+    representation, placement = create_representation(obj, ifcfile)
+    product = ifc_tools.api_run("root.create_entity", ifcfile, ifc_class=ifcclass, name=name)
+    ifc_tools.set_attribute(ifcfile, product, "Description", description)
+    ifc_tools.set_attribute(ifcfile, product, "ObjectPlacement", placement)
+    # TODO below cannot be used at the moment because the ArchIFC exporter returns an
+    # IfcProductDefinitionShape already and not an IfcShapeRepresentation
+    # ifc_tools.api_run("geometry.assign_representation", ifcfile, product=product, representation=representation)
+    ifc_tools.set_attribute(ifcfile, product, "Representation", representation)
+    # TODO treat subtractions/additions
+    return product
+
+
+def create_representation(obj, ifcfile):
+    """Creates a geometry representation for the given object"""
+
+    # TEMPORARY use the Arch exporter
+    # TODO this is temporary. We should rely on ifcopenshell for this with:
+    # https://blenderbim.org/docs-python/autoapi/ifcopenshell/api/root/create_entity/index.html
+    # a new FreeCAD 'engine' should be added to:
+    # https://blenderbim.org/docs-python/autoapi/ifcopenshell/api/geometry/index.html
+    # that should contain all typical use cases one could have to convert FreeCAD geometry
+    # to IFC.
+
+    # setup exporter - TODO do that in the module init
+    exportIFC.clones = {}
+    exportIFC.profiledefs = {}
+    exportIFC.surfstyles = {}
+    exportIFC.shapedefs = {}
+    exportIFC.ifcopenshell = ifcopenshell
+    exportIFC.ifcbin = exportIFCHelper.recycler(ifcfile, template=False)
+    prefs, context = get_export_preferences(ifcfile)
+    representation, placement, shapetype = exportIFC.getRepresentation(
+        ifcfile, context, obj, preferences=prefs
+    )
+    return representation, placement
+
+
+def is_annotation(obj):
+    """Determines if the given FreeCAD object should be saved as an IfcAnnotation"""
+
+    if getattr(obj, "IfcClass", None) == "IfcAnnotation":
+        return True
+    if getattr(obj, "IfcType", None) == "Annotation":
+        return True
+    if obj.isDerivedFrom("Part::Part2DObject"):
+        return True
+    elif obj.isDerivedFrom("App::Annotation"):
+        return True
+    elif Draft.getType(obj) in ["DraftText",
+                                "Text",
+                                "Dimension",
+                                "LinearDimension",
+                                "AngularDimension"]:
+        return True
+    elif obj.isDerivedFrom("Part::Feature"):
+        if obj.Shape and (not obj.Shape.Solids) and obj.Shape.Edges:
+            if not obj.Shape.Faces:
+                return True
+            elif (obj.Shape.BoundBox.XLength < 0.0001) \
+                or (obj.Shape.BoundBox.YLength < 0.0001) \
+                or (obj.Shape.BoundBox.ZLength < 0.0001):
+                return True
+    return False
+
+
+def create_annotation(obj, ifcfile):
+    """Adds an IfcAnnotation from the given object to the given IFC file"""
+
+    exportIFC.clones = {}
+    exportIFC.profiledefs = {}
+    exportIFC.surfstyles = {}
+    exportIFC.shapedefs = {}
+    exportIFC.curvestyles = {}
+    exportIFC.ifcopenshell = ifcopenshell
+    exportIFC.ifcbin = exportIFCHelper.recycler(ifcfile, template=False)
+    prefs, context = get_export_preferences(ifcfile)
+    history = get_history(ifcfile)
+    # TODO The following prints each edge as a separate IfcGeometricCurveSet
+    # It should be refined to create polylines instead
+    anno = exportIFC.create_annotation(obj, ifcfile, context, history, prefs)
+    return anno
+
+
+def get_history(ifcfile):
+    """Returns the owner history or None"""
+
+    history = ifcfile.by_type("IfcOwnerHistory")
+    if history:
+        history = history[0]
+    else:
+        # IFC4 allows to not write any history
+        history = None
+    return history

--- a/src/Mod/BIM/nativeifc/ifc_generator.py
+++ b/src/Mod/BIM/nativeifc/ifc_generator.py
@@ -26,12 +26,14 @@ used by the execute() method of ifc_objects"""
 
 
 import time
+import re
 import FreeCAD
 from FreeCAD import Base
 import Part
 import ifcopenshell
 from ifcopenshell.util import element
 from nativeifc import ifc_tools
+from nativeifc import ifc_export
 import multiprocessing
 import FreeCADGui
 from pivy import coin
@@ -57,13 +59,32 @@ def generate_geometry(obj, cached=False):
         return
     colors = None
 
-    # workaround for Group property bug: Avoid having a null shape, otherwise
-    # a default representation will be created from the object's Group contents
-    # obj.Shape = Part.makeBox(1, 1, 1)
-    # fixed in FreeCAD 0.22 - uncomment the line above for earlier versions
+    ifcfile = ifc_tools.get_ifcfile(obj)
+
+    # annotations
+    if ifc_export.is_annotation(obj):
+        element = ifc_tools.get_ifc_element(obj)
+        if not element:
+            return
+        if obj.ShapeMode == "Shape":
+            shape, placement = get_annotation_shape(element, ifcfile)
+            if shape:
+                obj.Shape = shape
+                if placement:
+                    obj.Placement = placement
+        elif obj.ViewObject and obj.ShapeMode == "Coin":
+            node, placement = get_annotation_shape(element, ifcfile, coin=True)
+            if node:
+                set_representation(obj.ViewObject, node)
+                colors = node[0]
+            else:
+                set_representation(obj.ViewObject, None)
+                print_debug(obj)
+            if placement:
+                obj.Placement = placement
+        return
 
     # generate the shape or coin node
-    ifcfile = ifc_tools.get_ifcfile(obj)
     elements = get_decomposition(obj)
     if obj.ShapeMode == "Shape":
         shape, colors = generate_shape(ifcfile, elements, cached)
@@ -77,6 +98,7 @@ def generate_geometry(obj, cached=False):
     elif obj.ViewObject and obj.ShapeMode == "Coin":
         node, placement = generate_coin(ifcfile, elements, cached)
         if node:
+            # TODO this still needs to be fixed
             #QtCore.QTimer.singleShot(0, lambda: set_representation(obj.ViewObject, node))
             set_representation(obj.ViewObject, node)
             colors = node[0]
@@ -339,7 +361,6 @@ def filter_types(elements, obj_ids=[]):
     elements = [e for e in elements if not e.is_a("IfcOpeningElement")]
     elements = [e for e in elements if not e.is_a("IfcSpace")]
     elements = [e for e in elements if not e.is_a("IfcFurnishingElement")]
-    elements = [e for e in elements if not e.is_a("IfcAnnotation")]
     elements = [e for e in elements if not e.id() in obj_ids]
     return elements
 
@@ -451,11 +472,12 @@ def set_representation(vobj, node):
     coords.point.deleteValues(0)
     if not node:
         return
-    if node[1] and node[2] and node[3] and node[4]:
+    if node[1] and node[3]:
         coords.point.setValues(node[1])
-        fset.coordIndex.setValues(node[2])
-        fset.partIndex.setValues(node[4])
         eset.coordIndex.setValues(node[3])
+        if node[2] and node[4]:
+            fset.coordIndex.setValues(node[2])
+            fset.partIndex.setValues(node[4])
 
 
 def print_debug(obj):
@@ -524,3 +546,45 @@ def delete_ghost(document):
             sg = FreeCADGui.getDocument(document.Name).ActiveView.getSceneGraph()
             sg.removeChild(document.Proxy.ghost)
             del document.Proxy.ghost
+
+
+def get_annotation_shape(annotation, ifcfile, coin=False):
+    """Returns a shape or a coin node form an IFC annotation"""
+
+    import Part
+    from importers import importIFCHelper
+
+    shape = None
+    placement = None
+    ifcscale = importIFCHelper.getScaling(ifcfile)
+    shapes2d = []
+    for rep in annotation.Representation.Representations:
+        if rep.RepresentationIdentifier in ["Annotation", "FootPrint", "Axis"]:
+            sh = importIFCHelper.get2DShape(rep, ifcscale)
+            if sh:
+                shapes2d.extend(sh)
+    if shapes2d:
+        shape = Part.makeCompound(shapes2d)
+        placement = importIFCHelper.getPlacement(annotation.ObjectPlacement, ifcscale)
+        if coin:
+            iv = shape.writeInventor()
+            iv = iv.replace("\n", "")
+            segs = re.findall(r"point \[.*?\]",iv)
+            segs = [s.replace("point [","").replace("]","").strip() for s in segs]
+            segs = [s.split("    ") for s in segs]
+            verts = []
+            edges = []
+            for pair in segs:
+                v1 = tuple([float(v) for v in pair[0].split()])
+                v2 = tuple([float(v) for v in pair[1].split()])
+                if not v1 in verts:
+                    verts.append(v1)
+                edges.append(verts.index(v1))
+                if not v2 in verts:
+                    verts.append(v2)
+                edges.append(verts.index(v2))
+                edges.append(-1)
+            shape = [[None, verts, [], edges]]
+            # unify nodes
+            shape = unify(shape)
+    return shape, placement

--- a/src/Mod/BIM/nativeifc/ifc_generator.py
+++ b/src/Mod/BIM/nativeifc/ifc_generator.py
@@ -72,17 +72,21 @@ def generate_geometry(obj, cached=False):
                 obj.Shape = shape
                 if placement:
                     obj.Placement = placement
+                    return
         elif obj.ViewObject and obj.ShapeMode == "Coin":
+            done = False
             node, placement = get_annotation_shape(element, ifcfile, coin=True)
             if node:
                 set_representation(obj.ViewObject, node)
                 colors = node[0]
+                done = True
             else:
                 set_representation(obj.ViewObject, None)
                 print_debug(obj)
             if placement:
                 obj.Placement = placement
-        return
+            if done:
+                return
 
     # generate the shape or coin node
     elements = get_decomposition(obj)

--- a/src/Mod/BIM/nativeifc/ifc_generator.py
+++ b/src/Mod/BIM/nativeifc/ifc_generator.py
@@ -564,7 +564,7 @@ def get_annotation_shape(annotation, ifcfile, coin=False):
     shapes2d = []
     for rep in annotation.Representation.Representations:
         if rep.RepresentationIdentifier in ["Annotation", "FootPrint", "Axis"]:
-            sh = importIFCHelper.get2DShape(rep, ifcscale)
+            sh = importIFCHelper.get2DShape(rep, ifcscale, notext=True)
             if sh:
                 shapes2d.extend(sh)
     if shapes2d:

--- a/src/Mod/BIM/nativeifc/ifc_objects.py
+++ b/src/Mod/BIM/nativeifc/ifc_objects.py
@@ -26,7 +26,8 @@ import FreeCAD
 translate = FreeCAD.Qt.translate
 
 # the property groups below should not be treated as psets
-NON_PSETS = ["Base", "IFC", "", "Geometry", "Dimension", "Linear/radial dimension", "SectionPlane", "PhysicalProperties"]
+NON_PSETS = ["Base", "IFC", "", "Geometry", "Dimension", "Linear/radial dimension", 
+             "SectionPlane", "Axis", "PhysicalProperties"]
 
 class ifc_object:
     """Base class for all IFC-based objects"""

--- a/src/Mod/BIM/nativeifc/ifc_objects.py
+++ b/src/Mod/BIM/nativeifc/ifc_objects.py
@@ -214,7 +214,7 @@ class ifc_object:
                             else:
                                 print("DEBUG: unknown dimension curve type:",sub)
             elif attribute in ["DisplayLength","DisplayHeight","Depth"]:
-                l = w = h = 1000
+                l = w = h = 1000.0
                 if obj.ViewObject:
                     if obj.ViewObject.DisplayLength.Value:
                         l = ifc_export.get_scaled_value(obj.ViewObject.DisplayLength.Value, ifcfile)

--- a/src/Mod/BIM/nativeifc/ifc_objects.py
+++ b/src/Mod/BIM/nativeifc/ifc_objects.py
@@ -25,6 +25,8 @@
 import FreeCAD
 translate = FreeCAD.Qt.translate
 
+# the property groups below should not be treated as psets
+NON_PSETS = ["Base", "IFC", "", "Geometry", "Dimension", "Linear/radial dimension", "PhysicalProperties"]
 
 class ifc_object:
     """Base class for all IFC-based objects"""
@@ -66,6 +68,8 @@ class ifc_object:
             self.edit_attribute(obj, "Name", obj.Label)
         elif prop == "Text":
             self.edit_annotation(obj, "Text", "\n".join(obj.Text))
+        elif prop in ["Start", "End"]:
+            self.edit_annotation(obj, prop)
         elif prop == "Placement":
             if getattr(self, "virgin_placement", False):
                 self.virgin_placement = False
@@ -77,7 +81,7 @@ class ifc_object:
                 obj.ViewObject.signalChangeIcon()
         elif obj.getGroupOfProperty(prop) == "Geometry":
             self.edit_geometry(obj, prop)
-        elif obj.getGroupOfProperty(prop) not in ["Base", "IFC", "", "Geometry", "PhysicalProperties"]:
+        elif obj.getGroupOfProperty(prop) not in NON_PSETS:
             # Treat all property groups outside the default ones as Psets
             # print("DEBUG: editinog pset prop",prop)
             self.edit_pset(obj, prop)
@@ -186,6 +190,23 @@ class ifc_object:
                 text = ifc_export.get_text(elt)
                 if text:
                     result = ifc_tools.set_attribute(ifcfile, text, "Literal", value)
+            elif attribute in ["Start", "End"]:
+                dim = ifc_export.get_dimension(elt)
+                if dim:
+                    rep = dim[0]
+                    for curve in rep.Items:
+                        for sub in curve.Elements:
+                            if sub.is_a("IfcIndexedPolyCurve"):
+                                points = sub.Points
+                                value = list(points.CoordList)
+                                is2d = "2D" in points.is_a()
+                                if attribute == "Start":
+                                    value[0] = ifc_export.get_scaled_point(obj.Start, ifcfile, is2d)
+                                else:
+                                    value[-1] = ifc_export.get_scaled_point(obj.End, ifcfile, is2d)
+                                result = ifc_tools.set_attribute(ifcfile, points, "CoordList", value)
+                            else:
+                                print("DEBUG: unknown dimension curve type:",sub)
 
     def edit_geometry(self, obj, prop):
         """Edits a geometry property of an object"""

--- a/src/Mod/BIM/nativeifc/ifc_objects.py
+++ b/src/Mod/BIM/nativeifc/ifc_objects.py
@@ -64,6 +64,8 @@ class ifc_object:
                 self.edit_attribute(obj, prop)
         elif prop == "Label":
             self.edit_attribute(obj, "Name", obj.Label)
+        elif prop == "Text":
+            self.edit_annotation(obj, "Text", "\n".join(obj.Text))
         elif prop == "Placement":
             if getattr(self, "virgin_placement", False):
                 self.virgin_placement = False
@@ -168,6 +170,22 @@ class ifc_object:
             if result:
                 if hasattr(result, "id") and (result.id() != obj.StepId):
                     obj.StepId = result.id()
+
+    def edit_annotation(self, obj, attribute, value=None):
+        """Edits an attribute of an underlying IFC annotation"""
+
+        from nativeifc import ifc_tools  # lazy import
+        from nativeifc import ifc_export
+
+        if not value:
+            value = obj.getPropertyByName(attribute)
+        ifcfile = ifc_tools.get_ifcfile(obj)
+        elt = ifc_tools.get_ifc_element(obj, ifcfile)
+        if elt:
+            if attribute == "Text":
+                text = ifc_export.get_text(elt)
+                if text:
+                    result = ifc_tools.set_attribute(ifcfile, text, "Literal", value)
 
     def edit_geometry(self, obj, prop):
         """Edits a geometry property of an object"""

--- a/src/Mod/BIM/nativeifc/ifc_objects.py
+++ b/src/Mod/BIM/nativeifc/ifc_objects.py
@@ -26,7 +26,7 @@ import FreeCAD
 translate = FreeCAD.Qt.translate
 
 # the property groups below should not be treated as psets
-NON_PSETS = ["Base", "IFC", "", "Geometry", "Dimension", "Linear/radial dimension", 
+NON_PSETS = ["Base", "IFC", "", "Geometry", "Dimension", "Linear/radial dimension",
              "SectionPlane", "Axis", "PhysicalProperties"]
 
 class ifc_object:

--- a/src/Mod/BIM/nativeifc/ifc_objects.py
+++ b/src/Mod/BIM/nativeifc/ifc_objects.py
@@ -198,6 +198,9 @@ class ifc_object:
                 if dim:
                     rep = dim[0]
                     for curve in rep.Items:
+                        if not hasattr(curve, "Elements"):
+                            # this is a TextLiteral for the dimension text - skip it
+                            continue
                         for sub in curve.Elements:
                             if sub.is_a("IfcIndexedPolyCurve"):
                                 points = sub.Points

--- a/src/Mod/BIM/nativeifc/ifc_objects.py
+++ b/src/Mod/BIM/nativeifc/ifc_objects.py
@@ -26,7 +26,7 @@ import FreeCAD
 translate = FreeCAD.Qt.translate
 
 # the property groups below should not be treated as psets
-NON_PSETS = ["Base", "IFC", "", "Geometry", "Dimension", "Linear/radial dimension", "PhysicalProperties"]
+NON_PSETS = ["Base", "IFC", "", "Geometry", "Dimension", "Linear/radial dimension", "SectionPlane", "PhysicalProperties"]
 
 class ifc_object:
     """Base class for all IFC-based objects"""
@@ -61,7 +61,7 @@ class ifc_object:
             self.edit_type(obj)
         elif prop == "Group":
             self.edit_group(obj)
-        elif obj.getGroupOfProperty(prop) == "IFC":
+        elif hasattr(obj, prop) and obj.getGroupOfProperty(prop) == "IFC":
             if prop not in ["StepId"]:
                 self.edit_attribute(obj, prop)
         elif prop == "Label":
@@ -69,6 +69,8 @@ class ifc_object:
         elif prop == "Text":
             self.edit_annotation(obj, "Text", "\n".join(obj.Text))
         elif prop in ["Start", "End"]:
+            self.edit_annotation(obj, prop)
+        elif prop in ["DisplayLength","DisplayHeight","Depth"]:
             self.edit_annotation(obj, prop)
         elif prop == "Placement":
             if getattr(self, "virgin_placement", False):
@@ -79,9 +81,9 @@ class ifc_object:
         elif prop == "Modified":
             if obj.ViewObject:
                 obj.ViewObject.signalChangeIcon()
-        elif obj.getGroupOfProperty(prop) == "Geometry":
+        elif hasattr(obj, prop) and obj.getGroupOfProperty(prop) == "Geometry":
             self.edit_geometry(obj, prop)
-        elif obj.getGroupOfProperty(prop) not in NON_PSETS:
+        elif hasattr(obj, prop) and obj.getGroupOfProperty(prop) not in NON_PSETS:
             # Treat all property groups outside the default ones as Psets
             # print("DEBUG: editinog pset prop",prop)
             self.edit_pset(obj, prop)
@@ -182,14 +184,15 @@ class ifc_object:
         from nativeifc import ifc_export
 
         if not value:
-            value = obj.getPropertyByName(attribute)
+            if hasattr(obj, attribute):
+                value = obj.getPropertyByName(attribute)
         ifcfile = ifc_tools.get_ifcfile(obj)
         elt = ifc_tools.get_ifc_element(obj, ifcfile)
         if elt:
             if attribute == "Text":
                 text = ifc_export.get_text(elt)
                 if text:
-                    result = ifc_tools.set_attribute(ifcfile, text, "Literal", value)
+                    ifc_tools.set_attribute(ifcfile, text, "Literal", value)
             elif attribute in ["Start", "End"]:
                 dim = ifc_export.get_dimension(elt)
                 if dim:
@@ -204,9 +207,29 @@ class ifc_object:
                                     value[0] = ifc_export.get_scaled_point(obj.Start, ifcfile, is2d)
                                 else:
                                     value[-1] = ifc_export.get_scaled_point(obj.End, ifcfile, is2d)
-                                result = ifc_tools.set_attribute(ifcfile, points, "CoordList", value)
+                                ifc_tools.set_attribute(ifcfile, points, "CoordList", value)
                             else:
                                 print("DEBUG: unknown dimension curve type:",sub)
+            elif attribute in ["DisplayLength","DisplayHeight","Depth"]:
+                l = w = h = 1000
+                if obj.ViewObject:
+                    if obj.ViewObject.DisplayLength.Value:
+                        l = ifc_export.get_scaled_value(obj.ViewObject.DisplayLength.Value)
+                    if obj.ViewObject.DisplayHeight.Value:
+                        w = ifc_export.get_scaled_value(obj.ViewObject.DisplayHeight.Value)
+                if obj.Depth.Value:
+                    h = ifc_export.get_scaled_value(obj.Depth.Value)
+                if elt.Representation.Representations:
+                    for rep in elt.Representation.Representations:
+                        for item in rep.Items:
+                            if item.is_a("IfcCsgSolid"):
+                                if item.TreeRootExpression.is_a("IfcBlock"):
+                                    block = item.TreeRootExpression
+                                    loc = block.Position.Location
+                                    ifc_tools.set_attribute(ifcfile, block, "XLength", l)
+                                    ifc_tools.set_attribute(ifcfile, block, "YLength", w)
+                                    ifc_tools.set_attribute(ifcfile, block, "ZLength", h)
+                                    ifc_tools.set_attribute(ifcfile, loc, "Coordinates", (-l/2, -h/2, -h))
 
     def edit_geometry(self, obj, prop):
         """Edits a geometry property of an object"""
@@ -325,6 +348,47 @@ class ifc_object:
             # TODO remove type?
             # Not doing anything right now because an unset Type property could screw the ifc file
             pass
+
+    def get_section_data(self, obj):
+        """Returns two things: a list of objects and a cut plane"""
+
+        from nativeifc import ifc_tools  # lazy import
+        import Part
+
+        if not obj.IfcClass == "IfcAnnotation":
+            return None, None
+        if obj.ObjectType != "DRAWING":
+            return None, None
+        objs = getattr(obj, "Objects", [])
+        if not objs:
+            # no object defined, we automatically use the project
+            objs = []
+            proj = ifc_tools.get_project(obj)
+            if isinstance(proj, FreeCAD.DocumentObject):
+                objs.append(proj)
+            objs.extend(ifc_tools.get_freecad_children(proj))
+        if objs:
+            s = []
+            for o in objs:
+                # TODO print a better message
+                if o.ShapeMode != "Shape":
+                    s.append(o)
+            if s:
+                FreeCAD.Console.PrintLog("DEBUG: Generating shapes. This might take some time...\n")
+                for o in s:
+                        o.ShapeMode = "Shape"
+                        o.recompute()
+            l = 1
+            h = 1
+            if obj.ViewObject:
+                if hasattr(obj.ViewObject,"DisplayLength"):
+                    l = obj.ViewObject.DisplayLength.Value
+                    h = obj.ViewObject.DisplayHeight.Value
+            plane = Part.makePlane(l,h,FreeCAD.Vector(l/2,-h/2,0),FreeCAD.Vector(0,0,1))
+            plane.Placement = obj.Placement
+            return objs, plane
+        else:
+            return None, None
 
 
 class document_object:

--- a/src/Mod/BIM/nativeifc/ifc_objects.py
+++ b/src/Mod/BIM/nativeifc/ifc_objects.py
@@ -214,11 +214,11 @@ class ifc_object:
                 l = w = h = 1000
                 if obj.ViewObject:
                     if obj.ViewObject.DisplayLength.Value:
-                        l = ifc_export.get_scaled_value(obj.ViewObject.DisplayLength.Value)
+                        l = ifc_export.get_scaled_value(obj.ViewObject.DisplayLength.Value, ifcfile)
                     if obj.ViewObject.DisplayHeight.Value:
-                        w = ifc_export.get_scaled_value(obj.ViewObject.DisplayHeight.Value)
+                        w = ifc_export.get_scaled_value(obj.ViewObject.DisplayHeight.Value, ifcfile)
                 if obj.Depth.Value:
-                    h = ifc_export.get_scaled_value(obj.Depth.Value)
+                    h = ifc_export.get_scaled_value(obj.Depth.Value, ifcfile)
                 if elt.Representation.Representations:
                     for rep in elt.Representation.Representations:
                         for item in rep.Items:
@@ -356,9 +356,9 @@ class ifc_object:
         import Part
 
         if not obj.IfcClass == "IfcAnnotation":
-            return None, None
+            return [], None
         if obj.ObjectType != "DRAWING":
-            return None, None
+            return [], None
         objs = getattr(obj, "Objects", [])
         if not objs:
             # no object defined, we automatically use the project
@@ -388,7 +388,8 @@ class ifc_object:
             plane.Placement = obj.Placement
             return objs, plane
         else:
-            return None, None
+            print("DEBUG: Section plane returned no objects")
+            return [], None
 
 
 class document_object:

--- a/src/Mod/BIM/nativeifc/ifc_status.py
+++ b/src/Mod/BIM/nativeifc/ifc_status.py
@@ -355,6 +355,7 @@ def lock_document():
     from nativeifc import ifc_tools  # lazy loading
     from importers import exportIFC
     from nativeifc import ifc_geometry
+    from nativeifc import ifc_export
     from PySide import QtCore
 
     doc = FreeCAD.ActiveDocument
@@ -379,7 +380,7 @@ def lock_document():
             if rest:
                 # 1b some objects are outside
                 objs = find_toplevel(rest)
-                prefs, context = ifc_tools.get_export_preferences(ifcfile)
+                prefs, context = ifc_export.get_export_preferences(ifcfile)
                 products = exportIFC.export(objs, ifcfile, preferences=prefs)
                 for product in products.values():
                     if not getattr(product, "ContainedInStructure", None):
@@ -416,7 +417,7 @@ def lock_document():
             ifc_tools.convert_document(doc, silent=True)
             ifcfile = doc.Proxy.ifcfile
             objs = find_toplevel(doc.Objects)
-            prefs, context = ifc_tools.get_export_preferences(ifcfile)
+            prefs, context = ifc_export.get_export_preferences(ifcfile)
             exportIFC.export(objs, ifcfile, preferences=prefs)
             for n in [o.Name for o in doc.Objects]:
                 if doc.getObject(n):

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -259,6 +259,8 @@ def create_object(ifcentity, document, ifcfile, shapemode=0, objecttype=None):
         if ifcentity.is_a("IfcAnnotation"):
             if ifc_export.get_text(ifcentity):
                 objecttype = "text"
+            elif ifc_export.get_dimension(ifcentity):
+                objecttype = "dimension"
     FreeCAD.Console.PrintLog(s)
     obj = add_object(document, otype=objecttype)
     add_properties(obj, ifcfile, ifcentity, shapemode=shapemode)
@@ -483,11 +485,21 @@ def add_object(document, otype=None, oname="IfcObject"):
     'material',
     'layer',
     'text',
+    'dimension',
     or anything else for a standard IFC object"""
 
     if not document:
         return None
-    if otype == "text":
+    if otype == "dimension":
+        obj = Draft.make_dimension(FreeCAD.Vector(), FreeCAD.Vector(1,0,0))
+        obj.Proxy = ifc_objects.ifc_object(otype)
+        obj.removeProperty("Diameter")
+        obj.removeProperty("Distance")
+        obj.setPropertyStatus("LinkedGeometry", "Hidden")
+        obj.setGroupOfProperty("Start", "Dimension")
+        obj.setGroupOfProperty("End", "Dimension")
+        obj.setGroupOfProperty("Direction", "Dimension")
+    elif otype == "text":
         obj = Draft.make_text("")
         obj.Proxy = ifc_objects.ifc_object(otype)
     elif otype == "layer":
@@ -653,6 +665,24 @@ def add_properties(
                 obj.addProperty("App::PropertyStringList", "Text", "Base")
             obj.Text = [text.Literal]
             obj.Placement = ifc_export.get_placement(ifcentity.ObjectPlacement, ifcfile)
+        else:
+            dim = ifc_export.get_dimension(ifcentity)
+            if dim and len(dim) >= 3:
+                # the two props below are already taken care of, normally
+                if "Start" not in obj.PropertiesList:
+                    obj.addProperty("App::PropertyVectorDistance", "Start", "Base")
+                if "End" not in obj.PropertiesList:
+                    obj.addProperty("App::PropertyVectorDistance", "End", "Base")
+                if "Dimline" not in obj.PropertiesList:
+                    obj.addProperty("App::PropertyVectorDistance", "Dimline", "Base")
+                obj.Start = dim[1]
+                obj.End = dim[2]
+                if len(dim) > 3:
+                    obj.Dimline = dim[3]
+                else:
+                    mid = obj.End.sub(obj.Start)
+                    mid.multiply(0.5)
+                    obj.Dimline = obj.Start.add(mid)
     # link Label2 and Description
     if "Description" in obj.PropertiesList and hasattr(obj, "setExpression"):
         obj.setExpression("Label2", "Description")

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -253,7 +253,7 @@ def create_object(ifcentity, document, ifcfile, shapemode=0, objecttype=None):
     if exobj:
         return exobj
     s = "IFC: Created #{}: {}, '{}'\n".format(
-        ifcentity.id(), ifcentity.is_a(), ifcentity.Name
+        ifcentity.id(), ifcentity.is_a(), getattr(ifcentity, "Name", "")
     )
     objecttype = ifc_export.get_object_type(ifcentity, objecttype)
     FreeCAD.Console.PrintLog(s)
@@ -494,6 +494,7 @@ def add_object(document, otype=None, oname="IfcObject"):
     'text',
     'dimension',
     'sectionplane',
+    'axis',
     or anything else for a standard IFC object"""
 
     if not document:
@@ -501,6 +502,15 @@ def add_object(document, otype=None, oname="IfcObject"):
     if otype == "sectionplane":
         obj = Arch.makeSectionPlane()
         obj.Proxy = ifc_objects.ifc_object(otype)
+    elif otype == "axis":
+        obj = Arch.makeAxis()
+        obj.Proxy = ifc_objects.ifc_object(otype)
+        obj.removeProperty("Angles")
+        obj.removeProperty("Distances")
+        obj.removeProperty("Labels")
+        obj.removeProperty("Limit")
+        if obj.ViewObject:
+            obj.ViewObject.DisplayMode = "Flat Lines"
     elif otype == "dimension":
         obj = Draft.make_dimension(FreeCAD.Vector(), FreeCAD.Vector(1,0,0))
         obj.Proxy = ifc_objects.ifc_object(otype)
@@ -666,7 +676,18 @@ def add_properties(
             if value is not None:
                 setattr(obj, attr, str(value))
     # annotation properties
-    if ifcentity.is_a("IfcAnnotation"):
+    if ifcentity.is_a("IfcGridAxis"):
+        axisdata = ifc_export.get_axis(ifcentity)
+        if axisdata:
+            if "Placement" not in obj.PropertiesList:
+                obj.addProperty("App::PropertyPlacement", "Placement", "Base")
+            if "CustomText" in obj.PropertiesList:
+                obj.setPropertyStatus("CustomText", "Hidden")
+                obj.setExpression("CustomText", "AxisTag")
+            if "Length" not in obj.PropertiesList:
+                obj.addProperty("App::PropertyLength","Length","Axis")
+            obj.Length = axisdata[1]
+    elif ifcentity.is_a("IfcAnnotation"):
         sectionplane = ifc_export.get_sectionplane(ifcentity)
         if sectionplane:
             if "Placement" not in obj.PropertiesList:
@@ -1028,6 +1049,13 @@ def set_placement(obj):
     if obj.Class in ["IfcProject", "IfcProjectLibrary"]:
         return
     element = get_ifc_element(obj)
+    if not hasattr(element, "ObjectPlacement"):
+        # special case: this is a grid axis, it has no placement
+        if element.is_a("IfcGridAxis"):
+            return set_axis_points(obj, element, ifcfile)
+        # other cases of objects without ObjectPlacement?
+        print("DEBUG: object without ObjectPlacement",element)
+        return False
     placement = FreeCAD.Placement(obj.Placement)
     placement.Base = FreeCAD.Vector(placement.Base).multiply(get_scale(ifcfile))
     new_matrix = get_ios_matrix(placement)
@@ -1050,6 +1078,29 @@ def set_placement(obj):
         api = "geometry.edit_object_placement"
         api_run(api, ifcfile, product=element, matrix=new_matrix, is_si=False)
         return True
+    return False
+
+
+def set_axis_points(obj, element, ifcfile):
+    """Sets the points of an axis from placement and length"""
+
+    if element.AxisCurve.is_a("IfcPolyline"):
+        p1 = obj.Placement.Base
+        p2 = obj.Placement.multVec(FreeCAD.Vector(0, obj.Length.Value, 0))
+        api_run(
+            "attribute.edit_attributes",
+            ifcfile,
+            product=element.AxisCurve.Points[0],
+            attributes={"Coordinates": tuple(p1)},
+        )
+        api_run(
+            "attribute.edit_attributes",
+            ifcfile,
+            product=element.AxisCurve.Points[-1],
+            attributes={"Coordinates": tuple(p2)},
+        )
+        return True
+    print("DEBUG: unhandled axis type:",element.AxisCurve.is_a())
     return False
 
 
@@ -1218,6 +1269,7 @@ def create_relationship(old_obj, obj, parent, element, ifcfile, mode=None):
         parent_element = get_ifc_element(parent)
     else:
         parent_element = parent
+    uprel = None
     # case 4: anything inside group
     if parent_element.is_a("IfcGroup"):
         # special case: adding a section plane to a grouo turns it into a drawing
@@ -1355,7 +1407,7 @@ def create_relationship(old_obj, obj, parent, element, ifcfile, mode=None):
             "void.add_opening", ifcfile, opening=element, element=parent_element
         )
     # case 3: element aggregated inside other element
-    else:
+    elif element.is_a("IfcProduct"):
         try:
             api_run("aggregate.unassign_object", ifcfile, products=[element])
         except:

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -1216,7 +1216,17 @@ def create_relationship(old_obj, obj, parent, element, ifcfile, mode=None):
         parent_element = parent
     # case 4: anything inside group
     if parent_element.is_a("IfcGroup"):
+        # special case: adding a section plane to a grouo turns it into a drawing
+        # and removes it from any containment
+        if element.is_a("IfcAnnotation") and element.ObjectType == "DRAWING":
+            parent.ObjectType = "DRAWING"
+            try:
+                api_run("spatial.unassign_container", ifcfile, products=[parent_element])
+            except:
+                # older version of IfcOpenShell
+                api_run("spatial.unassign_container", ifcfile, product=parent_element)
         # IFC objects can be part of multiple groups but we do the FreeCAD way here
+        # and remove from any previous group
         for assignment in getattr(element,"HasAssignments",[]):
             if assignment.is_a("IfcRelAssignsToGroup"):
                 if element in assignment.RelatedObjects:

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -48,6 +48,7 @@ from nativeifc import ifc_status
 from nativeifc import ifc_export
 
 from draftviewproviders import view_layer
+from PySide import QtCore
 
 SCALE = 1000.0  # IfcOpenShell works in meters, FreeCAD works in mm
 SHORT = False  # If True, only Step ID attribute is created
@@ -334,6 +335,8 @@ def create_children(
     for child in children:
         result.extend(create_child(obj, child))
     assign_groups(children)
+    # TEST: mark new objects to recompute
+    QtCore.QTimer.singleShot(0, lambda: recompute([get_object(c) for c in children]))
     return result
 
 
@@ -1419,6 +1422,9 @@ def load_orphans(obj):
             for o in rest:
                 project.Proxy.addObject(project, o)
 
+    # TEST: Try recomputing
+    QtCore.QTimer.singleShot(0, lambda: recompute(objs))
+
 
 def remove_tree(objs):
     """Removes all given objects and their children, if not used by others"""
@@ -1442,3 +1448,13 @@ def remove_tree(objs):
         doc.removeObject(n)
 
 
+def recompute(children):
+    """Temporary function to recompute objects. Some objects don't get their
+    shape correctly at creation"""
+    import time
+    stime = time.time()
+    for c in children:
+        c.touch()
+    FreeCAD.ActiveDocument.recompute()
+    endtime = "%02d:%02d" % (divmod(round(time.time() - stime, 1), 60))
+    print("DEBUG: Extra recomputing of",len(children),"objects took",endtime)

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -843,6 +843,9 @@ def set_attribute(ifcfile, element, attribute, value):
             return False
         if not val1 and not val2:
             return False
+        if isinstance(val1, (tuple, list)):
+            if tuple(val1) == tuple(val2):
+                return False
         if val1 is None and "NOTDEFINED" in str(val2).upper():
             return False
         if val1 is None and "UNDEFINED" in str(val2).upper():
@@ -882,12 +885,13 @@ def set_attribute(ifcfile, element, attribute, value):
         ):
             # do not consider default FreeCAD names given to unnamed alements
             return False
-        if differs(getattr(element, attribute, None),value):
+        if differs(getattr(element, attribute, None), value):
             FreeCAD.Console.PrintLog(
                 "Changing IFC attribute value of "
                 + str(attribute)
                 + ": "
                 + str(value)
+                + " (original value:" +str(getattr(element, attribute))+")"
                 + "\n"
             )
             api_run(cmd, ifcfile, product=element, attributes=attribs)

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -255,12 +255,7 @@ def create_object(ifcentity, document, ifcfile, shapemode=0, objecttype=None):
     s = "IFC: Created #{}: {}, '{}'\n".format(
         ifcentity.id(), ifcentity.is_a(), ifcentity.Name
     )
-    if not objecttype:
-        if ifcentity.is_a("IfcAnnotation"):
-            if ifc_export.get_dimension(ifcentity):
-                objecttype = "dimension"
-            elif ifc_export.get_text(ifcentity):
-                objecttype = "text"
+    objecttype = ifc_export.get_object_type(ifcentity, objecttype)
     FreeCAD.Console.PrintLog(s)
     obj = add_object(document, otype=objecttype)
     add_properties(obj, ifcfile, ifcentity, shapemode=shapemode)
@@ -399,6 +394,18 @@ def get_children(
     return result
 
 
+def get_freecad_children(obj):
+    """Returns the childen of this object that exist in the documemt"""
+
+    objs = []
+    children = get_children(obj)
+    for child in children:
+        childobj = get_object(child)
+        if childobj:
+            objs.extend(get_freecad_children(childobj))
+    return objs
+
+
 def get_object(element, document=None, ifcfile=None):
     """Returns the object that references this element, if any"""
 
@@ -486,11 +493,15 @@ def add_object(document, otype=None, oname="IfcObject"):
     'layer',
     'text',
     'dimension',
+    'sectionplane',
     or anything else for a standard IFC object"""
 
     if not document:
         return None
-    if otype == "dimension":
+    if otype == "sectionplane":
+        obj = Arch.makeSectionPlane()
+        obj.Proxy = ifc_objects.ifc_object(otype)
+    elif otype == "dimension":
         obj = Draft.make_dimension(FreeCAD.Vector(), FreeCAD.Vector(1,0,0))
         obj.Proxy = ifc_objects.ifc_object(otype)
         obj.removeProperty("Diameter")
@@ -656,31 +667,51 @@ def add_properties(
                 setattr(obj, attr, str(value))
     # annotation properties
     if ifcentity.is_a("IfcAnnotation"):
-        dim = ifc_export.get_dimension(ifcentity)
-        if dim and len(dim) >= 3:
-            if "Start" not in obj.PropertiesList:
-                obj.addProperty("App::PropertyVectorDistance", "Start", "Base")
-            if "End" not in obj.PropertiesList:
-                obj.addProperty("App::PropertyVectorDistance", "End", "Base")
-            if "Dimline" not in obj.PropertiesList:
-                obj.addProperty("App::PropertyVectorDistance", "Dimline", "Base")
-            obj.Start = dim[1]
-            obj.End = dim[2]
-            if len(dim) > 3:
-                obj.Dimline = dim[3]
-            else:
-                mid = obj.End.sub(obj.Start)
-                mid.multiply(0.5)
-                obj.Dimline = obj.Start.add(mid)
+        sectionplane = ifc_export.get_sectionplane(ifcentity)
+        if sectionplane:
+            if "Placement" not in obj.PropertiesList:
+                obj.addProperty("App::PropertyPlacement", "Placement", "Base")
+            if "Depth" not in obj.PropertiesList:
+                obj.addProperty("App::PropertyLength","Depth","SectionPlane")
+            obj.Placement = sectionplane[0]
+            if len(sectionplane) > 3:
+                obj.Depth = sectionplane[3]
+            vobj = obj.ViewObject
+            if vobj:
+                if "DisplayLength" not in vobj.PropertiesList:
+                    vobj.addProperty("App::PropertyLength","DisplayLength","SectionPlane")
+                if "DisplayHeight" not in vobj.PropertiesList:
+                    vobj.addProperty("App::PropertyLength","DisplayHeight","SectionPlane")
+                if len(sectionplane) > 1:
+                    vobj.DisplayLength = sectionplane[1]
+                if len(sectionplane) > 2:
+                    vobj.DisplayHeight = sectionplane[2]
         else:
-            text = ifc_export.get_text(ifcentity)
-            if text:
-                if "Placement" not in obj.PropertiesList:
-                    obj.addProperty("App::PropertyPlacement", "Placement", "Base")
-                if "Text" not in obj.PropertiesList:
-                    obj.addProperty("App::PropertyStringList", "Text", "Base")
-                obj.Text = [text.Literal]
-                obj.Placement = ifc_export.get_placement(ifcentity.ObjectPlacement, ifcfile)
+            dim = ifc_export.get_dimension(ifcentity)
+            if dim and len(dim) >= 3:
+                if "Start" not in obj.PropertiesList:
+                    obj.addProperty("App::PropertyVectorDistance", "Start", "Base")
+                if "End" not in obj.PropertiesList:
+                    obj.addProperty("App::PropertyVectorDistance", "End", "Base")
+                if "Dimline" not in obj.PropertiesList:
+                    obj.addProperty("App::PropertyVectorDistance", "Dimline", "Base")
+                obj.Start = dim[1]
+                obj.End = dim[2]
+                if len(dim) > 3:
+                    obj.Dimline = dim[3]
+                else:
+                    mid = obj.End.sub(obj.Start)
+                    mid.multiply(0.5)
+                    obj.Dimline = obj.Start.add(mid)
+            else:
+                text = ifc_export.get_text(ifcentity)
+                if text:
+                    if "Placement" not in obj.PropertiesList:
+                        obj.addProperty("App::PropertyPlacement", "Placement", "Base")
+                    if "Text" not in obj.PropertiesList:
+                        obj.addProperty("App::PropertyStringList", "Text", "Base")
+                    obj.Text = [text.Literal]
+                    obj.Placement = ifc_export.get_placement(ifcentity.ObjectPlacement, ifcfile)
 
     # link Label2 and Description
     if "Description" in obj.PropertiesList and hasattr(obj, "setExpression"):
@@ -1141,7 +1172,7 @@ def get_ifctype(obj):
     if dtype in ["App::Part","Part::Compound","Array"]:
         return "IfcElementAssembly"
     if dtype in ["App::DocumentObjectGroup"]:
-        ifctype = "IfcGroup"
+        return "IfcGroup"
     return "IfcBuildingElementProxy"
 
 

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -257,10 +257,10 @@ def create_object(ifcentity, document, ifcfile, shapemode=0, objecttype=None):
     )
     if not objecttype:
         if ifcentity.is_a("IfcAnnotation"):
-            if ifc_export.get_text(ifcentity):
-                objecttype = "text"
-            elif ifc_export.get_dimension(ifcentity):
+            if ifc_export.get_dimension(ifcentity):
                 objecttype = "dimension"
+            elif ifc_export.get_text(ifcentity):
+                objecttype = "text"
     FreeCAD.Console.PrintLog(s)
     obj = add_object(document, otype=objecttype)
     add_properties(obj, ifcfile, ifcentity, shapemode=shapemode)
@@ -656,33 +656,32 @@ def add_properties(
                 setattr(obj, attr, str(value))
     # annotation properties
     if ifcentity.is_a("IfcAnnotation"):
-        text = ifc_export.get_text(ifcentity)
-        if text:
-            # the two props below are already taken care of, normally
-            if "Placement" not in obj.PropertiesList:
-                obj.addProperty("App::PropertyPlacement", "Placement", "Base")
-            if "Text" not in obj.PropertiesList:
-                obj.addProperty("App::PropertyStringList", "Text", "Base")
-            obj.Text = [text.Literal]
-            obj.Placement = ifc_export.get_placement(ifcentity.ObjectPlacement, ifcfile)
+        dim = ifc_export.get_dimension(ifcentity)
+        if dim and len(dim) >= 3:
+            if "Start" not in obj.PropertiesList:
+                obj.addProperty("App::PropertyVectorDistance", "Start", "Base")
+            if "End" not in obj.PropertiesList:
+                obj.addProperty("App::PropertyVectorDistance", "End", "Base")
+            if "Dimline" not in obj.PropertiesList:
+                obj.addProperty("App::PropertyVectorDistance", "Dimline", "Base")
+            obj.Start = dim[1]
+            obj.End = dim[2]
+            if len(dim) > 3:
+                obj.Dimline = dim[3]
+            else:
+                mid = obj.End.sub(obj.Start)
+                mid.multiply(0.5)
+                obj.Dimline = obj.Start.add(mid)
         else:
-            dim = ifc_export.get_dimension(ifcentity)
-            if dim and len(dim) >= 3:
-                # the two props below are already taken care of, normally
-                if "Start" not in obj.PropertiesList:
-                    obj.addProperty("App::PropertyVectorDistance", "Start", "Base")
-                if "End" not in obj.PropertiesList:
-                    obj.addProperty("App::PropertyVectorDistance", "End", "Base")
-                if "Dimline" not in obj.PropertiesList:
-                    obj.addProperty("App::PropertyVectorDistance", "Dimline", "Base")
-                obj.Start = dim[1]
-                obj.End = dim[2]
-                if len(dim) > 3:
-                    obj.Dimline = dim[3]
-                else:
-                    mid = obj.End.sub(obj.Start)
-                    mid.multiply(0.5)
-                    obj.Dimline = obj.Start.add(mid)
+            text = ifc_export.get_text(ifcentity)
+            if text:
+                if "Placement" not in obj.PropertiesList:
+                    obj.addProperty("App::PropertyPlacement", "Placement", "Base")
+                if "Text" not in obj.PropertiesList:
+                    obj.addProperty("App::PropertyStringList", "Text", "Base")
+                obj.Text = [text.Literal]
+                obj.Placement = ifc_export.get_placement(ifcentity.ObjectPlacement, ifcfile)
+
     # link Label2 and Description
     if "Description" in obj.PropertiesList and hasattr(obj, "setExpression"):
         obj.setExpression("Label2", "Description")
@@ -1184,8 +1183,35 @@ def create_relationship(old_obj, obj, parent, element, ifcfile, mode=None):
         parent_element = get_ifc_element(parent)
     else:
         parent_element = parent
+    # case 4: anything inside group
+    if parent_element.is_a("IfcGroup"):
+        # IFC objects can be part of multiple groups but we do the FreeCAD way here
+        for assignment in getattr(element,"HasAssignments",[]):
+            if assignment.is_a("IfcRelAssignsToGroup"):
+                if element in assignment.RelatedObjects:
+                    oldgroup = assignment.RelatingGr
+                    try:
+                        api_run(
+                            "group.unassign_group",
+                            ifcfile,
+                            products=[element],
+                            group=oldgroup
+                        )
+                    except:
+                        # older version of IfcOpenShell
+                        api_run(
+                            "group.unassign_group",
+                            ifcfile,
+                            product=element,
+                            group=oldgroup
+                        )
+        try:
+            uprel = api_run("group.assign_group", ifcfile, products=[element], group=parent_element)
+        except:
+            # older version of IfcOpenShell
+            uprel = api_run("group.assign_group", ifcfile, product=element, group=parent_element)
     # case 1: element inside spatiual structure
-    if parent_element.is_a("IfcSpatialStructureElement") and element.is_a("IfcElement"):
+    elif parent_element.is_a("IfcSpatialStructureElement") and element.is_a("IfcElement"):
         # first remove the FreeCAD object from any parent
         if old_obj:
             for old_par in old_obj.InList:

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -47,6 +47,8 @@ from nativeifc import ifc_layers
 from nativeifc import ifc_status
 from nativeifc import ifc_export
 
+from draftviewproviders import view_layer
+
 SCALE = 1000.0  # IfcOpenShell works in meters, FreeCAD works in mm
 SHORT = False  # If True, only Step ID attribute is created
 ROUND = 8  # rounding value for placements
@@ -243,7 +245,7 @@ def api_run(*args, **kwargs):
     return result
 
 
-def create_object(ifcentity, document, ifcfile, shapemode=0):
+def create_object(ifcentity, document, ifcfile, shapemode=0, objecttype=None):
     """Creates a FreeCAD object from an IFC entity"""
 
     exobj = get_object(ifcentity, document)
@@ -253,7 +255,7 @@ def create_object(ifcentity, document, ifcfile, shapemode=0):
         ifcentity.id(), ifcentity.is_a(), ifcentity.Name
     )
     FreeCAD.Console.PrintLog(s)
-    obj = add_object(document)
+    obj = add_object(document, otype=objecttype)
     add_properties(obj, ifcfile, ifcentity, shapemode=shapemode)
     ifc_layers.add_layers(obj, ifcentity, ifcfile)
     if FreeCAD.GuiUp:
@@ -460,37 +462,41 @@ def can_expand(obj, ifcfile=None):
 
 def add_object(document, otype=None, oname="IfcObject"):
     """adds a new object to a FreeCAD document.
-    otype can be 'project', 'group', 'material', 'layer' or None (normal object)"""
+    otype can be:
+    'project',
+    'group',
+    'material',
+    'layer',
+    'text',
+    or anything else for a standard IFC object"""
 
     if not document:
         return None
-    proxy = ifc_objects.ifc_object(otype)
-    if otype == "group":
-        proxy = None
-        ftype = "App::DocumentObjectGroupPython"
-    elif otype == "material":
-        ftype = "App::MaterialObjectPython"
+    if otype == "text":
+        obj = Draft.make_text("")
+        obj.Proxy = ifc_objects.ifc_object(otype)
     elif otype == "layer":
-        ftype = "App::FeaturePython"
-    else:
-        ftype = "Part::FeaturePython"
-    if otype == "project":
-        vp = ifc_viewproviders.ifc_vp_document()
+        proxy = ifc_objects.ifc_object(otype)
+        obj = document.addObject("App::FeaturePython", oname, proxy, None, False)
+        if obj.ViewObject:
+            view_layer.ViewProviderLayer(obj.ViewObject)
+            obj.ViewObject.addProperty("App::PropertyBool", "HideChildren", "Layer")
+            obj.ViewObject.HideChildren = True
     elif otype == "group":
-        vp = ifc_viewproviders.ifc_vp_group()
+        vproxy = ifc_viewproviders.ifc_vp_group()
+        obj = document.addObject("App::DocumentObjectGroupPython", oname, None, vproxy, False)
     elif otype == "material":
-        vp = ifc_viewproviders.ifc_vp_material()
-    elif otype == "layer":
-        vp = None
-    else:
-        vp = ifc_viewproviders.ifc_vp_object()
-    obj = document.addObject(ftype, oname, proxy, vp, False)
-    if obj.ViewObject and otype == "layer":
-        from draftviewproviders import view_layer  # lazy import
-
-        view_layer.ViewProviderLayer(obj.ViewObject)
-        obj.ViewObject.addProperty("App::PropertyBool", "HideChildren", "Layer")
-        obj.ViewObject.HideChildren = True
+        proxy = ifc_objects.ifc_object(otype)
+        vproxy = ifc_viewproviders.ifc_vp_material()
+        obj = document.addObject("App::MaterialObjectPython", oname, proxy, vproxy, False)
+    elif otype == "project":
+        proxy = ifc_objects.ifc_object(otype)
+        vproxy = ifc_viewproviders.ifc_vp_document()
+        obj = document.addObject("Part::FeaturePython", oname, proxy, vproxy, False)
+    else:  # default case, standard IFC object
+        proxy = ifc_objects.ifc_object(otype)
+        vproxy = ifc_viewproviders.ifc_vp_object()
+        obj = document.addObject("Part::FeaturePython", oname, proxy, vproxy, False)
     return obj
 
 
@@ -621,6 +627,17 @@ def add_properties(
                 obj.addProperty("App::PropertyString", attr, "IFC")
             if value is not None:
                 setattr(obj, attr, str(value))
+    # annotation properties
+    if ifcentity.is_a("IfcAnnotation"):
+        text = ifc_export.get_text(ifcentity)
+        if text:
+            # the two props below are already taken care of, normally
+            if "Placement" not in obj.PropertiesList:
+                obj.addProperty("App::PropertyPlacement", "Placement", "Base")
+            if "Text" not in obj.PropertiesList:
+                obj.addProperty("App::PropertyStringList", "Text", "Base")
+            obj.Text = [text.Literal]
+            obj.Placement = ifc_export.get_placement(ifcentity.ObjectPlacement, ifcfile)
     # link Label2 and Description
     if "Description" in obj.PropertiesList and hasattr(obj, "setExpression"):
         obj.setExpression("Label2", "Description")
@@ -1008,12 +1025,15 @@ def aggregate(obj, parent, mode=None):
         ifcclass = None
         if mode == "opening":
             ifcclass = "IfcOpeningElement"
+        objecttype = None
         if ifc_export.is_annotation(obj):
             product = ifc_export.create_annotation(obj, ifcfile)
+            if Draft.get_type(obj) in ["DraftText","Text"]:
+                objecttype = "text"
         else:
             product = ifc_export.create_product(obj, parent, ifcfile, ifcclass)
         shapemode = getattr(parent, "ShapeMode", DEFAULT_SHAPEMODE)
-        newobj = create_object(product, obj.Document, ifcfile, shapemode)
+        newobj = create_object(product, obj.Document, ifcfile, shapemode, objecttype)
         new = True
     create_relationship(obj, newobj, parent, product, ifcfile, mode)
     base = getattr(obj, "Base", None)
@@ -1317,7 +1337,7 @@ def remove_ifc_element(obj,delete_obj=False):
 def get_orphan_elements(ifcfile):
     """returns a list of orphan products in an ifcfile"""
 
-    products = ifcfile.by_type("IfcElement")
+    products = ifcfile.by_type("IfcProduct")
     products = [p for p in products if not p.Decomposes]
     products = [p for p in products if not p.ContainedInStructure]
     products = [

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -254,13 +254,22 @@ def create_object(ifcentity, document, ifcfile, shapemode=0, objecttype=None):
     s = "IFC: Created #{}: {}, '{}'\n".format(
         ifcentity.id(), ifcentity.is_a(), ifcentity.Name
     )
+    if not objecttype:
+        if ifcentity.is_a("IfcAnnotation"):
+            if ifc_export.get_text(ifcentity):
+                objecttype = "text"
     FreeCAD.Console.PrintLog(s)
     obj = add_object(document, otype=objecttype)
     add_properties(obj, ifcfile, ifcentity, shapemode=shapemode)
     ifc_layers.add_layers(obj, ifcentity, ifcfile)
     if FreeCAD.GuiUp:
-        if ifcentity.is_a("IfcSpace") or ifcentity.is_a("IfcOpeningElement"):
-            obj.ViewObject.DisplayMode = "Wireframe"
+        if ifcentity.is_a("IfcSpace") or\
+           ifcentity.is_a("IfcOpeningElement") or\
+           ifcentity.is_a("IfcAnnotation"):
+            try:
+                obj.ViewObject.DisplayMode = "Wireframe"
+            except:
+                pass
     elements = [ifcentity]
     return obj
 
@@ -328,9 +337,10 @@ def create_children(
     return result
 
 
-def assign_groups(children):
-    """Fill the groups inthis list"""
+def assign_groups(children, ifcfile=None):
+    """Fill the groups in this list. Returns a list of processed FreeCAD objects"""
 
+    result = []
     for child in children:
         if child.is_a("IfcGroup"):
             mode = "IsGroupedBy"
@@ -339,10 +349,10 @@ def assign_groups(children):
         else:
             mode = None
         if mode:
-            grobj = get_object(child)
+            grobj = get_object(child, None, ifcfile)
             for rel in getattr(child, mode):
                 for elem in rel.RelatedObjects:
-                    elobj = get_object(elem)
+                    elobj = get_object(elem, None, ifcfile)
                     if elobj:
                         if len(elobj.InList) == 1:
                             p = elobj.InList[0]
@@ -353,6 +363,8 @@ def assign_groups(children):
                         g = grobj.Group
                         g.append(elobj)
                         grobj.Group = g
+                        result.append(elobj)
+    return result
 
 
 def get_children(
@@ -382,7 +394,7 @@ def get_children(
     return result
 
 
-def get_object(element, document=None):
+def get_object(element, document=None, ifcfile=None):
     """Returns the object that references this element, if any"""
 
     if document:
@@ -393,7 +405,7 @@ def get_object(element, document=None):
         for obj in d.Objects:
             if hasattr(obj, "StepId"):
                 if obj.StepId == element.id():
-                    if get_ifc_element(obj) == element:
+                    if get_ifc_element(obj, ifcfile) == element:
                         return obj
     return None
 
@@ -1343,6 +1355,14 @@ def get_orphan_elements(ifcfile):
     products = [
         p for p in products if not hasattr(p, "VoidsElements") or not p.VoidsElements
     ]
+    groups = []
+    for o in products:
+        for rel in getattr(o, "HasAssignments", []):
+            if rel.is_a("IfcRelAssignsToGroup"):
+                g = rel.RelatingGroup
+                if (g not in products) and (g not in groups):
+                    groups.append(g)
+    products.extend(groups)
     return products
 
 
@@ -1384,8 +1404,20 @@ def load_orphans(obj):
     ifcfile = get_ifcfile(obj)
     shapemode = obj.ShapeMode
     elements = get_orphan_elements(ifcfile)
+    objs = []
     for element in elements:
-        create_object(element, doc, ifcfile, shapemode)
+        nobj = create_object(element, doc, ifcfile, shapemode)
+        objs.append(nobj)
+    processed = assign_groups(elements, ifcfile)
+
+    # put things under project. This is important so orphan elements still can find
+    # their IFC file
+    rest = [o for o in objs if o not in processed]
+    if rest:
+        project = get_project(ifcfile)
+        if isinstance(project, FreeCAD.DocumentObject):
+            for o in rest:
+                project.Proxy.addObject(project, o)
 
 
 def remove_tree(objs):

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -427,7 +427,7 @@ def get_svg(obj,
     # all the SVG strings from the contents of the group
     if hasattr(obj, "isDerivedFrom"):
         if (obj.isDerivedFrom("App::DocumentObjectGroup")
-                or utils.get_type(obj) in ["Layer", "BuildingPart"]
+                or utils.get_type(obj) in ["Layer", "BuildingPart", "IfcGroup"]
                 or obj.isDerivedFrom("App::LinkGroup")
                 or (obj.isDerivedFrom("App::Link")
                         and obj.LinkedObject.isDerivedFrom("App::DocumentObjectGroup"))):
@@ -546,7 +546,8 @@ def get_svg(obj,
         svg = _svg_shape(svg, obj, plane,
                          fillstyle, pathdata, stroke, linewidth, lstyle)
 
-    elif utils.get_type(obj) in ["Dimension", "LinearDimension"]:
+    elif (utils.get_type(obj) in ["Dimension", "LinearDimension"]
+            or (utils.get_type(obj) == "IfcAnnotation" and obj.ObjectType == "DIMENSION")):
         svg = _svg_dimension(obj, plane, scale, linewidth, fontsize,
                              stroke, tstroke, pointratio, techdraw, rotation)
 
@@ -690,7 +691,8 @@ def get_svg(obj,
                                     rotation, position, text,
                                     linespacing, justification)
 
-    elif utils.get_type(obj) in ["Annotation", "DraftText", "Text"]:
+    elif (utils.get_type(obj) in ["Annotation", "DraftText", "Text"]
+        or (utils.get_type(obj) == "IfcAnnotation" and obj.ObjectType == "TEXT")):
         # returns an svg representation of a document annotation
         if not App.GuiUp:
             _wrn("Export of texts to SVG is only available in GUI mode")

--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -213,11 +213,15 @@ class Shape2DView(DraftObject):
         import DraftGeomUtils
         pl = obj.Placement
         if obj.Base:
-            if utils.get_type(obj.Base) in ["BuildingPart","SectionPlane"]:
+            if utils.get_type(obj.Base) in ["BuildingPart","SectionPlane","IfcAnnotation"]:
                 objs = []
                 if utils.get_type(obj.Base) == "SectionPlane":
                     objs = self.excludeNames(obj,obj.Base.Objects)
                     cutplane = obj.Base.Shape
+                elif utils.get_type(obj.Base) == "IfcAnnotation":
+                    # this is a NativeIFC section plane
+                    objs, cutplane = obj.Base.Proxy.get_section_data(obj.Base)
+                    objs = self.excludeNames(obj, objs)
                 else:
                     objs = self.excludeNames(obj,obj.Base.Group)
                     cutplane = Part.makePlane(1000, 1000, App.Vector(-500, -500, 0))


### PR DESCRIPTION
This is support for 2D objects in NativeIFC. Corresponds to item 6.A from https://github.com/yorikvanhavre/FreeCAD-NativeIFC/blob/main/doc/roadmap2024.md

With this, one is now able to embed 2D objects (linework, texts, dimensions) inside IFC files, as well as handle such entities produced by other BIM apps (Basically BlenderBIM/Bonsai), and define "Drawings", which are basically a section plane inside a group, which can contain other 2D entities too that compose the drawing.

One can now create groups inside IFC documents and place section planes inside, and these are interpreted correctly by BlenderBIM/Bonsai too.

- [x] Basic import/export structure
- [x] Support for linework
- [x] Support for texts
- [x] Support for dimensions
- [x] Support for hatches
- [x] Support for section planes (drawings)
- [x] Support for axes (needs some refactor of the Axis VP later on)
- [x] 2D elements grouped into a group with ObjectType == "DRAWING" should be imported as one (expandable) drawing object
- [x] 2D elements under root: A new Drawing object should be created