### PR TITLE
Part/PD: Fix cone creation if both radii are equal

### DIFF
--- a/src/Mod/Part/App/PrimitiveFeature.cpp
+++ b/src/Mod/Part/App/PrimitiveFeature.cpp
@@ -665,14 +665,14 @@ App::DocumentObjectExecReturn *Cone::execute()
             //Build a cylinder
             BRepPrimAPI_MakeCylinder mkCylr(Radius1.getValue(),
                                             Height.getValue(),
-                                            2.0 * M_PI);
+                                            Base::toRadians<double>(Angle.getValue()));
             ResultShape = mkCylr.Shape();
         } else {
             // Build a cone
             BRepPrimAPI_MakeCone mkCone(Radius1.getValue(),
                                         Radius2.getValue(),
                                         Height.getValue(),
-                                        angle/180.0f*M_PI);
+                                        Base::toRadians<double>(angle));
             ResultShape = mkCone.Shape();
         }
         this->Shape.setValue(ResultShape);

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -360,7 +360,7 @@ App::DocumentObjectExecReturn* Cone::execute()
             //Build a cylinder
             BRepPrimAPI_MakeCylinder mkCylr(Radius1.getValue(),
                                             Height.getValue(),
-                                            2.0 * M_PI);
+                                            Base::toRadians<double>(Angle.getValue()));
             return FeaturePrimitive::execute(mkCylr.Shape());
         }
         // Build a cone


### PR DESCRIPTION
The cone features in Part and PartDesign automatically create a cylinder if top and bottom radius are identical. However, the algorithm ignores the angle and always creates a full cylinder.