### PR TITLE
Fixing the checked toolbutton issue in Qsint

### DIFF
--- a/src/Gui/Stylesheets/FreeCAD Dark.qss
+++ b/src/Gui/Stylesheets/FreeCAD Dark.qss
@@ -1643,6 +1643,11 @@ QSint--ActionGroup QFrame[class="content"] QToolButton {
   border-radius: 3px;
 }
 
+QSint--ActionGroup QFrame[class="content"] QToolButton:checked {
+  background-color: qlineargradient(x1:0, y1:0.3, x2:0, y2:1, stop:0 #333333, stop:1 #444444);
+  border: 1px solid @ThemeAccentColor2;
+}
+
 /* QToolButtons with a menu found in Sketcher task panel*/
 QSint--ActionGroup QToolButton::menu-button {
   border-left: 1px solid #000000;

--- a/src/Gui/Stylesheets/FreeCAD Light.qss
+++ b/src/Gui/Stylesheets/FreeCAD Light.qss
@@ -1633,11 +1633,16 @@ QSint--ActionGroup QFrame[class="content"] QToolButton {
   color: black;
   text-align: center;
   background-color: qlineargradient(x1:0, y1:0.3, x2:0, y2:1, stop:0 #f0f0f0, stop:1 #fdfdfd);
-  border: 0px solid #adadad;
+  border: 1px solid #adadad;
   padding: 1px 1px; /* different than regular QPushButton */
   margin: 0px; /* different than regular QPushButton */
   min-height: 16px; /* same as QTabBar QPushButton min-width */
   border-radius: 3px;
+}
+
+QSint--ActionGroup QFrame[class="content"] QToolButton:checked {
+  background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #fefefe, stop:1 #f8f8f8);
+  border: 1px solid @ThemeAccentColor2;
 }
 
 /* QToolButtons with a menu found in Sketcher task panel*/


### PR DESCRIPTION
This fixes:
https://github.com/FreeCAD/FreeCAD/issues/17230
The button with the purple:
![image](https://github.com/user-attachments/assets/d094728f-d1d7-44c0-a8d0-abf2125fa63c)
![image](https://github.com/user-attachments/assets/70499909-5d38-4935-a0a9-de3fd8a21f3b)
