### PR TITLE
Gui: Fix showing multiple dialogs when adding properties to VarSet 

### DIFF
--- a/src/Gui/DlgAddPropertyVarSet.h
+++ b/src/Gui/DlgAddPropertyVarSet.h
@@ -42,14 +42,21 @@ namespace Dialog {
 class EditFinishedComboBox : public QComboBox {
     Q_OBJECT
 public:
-    explicit EditFinishedComboBox(QWidget *parent = nullptr) : QComboBox(parent) {}
+    explicit EditFinishedComboBox(QWidget *parent = nullptr) : QComboBox(parent) {
+        setEditable(true);
+        connect(this, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &EditFinishedComboBox::onIndexChanged);
+        connect(this->lineEdit(), &QLineEdit::editingFinished, this, &EditFinishedComboBox::onEditingFinished);
+    }
 
 Q_SIGNALS:
     void editFinished();
 
-protected:
-    void focusOutEvent(QFocusEvent *event) override {
-        QComboBox::focusOutEvent(event);
+private:
+    void onEditingFinished() {
+        Q_EMIT editFinished();
+    }
+
+    void onIndexChanged() {
         Q_EMIT editFinished();
     }
 };
@@ -94,6 +101,7 @@ private:
     void checkType();
     void onEditFinished();
     void onNamePropertyChanged(const QString& text);
+    void critical(const QString& title, const QString& text);
 
     void getSupportedTypes(std::vector<Base::Type>& types);
 


### PR DESCRIPTION
Closes https://github.com/FreeCAD/FreeCAD/issues/16776.

After some research, it turns out that it is very difficult to prevent a QComboBox with a QLineEdit from sending only one signal.  Clicking the triangle in the combo box results in two editFinished signals and this can be mitigated by using event filters that detect whether the dropdown menu is shown.  However, typing in a string that matches one of the items and then pressing tab to go to the next field, issues a QLineEdit::editingFinished event and a QComboBox::currentIndexChanged event and both make sense.

This means that the best way to deal with this is to record some state if one of such events is being handled and act accordingly.

This PR makes the signalling more elegant (because logically, we want to act on the editingFinished signal and/or the currentIndexChanged signal) and it keeps track of whether the critical QMessageBox is shown, preventing multiple to be opened in case we react to two events.