### PR TITLE
Measurement: Correctly handle unknown selections to avoid segfaults ( Fix #16794 )

### DIFF
--- a/src/Mod/Measure/App/Measurement.cpp
+++ b/src/Mod/Measure/App/Measurement.cpp
@@ -123,6 +123,7 @@ MeasureType Measurement::findType()
     int torus = 0;
     int spheres = 0;
     int vols = 0;
+    int other = 0;
 
     for (; obj != objects.end(); ++obj, ++subEl) {
 
@@ -184,12 +185,16 @@ MeasureType Measurement::findType()
                     }
                 } break;
                 default:
+                    other++;
                     break;
             }
         }
     }
 
-    if (vols > 0) {
+    if (other > 0) {
+        mode = MeasureType::Invalid;
+    }
+    else if (vols > 0) {
         if (verts > 0 || edges > 0 || faces > 0) {
             mode = MeasureType::Invalid;
         }


### PR DESCRIPTION
( Fix #16794 )

The measurement code did not handle mixed selections of known and unknown types correctly. Although a unknown selected object would leave the type at Invalid, selecting both known and unknown objects would have the type determined by the known object type and treat the unknown as the same. This causes exceptions and - worst case a segmentation fault.

This fix introduces a new category "other" which - if present in a selection always forces type to Invalid. This should be forward compatible in case new types are introduced in the future.