### PR TITLE
Include a warning to developers for unhandled exceptions in GUIApplication::notify

### DIFF
--- a/src/Gui/GuiApplication.cpp
+++ b/src/Gui/GuiApplication.cpp
@@ -75,6 +75,16 @@ bool GUIApplication::notify (QObject * receiver, QEvent * event)
             (int)event->type());
         return false;
     }
+
+    // https://github.com/FreeCAD/FreeCAD/issues/16905
+    std::string exceptionWarning =
+#if FC_DEBUG
+        "Exceptions must be caught before they go through Qt."
+        " Ignoring this will cause crashes on some systems.\n";
+#else
+        "";
+#endif
+
     try {
         if (event->type() == Spaceball::ButtonEvent::ButtonEventType ||
             event->type() == Spaceball::MotionEvent::MotionEventType)
@@ -89,14 +99,15 @@ bool GUIApplication::notify (QObject * receiver, QEvent * event)
     }
     catch (const Base::Exception& e) {
         Base::Console().Error("Unhandled Base::Exception caught in GUIApplication::notify.\n"
-                              "The error message is: %s\n", e.what());
+                              "The error message is: %s\n%s", e.what(), exceptionWarning);
     }
     catch (const std::exception& e) {
         Base::Console().Error("Unhandled std::exception caught in GUIApplication::notify.\n"
-                              "The error message is: %s\n", e.what());
+                              "The error message is: %s\n%s", e.what(), exceptionWarning);
     }
     catch (...) {
-        Base::Console().Error("Unhandled unknown exception caught in GUIApplication::notify.\n");
+        Base::Console().Error("Unhandled unknown exception caught in GUIApplication::notify.\n%s",
+                              exceptionWarning);
     }
 
     // Print some more information to the log file (if active) to ease bug fixing


### PR DESCRIPTION
This is a first step to fix https://github.com/FreeCAD/FreeCAD/issues/16905.
While the situation might work on some platforms, it will cause a crash on other platforms (confirmed on macOS).

Adding this message informs developers (on all platforms) that they just witnessed a situation that would cause a crash (on some platforms).
This hopefully makes them investigate the issue further and create a fix for it.