### PR TITLE
Don't prompt for recompute on toolbit files

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -633,7 +633,9 @@ void Application::open(const char* FileName, const char* Module)
                     Command::doCommand(Command::App,
                                        "FreeCAD.openDocument('%s')",
                                        unicodepath.c_str());
-                    Gui::Application::checkForRecomputes();
+                    // Intentionally case sensitive so we don't try to recompute "internal" files like toolbits
+                    if ( te == "FCStd")
+                        Gui::Application::checkForRecomputes();
                 }
             }
             else {


### PR DESCRIPTION
Possible fix #16765.

Have not duplicated, can't confirm fix.

Can confirm works correctly on user .FCStd files.