### PR TITLE
[Gui] Fix isBad asserts by removing old monkey patch

### DIFF
--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -279,21 +279,6 @@ FreeCADGui.Workbench = Workbench
 
 Gui.addWorkbench(NoneWorkbench())
 
-# Monkey patching pivy.coin.SoGroup.removeAllChildren to work around a bug
-# https://bitbucket.org/Coin3D/coin/pull-requests/119/fix-sochildlist-auditing/diff
-
-def _SoGroup_init(self,*args):
-    import types
-    _SoGroup_init_orig(self,*args)
-    self.removeAllChildren = \
-        types.MethodType(FreeCADGui.coinRemoveAllChildren,self)
-try:
-    from pivy import coin
-    _SoGroup_init_orig = coin.SoGroup.__init__
-    coin.SoGroup.__init__ = _SoGroup_init
-except Exception:
-    pass
-
 # init modules
 InitApplications()
 


### PR DESCRIPTION
Multiple places in code, asserts for bad types would trigger SIGABRT. This is not just limited to #16316 with SoZoomTranslation, but multiple more places, not described in issue, but I experienced myself. Fixes #16316