### PR TITLE
[PartDesign Groove/Revolution] minor dialog improvements, addresses i…

### DIFF
--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -57,8 +57,8 @@ Groove::Groove()
 
     ADD_PROPERTY_TYPE(Type, (0L), "Groove", App::Prop_None, "Groove type");
     Type.setEnums(TypeEnums);
-    ADD_PROPERTY_TYPE(Base, (Base::Vector3d(0.0f,0.0f,0.0f)), "Groove", App::Prop_ReadOnly, "Base");
-    ADD_PROPERTY_TYPE(Axis, (Base::Vector3d(0.0f,1.0f,0.0f)), "Groove", App::Prop_ReadOnly, "Axis");
+    ADD_PROPERTY_TYPE(Base, (Base::Vector3d(0.0f,0.0f,0.0f)), "Groove", App::PropertyType(App::Prop_ReadOnly | App::Prop_Hidden), "Base");
+    ADD_PROPERTY_TYPE(Axis, (Base::Vector3d(0.0f,1.0f,0.0f)), "Groove", App::PropertyType(App::Prop_ReadOnly | App::Prop_Hidden), "Axis");
     ADD_PROPERTY_TYPE(Angle, (360.0),"Groove", App::Prop_None, "Angle");
     ADD_PROPERTY_TYPE(Angle2, (60.0), "Groove", App::Prop_None, "Groove length in 2nd direction");
     ADD_PROPERTY_TYPE(UpToFace, (nullptr), "Groove", App::Prop_None, "Face where groove will end");

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -56,12 +56,11 @@ Revolution::Revolution()
 
     ADD_PROPERTY_TYPE(Type, (0L), "Revolution", App::Prop_None, "Revolution type");
     Type.setEnums(TypeEnums);
-    ADD_PROPERTY_TYPE(Base,(Base::Vector3d(0.0,0.0,0.0)),"Revolution", App::Prop_ReadOnly, "Base");
-    ADD_PROPERTY_TYPE(Axis,(Base::Vector3d(0.0,1.0,0.0)),"Revolution", App::Prop_ReadOnly, "Axis");
+    ADD_PROPERTY_TYPE(Base,(Base::Vector3d(0.0,0.0,0.0)),"Revolution", App::PropertyType(App::Prop_ReadOnly | App::Prop_Hidden), "Base");
+    ADD_PROPERTY_TYPE(Axis,(Base::Vector3d(0.0,1.0,0.0)),"Revolution", App::PropertyType(App::Prop_ReadOnly | App::Prop_Hidden), "Axis");
     ADD_PROPERTY_TYPE(Angle,(360.0),"Revolution", App::Prop_None, "Angle");
-    ADD_PROPERTY_TYPE(UpToFace, (nullptr), "Revolution", App::Prop_None, "Face where revolution will end");
     ADD_PROPERTY_TYPE(Angle2, (60.0), "Revolution", App::Prop_None, "Revolution length in 2nd direction");
-
+    ADD_PROPERTY_TYPE(UpToFace, (nullptr), "Revolution", App::Prop_None, "Face where revolution will end");
     Angle.setConstraints(&floatAngle);
     ADD_PROPERTY_TYPE(ReferenceAxis,(nullptr),"Revolution",(App::Prop_None),"Reference axis of revolution");
 }

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -39,6 +39,7 @@
 
 #include "ui_TaskRevolutionParameters.h"
 #include "TaskRevolutionParameters.h"
+#include "ViewProviderGroove.h"
 #include "ReferenceSelection.h"
 
 using namespace PartDesignGui;
@@ -46,8 +47,8 @@ using namespace Gui;
 
 /* TRANSLATOR PartDesignGui::TaskRevolutionParameters */
 
-TaskRevolutionParameters::TaskRevolutionParameters(PartDesignGui::ViewProvider* RevolutionView, QWidget *parent)
-    : TaskSketchBasedParameters(RevolutionView, parent, "PartDesign_Revolution", tr("Revolution parameters")),
+TaskRevolutionParameters::TaskRevolutionParameters(PartDesignGui::ViewProvider* RevolutionView, const char* pixname, QString title, QWidget *parent)
+    : TaskSketchBasedParameters(RevolutionView, parent, pixname, title),
       ui(new Ui_TaskRevolutionParameters),
       proxy(new QWidget(this)),
       selectionFace(false),
@@ -318,7 +319,9 @@ void TaskRevolutionParameters::setCheckboxes(PartDesign::Revolution::RevolMethod
 
     ui->checkBoxReversed->setEnabled(isReversedEnabled);
 
+    ui->buttonFace->setVisible(isFaceEditEnabled);
     ui->buttonFace->setEnabled(isFaceEditEnabled);
+    ui->lineFaceName->setVisible(isFaceEditEnabled);
     ui->lineFaceName->setEnabled(isFaceEditEnabled);
     if (!isFaceEditEnabled) {
         ui->buttonFace->setChecked(false);
@@ -691,11 +694,18 @@ void TaskRevolutionParameters::apply()
 //**************************************************************************
 // TaskDialog
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-TaskDlgRevolutionParameters::TaskDlgRevolutionParameters(PartDesignGui::ViewProvider *RevolutionView)
+TaskDlgRevolutionParameters::TaskDlgRevolutionParameters(ViewProviderRevolution *RevolutionView)
     : TaskDlgSketchBasedParameters(RevolutionView)
 {
     assert(RevolutionView);
-    Content.push_back(new TaskRevolutionParameters(RevolutionView));
+    Content.push_back(new TaskRevolutionParameters(RevolutionView, "PartDesign_Revolution", tr("Revolution parameters")));
+}
+
+TaskDlgGrooveParameters::TaskDlgGrooveParameters(ViewProviderGroove *GrooveView)
+    : TaskDlgSketchBasedParameters(GrooveView)
+{
+    assert(GrooveView);
+    Content.push_back(new TaskRevolutionParameters(GrooveView, "PartDesign_Groove", tr("Groove parameters")));
 }
 
 

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
@@ -27,6 +27,7 @@
 #include <Mod/PartDesign/App/FeatureGroove.h>
 #include "TaskSketchBasedParameters.h"
 #include "ViewProviderRevolution.h"
+#include "ViewProviderGroove.h"
 
 
 class Ui_TaskRevolutionParameters;
@@ -46,7 +47,10 @@ class TaskRevolutionParameters : public TaskSketchBasedParameters
     Q_OBJECT
 
 public:
-    explicit TaskRevolutionParameters(ViewProvider* RevolutionView, QWidget* parent = nullptr);
+    explicit TaskRevolutionParameters(ViewProvider* RevolutionView,
+                                      const char *pixname,
+                                      QString title = tr("Revolution parameters"),
+                                      QWidget* parent = nullptr);
     ~TaskRevolutionParameters() override;
 
     void apply() override;
@@ -121,9 +125,15 @@ class TaskDlgRevolutionParameters : public TaskDlgSketchBasedParameters
     Q_OBJECT
 
 public:
-    explicit TaskDlgRevolutionParameters(PartDesignGui::ViewProvider *RevolutionView);
+    explicit TaskDlgRevolutionParameters(PartDesignGui::ViewProviderRevolution *RevolutionView);
 };
+class TaskDlgGrooveParameters : public TaskDlgSketchBasedParameters
+{
+    Q_OBJECT
 
+public:
+    explicit TaskDlgGrooveParameters(PartDesignGui::ViewProviderGroove *GrooveView);
+};
 } //namespace PartDesignGui
 
 #endif // GUI_TASKVIEW_TASKAPPERANCE_H

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.ui
@@ -113,23 +113,6 @@
     </layout>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBoxMidplane">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="text">
-      <string>Symmetric to plane</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkBoxReversed">
-     <property name="text">
-      <string>Reversed</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QLabel" name="labelAngle2">
@@ -161,6 +144,23 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxMidplane">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Symmetric to plane</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxReversed">
+     <property name="text">
+      <string>Reversed</string>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_5">

--- a/src/Mod/PartDesign/Gui/ViewProviderGroove.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderGroove.cpp
@@ -49,5 +49,5 @@ void ViewProviderGroove::setupContextMenu(QMenu* menu, QObject* receiver, const 
 
 TaskDlgFeatureParameters *ViewProviderGroove::getEditDialog()
 {
-    return new TaskDlgRevolutionParameters( this );
+    return new TaskDlgGrooveParameters( this );
 }


### PR DESCRIPTION
…ssue #13298.

Issues addressed:

Groove dialog had Revolution window title and icon.
Moved Angle2 widget to just after the other Angle widget.
Hide Face button and line edit when not in the mode that needs it.
Make property sorting order the same for both objects.
Hide Base and Normal properties since they were already readonly.