### PR TITLE
[Cam Simulator][1.0] Fix minor Ambient Occlusion bug.

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/TaskCAMSimulator.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/TaskCAMSimulator.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>288</width>
+    <width>577</width>
     <height>335</height>
    </rect>
   </property>
@@ -76,11 +76,11 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="label">
-       <property name="maximumSize">
-        <size>
-         <width>24</width>
-         <height>16777215</height>
-        </size>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
        <property name="text">
         <string>Job:</string>
@@ -88,7 +88,14 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="comboJobs"/>
+      <widget class="QComboBox" name="comboJobs">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QToolButton" name="toolButtonPlay">

--- a/src/Mod/CAM/PathSimulator/AppGL/Shader.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/Shader.cpp
@@ -126,7 +126,7 @@ void Shader::UpdateNormalTexSlot(int normalSlot)
 void Shader::UpdateNoiseTexSlot(int noiseSlot)
 {
     if (mNoisePos >= 0) {
-        glUniform1i(mAlbedoPos, noiseSlot);
+        glUniform1i(mNoisePos, noiseSlot);
     }
 }
 
@@ -464,8 +464,8 @@ const char* FragShaderSSAO = R"(
 
     // parameters (you'd probably want to use them as uniforms to more easily tweak the effect)
     int kernelSize = 64;
-    float radius = 2.5f;
-    float bias = 0.025;
+    float radius = 30f;
+    float bias = 0.01;
 
     // tile noise texture over screen based on screen dimensions divided by noise size
     const vec2 noiseScale = vec2(800.0/4.0, 600.0/4.0);
@@ -505,7 +505,7 @@ const char* FragShaderSSAO = R"(
             occlusion += (sampleDepth >= samplePos.z + bias ? 1.0 : 0.0) * rangeCheck;
         }
         occlusion = 1.0 - (occlusion / kernelSize);
-        FragColor = vec4(pow(occlusion, 2), 0, 0, 1);
+        FragColor = vec4(occlusion, 0, 0, 1);
     }
 )";
 


### PR DESCRIPTION
Edit: fixes Issue #16707 as well.

This is not a critical bug, but still is a bug.
Minor shader fix.
Maintainers - up to you if it should enter 1.0.

Before (harsh and with noisy stripes):
![image](https://github.com/user-attachments/assets/7a2f31cc-636d-4a5d-bfd0-56b5a2fb0862)

After (much smoother):
![image](https://github.com/user-attachments/assets/69918eb0-b381-4c21-a7dc-7d109666e2dd)
 
