### PR TITLE
[Points WB] fix issue where points are inaccurately imported when the…

### DIFF
--- a/src/Mod/Points/Gui/Command.cpp
+++ b/src/Mod/Points/Gui/Command.cpp
@@ -105,8 +105,7 @@ void CmdPointsImport::activated(int iMsg)
          *  origin had inaccuracies in the relative positioning of the points due to
          *  imprecise floating point variables used in COIN
          **/
-        Points::Feature* pcFtr =
-            dynamic_cast<Points::Feature*>(doc->getDocument()->getActiveObject());
+        auto* pcFtr = dynamic_cast<Points::Feature*>(doc->getDocument()->getActiveObject());
         if (pcFtr) {
             auto points = pcFtr->Points.getValue();
             auto bbox = points.getBoundBox();

--- a/src/Mod/Points/Gui/Command.cpp
+++ b/src/Mod/Points/Gui/Command.cpp
@@ -24,6 +24,7 @@
 #ifndef _PreComp_
 #include <Inventor/events/SoMouseButtonEvent.h>
 #include <QInputDialog>
+#include <QMessageBox>
 #include <algorithm>
 #endif
 
@@ -98,7 +99,39 @@ void CmdPointsImport::activated(int iMsg)
         commitCommand();
 
         updateActive();
+
+        /** check if boundbox contains the origin, offer to move it to the origin if not
+         *  addresses issue #5808 where an imported points cloud that was far from the
+         *  origin had inaccuracies in the relative positioning of the points due to
+         *  imprecise floating point variables used in COIN
+         **/
+        Points::Feature *pcFtr = dynamic_cast<Points::Feature *>(doc->getDocument()->getActiveObject());
+        if (pcFtr) {
+            auto points = pcFtr->Points.getValue();
+            auto bbox = points.getBoundBox();
+            auto center = bbox.GetCenter();
+
+            if (!bbox.IsInBox(Base::Vector3d(0,0,0))) {
+                QMessageBox msgBox;
+                msgBox.setIcon(QMessageBox::Question);
+                msgBox.setWindowTitle(QObject::tr( "Points not at Origin"));
+                msgBox.setText(QObject::tr("The Bounding Box of the imported points does not contain the origin.  "
+                                             "Do you want to translate it to the origin?"));
+                msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+                msgBox.setDefaultButton(QMessageBox::Yes);
+                auto ret = msgBox.exec();
+
+                if (ret == QMessageBox::Yes) {
+                    Points::PointKernel translatedPoints;
+                    for (const auto& point : points) {
+                        translatedPoints.push_back(point - center);
+                    }
+                    pcFtr->Points.setValue(translatedPoints);
+                }
+            }
+        }
     }
+
 }
 
 bool CmdPointsImport::isActive()

--- a/src/Mod/Points/Gui/Command.cpp
+++ b/src/Mod/Points/Gui/Command.cpp
@@ -105,18 +105,20 @@ void CmdPointsImport::activated(int iMsg)
          *  origin had inaccuracies in the relative positioning of the points due to
          *  imprecise floating point variables used in COIN
          **/
-        Points::Feature *pcFtr = dynamic_cast<Points::Feature *>(doc->getDocument()->getActiveObject());
+        Points::Feature* pcFtr =
+            dynamic_cast<Points::Feature*>(doc->getDocument()->getActiveObject());
         if (pcFtr) {
             auto points = pcFtr->Points.getValue();
             auto bbox = points.getBoundBox();
             auto center = bbox.GetCenter();
 
-            if (!bbox.IsInBox(Base::Vector3d(0,0,0))) {
+            if (!bbox.IsInBox(Base::Vector3d(0, 0, 0))) {
                 QMessageBox msgBox;
                 msgBox.setIcon(QMessageBox::Question);
-                msgBox.setWindowTitle(QObject::tr( "Points not at Origin"));
-                msgBox.setText(QObject::tr("The Bounding Box of the imported points does not contain the origin.  "
-                                             "Do you want to translate it to the origin?"));
+                msgBox.setWindowTitle(QObject::tr("Points not at Origin"));
+                msgBox.setText(QObject::tr(
+                    "The Bounding Box of the imported points does not contain the origin.  "
+                    "Do you want to translate it to the origin?"));
                 msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
                 msgBox.setDefaultButton(QMessageBox::Yes);
                 auto ret = msgBox.exec();
@@ -131,7 +133,6 @@ void CmdPointsImport::activated(int iMsg)
             }
         }
     }
-
 }
 
 bool CmdPointsImport::isActive()


### PR DESCRIPTION
… points are far from the origin.  This PR checks if the bounding box contains the origin and offers to move it to the origin if not, addresses issue #5808

Based on some python code @wwmayer presented as an original workaround for the issue:

```
import Points

p=Points.Points()
p.read("problem.asc")
c=p.BoundBox.Center

n=Points.Points()
pts=[i-c for i in p.Points]
n.addPoints(pts)
Points.show(n)
```

Note: this only gets applied when the import is done from the Points workbench either the menu or the toolbar, but not from the File menu or when importing via scripting.  I will make a note of this in the wiki if/when it gets merged.