### PR TITLE
Measurement: Avoid null shapes to be returned in all code branches

### DIFF
--- a/src/Mod/Measure/App/Measurement.cpp
+++ b/src/Mod/Measure/App/Measurement.cpp
@@ -292,7 +292,11 @@ TopoDS_Shape Measurement::getShape(App::DocumentObject* rootObj, const char* sub
     std::vector<std::string> names = Base::Tools::splitSubName(subName);
 
     if (names.empty() || names.back() == "") {
-        return Part::Feature::getShape(rootObj);
+        TopoDS_Shape shape = Part::Feature::getShape(rootObj);
+        if (shape.IsNull()) {
+            throw Part::NullShapeException("null shape in measurement");
+        }
+        return shape;
     }
 
     try {


### PR DESCRIPTION
 (Fix  #16820)

Returning a null shape would have triggered an exception in the bottom branch but not in the top one - which later leads to a segfault - solution - raise an exception. OOC doesn't like null shapes.