### PR TITLE
CLI: Enforce LC_NUMERIC=C on Posix systems (#16724)

### DIFF
--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -99,6 +99,8 @@ int main(int argc, char** argv)
 {
 #if defined(FC_OS_LINUX) || defined(FC_OS_BSD)
     setlocale(LC_ALL, "");  // use native environment settings
+    setlocale(LC_NUMERIC, "C");  // except for numbers to not break XML import
+    // See https://github.com/FreeCAD/FreeCAD/issues/16724
 
     // Make sure to setup the Qt locale system before setting LANG and LC_ALL to C.
     // which is needed to use the system locale settings.

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -98,7 +98,7 @@ private:
 int main(int argc, char** argv)
 {
 #if defined(FC_OS_LINUX) || defined(FC_OS_BSD)
-    setlocale(LC_ALL, "");  // use native environment settings
+    setlocale(LC_ALL, "");       // use native environment settings
     setlocale(LC_NUMERIC, "C");  // except for numbers to not break XML import
     // See https://github.com/FreeCAD/FreeCAD/issues/16724
 


### PR DESCRIPTION
Initialising Qt with native LC_NUMERIC affects XML import on CLI (freecad -c) This causes sketch constraints and potentially other components relying on numeric constants to break or have incorrect values. Forcing LC_NUMERIC to C avoids this issue and enforces reproducible behaviour on all locales. This does not affect the number format displayed in the GUI, as set in preferences.