### PR TITLE
Fem: Fix gap in constraint fixed symbol

### DIFF
--- a/src/Mod/Fem/Gui/Resources/symbols/ConstraintFixed.iv
+++ b/src/Mod/Fem/Gui/Resources/symbols/ConstraintFixed.iv
@@ -42,7 +42,7 @@ Separator {
 
     }
     Translation {
-      translation 0 -0.525 0
+      translation 0 -0.5 0
 
     }
     Cube {


### PR DESCRIPTION
There is a small gap between the cone and the box in the fixed constraint symbol.