### PR TITLE
Placement Dialog: Use default tab order (Fix #16944)

### DIFF
--- a/src/Gui/Placement.ui
+++ b/src/Gui/Placement.ui
@@ -505,13 +505,6 @@
    <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>rotationInput</tabstop>
-  <tabstop>xAxis</tabstop>
-  <tabstop>yAxis</tabstop>
-  <tabstop>zAxis</tabstop>
-  <tabstop>applyIncrementalPlacement</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Fixes #16944

Unless the custom tabstops in this UI were deliberate, they should be removed as per this PR. The default order is the desired order.