### PR TITLE
Spreadsheet: Removes unnecessary fixme comment and closes issue

### DIFF
--- a/src/Mod/Spreadsheet/importXLSX.py
+++ b/src/Mod/Spreadsheet/importXLSX.py
@@ -329,7 +329,7 @@ def handleCells(cellList, actCellSheet, sList):
         if refType:
             cellType = getText(refType.childNodes)
         else:
-            cellType = "n"  # FIXME: some cells don't have t and s attributes
+            cellType = "n"
 
         # print("reference: ", ref, ' Cell type: ', cellType)
 


### PR DESCRIPTION
closes https://github.com/FreeCAD/FreeCAD/issues/13487

Recap:
There was a ticket created because a fixme comment in the xlsx importer looked important and overlooked.

@JonasVgt looked at the schema for xlsx files and verified that the current behaviour is correct (`t` is optional and the default is `n`).

For reference, the line JonasVgt refered to:
> `    <xsd:attribute name="t" type="ST_CellType" use="optional" default="n"/>`

Is available here:
[c071691_ISO_IEC_29500-1_2016_Electronic_inserts.zip](https://standards.iso.org/ittf/PubliclyAvailableStandards/c071691_ISO_IEC_29500-1_2016_Electronic_inserts.zip)/`OfficeOpenXML-XMLSchema-Strict/sml.xsd:2265`
