### PR TITLE
[Part Workbench] Fix issue with Sketcher_NewSketch icon moving on cha…

### DIFF
--- a/src/Mod/Part/Gui/Workbench.h
+++ b/src/Mod/Part/Gui/Workbench.h
@@ -40,6 +40,9 @@ public:
   Workbench();
   ~Workbench() override;
 
+private:
+  bool hasSketcher = false;
+
 protected:
   Gui::MenuItem* setupMenuBar() const override;
   Gui::ToolBarItem* setupToolBars() const override;

--- a/src/Mod/Part/InitGui.py
+++ b/src/Mod/Part/InitGui.py
@@ -38,21 +38,6 @@ class PartWorkbench(Gui.Workbench):
         self.__class__.MenuText = "Part"
         self.__class__.ToolTip = "Part workbench"
 
-    def tryAddManipulator(self):
-        try:
-            import SketcherGui
-
-            class Manipulator:
-                def modifyToolBars(self):
-                    return [{"insert" : "Sketcher_NewSketch", "toolItem" : "Part_Extrude"}]
-                def modifyMenuBar(self):
-                    return [{"insert" : "Sketcher_NewSketch", "menuItem" : "Part_Extrude"}]
-
-            manip = Manipulator()
-            Gui.addWorkbenchManipulator(manip)
-        except ImportError as err:
-            pass
-
     def Initialize(self):
         # load the module
         import PartGui
@@ -78,8 +63,6 @@ class PartWorkbench(Gui.Workbench):
         except Exception as err:
             App.Console.PrintError("'BOPTools' package cannot be loaded. "
                                    "{err}\n".format(err=str(err)))
-
-        self.tryAddManipulator()
 
     def GetClassName(self):
         return "PartGui::Workbench"


### PR DESCRIPTION
…nging back to workbench

https://github.com/FreeCAD/FreeCAD/issues/15717

This addresses a minor UI issue where the icon to create a new sketch from Part workbench moves from first position to last position upon returning to the workbench in some cases.

I have removed the Manipulator python code from the InitGui.py file because it is no longer needed.

I have a concern for adding dependencies on other workbenches to the Part workbench.  I view it as the primary workbench in FreeCAD because in that module most of the interface to OCCT resides.  It is possible, due to the modular construction of FreeCAD, to compile FreeCAD without certain modules, including Sketcher.  (See BUILD_SKETCHER parameter in cmake-gui.)  We don't want to break those compilations by adding dependencies to other workbenches in Part module.

I don't believe this PR will break any such builds, and the import of the SketcherGui module will simply fail silently in such cases.  If the import fails because Sketcher module was not built, then we make no attempt to add the new sketch action to either the menu or the toolbar.