### PR TITLE
Issue 16454 workaround: PropertyEditor selection colors

### DIFF
--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1357,8 +1357,10 @@ void PropertyListEditor::highlightCurrentLine()
         QTextEdit::ExtraSelection selection;
 
         QColor lineColor = QColor(Qt::yellow).lighter(160);
-
         selection.format.setBackground(lineColor);
+        QColor textColor = QColor(Qt::black);
+        selection.format.setForeground(textColor);
+
         selection.format.setProperty(QTextFormat::FullWidthSelection, true);
         selection.cursor = textCursor();
         selection.cursor.clearSelection();

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1356,10 +1356,9 @@ void PropertyListEditor::highlightCurrentLine()
     if (!isReadOnly()) {
         QTextEdit::ExtraSelection selection;
 
-        QColor lineColor = QColor(Qt::yellow).lighter(160);
-        selection.format.setBackground(lineColor);
-        QColor textColor = QColor(Qt::black);
-        selection.format.setForeground(textColor);
+        QPalette palette = style()->standardPalette();
+        selection.format.setBackground(palette.highlight().color());
+        selection.format.setForeground(palette.highlightedText().color());
 
         selection.format.setProperty(QTextFormat::FullWidthSelection, true);
         selection.cursor = textCursor();


### PR DESCRIPTION
As background is fixed yellow, then make text fixed black until a proper solution is provided to make it theme-able.