### PR TITLE
PD: Disable PartDesign_CompDatums & PartDesign_CompSketches if dialog…

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -2460,7 +2460,7 @@ public:
 
     bool isActive() override
     {
-        return hasActiveDocument();
+         return (hasActiveDocument() && !Gui::Control().activeDialog());
     }
 };
 
@@ -2495,7 +2495,7 @@ public:
 
     bool isActive() override
     {
-        return hasActiveDocument();
+         return (hasActiveDocument() && !Gui::Control().activeDialog());
     }
 };
 


### PR DESCRIPTION
… is open

A group command is not disabled if its default command is disabled. This allows it to invoke the command when it should be impossible. To fix the problem override the isActive() method in the sub-classes CmdPartDesignCompDatums & CmdPartDesignCompSketches

This fixes #16294