### PR TITLE
[PartDesign] change claimChildren() function to include all profile o…

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
@@ -43,7 +43,7 @@ ViewProviderSketchBased::~ViewProviderSketchBased() = default;
 std::vector<App::DocumentObject*> ViewProviderSketchBased::claimChildren() const {
     std::vector<App::DocumentObject*> temp;
     App::DocumentObject* sketch = static_cast<PartDesign::ProfileBased*>(getObject())->Profile.getValue();
-    if (sketch && sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
+    if (sketch && !sketch->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
         temp.push_back(sketch);
 
     return temp;


### PR DESCRIPTION
…bjects except for other Part Design features.

Any object used as the Profile of a Pad or Pocket or other sketch based PartDesign::Feature should be claimed as a child of the feature in the tree view, not only sketches and other objects derived from Part2DObject.  In particular SubShapeBinders should be claimed as children to tidy up the tree view and to make it clearer what the use and purpose of the binder object is in the model.  This PR only excludes other PartDesign::Feature objects, such as when the face of a previous Pad is used as the Profile in a subsequent Pad or Pocket.