### PR TITLE
BIM: Fix export as IFC

### DIFF
--- a/src/Mod/BIM/importers/exportIFCHelper.py
+++ b/src/Mod/BIM/importers/exportIFCHelper.py
@@ -24,7 +24,7 @@ import math
 
 import FreeCAD
 # import Draft
-import ifcopenshell
+import ifcopenshell.guid
 from draftutils import params
 
 def getObjectsOfIfcType(objects, ifcType):


### PR DESCRIPTION
```
pyException: Traceback (most recent call last):
  File "<string>", line 8, in <module>
  File "/usr/lib64/freecad/Mod/BIM/importers/exportIFC.py", line 305, in export
    contextCreator = exportIFCHelper.ContextCreator(ifcfile, objectslist)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/freecad/Mod/BIM/importers/exportIFCHelper.py", line 133, in __init__
    self.project = self.createProject()
                   ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/freecad/Mod/BIM/importers/exportIFCHelper.py", line 193, in createProject
    return self.createAutomaticProject()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/freecad/Mod/BIM/importers/exportIFCHelper.py", line 198, in createAutomaticProject
    self.getProjectGUID(),
    ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/freecad/Mod/BIM/importers/exportIFCHelper.py", line 217, in getProjectGUID
    return ifcopenshell.guid.new()
           ^^^^^^^^^^^^^^^^^
<class 'AttributeError'>: module 'ifcopenshell' has no attribute 'guid'
```

When doing a File / Export and selecting IFC format.

This needs backporting to 1.0.