### PR TITLE
[TD]Balloon origin drag modifiers (fix #15388)

### DIFF
--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -612,3 +612,32 @@ double Preferences::SnapLimitFactor()
 }
 
 
+//! returns the key combination that simulates multiple selection. Traditionally Ctrl+pick, as that
+//! is how QGraphicsScene implements multiple selection.  This method is likely to only be used by
+//! developers.
+Qt::KeyboardModifiers Preferences::multiselectModifiers()
+{
+    uint iModifiers = getPreferenceGroup("General")->GetUnsigned("MultiselectModifiers", (uint)Qt::ControlModifier);
+    return (Qt::KeyboardModifiers)iModifiers;
+//    Qt::KeyboardModifiers testMods = Qt::ControlModifier;
+//    return testMods;
+}
+
+
+//! returns the key combination that modifies Balloon drag behaviour so that the bubble and leader
+//! are moved together.  Traditionally Ctrl+drag, but that can be in conflict with multi selection.
+Qt::KeyboardModifiers Preferences::balloonDragModifiers()
+{
+    uint iModifiers = getPreferenceGroup("General")->GetUnsigned("BalloonDragModifier", (uint)Qt::ControlModifier);
+    return (Qt::KeyboardModifiers)iModifiers;
+//    Qt::KeyboardModifiers testMods = Qt::ShiftModifier | Qt::ControlModifier;
+//    return testMods;
+}
+
+
+void Preferences::setBalloonDragModifiers(Qt::KeyboardModifiers newModifiers)
+{
+    getPreferenceGroup("General")->SetUnsigned("BalloonDragModifier", (uint)newModifiers);
+}
+
+

--- a/src/Mod/TechDraw/App/Preferences.h
+++ b/src/Mod/TechDraw/App/Preferences.h
@@ -23,6 +23,7 @@
 #ifndef Preferences_h_
 #define Preferences_h_
 
+#include <Qt>
 #include <string>
 
 #include <Base/Parameter.h>
@@ -141,6 +142,11 @@ public:
 
     static bool SnapViews();
     static double SnapLimitFactor();
+
+    static Qt::KeyboardModifiers multiselectModifiers();
+
+    static Qt::KeyboardModifiers balloonDragModifiers();
+    static void setBalloonDragModifiers(Qt::KeyboardModifiers newModifiers);
 };
 
 

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>474</width>
-    <height>424</height>
+    <width>700</width>
+    <height>810</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -444,6 +444,149 @@ can be a performance penalty in complex models.</string>
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="gbBehaviour">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Some combinations of OS and Navigation style key bindings may conflict with the default modifier keys for Ballon dragging and View snapping override.  You can make adjustments here to find a non-conflicting key binding.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="title">
+      <string>Behaviour Overrides</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="cbBalloonDefault">
+          <property name="toolTip">
+           <string>Check this box to use the default modifier keys.  Uncheck this box to set a different key combination.</string>
+          </property>
+          <property name="text">
+           <string>Use Default</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QCheckBox" name="cbSnapShift">
+          <property name="toolTip">
+           <string>Check this box to include the Shift key in the modifiers.</string>
+          </property>
+          <property name="text">
+           <string>Shift</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QCheckBox" name="cbSnapDefault">
+          <property name="toolTip">
+           <string>Check this box to use the default modifier keys.  Uncheck this box to set a different key combination.</string>
+          </property>
+          <property name="text">
+           <string>Use Default</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QCheckBox" name="cbBalloonShift">
+          <property name="toolTip">
+           <string>Check this box to include the Shift key in the modifiers.</string>
+          </property>
+          <property name="text">
+           <string>Shift</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QCheckBox" name="cbSnapAlt">
+          <property name="toolTip">
+           <string>Check this box to include the Alt key in the modifiers.</string>
+          </property>
+          <property name="text">
+           <string>Alt</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QCheckBox" name="cbBalloonMeta">
+          <property name="toolTip">
+           <string>Check this box to include the Meta/Start/Super key in the modifiers.</string>
+          </property>
+          <property name="text">
+           <string>Meta</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Balloon Drag</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Snap Override</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="QCheckBox" name="cbSnapControl">
+          <property name="toolTip">
+           <string>Check this box to include the Control key in the modifiers.</string>
+          </property>
+          <property name="text">
+           <string>Control</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QCheckBox" name="cbBalloonControl">
+          <property name="toolTip">
+           <string>Check this box to include the Control key in the modifiers.</string>
+          </property>
+          <property name="text">
+           <string>Control</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="QCheckBox" name="cbSnapMeta">
+          <property name="toolTip">
+           <string>Check this box to include the Meta/Start/Super key in the modifiers.</string>
+          </property>
+          <property name="text">
+           <string>Meta</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="cbBalloonAlt">
+          <property name="toolTip">
+           <string>Check this box to include the Alt key in the modifiers.</string>
+          </property>
+          <property name="text">
+           <string>Alt</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="label_17">
      <property name="font">
       <font>
@@ -469,8 +612,8 @@ can be a performance penalty in complex models.</string>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>17</width>
-       <height>1</height>
+       <width>20</width>
+       <height>40</height>
       </size>
      </property>
     </spacer>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
@@ -467,56 +467,10 @@ can be a performance penalty in complex models.</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
-         <widget class="QCheckBox" name="cbSnapShift">
-          <property name="toolTip">
-           <string>Check this box to include the Shift key in the modifiers.</string>
-          </property>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_8">
           <property name="text">
-           <string>Shift</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QCheckBox" name="cbSnapDefault">
-          <property name="toolTip">
-           <string>Check this box to use the default modifier keys.  Uncheck this box to set a different key combination.</string>
-          </property>
-          <property name="text">
-           <string>Use Default</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QCheckBox" name="cbBalloonShift">
-          <property name="toolTip">
-           <string>Check this box to include the Shift key in the modifiers.</string>
-          </property>
-          <property name="text">
-           <string>Shift</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QCheckBox" name="cbSnapAlt">
-          <property name="toolTip">
-           <string>Check this box to include the Alt key in the modifiers.</string>
-          </property>
-          <property name="text">
-           <string>Alt</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QCheckBox" name="cbBalloonMeta">
-          <property name="toolTip">
-           <string>Check this box to include the Meta/Start/Super key in the modifiers.</string>
-          </property>
-          <property name="text">
-           <string>Meta</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -524,43 +478,6 @@ can be a performance penalty in complex models.</string>
          <widget class="QLabel" name="label_6">
           <property name="text">
            <string>Balloon Drag</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Snap Override</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QCheckBox" name="cbSnapControl">
-          <property name="toolTip">
-           <string>Check this box to include the Control key in the modifiers.</string>
-          </property>
-          <property name="text">
-           <string>Control</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QCheckBox" name="cbBalloonControl">
-          <property name="toolTip">
-           <string>Check this box to include the Control key in the modifiers.</string>
-          </property>
-          <property name="text">
-           <string>Control</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="2">
-         <widget class="QCheckBox" name="cbSnapMeta">
-          <property name="toolTip">
-           <string>Check this box to include the Meta/Start/Super key in the modifiers.</string>
-          </property>
-          <property name="text">
-           <string>Meta</string>
           </property>
          </widget>
         </item>
@@ -574,10 +491,33 @@ can be a performance penalty in complex models.</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_8">
+        <item row="0" column="1">
+         <widget class="QCheckBox" name="cbBalloonShift">
+          <property name="toolTip">
+           <string>Check this box to include the Shift key in the modifiers.</string>
+          </property>
           <property name="text">
-           <string/>
+           <string>Shift</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QCheckBox" name="cbBalloonMeta">
+          <property name="toolTip">
+           <string>Check this box to include the Meta/Start/Super key in the modifiers.</string>
+          </property>
+          <property name="text">
+           <string>Meta</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QCheckBox" name="cbBalloonControl">
+          <property name="toolTip">
+           <string>Check this box to include the Control key in the modifiers.</string>
+          </property>
+          <property name="text">
+           <string>Control</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvancedImp.h
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvancedImp.h
@@ -44,7 +44,19 @@ public:
 protected:
     void saveSettings() override;
     void loadSettings() override;
-    void changeEvent(QEvent *e) override;
+    void changeEvent(QEvent *event) override;
+
+    void loadBalloonOverride();
+    void saveBalloonOverride();
+
+    void clearBalloonOptions();
+
+    static bool flagsContainValue(uint flags, uint value);
+
+    void makeBalloonBoxConnections();
+    void slotBalloonBoxChecked();
+    void enableBalloonOptions(bool newState);
+
 
 private:
     std::unique_ptr<Ui_DlgPrefsTechDrawAdvancedImp> ui;

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -401,6 +401,9 @@ Base::Vector3d  QGIView::projItemPagePos(DrawViewPart* item)
 
 void QGIView::mousePressEvent(QGraphicsSceneMouseEvent * event)
 {
+    // this is never called for balloons (and dimensions?) because the label objects do not
+    // inherit from QGIView, but directly from QGraphicsItem. - wf
+
     Qt::KeyboardModifiers originalModifiers = event->modifiers();
     if (event->button()&Qt::LeftButton) {
         m_multiselectActivated = false;

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -158,8 +158,8 @@ private:
 
     QColor m_colNormal;
 
-    bool m_ctrl;
-    bool m_drag;
+    bool m_originDrag;
+    bool m_dragging;
 };
 
 //*******************************************************************
@@ -220,7 +220,7 @@ public Q_SLOTS:
 
 protected:
     void draw() override;
-    void drawBalloon(bool dragged = false);
+    void drawBalloon(bool originDrag = false);
     QVariant itemChange(GraphicsItemChange change, const QVariant& value) override;
     virtual void setSvgPens();
     virtual void setPens();
@@ -248,7 +248,6 @@ private:
 
     bool m_dragInProgress;
     bool m_originDragged = false;
-    bool m_ctrl;
     Base::Vector3d m_saveOriginOffset;
     Base::Vector3d m_saveOrigin;
     Base::Vector3d m_savePosition;

--- a/src/Mod/TechDraw/Gui/QGSPage.h
+++ b/src/Mod/TechDraw/Gui/QGSPage.h
@@ -147,6 +147,8 @@ public:
     void setBalloonGroups();
     void setLeaderParentage();
 
+    static bool itemClearsSelection(int itemTypeIn);
+    static Qt::KeyboardModifiers cleanModifierList(Qt::KeyboardModifiers mods);
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;


### PR DESCRIPTION
This PR implements a fix for issue #15388.

The change includes 
- changes to obscure variable names
- replacement of hard coded modifier key definitions with preferences
- changes to the handling of modifiers in QGIBalloonLabel
- support functions added to QGSPage
- changes to advanced preference tab.

![AdvancedTab_current](https://github.com/user-attachments/assets/67829686-7f50-4844-9427-9f71f1413c4b)
![AdvancedTab_proposed](https://github.com/user-attachments/assets/017bc844-15fe-4b73-8ff5-a22fda52630b)
