### PR TITLE
BIM: Make python Regex Strings raw to avoid py3.12 SyntaxError

### DIFF
--- a/src/Mod/AddonManager/Widgets/addonmanager_widget_readme_browser.py
+++ b/src/Mod/AddonManager/Widgets/addonmanager_widget_readme_browser.py
@@ -83,12 +83,12 @@ class WidgetReadmeBrowser(QtWidgets.QTextBrowser):
         self.setGeometry(geometry)
 
     def _clean_markdown(self, md: str):
-        # Remove some HTML tags (for now just img and br, which are the most common offenders that break rendering)
+        # Remove some HTML tags ( for now just img and br, which are the most common offenders that break rendering )
         br_re = re.compile(r"<br\s*/?>")
         img_re = re.compile(r"<img\s.*?src=(?:'|\")([^'\">]+)(?:'|\").*?\/?>")
 
-        cleaned = br_re.sub("\n", md)
-        cleaned = img_re.sub("[html tag removed]", cleaned)
+        cleaned = br_re.sub(r"\n", md)
+        cleaned = img_re.sub(r"[html tag removed]", cleaned)
 
         return cleaned
 

--- a/src/Mod/AddonManager/addonmanager_macro.py
+++ b/src/Mod/AddonManager/addonmanager_macro.py
@@ -183,7 +183,7 @@ class Macro:
             desc = "No description available"
         self.desc = desc
         self.comment, _, _ = desc.partition("<br")  # Up to the first line break
-        self.comment = re.sub("<.*?>", "", self.comment)  # Strip any tags
+        self.comment = re.sub(r"<.*?>", "", self.comment)  # Strip any tags
         self.url = url
         if isinstance(code, list):
             code = "".join(code)
@@ -201,7 +201,7 @@ class Macro:
     def _fetch_raw_code(self, page_data) -> Optional[str]:
         """Fetch code from the raw code URL specified on the wiki page."""
         code = None
-        self.raw_code_url = re.findall('rawcodeurl.*?href="(http.*?)">', page_data)
+        self.raw_code_url = re.findall(r'rawcodeurl.*?href="(http.*?)">', page_data)
         if self.raw_code_url:
             self.raw_code_url = self.raw_code_url[0]
             u2 = Macro.blocking_get(self.raw_code_url)

--- a/src/Mod/AddonManager/addonmanager_macro_parser.py
+++ b/src/Mod/AddonManager/addonmanager_macro_parser.py
@@ -201,7 +201,7 @@ class MacroParser:
     def _cleanup_comment(self):
         """Remove HTML from the comment line, and truncate it at 512 characters."""
 
-        self.parse_results["comment"] = re.sub("<.*?>", "", self.parse_results["comment"])
+        self.parse_results["comment"] = re.sub(r"<.*?>", "", self.parse_results["comment"])
         if len(self.parse_results["comment"]) > 512:
             self.parse_results["comment"] = self.parse_results["comment"][:511] + "…"
 

--- a/src/Mod/AddonManager/addonmanager_workers_startup.py
+++ b/src/Mod/AddonManager/addonmanager_workers_startup.py
@@ -399,7 +399,7 @@ class CreateAddonListWorker(QtCore.QThread):
             )
             return
         p = p.data().decode("utf8")
-        macros = re.findall('title="(Macro.*?)"', p)
+        macros = re.findall(r'title="(Macro.*?)"', p)
         macros = [mac for mac in macros if "translated" not in mac]
         macro_names = []
         for _, mac in enumerate(macros):

--- a/src/Mod/BIM/ArchAxis.py
+++ b/src/Mod/BIM/ArchAxis.py
@@ -398,7 +398,7 @@ class _ViewProviderAxis:
                                     except Exception:
                                         # workaround for pivy SoInput.setBuffer() bug
                                         buf = buf.replace("\n","")
-                                        pts = re.findall("point \[(.*?)\]",buf)[0]
+                                        pts = re.findall(r"point \[(.*?)\]",buf)[0]
                                         pts = pts.split(",")
                                         pc = []
                                         for point in pts:

--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -971,12 +971,12 @@ class ViewProviderBuildingPart:
                 iv = self.Object.Shape.writeInventor()
                 import re
                 if colors:
-                    if len(re.findall("IndexedFaceSet",iv)) == len(obj.Shape.Faces):
+                    if len(re.findall(r"IndexedFaceSet",iv)) == len(obj.Shape.Faces):
                         # convert colors to iv representations
                         colors = ["Material { diffuseColor "+str(color[0])+" "+str(color[1])+" "+str(color[2])+"}\n    IndexedFaceSet" for color in colors]
                         # replace
                         callback.v=iter(colors)
-                        iv = re.sub("IndexedFaceSet",callback,iv)
+                        iv = re.sub(r"IndexedFaceSet",callback,iv)
                     else:
                         print("Debug: IndexedFaceSet mismatch in",obj.Label)
                 # save embedded file

--- a/src/Mod/BIM/ArchRebar.py
+++ b/src/Mod/BIM/ArchRebar.py
@@ -450,7 +450,7 @@ class _ViewProviderRebar(ArchComponent.ViewProviderComponent):
                     import re
                     self.centerline = coin.SoSeparator()
                     comp = Part.makeCompound(obj.Proxy.wires)
-                    buf = re.findall("point \[(.*?)\]",comp.writeInventor().replace("\n",""))
+                    buf = re.findall(r"point \[(.*?)\]",comp.writeInventor().replace("\n",""))
                     pts = [zip(*[iter( c.split() )]*3) for c in buf]
                     for pt in pts:
                         vlist = [ [float(v[0]),float(v[1]),float(v[2])] for v in pt ]

--- a/src/Mod/BIM/ArchReference.py
+++ b/src/Mod/BIM/ArchReference.py
@@ -390,28 +390,28 @@ class ArchReference:
             for line in docf:
                 line = line.decode("utf8")
                 if "<Object name=" in line:
-                    n = re.findall('name=\"(.*?)\"',line)
+                    n = re.findall(r'name=\"(.*?)\"',line)
                     if n:
                         name = n[0]
                 elif "<Property name=\"Label\"" in line:
                     writemode = True
                 elif writemode and "<String value=" in line:
-                    n = re.findall('value=\"(.*?)\"',line)
+                    n = re.findall(r'value=\"(.*?)\"',line)
                     if n:
                         label = n[0]
                         writemode = False
                 elif "<Property name=\"Shape\" type=\"Part::PropertyPartShape\"" in line:
                     writemode = True
                 elif writemode and "<Part file=" in line:
-                    n = re.findall('file=\"(.*?)\"',line)
+                    n = re.findall(r'file=\"(.*?)\"',line)
                     if n:
                         part = n[0]
                         writemode = False
                 elif "<Property name=\"MaterialsTable\" type=\"App::PropertyMap\"" in line:
                     writemode = True
                 elif writemode and "<Item key=" in line:
-                    n = re.findall('key=\"(.*?)\"',line)
-                    v = re.findall('value=\"(.*?)\"',line)
+                    n = re.findall(r'key=\"(.*?)\"',line)
+                    v = re.findall(r'value=\"(.*?)\"',line)
                     if n and v:
                         materials[n[0]] = v[0]
                 elif writemode and "</Map>" in line:
@@ -469,7 +469,7 @@ class ArchReference:
                         writemode1 = False
                         writemode2 = True
                     elif writemode2 and ("<ColorList file=" in line):
-                        n = re.findall('file=\"(.*?)\"',line)
+                        n = re.findall(r'file=\"(.*?)\"',line)
                         if n:
                             colorfile = n[0]
                             break
@@ -808,7 +808,7 @@ class ViewProviderArchReference:
                     writemode1 = False
                     writemode2 = True
                 elif writemode2 and ("<FileIncluded file=" in line):
-                    n = re.findall('file=\"(.*?)\"',line)
+                    n = re.findall(r'file=\"(.*?)\"',line)
                     if n:
                         ivfile = n[0]
                         break

--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -734,7 +734,7 @@ def getCoinSVG(cutplane,objs,cameradata=None,linewidth=0.2,singleface=False,face
     wp.align_to_point_and_axis_svg(Vector(0,0,0),cutplane.normalAt(0,0),0)
     p = wp.get_local_coords(markervec)
     orlength = FreeCAD.Vector(p.x,p.y,0).Length
-    marker = re.findall("<line x1=.*?stroke=\"\#ffffff\".*?\/>",svg)
+    marker = re.findall(r"<line x1=.*?stroke=\"\#ffffff\".*?\/>",svg)
     if marker:
         marker = marker[0].split("\"")
         x1 = float(marker[1])
@@ -750,21 +750,21 @@ def getCoinSVG(cutplane,objs,cameradata=None,linewidth=0.2,singleface=False,face
             scaledp1 = FreeCAD.Vector(p1.x*factor,p1.y*factor,0)
             trans = orig.sub(scaledp1)
         # remove marker
-        svg = re.sub("<line x1=.*?stroke=\"\#ffffff\".*?\/>","",svg,count=1)
+        svg = re.sub(r"<line x1=.*?stroke=\"\#ffffff\".*?\/>","",svg,count=1)
 
     # remove background rectangle
-    svg = re.sub("<path.*?>","",svg,count=1,flags=re.MULTILINE|re.DOTALL)
+    svg = re.sub(r"<path.*?>","",svg,count=1,flags=re.MULTILINE|re.DOTALL)
 
     # set face color to white
     if facecolor:
-        res = re.findall("fill:(.*?); stroke:(.*?);",svg)
+        res = re.findall(r"fill:(.*?); stroke:(.*?);",svg)
         pairs = []
         for pair in res:
             if (pair not in pairs) and (pair[0] == pair[1]) and(pair[0] not in ["#0a0a0a"]):
                 # coin seems to be rendering a lot of lines as thin triangles with the #0a0a0a color...
                 pairs.append(pair)
         for pair in pairs:
-            svg = re.sub("fill:"+pair[0]+"; stroke:"+pair[1]+";","fill:"+facecolor+"; stroke:"+facecolor+";",svg)
+            svg = re.sub(r"fill:"+pair[0]+"; stroke:"+pair[1]+";","fill:"+facecolor+"; stroke:"+facecolor+";",svg)
 
     # embed everything in a scale group and scale the viewport
     if factor:
@@ -778,9 +778,9 @@ def getCoinSVG(cutplane,objs,cameradata=None,linewidth=0.2,singleface=False,face
     QtCore.QTimer.singleShot(1,lambda: closeViewer(view_window_name))
 
     # strip svg tags (needed for TD Arch view)
-    svg = re.sub("<\?xml.*?>","",svg,flags=re.MULTILINE|re.DOTALL)
-    svg = re.sub("<svg.*?>","",svg,flags=re.MULTILINE|re.DOTALL)
-    svg = re.sub("<\/svg>","",svg,flags=re.MULTILINE|re.DOTALL)
+    svg = re.sub(r"<\?xml.*?>","",svg,flags=re.MULTILINE|re.DOTALL)
+    svg = re.sub(r"<svg.*?>","",svg,flags=re.MULTILINE|re.DOTALL)
+    svg = re.sub(r"<\/svg>","",svg,flags=re.MULTILINE|re.DOTALL)
 
     ISRENDERING = False
 

--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -67,7 +67,7 @@ def toNode(shape):
 
     from pivy import coin
     buf = shape.writeInventor(2,0.01).replace("\n","")
-    buf = re.findall("point \[(.*?)\]",buf)
+    buf = re.findall(r"point \[(.*?)\]",buf)
     pts = []
     for c in buf:
         pts.extend(zip(*[iter( c.split() )]*3) )

--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -525,13 +525,13 @@ class BIM_Classification:
                     currentItem.parent.children.append(currentItem)
                 if "</Item>" in l:
                     currentItem = currentItem.parent
-                elif currentItem and re.findall("<ID>(.*?)</ID>", l):
-                    currentItem.ID = re.findall("<ID>(.*?)</ID>", l)[0]
-                elif currentItem and re.findall("<Name>(.*?)</Name>", l):
-                    currentItem.Name = re.findall("<Name>(.*?)</Name>", l)[0]
+                elif currentItem and re.findall(r"<ID>(.*?)</ID>", l):
+                    currentItem.ID = re.findall(r"<ID>(.*?)</ID>", l)[0]
+                elif currentItem and re.findall(r"<Name>(.*?)</Name>", l):
+                    currentItem.Name = re.findall(r"<Name>(.*?)</Name>", l)[0]
                 elif (
                     currentItem
-                    and re.findall("<Description>(.*?)</Description>", l)
+                    and re.findall(r"<Description>(.*?)</Description>", l)
                     and not currentItem.Name
                 ):
                     currentItem.Name = re.findall(

--- a/src/Mod/BIM/bimcommands/BimLibrary.py
+++ b/src/Mod/BIM/bimcommands/BimLibrary.py
@@ -779,8 +779,8 @@ class BIM_Library_TaskPanel:
             p = u.read()
             if sys.version_info.major >= 3:
                 p = str(p)
-            dirs = re.findall("<.*?octicon-file-directory.*?href.*?>(.*?)</a>", p)
-            files = re.findall('<.*?octicon-file".*?href.*?>(.*?)</a>', p)
+            dirs = re.findall(r"<.*?octicon-file-directory.*?href.*?>(.*?)</a>", p)
+            files = re.findall(r'<.*?octicon-file".*?href.*?>(.*?)</a>', p)
             nfiles = []
             for f in files:
                 for ft in self.getFilters():
@@ -791,8 +791,8 @@ class BIM_Library_TaskPanel:
             for d in dirs:
                 # <spans>
                 if "</span" in d:
-                    d1 = re.findall("<span.*?>(.*?)<", d)
-                    d2 = re.findall("</span>(.*?)$", d)
+                    d1 = re.findall(r"<span.*?>(.*?)<", d)
+                    d2 = re.findall(r"</span>(.*?)$", d)
                     if d1 and d2:
                         d = d1[0] + "/" + d2[0]
                 r = self.getOnlineContentsWEB(url + "/" + d.replace(" ", "%20"))

--- a/src/Mod/BIM/bimcommands/BimPreflight.py
+++ b/src/Mod/BIM/bimcommands/BimPreflight.py
@@ -287,7 +287,7 @@ class BIM_Preflight_TaskPanel:
         label = test.replace("test", "label")
         tooltip = getattr(self.form, label).toolTip()
         tooltip = tooltip.replace("</p>", "</p>\n\n")
-        tooltip = re.sub("<.*?>", "", tooltip)  # strip html tags
+        tooltip = re.sub(r"<.*?>", "", tooltip)  # strip html tags
         return tooltip
 
     def testAll(self):

--- a/src/Mod/BIM/bimcommands/BimSetup.py
+++ b/src/Mod/BIM/bimcommands/BimSetup.py
@@ -689,7 +689,7 @@ class BIM_Setup:
                     u.close()
                     d = json.loads(r)
                     l = d[-1]["body"]
-                    links = re.findall("http.*?zip", l)
+                    links = re.findall(r"http.*?zip", l)
                     pyv = (
                         "python-"
                         + str(sys.version_info.major)

--- a/src/Mod/BIM/bimcommands/BimTutorial.py
+++ b/src/Mod/BIM/bimcommands/BimTutorial.py
@@ -141,16 +141,16 @@ class BIM_Tutorial:
             f.close()
 
         # setup title and progress bar
-        self.steps = len(re.findall("infotext", html)) - 1
+        self.steps = len(re.findall(r"infotext", html)) - 1
 
         # setup description texts and goals
         self.descriptions = [""] + re.findall(
             "<p><br /> </p><p><br /> </p> (.*?)<p><b>Tutorial step", html
         )
-        self.goal1 = re.findall('goal1">(.*?)</div', html)
-        self.goal2 = re.findall('goal2">(.*?)</div', html)
-        self.test1 = re.findall('test1".*?>(.*?)</div', html)
-        self.test2 = re.findall('test2".*?>(.*?)</div', html)
+        self.goal1 = re.findall(r'goal1">(.*?)</div', html)
+        self.goal2 = re.findall(r'goal2">(.*?)</div', html)
+        self.test1 = re.findall(r'test1".*?>(.*?)</div', html)
+        self.test2 = re.findall(r'test2".*?>(.*?)</div', html)
 
         # fix mediawiki encodes
         self.test1 = [t.replace("&lt;", "<").replace("&gt;", ">") for t in self.test1]
@@ -162,14 +162,14 @@ class BIM_Tutorial:
         )
         nd = []
         for descr in self.descriptions:
-            imagepaths = re.findall('<img.*?src="(.*?)"', descr)
+            imagepaths = re.findall(r'<img.*?src="(.*?)"', descr)
             if imagepaths:
                 store = os.path.join(FreeCAD.getUserAppDataDir(), "BIM", "Tutorial")
                 if not os.path.exists(store):
                     os.makedirs(store)
                 for path in imagepaths:
-                    # name = re.findall("[\\w.-]+\\.(?i)(?:jpg|png|gif|bmp)",path)
-                    name = re.findall("(?i)[\\w.-]+\\.(?:jpg|png|gif|bmp)", path)
+                    # name = re.findall(r"[\\w.-]+\\.(?i)(?:jpg|png|gif|bmp)",path)
+                    name = re.findall(r"(?i)[\\w.-]+\\.(?:jpg|png|gif|bmp)", path)
                     if name:
                         name = name[-1]
                         storename = os.path.join(store, name)

--- a/src/Mod/BIM/importers/importIFClegacy.py
+++ b/src/Mod/BIM/importers/importIFClegacy.py
@@ -41,7 +41,7 @@ SCHEMA = "http://www.steptools.com/support/stdev_docs/ifcbim/ifc4.exp" # only fo
 MAKETEMPFILES = False # if True, shapes are passed from ifcopenshell to freecad through temp files
 DEBUG = True # this is only for the python console, this value is overridden when importing through the GUI
 SKIP = ["IfcBuildingElementProxy","IfcFlowTerminal","IfcFurnishingElement"] # default. overwritten by the GUI options
-IFCLINE_RE = re.compile("#(\d+)[ ]?=[ ]?(.*?)\((.*)\);[\\r]?$")
+IFCLINE_RE = re.compile(r"#(\d+)[ ]?=[ ]?(.*?)\((.*)\);[\\r]?$")
 APPLYFIX = True # if true, the ifcopenshell bug-fixing function is applied when saving files
 # end config
 

--- a/src/Mod/BIM/nativeifc/ifc_psets.py
+++ b/src/Mod/BIM/nativeifc/ifc_psets.py
@@ -96,7 +96,7 @@ def show_psets(obj):
             ptype, value = pvalue.split("(", 1)
             value = value.strip(")")
             value = value.strip("'")
-            pname = re.sub("[^0-9a-zA-Z]+", "", pname)
+            pname = re.sub(r"[^0-9a-zA-Z]+", "", pname)
             if pname[0].isdigit():
                 pname = "_" + pname
             ttip = (

--- a/src/Mod/BIM/utils/buildPsets.py
+++ b/src/Mod/BIM/utils/buildPsets.py
@@ -37,7 +37,7 @@ u = urlopen(
 )
 p = u.read().decode('utf-8')
 u.close()
-psets = re.findall(">Pset_(.*?)</a>", p)
+psets = re.findall(r">Pset_(.*?)</a>", p)
 
 # retrieve xml data from each Pset type
 psetdefs = ""

--- a/src/Mod/CAM/Path/Post/Utils.py
+++ b/src/Mod/CAM/Path/Post/Utils.py
@@ -97,7 +97,7 @@ class FilenameGenerator:
             ext = ".nc"
 
         # Check for invalid matches
-        for match in re.findall("%(.)", outputpath):
+        for match in re.findall(r"%(.)", outputpath):
             Path.Log.debug(f"match: {match}")
             if match not in validPathSubstitutions:
                 outputpath = outputpath.replace(f"%{match}", "")
@@ -105,7 +105,7 @@ class FilenameGenerator:
                     "Invalid substitution strings will be ignored in output path: %s\n" % match
                 )
 
-        for match in re.findall("%(.)", filename):
+        for match in re.findall(r"%(.)", filename):
             Path.Log.debug(f"match: {match}")
             if match not in validFilenameSubstitutions:
                 filename = filename.replace(f"%{match}", "")
@@ -156,10 +156,10 @@ class FilenameGenerator:
             temp_filename = self.qualified_filename
             Path.Log.debug(f"temp_filename: {temp_filename}")
             explicit_sequence = False
-            matches = re.findall("%S", temp_filename)
+            matches = re.findall(r"%S", temp_filename)
             if matches:
                 Path.Log.debug(f"matches: {matches}")
-                temp_filename = re.sub("%S", str(self.sequencenumber), temp_filename)
+                temp_filename = re.sub(r"%S", str(self.sequencenumber), temp_filename)
                 explicit_sequence = True
 
             subpart = f"-{self.subpartname}" if self.subpartname else ""

--- a/src/Mod/CAM/Path/Post/scripts/gcode_pre.py
+++ b/src/Mod/CAM/Path/Post/scripts/gcode_pre.py
@@ -188,7 +188,7 @@ def _identifygcodeByToolNumberList(filename):
     gfile.close()
 
     # Regular expression to match tool changes in the format 'M6 Tn'
-    p = re.compile("[mM]+?\s?0?6\s?T\d*\s")
+    p = re.compile(r"[mM]+?\s?0?6\s?T\d*\s")
 
     # split the gcode on tool changes
     paths = re.split("([mM]+?\s?0?6\s?T\d*\s)", gcode)

--- a/src/Mod/CAM/Path/Tool/Gui/BitEdit.py
+++ b/src/Mod/CAM/Path/Tool/Gui/BitEdit.py
@@ -108,7 +108,7 @@ class ToolBitEditor(object):
         # which aren't being needed anymore.
 
         def labelText(name):
-            return re.sub("([A-Z][a-z]+)", r" \1", re.sub("([A-Z]+)", r" \1", name))
+            return re.sub(r"([A-Z][a-z]+)", r" \1", re.sub(r"([A-Z]+)", r" \1", name))
 
         layout = self.form.bitParams.layout()
         ui = FreeCADGui.UiLoader()

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -462,7 +462,7 @@ class bsplineTracker(Tracker):
             except Exception:
                 # workaround for pivy SoInput.setBuffer() bug
                 buf = buf.replace("\n", "")
-                pts = re.findall("point \\[(.*?)\\]", buf)[0]
+                pts = re.findall(r"point \\[(.*?)\\]", buf)[0]
                 pts = pts.split(",")
                 pc = []
                 for p in pts:
@@ -540,7 +540,7 @@ class bezcurveTracker(Tracker):
                 except Exception:
                     # workaround for pivy SoInput.setBuffer() bug
                     buf = buf.replace("\n","")
-                    pts = re.findall("point \\[(.*?)\\]", buf)[0]
+                    pts = re.findall(r"point \\[(.*?)\\]", buf)[0]
                     pts = pts.split(",")
                     pc = []
                     for p in pts:
@@ -669,7 +669,7 @@ class arcTracker(Tracker):
         except Exception:
             # workaround for pivy SoInput.setBuffer() bug
             buf = buf.replace("\n", "")
-            pts = re.findall("point \\[(.*?)\\]", buf)[0]
+            pts = re.findall(r"point \\[(.*?)\\]", buf)[0]
             pts = pts.split(",")
             pc = []
             for p in pts:

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -221,18 +221,18 @@ def deformat(text):
         The deformatted string.
     """
     # remove ACAD string formatation
-    # t = re.sub('{([^!}]([^}]|\n)*)}', '', text)
+    # t = re.sub(r'{([^!}]([^}]|\n)*)}', '', text)
     # print("input text: ",text)
     t = text.strip("{}")
-    t = re.sub("\\\\.*?;", "", t)
+    t = re.sub(r"\\\\.*?;", "", t)
     # replace UTF codes by utf chars
     sts = re.split("\\\\(U\\+....)", t)
     t = u"".join(sts)
     # replace degrees, diameters chars
-    t = re.sub('%%d', u'°', t)
-    t = re.sub('%%c', u'Ø', t)
-    t = re.sub('%%D', u'°', t)
-    t = re.sub('%%C', u'Ø', t)
+    t = re.sub(r'%%d', u'°', t)
+    t = re.sub(r'%%c', u'Ø', t)
+    t = re.sub(r'%%D', u'°', t)
+    t = re.sub(r'%%C', u'Ø', t)
     # print("output text: ", t)
     return t
 
@@ -3934,7 +3934,7 @@ def exportPage(page, filename):
         f = pyopen(page.Template, "rb")
         svgtemplate = f.read()
         f.close()
-        editables = re.findall("freecad:editable=\"(.*?)\"", svgtemplate)
+        editables = re.findall(r"freecad:editable=\"(.*?)\"", svgtemplate)
         values = page.EditableTexts
         for i in range(len(editables)):
             if len(values) > i:
@@ -3953,7 +3953,7 @@ def exportPage(page, filename):
     blocks = ""
     entities = ""
     r12 = False
-    ver = re.findall("\\$ACADVER\n.*?\n(.*?)\n", template)
+    ver = re.findall(r"\\$ACADVER\n.*?\n(.*?)\n", template)
     if ver:
         # at the moment this is not used.
         # TODO: if r12, do not print ellipses or splines
@@ -3969,7 +3969,7 @@ def exportPage(page, filename):
     if entities:
         template = template.replace("999\n$entities", entities[:-1])
     c = dxfcounter()
-    pat = re.compile("(_handle_)")
+    pat = re.compile(r"(_handle_)")
     template = pat.sub(c.incr, template)
     f = pyopen(filename, "w")
     f.write(template)

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -1712,7 +1712,7 @@ def getContents(filename, tag, stringmode=False):
     searchpat = '<' + tag + '.*?</' + tag + '>'
     tags = re.findall(searchpat, contents)
     for t in tags:
-        tagid = re.findall('id="(.*?)"', t)
+        tagid = re.findall(r'id="(.*?)"', t)
         if tagid:
             tagid = tagid[0]
         else:

--- a/src/Mod/Import/App/SCL/Part21.py
+++ b/src/Mod/Import/App/SCL/Part21.py
@@ -34,7 +34,7 @@ from . import Utils
 import time
 
 
-INSTANCE_DEFINITION_RE = re.compile("#(\d+)[^\S\n]?=[^\S\n]?(.*?)\((.*)\)[^\S\n]?;[\\r]?$")
+INSTANCE_DEFINITION_RE = re.compile(r"#(\d+)[^\S\n]?=[^\S\n]?(.*?)\((.*)\)[^\S\n]?;[\\r]?$")
 
 
 def map_string_to_num(stri):

--- a/src/Tools/generateBase/generateTools.py
+++ b/src/Tools/generateBase/generateTools.py
@@ -141,10 +141,10 @@ def replace(template, dict, file):
     "Test: copy a block of lines, with full processing"
     import re
 
-    rex = re.compile("@([^@]+)@")
+    rex = re.compile(r"@([^@]+)@")
     rbe = re.compile(r"\+")
-    ren = re.compile("-")
-    rco = re.compile("= ")
+    ren = re.compile(r"-")
+    rco = re.compile(r"= ")
     x = 23  # just a variable to try substitution
     cop = copier(rex, dict, rbe, ren, rco)
     lines_block = [line + "\n" for line in template.split("\n")]
@@ -156,10 +156,10 @@ if __name__ == "__main__":
     "Test: copy a block of lines, with full processing"
     import re
 
-    rex = re.compile("@([^@]+)@")
+    rex = re.compile(r"@([^@]+)@")
     rbe = re.compile(r"\+")
-    ren = re.compile("-")
-    rco = re.compile("= ")
+    ren = re.compile(r"-")
+    rco = re.compile(r"= ")
     x = 23  # just a variable to try substitution
     cop = copier(rex, globals(), rbe, ren, rco)
     lines_block = [


### PR DESCRIPTION
Python 3.6 deprecated certain escapes in strings that happen to be common in regex expressions.  Python 3.12 made this a hard syntax error.  After running into a couple using the start page BIMExample, I've decided to pull out the howitzer and blanket change all the python RE strings I can find into raw strings to avoid future problems.