### PR TITLE
QuickMeasure: Prevent crash by limiting selection to Part::Features

### DIFF
--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -120,7 +120,7 @@ bool QuickMeasure::isObjAcceptable(App::DocumentObject* obj)
 
     std::string vpType = obj->getViewProviderName();
     auto* vp = Gui::Application::Instance->getViewProvider(obj);
-    return !(vpType == "SketcherGui::ViewProviderSketch" && vp->isEditing());
+    return !(vpType == "SketcherGui::ViewProviderSketch" && vp && vp->isEditing());
 }
 
 void QuickMeasure::addSelectionToMeasurement()

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -65,7 +65,7 @@ QuickMeasure::~QuickMeasure()
 
 void QuickMeasure::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
-    if (canMeasureSelection(msg)) {
+    if (shouldMeasure(msg)) {
         if (!pendingProcessing) {
             selectionTimer->start(100);
         }
@@ -101,7 +101,7 @@ void QuickMeasure::tryMeasureSelection()
     printResult();
 }
 
-bool QuickMeasure::canMeasureSelection(const Gui::SelectionChanges& msg) const
+bool QuickMeasure::shouldMeasure(const Gui::SelectionChanges& msg) const
 {
     if (msg.Type == Gui::SelectionChanges::SetPreselect
         || msg.Type == Gui::SelectionChanges::RmvPreselect) {
@@ -112,21 +112,21 @@ bool QuickMeasure::canMeasureSelection(const Gui::SelectionChanges& msg) const
     return doc != nullptr;
 }
 
+bool QuickMeasure::isObjAcceptable(App::DocumentObject* obj)
+{
+    if (!obj || !obj->isDerivedFrom(Part::Feature::getClassTypeId())) {
+        return false;
+    }
+
+    std::string vpType = obj->getViewProviderName();
+    auto* vp = Gui::Application::Instance->getViewProvider(obj);
+    return !(vpType == "SketcherGui::ViewProviderSketch" && vp->isEditing());
+}
+
 void QuickMeasure::addSelectionToMeasurement()
 {
     int count = 0;
     int limit = 100;
-
-    // Lambda function to check whether to continue
-    auto shouldSkip = [](App::DocumentObject* obj) {
-        std::string vpType = obj->getViewProviderName();
-        auto* vp = Gui::Application::Instance->getViewProvider(obj);
-        return (vpType == "SketcherGui::ViewProviderSketch" && vp->isEditing())
-            || vpType.find("Gui::ViewProviderOrigin") != std::string::npos
-            || vpType.find("Gui::ViewProviderPart") != std::string::npos
-            || vpType.find("SpreadsheetGui") != std::string::npos
-            || vpType.find("TechDrawGui") != std::string::npos;
-    };
 
     auto selObjs = Gui::Selection().getSelectionEx(nullptr,
                                                    App::DocumentObject::getClassTypeId(),
@@ -144,7 +144,7 @@ void QuickMeasure::addSelectionToMeasurement()
         }
 
         if (subNames.empty()) {
-            if (!shouldSkip(rootObj)) {
+            if (isObjAcceptable(rootObj)) {
                 measurement->addReference3D(rootObj, "");
             }
             continue;
@@ -153,7 +153,7 @@ void QuickMeasure::addSelectionToMeasurement()
         for (auto& subName : subNames) {
             App::DocumentObject* obj = rootObj->getSubObject(subName.c_str());
 
-            if (shouldSkip(obj)) {
+            if (!isObjAcceptable(obj)) {
                 continue;
             }
             measurement->addReference3D(rootObj, subName);

--- a/src/Mod/Measure/Gui/QuickMeasure.h
+++ b/src/Mod/Measure/Gui/QuickMeasure.h
@@ -52,8 +52,9 @@ private:
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;
     void tryMeasureSelection();
 
-    bool canMeasureSelection(const Gui::SelectionChanges& msg) const;
+    bool shouldMeasure(const Gui::SelectionChanges& msg) const;
     void addSelectionToMeasurement();
+    bool isObjAcceptable(App::DocumentObject* obj);
     void printResult();
     void print(const QString& message);
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/16888
Fix https://github.com/FreeCAD/FreeCAD/issues/16961
Potential fix for https://github.com/FreeCAD/FreeCAD/issues/16844 but as the report is missing information I can't be sure.