### PR TITLE
Updated Tolerance feature to optionally restrict maximum tolerance and repair shapes

### DIFF
--- a/src/Mod/Part/BOPTools/ToleranceFeatures.py
+++ b/src/Mod/Part/BOPTools/ToleranceFeatures.py
@@ -116,7 +116,7 @@ class FeatureToleranceSet:
         obj.Proxy = self
         self.Type = "FeatureToleranceSet"
 
-    def onChanged(self, obj, prop):
+    def onDocumentRestored(self, obj):
         if not hasattr(obj, 'maxTolerance'):
             obj.addProperty("App::PropertyLength","maxTolerance","ToleranceSet", "0")
 

--- a/src/Mod/Part/BOPTools/ToleranceFeatures.py
+++ b/src/Mod/Part/BOPTools/ToleranceFeatures.py
@@ -47,14 +47,15 @@ def getParamRefine():
     return FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Part/Boolean").GetBool("RefineModel")
 
 
-def cmdCreateToleranceSetFeature(name, minTolerance=1e-7):
-    """cmdCreateToleranceSetFeature(name, minTolerance): generalized implementation of GUI commands."""
+def cmdCreateToleranceSetFeature(name, minTolerance=1e-7, maxTolerance=0):
+    """cmdCreateToleranceSetFeature(name, minTolerance, maxTolerance): generalized implementation of GUI commands."""
     sel = FreeCADGui.Selection.getSelectionEx()
 
     FreeCAD.ActiveDocument.openTransaction("Create ToleranceSet")
     FreeCADGui.addModule("BOPTools.ToleranceFeatures")
     FreeCADGui.doCommand("j = BOPTools.ToleranceFeatures.makeToleranceSet(name='{name}')".format(name=name))
     FreeCADGui.doCommand("j.minTolerance = {minTolerance}".format(minTolerance=minTolerance))
+    FreeCADGui.doCommand("j.maxTolerance = {maxTolerance}".format(maxTolerance=maxTolerance))
     FreeCADGui.doCommand("j.Objects = {sel}".format(
        sel= "["  +  ", ".join(["App.ActiveDocument."+so.Object.Name for so in sel])  +  "]"
     ))
@@ -108,19 +109,26 @@ class FeatureToleranceSet:
         obj.addProperty("App::PropertyLinkList","Objects","ToleranceSet","Objects to have tolerance adjusted.")
         obj.addProperty("App::PropertyBool","Refine","ToleranceSet",
                         "True = refine resulting shape. False = output as is.")
-        obj.addProperty("App::PropertyFloat","minTolerance","ToleranceSet", "1e-7")
+        obj.addProperty("App::PropertyLength","minTolerance","ToleranceSet", "0.1 nm")
+        obj.addProperty("App::PropertyLength","maxTolerance","ToleranceSet", "0")
         obj.Refine = getParamRefine()
 
         obj.Proxy = self
         self.Type = "FeatureToleranceSet"
 
+    def onChanged(self, obj, prop):
+        if not hasattr(obj, 'maxTolerance'):
+            obj.addProperty("App::PropertyLength","maxTolerance","ToleranceSet", "0")
+
     def execute(self,selfobj):
         shapes = []
         for obj in selfobj.Objects:
             sh = obj.Shape.copy(True,False)
-            sh.limitTolerance(selfobj.minTolerance)
+            sh.limitTolerance(selfobj.minTolerance,selfobj.maxTolerance)
             if selfobj.Refine:
+                sh.fix(selfobj.minTolerance,selfobj.minTolerance,selfobj.maxTolerance)
                 sh = sh.removeSplitter()
+                sh.fix(selfobj.minTolerance,selfobj.minTolerance,selfobj.maxTolerance)
             shapes.append(sh)
 
         if len(shapes)>1:


### PR DESCRIPTION
In the previous iteration, the Part->Compound->Tolerance tool allowed to set a minimum tolerance for a part which sets all vertices, edges and shape tolerances to at least that high.

This is useful to allow OCCT to move these shapes around when it performs booleans, camfers, skins, etc... which can make operations succeed that normally wouldn't

However repeated use of the tool can make tolerances get too large, which leads to "edge too short" errors (that basically happens every time an edge is shorter than the tolerance of the neighboring vertices or faces)

With this patch, its now possible to also limit the maximum tolerance (which only takes effect if maxTolerance>0) and as such effectively reduce the imprecision of a part. This is not always possible and can cause shapes to become invalid.

By setting Refine=True - OCCT will try to not just refine but also fix the shape. This includes delelting small edges and faces, but also refining the shape and removing surplus and unneeded edges.

As before the tool is fully parametric. In some circumstances it can magically "fix" a broken shape that fails BOP tests. However wrong use can also produce additional issues.

As such the tool is definitely for developers and advanced users of FreeCAD and not included in toolbars.

This patch is backward compatible, it doesn't break FCStd files that already use the (previous incarnation of) Tolerance feature.


As before this is probably a post 1.0 feature but should be merged into main asap. It has no side effects (meaning, if the tool isn't used, it also doesn't affect anyone)