### PR TITLE
Remove mentions of FLANN

### DIFF
--- a/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
+++ b/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
@@ -169,7 +169,7 @@ macro(InitializeFreeCADBuildOptions)
 
     if(MSVC)
         option(BUILD_FEM_NETGEN "Build the FreeCAD FEM module with the NETGEN mesher" ON)
-        option(FREECAD_USE_PCL "Build the features that use PCL libs" OFF) # 3/5/2021 current LibPack uses non-C++17 FLANN
+        option(FREECAD_USE_PCL "Build the features that use PCL libs" OFF)
     endif(MSVC)
     if(NOT MSVC)
         option(BUILD_FEM_NETGEN "Build the FreeCAD FEM module with the NETGEN mesher" OFF)


### PR DESCRIPTION
FLANN_INCLUDE_DIRS was added in:
58a7be992b ("Intergrate Werners PCL Triangulation patch and upgrade it to PCL 1.7", 2014-08-26)

cMake/UseLibPack10x.cmake was removed in:
e0220e7830 ("Remove unused cMakes", 2022-02-22)

---

As far as I can see there is no current use of FLANN - but please be sure!