### PR TITLE
Measurement: Fix macos crashes caused by unhandled exceptions reaching qt

### DIFF
--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -48,6 +48,8 @@
 using namespace Measure;
 using namespace MeasureGui;
 
+FC_LOG_LEVEL_INIT("QuickMeasure", true, true)
+
 QuickMeasure::QuickMeasure(QObject* parent)
     : QObject(parent)
     , measurement {new Measure::Measurement()}
@@ -90,6 +92,12 @@ void QuickMeasure::processSelection()
         }
         catch (const Base::Exception& e) {
             e.ReportException();
+        }
+        catch (const Standard_Failure& e) {
+            FC_ERR(e);
+        }
+        catch (...) {
+            FC_ERR("Unhandled unknown exception");
         }
     }
 }


### PR DESCRIPTION
As described in https://github.com/FreeCAD/FreeCAD/issues/16905, macos crashes when exceptions are reaching qt.

The crash this PR fixes is described this comment: https://github.com/FreeCAD/FreeCAD/issues/16888#issuecomment-2381031659

The reason why FreeCAD crashes is:
1. OCCT throws an exception [here](https://github.com/FreeCAD/FreeCAD/blob/6e2cd4e73303f817e4bf5e908abe39030b7c5fb3/src/Mod/Measure/App/Measurement.cpp#L361)
2. The exception is not caught in `QuickMeasure::processSelection()`

This PR adds a catch for OCCT exceptions as well as a generic for unknown exceptions.

Note, this doesn't fix the bug, but it fixes the crash.