### PR TITLE
FEM: Translation error causing a crash

### DIFF
--- a/src/Mod/Fem/Gui/Resources/translations/Fem_it.ts
+++ b/src/Mod/Fem/Gui/Resources/translations/Fem_it.ts
@@ -5890,7 +5890,7 @@ usata per il solutore Elmer</translation>
     <message>
       <location filename="../../../femguiutils/selection_widgets.py" line="275"/>
       <source>Click on "Add" and select geometric elements to add them to the list.{}The following geometry elements can be selected: {}{}{}</source>
-      <translation>Fare clic su "Aggiungi" e selezionare gli elementi geometrici per aggiungerli alla lista.{}I seguenti elementi geometrici possono essere selezionati: {}{}{}{}</translation>
+      <translation>Fare clic su "Aggiungi" e selezionare gli elementi geometrici per aggiungerli alla lista.{}I seguenti elementi geometrici possono essere selezionati: {}{}{}</translation>
     </message>
     <message>
       <location filename="../../../femguiutils/selection_widgets.py" line="278"/>


### PR DESCRIPTION
An error in the Italian translation added an extra '{}' to the translation string resulting in a dump when formatting.

This has also been updated in CrowdIn but as it's causing a crash is also beiung changed via this PR. It should updated correctly when doing the next translation pull.

Fixes #16704