### PR TITLE
[PartDesign AllowCompound] recompute all features when AllowCompound …

### DIFF
--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -465,11 +465,11 @@ void Body::onChanged(const App::Property* prop) {
         else if (prop == &AllowCompound) {
             // As disallowing compounds can break the model we need to recompute the whole tree.
             // This will inform user about first place where there is more than one solid.
-            if (!AllowCompound.getValue()) {
-                for (auto feature : getFullModel()) {
-                    feature->enforceRecompute();
-                }
+            // On allowing compounds we must also recompute the entire feature tree
+            for (auto feature : getFullModel()) {
+                feature->enforceRecompute();
             }
+
         }
     }
 


### PR DESCRIPTION
…property is changed either from true to false or from false to true

https://github.com/FreeCAD/FreeCAD/issues/16420

Currently, you must mark to recompute the document, and then refresh upon changing this property from false to true, but not when switching from true to false.  This PR removes the test for whether the property is now disabled and does the recompute whether disabled or not.