### PR TITLE
Use backspace as default to delete on mac

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1318,7 +1318,11 @@ StdCmdDelete::StdCmdDelete()
   sWhatsThis    = "Std_Delete";
   sStatusTip    = QT_TR_NOOP("Deletes the selected objects");
   sPixmap       = "edit-delete";
+#ifdef FC_OS_MACOSX
+  sAccel        = "Backspace";
+#else
   sAccel        = keySequenceToAccel(QKeySequence::Delete);
+#endif
   eType         = ForEdit;
 }
 


### PR DESCRIPTION
closes https://github.com/FreeCAD/FreeCAD/issues/16656

There's a mapping issue between mac and non-mac keyboard layout. And while Qt tries to solve it, it fails to give the users what they expect (see old bug here: https://bugreports.qt.io/browse/QTBUG-1616)

Apple calls the keys "Forward/Backward Delete" instead of "Delete" and "Backspace" ("Backward Delete" is some often just called "Delete", even though it has the same functionality as backspace in windows).
Apple's laptops doesn't come with a "delete"/"forward delete" key as only their external keyboard with numeric keypad has that.

Since apple don't include a forward delete key on most of their keyboards, they have mapped Fn+Backspace to that function. And this is the key that Qt maps QKeySequence::Delete to (see https://doc.qt.io/qt-6/qkeysequence.html#standard-shortcuts).
This is also the shortcut for StdCmdDelete to allow items to be removed in FreeCAD currently.

What most programs on mac os does is to use the backward delete key (backspace) to remove items instead: https://superuser.com/questions/482771/difference-between-cmdbackspace-and-fnbackspace-keyboard-shortcuts-in-osx


While it is possible to change the shortcut for StdCmdDelete to "Forward Delete" ([discussed and fixed here](https://forum.freecad.org/viewtopic.php?t=59054&start=10)), but that won't help new users that tries FreeCAD for their first time.

---

This pull request changes delete to "Forward Delete" (backspace) to delete items on mac.

This will work for all mac users, and while it change the default behaviour. Old users using the old default shortcut should be able to pick it up quickly, as they should be used with it in all most other mac applications that they are using.

Preferred would have been if it was possible to have multiple shortcuts to commands, [but that feature didn't get traction](https://forum.freecad.org/viewtopic.php?style=4&t=75699).
Since the PR only changes the default value, it will still be possible to modify the shortcut to use the old key if that is preferred.