### PR TITLE
Addon Manager: Show repository URL if it exists on the metadata

### DIFF
--- a/src/Mod/AddonManager/Widgets/addonmanager_widget_package_details_view.py
+++ b/src/Mod/AddonManager/Widgets/addonmanager_widget_package_details_view.py
@@ -92,6 +92,7 @@ class PackageDetailsView(QtWidgets.QWidget):
         self.readme_browser = None
         self.message_label = None
         self.location_label = None
+        self.url_label = None
         self.installed = False
         self.disabled = False
         self.update_info = UpdateInformation()
@@ -108,10 +109,13 @@ class PackageDetailsView(QtWidgets.QWidget):
         self.readme_browser = WidgetReadmeBrowser(self)
         self.message_label = QtWidgets.QLabel(self)
         self.location_label = QtWidgets.QLabel(self)
+        self.url_label = QtWidgets.QLabel(self)
+        self.url_label.setOpenExternalLinks(True)
         self.location_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
         self.vertical_layout.addWidget(self.button_bar)
         self.vertical_layout.addWidget(self.message_label)
         self.vertical_layout.addWidget(self.location_label)
+        self.vertical_layout.addWidget(self.url_label)
         self.vertical_layout.addWidget(self.readme_browser)
         self.button_bar.hide()  # Start with no bar
 
@@ -126,6 +130,21 @@ class PackageDetailsView(QtWidgets.QWidget):
             self.location_label.show()
         else:
             self.location_label.hide()
+
+    def set_url(self, url: Optional[str]):
+        if url is not None:
+            text = (
+                translate("AddonsInstaller", "Repository URL")
+                + ': <a href="'
+                + url
+                + '">'
+                + url
+                + "</a>"
+            )
+            self.url_label.setText(text)
+            self.url_label.show()
+        else:
+            self.url_label.hide()
 
     def set_installed(
         self,

--- a/src/Mod/AddonManager/addonmanager_metadata.py
+++ b/src/Mod/AddonManager/addonmanager_metadata.py
@@ -244,6 +244,12 @@ def get_branch_from_metadata(metadata: Metadata) -> str:
     return "master"  # Legacy default
 
 
+def get_repo_url_from_metadata(metadata: Metadata) -> str:
+    for url in metadata.url:
+        if url.type == UrlType.repository:
+            return url.location
+
+
 class MetadataReader:
     """Read metadata XML data and construct a Metadata object"""
 

--- a/src/Mod/AddonManager/addonmanager_package_details_controller.py
+++ b/src/Mod/AddonManager/addonmanager_package_details_controller.py
@@ -21,7 +21,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-""" Provides the PackageDetails widget. """
+"""Provides the PackageDetails widget."""
 
 import os
 from typing import Optional
@@ -35,6 +35,7 @@ from addonmanager_metadata import (
     Version,
     get_first_supported_freecad_version,
     get_branch_from_metadata,
+    get_repo_url_from_metadata,
 )
 from addonmanager_workers_startup import GetMacroDetailsWorker, CheckSingleUpdateWorker
 from addonmanager_git import GitManager, NoGitFound
@@ -98,6 +99,10 @@ class PackageDetailsController(QtCore.QObject):
 
         installed = self.addon.status() != Addon.Status.NOT_INSTALLED
         self.ui.set_installed(installed)
+        if repo.metadata is not None:
+            self.ui.set_url(get_repo_url_from_metadata(repo.metadata))
+        else:
+            self.ui.set_url(None)  # to reset it and  hide it
         update_info = UpdateInformation()
         if installed:
             update_info.unchecked = self.addon.status() == Addon.Status.UNCHECKED
@@ -109,7 +114,6 @@ class PackageDetailsController(QtCore.QObject):
             elif repo.macro:
                 update_info.version = repo.macro.version
             self.ui.set_update_available(update_info)
-            self.ui.set_location(os.path.join(self.addon.mod_directory, self.addon.name))
             self.ui.set_location(os.path.join(self.addon.mod_directory, self.addon.name))
             self.ui.set_disabled(self.addon.is_disabled())
         self.ui.allow_running(repo.repo_type == Addon.Kind.MACRO)


### PR DESCRIPTION
@maxwxyz, is this what you were thinking?

~~Draft because links are not opened.~~

As you can see translation is being reused.

![image](https://github.com/user-attachments/assets/6d9575d9-bd2f-4ef4-ab09-0c4b5d09dd30)

Fix: #14777