### PR TITLE
PartDesign: Loft Intelligence - Select the whole sketch if the selected shape is …

### DIFF
--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -72,7 +72,9 @@ Loft::getSectionShape(const char *name,
                       size_t expected_size)
 {
     std::vector<TopoShape> shapes;
-    if (subs.empty() || std::find(subs.begin(), subs.end(), std::string()) != subs.end()) {
+    auto subName = subs.empty() ? "" : subs.front();
+    // Be smart. If part of a sketch is selected, use the entire sketch unless it is a single vertex - backward compatibility (#16630)
+    if (subs.empty() || std::find(subs.begin(), subs.end(), std::string()) != subs.end() || ( obj->isDerivedFrom(Part::Part2DObject::getClassTypeId()) &&  subName.compare(0, 6, "Vertex") != 0)) {
         shapes.push_back(Part::Feature::getTopoShape(obj));
         if (shapes.back().isNull())
             FC_THROWM(Part::NullShapeException, "Failed to get shape of "


### PR DESCRIPTION
…a component of a sketch that is not a vertex (Fix #16630)

In fa8f29aed489247e931631dbd1e600cc7610c38f FeatureLoft.cpp was refactured, dropping some functionality, mainly the ability to create lofts to entire sketches or other 2d shapes if a single component that was not a single vertex was selected as either the base shape or a section

the old code was:

1     auto getSectionShape =
2          [](App::DocumentObject* feature, const std::vector<std::string> &subs) -> TopoDS_Shape {
3              if (!feature ||
4                  !feature->isDerivedFrom(Part::Feature::getClassTypeId()))
5                  throw Base::TypeError("Loft: Invalid profile/section");
6
7              auto subName = subs.empty() ? "" : subs.front();
8
9              // only take the entire shape when we have a sketch selected, but
10             // not a point of the sketch
11             if (feature->isDerivedFrom(Part::Part2DObject::getClassTypeId()) &&
12                 subName.compare(0, 6, "Vertex") != 0)
13                 return static_cast<Part::Part2DObject*>(feature)->Shape.getValue();
14             else {
15                 if(subName.empty())
16                     throw Base::ValueError("No valid subelement linked in Part::Feature");
17                 return static_cast<Part::Feature*>(feature)->Shape.getShape().getSubShape(subName.c_str());
18             }
19         };

this commit forward-ports the missing functionality provided by line 7-12 in above snippet