### PR TITLE
Part: Fix XML output of PropertyGeometryList::Save

### DIFF
--- a/src/Mod/Part/App/PropertyGeometryList.cpp
+++ b/src/Mod/Part/App/PropertyGeometryList.cpp
@@ -229,12 +229,12 @@ void PropertyGeometryList::Save(Writer &writer) const
     writer.incInd();
     for (int i = 0; i < getSize(); i++) {
         writer.Stream() << writer.ind() << "<Geometry type=\""
-                                        << _lValueList[i]->getTypeId().getName() << "\"" << endl;
-        for( auto &e : _lValueList[i]->getExtensions() ) {
+                                        << _lValueList[i]->getTypeId().getName() << "\"";
+        for (auto &e : _lValueList[i]->getExtensions() ) {
             auto ext = e.lock();
-            auto gpe = freecad_dynamic_cast<GeometryMigrationPersistenceExtension>(ext.get());
-            if (gpe)
+            if (auto gpe = freecad_dynamic_cast<GeometryMigrationPersistenceExtension>(ext.get())) {
                 gpe->preSave(writer);
+            }
         }
         writer.Stream() << " migrated=\"1\">\n";
 


### PR DESCRIPTION
Write all XML attributes of the Geometry element into a single line.

Currently the XML output looks:
```
                        <Geometry type="Part::GeomLineSegment"
 id="-1" migrated="1">

```
With the fix it will be:
`                        <Geometry type="Part::GeomLineSegment" id="-1" migrated="1">`