### PR TITLE
[Gui] Qt6 OpenGLWidget - move black rectangle off screen

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -397,7 +397,8 @@ MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
     // after opening project and prevent issues with double initialization of the window
     //
     // https://stackoverflow.com/questions/76026196/how-to-force-qt-to-use-the-opengl-window-type
-    new QOpenGLWidget(this);
+    auto _OpenGLWidget = new QOpenGLWidget(this);
+    _OpenGLWidget->move(QPoint(-100,-100));
 #endif
 
     // global access


### PR DESCRIPTION
Remembering a similar issue in the past, inspiration came from https://github.com/FreeCAD/FreeCAD/commit/48ca8d5

@kadet1090 thoughts, is this too much of a hack upon a hack?

Fixes https://github.com/FreeCAD/FreeCAD/issues/16792

If accepted, please backport to 1.0

Tested with clean configs using:

```
OS: EndeavourOS (KDE/plasmax11)
Word size of FreeCAD: 64-bit
Version: 1.1.0dev.38835 (Git)
Build type: Release
Branch: main
Hash: 256ad7a01aa2753ef7b8925ede93dd9448d80a82
Python 3.12.4, Qt 6.7.2, Coin 4.0.2, Vtk 9.3.0, OCC 7.7.2
Locale: English/United Kingdom (en_GB)
Stylesheet/Theme/QtStyle: unset/FreeCAD Classic/breeze
Installed mods: 
  * Behave-Dark-Colors 0.1.1
  * FreeCAD-themes 2024.7.24
```
