### PR TITLE
Prevent naming properties with reserved words (Fix #16846)

### DIFF
--- a/src/Gui/DlgAddProperty.cpp
+++ b/src/Gui/DlgAddProperty.cpp
@@ -28,6 +28,7 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
+#include <App/ExpressionParser.h>
 #include <Base/Tools.h>
 
 #include "DlgAddProperty.h"
@@ -110,6 +111,13 @@ void DlgAddProperty::accept()
 
     if(ui->chkAppend->isChecked())
         name = group + "_" + name;
+
+    if (App::ExpressionParser::isTokenAUnit(name)) {
+        QMessageBox::critical(getMainWindow(),
+            QObject::tr("Invalid name"),
+            QObject::tr("The property name is a reserved word."));
+        return;
+    }
 
     for(auto c : containers) {
         auto prop = c->getPropertyByName(name.c_str());

--- a/src/Gui/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/DlgAddPropertyVarSet.cpp
@@ -30,6 +30,7 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
+#include <App/ExpressionParser.h>
 #include <App/PropertyUnits.h>
 #include <Base/Tools.h>
 
@@ -347,6 +348,14 @@ void DlgAddPropertyVarSet::checkName() {
                               QObject::tr("Invalid name"),
                               QObject::tr("The property name must only contain alpha numericals,\n"
                                           "underscore, and must not start with a digit."));
+        clearEditors(!CLEAR_NAME);
+        throw CreatePropertyException("Invalid name");
+    }
+
+    if(App::ExpressionParser::isTokenAUnit(name)) {
+        QMessageBox::critical(getMainWindow(),
+                              QObject::tr("Invalid name"),
+                              QObject::tr("The property name is a reserved word."));
         clearEditors(!CLEAR_NAME);
         throw CreatePropertyException("Invalid name");
     }

--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -428,6 +428,11 @@ static bool isNamePropOk(const QString& nameProp, App::DocumentObject* obj,
         return false;
     }
 
+    if (ExpressionParser::isTokenAUnit(name)) {
+        message << name << " is a reserved word";
+        return false;
+    }
+
     auto prop = obj->getPropertyByName(name.c_str());
     if (prop && prop->getContainer() == obj) {
         message << name << " already exists";


### PR DESCRIPTION
**Since this fixes a prominent new feature in 1.0, I suggest that it be reviewed prior to the official release.**

This PR fixes #16846. It prevents the use of reserved words (eg. `T`, `K`, `rad`, ...) for properties. It affects both the new VarSet feature and the pre-existing "Add Property" dialog box.

Please note:

- Although I've used FreeCAD for some time, this is my first code contribution. Apologies for any misstep(s)!
- I compiled and tested this fix on my WIndows 11 PC using the MSVC toolchain.

I look forward to feedback!