### PR TITLE
Gui: add Qt Platform name to splashscreen information dump

### DIFF
--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -819,13 +819,20 @@ void AboutDialog::copyToClipboard()
 
     QString deskEnv = QProcessEnvironment::systemEnvironment().value(QStringLiteral("XDG_CURRENT_DESKTOP"), QString());
     QString deskSess = QProcessEnvironment::systemEnvironment().value(QStringLiteral("DESKTOP_SESSION"), QString());
+    QStringList deskInfoList;
     QString deskInfo;
 
-    if ( !(deskEnv.isEmpty() && deskSess.isEmpty()) ) {
-        if ( deskEnv.isEmpty() || deskSess.isEmpty() )
-            deskInfo = QLatin1String(" (") + deskEnv + deskSess + QLatin1String(")");
-        else
-            deskInfo = QLatin1String(" (") + deskEnv + QLatin1String("/") + deskSess + QLatin1String(")");
+    if (!deskEnv.isEmpty()) {
+        deskInfoList.append(deskEnv);
+    }
+    if (!deskSess.isEmpty()) {
+        deskInfoList.append(deskSess);
+    }
+    if (qGuiApp->platformName() != QLatin1String("windows") && qGuiApp->platformName() != QLatin1String("cocoa")) {
+        deskInfoList.append(qGuiApp->platformName());
+    }
+    if(!deskInfoList.isEmpty()) {
+        deskInfo = QLatin1String(" (") + deskInfoList.join(QLatin1String("/")) + QLatin1String(")");
     }
 
     str << "OS: " << prettyProductInfoWrapper() << deskInfo << '\n';


### PR DESCRIPTION
There is several bugs in FreeCAD which are related to platform (eg wayland/X11/...), the hope is this will make it easier to identify the dependence of bug on the platform

Example:

```
OS: Arch Linux (KDE)
Word size of FreeCAD: 64-bit
Version: 1.1.0dev.38943 (Git)
Build type: Release
Branch: makepkg
Hash: b63c0e15919af5a967b043a141a7163c6c241b6d
Python 3.12.6, Qt 6.7.3, Coin 4.0.3, Vtk 9.3.1, OCC 7.8.1
Platform: wayland
Locale: English/United States (en_US)
Stylesheet/Theme/QtStyle: FreeCAD Dark.qss/FreeCAD Dark/
```