### PR TITLE
Gui: Added SendToPythonConsole item in PartDesign tree view right-click menu.

### DIFF
--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -156,6 +156,7 @@ void Workbench::setupContextMenu(const char* recipient, Gui::MenuItem* item) con
                       << "Std_Copy"
                       << "Std_Paste"
                       << "Std_Delete"
+                      << "Std_SendToPythonConsole"
                       << "Separator";
             }
         }


### PR DESCRIPTION
Fix [#14144](https://github.com/FreeCAD/FreeCAD/issues/14144)

Right-click menu before and after:
![image](https://github.com/user-attachments/assets/809ba2c3-feee-48fd-a9cf-5a8ac764508e)


