### PR TITLE
Draft: Stop draftToolBar.escape() executing multiple times

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -143,9 +143,8 @@ class DraftTaskPanel:
         # https://github.com/FreeCAD/FreeCAD/issues/17027
         # Function can be called multiple times if Esc is pressed during mouse
         # move. We need to prevent multiple calls to draftToolBar.escape():
-        if getattr(FreeCAD, "activeDraftCommand", None) is None:
+        if not FreeCADGui.draftToolBar.isTaskOn:
             return
-        FreeCAD.activeDraftCommand = None
         FreeCADGui.draftToolBar.isTaskOn = False
         FreeCADGui.draftToolBar.escape()
         if FreeCADGui.ActiveDocument:

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -140,6 +140,12 @@ class DraftTaskPanel:
                 FreeCADGui.ActiveDocument.resetEdit()
             return True
     def reject(self):
+        # https://github.com/FreeCAD/FreeCAD/issues/17027
+        # Function can be called multiple times if Esc is pressed during mouse
+        # move. We need to prevent multiple calls to draftToolBar.escape():
+        if getattr(FreeCAD, "activeDraftCommand", None) is None:
+            return
+        FreeCAD.activeDraftCommand = None
         FreeCADGui.draftToolBar.isTaskOn = False
         FreeCADGui.draftToolBar.escape()
         if FreeCADGui.ActiveDocument:


### PR DESCRIPTION
Fixes #17027.

The `DraftTaskPanel.reject()` function can be called multiple times if Esc is pressed during a fast mouse move. We need to prevent multiple calls to `draftToolBar.escape()` as this will lead to multiple calls to `gui_utils.end_all_events()` which results in a crash.
