### PR TITLE
Part: Disable tesselation limit in ViewProviderGUI to prevent large parts from freezing FreeCAD

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -975,7 +975,7 @@ void ViewProviderPartExt::updateVisual()
         // For very big objects the computed deflection can become very high and thus leads to a useless
         // tessellation. To avoid this the upper limit is set to 20.0
         // See also forum: https://forum.freecad.org/viewtopic.php?t=77521
-        deflection = std::min(deflection, 20.0);
+        //deflection = std::min(deflection, 20.0);
 
         // create or use the mesh on the data structure
         Standard_Real AngDeflectionRads = AngularDeflection.getValue() / 180.0 * M_PI;


### PR DESCRIPTION
fix #17183
Part: Disable tesselation limit in ViewProviderGUI to prevent large parts from freezing FreeCAD

took this from #17214

required for work on #9377

@ Triage see https://github.com/FreeCAD/FreeCAD/pull/17214#issuecomment-2411342073 - assign for 1.0 ?
