### PR TITLE
updated conda-libmamba-solver

### DIFF
--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -2,7 +2,7 @@ name: freecad
 channels:
 - conda-forge
 dependencies:
-- conda-forge/noarch::conda-libmamba-solver==24.7.0
+- conda-forge/noarch::conda-libmamba-solver==24.9.0
 - libspnav                             # [linux]
 - kernel-headers_linux-64              # [linux and x86_64]
 - libdrm-cos6-x86_64                   # [linux and x86_64]


### PR DESCRIPTION
updated conda-libmamba-solver to last version
Bug fixes
Use Solver instance configuration to initialize the libmamba context without implicitly relying on the conda context settings.  Fix conda-build compatibility regression where arch-specific outputs can't be found in the test phase if a noarch output was built first.  Docs
Add installation workarounds FAQ with conda-standalone.  Update user guide to reflect conda-libmamba-solver being the default solver in conda.  Include mamba-org/mamba as a required cloned repository for setting up a dev environment.