### PR TITLE
Prepend a single quote to BOM index to be interpreted as a string in …

### DIFF
--- a/src/Mod/Assembly/App/BomObject.cpp
+++ b/src/Mod/Assembly/App/BomObject.cpp
@@ -228,7 +228,7 @@ void BomObject::addObjectToBom(App::DocumentObject* obj, size_t row, std::string
     size_t col = 0;
     for (auto& columnName : columnsNames.getValues()) {
         if (columnName == "Index") {
-            setCell(App::CellAddress(row, col), index.c_str());
+            setCell(App::CellAddress(row, col), (std::string("'") + index).c_str());
         }
         else if (columnName == "Name") {
             setCell(App::CellAddress(row, col), obj->Label.getValue());


### PR DESCRIPTION
…generated spreadsheets

Before, the Index cells in a BOM were written as numbers in the spreadsheet, which caused indexes such as 1.1 and 1.10 to become both 1.10 and break the numerical sequence. In addition, unintendedly the original dot was converted to the regional decimal separator (comma, in my case). This is due to the cell formatting for numbers in the Spreadsheet Workbench, which is not editable.

I would think the original intention was to write the index as a string to the spreadsheet. In order to do that, a single quote needs to be prepended to the value for the spreadsheet to interpret it as a string. This is what this PR does.

Fixes: #15370

| Before | After |
|--- |--- |
| ![Captura de pantalla de 2024-10-03 23-38-47](https://github.com/user-attachments/assets/3acb64d6-79a6-43b8-a4ee-ce9054bf54cb)  | ![Captura de pantalla de 2024-10-03 23-35-40](https://github.com/user-attachments/assets/cfd4077f-aef1-4bed-876d-365ed2a03ad7) |

In the _Before_ screenshot, note: the decimal commas, subindex increment of 10 instead of 1, and cells **A3** and **A12** having a duplicate index.