### PR TITLE
Gui: Fix segfault in Expression Editor/VarSet

### DIFF
--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -118,6 +118,15 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
 
 DlgExpressionInput::~DlgExpressionInput()
 {
+    disconnect(ui->checkBoxVarSets, &QCheckBox::stateChanged,
+               this, &DlgExpressionInput::onCheckVarSets);
+    disconnect(ui->comboBoxVarSet, qOverload<int>(&QComboBox::currentIndexChanged),
+               this, &DlgExpressionInput::onVarSetSelected);
+    disconnect(ui->lineEditGroup, &QLineEdit::textChanged,
+               this, &DlgExpressionInput::onTextChangedGroup);
+    disconnect(ui->lineEditPropNew, &QLineEdit::textChanged,
+               this, &DlgExpressionInput::namePropChanged);
+
     delete ui;
 }
 


### PR DESCRIPTION
Closes https://github.com/FreeCAD/FreeCAD/issues/16946.

Disconnect the VarSet signal handlers in the destructor of the expression editor dialog.

It appeared (also clear in the stacktrace in the issue) that on destruction of the dialog, a QComboBox is deconstructed with a QTreeModel. In this destructor, the model is reset and that sends some signal. The signal handlers of the logic handling the VarSets don't anticipate that it can receive signals while destructing. 

I disconnected the signal handlers in the deconstructor to fix this. I did not add the other signal handlers as no issues have been reported with them. However, disconnecting signal handlers could be considered good practice, so I'm happy to disconnect them as well in this PR.