### PR TITLE
Add monkey patch regression test in random place

### DIFF
--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -42,6 +42,7 @@ class TemporaryGuiTest(unittest.TestCase):
     def test_monkey_patch_regression(self):
         # Given
         from pivy import coin
+
         parent = coin.SoGroup()
         child1 = coin.SoGroup()
         child2 = coin.SoGroup()

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -38,6 +38,31 @@ v = Base.Vector
 # ----------------------------------------------------------------------------------
 
 
+class TemporaryGuiTest(unittest.TestCase):
+    def test_monkey_patch_regression(self):
+        # Given
+        from pivy import coin
+        parent = coin.SoGroup()
+        child1 = coin.SoGroup()
+        child2 = coin.SoGroup()
+        parent.addChild(child1)
+        parent.addChild(child2)
+        path = coin.SoPath(2)
+        path.append(parent)
+        path.append(child2)
+
+        # When
+        before_removal = path.getLength()
+        parent.removeAllChildren()
+        after_removal = path.getLength()
+
+        # Then
+        expected_before = 2
+        expected_after = 1
+        self.assertEqual(before_removal, expected_before)
+        self.assertEqual(after_removal, expected_after)
+
+
 class SpreadsheetCases(unittest.TestCase):
     def setUp(self):
         self.doc = FreeCAD.newDocument()


### PR DESCRIPTION
This will test if #17073 was safe to remove.
By creating a test we can see if it works on ubuntu 20.04 LTS.

I didn't find a good place to put this test, but we really just need to run it once to verify the old coin version doesn't have an even older bug.