### PR TITLE
Assembly: Fix lag during dragging of large assemblies.

### DIFF
--- a/src/Mod/Assembly/App/AssemblyObject.h
+++ b/src/Mod/Assembly/App/AssemblyObject.h
@@ -170,6 +170,7 @@ public:
     void setNewPlacements();
     static void recomputeJointPlacements(std::vector<App::DocumentObject*> joints);
     static void redrawJointPlacements(std::vector<App::DocumentObject*> joints);
+    static void redrawJointPlacement(App::DocumentObject* joint);
 
     // This makes sure that LinkGroups or sub-assemblies have identity placements.
     void ensureIdentityPlacements();
@@ -179,6 +180,16 @@ public:
     std::shared_ptr<MbD::ASMTPart>
     makeMbdPart(std::string& name, Base::Placement plc = Base::Placement(), double mass = 1.0);
     std::shared_ptr<MbD::ASMTPart> getMbDPart(App::DocumentObject* obj);
+    // To help the solver, during dragging, we are bundling parts connected by a fixed joint.
+    // So several assembly components are bundled in a single ASMTPart.
+    // So we need to store the plc of each bundled object relative to the bundle origin (first obj
+    // of objectPartMap).
+    struct MbDPartData
+    {
+        std::shared_ptr<MbD::ASMTPart> part;
+        Base::Placement offsetPlc;  // This is the offset within the bundled parts
+    };
+    MbDPartData getMbDData(App::DocumentObject* obj);
     std::shared_ptr<MbD::ASMTMarker> makeMbdMarker(std::string& name, Base::Placement& plc);
     std::vector<std::shared_ptr<MbD::ASMTJoint>> makeMbdJoint(App::DocumentObject* joint);
     std::shared_ptr<MbD::ASMTJoint> makeMbdJointOfType(App::DocumentObject* joint,
@@ -236,12 +247,13 @@ public:
 private:
     std::shared_ptr<MbD::ASMTAssembly> mbdAssembly;
 
-    std::unordered_map<App::DocumentObject*, std::shared_ptr<MbD::ASMTPart>> objectPartMap;
+    std::unordered_map<App::DocumentObject*, MbDPartData> objectPartMap;
     std::vector<std::pair<App::DocumentObject*, double>> objMasses;
     std::vector<std::shared_ptr<MbD::ASMTPart>> dragMbdParts;
 
     std::vector<std::pair<App::DocumentObject*, Base::Placement>> previousPositions;
 
+    bool bundleFixed;
     // void handleChangedPropertyType(Base::XMLReader &reader, const char *TypeName, App::Property
     // *prop) override;
 

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.h
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.h
@@ -203,7 +203,6 @@ public:
     bool enableMovement;
     bool moveOnlyPreselected;
     bool moveInCommand;
-    bool jointVisibilityBackup;
     bool ctrlPressed;
 
     long lastClickTime;  // Store last click time as milliseconds
@@ -218,6 +217,7 @@ public:
 
     App::DocumentObject* movingJoint;
 
+    std::vector<std::pair<App::DocumentObject*, bool>> jointVisibilitiesBackup;
     std::vector<std::pair<App::DocumentObject*, double>> objectMasses;
     std::vector<MovingObject> docsToMove;
 


### PR DESCRIPTION
 - Bundle fix joints together when dragging to make things simpler for solver. 
 - Show and redraw only the movingJoint during dragging. 
 - Do not recompute joints during dragging.

This together make the dragging steps much faster.

Fix https://github.com/FreeCAD/FreeCAD/issues/16771