### PR TITLE
PadDesign: Work around issue 16690

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -684,7 +684,11 @@ App::DocumentObjectExecReturn* FeatureExtrude::buildExtrusion(ExtrudeOptions opt
                 return App::DocumentObject::StdReturn;
             }
             try {
-                prism.makeElementPrismUntil(base,
+                TopoShape _base;
+                if (addSubType!=FeatureAddSub::Subtractive) {
+                    _base=base; // avoid issue #16690
+                }
+                prism.makeElementPrismUntil(_base,
                                             sketchshape,
                                             supportface,
                                             upToShape,


### PR DESCRIPTION
PadDesign: Work around issue #16690

This is a stopgap measure, I don't know if the underlying issue is fully understood - but this prevents it from happening in the given test case.

By overriding the base for the pocket prism, which is a trick also applied by TopoShape::makeElementPrismUntil() if the prism creation fails on first try, the bug where said prism goes to the wrong shape is avoided - this on its own would however break a pad in the inverse case, so we only do that when pocketing