### PR TITLE
Hide visibility icon (eye) for spreadsheets and varsets

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -5441,6 +5441,11 @@ void DocumentObjectItem::testStatus(bool resetStatus, QIcon& icon1, QIcon& icon2
         icon = object()->mergeColorfulOverlayIcons(icon);
 
         if (isVisibilityIconEnabled()) {
+            // TODO: Find a better way to identify if objects should have a visibility icon
+            bool has_visibility_state = true;
+            has_visibility_state &= std::string(pObject->getTypeId().getName()) != "App::VarSet";
+            has_visibility_state &= std::string(pObject->getTypeId().getName()) != "Spreadsheet::Sheet";
+
             static QPixmap pxVisible, pxInvisible;
             if (pxVisible.isNull()) {
                 pxVisible = BitmapFactory().pixmap("TreeItemVisible");
@@ -5462,7 +5467,9 @@ void DocumentObjectItem::testStatus(bool resetStatus, QIcon& icon1, QIcon& icon2
                 QPainter pt;
                 pt.begin(&px);
                 pt.setPen(Qt::NoPen);
-                pt.drawPixmap(0, 0, px_org.width(), px_org.height(), (currentStatus & Status::Visible) ? pxVisible : pxInvisible);
+                if (has_visibility_state) {
+                    pt.drawPixmap(0, 0, px_org.width(), px_org.height(), (currentStatus & Status::Visible) ? pxVisible : pxInvisible);
+                }
                 pt.drawPixmap(px_org.width() + spacing, 0, px_org.width(), px_org.height(), px_org);
                 pt.end();
 


### PR DESCRIPTION
This is a temporary fix for https://github.com/FreeCAD/FreeCAD/issues/16816 that could be included in 1.0.

I had to hardcode which object types to hide the icon for to make this PR as small as possible. This as I couldn't find a current way to identify which objects are never shown in the 3d view.

A post 1.0 solution could be to make DocumentObject store if it can show anything in the 3d view.


Left is from 1.0RC2, right is after this fix (spreadsheet icon was changed between these versions):
![image](https://github.com/user-attachments/assets/6cae3383-6723-407c-bf29-bd524e8fe134)
