### PR TITLE
[Python Console] prevent crash on autocomplete if python module is in…

### DIFF
--- a/src/Gui/CallTips.cpp
+++ b/src/Gui/CallTips.cpp
@@ -204,7 +204,11 @@ QMap<QString, CallTip> CallTipsList::extractTips(const QString& context) const
         return tips;
 
     try {
+        PyErr_Clear();
         Py::Module module("__main__");
+        if (module.ptr() == nullptr) {
+            return tips;
+        }
         Py::Dict dict = module.getDict();
 
         // this is used to filter out input of the form "1."


### PR DESCRIPTION
…valid, fixes issue #17299.

In the Objects.hxx file there are these lines:

```
        Dict getDict() const
        {
            return Dict( PyModule_GetDict( ptr() ) );
            // Caution -- PyModule_GetDict returns borrowed reference!
        }
```
My fix is to check the same ptr() call to check if it is a null pointer before passing in the Py::Module to get the dictionary.  The dictionary returned is a borrowed reference, which I believe means it gets garbage collected when it goes out of scope.  Maybe we could keep a reference to it somehow, but I'm not sure that is the underlying issue.  It's the module that is invalid not the dictionary.  But regardless of that, there is the possibility that the module is invalid, so this PR checks for that, which should be done in any case, even if a better solution is found later.