### PR TITLE
Assembly: Support macros and console logs in Assembly

### DIFF
--- a/src/App/DocumentPy.xml
+++ b/src/App/DocumentPy.xml
@@ -56,6 +56,18 @@ For a temporary document it returns its transient directory.
         </UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="getUniqueObjectName">
+      <Documentation>
+        <UserDocu>getUniqueObjectName(objName) -> objName
+
+          Return the same name, or the name made unique, for Example Box -> Box002 if there are conflicting name
+          already in the document.
+
+          ObjName : str
+          Object name.
+        </UserDocu>
+      </Documentation>
+    </Methode>
     <Methode Name="mergeProject">
       <Documentation>
         <UserDocu>Merges this document with another project file</UserDocu>

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -217,6 +217,18 @@ PyObject* DocumentPy::getFileName(PyObject* args)
     return Py::new_reference_to(Py::String(fn));
 }
 
+PyObject* DocumentPy::getUniqueObjectName(PyObject *args)
+{
+    char *sName;
+    if (!PyArg_ParseTuple(args, "s", &sName))
+        return nullptr;
+    PY_TRY {
+        auto newName  = getDocumentPtr()->getUniqueObjectName(sName);
+        return Py::new_reference_to(Py::String(newName));
+    }
+    PY_CATCH;
+}
+
 PyObject*  DocumentPy::mergeProject(PyObject * args)
 {
     char* filename;

--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -159,7 +159,7 @@ DocumentObject *GeoFeature::resolveElement(DocumentObject *obj, const char *subn
     }
     if(geoFeature)
         *geoFeature = geo;
-    if(!obj || (filter && geo!=filter))
+    if(filter && geo!=filter)
         return nullptr;
     if(!element || !element[0]) {
         if(append) 

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -28,8 +28,6 @@
 #include <map>
 #include <string>
 
-#define  putpix()
-
 #include <App/Application.h>
 
 class QCloseEvent;
@@ -340,6 +338,8 @@ public:
 
     static PyObject* sDoCommand                (PyObject *self,PyObject *args);
     static PyObject* sDoCommandGui             (PyObject *self,PyObject *args);
+    static PyObject* sDoCommandEval            (PyObject *self,PyObject *args);
+    static PyObject* sDoCommandSkip            (PyObject *self,PyObject *args);
     static PyObject* sAddModule                (PyObject *self,PyObject *args);
 
     static PyObject* sShowDownloads            (PyObject *self,PyObject *args);

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -316,6 +316,19 @@ PyMethodDef Application::Methods[] = {
    "but doesn't record it in macros.\n"
    "\n"
    "cmd : str"},
+  {"doCommandEval",               (PyCFunction) Application::sDoCommandEval, METH_VARARGS,
+          "doCommandEval(cmd) -> PyObject\n"
+          "\n"
+          "Runs the given string without showing in the python console or recording in\n"
+          "macros, and returns the result.\n"
+          "\n"
+          "cmd : str"},
+  {"doCommandSkip",               (PyCFunction) Application::sDoCommandSkip, METH_VARARGS,
+          "doCommandSkip(cmd) -> None\n"
+          "\n"
+          "Record the given string in the Macro but comment it out in the console\n"
+          "\n"
+          "cmd : str"},
   {"addModule",               (PyCFunction) Application::sAddModule, METH_VARARGS,
    "addModule(mod) -> None\n"
    "\n"
@@ -1350,6 +1363,43 @@ PyObject* Application::sDoCommandGui(PyObject * /*self*/, PyObject *args)
         return nullptr;
 
     return PyRun_String(sCmd, Py_file_input, dict, dict);
+}
+
+PyObject* Application::sDoCommandEval(PyObject * /*self*/, PyObject *args)
+{
+    char *sCmd = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &sCmd))
+        return nullptr;
+
+    Gui::Command::LogDisabler d1;
+    Gui::SelectionLogDisabler d2;
+
+    PyObject *module, *dict;
+
+    Base::PyGILStateLocker locker;
+    module = PyImport_AddModule("__main__");
+    if (!module)
+        return nullptr;
+
+    dict = PyModule_GetDict(module);
+    if (!dict)
+        return nullptr;
+
+    return PyRun_String(sCmd, Py_eval_input, dict, dict);
+}
+
+PyObject* Application::sDoCommandSkip(PyObject * /*self*/, PyObject *args)
+{
+    char *sCmd = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &sCmd))
+        return nullptr;
+
+    Gui::Command::LogDisabler d1;
+    Gui::SelectionLogDisabler d2;
+
+    Gui::Command::printPyCaller();
+    Gui::Application::Instance->macroManager()->addLine(MacroManager::App, sCmd);
+    return Py::None().ptr();
 }
 
 PyObject* Application::sAddModule(PyObject * /*self*/, PyObject *args)

--- a/src/Mod/Assembly/CommandCreateAssembly.py
+++ b/src/Mod/Assembly/CommandCreateAssembly.py
@@ -70,15 +70,24 @@ class CommandCreateAssembly:
         App.setActiveTransaction("Create assembly")
 
         activeAssembly = UtilsAssembly.activeAssembly()
+        Gui.addModule("UtilsAssembly")
         if activeAssembly:
-            assembly = activeAssembly.newObject("Assembly::AssemblyObject", "Assembly")
+            commands = (
+                "activeAssembly = UtilsAssembly.activeAssembly()\n"
+                'assembly = activeAssembly.newObject("Assembly::AssemblyObject", "Assembly")\n'
+            )
         else:
-            assembly = App.ActiveDocument.addObject("Assembly::AssemblyObject", "Assembly")
+            commands = (
+                'assembly = App.ActiveDocument.addObject("Assembly::AssemblyObject", "Assembly")\n'
+            )
 
-        assembly.Type = "Assembly"
+        commands = commands + 'assembly.Type = "Assembly"\n'
+        commands = commands + 'assembly.newObject("Assembly::JointGroup", "Joints")'
+
+        Gui.doCommand(commands)
         if not activeAssembly:
-            Gui.ActiveDocument.setEdit(assembly)
-        assembly.newObject("Assembly::JointGroup", "Joints")
+            Gui.doCommandGui("Gui.ActiveDocument.setEdit(assembly)")
+
         App.closeActiveTransaction()
 
 

--- a/src/Mod/Assembly/CommandCreateBom.py
+++ b/src/Mod/Assembly/CommandCreateBom.py
@@ -324,11 +324,16 @@ class TaskAssemblyCreateBom(QtCore.QObject):
 
     def createBomObject(self):
         assembly = UtilsAssembly.activeAssembly()
+        Gui.addModule("UtilsAssembly")
         if assembly is not None:
-            bom_group = UtilsAssembly.getBomGroup(assembly)
-            self.bomObj = bom_group.newObject("Assembly::BomObject", "Bill of Materials")
+            commands = (
+                "bom_group = UtilsAssembly.getBomGroup(assembly)\n"
+                'bomObj = bom_group.newObject("Assembly::BomObject", "Bill of Materials")'
+            )
         else:
-            self.bomObj = App.activeDocument().addObject("Assembly::BomObject", "Bill of Materials")
+            commands = 'bomObj = App.activeDocument().addObject("Assembly::BomObject", "Bill of Materials")'
+        Gui.doCommand(commands)
+        self.bomObj = Gui.doCommandEval("bomObj")
 
     def export(self):
         self.bomObj.recompute()

--- a/src/Mod/Assembly/CommandExportASMT.py
+++ b/src/Mod/Assembly/CommandExportASMT.py
@@ -74,7 +74,7 @@ class CommandExportASMT:
         )
 
         if filePath:
-            assembly.exportAsASMT(filePath)
+            Gui.doCommand(f'assembly.exportAsASMT("{filePath}")')
 
 
 if App.GuiUp:

--- a/src/Mod/Assembly/CommandSolveAssembly.py
+++ b/src/Mod/Assembly/CommandSolveAssembly.py
@@ -67,8 +67,9 @@ class CommandSolveAssembly:
         if not assembly:
             return
 
+        Gui.addModule("UtilsAssembly")
         App.setActiveTransaction("Solve assembly")
-        assembly.solve()
+        Gui.doCommand("UtilsAssembly.activeAssembly().solve()")
         App.closeActiveTransaction()
 
 

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -1417,6 +1417,9 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
         else:
             self.joint.Document.removeObject(self.joint.Name)
 
+        cmds = UtilsAssembly.generatePropertySettings("obj", self.joint)
+        Gui.doCommand(cmds)
+
         App.closeActiveTransaction()
         return True
 

--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -1170,3 +1170,34 @@ def getParentPlacementIfNeeded(part):
             return linkGroup.Placement
 
     return Base.Placement()
+
+
+def generatePropertySettings(objectName, documentObject):
+    commands = []
+    if hasattr(documentObject, "Name"):
+        commands.append(f'{objectName} = App.ActiveDocument.getObject("{documentObject.Name}")')
+    for propertyName in documentObject.PropertiesList:
+        propertyValue = documentObject.getPropertyByName(propertyName)
+        propertyType = documentObject.getTypeIdOfProperty(propertyName)
+        # Note: OpenCascade precision is 1e-07, angular precision is 1e-05.  For purposes of creating a Macro,
+        # we are forcing a reduction in precision so as to get round numbers like 0 instead of tiny near 0 values
+        if propertyType == "App::PropertyFloat":
+            commands.append(f"{objectName}.{propertyName} = {propertyValue:.5f}")
+        elif propertyType == "App::PropertyInt" or propertyType == "App::PropertyBool":
+            commands.append(f"{objectName}.{propertyName} = {propertyValue}")
+        elif propertyType == "App::PropertyString" or propertyType == "App::PropertyEnumeration":
+            commands.append(f'{objectName}.{propertyName} = "{propertyValue}"')
+        elif propertyType == "App::PropertyPlacement":
+            commands.append(
+                f"{objectName}.{propertyName} = App.Placement("
+                f"App.Vector({propertyValue.Base.x:.5f},{propertyValue.Base.y:.5f},{propertyValue.Base.z:.5f}),"
+                f"App.Rotation(*{[round(n,5) for n in propertyValue.Rotation.getYawPitchRoll()]}))"
+            )
+        elif propertyType == "App::PropertyXLinkSubHidden":
+            commands.append(
+                f'{objectName}.{propertyName} = [App.ActiveDocument.getObject("{propertyValue[0].Name}"), {propertyValue[1]}]'
+            )
+        else:
+            # print("Not processing properties of type ", propertyType)
+            pass
+    return "\n".join(commands) + "\n"


### PR DESCRIPTION
Added support code to core to allow getting python objects back from python commands.

Added necessary wrappers and code to Assembly to provide console logs and Macro info for all commands executed.

Feedback requested, ~and this might best be a post 1.0 change, unless it gets a lot of attention.~  Feeling confident in it now, and it changes the game with reporting problems with Assembly since we can see what's going on.

@PaddleStroke Apologies for what this does to pristine code.  If there's another way, I'm all ears.