### PR TITLE
Core: getGlobalPlacement : add python binding

### DIFF
--- a/src/App/GeoFeature.h
+++ b/src/App/GeoFeature.h
@@ -108,8 +108,9 @@ public:
             const DocumentObject *filter=nullptr,const char **element=nullptr, GeoFeature **geo=nullptr);
 
     /**
-     * @brief Calculates the placement in the global reference coordinate system
+     * @brief Deprecated. Calculates the placement in the global reference coordinate system
      * 
+     * Deprecated: This does not handle App::Links correctly. Use getGlobalPlacement() instead.
      * In FreeCAD the GeoFeature placement describes the local placement of the object in its parent
      * coordinate system. This is however not always the same as the global reference system. If the
      * object is in a GeoFeatureGroup, hence in another local coordinate system, the Placement

--- a/src/App/GeoFeaturePy.xml
+++ b/src/App/GeoFeaturePy.xml
@@ -30,11 +30,28 @@ Note: Not implemented.</UserDocu>
     <Methode Name="getGlobalPlacement">
       <Documentation>
         <UserDocu>getGlobalPlacement() -> Base.Placement
+Deprecated: This function does not handle Links correctly. Use getGlobalPlacementOf instead.
 
 Returns the placement of the object in the global coordinate space, respecting all stacked
 relationships.
 Note: This function is not available during recompute, as there the placements of parents
 can change after the execution of this object, rendering the result wrong.</UserDocu>
+      </Documentation>
+    </Methode>
+    <Methode Name="getGlobalPlacementOf" Static="true">
+      <Documentation>
+        <UserDocu>getGlobalPlacementOf(targetObj, rootObj, subname) -> Base.Placement
+Selection example: obj = "part1" sub = "linkToPart2.LinkToBody.Pad.face1"
+
+Global placement of Pad in this context :
+getGlobalPlacementOf(pad, part1, "linkToPart2.LinkToBody.Pad.face1")
+
+Global placement of linkToPart2 in this context :
+getGlobalPlacementOf(linkToPart2, part1, "linkToPart2.LinkToBody.Pad.face1")
+
+Returns the placement of the object in the global coordinate space, respecting all stacked
+relationships.
+        </UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="getPropertyNameOfGeometry">

--- a/src/App/GeoFeaturePyImp.cpp
+++ b/src/App/GeoFeaturePyImp.cpp
@@ -59,8 +59,8 @@ PyObject* GeoFeaturePy::getGlobalPlacement(PyObject * args) {
 
 PyObject* GeoFeaturePy::getGlobalPlacementOf(PyObject * args) {
 
-    PyObject* pyTargetObj;
-    PyObject* pyRootObj;
+    PyObject* pyTargetObj {nullptr};
+    PyObject* pyRootObj {nullptr};
     char* pname;
 
     if (!PyArg_ParseTuple(args, "OOs", &pyTargetObj, &pyRootObj, &pname)) {

--- a/src/App/GeoFeaturePyImp.cpp
+++ b/src/App/GeoFeaturePyImp.cpp
@@ -57,6 +57,27 @@ PyObject* GeoFeaturePy::getGlobalPlacement(PyObject * args) {
     }
 }
 
+PyObject* GeoFeaturePy::getGlobalPlacementOf(PyObject * args) {
+
+    PyObject* pyTargetObj;
+    PyObject* pyRootObj;
+    char* pname;
+
+    if (!PyArg_ParseTuple(args, "OOs", &pyTargetObj, &pyRootObj, &pname)) {
+        return nullptr;
+    }
+    auto* targetObj = static_cast<App::DocumentObjectPy*>(pyTargetObj)->getDocumentObjectPtr();
+    auto* rootObj = static_cast<App::DocumentObjectPy*>(pyRootObj)->getDocumentObjectPtr();
+
+    try {
+        Base::Placement p = GeoFeature::getGlobalPlacement(targetObj, rootObj, pname);
+        return new Base::PlacementPy(new Base::Placement(p));
+    }
+    catch (const Base::Exception& e) {
+        throw Py::RuntimeError(e.what());
+    }
+}
+
 PyObject* GeoFeaturePy::getPropertyNameOfGeometry(PyObject * args)
 {
     if (!PyArg_ParseTuple(args, ""))

--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -260,32 +260,13 @@ def getGlobalPlacement(ref, targetObj=None):
 
     if targetObj is None:  # If no targetObj is given, we consider it's the getObject(ref)
         targetObj = getObject(ref)
-
-    if targetObj is None:
-        return App.Placement()
+        if targetObj is None:
+            return App.Placement()
 
     rootObj = ref[0]
-    names = ref[1][0].split(".")
+    subName = ref[1][0]
 
-    doc = rootObj.Document
-    plc = rootObj.Placement
-
-    for objName in names:
-        obj = doc.getObject(objName)
-        if not obj:
-            continue
-
-        plc = plc * obj.Placement
-
-        if obj == targetObj:
-            return plc
-
-        if isLink(obj):
-            linked_obj = obj.getLinkedObject()
-            doc = linked_obj.Document  # in case its an external link.
-
-    # If targetObj has not been found there's a problem
-    return App.Placement()
+    return App.GeoFeature.getGlobalPlacementOf(targetObj, rootObj, subName)
 
 
 def isThereOneRootAssembly():


### PR DESCRIPTION
This PR adds python binding to the new getGlobalPlacement. You can now do: 
`App.GeoFeature.getGlobalPlacementOf(targetObj, rootObj, subname)`

This PR also remove the reimplementation of getGlobalPlacement in python and use instead the cpp python binding.

Fix the comment : https://github.com/FreeCAD/FreeCAD/pull/15262#issuecomment-2371447889
