### PR TITLE
Change to enclose field values ​​with quotation character in exported CSV file if they contain delimiters in Spreadsheet workbench

### DIFF
--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -342,7 +342,7 @@ bool Sheet::exportToFile(const std::string& filename,
 
         std::string str = field.str();
 
-        if (quoteChar && str.find(quoteChar) != std::string::npos) {
+        if (quoteChar && str.find_first_of(std::string(quoteChar, delimiter)) != std::string::npos) {
             writeEscaped(str, quoteChar, escapeChar, file);
         }
         else {

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -342,7 +342,8 @@ bool Sheet::exportToFile(const std::string& filename,
 
         std::string str = field.str();
 
-        if (quoteChar && str.find_first_of(std::string(quoteChar, delimiter)) != std::string::npos) {
+        if (quoteChar
+            && str.find_first_of(std::string(quoteChar, delimiter)) != std::string::npos) {
             writeEscaped(str, quoteChar, escapeChar, file);
         }
         else {


### PR DESCRIPTION
#16940

If field values contain a delimiter character, the values will be enclosed with quotation character in exported CSV file.
This change does not affect the default behavior in TAB delemited CSV file.