### PR TITLE
[PD Helix] allow the operation to succes even with a failing refine

### DIFF
--- a/src/Mod/PartDesign/App/FeatureAddSub.cpp
+++ b/src/Mod/PartDesign/App/FeatureAddSub.cpp
@@ -64,13 +64,21 @@ short FeatureAddSub::mustExecute() const
     return PartDesign::Feature::mustExecute();
 }
 
-
-TopoShape FeatureAddSub::refineShapeIfActive(const TopoShape& oldShape) const
+TopoShape FeatureAddSub::refineShapeIfActive(const TopoShape& oldShape, const RefineErrorPolicy onError) const
 {
     if (this->Refine.getValue()) {
         TopoShape shape(oldShape);
         //        this->fixShape(shape);        // Todo:  Not clear that this is required
-        return shape.makeElementRefine();
+        try{
+            return shape.makeElementRefine();
+        }
+        catch (Standard_Failure& err) {
+            if(onError == RefineErrorPolicy::Warn){
+                Base::Console().Warning((std::string("Refine failed: ") + err.GetMessageString()).c_str());
+            } else {
+                throw;
+            }
+        }
     }
     return oldShape;
 }

--- a/src/Mod/PartDesign/App/FeatureAddSub.h
+++ b/src/Mod/PartDesign/App/FeatureAddSub.h
@@ -40,6 +40,11 @@ public:
         Subtractive
     };
 
+    enum class RefineErrorPolicy {
+        Raise = 0,
+        Warn
+    };
+
     FeatureAddSub();
 
     Type getAddSubType();
@@ -54,7 +59,7 @@ public:
 protected:
     Type addSubType{Additive};
 
-   TopoShape refineShapeIfActive(const TopoShape&) const;
+    TopoShape refineShapeIfActive(const TopoShape& oldShape, const RefineErrorPolicy onError = RefineErrorPolicy::Raise) const;
 };
 
 using FeatureAddSubPython = App::FeaturePythonT<FeatureAddSub>;

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -272,7 +272,7 @@ App::DocumentObjectExecReturn* Helix::execute()
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Result has multiple solids"));
             }
 
-            boolOp = refineShapeIfActive(boolOp);
+            boolOp = refineShapeIfActive(boolOp, RefineErrorPolicy::Warn);
             Shape.setValue(getSolid(boolOp));
         }
         else if (getAddSubType() == FeatureAddSub::Subtractive) {
@@ -301,7 +301,7 @@ App::DocumentObjectExecReturn* Helix::execute()
                 return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception", "Error: Result has multiple solids"));
             }
 
-            boolOp = refineShapeIfActive(boolOp);
+            boolOp = refineShapeIfActive(boolOp, RefineErrorPolicy::Warn);
             Shape.setValue(getSolid(boolOp));
         }
 


### PR DESCRIPTION
Consider refinement not critical for Helix operation.
If the Refine property is set but its process fails it only warns and the feature is not put in an error state.

ref: https://github.com/FreeCAD/FreeCAD/issues/16081#issuecomment-2378786627

