### PR TITLE
Draft: Make independent of BIM

### DIFF
--- a/src/Mod/Draft/drafttests/test_svg.py
+++ b/src/Mod/Draft/drafttests/test_svg.py
@@ -37,6 +37,13 @@ import drafttests.auxiliary as aux
 
 from draftutils.messages import _msg
 
+try:
+    import Arch
+except ModuleNotFoundError:
+    have_arch = False
+else:
+    have_arch = True
+
 
 class DraftSVG(unittest.TestCase):
     """Test reading and writing of SVGs with Draft."""
@@ -87,10 +94,10 @@ class DraftSVG(unittest.TestCase):
         obj = Draft.export_svg(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
+    @unittest.skipIf(not have_arch, "BIM module is not installed")
     def test_get_svg_from_arch_space_with_zero_vector(self):
         """Try to get a svg string from an Arch Space with a zero-vector as direction."""
         import Part
-        import Arch
         import Draft
 
         sb = Part.makeBox(1,1,1)

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -28,7 +28,10 @@ import xml.etree.ElementTree as ET
 
 import FreeCAD as App
 import Draft_rc
-import Arch_rc
+try:
+    import Arch_rc
+except ModuleNotFoundError:
+    pass
 
 from draftutils import init_draft_statusbar
 from draftutils.translate import translate

--- a/src/Mod/Draft/draftviewproviders/view_wpproxy.py
+++ b/src/Mod/Draft/draftviewproviders/view_wpproxy.py
@@ -71,7 +71,9 @@ class ViewProviderWorkingPlaneProxy:
         vobj.Transparency = 70
         vobj.LineWidth = 1
 
-        vobj.LineColor = params.get_param_arch("ColorHelpers") & 0xFFFFFF00
+        ch = params.get_param_arch("ColorHelpers")
+        if ch:
+            vobj.LineColor = ch & 0xFFFFFF00
 
         vobj.Proxy = self
         vobj.RestoreView = True


### PR DESCRIPTION
With FreeCAD built and installed with -DBUILD_DRAFT=ON and -DBUILD_BIM=no.

When switching to the Draft Workbench this prevents a "Workbench failure" dialog - "No module name 'Arch_rc'" - and exception messages in the Report view.

And avoids a test failure when the Test Workbench is used.