### PR TITLE
Revert 9b409da due to a regression in some platforms

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1917,18 +1917,13 @@ void MainWindow::startSplasher()
             GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("General");
         // first search for an external image file
         if (hGrp->GetBool("ShowSplasher", true)) {
-            const auto isWayland = qGuiApp->platformName() == QLatin1String("wayland");
-            const auto flags = isWayland ? Qt::WindowFlags() : Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint;
-            d->splashscreen = new SplashScreen(this->splashImage(), flags);
+            d->splashscreen = new SplashScreen(this->splashImage());
 
             if (!hGrp->GetBool("ShowSplasherMessages", false)) {
                 d->splashscreen->setShowMessages(false);
             }
 
             d->splashscreen->show();
-            if (!isWayland) {
-                QApplication::processEvents();
-            }
         }
         else {
             d->splashscreen = nullptr;
@@ -1938,24 +1933,11 @@ void MainWindow::startSplasher()
 
 void MainWindow::stopSplasher()
 {
-    const auto isWayland = qGuiApp->platformName() == QLatin1String("wayland");
-    if (isWayland) {
-        if (d->splashscreen) {
-            d->splashscreen->finish(this);
-            d->splashscreen->deleteLater();
-            d->splashscreen = nullptr;
-        }
-        return;
+    if (d->splashscreen) {
+        d->splashscreen->finish(this);
+        delete d->splashscreen;
+        d->splashscreen = nullptr;
     }
-
-    QApplication::processEvents();
-    QTimer::singleShot(3000, this, [this]() {
-        if (d->splashscreen) {
-            d->splashscreen->finish(this);
-            d->splashscreen->deleteLater();
-            d->splashscreen = nullptr;
-        }
-    });
 }
 
 QPixmap MainWindow::aboutImage() const

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -212,7 +212,6 @@ void StartupPostProcess::setLoadFromPythonModule(bool value)
 
 void StartupPostProcess::execute()
 {
-    showSplashScreen();
     setWindowTitle();
     setProcessMessages();
     setAutoSaving();
@@ -421,7 +420,7 @@ bool StartupPostProcess::hiddenMainWindow() const
     return hidden;
 }
 
-void StartupPostProcess::showSplashScreen()
+void StartupPostProcess::showMainWindow()
 {
     bool hidden = hiddenMainWindow();
 
@@ -429,10 +428,7 @@ void StartupPostProcess::showSplashScreen()
     if (!hidden && !loadFromPythonModule) {
         mainWindow->startSplasher();
     }
-}
 
-void StartupPostProcess::showMainWindow()
-{
     // running the GUI init script
     try {
         Base::Console().Log("Run Gui init script\n");

--- a/src/Gui/StartupProcess.h
+++ b/src/Gui/StartupProcess.h
@@ -74,7 +74,6 @@ private:
     void setImportImageFormats();
     bool hiddenMainWindow() const;
     void showMainWindow();
-    void showSplashScreen();
     void activateWorkbench();
     void checkParameters();
 


### PR DESCRIPTION
Hello, I am submitting here a rollback of 9b409da. Due to reported regressions in some platforms.

References:
https://github.com/FreeCAD/FreeCAD/issues/16798
https://github.com/FreeCAD/FreeCAD/issues/16264

Reverted Commits:
9b409da

Effects:

This restores the splash screen to its previous state, so it appears for a ridiculous short time in all platforms but allows the fragile startup process to continue without interference on all platforms.