### PR TITLE
Fix tab order in Add Property Dialog (VarSets)

### DIFF
--- a/src/Gui/DlgAddPropertyVarSet.ui
+++ b/src/Gui/DlgAddPropertyVarSet.ui
@@ -81,12 +81,6 @@
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>lineEditName</tabstop>
-  <tabstop>comboBoxType</tabstop>
-  <tabstop>checkBoxAdd</tabstop>
-  <tabstop>lineEditToolTip</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Fixes #17067

Tested/compiled on Windows 11 23H2.