### PR TITLE
[TD]throttle over aggressive dimension autocorrect (fix #17189)

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -457,7 +457,7 @@ short DrawViewDimension::mustExecute() const
 App::DocumentObjectExecReturn* DrawViewDimension::execute()
 {
     if (!okToProceed()) {
-        // if we set an error here, it will be triggering many times during
+        // if we set an error here, it will be triggered many times during
         // document load.
         return  DrawView::execute();
     }
@@ -467,10 +467,10 @@ App::DocumentObjectExecReturn* DrawViewDimension::execute()
         m_referencesCorrect = autocorrectReferences();
     }
     if (!m_referencesCorrect) {
-        return new App::DocumentObjectExecReturn("Autocorrect failed to fix broken references", this);
+        // this test needs Phase 2 of auto correct to be useful
+        Base::Console().Log("The references for %s have changed and autocorrect could not match the geometry\n", Label.getValue());
     }
 
-    // references are good, we can proceed
     resetLinear();
     resetAngular();
     resetArc();
@@ -1677,7 +1677,7 @@ pointPair DrawViewDimension::closestPoints(TopoDS_Shape s1, TopoDS_Shape s2) con
 }
 
 // set the reference property from a reference vector
-void DrawViewDimension::setReferences2d(ReferenceVector refsAll)
+void DrawViewDimension::setReferences2d(const ReferenceVector& refsAll)
 {
     // Base::Console().Message("DVD::setReferences2d(%d)\n", refs.size());
     std::vector<App::DocumentObject*> objects;
@@ -1692,10 +1692,11 @@ void DrawViewDimension::setReferences2d(ReferenceVector refsAll)
     }
 
     References2D.setValues(objects, subNames);
+    m_referencesCorrect = true;
 }
 
 // set the reference property from a reference vector
-void DrawViewDimension::setReferences3d(ReferenceVector refsAll)
+void DrawViewDimension::setReferences3d(const ReferenceVector &refsAll)
 {
     // Base::Console().Message("DVD::setReferences3d()\n");
     if (refsAll.empty() && !References3D.getValues().empty()) {
@@ -1726,6 +1727,7 @@ void DrawViewDimension::setReferences3d(ReferenceVector refsAll)
     }
 
     References3D.setValues(objects, subNames);
+    m_referencesCorrect = true;
 }
 
 //! add Dimension 3D references to measurement

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -143,8 +143,8 @@ public:
     static int
     getRefTypeSubElements(const std::vector<std::string>&);  // Vertex-Vertex, Edge, Edge-Edge
 
-    void setReferences2d(ReferenceVector refs);
-    void setReferences3d(ReferenceVector refs);
+    void setReferences2d(const ReferenceVector& refs);
+    void setReferences3d(const ReferenceVector& refs);
     ReferenceVector getReferences2d() const;
     ReferenceVector getReferences3d() const;
     bool hasGoodReferences() const

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -671,11 +671,12 @@ QGIViewDimension::QGIViewDimension() : dvDimension(nullptr), hasHover(false), m_
                                  //above this Dimension's parent view.   need Layers?
     hideFrame();
 
-    m_refFlag = new QGCustomSvg();
-    m_refFlag->setParentItem(this);
-    m_refFlag->load(QString::fromUtf8(":/icons/TechDraw_RefError.svg"));
-    m_refFlag->setZValue(ZVALUE::LOCK);
-    m_refFlag->hide();
+    // needs phase 2 of autocorrect to be useful
+    // m_refFlag = new QGCustomSvg();
+    // m_refFlag->setParentItem(this);
+    // m_refFlag->load(QString::fromUtf8(":/icons/TechDraw_RefError.svg"));
+    // m_refFlag->setZValue(ZVALUE::LOCK);
+    // m_refFlag->hide();
 }
 
 QVariant QGIViewDimension::itemChange(GraphicsItemChange change, const QVariant& value)
@@ -812,12 +813,13 @@ void QGIViewDimension::updateView(bool update)
         updateDim();
     }
 
-    if (dim->hasGoodReferences()) {
-        m_refFlag->hide();
-    } else {
-        m_refFlag->centerAt(datumLabel->pos() + datumLabel->boundingRect().center());
-        m_refFlag->show();
-    }
+    // needs Phase 2 of autocorrect to be useful
+    // if (dim->hasGoodReferences()) {
+    //     m_refFlag->hide();
+    // } else {
+    //     m_refFlag->centerAt(datumLabel->pos() + datumLabel->boundingRect().center());
+    //     m_refFlag->show();
+    // }
 
     draw();
 }

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.h
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.h
@@ -317,7 +317,8 @@ private:
     QGIArrow* aHead2;
     double m_lineWidth;
 
-    QGCustomSvg* m_refFlag;
+    // needs Phase2 of autocorrect to be useful
+    // QGCustomSvg* m_refFlag;
 
 };
 


### PR DESCRIPTION
This PR implements a fix for issue #17189.  The dimension reference autocorrect process was overly strict in dealing with changed geometry.