### PR TITLE
Add help message about customizing BOM export file format in Assembly workbench

### DIFF
--- a/src/Mod/Assembly/CommandCreateBom.py
+++ b/src/Mod/Assembly/CommandCreateBom.py
@@ -411,14 +411,26 @@ class TaskAssemblyCreateBom(QtCore.QObject):
             )
             + "\n"
         )
+        export_title = QtWidgets.QLabel("<b>" + translate("Assembly", "Export:") + "</b>")
+        export_text = QtWidgets.QLabel(
+            " - "
+            + translate(
+                "Assembly",
+                "The exported file format can be customized in the Spreadsheet workbench preferences.",
+            )
+            + "\n"
+        )
 
         options_text.setWordWrap(True)
         columns_text.setWordWrap(True)
+        export_text.setWordWrap(True)
 
         layout.addWidget(options_title)
         layout.addWidget(options_text)
         layout.addWidget(columns_title)
         layout.addWidget(columns_text)
+        layout.addWidget(export_title)
+        layout.addWidget(export_text)
 
         help_dialog.setLayout(layout)
         help_dialog.setFixedWidth(500)


### PR DESCRIPTION
#16940

Add help message that file format customization can be done in the Spreadsheet Workbench settings.