### PR TITLE
Bim remove py2 compatibility code

### DIFF
--- a/conda/environment-qt6.devenv.yml
+++ b/conda/environment-qt6.devenv.yml
@@ -92,7 +92,6 @@ dependencies:
 - python==3.12.*
 - pyyaml
 - qt6-main
-- six
 - smesh
 - swig
 - vtk==9.2.6

--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -92,7 +92,6 @@ dependencies:
 - python==3.11.*
 - pyyaml
 - qt-main
-- six
 - smesh
 - swig
 - vtk==9.2.6

--- a/src/Mod/BIM/bimcommands/BimIfcExplorer.py
+++ b/src/Mod/BIM/bimcommands/BimIfcExplorer.py
@@ -566,20 +566,10 @@ class BIM_IfcExplorer:
                                 self.addAttributes(prop.id(), subitem)
 
     def tostr(self, text):
-        "resolves py2/py3 string representation hassles"
-
-        import six
-
-        if six.PY2:
-            if isinstance(text, unicode):
-                return text.encode("utf8")
-            else:
-                return str(text)
+        if isinstance(text, str):
+            return text
         else:
-            if isinstance(text, str):
-                return text
-            else:
-                return str(text)
+            return str(text)
 
     def onSelectTree(self, item, previous):
         "displays attributes and properties of a tree item"


### PR DESCRIPTION
we dropped python2 support a long time ago so this is not needed