### PR TITLE
[BIM] Fix error starting BIM Wb for certain new users

### DIFF
--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -267,11 +267,12 @@ class BIM_Views:
                     top = QtGui.QTreeWidgetItem([translate("BIM","2D Views"), ""])
                     top.setIcon(0, ficon)
                     for v in views:
-                        i = QtGui.QTreeWidgetItem([v.Label, ""])
-                        if hasattr(v.ViewObject, "Icon"):
-                            i.setIcon(0, v.ViewObject.Icon)
-                        i.setToolTip(0, v.Name)
-                        top.addChild(i)
+                        if hasattr(v, "Label"):
+                            i = QtGui.QTreeWidgetItem([v.Label, ""])
+                            if hasattr(v.ViewObject, "Icon"):
+                                i.setIcon(0, v.ViewObject.Icon)
+                            i.setToolTip(0, v.Name)
+                            top.addChild(i)
                     vm.tree.addTopLevelItem(top)
 
                 # add pages


### PR DESCRIPTION
Fix error starting BIM Wb in certain scenarios:

```
11:21:36  Traceback (most recent call last):
11:21:36    File "/home/username/freecad-daily-build-coin403/Mod/BIM/bimcommands/BimViews.py", line 270, in update
11:21:36      i = QtGui.QTreeWidgetItem([v.Label, ""])
11:21:36                                 ^^^^^^^
11:21:36  AttributeError: 'list' object has no attribute 'Label'
```