### PR TITLE
BIM: Remove calls to end_all_events to avoid Linux crash

### DIFF
--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -412,7 +412,7 @@ class _CommandStructure:
         FreeCADGui.doCommand("Draft.autogroup(s)")
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()
-        gui_utils.end_all_events()
+        # gui_utils.end_all_events()  # Causes a crash on Linux.
         self.tracker.finalize()
         if self.continueCmd:
             self.Activated()

--- a/src/Mod/BIM/bimcommands/BimWall.py
+++ b/src/Mod/BIM/bimcommands/BimWall.py
@@ -191,7 +191,7 @@ class Arch_Wall:
                         FreeCADGui.doCommand('Arch.addComponents(FreeCAD.ActiveDocument.'+FreeCAD.ActiveDocument.Objects[-1].Name+',FreeCAD.ActiveDocument.'+self.existing[0].Name+')')
             FreeCAD.ActiveDocument.commitTransaction()
             FreeCAD.ActiveDocument.recompute()
-            gui_utils.end_all_events()
+            # gui_utils.end_all_events()  # Causes a crash on Linux.
             self.tracker.finalize()
             if self.continueCmd:
                 self.Activated()

--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -225,7 +225,7 @@ class Arch_Window:
 
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()
-        gui_utils.end_all_events()
+        # gui_utils.end_all_events()  # Causes a crash on Linux.
         self.tracker.finalize()
         return
 


### PR DESCRIPTION
Fixes #15723.
