### PR TITLE
[PartDesign DuplicateSelected] do not put duplicated feature into act…

### DIFF
--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -30,6 +30,7 @@
 #endif
 
 #include <App/Document.h>
+#include <App/GeoFeatureGroupExtension.h>
 #include <App/Origin.h>
 #include <App/Part.h>
 #include <Base/Console.h>
@@ -635,8 +636,12 @@ void CmdPartDesignDuplicateSelection::activated(int iMsg)
 
         for (auto feature : newFeatures) {
             if (PartDesign::Body::isAllowed(feature)) {
-                FCMD_OBJ_CMD(pcActiveBody,"addObject(" << getObjectCmd(feature) << ")");
-                FCMD_OBJ_HIDE(feature);
+                // if feature already is in a body, then we don't put it into the active body issue #6278
+                auto body = App::GeoFeatureGroupExtension::getGroupOfObject(feature);
+                if (!body) {
+                    FCMD_OBJ_CMD(pcActiveBody,"addObject(" << getObjectCmd(feature) << ")");
+                    FCMD_OBJ_HIDE(feature);
+                }
             }
         }
 


### PR DESCRIPTION
…ive body if it is already in another body -- addresses issue #6278

Forum topic:
https://forum.freecad.org/viewtopic.php?style=3&p=380438#p380438
https://forum.freecad.org/viewtopic.php?style=3&p=786701#p786701

The reason for the exception is when duplicating a part design feature the new copy is being put into the active body even if it is already in a new body that was duplicated along with the feature.  This code checks that the feature is not already in a body before attempting to add it to the current active body.

