### PR TITLE
Fem: Use reference subshape transformation on the underlying geometry when finding points for constraint symbols

### DIFF
--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -436,7 +436,11 @@ bool Constraint::getPoints(std::vector<Base::Vector3d>& points,
                 BRepGProp::LinearProperties(compCurve.Wire(), linProps);
                 double outWireLength = linProps.Mass();
                 int stepWire = stepsu + stepsv;
-                ShapeAnalysis_Surface surfAnalysis(surface.Surface().Surface());
+                // apply subshape transformation to the geometry
+                gp_Trsf faceTrans = face.Location().Transformation();
+                Handle(Geom_Geometry) transGeo =
+                    surface.Surface().Surface()->Transformed(faceTrans);
+                ShapeAnalysis_Surface surfAnalysis(Handle(Geom_Surface)::DownCast(transGeo));
                 for (int i = 0; i < stepWire; ++i) {
                     gp_Pnt p = compCurve.Value(outWireLength * i / stepWire);
                     gp_Pnt2d pUV = surfAnalysis.ValueOfUV(p, Precision::Confusion());


### PR DESCRIPTION
For trimmed surfaces, the algorithm to find reference points used by constraint symbols may fail. In that case points on the outer wire of the Face are used.
For this second case to work correctly the underlying surface must be transformed with the global placement of the reference face.

The following file shows the current incorrect behavior:
With the Sketch using the XZ plane as attachment support, the algorithm fails to generate points to place the Fem Constraint symbol because the global placement of the outer wire of the reference face is different from the placement of the underlying surface geometry.
If the attachment support is changed to the XY plane, the constraint symbols are generated. In this case the algorithm works because the placement of the outer wire of the face and the underlying surface are the same.

[test_fail_points.FCStd.gz](https://github.com/user-attachments/files/17069401/test_fail_points.FCStd.gz)

@FEA-eng
