### PR TITLE
Materials: Child ignoring parent material

### DIFF
--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -86,7 +86,7 @@ App::DocumentObjectExecReturn *Chamfer::execute()
 
         TopoShape res(0);
         this->Shape.setValue(res.makeElementShape(mkChamfer,baseTopoShape,Part::OpCodes::Chamfer));
-        return Part::Feature::execute();
+        return Part::FilletBase::execute();
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());

--- a/src/Mod/Part/App/FeatureCompound.cpp
+++ b/src/Mod/Part/App/FeatureCompound.cpp
@@ -69,6 +69,10 @@ App::DocumentObjectExecReturn *Compound::execute()
             }
         }
         this->Shape.setValue(TopoShape().makeElementCompound(shapes));
+        if (Links.getSize() > 0) {
+            App::DocumentObject* link = Links.getValues()[0];
+            copyMaterial(link);
+        }
         return Part::Feature::execute();
     }
     catch (Standard_Failure& e) {

--- a/src/Mod/Part/App/FeatureFillet.cpp
+++ b/src/Mod/Part/App/FeatureFillet.cpp
@@ -90,7 +90,7 @@ App::DocumentObjectExecReturn *Fillet::execute()
 
         TopoShape res(0);
         this->Shape.setValue(res.makeElementShape(mkFillet,baseTopoShape,Part::OpCodes::Fillet));
-        return Part::Feature::execute();
+        return Part::FilletBase::execute();
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());

--- a/src/Mod/Part/App/FeatureMirroring.cpp
+++ b/src/Mod/Part/App/FeatureMirroring.cpp
@@ -257,6 +257,8 @@ App::DocumentObjectExecReturn *Mirroring::execute()
         if (shape.isNull())
             Standard_Failure::Raise("Cannot mirror empty shape");
         this->Shape.setValue(TopoShape(0).makeElementMirror(shape,ax2));
+        copyMaterial(link);
+
         return Part::Feature::execute();
     }
     catch (Standard_Failure& e) {

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -136,6 +136,7 @@ App::DocumentObjectExecReturn* Boolean::execute()
             res = res.makeElementRefine();
         }
         this->Shape.setValue(res);
+        copyMaterial(base);
         return Part::Feature::execute();
     }
     catch (...) {

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -117,6 +117,10 @@ App::DocumentObjectExecReturn *MultiCommon::execute()
         res = res.makeElementRefine();
     }
     this->Shape.setValue(res);
+    if (Shapes.getSize() > 0) {
+        App::DocumentObject* link = Shapes.getValues()[0];
+        copyMaterial(link);
+    }
 
     return Part::Feature::execute();
 }

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -208,6 +208,9 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
             }
             this->Shape.setValue(res);
             this->History.setValues(history);
+
+            App::DocumentObject* link = Shapes.getValues()[0];
+            copyMaterial(link);
             return Part::Feature::execute();
         }
         catch (Standard_Failure& e) {

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -128,6 +128,26 @@ PyObject *Feature::getPyObject()
     return Py::new_reference_to(PythonObject);
 }
 
+void Feature::copyMaterial(Feature* feature)
+{
+    auto mat = Materials::MaterialManager::defaultMaterial();
+    if (feature) {
+        if (ShapeMaterial.getValue().getUUID() != feature->ShapeMaterial.getValue().getUUID()) {
+            if (ShapeMaterial.getValue().getUUID() == mat->getUUID()) {
+                ShapeMaterial.setValue(feature->ShapeMaterial.getValue());
+            }
+        }
+    }
+}
+
+void Feature::copyMaterial(App::DocumentObject* link)
+{
+    auto feature = dynamic_cast<Part::Feature*>(link);
+    if (feature) {
+        copyMaterial(feature);
+    }
+}
+
 /**
  * Override getElementName to support the Export type.  Other calls are passed to the original
  * method
@@ -1707,6 +1727,16 @@ short FilletBase::mustExecute() const
     if (Base.isTouched() || Edges.isTouched() || EdgeLinks.isTouched())
         return 1;
     return 0;
+}
+
+App::DocumentObjectExecReturn* FilletBase::execute()
+{
+    App::DocumentObject* link = this->Base.getValue();
+    if (!link) {
+        return new App::DocumentObjectExecReturn("No object linked");
+    }
+    copyMaterial(link);
+    return Part::Feature::execute();
 }
 
 void FilletBase::onChanged(const App::Property *prop) {

--- a/src/Mod/Part/App/PartFeature.h
+++ b/src/Mod/Part/App/PartFeature.h
@@ -169,6 +169,9 @@ protected:
     void onBeforeChange(const App::Property* prop) override;
     void onChanged(const App::Property* prop) override;
 
+    void copyMaterial(Feature* feature);
+    void copyMaterial(App::DocumentObject* link);
+
     void registerElementCache(const std::string &prefix, PropertyPartShape *prop);
 
     /** Helper function to obtain mapped and indexed element name from a shape
@@ -210,7 +213,8 @@ public:
     App::PropertyLinkSub   EdgeLinks;
 
     short mustExecute() const override;
-    void onUpdateElementReference(const App::Property *prop) override;
+    App::DocumentObjectExecReturn* execute() override;
+    void onUpdateElementReference(const App::Property* prop) override;
 
 protected:
     void onDocumentRestored() override;

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -471,6 +471,20 @@ void Body::onChanged(const App::Property* prop) {
             }
 
         }
+        else if (prop == &ShapeMaterial) {
+            std::vector<App::DocumentObject*> features = Group.getValues();
+            if (!features.empty()) {
+                for (auto it : features) {
+                    auto feature = dynamic_cast<Part::Feature*>(it);
+                    if (feature) {
+                        if (feature->ShapeMaterial.getValue().getUUID()
+                            != ShapeMaterial.getValue().getUUID()) {
+                            feature->ShapeMaterial.setValue(ShapeMaterial.getValue());
+                        }
+                    }
+                }
+            }
+        }
     }
 
     Part::BodyBase::onChanged(prop);

--- a/src/Mod/PartDesign/App/Feature.h
+++ b/src/Mod/PartDesign/App/Feature.h
@@ -110,6 +110,11 @@ protected:
 
     void updateSuppressedShape();
 
+    /**
+     * Set the Material To Body Material object
+     */
+    void setMaterialToBodyMaterial();
+
     /// Grab any point from the given face
     static const gp_Pnt getPointFromFace(const TopoDS_Face& f);
     /// Make a shape from a base plane (convenience method)

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -397,8 +397,10 @@ void TaskExtrudeParameters::selectedShapeFace(const Gui::SelectionChanges& msg)
     }
 
     auto base = static_cast<Part::Feature*>(extrude->UpToShape.getValue());
-
-    if (strcmp(msg.pObjectName, base->getNameInDocument()) != 0) {
+    if (!base){
+        base = static_cast<Part::Feature*>(extrude);
+    }
+    else if (strcmp(msg.pObjectName, base->getNameInDocument()) != 0) {
         return;
     }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -247,21 +247,9 @@ void ViewProviderBody::updateData(const App::Property* prop)
                 static_cast<PartDesignGui::ViewProvider*>(vp)->setTipIcon(feature == tip);
             }
         }
-
-        if (tip)
-            copyColorsfromTip(tip);
     }
 
     PartGui::ViewProviderPart::updateData(prop);
-}
-
-void ViewProviderBody::copyColorsfromTip(App::DocumentObject* tip) {
-    // update ShapeAppearance
-    Gui::ViewProvider* vptip = Gui::Application::Instance->getViewProvider(tip);
-    if (vptip && vptip->isDerivedFrom(PartGui::ViewProviderPartExt::getClassTypeId())) {
-        auto materials = static_cast<PartGui::ViewProviderPartExt*>(vptip)->ShapeAppearance.getValues();
-        this->ShapeAppearance.setValues(materials);
-    }
 }
 
 void ViewProviderBody::slotChangedObjectApp ( const App::DocumentObject& obj, const App::Property& prop ) {

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.h
@@ -98,9 +98,6 @@ protected:
     void setVisualBodyMode(bool bodymode);
 
 private:
-    void copyColorsfromTip(App::DocumentObject* tip);
-
-private:
     static const char* BodyModeEnum[];
 
     boost::signals2::connection connectChangedObjectApp;


### PR DESCRIPTION
Inherit the material from the parent object when creating a new object, such as during a boolean operation, or when extruding a sketch.

fixes #15503