### PR TITLE
Assembly: make "Solve failed" error more verbose

### DIFF
--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -170,9 +170,11 @@ int AssemblyObject::solve(bool enableRedo, bool updateJCS)
 
     try {
         mbdAssembly->runPreDrag();  // solve() is causing some issues with limits.
-    }
-    catch (...) {
-        FC_ERR("Solve failed\n");
+    } catch (const std::exception &e) {
+        FC_ERR("Solve failed: " << e.what());
+        return -1;
+    } catch (...) {
+        FC_ERR("Solve failed: unhandled exception");
         return -1;
     }
 

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -87,6 +87,8 @@
 #include "JointGroup.h"
 #include "ViewGroup.h"
 
+FC_LOG_LEVEL_INIT("Assembly", true, true, true)
+
 namespace PartApp = Part;
 
 using namespace Assembly;
@@ -170,7 +172,7 @@ int AssemblyObject::solve(bool enableRedo, bool updateJCS)
         mbdAssembly->runPreDrag();  // solve() is causing some issues with limits.
     }
     catch (...) {
-        Base::Console().Error("Solve failed\n");
+        FC_ERR("Solve failed\n");
         return -1;
     }
 


### PR DESCRIPTION
Fixes: #15385

The original code has a try-catch-all block that masks exceptions when a solve operation fails. This PR adds functionality to catch standard exceptions and show some more information. In addition, it uses the existing `FC_ERR` macro to log standard, extended info to the report window and stderr. All in all, it is not a fix, but it does use the user more informed input on where to look at to investigate the error.

I've found a couple of other exception types in the code that could also be caught (`Base::Exception`, `Py::Exception`, etc). They could be added too, if it makes sense.

To test:
1. Download and uncompress the test file
2. Go to your uncompressed folder with the files and open `FC4.FCStd` with FreeCAD; ensure the Report view is open
1. Click on Recompute or press <kbd>Ctrl</kbd> + <kbd>R</kbd> to recompute the document
1. When the assembly solve operation fails, the Report view now displays the timestamp, the module the exception was caught at, and the exception info ()