### PR TITLE
[Start] Fix filecard thumbnail hover colors

### DIFF
--- a/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
@@ -93,6 +93,9 @@
         <FCParamGroup Name="Mod">
           <FCParamGroup Name="Start">
             <FCBool Name="FileCardUseStyleSheet" Value="0"/>
+            <FCUInt Name="FileThumbnailBorderColor" Value="1252392959"/>
+            <FCUInt Name="FileThumbnailBackgroundColor" Value="858993663"/>
+            <FCUInt Name="FileThumbnailSelectionColor" Value="648178175"/>
           </FCParamGroup>
           <FCParamGroup Name="Arch">
             <FCUInt Name="WallColor" Value="3604403967"/>

--- a/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
@@ -11,6 +11,9 @@
         <FCParamGroup Name="Mod">
           <FCParamGroup Name="Start">
             <FCBool Name="FileCardUseStyleSheet" Value="0"/>
+            <FCUInt Name="FileThumbnailBorderColor" Value="1252392959"/>
+            <FCUInt Name="FileThumbnailBackgroundColor" Value="4042322175"/>
+            <FCUInt Name="FileThumbnailSelectionColor" Value="648178175"/>
           </FCParamGroup>
           <FCParamGroup Name="Arch">
             <FCUInt Name="WallColor" Value="2914369023"/>

--- a/src/Mod/Start/Gui/FileCardDelegate.cpp
+++ b/src/Mod/Start/Gui/FileCardDelegate.cpp
@@ -115,37 +115,35 @@ void FileCardDelegate::paint(QPainter* painter,
     _widget->setProperty("state", QStringLiteral(""));
     if (option.state & QStyle::State_Selected) {
         _widget->setProperty("state", QStringLiteral("pressed"));
-        if (qApp->styleSheet().isEmpty()) {
-            QColor color = getSelectionColor();
-            _widget->setStyleSheet(QString::fromLatin1("QWidget#thumbnailWidget {"
-                                                       " border: 2px solid rgb(%1, %2, %3);"
-                                                       " border-radius: 4px;"
-                                                       " padding: 2px;"
-                                                       "}")
-                                       .arg(color.red())
-                                       .arg(color.green())
-                                       .arg(color.blue()));
-        }
+        QColor color = getSelectionColor();
+        _widget->setStyleSheet(QString::fromLatin1("QWidget#thumbnailWidget {"
+                                                    " border: 2px solid rgb(%1, %2, %3);"
+                                                    " border-radius: 4px;"
+                                                    " padding: 8px;"
+                                                    "}")
+                                    .arg(color.red())
+                                    .arg(color.green())
+                                    .arg(color.blue()));
     }
     else if (option.state & QStyle::State_MouseOver) {
         _widget->setProperty("state", QStringLiteral("hovered"));
-        if (qApp->styleSheet().isEmpty()) {
-            QColor color = getBorderColor();
-            _widget->setStyleSheet(QString::fromLatin1("QWidget#thumbnailWidget {"
-                                                       " border: 2px solid rgb(%1, %2, %3);"
-                                                       " border-radius: 4px;"
-                                                       " padding: 2px;"
-                                                       "}")
-                                       .arg(color.red())
-                                       .arg(color.green())
-                                       .arg(color.blue()));
-        }
+        QColor color = getBorderColor();
+        _widget->setStyleSheet(QString::fromLatin1("QWidget#thumbnailWidget {"
+                                                    " border: 2px solid rgb(%1, %2, %3);"
+                                                    " border-radius: 4px;"
+                                                    " padding: 8px;"
+                                                    "}")
+                                    .arg(color.red())
+                                    .arg(color.green())
+                                    .arg(color.blue()));
     }
-    else if (qApp->styleSheet().isEmpty()) {
+    else {
         QColor color = getBackgroundColor();
         _widget->setStyleSheet(QString::fromLatin1("QWidget#thumbnailWidget {"
                                                    " background-color: rgb(%1, %2, %3);"
-                                                   " border-radius: 8px;"
+                                                   " border: 2px solid transparent;"
+                                                   " border-radius: 4px;"
+                                                    " padding: 8px;"
                                                    "}")
                                    .arg(color.red())
                                    .arg(color.green())
@@ -183,7 +181,7 @@ QSize FileCardDelegate::sizeHint(const QStyleOptionViewItem& option, const QMode
     auto qfm = QFontMetrics(font);
     auto textHeight = 2 * qfm.lineSpacing();
     auto cardHeight =
-        thumbnailSize + textHeight + 2 * spacing + cardMargin.top() + cardMargin.bottom();
+        thumbnailSize + textHeight + 2 * spacing + cardMargin.top() + cardMargin.bottom() + 4;
 
     return {static_cast<int>(cardWidth), static_cast<int>(cardHeight)};
 }

--- a/src/Mod/Start/Gui/FileCardDelegate.cpp
+++ b/src/Mod/Start/Gui/FileCardDelegate.cpp
@@ -117,25 +117,25 @@ void FileCardDelegate::paint(QPainter* painter,
         _widget->setProperty("state", QStringLiteral("pressed"));
         QColor color = getSelectionColor();
         _widget->setStyleSheet(QString::fromLatin1("QWidget#thumbnailWidget {"
-                                                    " border: 2px solid rgb(%1, %2, %3);"
-                                                    " border-radius: 4px;"
-                                                    " padding: 8px;"
-                                                    "}")
-                                    .arg(color.red())
-                                    .arg(color.green())
-                                    .arg(color.blue()));
+                                                   " border: 2px solid rgb(%1, %2, %3);"
+                                                   " border-radius: 4px;"
+                                                   " padding: 8px;"
+                                                   "}")
+                                   .arg(color.red())
+                                   .arg(color.green())
+                                   .arg(color.blue()));
     }
     else if (option.state & QStyle::State_MouseOver) {
         _widget->setProperty("state", QStringLiteral("hovered"));
         QColor color = getBorderColor();
         _widget->setStyleSheet(QString::fromLatin1("QWidget#thumbnailWidget {"
-                                                    " border: 2px solid rgb(%1, %2, %3);"
-                                                    " border-radius: 4px;"
-                                                    " padding: 8px;"
-                                                    "}")
-                                    .arg(color.red())
-                                    .arg(color.green())
-                                    .arg(color.blue()));
+                                                   " border: 2px solid rgb(%1, %2, %3);"
+                                                   " border-radius: 4px;"
+                                                   " padding: 8px;"
+                                                   "}")
+                                   .arg(color.red())
+                                   .arg(color.green())
+                                   .arg(color.blue()));
     }
     else {
         QColor color = getBackgroundColor();
@@ -143,7 +143,7 @@ void FileCardDelegate::paint(QPainter* painter,
                                                    " background-color: rgb(%1, %2, %3);"
                                                    " border: 2px solid transparent;"
                                                    " border-radius: 4px;"
-                                                    " padding: 8px;"
+                                                   " padding: 8px;"
                                                    "}")
                                    .arg(color.red())
                                    .arg(color.green())

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -259,7 +259,10 @@ void StartView::configureNewFileButtons(QLayout* layout) const
 
 QString StartView::fileCardStyle() const
 {
-    if (!qApp->styleSheet().isEmpty()) {
+    auto hGrpView = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/MainWindow");
+    auto qssFile = hGrpView->GetASCII("StyleSheet", "");
+    if (!qssFile.empty()) {
         return {};
     }
 


### PR DESCRIPTION
This PR correctly fixes the stylesheet lookup and uses the three parameters in the config files for the border, background and hover colors for the recent and example file thumbnails.

See Blocker issue https://github.com/FreeCAD/FreeCAD/issues/15756 

@MisterMakerNL your input would be appreciated, note FreeCAD Classic already has the default colors in it's config file.