### PR TITLE
Core: Enable TaskDialogs to associate view

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1411,6 +1411,11 @@ void Application::viewActivated(MDIView* pcView)
     }
 }
 
+/// Gets called if a view gets closed
+void Application::viewClosed(MDIView* pcView)
+{
+    signalCloseView(pcView);
+}
 
 void Application::updateActive()
 {

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -97,6 +97,8 @@ public:
     void detachView(Gui::BaseView* pcView);
     /// get called if a view gets activated, this manage the whole activation scheme
     void viewActivated(Gui::MDIView* pcView);
+    /// get called if a view gets closed
+    void viewClosed(Gui::MDIView* pcView);
     /// call update to all documents and all views (costly!)
     void onUpdate();
     /// call update to all views of the active document
@@ -137,6 +139,8 @@ public:
     boost::signals2::signal<void (const Gui::Document&)> signalShowHidden;
     /// signal on activating view
     boost::signals2::signal<void (const Gui::MDIView*)> signalActivateView;
+    /// signal on closing view
+    boost::signals2::signal<void (const Gui::MDIView*)> signalCloseView;
     /// signal on entering in edit mode
     boost::signals2::signal<void (const Gui::ViewProviderDocumentObject&)> signalInEdit;
     /// signal on leaving edit mode

--- a/src/Gui/EditableDatumLabel.h
+++ b/src/Gui/EditableDatumLabel.h
@@ -25,6 +25,7 @@
 #define GUI_EDITABLEDATUMLABEL_H
 
 #include <QObject>
+#include <QPointer>
 #include <Gui/QuantitySpinBox.h>
 
 #include "SoDatumLabel.h"
@@ -98,7 +99,7 @@ private:
 private:
     SoSeparator* root;
     SoTransform* transform;
-    View3DInventorViewer* viewer;
+    QPointer<View3DInventorViewer> viewer;
     QuantitySpinBox* spinBox;
     SoNodeSensor* cameraSensor;
     SbVec3f midpos;

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -209,6 +209,8 @@ void MDIView::closeEvent(QCloseEvent *e)
 {
     if (canClose()) {
         e->accept();
+        Application::Instance->viewClosed(this);
+
         if (!bIsPassive) {
             // must be detached so that the last view can get asked
             Document* doc = this->getGuiDocument();

--- a/src/Gui/TaskView/TaskDialog.cpp
+++ b/src/Gui/TaskView/TaskDialog.cpp
@@ -110,8 +110,10 @@ void TaskDialog::associateToObject3dView(App::DocumentObject* obj)
     }
 
     Gui::Document* guiDoc = Gui::Application::Instance->getDocument(obj->getDocument());
+    // By default we associate to the active view.
     auto* view = guiDoc->getActiveView();
     if (!view->isDerivedFrom<View3DInventor>()) {
+        // But if the active view is not a 3dView, then we default to the first
         auto views = guiDoc->getMDIViewsOfType(View3DInventor::getClassTypeId());
         if (views.empty()) {
             // No 3dViews available so we can't associate to it.

--- a/src/Gui/TaskView/TaskDialog.cpp
+++ b/src/Gui/TaskView/TaskDialog.cpp
@@ -27,6 +27,11 @@
 # include <QMessageBox>
 #endif
 
+#include <App/Document.h>
+#include <Gui/Application.h>
+#include <Gui/Document.h>
+#include <Gui/View3DInventor.h>
+
 #include "TaskDialog.h"
 #include "TaskView.h"
 
@@ -42,6 +47,8 @@ TaskDialog::TaskDialog()
     : QObject(nullptr), pos(North)
     , escapeButton(true)
     , autoCloseTransaction(false)
+    , autoCloseDeletedDocument(false)
+    , autoCloseClosedView(false)
 {
 
 }
@@ -96,6 +103,27 @@ bool TaskDialog::canClose() const
     return (ret == QMessageBox::Yes);
 }
 
+void TaskDialog::associateToObject3dView(App::DocumentObject* obj)
+{
+    if (!obj) {
+        return;
+    }
+
+    Gui::Document* guiDoc = Gui::Application::Instance->getDocument(obj->getDocument());
+    auto* view = guiDoc->getActiveView();
+    if (!view->isDerivedFrom<View3DInventor>()) {
+        auto views = guiDoc->getMDIViewsOfType(View3DInventor::getClassTypeId());
+        if (views.empty()) {
+            // No 3dViews available so we can't associate to it.
+            return;
+        }
+        view = views.front();
+    }
+
+    setAssociatedView(view);
+    setAutoCloseOnClosedView(true);
+}
+
 //==== calls from the TaskView ===============================================================
 
 void TaskDialog::open()
@@ -114,6 +142,11 @@ void TaskDialog::autoClosedOnTransactionChange()
 }
 
 void TaskDialog::autoClosedOnDeletedDocument()
+{
+
+}
+
+void TaskDialog::autoClosedOnClosedView()
 {
 
 }

--- a/src/Gui/TaskView/TaskDialog.cpp
+++ b/src/Gui/TaskView/TaskDialog.cpp
@@ -110,16 +110,12 @@ void TaskDialog::associateToObject3dView(App::DocumentObject* obj)
     }
 
     Gui::Document* guiDoc = Gui::Application::Instance->getDocument(obj->getDocument());
-    // By default we associate to the active view.
-    auto* view = guiDoc->getActiveView();
-    if (!view->isDerivedFrom<View3DInventor>()) {
-        // But if the active view is not a 3dView, then we default to the first
-        auto views = guiDoc->getMDIViewsOfType(View3DInventor::getClassTypeId());
-        if (views.empty()) {
-            // No 3dViews available so we can't associate to it.
-            return;
-        }
-        view = views.front();
+    auto* vp = Gui::Application::Instance->getViewProvider(obj);
+    auto* vpdo = static_cast<Gui::ViewProviderDocumentObject*>(vp);
+    auto* view = guiDoc->openEditingView3D(vpdo);
+
+    if (!view) {
+        return;
     }
 
     setAssociatedView(view);

--- a/src/Gui/TaskView/TaskDialog.cpp
+++ b/src/Gui/TaskView/TaskDialog.cpp
@@ -31,6 +31,8 @@
 #include <Gui/Application.h>
 #include <Gui/Document.h>
 #include <Gui/View3DInventor.h>
+#include <Gui/ViewProviderDocumentObject.h>
+
 
 #include "TaskDialog.h"
 #include "TaskView.h"

--- a/src/Gui/TaskView/TaskDialog.h
+++ b/src/Gui/TaskView/TaskDialog.h
@@ -33,10 +33,11 @@
 
 
 namespace App {
-
+class DocumentObject;
 }
 
 namespace Gui {
+class MDIView;
 namespace TaskView {
 
 class TaskContent;
@@ -104,6 +105,22 @@ public:
     { return documentName; }
     void setDocumentName(const std::string& doc)
     { documentName = doc; }
+
+    /// Defines whether a task dialog must be closed if the associated view
+    /// is deleted.
+    void setAutoCloseOnClosedView(bool on) {
+        autoCloseClosedView = on;
+    }
+    bool isAutoCloseOnClosedView() const {
+        return autoCloseClosedView;
+    }
+    void associateToObject3dView(App::DocumentObject* obj);
+
+    const Gui::MDIView* getAssociatedView() const
+    { return associatedView; }
+    void setAssociatedView(const Gui::MDIView* view)
+    { associatedView = view; }
+
     /*!
       Indicates whether this task dialog allows other commands to modify
       the document while it is open.
@@ -136,6 +153,9 @@ public:
     /// is called by the framework when the dialog is automatically closed due to
     /// deleting the document
     virtual void autoClosedOnDeletedDocument();
+    /// is called by the framework when the dialog is automatically closed due to
+    /// closing of associated view
+    virtual void autoClosedOnClosedView();
     /// is called by the framework if a button is clicked which has no accept or reject role
     virtual void clicked(int);
     /// is called by the framework if the dialog is accepted (Ok)
@@ -160,9 +180,11 @@ protected:
 
 private:
     std::string documentName;
+    const Gui::MDIView* associatedView;
     bool escapeButton;
     bool autoCloseTransaction;
     bool autoCloseDeletedDocument;
+    bool autoCloseClosedView;
 
     friend class TaskDialogAttorney;
 };

--- a/src/Gui/TaskView/TaskImage.cpp
+++ b/src/Gui/TaskView/TaskImage.cpp
@@ -679,9 +679,7 @@ TaskImageDialog::TaskImageDialog(Image::ImagePlane* obj)
 {
     addTaskBox(Gui::BitmapFactory().pixmap("image-plane"), widget);
 
-    auto doc = obj->getDocument();
-    setDocumentName(doc->getName());
-    setAutoCloseOnDeletedDocument(true);
+    associateToObject3dView(obj);
 }
 
 void TaskImageDialog::open()

--- a/src/Gui/TaskView/TaskView.h
+++ b/src/Gui/TaskView/TaskView.h
@@ -37,6 +37,7 @@ class Property;
 }
 
 namespace Gui {
+class MDIView;
 class ControlSingleton;
 namespace DockWnd{
 class ComboView;
@@ -183,6 +184,7 @@ private:
     void tryRestoreWidth();
     void slotActiveDocument(const App::Document&);
     void slotDeletedDocument(const App::Document&);
+    void slotViewClosed(const Gui::MDIView*);
     void slotUndoDocument(const App::Document&);
     void slotRedoDocument(const App::Document&);
     void transactionChangeOnDocument(const App::Document&);
@@ -210,6 +212,7 @@ protected:
 
     Connection connectApplicationActiveDocument;
     Connection connectApplicationDeleteDocument;
+    Connection connectApplicationClosedView;
     Connection connectApplicationUndoDocument;
     Connection connectApplicationRedoDocument;
 };

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.cpp
@@ -79,6 +79,8 @@ TaskDlgEditSketch::TaskDlgEditSketch(ViewProviderSketch* sketchView)
         std::bind(&SketcherGui::TaskDlgEditSketch::slotToolChanged, this, sp::_1));
 
     ToolSettings->setHidden(true);
+
+    associateToObject3dView(sketchView->getObject());
 }
 
 TaskDlgEditSketch::~TaskDlgEditSketch()
@@ -144,5 +146,11 @@ bool TaskDlgEditSketch::reject()
     return true;
 }
 
+
+void TaskDlgEditSketch::autoClosedOnClosedView()
+{
+    // Make sure the edit mode is exited when the view is closed.
+    reject();
+}
 
 #include "moc_TaskDlgEditSketch.cpp"

--- a/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
+++ b/src/Mod/Sketcher/Gui/TaskDlgEditSketch.h
@@ -67,6 +67,7 @@ public:
     {
         return false;
     }
+    void autoClosedOnClosedView() override;
 
     /// returns for Close and Help button
     QDialogButtonBox::StandardButtons getStandardButtons() const override


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/16702

This PR enables task dialogs to associate a view, and can be set to be closed when the view is closed.
For Sketcher's task dialogs this enable to associate them to the sketchObject's 3dView. And if this 3dview is closed, then the sketch edit and task dialog are closed. Thus preventing the 3 crashes that  were reported in #16702

