### PR TITLE
Draft: ShapeString Fuse caused single face string to lose fill

### DIFF
--- a/src/Mod/Draft/draftobjects/shapestring.py
+++ b/src/Mod/Draft/draftobjects/shapestring.py
@@ -127,8 +127,7 @@ class ShapeString(DraftObject):
             return
 
         if obj.String and obj.FontFile:
-            if obj.Placement:
-                plm = obj.Placement
+            plm = obj.Placement
 
             fill = obj.MakeFace
             if fill is True:
@@ -190,8 +189,7 @@ class ShapeString(DraftObject):
             else:
                 App.Console.PrintWarning(translate("draft", "ShapeString: string has no wires") + "\n")
 
-            if plm:
-                obj.Placement = plm
+            obj.Placement = plm
 
         obj.positionBySupport()
         self.props_changed_clear()

--- a/src/Mod/Draft/draftobjects/shapestring.py
+++ b/src/Mod/Draft/draftobjects/shapestring.py
@@ -159,6 +159,10 @@ class ShapeString(DraftObject):
                 if fill and obj.Fuse:
                     ss_shape = shapes[0].fuse(shapes[1:])
                     ss_shape = faces.concatenate(ss_shape)
+                    # Concatenate returns a Face or a Compound. We always
+                    # need a Compound as we use ss_shape.SubShapes later.
+                    if ss_shape.ShapeType == "Face":
+                        ss_shape = Part.Compound([ss_shape])
                 else:
                     ss_shape = Part.Compound(shapes)
                 cap_char = Part.makeWireString("M", obj.FontFile, obj.Size, obj.Tracking)[0]


### PR DESCRIPTION
The `faces.concatenate` function can return a Face or a Compound. The code did not take that into account.
