### PR TITLE
Changed QuickMeasurement to be conservative

### DIFF
--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -72,9 +72,11 @@ void QuickMeasure::onSelectionChanged(const Gui::SelectionChanges& msg)
             selectionTimer->start(100);
         }
         pendingProcessing = true;
-    } else {
-        // avoid unlikely potential race condition where a tool dialog was opened while the timer was already running
-       pendingProcessing = false;
+    }
+    else {
+        // avoid unlikely potential race condition where a tool dialog was opened while the timer
+        // was already running
+        pendingProcessing = false;
     }
 }
 

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -73,11 +73,6 @@ void QuickMeasure::onSelectionChanged(const Gui::SelectionChanges& msg)
         }
         pendingProcessing = true;
     }
-    else {
-        // avoid unlikely potential race condition where a tool dialog was opened while the timer
-        // was already running
-        pendingProcessing = false;
-    }
 }
 
 void QuickMeasure::processSelection()
@@ -109,8 +104,12 @@ void QuickMeasure::processSelection()
 
 void QuickMeasure::tryMeasureSelection()
 {
+    Gui::Document* doc = Gui::Application::Instance->activeDocument();
     measurement->clear();
-    addSelectionToMeasurement();
+    if (doc && Gui::Control().activeDialog() == nullptr) {
+        // we (still) have a doc and are not in a tool dialog where the user needs to click on stuff
+        addSelectionToMeasurement();
+    }
     printResult();
 }
 
@@ -126,10 +125,7 @@ bool QuickMeasure::shouldMeasure(const Gui::SelectionChanges& msg) const
             || msg.Type == Gui::SelectionChanges::SetSelection
             || msg.Type == Gui::SelectionChanges::ClrSelection) {
             // the event is about a change in selected objects
-            if (Gui::Control().activeDialog() == nullptr) {
-                // we are not in a tool dialog where the user needs to click on stuff
-                return true;
-            }
+            return true;
         }
     }
     return false;

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -72,6 +72,9 @@ void QuickMeasure::onSelectionChanged(const Gui::SelectionChanges& msg)
             selectionTimer->start(100);
         }
         pendingProcessing = true;
+    } else {
+        // avoid unlikely potential race condition where a tool dialog was opened while the timer was already running
+       pendingProcessing = false;
     }
 }
 

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -116,9 +116,12 @@ bool QuickMeasure::shouldMeasure(const Gui::SelectionChanges& msg) const
     Gui::Document* doc = Gui::Application::Instance->activeDocument();
     if (doc) {
         // we have a document
-        if (msg.Type == Gui::SelectionChanges::AddSelection || msg.Type == Gui::SelectionChanges::RmvSelection || msg.Type == Gui::SelectionChanges::SetSelection ||  msg.Type == Gui::SelectionChanges::ClrSelection) {
+        if (msg.Type == Gui::SelectionChanges::AddSelection
+            || msg.Type == Gui::SelectionChanges::RmvSelection
+            || msg.Type == Gui::SelectionChanges::SetSelection
+            || msg.Type == Gui::SelectionChanges::ClrSelection) {
             // the event is about a change in selected objects
-            if (Gui::Control().activeDialog()==nullptr) {
+            if (Gui::Control().activeDialog() == nullptr) {
                 // we are not in a tool dialog where the user needs to click on stuff
                 return true;
             }


### PR DESCRIPTION
fix #16888

QuickMeasurement should not measure while tool dialogs are open this includes but is not limited to editing sketches also changed several other sanity checks to be opt-in vs opt-out, as discussed.