### PR TITLE
Addon Manager: Don't crash on bad XML

### DIFF
--- a/src/Mod/AddonManager/Addon.py
+++ b/src/Mod/AddonManager/Addon.py
@@ -30,6 +30,7 @@ from urllib.parse import urlparse
 from typing import Dict, Set, List, Optional
 from threading import Lock
 from enum import IntEnum, auto
+import xml.etree.ElementTree
 
 import addonmanager_freecad_interface as fci
 from addonmanager_macro import Macro
@@ -372,7 +373,14 @@ class Addon:
         """Read a given metadata file and set it as this object's metadata"""
 
         if os.path.exists(file):
-            metadata = MetadataReader.from_file(file)
+            try:
+                metadata = MetadataReader.from_file(file)
+            except xml.etree.ElementTree.ParseError:
+                fci.Console.PrintWarning(
+                    "An invalid or corrupted package.xml file was found in the cache for"
+                )
+                fci.Console.PrintWarning(f" {self.name}... ignoring the bad data.\n")
+                return
             self.set_metadata(metadata)
             self._clean_url()
         else:
@@ -384,7 +392,14 @@ class Addon:
         mod_dir = os.path.join(self.mod_directory, self.name)
         installed_metadata_path = os.path.join(mod_dir, "package.xml")
         if os.path.isfile(installed_metadata_path):
-            self.installed_metadata = MetadataReader.from_file(installed_metadata_path)
+            try:
+                self.installed_metadata = MetadataReader.from_file(installed_metadata_path)
+            except xml.etree.ElementTree.ParseError:
+                fci.Console.PrintWarning(
+                    "An invalid or corrupted package.xml file was found in installation of"
+                )
+                fci.Console.PrintWarning(f" {self.name}... ignoring the bad data.\n")
+                return
 
     def set_metadata(self, metadata: Metadata) -> None:
         """Set the given metadata object as this object's metadata, updating the

--- a/src/Mod/AddonManager/addonmanager_workers_installation.py
+++ b/src/Mod/AddonManager/addonmanager_workers_installation.py
@@ -30,6 +30,7 @@ import json
 import os
 from typing import Dict
 from enum import Enum, auto
+import xml.etree.ElementTree
 
 from PySide import QtCore
 
@@ -188,7 +189,12 @@ class UpdateMetadataCacheWorker(QtCore.QThread):
         with open(new_xml_file, "w", encoding="utf-8") as f:
             string_data = self._ensure_string(data, repo.name, "package.xml")
             f.write(string_data)
-        metadata = MetadataReader.from_file(new_xml_file)
+        try:
+            metadata = MetadataReader.from_file(new_xml_file)
+        except xml.etree.ElementTree.ParseError:
+            fci.Console.PrintWarning("An invalid or corrupted package.xml file was downloaded for")
+            fci.Console.PrintWarning(f" {self.name}... ignoring the bad data.\n")
+            return
         repo.set_metadata(metadata)
         FreeCAD.Console.PrintLog(f"Downloaded package.xml for {repo.name}\n")
         self.status_message.emit(


### PR DESCRIPTION
Wrap all metadata reads in try/except blocks and gracefully bail out if the data is bad. Fixes #16643.