### PR TITLE
Fem: Fix flickering between faces and wireframe in FemMesh view provider

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemMesh.cpp
@@ -195,7 +195,7 @@ ViewProviderFemMesh::ViewProviderFemMesh()
     ADD_PROPERTY(PointColor, (App::Color(0.7f, 0.7f, 0.7f)));
     ADD_PROPERTY(PointSize, (5.0f));
     PointSize.setConstraints(&floatRange);
-    ADD_PROPERTY(LineWidth, (2.0f));
+    ADD_PROPERTY(LineWidth, (1.0f));
     LineWidth.setConstraints(&floatRange);
 
     ShapeAppearance.setDiffuseColor(App::Color(1.0f, 0.7f, 0.0f));
@@ -334,14 +334,11 @@ void ViewProviderFemMesh::attach(App::DocumentObject* pcObj)
     // because the group affects nodes that are rendered afterwards (#0003769)
 
     // Faces + Wireframe (Elements)
-    // SoPolygonOffset* offset = new SoPolygonOffset();
-    // offset->styles = SoPolygonOffset::FILLED;
-    // offset->factor = 2.0f;
-    // offset->units = 1.0f;
+    SoPolygonOffset* offset = new SoPolygonOffset();
 
     SoGroup* pcFlatWireRoot = new SoGroup();
     pcFlatWireRoot->addChild(pcWireRoot);
-    // pcFlatWireRoot->addChild(offset);
+    pcFlatWireRoot->addChild(offset);
     pcFlatWireRoot->addChild(pcFlatRoot);
     addDisplayMaskMode(pcFlatWireRoot, Private::dm_face_wire);
 
@@ -349,7 +346,7 @@ void ViewProviderFemMesh::attach(App::DocumentObject* pcObj)
     SoGroup* pcElemNodesRoot = new SoGroup();
     pcElemNodesRoot->addChild(pcPointsRoot);
     pcElemNodesRoot->addChild(pcWireRoot);
-    // pcElemNodesRoot->addChild(offset);
+    pcElemNodesRoot->addChild(offset);
     pcElemNodesRoot->addChild(pcFlatRoot);
     addDisplayMaskMode(pcElemNodesRoot, Private::dm_face_wire_node);
 


### PR DESCRIPTION
There is a flickering between the wireframe and the faces in the FemMesh view.
Adding the SoPolygonOffset node with default values fixes this.
The default line width is changed to 1.0 because the current value seems to be too wide due the offset correction.

@FEA-eng 