### PR TITLE
Fix `name 'PyExc_FC_AbortIOException' is not defined`

### DIFF
--- a/src/Ext/freecad/module_io.py
+++ b/src/Ext/freecad/module_io.py
@@ -1,3 +1,6 @@
+from FreeCAD import Base
+
+
 def OpenInsertObject(importerModule, objectPath, importMethod, docName = ""):
     try:
         importArgs = []
@@ -9,5 +12,5 @@ def OpenInsertObject(importerModule, objectPath, importMethod, docName = ""):
             importKwargs["options"] = importerModule.importOptions(objectPath)
 
         getattr(importerModule, importMethod)(objectPath, *importArgs, **importKwargs)
-    except PyExc_FC_AbortIOException:
+    except Base.AbortIOException:
         pass


### PR DESCRIPTION
The python file `module_io.py` accidentally uses the c++ exception name instead of the python exception name.
This bug was introduced here: https://github.com/FreeCAD/FreeCAD/commit/f763425b4f64bd36ce5e184becca62be29fcccab

The bug writes the following in the console:
```
10:40:17  pyException: Traceback (most recent call last):
  File "D:\Tools\FreeCAD_1.0.0RC2-conda-Windows-x86_64-py311\bin\Lib\site-packages\freecad\module_io.py", line 12, in OpenInsertObject
    except PyExc_FC_AbortIOException:
           ^^^^^^^^^^^^^^^^^^^^^^^^^
<class 'NameError'>: name 'PyExc_FC_AbortIOException' is not defined
```

This fix is related to [this issue](https://github.com/FreeCAD/FreeCAD/issues/16835), but it doesn't solve that it. 