### PR TITLE
Fix uptoshape crash when selecting a face without assigned shape

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -397,8 +397,10 @@ void TaskExtrudeParameters::selectedShapeFace(const Gui::SelectionChanges& msg)
     }
 
     auto base = static_cast<Part::Feature*>(extrude->UpToShape.getValue());
-
-    if (strcmp(msg.pObjectName, base->getNameInDocument()) != 0) {
+    if (!base){
+        base = static_cast<Part::Feature*>(extrude);
+    }
+    else if (strcmp(msg.pObjectName, base->getNameInDocument()) != 0) {
         return;
     }
 


### PR DESCRIPTION
Fix #17034