### PR TITLE
PartDesign: Fix primitive placement

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -119,15 +119,20 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Failed to perform boolean operation"));
         }
-        boolOp = this->getSolid(boolOp);
+
+        TopoShape solidBoolOp = getSolid(boolOp);
         // lets check if the result is a solid
-        if (boolOp.isNull()) {
+        if (solidBoolOp.isNull()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Resulting shape is not a solid"));
         }
-        boolOp = refineShapeIfActive(boolOp);
-        Shape.setValue(getSolid(boolOp));
-        AddSubShape.setValue(primitiveShape);
+        if (solidBoolOp == base){
+            //solidBoolOp is misplaced but boolOp is ok
+            Shape.setValue(boolOp);
+            return App::DocumentObject::StdReturn;
+        }
+        solidBoolOp = refineShapeIfActive(solidBoolOp);
+        Shape.setValue(getSolid(solidBoolOp));
     }
     catch (Standard_Failure& e) {
 

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -139,6 +139,10 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
 
 void FeaturePrimitive::onChanged(const App::Property* prop)
 {
+    if (prop == &AttachmentOffset){
+        this->touch();
+        return;
+    }
     FeatureAddSub::onChanged(prop);
 }
 


### PR DESCRIPTION
2276ffb fix the body movement when the AttachementOffset property is edited.
22131b3 fix the misplaced shape when the subtractive doesn't remove anything. Fix #12072 

A misplaced shape still occurs when a pattern is applied to a subtractive which doesn't remove material.

I think the error comes from `TopoShape::getSubTopoShape`. As I understand when the shape is not modified it returns the ancestor but the AttachementOffset is applied. @bgbsww @chennes @realthunder would you analyze this?