### PR TITLE
[TechDraw] Fix error for some compilers

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -25,7 +25,7 @@
 #ifndef _PreComp_
 # include <boost/uuid/uuid_generators.hpp>
 # include <boost/uuid/uuid_io.hpp>
-
+# include <boost/random.hpp>
 # include <Approx_Curve3d.hxx>
 # include <BRep_Tool.hxx>
 # include <BRepAdaptor_Curve.hxx>


### PR DESCRIPTION
Fix for error as reported on forum https://forum.freecad.org/viewtopic.php?p=787095#p787095:

```
[ 75%] Building CXX object src/Mod/Inspection/Gui/CMakeFiles/InspectionGui.dir/Workbench.cpp.o
/opt/freecad-source/src/Mod/TechDraw/App/Geometry.cpp: In member function ‘void TechDraw::Vertex::createNewTag()’:
/opt/freecad-source/src/Mod/TechDraw/App/Geometry.cpp:1403:19: error: ‘mt19937’ in namespace ‘boost’ does not name a type
 1403 |     static boost::mt19937 ran;
      |                   ^~~~~~~
/opt/freecad-source/src/Mod/TechDraw/App/Geometry.cpp:1409:9: error: ‘ran’ was not declared in this scope; did you mean ‘tan’?
 1409 |         ran.seed(static_cast<unsigned int>(std::time(nullptr)));
      |         ^~~
      |         tan
/opt/freecad-source/src/Mod/TechDraw/App/Geometry.cpp:1412:56: error: ‘mt19937’ is not a member of ‘boost’; did you mean ‘std::mt19937’?
 1412 |     static boost::uuids::basic_random_generator<boost::mt19937> gen(&ran);
      |                                                        ^~~~~~~
In file included from /usr/include/c++/14.2.1/random:48,
                 from /usr/include/boost/uuid/detail/random_device.hpp:65,
                 from /usr/include/boost/uuid/detail/random_provider.hpp:9,
                 from /usr/include/boost/uuid/basic_random_generator.hpp:11,
                 from /usr/include/boost/uuid/random_generator.hpp:10,
                 from /usr/include/boost/uuid/uuid_generators.hpp:14,
                 from /opt/freecad-source/src/Mod/TechDraw/App/Geometry.cpp:26:
/usr/include/c++/14.2.1/bits/random.h:1717:37: note: ‘std::mt19937’ declared here
 1717 |     0xefc60000UL, 18, 1812433253UL> mt19937;
      |                                     ^~~~~~~
/opt/freecad-source/src/Mod/TechDraw/App/Geometry.cpp:1412:63: error: template argument 1 is invalid
 1412 |     static boost::uuids::basic_random_generator<boost::mt19937> gen(&ran);
      |                                                               ^
/opt/freecad-source/src/Mod/TechDraw/App/Geometry.cpp:1412:70: error: ‘ran’ was not declared in this scope; did you mean ‘tan’?
 1412 |     static boost::uuids::basic_random_generator<boost::mt19937> gen(&ran);
      |                                                                      ^~~
      |                                                                      tan
/opt/freecad-source/src/Mod/TechDraw/App/Geometry.cpp:1414:14: error: ‘gen’ cannot be used as a function
 1414 |     tag = gen();
      |           ~~~^~
```