### PR TITLE
PD: Fix TwoLengths and Midplane both enabled

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -305,15 +305,10 @@ void FeatureExtrude::generatePrism(TopoShape& prism,
             Ltotal = getThroughAllLength();
         }
 
-
         if (method == "TwoLengths") {
-            // midplane makes no sense here
             Ltotal += L2;
             if (reversed) {
                 Loffset = -L;
-            }
-            else if (midplane) {
-                Loffset = -0.5 * (L2 + L);
             }
             else {
                 Loffset = -L2;


### PR DESCRIPTION
This fixes regression introduced with TNP fix. It removes code responsible for centering the extrusion when symmetry was checked, this is exactly how it was done in 0.21. 

No UI changes are necessary since UI was already in a good condition. Migration code is also not necessary since it only aligns toponaming aware code with one that is not.

Fixes: #16072