### PR TITLE
Assembly: BOM - create the assembly object inside the list of commands

### DIFF
--- a/src/Mod/Assembly/CommandCreateBom.py
+++ b/src/Mod/Assembly/CommandCreateBom.py
@@ -327,6 +327,7 @@ class TaskAssemblyCreateBom(QtCore.QObject):
         Gui.addModule("UtilsAssembly")
         if assembly is not None:
             commands = (
+                "assembly = UtilsAssembly.activeAssembly()\n"
                 "bom_group = UtilsAssembly.getBomGroup(assembly)\n"
                 'bomObj = bom_group.newObject("Assembly::BomObject", "Bill of Materials")'
             )


### PR DESCRIPTION
Fixes: #16972

I don't claim to fully understand how `Gui.doCommand()` works, but it seemed to me that creating the `assembly` object inside the list of commands would address this.

Feel free to propose a more elegant solution if there is one.

