### PR TITLE
TD: Fix compiler warnings

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -69,6 +69,7 @@ TaskProjGroup::TaskProjGroup(TechDraw::DrawView* featView, bool mode) :
     ui(new Ui_TaskProjGroup),
     view(featView),
     multiView(dynamic_cast<TechDraw::DrawProjGroup*>(view)),
+    m_createMode(mode),
     blockCheckboxes(false)
 {
     ui->setupUi(this);


### PR DESCRIPTION
This fixes the compiler warning: unused parameter 'mode' [-Wunused-parameter]

It's a regression of #16889 to not initialize the class member m_createMode any more that causes UB, i.e. whenever m_createMode is accessed it may return an unexpected value.