### PR TITLE
Start: little layout tweak to First Start Region

### DIFF
--- a/src/Mod/Start/Gui/FirstStartWidget.cpp
+++ b/src/Mod/Start/Gui/FirstStartWidget.cpp
@@ -58,7 +58,7 @@ FirstStartWidget::FirstStartWidget(QWidget* parent)
 void FirstStartWidget::setupUi()
 {
     auto outerLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout(this));
-    outerLayout->addStretch();
+    outerLayout->setAlignment(Qt::AlignCenter);
     QString application = QString::fromUtf8(App::Application::Config()["ExeName"].c_str());
     _welcomeLabel = gsl::owner<QLabel*>(new QLabel);
     outerLayout->addWidget(_welcomeLabel);
@@ -74,10 +74,9 @@ void FirstStartWidget::setupUi()
     _doneButton = gsl::owner<QPushButton*>(new QPushButton);
     connect(_doneButton, &QPushButton::clicked, this, &FirstStartWidget::dismissed);
     auto buttonBar = gsl::owner<QHBoxLayout*>(new QHBoxLayout);
-    buttonBar->addStretch();
+    buttonBar->setAlignment(Qt::AlignRight);
     buttonBar->addWidget(_doneButton);
     outerLayout->addLayout(buttonBar);
-    outerLayout->addStretch();
 
     retranslateUi();
 }

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -122,14 +122,13 @@ StartView::StartView(QWidget* parent)
     firstStartScrollArea->setWidgetResizable(true);
 
     auto firstStartRegion = gsl::owner<QHBoxLayout*>(new QHBoxLayout(firstStartScrollWidget));
-    firstStartRegion->addStretch();
+    firstStartRegion->setAlignment(Qt::AlignCenter);
     auto firstStartWidget = gsl::owner<FirstStartWidget*>(new FirstStartWidget(this));
     connect(firstStartWidget,
             &FirstStartWidget::dismissed,
             this,
             &StartView::firstStartWidgetDismissed);
     firstStartRegion->addWidget(firstStartWidget);
-    firstStartRegion->addStretch();
     _contents->addWidget(firstStartScrollArea);
 
     // Documents page


### PR DESCRIPTION
This is a small adjustment to the First Start page, so the BoxLayout is centered vertically and horizontally with no "extended/stretched" area.

Before:

![before](https://github.com/user-attachments/assets/6ff10bb9-6a4b-4ad0-9288-590eef8cf029)

After:

![after](https://github.com/user-attachments/assets/3c06448a-d589-46cd-9d65-fb65ebb6d83b)


I could only test on :

```
OS: GNU/LInux Ubuntu 22.04 LTS (DE:Gnome/pop)
Word size of FreeCAD: 64-bit
Version: 1.1.0dev.38844 +1 (Git)
Build type: Release
Branch: first-start-layout-tweak
Hash: bc81bdff670f93ca099e20857ea35911a222b1f6
Python 3.10.12, Qt 5.15.3, Coin 4.0.0, Vtk , OCC 7.6.3
Stylesheet/Theme/QtStyle: FreeCAD Light.qss/FreeCAD Light/Fusion
```

Let me know if it is OK too for Qt6 and other configs =D