### PR TITLE
Fix nested groups and dependency edges for groups in the dependency graph

### DIFF
--- a/src/App/Graphviz.cpp
+++ b/src/App/Graphviz.cpp
@@ -389,12 +389,15 @@ void Document::exportGraphviz(std::ostream& out) const
             if(CSSubgraphs) {
                 //first build up the coordinate system subgraphs
                 for (auto objectIt : d->objectArray) {
-                    // do not require an empty inlist (#0003465: Groups breaking dependency graph)
+                    // ignore groups inside other groups, these will be processed in one of the next recursive calls.
                     // App::Origin now has the GeoFeatureGroupExtension but it should not move its
                     // group symbol outside its parent
                     if (!objectIt->isDerivedFrom(Origin::getClassTypeId()) &&
-                         objectIt->hasExtension(GeoFeatureGroupExtension::getExtensionClassTypeId()))
+                        objectIt->hasExtension(GeoFeatureGroupExtension::getExtensionClassTypeId()) &&
+                        GeoFeatureGroupExtension::getGroupOfObject(objectIt) == nullptr)
+                    {
                         recursiveCSSubgraphs(objectIt, nullptr);
+                    }
                 }
             }
 

--- a/src/App/Graphviz.cpp
+++ b/src/App/Graphviz.cpp
@@ -489,23 +489,20 @@ void Document::exportGraphviz(std::ostream& out) const
             // Add edges between document objects
             for (const auto & It : d->objectMap) {
 
-                if(omitGeoFeatureGroups) {
-                    //coordinate systems are represented by subgraphs
-                    if(It.second->hasExtension(GeoFeatureGroupExtension::getExtensionClassTypeId()))
-                        continue;
-
-                    //as well as origins
-                    if(It.second->isDerivedFrom(Origin::getClassTypeId()))
-                        continue;
+                if(omitGeoFeatureGroups && It.second->isDerivedFrom(Origin::getClassTypeId())) {
+                    continue;
                 }
 
                 std::map<DocumentObject*, int> dups;
                 std::vector<DocumentObject*> OutList = It.second->getOutList();
                 const DocumentObject * docObj = It.second;
+                const bool docObj_is_group = docObj->hasExtension(GeoFeatureGroupExtension::getExtensionClassTypeId());
 
                 for (auto obj : OutList) {
                     if (obj) {
-
+                        if(omitGeoFeatureGroups && docObj_is_group && GeoFeatureGroupExtension::getGroupOfObject(obj) == docObj) {
+                            continue;
+                        }
                         // Count duplicate edges
                         bool inserted = edge(GlobalVertexList[getId(docObj)], GlobalVertexList[getId(obj)], DepList).second;
                         if (inserted) {


### PR DESCRIPTION
Fixes two problems with the dependency graph.

  * #16878
  * #16879

Nested `GeoFeatureGroupExtension` are always shown nested independent of their creation order
![nested_fix](https://github.com/user-attachments/assets/b87d0ebf-3c7f-4804-adbd-73bb1c38da4a)

Depencency edges for `GeoFeatureGroupExtension` are only ommited if the dependency is a child of the group
![link_fix](https://github.com/user-attachments/assets/433fafbb-266c-4bcb-b363-04f8d08f77e0)