### PR TITLE
MeasureGui: Remove leftover reset of _mMeasureObject

### DIFF
--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -409,7 +409,6 @@ bool TaskMeasure::reject()
 void TaskMeasure::reset()
 {
     // Reset tool state
-    _mMeasureObject = nullptr;
     this->clearSelection();
 
     // Should the explicit mode also be reset?


### PR DESCRIPTION
This was introduced in af9097ce875d1378fd6487bc5ffedb35bd148274 due to a faulty resolve of a merge conflict.

Fixes #16564
Fixes #16829