### PR TITLE
Core: QuantitySpinbox: Reduce minimum width.

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -792,41 +792,22 @@ QSize QuantitySpinBox::sizeForText(const QString& txt) const
 
 QSize QuantitySpinBox::sizeHint() const
 {
-    Q_D(const QuantitySpinBox);
-    ensurePolished();
-
-    const QFontMetrics fm(fontMetrics());
-    int h = lineEdit()->sizeHint().height();
-    int w = 0;
-
-    QString s;
-    QString fixedContent = QLatin1String(" ");
-
-    Base::Quantity q(d->quantity);
-    q.setValue(d->maximum);
-    s = textFromValue(q);
-    s.truncate(18);
-    s += fixedContent;
-    w = qMax(w, QtTools::horizontalAdvance(fm, s));
-
-    w += 2; // cursor blinking space
-    w += iconHeight;
-
-    QStyleOptionSpinBox opt;
-    initStyleOption(&opt);
-    QSize hint(w, h);
-    QSize size = style()->sizeFromContents(QStyle::CT_SpinBox, &opt, hint, this);
-    return size;
+    return sizeHintCalculator(lineEdit()->sizeHint().height());
 }
 
 QSize QuantitySpinBox::minimumSizeHint() const
+{
+    return sizeHintCalculator(lineEdit()->minimumSizeHint().height());
+}
+
+QSize QuantitySpinBox::sizeHintCalculator(int h) const
 {
     Q_D(const QuantitySpinBox);
     ensurePolished();
 
     const QFontMetrics fm(fontMetrics());
-    int h = lineEdit()->minimumSizeHint().height();
     int w = 0;
+    constexpr int maxStrLen = 12;
 
     QString s;
     QString fixedContent = QLatin1String(" ");
@@ -834,7 +815,7 @@ QSize QuantitySpinBox::minimumSizeHint() const
     Base::Quantity q(d->quantity);
     q.setValue(d->maximum);
     s = textFromValue(q);
-    s.truncate(18);
+    s.truncate(maxStrLen);
     s += fixedContent;
     w = qMax(w, QtTools::horizontalAdvance(fm, s));
 

--- a/src/Gui/QuantitySpinBox.h
+++ b/src/Gui/QuantitySpinBox.h
@@ -166,6 +166,7 @@ private:
     void updateFromCache(bool notify, bool updateUnit = true);
     QString getUserString(const Base::Quantity& val, double& factor, QString& unitString) const;
     QString getUserString(const Base::Quantity& val) const;
+    QSize sizeHintCalculator(int height) const;
 
 Q_SIGNALS:
     /** Gets emitted if the user has entered a VALID input


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/16810

The way the minimum size was defined, is that it set the value of the quantity to maximum. Then truncated the string to 18 characters. Then calculating the size.

This PR does 2 things : 
- Change truncate value from 18 to 12. Ensuring a more reasonable width.
- Refactor the code as sizeHint and minimumSizeHint were copy-pastes.

Example, minimum size of Placement dialog with 12 : 
![image](https://github.com/user-attachments/assets/8847e75b-dbcd-4416-bc3e-bc28a3cb9bca)
