### PR TITLE
[AddonManager] Set default filter to ANY package type

### DIFF
--- a/src/Mod/AddonManager/addonmanager_preferences_defaults.json
+++ b/src/Mod/AddonManager/addonmanager_preferences_defaults.json
@@ -27,7 +27,7 @@
     "MacroUpdateStatsURL": "https://addons.freecad.org/macro_update_stats.json",
     "MacroWikiURL": "https://wiki.freecad.org/Macros_recipes",
     "NoProxyCheck": "",
-    "PackageTypeSelection": 1,
+    "PackageTypeSelection": 0,
     "PrimaryAddonsSubmoduleURL":
         "https://raw.githubusercontent.com/FreeCAD/FreeCAD-addons/master/.gitmodules",
     "ProxyUrl": "",

--- a/src/Mod/AddonManager/package_list.py
+++ b/src/Mod/AddonManager/package_list.py
@@ -73,7 +73,7 @@ class PackageList(QtWidgets.QWidget):
 
         # Set up the view the same as the last time:
         pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
-        package_type = pref.GetInt("PackageTypeSelection", 1)
+        package_type = pref.GetInt("PackageTypeSelection", 0)
         status = pref.GetInt("StatusSelection", 0)
         search_string = pref.GetString("SearchString", "")
         self.ui.view_bar.filter_selector.set_contents_filter(package_type)


### PR DESCRIPTION
Default filter should be not filter at all. It makes discover-ability of addons easier for new users.