### PR TITLE
Workaround for macOS crash when loading FreeCAD by opening a `.FCStd` file from Finder

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -975,10 +975,6 @@ void Application::checkForRecomputes() {
         return;
     WaitCursor wc;
     wc.restoreCursor();
-
-    // Splasher is shown ontop of warnings on macOS so stop it before it's too late
-    getMainWindow()->stopSplasher();
-
     auto res = QMessageBox::warning(getMainWindow(), QObject::tr("Recomputation required"),
                                     QObject::tr("Some document(s) require recomputation for migration purposes. "
                                                 "It is highly recommended to perform a recomputation before "


### PR DESCRIPTION
Fixes #17280

TL;DR
Files are loaded before main window is loaded, things go kaboom.
Delay the load event a bit fixes the issue

Please, don't squash this PR, one of the commit reverts an earlier attempt, it makes sense to keep that revert that change in a separate commit.
Only backport the second commit "Repost QFileOpenEvent event to avoid an undefined state", as the previous attempt was never backported.

---

When the user double clicks a `.FCStd` file in Finder when FreeCAD isn't open, FreeCAD will start and get an event from Qt immediately.
This event will be processed when the event loop is started, which by design is done when the main window has been loaded as evident in `Gui::Application::runApplication()`.
Normally loading files are postponed and handled in `delayedStartup` but if a QFileOpenEvent would be handled before the MainWindow would be completely loaded, we will end up in an undefined state.

The issue we get is that events _are_ handled before, more specifically, they are handled when the splash screen is shown.
And this was what happened in 1.0RC2. The MainWindow wasn't shown and coin didn't have a context at that point which led to the strange crash log.
<details><summary>Click to expand crash log</summary>
<p>

```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_pthread.dylib       	       0x18a3c94f8 pthread_mutex_lock + 12
1   libCoin.80.0.3.dylib          	       0x1079fbd58 SoGLCacheContextElement::getUniqueCacheContext() + 28
2   libFreeCADGui.dylib           	       0x1051b05b0 SIM::Coin3D::Quarter::QuarterWidgetP::findCacheContext(SIM::Coin3D::Quarter::QuarterWidget*, QOpenGLWidget const*) + 184
3   libFreeCADGui.dylib           	       0x1051b04ac SIM::Coin3D::Quarter::QuarterWidgetP::QuarterWidgetP(SIM::Coin3D::Quarter::QuarterWidget*, QOpenGLWidget const*) + 156
4   libFreeCADGui.dylib           	       0x1051ad078 SIM::Coin3D::Quarter::QuarterWidget::constructor(QSurfaceFormat const&, QOpenGLWidget const*) + 212
5   libFreeCADGui.dylib           	       0x1051ad3c0 SIM::Coin3D::Quarter::QuarterWidget::QuarterWidget(QWidget*, QOpenGLWidget const*, QFlags<Qt::WindowType>) + 92
6   libFreeCADGui.dylib           	       0x1051b3b08 SIM::Coin3D::Quarter::SoQTQuarterAdaptor::SoQTQuarterAdaptor(QWidget*, QOpenGLWidget const*, QFlags<Qt::WindowType>) + 52
7   libFreeCADGui.dylib           	       0x1051dc390 Gui::View3DInventorViewer::View3DInventorViewer(QWidget*, QOpenGLWidget const*) + 44
8   libFreeCADGui.dylib           	       0x1051d7610 Gui::View3DInventor::View3DInventor(Gui::Document*, QWidget*, QOpenGLWidget const*, QFlags<Qt::WindowType>) + 252
9   libFreeCADGui.dylib           	       0x104de1858 Gui::Document::createView(Base::Type const&) + 256
10  libFreeCADGui.dylib           	       0x104d5e0c4 Gui::Application::slotNewDocument(App::Document const&, bool) + 2540
11  libFreeCADApp.dylib           	       0x103a837b0 boost::signals2::detail::slot_call_iterator_t<boost::signals2::detail::variadic_slot_invoker<boost::signals2::detail::void_type, App::Document const&, bool>, std::__1::__list_iterator<boost::shared_ptr<boost::signals2::detail::connection_body<std::__1::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (App::Document const&, bool), boost::function<void (App::Document const&, bool)>>, boost::signals2::mutex>>, void*>, boost::signals2::detail::connection_body<std::__1::pair<boost::signals2::detail::slot_meta_group, boost::optional<int>>, boost::signals2::slot<void (App::Document const&, bool), boost::function<void (App::Document const&, bool)>>, boost::signals2::mutex>>::dereference() const + 96
12  libFreeCADApp.dylib           	       0x103a831dc boost::signals2::detail::signal_impl<void (App::Document const&, bool), boost::signals2::optional_last_value<void>, int, std::__1::less<int>, boost::function<void (App::Document const&, bool)>, boost::function<void (boost::signals2::connection const&, App::Document const&, bool)>, boost::signals2::mutex>::operator()(App::Document const&, bool) + 600
13  libFreeCADApp.dylib           	       0x103c67278 App::Application::newDocument(char const*, char const*, bool, bool) + 8412
14  libFreeCADApp.dylib           	       0x103c6cf0c App::Application::openDocumentPrivate(char const*, char const*, char const*, bool, bool, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>&&) + 532
15  libFreeCADApp.dylib           	       0x103c9ba9c App::Application::openDocuments(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const*, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const*, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>*, bool) (.504) + 1976
16  libFreeCADApp.dylib           	       0x103c68fd4 App::Application::openDocument(char const*, bool) + 204
17  libFreeCADApp.dylib           	       0x103ca1998 App::Application::sOpenDocument(_object*, _object*, _object*) + 312
18  libpython3.11.dylib           	       0x102f37e20 cfunction_call + 124
19  libpython3.11.dylib           	       0x102ee05e4 _PyObject_MakeTpCall + 332
20  libpython3.11.dylib           	       0x102fe2774 _PyEval_EvalFrameDefault + 46152
21  libpython3.11.dylib           	       0x102fd635c PyEval_EvalCode + 220
22  libpython3.11.dylib           	       0x10303c4f8 run_mod + 144
23  libpython3.11.dylib           	       0x1030400a4 PyRun_StringFlags + 112
24  libFreeCADBase.dylib          	       0x102bd1ab8 Base::InterpreterSingleton::runString(char const*) + 108
25  libFreeCADGui.dylib           	       0x104e7a9f8 Gui::Command::_runCommand(char const*, int, Gui::Command::DoCmd_Type, char const*) + 164
26  libFreeCADGui.dylib           	       0x104e7a848 Gui::Command::_doCommand(char const*, int, Gui::Command::DoCmd_Type, char const*, ...) + 124
27  libFreeCADGui.dylib           	       0x104d5ff64 Gui::Application::open(char const*, char const*) + 1172
28  libFreeCADGui.dylib           	       0x104e35e38 Gui::GUIApplication::event(QEvent*) + 304
29  libQt5Widgets.5.15.13.dylib   	       0x10402a264 QApplicationPrivate::notify_helper(QObject*, QEvent*) + 232
30  libQt5Core.5.15.13.dylib      	       0x10491d094 QCoreApplication::notifyInternal2(QObject*, QEvent*) + 176
31  AppKit                        	       0x18e15f3e0 -[NSApplication(NSAppleEventHandling) _openURLs:requestedBySourceApp:completionHandler:] + 1108
32  AppKit                        	       0x18df6d59c __69-[NSApplication(NSAppleEventHandling) _handleAEOpenDocumentsForURLs:]_block_invoke + 564
33  AppKit                        	       0x18e152bfc __102-[NSApplication _reopenWindowsAsNecessaryIncludingRestorableState:withFullFidelity:completionHandler:]_block_invoke + 96
34  AppKit                        	       0x18de31c44 __97-[NSDocumentController(NSInternal) _autoreopenDocumentsIgnoringExpendable:withCompletionHandler:]_block_invoke_3 + 172
35  AppKit                        	       0x18de31480 -[NSDocumentController(NSInternal) _autoreopenDocumentsIgnoringExpendable:withCompletionHandler:] + 676
36  AppKit                        	       0x18e152b08 -[NSApplication _reopenWindowsAsNecessaryIncludingRestorableState:withFullFidelity:completionHandler:] + 256
37  AppKit                        	       0x18df6d2e4 -[NSApplication(NSAppleEventHandling) _handleAEOpenDocumentsForURLs:] + 244
38  AppKit                        	       0x18dd122c0 -[NSApplication(NSAppleEventHandling) _handleCoreEvent:withReplyEvent:] + 412
39  Foundation                    	       0x18b5b7374 -[NSAppleEventManager dispatchRawAppleEvent:withRawReply:handlerRefCon:] + 316
40  Foundation                    	       0x18b5b7168 _NSAppleEventManagerGenericHandler + 80
41  AE                            	       0x1914cc9c4 0x1914c1000 + 47556
42  AE                            	       0x1914cc2ec 0x1914c1000 + 45804
43  AE                            	       0x1914c58a8 aeProcessAppleEvent + 488
44  HIToolbox                     	       0x194c6002c AEProcessAppleEvent + 68
45  AppKit                        	       0x18dd0c074 _DPSNextEvent + 1440
46  AppKit                        	       0x18e501808 -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 700
47  libqcocoa.dylib               	       0x108e442b0 0x108e18000 + 180912
48  libFreeCADGui.dylib           	       0x104e60d00 Gui::StartupPostProcess::execute() + 40
49  libFreeCADGui.dylib           	       0x104d69430 Gui::Application::runApplication() + 1492
50  freecad                       	       0x1024a7248 main + 3464
51  dyld                          	       0x18a0460e0 start + 2360
```

</p>
</details> 

And lately the splash screen crash when trying to close splash screen before showing the dialog (17178).
<details><summary>Click to expand crash in splash screen</summary>
<p>

```
0   libQt5Widgets.5.15.13.dylib   	       0x10634d244 QWidgetPrivate::close_helper(QWidgetPrivate::CloseMode) + 16
1   libQt5Widgets.5.15.13.dylib   	       0x1064333b4 QSplashScreen::finish(QWidget*) + 184
2   libFreeCADGui.dylib           	       0x1071523c8 Gui::StartupPostProcess::showMainWindow() + 372
3   libFreeCADGui.dylib           	       0x107150b84 Gui::StartupPostProcess::execute() + 236
4   libFreeCADGui.dylib           	       0x10705f18c Gui::Application::runApplication() + 1236
5   freecad                       	       0x1047d3184 main + 5128
6   dyld                          	       0x18a0460e0 start + 2360
```

</p>
</details> 

The reason the latest "fix" failed, was that showing the splash screen led to the QFileOpen event to be handled _inside_ of `splashscreen.show()`. When trying to stop the splasher, it also tried to delete it - while qt was still accessing it.

Click to show stack trace for when the event is being handled:

<details><summary>Details</summary>
<p>

```
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 11.1
  * frame #0: 0x0000000104cdbb68 libFreeCADGui.dylib`Gui::GUIApplication::event(this=0x000000016fdfe2b8, ev=0x000000013df772e0) at GuiApplication.cpp:166:14
    frame #1: 0x0000000103c24974 libQt5Widgets.5.15.8.dylib`QApplicationPrivate::notify_helper(QObject*, QEvent*) + 232
    frame #2: 0x0000000103c257ac libQt5Widgets.5.15.8.dylib`QApplication::notify(QObject*, QEvent*) + 472
    frame #3: 0x0000000104cdb418 libFreeCADGui.dylib`Gui::GUIApplication::notify(this=0x000000016fdfe2b8, receiver=0x000000016fdfe2b8, event=0x000000013df772e0) at GuiApplication.cpp:93:34
    frame #4: 0x00000001099a0c74 libQt5Core.5.15.8.dylib`QCoreApplication::notifyInternal2(QObject*, QEvent*) + 176
    frame #5: 0x00000001099a1928 libQt5Core.5.15.8.dylib`QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) + 508
    frame #6: 0x000000010a337f6c libqcocoa.dylib`___lldb_unnamed_symbol3686 + 176
    frame #7: 0x000000010a3375b4 libqcocoa.dylib`___lldb_unnamed_symbol3677 + 548
    frame #8: 0x0000000103c49634 libQt5Widgets.5.15.8.dylib`QWidgetPrivate::show_helper() + 456
    frame #9: 0x0000000103c49da0 libQt5Widgets.5.15.8.dylib`QWidgetPrivate::setVisible(bool) + 568
    frame #10: 0x000000010548fba8 libFreeCADGui.dylib`Gui::MainWindow::startSplasher(this=0x000000016fdfe050) at MainWindow.cpp:1929:30
    frame #11: 0x0000000104d3dca4 libFreeCADGui.dylib`Gui::StartupPostProcess::showMainWindow(this=0x000000016fdfe018) at StartupProcess.cpp:429:21
    frame #12: 0x0000000104d3c66c libFreeCADGui.dylib`Gui::StartupPostProcess::execute(this=0x000000016fdfe018) at StartupProcess.cpp:226:5
    frame #13: 0x0000000104ac4844 libFreeCADGui.dylib`Gui::Application::runApplication() at Application.cpp:2273:17
    frame #14: 0x0000000100009c04 FreeCAD`main(argc=3, argv=0x000000016fdfeef8) at MainGui.cpp:295:13
    frame #15: 0x000000018a0460e0 dyld`start + 2360
```

</p>
</details> 

The lines of interest here are:
```
  * frame #0: 0x0000000104cdbb68 libFreeCADGui.dylib`Gui::GUIApplication::event(this=0x000000016fdfe2b8, ev=0x000000013df772e0) at GuiApplication.cpp:166:14
    ...
    frame #10: 0x000000010548fba8 libFreeCADGui.dylib`Gui::MainWindow::startSplasher(this=0x000000016fdfe050) at MainWindow.cpp:1929:30
```

`MainWindow.cpp:1929` is`d->splashscreen->show()`:
```c++
void MainWindow::startSplasher()
{
    // startup splasher
    // when running in verbose mode no splasher
    if (!(App::Application::Config()["Verbose"] == "Strict") &&
         (App::Application::Config()["RunMode"] == "Gui")) {
        ParameterGrp::handle hGrp = App::GetApplication().GetUserParameter().
            GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("General");
        // first search for an external image file
        if (hGrp->GetBool("ShowSplasher", true)) {
            d->splashscreen = new SplashScreen(this->splashImage());

            if (!hGrp->GetBool("ShowSplasherMessages", false)) {
                d->splashscreen->setShowMessages(false);
            }

            d->splashscreen->show();   // <---------- Here
        }
        else {
            d->splashscreen = nullptr;
        }
    }
}
```

---

To reproduce this issue, inject a `QFileOpenEvent` before `process.execute()` in `src/Gui/Application.cpp`: https://github.com/FreeCAD/FreeCAD/blob/main/src/Gui/Application.cpp#L2264

It looks like this for me with my test file:
```c++
    setAppNameAndIcon();

    StartupProcess process;
    /* vvvvv*/
    QFileOpenEvent *event = new QFileOpenEvent(QString::fromStdString("/Users/nauck/Downloads/FC100RC crash 2.FCStd"));
    QCoreApplication::postEvent(qApp, event);
    /* ^^^^^ */
    process.execute();

    Application app(true);
```

---

On to the proposed solution of the issue:
1. Revert the old fix (that was coded in the dark due to the difficulty of reproducing the issue in a dev build) and isn't needed anymore
3. Postpone the handling of the QFileOpenEvent to _after_ the real event loop is ready.

This is "just" a workaround, but since we're so close to a 1.0 release I don't feel comfortable in touching the splash screen code (it is waaay too easy to introduce new platform specific regressions by doing that) I think this is an ok way to fix the issue. The splash screen code will also be rewritten later, so I'm trying to keep the fix as simple as possible :)
