### PR TITLE
Disable Qt bug 129596 workeround for Qt >= 6.8.1

### DIFF
--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -30,7 +30,7 @@
 
 #include <App/Application.h>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0) && QT_VERSION < QT_VERSION_CHECK(6,8,1)
 # define HAS_QTBUG_129596
 #endif
 


### PR DESCRIPTION
The fix is also in 6.5.8+, but honestly I would not bother ...

Consider also backport to 1.0 version