### PR TITLE
Improve/fix debian docker build

### DIFF
--- a/tools/build/Docker/Dockerfile.Debian
+++ b/tools/build/Docker/Dockerfile.Debian
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:12
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC

--- a/tools/build/Docker/Dockerfile.Debian
+++ b/tools/build/Docker/Dockerfile.Debian
@@ -12,6 +12,16 @@ RUN apt-get update && \
     sh /tmp/debian.sh && \
     mkdir /builds
 
+# Debian 12 (bookworm) contains opencascade 7.6.x which contains deprecated constructs
+# (inheriting from std::iterator) which have been fixed in 7.7.x
+# lets bring the changes here to have less warnings during the build
+# https://github.com/Open-Cascade-SAS/OCCT/commit/8af9bbd59aecf24c765e7ea0eeeb8c9dd5c1f8db
+
+RUN apt-get install curl --yes
+RUN curl --silent --location --output-dir /usr/include/opencascade/ \
+       --remote-name https://github.com/Open-Cascade-SAS/OCCT/raw/8af9bbd59aecf24c765e7ea0eeeb8c9dd5c1f8db/src/NCollection/NCollection_StlIterator.hxx --next \
+       --remote-name https://github.com/Open-Cascade-SAS/OCCT/raw/8af9bbd59aecf24c765e7ea0eeeb8c9dd5c1f8db/src/OSD/OSD_Parallel.hxx
+
 WORKDIR /builds
 
 VOLUME [ "/builds" ]

--- a/tools/build/Docker/README.rst
+++ b/tools/build/Docker/README.rst
@@ -73,7 +73,7 @@ The following commands are used to create and run a Arch Linux build environment
 
 .. code-block:: console
 
-    docker build --file tools/build/Dockerfile.Arch --tag freecad-arch
+    docker build --file tools/build/Docker/Dockerfile.Arch --tag freecad-arch
     docker run --rm --interactive --tty --volume $(pwd):/builds:z freecad-arch
 
 
@@ -84,7 +84,7 @@ The following commands are used to create and run a Debian build environment.
 
 .. code-block:: console
 
-    docker build --file tools/build/Dockerfile.Debian --tag freecad-debian
+    docker build --file tools/build/Docker/Dockerfile.Debian --tag freecad-debian
     docker run --rm --interactive --tty --volume $(pwd):/builds:z freecad-debian
 
 
@@ -95,7 +95,7 @@ The following commands are used to create and run a Fedora build environment.
 
 .. code-block:: console
 
-    docker build --file tools/build/Dockerfile.Fedora --tag freecad-fedora
+    docker build --file tools/build/Docker/Dockerfile.Fedora --tag freecad-fedora
     docker run --rm --interactive --tty --volume $(pwd):/builds:z freecad-fedora
 
 
@@ -106,7 +106,7 @@ The following commands are used to create and run a Manjaro build environment.
 
 .. code-block:: console
 
-    docker build --file tools/build/Dockerfile.Manjaro --tag freecad-manjaro
+    docker build --file tools/build/Docker/Dockerfile.Manjaro --tag freecad-manjaro
     docker run --rm --interactive --tty --volume $(pwd):/builds:z freecad-manjaro
 
 
@@ -118,7 +118,7 @@ The following commands are used to create and run a Ubuntu build environment.
 
 .. code-block:: console
 
-    docker build --file tools/build/Dockerfile.Ubuntu --tag freecad-ubuntu
+    docker build --file tools/build/Docker/Dockerfile.Ubuntu --tag freecad-ubuntu
     docker run --rm --interactive --tty --volume $(pwd):/builds:z freecad-ubuntu
 
 

--- a/tools/build/Docker/debian.sh
+++ b/tools/build/Docker/debian.sh
@@ -12,4 +12,5 @@ apt-get install --no-install-recommends --yes build-essential cmake doxygen \
     libvtk-dicom-dev libx11-dev libxerces-c-dev libxmu-dev libxmuu-dev \
     libzipios++-dev netgen netgen-headers pyside2-tools python3-dev \
     python3-matplotlib python3-pivy python3-ply python3-pyside2.qtsvg \
-    python3-pyside2.qtuitools qtchooser qttools5-dev shiboken2 swig
+    python3-pyside2.qtuitools qtchooser qttools5-dev shiboken2 swig \
+    python3-pyside2.qtnetwork libyaml-cpp-dev


### PR DESCRIPTION
While trying to find a way to contribute to Freecad, I tried building it. I have first went through the wiki pages mentioned in the main [README](../blob/main/README.md#compiling)

- https://wiki.freecad.org/Compile_on_Docker
- https://wiki.freecad.org/Compile_on_Linux

However that information is outdated as I have later found out as the repository contains scripts to install dependencies for many distributions with a nice explanation in its own readme file.

To bring it up to date I have
- updated the readme to fix paths following a past renames (9d7c8b132653eb7cad60a7e4ac313cdc70b562ff)
- switched to `debian:latest` (from `bullseye`)
- added missing dependencies to the `debian.sh` script (as that is what I use)
- patched 2 header files from opencascade to silence warnings first mentioned in [std::iterator is deprecated](https://forum.freecad.org/viewtopic.php?style=4&t=76599) forum post

I use `podman` and with these changes I am able to build FreeCAD inside the container with almost no warnings. I am also able to run it using the following

```
$ podman run --rm --interactive --tty \
  -v $(pwd):/builds:z \
  -v /tmp/.X11-unix:/tmp/.X11-unix:Z \
  -v $XAUTHORITY:$XAUTHORITY:ro 
  -e DISPLAY -e XAUTHORITY \
  freecad-debian
root@9304099add3b:/builds# ./freecad-build/bin/FreeCAD
```

I'd appreciate any feedback as this is my first PR to FreeCAD.
