### PR TITLE
[Material][1.0] Fix issue #17035

### DIFF
--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -1087,24 +1087,12 @@ QString Material::getAppearanceValueString(const QString& name) const
 
 bool Material::hasPhysicalProperty(const QString& name) const
 {
-    try {
-        static_cast<void>(_physical.at(name));
-    }
-    catch (std::out_of_range const&) {
-        return false;
-    }
-    return true;
+    return _physical.find(name) != _physical.end();
 }
 
 bool Material::hasAppearanceProperty(const QString& name) const
 {
-    try {
-        static_cast<void>(_appearance.at(name));
-    }
-    catch (std::out_of_range const&) {
-        return false;
-    }
-    return true;
+    return _appearance.find(name) != _appearance.end();
 }
 
 bool Material::hasNonLegacyProperty(const QString& name) const


### PR DESCRIPTION
This PR fixes issue #17035.
Though it looks like its just a cosmetic code change, I found out that it also fixes something I noticed that lately it takes several seconds till freecad start responding after startup (Example, start freecad, start new document, select part work bench, then click on the cube. it takes about 2 seconds to appear)
After this fix it takes a fraction of a second.
it looks like the std exceptions when loading the material library outputs the errors to the log, and with about ~12K of such messages it slows down freecad. 