### PR TITLE
Part: fix ruled surface

### DIFF
--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -126,9 +126,15 @@ App::DocumentObjectExecReturn* RuledSurface::execute()
         std::vector<TopoShape> shapes;
         std::array<App::PropertyLinkSub*, 2> links = {&Curve1, &Curve2};
         for (auto link : links) {
+            App::DocumentObject* obj = link->getValue();
+            const Part::TopoShape part = Part::Feature::getTopoShape(obj);
+            if (part.isNull()) {
+                return new App::DocumentObjectExecReturn("No shape linked.");
+            }
+            // if no explicit sub-shape is selected use the whole part
             const auto& subs = link->getSubValues();
             if (subs.empty()) {
-                shapes.push_back(getTopoShape(link->getValue()));
+                shapes.push_back(part);
             }
             else if (subs.size() != 1) {
                 return new App::DocumentObjectExecReturn("Not exactly one sub-shape linked.");

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -2165,9 +2165,6 @@ TopoShape& TopoShape::makeElementRuledSurface(const std::vector<TopoShape>& shap
         }
         auto countOfWires = s.countSubShapes(TopAbs_WIRE);
         if (countOfWires > 1) {
-            FC_THROWM(Base::CADKernelError, "Input shape has more than one wire");
-        }
-        if (countOfWires == 1) {
             curves[i++] = s.getSubTopoShape(TopAbs_WIRE, 1);
             continue;
         }


### PR DESCRIPTION
Address issue found during #16634 investigation. Provides backwards compatibility with the implementation of Ruled Surface prior to toponaming changes.