### PR TITLE
[Part RuledSurface] fix issue where ruled surface is failing if both …

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -3422,6 +3422,7 @@ TopoShape::makeElementCopy(const TopoShape& shape, const char* op, bool copyGeom
 
     TopoShape tmp(shape);
     tmp.setShape(BRepBuilderAPI_Copy(shape.getShape(), copyGeom, copyMesh).Shape(), false);
+    tmp.setTransform(shape.getTransform());
     if (op || (shape.Tag && shape.Tag != Tag)) {
         setShape(tmp._Shape);
         initCache();


### PR DESCRIPTION
…edges are from same object and the object is not at the identity placement, addresses issue #17235

This issue surfaced back in 2017.  The workaround then was to make copies of the 2 input shapes with 

```
S1 = S1.makeCopy()
S2 = S2.makeCopy()

```
Then later when the TNP mitigation code was added, evidently makeCopy() was done away with and replaced with

` makeElementCopy()

But  makeElementCopy() isn't working in this particular case to resolve the issue with open cascade when it comes to make ruled surfaces where both edges are from the same parent object and where the parent object is not at the identity placement.

This workaround involves applying a transformation to the input shapes, but no real transformation is applied since the transformation applied is the current transformation already in use, but this does seem to produce independent copies, which is what is needed to work around the bug in OCCT.

This fixes both the Gui Make Ruled Surface command and also the python implementation.  Only one minor issue remains, which I could not figure out -- when invokving from python a warning is produced about duplicate element mapping.

Select the sketch with the slot, press Ctrl+Shift+P, then in the console:

rs = Part.makeRuledSurface(obj.Shape.Edge1, obj.Shape.Edge3)
Part.show(rs, "rs")

This seems to work fine, but the warning gets printed to the report view.

I have tested this for topo naming by adding 2 more lines to the sketch, creating a new ruled surface in the Gui from those 2 lines, and then deleting the 2 unused lines from the sketch.  The edges get renamed automatically in the Ruled Surface objects and all works as expected, so commenting out makeElementCopy() does not appear to have broken TNP mitigation in this case.

The sketch I refer to is the failed_ruled_surface.FCStd file attached to a related issue, which I reattach here since I can't find the original source for it.

[fail_ruled_surface.FCStd.gz](https://github.com/user-attachments/files/17499214/fail_ruled_surface.FCStd.gz)

