### PR TITLE
Measure: Store Document on temporary measurement

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3388,7 +3388,7 @@ std::vector<DocumentObject *> Document::addObjects(const char* sType, const std:
 
 void Document::addObject(DocumentObject* pcObject, const char* pObjectName)
 {
-    if (pcObject->getDocument()) {
+    if (pcObject->isAttachedToDocument()) {
         throw Base::RuntimeError("Document object is already added to a document");
     }
 

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -687,13 +687,21 @@ void DocumentObject::onLostLinkToObject(DocumentObject*)
 
 App::Document *DocumentObject::getDocument() const
 {
+    if (!_pDoc)
+        return _pTempDoc;
     return _pDoc;
 }
 
 void DocumentObject::setDocument(App::Document* doc)
 {
+    _pTempDoc = nullptr;
     _pDoc=doc;
     onSettingDocument();
+}
+
+void DocumentObject::setTemporaryDocument(App::Document* doc)
+{
+    _pTempDoc = doc;
 }
 
 bool DocumentObject::removeDynamicProperty(const char* name)

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -151,6 +151,8 @@ public:
     const char* detachFromDocument() override;
     /// gets the document in which this Object is handled
     App::Document *getDocument() const;
+    /// sets the temporary document for detached objects which will be used as a fallback
+    void setTemporaryDocument(App::Document* doc);
 
     /** Set the property touched -> changed, cause recomputation in Update()
      */
@@ -670,6 +672,9 @@ protected: // attributes
     Py::SmartPtr PythonObject;
     /// pointer to the document this object belongs to
     App::Document* _pDoc{nullptr};
+
+    /// pointer to the temporary document for detached objects
+    App::Document* _pTempDoc{nullptr};
 
     /// Old label; used for renaming expressions
     std::string oldLabel;

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -204,6 +204,10 @@ App::DocumentObject* TaskMeasure::createObject(const App::MeasureType* measureTy
         Py_XDECREF(result);
     }
 
+    // Store the document in the document object
+    _mDocument = App::GetApplication().getActiveDocument();
+    _mMeasureObject->setTemporaryDocument(_mDocument);
+
     return static_cast<App::DocumentObject*>(_mMeasureObject);
 }
 
@@ -249,7 +253,6 @@ void TaskMeasure::saveObject()
         _mViewObject = nullptr;
     }
 
-    _mDocument = App::GetApplication().getActiveDocument();
     _mDocument->addObject(_mMeasureObject,
                           modeSwitch->currentIndex() != 0 ? modeSwitch->currentText().toLatin1()
                                                           : QString().toLatin1());


### PR DESCRIPTION
This fixes #16699 which was introduced with #15122 as DocumentObjects that aren't attached to a document have no knowledge of any document which makes some features fail that depend on a document.
As an example of failing case: PropertyLinks check if the assigned element is external by checking the document of the properties container. https://github.com/FreeCAD/FreeCAD/blob/69676a0f9d2d5b288bda3d1c6dbad5a6ec26bfaa/src/App/PropertyLinks.cpp#L662

This PR adds the concept of a temporary Document to the DocumentObject class which will be used as a fallback value for getDocument(). The 'isAttachedToDocument' method still returns false in that case.