### PR TITLE
App: Property.h correct comment for NoRecompute status

### DIFF
--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -71,7 +71,7 @@ public:
         LockDynamic = 8,         // prevent being removed from dynamic property
         NoModify = 9,            // prevent causing Gui::Document::setModified()
         PartialTrigger = 10,     // allow change in partial doc
-        NoRecompute = 11,        // touch owner for recompute on property change
+        NoRecompute = 11,        // don't touch owner for recompute on property change
         Single = 12,             // for save/load of floating point numbers
         Ordered = 13,            // for PropertyLists whether the order of the elements is
                                  // relevant for the container using it


### PR DESCRIPTION
Compare:
https://github.com/FreeCAD/FreeCAD/blob/ef2156d0f6d116b1642a5531a2d44fc6b7d17042/src/App/PropertyContainer.h#L53
