### PR TITLE
[QuickMeasure] prevent crash when attempting to access null pointer

### DIFF
--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -119,6 +119,9 @@ void QuickMeasure::addSelectionToMeasurement()
 
     // Lambda function to check whether to continue
     auto shouldSkip = [](App::DocumentObject* obj) {
+        if (!obj){
+            return true;
+        }
         std::string vpType = obj->getViewProviderName();
         auto* vp = Gui::Application::Instance->getViewProvider(obj);
         return (vpType == "SketcherGui::ViewProviderSketch" && vp->isEditing())

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -119,7 +119,7 @@ void QuickMeasure::addSelectionToMeasurement()
 
     // Lambda function to check whether to continue
     auto shouldSkip = [](App::DocumentObject* obj) {
-        if (!obj){
+        if (!obj) {
             return true;
         }
         std::string vpType = obj->getViewProviderName();


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?t=90937&sid=e8531881f5e1ddd49eefd21901bf6e1c

Instructions to reproduce crash are in the above link, but I will recount them here.  Note that some steps might not be necessary, but these are the ones I used.

Create a new Part Design Body, add a default primitive additive box.
Switch to Assembly workbench, create new assembly.
In assembly menu -> add new component, select the body, answer Yes to dialog.
In view menu -> panels, open selection view if not already open.
Check the Picked object list checkbox.
Select a face on the additive box in the 3d view.
Double click a few items in the picked list, should crash within a few clicks.

I am presuming true should be returned here based on the name of the function (shouldSkip) since we should skip processing a null pointer object, but I didn't investigate why exactly a null pointer is being passed to this function in the first place.  There is likely some logical issue that needs to be further addressed there.   Even so, this patch seems harmless enough even should the other issue be fixed.

I ran the unit tests before submitting this PR.  No additional failures other than the already existing failure in CAMWorkbench.