### PR TITLE
Sketcher: Symmetric: Do not copy names of constraints

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -4806,6 +4806,7 @@ int SketchObject::addSymmetric(const std::vector<int>& geoIdList, int refGeoId,
                         if (constr->Type != Sketcher::DistanceX
                             && constr->Type != Sketcher::DistanceY) {
                             Constraint* constNew = constr->copy();
+                            constNew->Name = ""; // Make sure we don't have 2 constraint with same name.
                             constNew->First = fit->second;
                             newconstrVals.push_back(constNew);
                         }
@@ -4818,6 +4819,7 @@ int SketchObject::addSymmetric(const std::vector<int>& geoIdList, int refGeoId,
                         // diameter, weight,...
 
                         Constraint* constNew = constr->copy();
+                        constNew->Name = "";
                         constNew->First = fit->second;
                         newconstrVals.push_back(constNew);
                     }
@@ -4838,7 +4840,7 @@ int SketchObject::addSymmetric(const std::vector<int>& geoIdList, int refGeoId,
                                 || constr->Type == Sketcher::PointOnObject
                                 || constr->Type == Sketcher::InternalAlignment) {
                                 Constraint* constNew = constr->copy();
-
+                                constNew->Name = "";
                                 constNew->First = fit->second;
                                 constNew->Second = sit->second;
                                 if (isStartEndInverted[constr->First]) {
@@ -4870,6 +4872,7 @@ int SketchObject::addSymmetric(const std::vector<int>& geoIdList, int refGeoId,
 
                             if (tit != geoIdMap.end()) {// Third is also in the list
                                 Constraint* constNew = constr->copy();
+                                constNew->Name = "";
                                 constNew->First = fit->second;
                                 constNew->Second = sit->second;
                                 constNew->Third = tit->second;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -4751,12 +4751,9 @@ int SketchObject::addSymmetric(const std::vector<int>& geoIdList, int refGeoId,
     Base::StateLocker lock(managedoperation, true);
 
     const std::vector<Part::Geometry*>& geovals = getInternalGeometry();
-    std::vector<Part::Geometry*> newgeoVals(geovals);
 
     const std::vector<Constraint*>& constrvals = this->Constraints.getValues();
     std::vector<Constraint*> newconstrVals(constrvals);
-
-    newgeoVals.reserve(geovals.size() + geoIdList.size());
 
     std::map<int, int> geoIdMap;
     std::map<int, bool> isStartEndInverted;
@@ -4777,15 +4774,10 @@ int SketchObject::addSymmetric(const std::vector<int>& geoIdList, int refGeoId,
         }
     }
 
-    // add the geometry
-    std::vector<Part::Geometry*> symmetricVals = getSymmetric(geoIdList, geoIdMap, isStartEndInverted, refGeoId, refPosId);
-    newgeoVals.insert(newgeoVals.end(), symmetricVals.begin(), symmetricVals.end());
+    std::vector<Part::Geometry*> symgeos = getSymmetric(geoIdList, geoIdMap, isStartEndInverted, refGeoId, refPosId);
 
-    // Block acceptGeometry in OnChanged to avoid unnecessary checks and updates
     {
-        Base::StateLocker lock(internaltransaction, true);
-        Geometry.setValues(std::move(newgeoVals));
-
+        addGeometry(symgeos);
 
         for (auto* constr :  constrvals) {
             // we look in the map, because we might have skipped internal alignment geometry


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/13943
Fix https://github.com/FreeCAD/FreeCAD/issues/17442

We could change the Constraint::copy() function not to copy the name, but I'm not confident that would not generate issues.