### PR TITLE
Materials: Set transparency from DiffuseColor

### DIFF
--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -3018,6 +3018,17 @@ void PropertyMaterialList::setTransparency(int index, float val)
     hasSetValue();
 }
 
+void PropertyMaterialList::setTransparencies(const std::vector<float>& transparencies)
+{
+    aboutToSetValue();
+    setSize(transparencies.size(), _lValueList[0]);
+
+    for (std::size_t i = 0; i < transparencies.size(); i++) {
+        _lValueList[i].transparency = transparencies[i];
+    }
+    hasSetValue();
+}
+
 const Color& PropertyMaterialList::getAmbientColor() const
 {
     return _lValueList[0].ambientColor;

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -1156,6 +1156,7 @@ public:
 
     void setTransparency(float);
     void setTransparency(int index, float);
+    void setTransparencies(const std::vector<float>& transparencies);
 
     const Color& getAmbientColor() const;
     const Color& getAmbientColor(int index) const;

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -341,8 +341,17 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
     }
     else if (prop == &_diffuseColor) {
         // Used to load the old DiffuseColor values asynchronously
-        ShapeAppearance.setDiffuseColors(_diffuseColor.getValues());
-        ShapeAppearance.setTransparency(Transparency.getValue() / 100.0F);
+        // v0.21 used the alpha channel to store transparency values
+        std::vector<App::Color> colors = _diffuseColor.getValues();
+        std::vector<float> transparencies;
+        transparencies.resize(static_cast<int>(colors.size()));
+        for (int i = 0; i < static_cast<int>(colors.size()); i++) {
+            Base::Console().Log("%d: %f\n", i, colors[i].a);
+            transparencies[i] = colors[i].a;
+            colors[i].a = 1.0;
+        }
+        ShapeAppearance.setDiffuseColors(colors);
+        ShapeAppearance.setTransparencies(transparencies);
     }
     else if (prop == &ShapeAppearance) {
         setHighlightedFaces(ShapeAppearance);


### PR DESCRIPTION
Migrate the transparency from the DiffuseColor alpha channel to the transparency color attribute. This allows the alpha channel to be used as designed

fixes #14938