### PR TITLE
Gui: fix warning with duplicate name in DlgSettingsLightSources

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsLightSources.ui
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.ui
@@ -294,7 +294,7 @@
        </widget>
       </item>
       <item row="0" column="2">
-       <spacer name="horizontalSpacer">
+       <spacer name="horizontalSpacer1">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>


### PR DESCRIPTION
Already defined at line 239. Emits warning during compilation (Qt6)