### PR TITLE
Core: Do not save changes of a text object if the GUI document is abo…

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -997,6 +997,10 @@ bool Document::isModified() const
     return d->_isModified;
 }
 
+bool Document::isAboutToClose() const
+{
+    return d->_isClosing;
+}
 
 ViewProviderDocumentObject* Document::getViewProviderByPathFromTail(SoPath * path) const
 {

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -169,6 +169,9 @@ public:
     void setModified(bool);
     bool isModified() const;
 
+    /// Returns true if the document is about to be closed, false otherwise
+    bool isAboutToClose() const;
+
     /// Getter for the App Document
     App::Document*  getDocument() const;
 

--- a/src/Gui/TextDocumentEditorView.h
+++ b/src/Gui/TextDocumentEditorView.h
@@ -66,6 +66,7 @@ private:
     void labelChanged();
     void refresh();
     bool isEditorModified() const;
+    int execSaveDialog();
 
 private:
     QPlainTextEdit *const editor;


### PR DESCRIPTION
…ut to be closed

This fixes #16873: Text document breaks some Analysis container objects