### PR TITLE
[Cam simulator][1.0] Fix shader compilation error on linux.

### DIFF
--- a/src/Mod/CAM/PathSimulator/AppGL/Shader.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/Shader.cpp
@@ -546,7 +546,7 @@ const char* FragShaderSSAOBlur = R"(
         float sum = 0.0;
         for( int x = -1; x <= 2; ++x ) {
             for( int y = -1; y <= 2; y++ ) {
-                sum += texelFetchOffset( AoTex, pix, 0, ivec2(x,y) ).r;
+                sum += texelFetch( AoTex, pix + ivec2(x,y), 0).r;
             }
         }
 


### PR DESCRIPTION
This issue was reported on the forum [Here :](https://forum.freecad.org/viewtopic.php?p=786746#p786746)

```
18:33:37  Error compiling Blur fragment shader: 0:15(42): error: parameter `in offset' must be a constant expression
0:15(9): error: type mismatch
```

its a small shader fix and should be safe.