### PR TITLE
[Step Import] fix issue with non-latin characters in import path

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -690,7 +690,7 @@ void Application::importFrom(const char* FileName, const char* DocName, const ch
     wc.setIgnoreEvents(WaitCursor::NoEvents);
     Base::FileInfo File(FileName);
     std::string te = File.extension();
-    string unicodepath = Base::Tools::escapedUnicodeFromUtf8(File.filePath().c_str());
+    string unicodepath = File.filePath().c_str();
     unicodepath = Base::Tools::escapeEncodeFilename(unicodepath);
 
     if (Module) {


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?t=90816&start=10#p783801

To reproduce the issue try to import a step file with a filename containing non-latin characters.  I used a file named: δοκιμή.stp (which I believe to mean "test.stp" in Greek, but it's all Greek to me.  I cannot upload it here because the file extension is not supported.

I could not import the file in the current build, but was able to import after applying this PR.  I was also able to import other files that did not contain non-latin characters in step format and in other formats, too.

I believe the Base::Tools::escapedUnicodeFromUtf8() function is a holdover from python2 support and is probably no longer needed, but I'm not 100% certain of this.

There might be another, better way to fix this issue.