### PR TITLE
Fem: Fix flickering between faces and wireframe in FemPostObject view provider

### DIFF
--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -32,6 +32,7 @@
 #include <Inventor/nodes/SoIndexedTriangleStripSet.h>
 #include <Inventor/nodes/SoMaterial.h>
 #include <Inventor/nodes/SoNormal.h>
+#include <Inventor/nodes/SoPolygonOffset.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoShapeHints.h>
 #include <Inventor/nodes/SoSwitch.h>
@@ -175,7 +176,7 @@ ViewProviderFemPostObject::ViewProviderFemPostObject()
                       "Object Style",
                       App::Prop_None,
                       "Use plain color for edges on surface.");
-    ADD_PROPERTY_TYPE(LineWidth, (2), "Object Style", App::Prop_None, "Set wireframe line width.");
+    ADD_PROPERTY_TYPE(LineWidth, (1), "Object Style", App::Prop_None, "Set wireframe line width.");
     ADD_PROPERTY_TYPE(PointSize, (3), "Object Style", App::Prop_None, "Set node point size.");
 
 
@@ -305,12 +306,14 @@ void ViewProviderFemPostObject::attach(App::DocumentObject* pcObj)
     m_sepMarkerLine->addChild(m_lines);
 
     // face nodes
+    SoPolygonOffset* offset = new SoPolygonOffset();
     m_separator->addChild(m_shapeHints);
     m_separator->addChild(m_materialBinding);
     m_separator->addChild(m_material);
     m_separator->addChild(m_coordinates);
-    m_separator->addChild(m_faces);
     m_separator->addChild(m_sepMarkerLine);
+    m_separator->addChild(offset);
+    m_separator->addChild(m_faces);
 
     // Check for an already existing color bar
     Gui::SoFCColorBar* pcBar =


### PR DESCRIPTION
Similar to https://github.com/FreeCAD/FreeCAD/pull/16714, in this case for pipelines and filters.

Flickering is more noticeable on curved surfaces and using flat color for the wireframe (view property `PlaneColorOnSurface = True`)

@FEA-eng 