### PR TITLE
replace exec_program() with execute_process()

### DIFF
--- a/src/Tools/plugins/widget/CMakeLists.txt
+++ b/src/Tools/plugins/widget/CMakeLists.txt
@@ -57,7 +57,7 @@ target_compile_options(FreeCAD_widgets PRIVATE ${COMPILE_OPTIONS})
 
 # Get the install location of a plugin to determine the path to designer plguins
 get_target_property(QMAKE_EXECUTABLE Qt${FREECAD_QT_MAJOR_VERSION}::qmake LOCATION)
-exec_program(${QMAKE_EXECUTABLE} ARGS "-query QT_INSTALL_PLUGINS" RETURN_VALUE return_code OUTPUT_VARIABLE DEFAULT_QT_PLUGINS_DIR )
+execute_process(COMMAND ${QMAKE_EXECUTABLE} "-query" "QT_INSTALL_PLUGINS" RESULT_VARIABLE return_code OUTPUT_VARIABLE DEFAULT_QT_PLUGINS_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
 set(DESIGNER_PLUGIN_LOCATION ${DEFAULT_QT_PLUGINS_DIR}/designer CACHE PATH "Path where the plugin will be installed to")
 
 if (NOT IS_SUB_PROJECT)


### PR DESCRIPTION
Recent CMake (>= 3.28) do not allow exec_program() any more by default, but prefer execute_process(), which takes slightly different flags. According to the documentation, exec_program() has been deprecated since CMake 3.0 (which was released in 2014, so it should be common enough that I don't feel like making allowances for any really old CMake).

References: https://cmake.org/cmake/help/latest/policy/CMP0153.html