### PR TITLE
Set bim welcome max size to preferred and min so it isn't squashed

### DIFF
--- a/src/Mod/BIM/Resources/ui/dialogWelcome.ui
+++ b/src/Mod/BIM/Resources/ui/dialogWelcome.ui
@@ -10,6 +10,24 @@
     <height>789</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>412</width>
+    <height>730</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>412</width>
+    <height>789</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Welcome</string>
   </property>


### PR DESCRIPTION
Currently, the bim welcome panel looks like this for me:
<img width="534" alt="image" src="https://github.com/user-attachments/assets/37ba86ce-2feb-4f2a-aced-53049bc2fd10">

On my 14" macbook pro, the dialog gets a bit squashed. The problem is that the dialog's size can be changed and qt tries to adapt to the screen size.

For reference, the dialog can be resized like this too:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/3a88aeec-d5f4-47c8-9b39-b54c42c3bf25"> <img width="350" alt="image" src="https://github.com/user-attachments/assets/54b44331-a297-4c0c-8430-dc9249dac027">

The designed size looks like this:
<img width="524" alt="image" src="https://github.com/user-attachments/assets/019c592d-f745-41e9-80d2-7a882ea04246">

---

This PR keeps the standard size as the preferred, but sets a max and minimum size.
* maximum size has been set to the original size
* the minimum size is close to the original size, but with a slight tap on the top.

minimum size will then looks like this:

<img width="524" alt="image" src="https://github.com/user-attachments/assets/e9540d35-3f12-443c-abfc-4bc85f25d38c">

---

To test this, run the following command when BIM is loaded:
```python
Gui.runCommand('BIM_Welcome')
```