### PR TITLE
[Macros Dialog] Fix broken toolbar walkthrough

### DIFF
--- a/src/Gui/DlgToolbarsImp.cpp
+++ b/src/Gui/DlgToolbarsImp.cpp
@@ -172,6 +172,11 @@ void DlgCustomToolbars::hideEvent(QHideEvent* event)
 void DlgCustomToolbars::onActivateCategoryBox()
 {}
 
+// called from DlgMacroExecuteImp toolbar walkthrough function
+void DlgCustomToolbars::activateWorkbenchBox(int index) {
+    onWorkbenchBoxActivated(index);
+}
+
 void DlgCustomToolbars::onWorkbenchBoxActivated(int index)
 {
     QVariant data = ui->workbenchBox->itemData(index, Qt::UserRole);

--- a/src/Gui/DlgToolbarsImp.h
+++ b/src/Gui/DlgToolbarsImp.h
@@ -52,6 +52,9 @@ protected:
     explicit DlgCustomToolbars(Type, QWidget* parent = nullptr);
     ~DlgCustomToolbars() override;
 
+public:
+    void activateWorkbenchBox(int index);  // Public accessor for DlgMacroExecuteImp
+
 protected:
     void setupConnections();
     void onWorkbenchBoxActivated(int index);


### PR DESCRIPTION
In the Macros Execute dialog there is a toolbar button.  Clicking that with a macro selected takes the user to a toolbar installation walkthrough.  This function creates a modified version of the customize dialog with instructions tailored specifically for adding a macro to a custom toolbar.  Because some of the functions needed to be called were protected, QMetaObject::invokeMethod() was used to call those functions.  The problem is this uses a string to name the method to call, and thus did not produce a compile time error when those methods were subsequently renamed in a later commit.  To avoid this problem happening again I have made those functions public and called them directly rather than using invokeMethod().

The methods that weren't being called were supposed to be selecting the items from lists for the user, but I think the failure to find the method (because the names had changed) also might have cause FreeCAD to prematurely exit the function.

Another change was to update the instructions to advise the user to select the items in case they were not properly selected by the code.

The final change was to add some code to refresh the toolbar immediately rather than require the user to switch to another workbench and back in order to refresh and show the toolbar changes.