### PR TITLE
Fem: Use default size for mesh task panel quantity spin boxes

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/MeshGmsh.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MeshGmsh.ui
@@ -56,12 +56,6 @@
           <property name="unit" stdset="0">
            <string notr="true">mm</string>
           </property>
-          <property name="minimumSize">
-           <size>
-            <width>100</width>
-            <height>20</height>
-           </size>
-          </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
@@ -96,12 +90,6 @@
           </property>
           <property name="unit" stdset="0">
            <string notr="true">mm</string>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>100</width>
-            <height>20</height>
-           </size>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/Fem/Gui/Resources/ui/MeshNetgen.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MeshNetgen.ui
@@ -56,12 +56,6 @@
           <property name="unit" stdset="0">
            <string notr="true">mm</string>
           </property>
-          <property name="minimumSize">
-           <size>
-            <width>100</width>
-            <height>20</height>
-           </size>
-          </property>
           <property name="alignment">
            <set>Qt::AlignLeft|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
@@ -96,12 +90,6 @@
           </property>
           <property name="unit" stdset="0">
            <string notr="true">mm</string>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>100</width>
-            <height>20</height>
-           </size>
           </property>
           <property name="alignment">
            <set>Qt::AlignLeft|Qt::AlignTrailing|Qt::AlignVCenter</set>


### PR DESCRIPTION
At the current size, the quantity spin boxes are cropped  (may depend on resolution and stylesheet used).

![Screenshot_20240928_202517](https://github.com/user-attachments/assets/db8d942f-c284-4cc9-a4f3-528b93c85cce)

