### PR TITLE
Swaps out the hard coded icon to the standard svg icon

### DIFF
--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -73,31 +73,7 @@ std::vector<std::string> ViewProviderSheet::getDisplayModes() const
 
 QIcon ViewProviderSheet::getIcon() const
 {
-    // clang-format off
-    static const char* const Points_Feature_xpm[] = {
-        "16 16 3 1",
-        "       c None",
-        ".      c #000000",
-        "+      c #FFFFFF",
-        "                ",
-        "                ",
-        "................",
-        ".++++.++++.++++.",
-        ".++++.++++.++++.",
-        "................",
-        ".++++.++++.++++.",
-        ".++++.++++.++++.",
-        "................",
-        ".++++.++++.++++.",
-        ".++++.++++.++++.",
-        "................",
-        ".++++.++++.++++.",
-        ".++++.++++.++++.",
-        "................",
-        "                "};
-    QPixmap px(Points_Feature_xpm);
-    return px;
-    // clang-format on
+    return QIcon(QLatin1String(":icons/Spreadsheet.svg"));
 }
 
 bool ViewProviderSheet::setEdit(int ModNum)


### PR DESCRIPTION
The spreadsheet has its icon hardcoded in the view provider source file.
This isn't the normal case for icons and makes it difficult to improve on the look and feel.

As a side effect of using a low res pixmap icon, other icons on the same tree item seem to become the same resoultion. (as can be seen on the eye-icon).

Left is before and right is after the change:
![image](https://github.com/user-attachments/assets/d595b3f5-74d2-403e-a261-dd287bd8b4c4)

The icon is the same as the one for creating a new spreadsheet:
![image](https://github.com/user-attachments/assets/a46254cd-4e2b-4587-9543-c58a1f1b64c1)