### PR TITLE
Fem: Fix examples affected by Part workbench preference parameter

### DIFF
--- a/src/Mod/Fem/femexamples/constraint_centrif.py
+++ b/src/Mod/Fem/femexamples/constraint_centrif.py
@@ -92,6 +92,7 @@ def setup(doc=None, solvertype="ccxtools"):
 
     fusion = doc.addObject("Part::MultiFuse", "Fusion")
     fusion.Shapes = [stiffener, circumference]
+    fusion.Refine = True
     doc.recompute()
 
     centerhole = doc.addObject("Part::Cylinder", "CenterHole")
@@ -102,6 +103,7 @@ def setup(doc=None, solvertype="ccxtools"):
     ring_bottom = doc.addObject("Part::Cut", "RingBottom")
     ring_bottom.Base = fusion
     ring_bottom.Tool = centerhole
+    ring_bottom.Refine = True
     doc.recompute()
 
     # standard ring

--- a/src/Mod/Fem/femexamples/constraint_contact_solid_solid.py
+++ b/src/Mod/Fem/femexamples/constraint_contact_solid_solid.py
@@ -106,6 +106,7 @@ def setup(doc=None, solvertype="ccxtools"):
     # all geom fusion
     geom_obj = doc.addObject("Part::MultiFuse", "AllGeomFusion")
     geom_obj.Shapes = [bottom_box_obj, top_halfcyl_obj]
+    geom_obj.Refine = True
     if FreeCAD.GuiUp:
         bottom_box_obj.ViewObject.hide()
         top_halfcyl_obj.ViewObject.hide()


### PR DESCRIPTION
`constraint_centrif` and `contact_solid_solid` examples are broken if Part workbench preference `Automatically refine model after boolean operation` is not checked.