### PR TITLE
Gui: extend warning filters

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1912,8 +1912,13 @@ void setCategoryFilterRules()
     QTextStream stream(&filter);
     stream << "qt.qpa.xcb.warning=false\n";
     stream << "qt.qpa.mime.warning=false\n";
+    stream << "qt.qpa.wayland.warning=false\n";
     stream << "qt.svg.warning=false\n";
     stream << "qt.xkb.compose.warning=false\n";
+    stream << "kf.config.core.warning=false\n";
+    stream << "kf.kio.widgets.warning=false\n";
+    stream << "kf.service.sycoca.warning=false\n";
+    stream << "kf.solid.backends.udisks2=false\n";
     stream.flush();
     QLoggingCategory::setFilterRules(filter);
 }


### PR DESCRIPTION
filter out:
-qt.qpa.wayland
-kf.config.core
-kf.kio.widgets
-kf.service.sycoca
-kf.solid.backends.udisks2

all the kf messages come from kde components usually when using the file open dialog so I don't think they are relevant to us. Should fix #16687 but I couldn't reproduce to actually test it