### PR TITLE
[CAM] Make adaptive operations use actual stock outline

### DIFF
--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -42,7 +42,7 @@ __doc__ = "Class and implementation of the Adaptive CAM operation."
 from lazy_loader.lazy_loader import LazyLoader
 
 Part = LazyLoader("Part", globals(), "Part")
-# TechDraw = LazyLoader('TechDraw', globals(), 'TechDraw')
+TechDraw = LazyLoader("TechDraw", globals(), "TechDraw")
 FeatureExtensions = LazyLoader("Path.Op.FeatureExtension", globals(), "Path.Op.FeatureExtension")
 DraftGeomUtils = LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
@@ -649,19 +649,10 @@ def Execute(op, obj):
 
         path2d = convertTo2d(pathArray)
 
-        stockPaths = []
-        if hasattr(op.stock, "StockType") and op.stock.StockType == "CreateCylinder":
-            stockPaths.append([discretize(op.stock.Shape.Edges[0])])
-
-        else:
-            stockBB = op.stock.Shape.BoundBox
-            v = []
-            v.append(FreeCAD.Vector(stockBB.XMin, stockBB.YMin, 0))
-            v.append(FreeCAD.Vector(stockBB.XMax, stockBB.YMin, 0))
-            v.append(FreeCAD.Vector(stockBB.XMax, stockBB.YMax, 0))
-            v.append(FreeCAD.Vector(stockBB.XMin, stockBB.YMax, 0))
-            v.append(FreeCAD.Vector(stockBB.XMin, stockBB.YMin, 0))
-            stockPaths.append([v])
+        # Use the 2D outline of the stock as the stock
+        # FIXME: This does not account for holes in the middle of stock!
+        outer_wire = TechDraw.findShapeOutline(op.stock.Shape, 1, FreeCAD.Vector(0, 0, 1))
+        stockPaths = [[discretize(outer_wire)]]
 
         stockPath2d = convertTo2d(stockPaths)
 


### PR DESCRIPTION
This pull request changes how stock is calculated for generating Adaptive toolpaths. Currently, there are two cases:

- Generated cylinder, in which case a cylinder is used as the stock
- Every other case, in which case the bounding box of stock model is used (including if an externally-generated cylinder is used as stock)

This results in inefficient toolpaths where a lot of air-cutting can occur even if the stock is modeled correctly. This change causes the stock boundary to always be calculated from the stock model by projecting the stock to the XY plane then taking the outside edges of the result. The general method was copied from here, with slight tweaks: https://forum.freecad.org/viewtopic.php?t=69976

Example of a model/stock combo exhibiting this issue:
![path_original](https://github.com/user-attachments/assets/887ac7a8-b030-4f98-8e06-62931a883bc9)

Result after this change:
![path_new](https://github.com/user-attachments/assets/aed5e8c8-4baf-4c3b-93ad-355eb779a981)

Forum thread: https://forum.freecad.org/viewtopic.php?t=91255

NOTE: This breaks generating toolpaths from cylindrical stock- I believe the bug is similar to https://github.com/FreeCAD/FreeCAD/issues/12601, and is separate from these changes AFAICT. Actually, more generally it's broken for _any_ stock that has a single-closed-wire outline, eg an oval.

Model from which above images are generated:
[freecad_dev_cam_test_complicated.FCStd.zip](https://github.com/user-attachments/files/17320128/freecad_dev_cam_test_complicated.FCStd.zip)

