### PR TITLE
Addon Manager: Show involved branches' names on branch change operation

### DIFF
--- a/src/Mod/AddonManager/addonmanager_package_details_controller.py
+++ b/src/Mod/AddonManager/addonmanager_package_details_controller.py
@@ -21,7 +21,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-""" Provides the PackageDetails widget. """
+"""Provides the PackageDetails widget."""
 
 import os
 from typing import Optional
@@ -237,7 +237,7 @@ class PackageDetailsController(QtCore.QObject):
             self.addon.set_status(self.original_status)
         self.update_status.emit(self.addon)
 
-    def branch_changed(self, name: str) -> None:
+    def branch_changed(self, old_branch: str, name: str) -> None:
         """Displays a dialog confirming the branch changed, and tries to access the
         metadata file from that branch."""
         QtWidgets.QMessageBox.information(
@@ -245,8 +245,12 @@ class PackageDetailsController(QtCore.QObject):
             translate("AddonsInstaller", "Success"),
             translate(
                 "AddonsInstaller",
-                "Branch change succeeded, please restart to use the new version.",
-            ),
+                "Branch change succeeded.\n"
+                "Moved\n"
+                "from: {}\n"
+                "to: {}\n"
+                "Please restart to use the new version.",
+            ).format(old_branch, name),
         )
         # See if this branch has a package.xml file:
         basedir = fci.getUserAppDataDir()

--- a/src/Mod/AddonManager/change_branch.py
+++ b/src/Mod/AddonManager/change_branch.py
@@ -34,7 +34,7 @@ translate = FreeCAD.Qt.translate
 
 class ChangeBranchDialog(QtWidgets.QWidget):
 
-    branch_changed = QtCore.Signal(str)
+    branch_changed = QtCore.Signal(str, str)
 
     def __init__(self, path: str, parent=None):
         super().__init__(parent)
@@ -55,10 +55,10 @@ class ChangeBranchDialog(QtWidgets.QWidget):
         # Figure out what row gets selected:
         git_manager = initialize_git()
         row = 0
-        current_ref = git_manager.current_branch(path)
+        self.current_ref = git_manager.current_branch(path)
         selection_model = self.ui.tableView.selectionModel()
         for ref in self.item_model.branches:
-            if ref["ref_name"] == current_ref:
+            if ref["ref_name"] == self.current_ref:
                 index = self.item_filter.mapFromSource(self.item_model.index(row, 0))
                 selection_model.select(index, QtCore.QItemSelectionModel.ClearAndSelect)
                 selection_model.select(index.siblingAtColumn(1), QtCore.QItemSelectionModel.Select)
@@ -118,7 +118,7 @@ class ChangeBranchDialog(QtWidgets.QWidget):
                 gm.checkout(self.item_model.path, remote_name)
             else:
                 gm.checkout(self.item_model.path, remote_name, args=["-b", local_name])
-            self.branch_changed.emit(local_name)
+            self.branch_changed.emit(self.current_ref, local_name)
 
 
 class ChangeBranchDialogModel(QtCore.QAbstractTableModel):


### PR DESCRIPTION
![Screenshot_2024-09-18_12-30-12](https://github.com/user-attachments/assets/d9ae931d-4e1a-47ec-aca9-59ba57272de2)

Edit: want html tags to show branches on _italic_?

Fix #12969