### PR TITLE
macOS+win+qt6.4+: Hide classic and auto choose light or dark mode depending on os setting

### DIFF
--- a/src/Mod/Start/Gui/CMakeLists.txt
+++ b/src/Mod/Start/Gui/CMakeLists.txt
@@ -88,6 +88,16 @@ if (FREECAD_USE_PCH)
     ADD_MSVC_PRECOMPILED_HEADER(StartGui PreCompiled.h PreCompiled.cpp PCH_SRCS)
 endif (FREECAD_USE_PCH)
 
+# Add CoreFoundation to StartGui_LIBS on macOS
+if (APPLE)
+    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+    if (COREFOUNDATION_LIBRARY)
+        list(APPEND StartGui_LIBS ${COREFOUNDATION_LIBRARY})
+    else()
+        message(SEND_ERROR "CoreFoundation not found. Please ensure you're building on macOS.")
+    endif()
+endif()
+
 add_library(StartGui SHARED ${StartGui_SRCS} ${StartGuiIcon_SVG} ${StartGuiThumbnail_PNG})
 # target_link_libraries(StartGui ${StartGui_LIBS} Qt::Quick Qt::Qml Qt::QuickWidgets)
 target_link_libraries(StartGui ${StartGui_LIBS})

--- a/src/Mod/Start/Gui/PreCompiled.h
+++ b/src/Mod/Start/Gui/PreCompiled.h
@@ -66,6 +66,7 @@
 #include <QSpacerItem>
 #include <QStackedWidget>
 #include <QString>
+#include <QStyleHints>
 #include <QStyleOptionViewItem>
 #include <QTimer>
 #include <QToolButton>

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -27,6 +27,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QString>
+#include <QStyleHints>
 #include <QToolButton>
 #endif
 
@@ -36,7 +37,53 @@
 #include <Gui/Command.h>
 #include <Gui/PreferencePackManager.h>
 
+#ifdef FC_OS_MACOSX
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
 using namespace StartGui;
+
+
+static bool isSystemInDarkMode()
+{
+    // Auto-detect system setting and default to light mode
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+    // https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
+    const QPalette defaultPalette;
+    return defaultPalette.color(QPalette::WindowText).lightness()
+        > defaultPalette.color(QPalette::Window).lightness();
+#else
+#ifdef FC_OS_MACOSX
+    auto key = CFSTR("AppleInterfaceStyle");
+    if (auto value = CFPreferencesCopyAppValue(key, kCFPreferencesAnyApplication)) {
+        // If the value is "Dark", Dark Mode is enabled
+        if (CFGetTypeID(value) == CFStringGetTypeID()) {
+            if (CFStringCompare((CFStringRef)value, CFSTR("Dark"), kCFCompareCaseInsensitive)
+                == kCFCompareEqualTo) {
+                CFRelease(value);
+                return true;
+            }
+        }
+        CFRelease(value);
+    }
+#endif  // FC_OS_MACOSX
+#endif  // QT_VERSION >= 6.4+
+    return false;
+}
+
+
+static bool shouldHideClassicTheme()
+{
+    // Classic on macOS and windows 11 with qt6(.4+?) doesn't work when system
+    // is in dark mode and to make matter worse, on macOS there's a setting that
+    // changes mode depending on time of day.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0) || defined(FC_OS_MACOSX) || defined(FC_OS_WIN32)
+    return true;
+#else
+    return false;
+#endif
+}
+
 
 ThemeSelectorWidget::ThemeSelectorWidget(QWidget* parent)
     : QWidget(parent)
@@ -45,6 +92,9 @@ ThemeSelectorWidget::ThemeSelectorWidget(QWidget* parent)
     , _buttons {nullptr, nullptr, nullptr}
 {
     setObjectName(QLatin1String("ThemeSelectorWidget"));
+    if (shouldHideClassicTheme()) {
+        preselectThemeFromSystemSettings();
+    }
     setupUi();
     qApp->installEventFilter(this);
 }
@@ -67,6 +117,11 @@ void ThemeSelectorWidget::setupButtons(QBoxLayout* layout)
     auto styleSheetName = QString::fromStdString(hGrp->GetASCII("StyleSheet"));
     for (const auto& theme : themeMap) {
         auto button = gsl::owner<QToolButton*>(new QToolButton());
+
+        if (theme.first == Theme::Classic && shouldHideClassicTheme()) {
+            button->setVisible(false);
+        }
+
         button->setCheckable(true);
         button->setAutoExclusive(true);
         button->setToolButtonStyle(Qt::ToolButtonStyle::ToolButtonTextUnderIcon);
@@ -124,6 +179,18 @@ void ThemeSelectorWidget::onLinkActivated(const QString& link)
     pref->SetInt("StatusSelection", 0);       // 0 stands for any installation status
 
     Gui::Application::Instance->commandManager().runCommandByName("Std_AddonMgr");
+}
+
+void ThemeSelectorWidget::preselectThemeFromSystemSettings()
+{
+    auto nullStyle("<N/A>");
+    auto hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/MainWindow");
+    auto styleSheetName = QString::fromStdString(hGrp->GetASCII("StyleSheet", nullStyle));
+    if (styleSheetName == QString::fromStdString(nullStyle)) {
+        auto theme = isSystemInDarkMode() ? Theme::Dark : Theme::Light;
+        themeChanged(theme);
+    }
 }
 
 void ThemeSelectorWidget::themeChanged(Theme newTheme)

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -47,11 +47,16 @@ using namespace StartGui;
 static bool isSystemInDarkMode()
 {
     // Auto-detect system setting and default to light mode
-#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    // https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
+    const auto scheme = QGuiApplication::styleHints()->colorScheme();
+    return scheme == Qt::ColorScheme::Dark;
+#elif QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
     // https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
     const QPalette defaultPalette;
-    return defaultPalette.color(QPalette::WindowText).lightness()
-        > defaultPalette.color(QPalette::Window).lightness();
+    const auto text = defaultPalette.color(QPalette::WindowText);
+    const auto window = defaultPalette.color(QPalette::Window);
+    return text.lightness() > window.lightness();
 #else
 #ifdef FC_OS_MACOSX
     auto key = CFSTR("AppleInterfaceStyle");

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.h
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.h
@@ -57,6 +57,7 @@ private:
     void setupUi();
     void setupButtons(QBoxLayout* layout);
     void onLinkActivated(const QString& link);
+    void preselectThemeFromSystemSettings();
 
     QLabel* _titleLabel;
     QLabel* _descriptionLabel;


### PR DESCRIPTION
This is a workaround for the broken default style "classic" on macOS when in dark mode (system settings).

When using dark mode on macOS FreeCAD, in classic, looks like this:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/cfdb98ab-720f-4d03-8916-afd575b3d59d">

While it would be nice with a working classic theme, as a last resort for 1.0 this might be a solution to give new users a good first impression.

The issue has been reported on windows 11 as well.

The workaround does the following (if running on macOS, Windows, or has qt 6.4+):
* hides classic button in the start welcome screen (can still change to it in preferences)
* if the user has never selected a style, it auto-selects light or dark depending on system dark/light mode setting - default to light mode if it can't auto detect system setting (only works on macOS and qt6.4+).

https://github.com/user-attachments/assets/b232caab-789c-4292-919a-ca7265f3073a

Verification (help needed):
 - [x] Qt 5 macOS
 - [ ] Qt 5 windows
 - [ ] Qt 6.4 macOS
 - [ ] Qt 6.4 windows
 - [ ] Qt 6.4 linux
 - [ ] Qt 6.5+ any system

To test this:
1. Set system to light mode 
2. Restart freecad in safe mode
3. Light mode should now be used for gui
4. mac & win & other with qt6.4: classic should be hidden (only show light and dark options)
5. Set system to dark mode
6. Restart freecad into safe mode
7. mac & qt6.4+: dark mode should now be used for gui (light mode will be used for other systems)
8. mac & win & other with qt6.4+: classic should still be hidden (only show light and dark options)