### PR TITLE
BIM: Only dusplay context menu items when in BIM WB

### DIFF
--- a/src/Mod/BIM/ArchAxis.py
+++ b/src/Mod/BIM/ArchAxis.py
@@ -578,6 +578,8 @@ class _ViewProviderAxis:
         return True
 
     def setupContextMenu(self, vobj, menu):
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
         actionEdit = QtGui.QAction(translate("Arch", "Edit"),
                                    menu)
         QtCore.QObject.connect(actionEdit,

--- a/src/Mod/BIM/ArchAxisSystem.py
+++ b/src/Mod/BIM/ArchAxisSystem.py
@@ -200,6 +200,8 @@ class _ViewProviderAxisSystem:
         self.edit()
 
     def setupContextMenu(self, vobj, menu):
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
         actionEdit = QtGui.QAction(translate("Arch", "Edit"),
                                    menu)
         QtCore.QObject.connect(actionEdit,

--- a/src/Mod/BIM/ArchBuilding.py
+++ b/src/Mod/BIM/ArchBuilding.py
@@ -305,6 +305,8 @@ class _ViewProviderBuilding(ArchFloor._ViewProviderFloor):
     def setupContextMenu(self,vobj,menu):
         from PySide import QtCore,QtGui
         import Arch_rc
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
         action1 = QtGui.QAction(QtGui.QIcon(":/icons/Arch_BuildingPart.svg"),"Convert to BuildingPart",menu)
         QtCore.QObject.connect(action1,QtCore.SIGNAL("triggered()"),self.convertToBuildingPart)
         menu.addAction(action1)

--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -803,7 +803,8 @@ class ViewProviderBuildingPart:
     def setupContextMenu(self, vobj, menu):
         from PySide import QtCore, QtGui
         import Draft_rc
-
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
         if (not hasattr(vobj,"DoubleClickActivates")) or vobj.DoubleClickActivates:
             if FreeCADGui.ActiveDocument.ActiveView.getActiveObject("Arch") == self.Object:
                 menuTxt = translate("Arch", "Deactivate")

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -1498,6 +1498,8 @@ class ViewProviderComponent:
             The context menu already assembled prior to this method being
             called.
         """
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
         self.contextMenuAddEdit(menu)
         self.contextMenuAddToggleSubcomponents(menu)
 

--- a/src/Mod/BIM/ArchFloor.py
+++ b/src/Mod/BIM/ArchFloor.py
@@ -399,6 +399,8 @@ class _ViewProviderFloor:
 
         from PySide import QtCore,QtGui
         import Arch_rc
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
         action1 = QtGui.QAction(QtGui.QIcon(":/icons/Arch_BuildingPart.svg"),"Convert to BuildingPart",menu)
         QtCore.QObject.connect(action1,QtCore.SIGNAL("triggered()"),self.convertToBuildingPart)
         menu.addAction(action1)

--- a/src/Mod/BIM/ArchGrid.py
+++ b/src/Mod/BIM/ArchGrid.py
@@ -282,6 +282,8 @@ class ViewProviderArchGrid:
         return True
 
     def setupContextMenu(self, vobj, menu):
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
         actionEdit = QtGui.QAction(translate("Arch", "Edit"),
                                    menu)
         QtCore.QObject.connect(actionEdit,

--- a/src/Mod/BIM/ArchIFCView.py
+++ b/src/Mod/BIM/ArchIFCView.py
@@ -53,6 +53,8 @@ class IfcContextView:
         return True
 
     def setupContextMenu(self, vobj, menu):
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
         actionEdit = QtGui.QAction(translate("Arch", "Edit"),
                                    menu)
         QtCore.QObject.connect(actionEdit,

--- a/src/Mod/BIM/ArchMaterial.py
+++ b/src/Mod/BIM/ArchMaterial.py
@@ -84,6 +84,8 @@ class _ViewProviderArchMaterialContainer:
         self.Object = vobj.Object
 
     def setupContextMenu(self, vobj, menu):
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
         actionMergeByName = QtGui.QAction(QtGui.QIcon(":/icons/Arch_Material_Group.svg"),
                                           translate("Arch", "Merge duplicates"),
                                           menu)
@@ -360,6 +362,8 @@ class _ViewProviderArchMaterial:
         return True
 
     def setupContextMenu(self, vobj, menu):
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
         actionEdit = QtGui.QAction(translate("Arch", "Edit"),
                                    menu)
         actionEdit.triggered.connect(self.edit)
@@ -660,6 +664,8 @@ class _ViewProviderArchMultiMaterial:
         self.edit()
 
     def setupContextMenu(self, vobj, menu):
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
         actionEdit = QtGui.QAction(translate("Arch", "Edit"),
                                    menu)
         actionEdit.triggered.connect(self.edit)

--- a/src/Mod/BIM/ArchReference.py
+++ b/src/Mod/BIM/ArchReference.py
@@ -649,6 +649,9 @@ class ViewProviderArchReference:
 
     def setupContextMenu(self, vobj, menu):
 
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
+
         actionEdit = QtGui.QAction(translate("Arch", "Edit"),
                                    menu)
         QtCore.QObject.connect(actionEdit,

--- a/src/Mod/BIM/ArchSchedule.py
+++ b/src/Mod/BIM/ArchSchedule.py
@@ -429,6 +429,10 @@ class _ViewProviderArchSchedule:
         self.edit()
 
     def setupContextMenu(self, vobj, menu):
+
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
+
         actionEdit = QtGui.QAction(translate("Arch", "Edit"),
                                    menu)
         QtCore.QObject.connect(actionEdit,

--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -1135,6 +1135,9 @@ class _ViewProviderSectionPlane:
         self.edit()
 
     def setupContextMenu(self, vobj, menu):
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
+
         actionEdit = QtGui.QAction(translate("Arch", "Edit"),
                                    menu)
         QtCore.QObject.connect(actionEdit,

--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -853,6 +853,10 @@ class _ViewProviderSite:
         return True
 
     def setupContextMenu(self, vobj, menu):
+
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
+
         actionEdit = QtGui.QAction(translate("Arch", "Edit"),
                                    menu)
         QtCore.QObject.connect(actionEdit,

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1297,6 +1297,10 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
         return ArchComponent.ViewProviderComponent.setDisplayMode(self,mode)
 
     def setupContextMenu(self, vobj, menu):
+
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
+
         super().contextMenuAddEdit(menu)
 
         actionFlipDirection = QtGui.QAction(QtGui.QIcon(":/icons/Arch_Wall_Tree.svg"),

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -817,6 +817,10 @@ class _ViewProviderWindow(ArchComponent.ViewProviderComponent):
         return True
 
     def setupContextMenu(self, vobj, menu):
+
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
+
         hingeIdxs = self.getHingeEdgeIndices()
 
         super().contextMenuAddEdit(menu)

--- a/src/Mod/BIM/nativeifc/ifc_viewproviders.py
+++ b/src/Mod/BIM/nativeifc/ifc_viewproviders.py
@@ -89,6 +89,9 @@ class ifc_vp_object:
         from nativeifc import ifc_materials
         from PySide import QtCore, QtGui  # lazy import
 
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
+
         icon = QtGui.QIcon(":/icons/IFC.svg")
         element = ifc_tools.get_ifc_element(vobj.Object)
         ifc_menu = None
@@ -396,6 +399,9 @@ class ifc_vp_document(ifc_vp_object):
 
         from PySide import QtCore, QtGui  # lazy import
 
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
+
         ifc_menu = super().setupContextMenu(vobj, menu)
         if not ifc_menu:
             ifc_menu = menu
@@ -575,6 +581,9 @@ class ifc_vp_material:
         from nativeifc import ifc_tools  # lazy import
         from nativeifc import ifc_psets
         from PySide import QtCore, QtGui  # lazy import
+
+        if FreeCADGui.activeWorkbench().name() != 'BIMWorkbench':
+            return
 
         icon = QtGui.QIcon(":/icons/IFC.svg")
         if ifc_psets.has_psets(self.Object):


### PR DESCRIPTION
BIM context menu items need the BIM WB loaded and therefore should not appear when not in BIM WB

Fixes #17043