### PR TITLE
Core: Disallow end_all_events in Gesture Nav Style

### DIFF
--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -866,6 +866,14 @@ def get_bbox(obj, debug=False):
 # See https://forum.freecadweb.org/viewtopic.php?p=656362#p656362.
 # Used to fix https://github.com/FreeCAD/FreeCAD/issues/10469.
 def end_all_events():
+    view = get_3d_view()
+    if view is None:
+        return
+    if view.getNavigationType() in (
+            "Gui::GestureNavigationStyle", "Gui::MayaGestureNavigationStyle"
+    ):
+        return
+
     class DelayEnder:
         def __init__(self):
             self.delay_is_done = False


### PR DESCRIPTION
Fix #16332.   ~std::queue is not thread safe, and QTApplication timer delays can go out on another thread.  I didn't bother to fully analyze the thread behavior, I just brute forced a mutex around every likely problem area.  This could probably be refined, but I'm not sure there would be much benefit.  Building or finding a thread safe queue to use instead would likely be prettier, but this is hopefully a clear, minimal change solution to deal with bug for now.~

Replaced with suggestion from Roy-043