### PR TITLE
BIM: Fix BIM_Leader callback bug

### DIFF
--- a/src/Mod/BIM/bimcommands/BimLeader.py
+++ b/src/Mod/BIM/bimcommands/BimLeader.py
@@ -52,6 +52,7 @@ class BIM_Leader(gui_lines.Line):
 
     def finish(self, closed=False, cont=False):
         import DraftVecUtils
+        self.end_callbacks(self.call)
         self.removeTemporaryObject()
         if getattr(self,"oldWP",None):
             FreeCAD.DraftWorkingPlane = self.oldWP


### PR DESCRIPTION
Probably due to changes in gui_lines `self.call` was no longer ended.

Fixes #17283.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=91413
