### PR TITLE
Fix crashes when importing and opening .csv files on macOS

### DIFF
--- a/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp
+++ b/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp
@@ -65,13 +65,12 @@ public:
     }
 
 private:
-    void load(App::Document* pcDoc, const std::string &Name)
+    void load(App::Document* pcDoc, const std::string& Name)
     {
         try {
             Base::FileInfo file(Name);
             Spreadsheet::Sheet* pcSheet = static_cast<Spreadsheet::Sheet*>(
-                pcDoc->addObject("Spreadsheet::Sheet", file.fileNamePure().c_str())
-            );
+                pcDoc->addObject("Spreadsheet::Sheet", file.fileNamePure().c_str()));
 
             pcSheet->importFromFile(Name, '\t', '"', '\\');
             pcSheet->execute();

--- a/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp
+++ b/src/Mod/Spreadsheet/Gui/AppSpreadsheetGui.cpp
@@ -65,6 +65,21 @@ public:
     }
 
 private:
+    void load(App::Document* pcDoc, const std::string &Name)
+    {
+        try {
+            Base::FileInfo file(Name);
+            Spreadsheet::Sheet* pcSheet = static_cast<Spreadsheet::Sheet*>(
+                pcDoc->addObject("Spreadsheet::Sheet", file.fileNamePure().c_str())
+            );
+
+            pcSheet->importFromFile(Name, '\t', '"', '\\');
+            pcSheet->execute();
+        }
+        catch (const Base::Exception& e) {
+            throw Py::RuntimeError(e.what());
+        }
+    }
     Py::Object open(const Py::Tuple& args)
     {
         char* Name;
@@ -75,19 +90,9 @@ private:
         std::string EncodedName = std::string(Name);
         PyMem_Free(Name);
 
-        try {
-            Base::FileInfo file(EncodedName);
-            App::Document* pcDoc =
-                App::GetApplication().newDocument(DocName ? DocName : QT_TR_NOOP("Unnamed"));
-            Spreadsheet::Sheet* pcSheet = static_cast<Spreadsheet::Sheet*>(
-                pcDoc->addObject("Spreadsheet::Sheet", file.fileNamePure().c_str()));
-
-            pcSheet->importFromFile(EncodedName, '\t', '"', '\\');
-            pcSheet->execute();
-        }
-        catch (const Base::Exception& e) {
-            throw Py::RuntimeError(e.what());
-        }
+        App::Document* pcDoc =
+            App::GetApplication().newDocument(DocName ? DocName : QT_TR_NOOP("Unnamed"));
+        load(pcDoc, EncodedName);
 
         return Py::None();
     }
@@ -102,18 +107,11 @@ private:
         std::string EncodedName = std::string(Name);
         PyMem_Free(Name);
 
-        try {
-            Base::FileInfo file(EncodedName);
-            App::Document* pcDoc = Gui::Application::Instance->activeDocument()->getDocument();
-            Spreadsheet::Sheet* pcSheet = static_cast<Spreadsheet::Sheet*>(
-                pcDoc->addObject("Spreadsheet::Sheet", file.fileNamePure().c_str()));
-
-            pcSheet->importFromFile(EncodedName, '\t', '"', '\\');
-            pcSheet->execute();
+        App::Document* pcDoc = App::GetApplication().getDocument(DocName);
+        if (!pcDoc) {
+            pcDoc = App::GetApplication().newDocument(DocName ? DocName : QT_TR_NOOP("Unnamed"));
         }
-        catch (const Base::Exception& e) {
-            throw Py::RuntimeError(e.what());
-        }
+        load(pcDoc, EncodedName);
 
         return Py::None();
     }

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -30,6 +30,7 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QListView>
+#include <QMessageBox>
 #include <QPushButton>
 #include <QScrollArea>
 #include <QWidget>
@@ -41,14 +42,16 @@
 #include "FileCardView.h"
 #include "FirstStartWidget.h"
 #include "FlowLayout.h"
-#include "Gui/Workbench.h"
-#include <Gui/Document.h>
 #include <App/DocumentObject.h>
 #include <App/Application.h>
 #include <Base/Interpreter.h>
 #include <Base/Tools.h>
 #include <Gui/Application.h>
 #include <Gui/Command.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Document.h>
+#include <Gui/Workbench.h>
+#include <Gui/FileDialog.h>
 #include <gsl/pointers>
 
 using namespace StartGui;
@@ -433,11 +436,19 @@ void StartView::fileCardSelected(const QModelIndex& index)
     auto file = index.data(static_cast<int>(Start::DisplayedFilesModelRoles::path)).toString();
     std::string escapedstr = Base::Tools::escapedUnicodeFromUtf8(file.toStdString().c_str());
     escapedstr = Base::Tools::escapeEncodeFilename(escapedstr);
-    auto command = std::string("FreeCAD.loadFile('") + escapedstr + "')";
     try {
-        Base::Interpreter().runString(command.c_str());
-        Gui::Application::checkForRecomputes();
-        postStart(PostStartBehavior::doNotSwitchWorkbench);
+        QString filename = QString::fromStdString(escapedstr);
+        QFileInfo fi(filename);
+        if (!fi.exists() || !fi.isFile()) {
+            QMessageBox::critical(Gui::getMainWindow(), tr("File not found"), tr("The file '%1' cannot be opened.").arg(filename));
+        } else {
+            // invokes appendFile()
+            Gui::SelectModule::Dict dict = Gui::SelectModule::importHandler(filename);
+            for (Gui::SelectModule::Dict::iterator it = dict.begin(); it != dict.end(); ++it) {
+                Gui::Application::Instance->open(it.key().toUtf8(), it.value().toLatin1());
+                break;
+            }
+        }
     }
     catch (Base::PyException& e) {
         Base::Console().Error(e.getMessage().c_str());

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -440,8 +440,11 @@ void StartView::fileCardSelected(const QModelIndex& index)
         QString filename = QString::fromStdString(escapedstr);
         QFileInfo fi(filename);
         if (!fi.exists() || !fi.isFile()) {
-            QMessageBox::critical(Gui::getMainWindow(), tr("File not found"), tr("The file '%1' cannot be opened.").arg(filename));
-        } else {
+            QMessageBox::critical(Gui::getMainWindow(),
+                                  tr("File not found"),
+                                  tr("The file '%1' cannot be opened.").arg(filename));
+        }
+        else {
             // invokes appendFile()
             Gui::SelectModule::Dict dict = Gui::SelectModule::importHandler(filename);
             for (Gui::SelectModule::Dict::iterator it = dict.begin(); it != dict.end(); ++it) {


### PR DESCRIPTION
fixes #17056 

This PR does the following:
* Combines open and insert spreadsheet to reduce code duplication
* Creates new document on import of docName does not exist as required by [MainWindow](https://github.com/FreeCAD/FreeCAD/blob/main/src/Gui/MainWindow.cpp#L2415):
    > `// if the passed document name doesn't exist the module should create it, if needed`
* Let recent file cards in start open files instead of importing them. This also makes start open the recent files in the same way as [CmdStdOpen](https://github.com/FreeCAD/FreeCAD/blob/main/src/Gui/CommandDoc.cpp#L158) and [RecentFilesAction](https://github.com/FreeCAD/FreeCAD/blob/main/src/Gui/Action.cpp#L916)

By doing this it avoids two crashes on macos (and most likely error messages on windows and linux)