### PR TITLE
Fem: Use shape global placement in Mesh Netgen new implementation

### DIFF
--- a/src/Mod/Fem/femmesh/netgentools.py
+++ b/src/Mod/Fem/femmesh/netgentools.py
@@ -76,10 +76,14 @@ class NetgenTools:
         if not self.tmpdir:
             self.tmpdir = tempfile.mkdtemp(prefix="fem_")
 
-        sh = self.obj.Shape.getPropertyOfGeometry()
+        global_pla = self.obj.Shape.getGlobalPlacement()
+        geom = self.obj.Shape.getPropertyOfGeometry()
+        # get partner shape
+        geom_trans = geom.transformed(FreeCAD.Placement().Matrix)
+        geom_trans.Placement = global_pla
         self.brep_file = self.tmpdir + "/shape.brep"
         self.result_file = self.tmpdir + "/result.npy"
-        sh.exportBrep(self.brep_file)
+        geom_trans.exportBrep(self.brep_file)
 
     code = """
 from femmesh.netgentools import NetgenTools


### PR DESCRIPTION
If the shape to be meshed is inside a container, the generated mesh must reflect the global placement of the shape.

Example (using new Mesh Netgen implementation):
Create a PartDesing Body with some shape (or a Part shape inside a Part container)
Change the Body placement (or Part container placement)
Regenerate the mesh -> new mesh doesn't reflect global placement of the shape.

@FEA-eng 