### PR TITLE
Regenerate Version.h if the git hash changes

### DIFF
--- a/src/Build/CMakeLists.txt
+++ b/src/Build/CMakeLists.txt
@@ -10,19 +10,17 @@ if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/Version.h)
                 ${CMAKE_CURRENT_BINARY_DIR}/Version.h.in)
 
     add_custom_command(
-        OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/Version.h
+        OUTPUT version_file
+        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Version.h
+        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/Tools/SubWCRev.py
+            --srcdir=${CMAKE_SOURCE_DIR} --bindir=${CMAKE_BINARY_DIR}
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/Version.h.out
             ${CMAKE_CURRENT_BINARY_DIR}/Version.h
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DEPENDS version_check)
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Version.h.in)
+    set_source_files_properties(version_file PROPERTIES SYMBOLIC true)
 
-    add_custom_command(
-        OUTPUT  version_check
-        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/src/Tools/SubWCRev.py
-        --srcdir=${CMAKE_SOURCE_DIR} --bindir=${CMAKE_BINARY_DIR}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-    ADD_CUSTOM_TARGET(fc_version DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Version.h)
+    ADD_CUSTOM_TARGET(fc_version DEPENDS version_file ${CMAKE_CURRENT_BINARY_DIR}/Version.h)
 
 else (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/Version.h)
 


### PR DESCRIPTION
Prevous Version.h was not regenerated after it was initially created. This prevented an accurate commit hash in the About dialog when incrementally building from source.

Now the file is always rewritten when it's content is changed.

Fixes #16871