### PR TITLE
[TD]fix continuous line detail highlight not shown

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIHighlight.cpp
+++ b/src/Mod/TechDraw/Gui/QGIHighlight.cpp
@@ -191,7 +191,6 @@ void QGIHighlight::setTools()
 {
     m_pen.setWidthF(m_width);
     m_pen.setColor(m_colCurrent);
-    m_pen.setStyle(Qt::CustomDashLine);
 
     m_brush.setStyle(m_brushCurrent);
     m_brush.setColor(m_colCurrent);


### PR DESCRIPTION
This PR implements a fix for an issue with continuous lines in detail highlights as reported here: https://forum.freecad.org/viewtopic.php?t=90933
