### PR TITLE
PartDesign: Remove legacy/modern workflow checks.

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1104,8 +1104,6 @@ void CmdPartDesignPad::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     prepareProfileBased(this, "Pad", 10.0);
 }
@@ -1136,8 +1134,6 @@ void CmdPartDesignPocket::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     prepareProfileBased(this, "Pocket", 5.0);
 }
@@ -1168,8 +1164,6 @@ void CmdPartDesignHole::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-                return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -1215,8 +1209,6 @@ void CmdPartDesignRevolution::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -1274,8 +1266,6 @@ void CmdPartDesignGroove::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -1341,8 +1331,6 @@ void CmdPartDesignAdditivePipe::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -1392,8 +1380,6 @@ void CmdPartDesignSubtractivePipe::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -1443,8 +1429,6 @@ void CmdPartDesignAdditiveLoft::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -1494,8 +1478,6 @@ void CmdPartDesignSubtractiveLoft::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -1544,8 +1526,6 @@ void CmdPartDesignAdditiveHelix::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -1621,8 +1601,6 @@ void CmdPartDesignSubtractiveHelix::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -1666,8 +1644,6 @@ bool dressupGetSelected(Gui::Command* cmd, const std::string& which,
 {
     // No PartDesign feature without Body past FreeCAD 0.16
     App::Document *doc = cmd->getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return false;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -2053,8 +2029,6 @@ void CmdPartDesignMirrored::activated(int iMsg)
     Q_UNUSED(iMsg);
     // No PartDesign feature without Body past FreeCAD 0.16
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -2108,8 +2082,6 @@ void CmdPartDesignLinearPattern::activated(int iMsg)
     Q_UNUSED(iMsg);
     // No PartDesign feature without Body past FreeCAD 0.16
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -2165,8 +2137,6 @@ void CmdPartDesignPolarPattern::activated(int iMsg)
     Q_UNUSED(iMsg);
     // No PartDesign feature without Body past FreeCAD 0.16
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -2223,8 +2193,6 @@ void CmdPartDesignScaled::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 
@@ -2269,8 +2237,6 @@ void CmdPartDesignMultiTransform::activated(int iMsg)
     Q_UNUSED(iMsg);
     // No PartDesign feature without Body past FreeCAD 0.16
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -95,9 +95,6 @@ CmdPartDesignBody::CmdPartDesignBody()
 void CmdPartDesignBody::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    // if user decides for old-style workflow then abort the command
-    if (PartDesignGui::assureLegacyWorkflow(getDocument()))
-        return;
 
     App::Part *actPart = PartDesignGui::getActivePart ();
     App::Part* partOfBaseFeature = nullptr;
@@ -301,7 +298,7 @@ void CmdPartDesignBody::activated(int iMsg)
 
 bool CmdPartDesignBody::isActive()
 {
-    return hasActiveDocument() && !PartDesignGui::isLegacyWorkflow ( getDocument () );
+    return hasActiveDocument();
 }
 
 //===========================================================================
@@ -826,7 +823,7 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
 
 bool CmdPartDesignMoveFeature::isActive()
 {
-    return hasActiveDocument () && !PartDesignGui::isLegacyWorkflow ( getDocument () );
+    return hasActiveDocument();
 }
 
 DEF_STD_CMD_A(CmdPartDesignMoveFeatureInTree)
@@ -977,7 +974,7 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
 
 bool CmdPartDesignMoveFeatureInTree::isActive()
 {
-    return hasActiveDocument () && !PartDesignGui::isLegacyWorkflow ( getDocument () );
+    return hasActiveDocument();
 }
 
 

--- a/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
@@ -76,8 +76,6 @@ CmdPrimtiveCompAdditive::CmdPrimtiveCompAdditive()
 void CmdPrimtiveCompAdditive::activated(int iMsg)
 {
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     // We need either an active Body, or for there to be no Body objects
     // (in which case, just make one) to make a new additive shape.
@@ -251,8 +249,6 @@ CmdPrimtiveCompSubtractive::CmdPrimtiveCompSubtractive()
 void CmdPrimtiveCompSubtractive::activated(int iMsg)
 {
     App::Document *doc = getDocument();
-    if (!PartDesignGui::assureModernWorkflow(doc))
-        return;
 
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
 

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.h
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.h
@@ -48,8 +48,6 @@ public:
 
 private:
     void tryCreateSketch();
-    void createSketchWithModernWorkflow();
-    void createSketchWithLegacyWorkflow();
     std::tuple<bool, PartDesign::Body*> shouldCreateBody();
     bool shouldAbort(bool) const;
     std::tuple<Gui::SelectionFilter, Gui::SelectionFilter> getFaceAndPlaneFilter() const;

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -120,7 +120,7 @@ PartDesign::Body *getBody(bool messageIfNot, bool autoActivate, bool assertModer
     if (activeView) {
         auto doc = activeView->getAppDocument();
         bool singleBodyDocument = doc->countObjectsOfType(PartDesign::Body::getClassTypeId()) == 1;
-        if (assertModern && PartDesignGui::assureModernWorkflow (doc) ) {
+        if (assertModern) {
             activeBody = activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY,topParent,subname);
 
             if (!activeBody && singleBodyDocument && autoActivate) {

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -83,7 +83,7 @@ void Workbench::setupContextMenu(const char* recipient, Gui::MenuItem* item) con
         App::DocumentObject *feature = selection.front().pObject;
         PartDesign::Body *body = nullptr;
 
-        body = PartDesignGui::getBodyFor (feature, false, false, assertModern);
+        body = PartDesignGui::getBodyFor (feature, false, false, true);
         // lote of assertion so feature should be marked as a tip
         if ( selection.size () == 1 && feature && (
             ( feature->isDerivedFrom ( PartDesign::Feature::getClassTypeId () ) && body ) ||

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -83,13 +83,6 @@ void Workbench::setupContextMenu(const char* recipient, Gui::MenuItem* item) con
         App::DocumentObject *feature = selection.front().pObject;
         PartDesign::Body *body = nullptr;
 
-        // if PD workflow is not new-style then add a command to the context-menu
-        bool assertModern = true;
-        if (feature && !isModernWorkflow(feature->getDocument())) {
-            assertModern = false;
-            *item << "PartDesign_Migrate";
-        }
-
         body = PartDesignGui::getBodyFor (feature, false, false, assertModern);
         // lote of assertion so feature should be marked as a tip
         if ( selection.size () == 1 && feature && (


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/15655

That crash was due to the migration scripts.
As @FEA-eng mentioned in the forum (https://forum.freecad.org/viewtopic.php?t=89431#p773404) the migration checks are very obsolete.

This PR removes those checks.