### PR TITLE
PD: Avoid touching the document when opening pad or pocket dialog

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -380,22 +380,28 @@ void TaskDressUpParameters::hideOnError()
         showObject();
 }
 
-void TaskDressUpParameters::hideObject()
+void TaskDressUpParameters::setDressUpVisibility(bool visible)
 {
     App::DocumentObject* base = getBase();
-    if(base) {
-        DressUpView->getObject()->Visibility.setValue(false);
-        base->Visibility.setValue(true);
+    if (base) {
+        App::DocumentObject* duv = DressUpView->getObject();
+        if (duv->Visibility.getValue() != visible) {
+            duv->Visibility.setValue(visible);
+        }
+        if (base->Visibility.getValue() == visible) {
+            base->Visibility.setValue(!visible);
+        }
     }
+}
+
+void TaskDressUpParameters::hideObject()
+{
+    setDressUpVisibility(false);
 }
 
 void TaskDressUpParameters::showObject()
 {
-    App::DocumentObject* base = getBase();
-    if (base) {
-        DressUpView->getObject()->Visibility.setValue(true);
-        base->Visibility.setValue(false);
-    }
+    setDressUpVisibility(true);
 }
 
 ViewProviderDressUp* TaskDressUpParameters::getDressUpView() const

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
@@ -104,6 +104,7 @@ protected:
 
 private:
     void tryAddSelection(const std::string& doc, const std::string& obj, const std::string& sub);
+    void setDressUpVisibility(bool visible);
 
 protected:
     QWidget* proxy;

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -186,10 +186,9 @@ void TaskExtrudeParameters::setupDialog()
 
     ui->listWidgetReferences->addAction(unselectShapeFaceAction);
     ui->listWidgetReferences->setContextMenuPolicy(Qt::ActionsContextMenu);
+    ui->checkBoxAllFaces->setChecked(ui->listWidgetReferences->count() == 0);
 
     connectSlots();
-
-    ui->checkBoxAllFaces->setChecked(ui->listWidgetReferences->count() == 0);
 
     this->propReferenceAxis = &(extrude->ReferenceAxis);
 


### PR DESCRIPTION
When loading a project it suffices to open the pad or pocket dialog to touch the document and mark it as modified even if the user cancels the dialog without changing anything.