### PR TITLE
Gui: remove declaration of value which should not be used

### DIFF
--- a/src/Gui/DAGView/DAGFilter.h
+++ b/src/Gui/DAGView/DAGFilter.h
@@ -37,8 +37,8 @@ namespace Gui
     public:
       enum class Type
       {
-        None = 0, //!< no type designation. shouldn't be used.
-        Inclusion,
+        // None = 0, //!< no type designation. shouldn't be used.
+        Inclusion = 1,
         Exclusion
       };
       FilterBase();


### PR DESCRIPTION
IMHO when the value should not be used it should not be possible to use it, if there is not good reason to keep it.