### PR TITLE
Gui: Remove newline from dialog string

### DIFF
--- a/src/Gui/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/DlgAddPropertyVarSet.cpp
@@ -386,9 +386,10 @@ private:
 void DlgAddPropertyVarSet::checkName() {
     std::string name = ui->lineEditName->text().toStdString();
     if(name.empty() || name != Base::Tools::getIdentifier(name)) {
-        critical(QObject::tr("Invalid name"),
-                 QObject::tr("The property name must only contain alpha numericals,\n"
-                             "underscore, and must not start with a digit."));
+        QMessageBox::critical(getMainWindow(),
+                              QObject::tr("Invalid name"),
+                              QObject::tr("The property name must only contain alpha numericals, "
+                                          "underscore, and must not start with a digit."));
         clearEditors(!CLEAR_NAME);
         throw CreatePropertyException("Invalid name");
     }


### PR DESCRIPTION
This commit removes superflous newline that disrupts the flow of the sentence displayed in the VarSet dialog. See https://github.com/FreeCAD/FreeCAD/issues/16776#issuecomment-2371188438

Fixes this dialog:  
![Screenshot_20240924_223114](https://github.com/user-attachments/assets/d785738b-1da4-4215-9789-1adc57e00fd7)
