### PR TITLE
Draft: Improve layer drag-drop fix.

### DIFF
--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -910,9 +910,14 @@ def _get_layer(obj):
     finds = obj.Document.findObjects(Name="LayerContainer")
     if not finds:
         return None
+    # First look in the LayerContainer:
     for layer in finds[0].Group:
         if utils.get_type(layer) == "Layer" and obj in layer.Group:
             return layer
+    # If not found, look through all App::FeaturePython objects (not just layers):
+    for find in obj.Document.findObjects(Type="App::FeaturePython"):
+        if utils.get_type(find) == "Layer" and obj in find.Group:
+            return find
     return None
 
 

--- a/src/Mod/Draft/draftviewproviders/view_layer.py
+++ b/src/Mod/Draft/draftviewproviders/view_layer.py
@@ -333,9 +333,14 @@ class ViewProviderLayer:
         """Get the layer the object belongs to.
         """
         from draftmake.make_layer import get_layer_container
+        # First look in the LayerContainer:
         for layer in get_layer_container().Group:
             if utils.get_type(layer) == "Layer" and obj in layer.Group:
                 return layer
+        # If not found, look through all App::FeaturePython objects (not just layers):
+        for find in obj.Document.findObjects(Type="App::FeaturePython"):
+            if utils.get_type(find) == "Layer" and obj in find.Group:
+                return find
         return None
 
     def canDragObject(self, obj):


### PR DESCRIPTION
The fix in #16212 only checks the LayerContainer for layers. Since we do not stop users from moving layers out of that container, we should search the whole document instead.

Fixes: #16201.
