### PR TITLE
[Part CheckGeometry] prevent crash when attempting to check origin axis

### DIFF
--- a/src/Mod/Part/Gui/TaskCheckGeometry.cpp
+++ b/src/Mod/Part/Gui/TaskCheckGeometry.cpp
@@ -433,11 +433,16 @@ void TaskCheckGeometryResults::goCheck()
     for(const auto &sel :  selection) {
         selectedCount++;
         TopoDS_Shape shape = Part::Feature::getShape(sel.pObject,sel.SubName,true);
-        if (shape.IsNull())
+        if (shape.IsNull()) {
             continue;
+        }
+        if (shape.Infinite()) {
+            continue;
+        }
         currentSeparator = Gui::Application::Instance->getViewProvider(sel.pObject)->getRoot();
-        if (!currentSeparator)
+        if (!currentSeparator) {
             continue;
+        }
         QString baseName;
         QTextStream baseStream(&baseName);
         baseStream << sel.DocName;


### PR DESCRIPTION
https://github.com/FreeCAD/FreeCAD/issues/16625

Crash occurs when expanding Origin object in Part Design and attempting to run Part workbench CheckGeometry on the X-axis object when the too small edge option is enabled.

This PR bypassing checking such objects by checking boundbox diagonal length > 1e100.  A warning is displayed in the report view on skipping these objects, and also a warning is shown when skipping objects with null shapes or no shapes, such as spreadsheet objects.