### PR TITLE
Fem: Netgen meshing parameters improvements

### DIFF
--- a/src/Mod/Fem/femcommands/commands.py
+++ b/src/Mod/Fem/femcommands/commands.py
@@ -837,6 +837,7 @@ class _MeshNetgenFromShape(CommandManager):
             )
         )
         FreeCADGui.doCommand("FreeCAD.ActiveDocument.ActiveObject.Fineness = 'Moderate'")
+        FreeCADGui.doCommand("FreeCAD.ActiveDocument.ActiveObject.EndStep = 'OptimizeVolume'")
         # Netgen mesh object could be added without an active analysis
         # but if there is an active analysis move it in there
         import FemGui

--- a/src/Mod/Fem/femmesh/netgentools.py
+++ b/src/Mod/Fem/femmesh/netgentools.py
@@ -35,7 +35,8 @@ import FreeCAD
 import Fem
 
 try:
-    from netgen import occ, config as ng_config
+    from netgen import occ, meshing, config as ng_config
+    import pyngcore as ngcore
 except ModuleNotFoundError:
     FreeCAD.Console.PrintError("To use FemMesh Netgen objects, install the Netgen Python bindings")
 
@@ -62,6 +63,15 @@ class NetgenTools:
         13: [0, 1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],  # pyra13
         6: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],  # penta6
         15: [0, 1, 2, 3, 4, 5, 6, 8, 7, 12, 14, 13, 9, 10, 11, 15, 16, 17, 18, 19],  # penta15
+    }
+
+    meshing_step = {
+        "AnalizeGeometry": 1,  # MESHCONST_ANALYSE
+        "MeshEdges": 2,  # MESHCONST_MESHEDGES
+        "MeshSurface": 3,  # MESHCONST_MESHSURFACE
+        "OptimizeSurface": 4,  # MESHCONST_OPTSURFACE
+        "MeshVolume": 5,  # MESHCONST_MESHVOLUME
+        "OptimizeVolume": 6,  # MESHCONST_OPTVOLUME
     }
 
     name = "Netgen"
@@ -97,7 +107,6 @@ NetgenTools.run_netgen(**{params})
             "brep_file": self.brep_file,
             "threads": self.obj.Threads,
             "heal": self.obj.HealShape,
-            "fineness": self.obj.Fineness,
             "params": self.get_meshing_parameters(),
             "second_order": self.obj.SecondOrder,
             "result_file": self.result_file,
@@ -118,30 +127,15 @@ NetgenTools.run_netgen(**{params})
         return True
 
     @staticmethod
-    def run_netgen(brep_file, threads, heal, fineness, params, second_order, result_file):
-        import pyngcore as ngcore
-        from netgen import meshing
+    def run_netgen(brep_file, threads, heal, params, second_order, result_file):
 
         geom = occ.OCCGeometry(brep_file)
         ngcore.SetNumThreads(threads)
 
-        if fineness == "UserDefined":
-            mp = meshing.MeshingParameters(**params)
-        elif fineness == "VeryCoarse":
-            mp = meshing.meshsize.very_coarse
-        elif fineness == "Coarse":
-            mp = meshing.meshsize.coarse
-        elif fineness == "Moderate":
-            mp = meshing.meshsize.moderate
-        elif fineness == "Fine":
-            mp = meshing.meshsize.fine
-        elif fineness == "VeryFine":
-            mp = meshing.meshsize.very_fine
-
         with ngcore.TaskManager():
             if heal:
                 geom.Heal()
-            mesh = geom.GenerateMesh(mp=mp)
+            mesh = geom.GenerateMesh(mp=meshing.MeshingParameters(**params))
 
         if second_order:
             mesh.SecondOrder()
@@ -256,8 +250,8 @@ NetgenTools.run_netgen(**{params})
             "segmentsperedge": self.obj.SegmentsPerEdge,
             "elsizeweight": self.obj.ElementSizeWeight,
             "parthread": self.obj.ParallelMeshing,
-            "perfstepsstart": self.obj.StartStep,
-            "perfstepsend": self.obj.EndStep,
+            "perfstepsstart": NetgenTools.meshing_step[self.obj.StartStep],
+            "perfstepsend": NetgenTools.meshing_step[self.obj.EndStep],
             "giveuptol2d": self.obj.GiveUpTolerance2d,
             "giveuptol": self.obj.GiveUpTolerance,
             "giveuptolopenquads": self.obj.GiveUpToleranceOpenQuads,
@@ -279,6 +273,42 @@ NetgenTools.run_netgen(**{params})
             "nthreads": self.obj.Threads,
             "closeedgefac": self.obj.CloseEdgeFactor,
         }
+
+        # set specific parameters by fineness
+        if self.obj.Fineness == "VeryCoarse":
+            params["curvaturesafety"] = 1
+            params["segmentsperedge"] = 0.3
+            params["grading"] = 0.7
+            params["closeedgefac"] = 0.5
+            params["optsteps3d"] = 5
+
+        elif self.obj.Fineness == "Coarse":
+            params["curvaturesafety"] = 1.5
+            params["segmentsperedge"] = 0.5
+            params["grading"] = 0.5
+            params["closeedgefac"] = 1
+            params["optsteps3d"] = 5
+
+        elif self.obj.Fineness == "Moderate":
+            params["curvaturesafety"] = 2
+            params["segmentsperedge"] = 1
+            params["grading"] = 0.3
+            params["closeedgefac"] = 2
+            params["optsteps3d"] = 5
+
+        elif self.obj.Fineness == "Fine":
+            params["curvaturesafety"] = 3
+            params["segmentsperedge"] = 2
+            params["grading"] = 0.2
+            params["closeedgefac"] = 3.5
+            params["optsteps3d"] = 5
+
+        elif self.obj.Fineness == "VeryFine":
+            params["curvaturesafety"] = 5
+            params["segmentsperedge"] = 3
+            params["grading"] = 0.1
+            params["closeedgefac"] = 5
+            params["optsteps3d"] = 5
 
         return params
 

--- a/src/Mod/Fem/femobjects/base_fempythonobject.py
+++ b/src/Mod/Fem/femobjects/base_fempythonobject.py
@@ -68,7 +68,8 @@ class _PropHelper:
 
     def handle_change_type(self, obj, old_type, convert_old_value=lambda x: x):
         if obj.getTypeIdOfProperty(self.name) == old_type:
-            self.value = convert_old_value(obj.getPropertyByName(self.name))
+            new_value = convert_old_value(obj.getPropertyByName(self.name))
             obj.setPropertyStatus(self.name, "-LockDynamic")
             obj.removeProperty(self.name)
             self.add_to_object(obj)
+            setattr(obj, self.name, new_value)


### PR DESCRIPTION
~To be merged after https://github.com/FreeCAD/FreeCAD/pull/17170 just to avoid conflicts (The first two commits come from that pull request).~

Currently, the first and last mesh steps are defined by integer values. More meaningful enumeration values ​​are now used.

Fineness has a few predefined values ​​(`VeryCoarse`, `Coarse`, etc.) and `UserDefined` which is used to set custom parameter values. The predefined values ​​basically set a few parameters and leave all others as Netgen internal defaults, which makes all remaining properties obsolete. Now, only explicit parameters set by predefined fineness values ​​are set, while the rest can be defined by the user.

@FEA-eng 