### PR TITLE
Make sure splasher is stopped before showing recompute dialog

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -968,6 +968,10 @@ void Application::checkForRecomputes() {
         return;
     WaitCursor wc;
     wc.restoreCursor();
+
+    // Splasher is shown ontop of warnings on macOS so stop it before it's too late
+    getMainWindow()->stopSplasher();
+
     auto res = QMessageBox::warning(getMainWindow(), QObject::tr("Recomputation required"),
                                     QObject::tr("Some document(s) require recomputation for migration purposes. "
                                                 "It is highly recommended to perform a recomputation before "


### PR DESCRIPTION
On macOS, we can get a state where the splashscreen is shown on top of a dialog.
Since dialogs pauses FreeCAD, the splashscreen never closes.
For the user, this looks like FreeCAD stops responding. 

The severity is equal to a crash in my opinion.

---

This behavior can be seen when opening FreeCAD with an old file from closed state (double click a FreeCAD document or drag a document to FreeCAD.app). Then the recompute required warning will pop up under the splasher.

This behavior can only be seen when FreeCAD is built as a bundle. I haven't been able to reproduce the exact scenario on a "naked" dev binary build.

The issue has been discussed in this thread (though that started as a crash which has been fixed):
https://github.com/FreeCAD/FreeCAD/issues/16828#issuecomment-2380554810
https://github.com/FreeCAD/FreeCAD/issues/16828#issuecomment-2403324245

---

I've been trying to find someone who can build a bundle on macOS and has time to help me with this issue for the last two weeks without success so my proposal is as follows:
* We merge this PR into the *main* branch
* When weekly has been built, I'll verify if this works or not
* If it works we can backport it to 1.0 (if it doesn't we'll revert this and try with something else)


<details><summary>Full version (weekly 2024-10-08)</summary>
<p>

```
OS: macOS 14.5
Word size of FreeCAD: 64-bit
Version: 1.1.0dev.38923 (Git)
Build type: Release
Branch: main
Hash: d20cb9e6ee198beb2bfd7e72d3dec0a575e3f28c
Python 3.11.9, Qt 5.15.13, Coin 4.0.3, Vtk 9.2.6, OCC 7.7.2
Locale: C/Default (C)
Stylesheet/Theme/QtStyle: FreeCAD Dark.qss/FreeCAD Dark/Fusion
Installed mods: 
  * CfdOF 1.27.10
  * A2plus 0.4.68
  * lattice2 1.0.0
  * CurvedShapes 1.0.10
  * sheetmetal 0.4.26
  * Curves 0.6.6
```

</p>
</details> 

FIY @mnesarco @3x380V