### PR TITLE
Fem: Remove unnecessary system name check

### DIFF
--- a/src/Mod/Fem/femsolver/elmer/tasks.py
+++ b/src/Mod/Fem/femsolver/elmer/tasks.py
@@ -131,18 +131,13 @@ class Solve(run.Solve):
                     args.extend(["mpiexec"])
                 args.extend(["-np", str(num_cores)])
             args.extend([binary])
-            if system() == "Windows":
-                self._process = subprocess.Popen(
-                    args,
-                    cwd=self.directory,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    startupinfo=femutils.startProgramInfo("hide"),
-                )
-            else:
-                self._process = subprocess.Popen(
-                    args, cwd=self.directory, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-                )
+            self._process = subprocess.Popen(
+                args,
+                cwd=self.directory,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                startupinfo=femutils.startProgramInfo("hide"),
+            )
             self.signalAbort.add(self._process.terminate)
             output = self._observeSolver(self._process)
             self._process.communicate()

--- a/src/Mod/Fem/femsolver/z88/tasks.py
+++ b/src/Mod/Fem/femsolver/z88/tasks.py
@@ -126,21 +126,13 @@ class Solve(run.Solve):
     def runZ88(self, command, binary, solver, state):
         solver_name = solver
         # minimize or hide the popups on Windows
-        if system() == "Windows":
-            self._process = subprocess.Popen(
-                [binary, command, "-" + solver_name],
-                cwd=self.directory,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                startupinfo=femutils.startProgramInfo(state),
-            )
-        else:
-            self._process = subprocess.Popen(
-                [binary, command, "-" + solver_name],
-                cwd=self.directory,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
+        self._process = subprocess.Popen(
+            [binary, command, "-" + solver_name],
+            cwd=self.directory,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            startupinfo=femutils.startProgramInfo(state),
+        )
         self.signalAbort.add(self._process.terminate)
         self._process.communicate()
         self.signalAbort.remove(self._process.terminate)

--- a/src/Mod/Fem/femtools/ccxtools.py
+++ b/src/Mod/Fem/femtools/ccxtools.py
@@ -442,11 +442,6 @@ class FemToolsCcx(QtCore.QRunnable, QtCore.QObject):
                     FreeCAD.Console.PrintError(error_message)
             self.ccx_binary = ccx_binary
 
-        startup_info = None
-        if system() == "Windows":
-            # Windows workaround to avoid blinking terminal window
-            startup_info = subprocess.STARTUPINFO()
-            startup_info.dwFlags = subprocess.STARTF_USESHOWWINDOW
         ccx_stdout = None
         ccx_stderr = None
         try:
@@ -455,7 +450,7 @@ class FemToolsCcx(QtCore.QRunnable, QtCore.QObject):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 shell=False,
-                startupinfo=startup_info,
+                startupinfo=femutils.startProgramInfo(""),
             )
             ccx_stdout, ccx_stderr = p.communicate()
             if ccx_binary_sig in str(ccx_stdout):
@@ -534,11 +529,6 @@ class FemToolsCcx(QtCore.QRunnable, QtCore.QObject):
         import re
         from platform import system
 
-        startup_info = None
-        if system() == "Windows":
-            # Windows workaround to avoid blinking terminal window
-            startup_info = subprocess.STARTUPINFO()
-            startup_info.dwFlags = subprocess.STARTF_USESHOWWINDOW
         ccx_stdout = None
         ccx_stderr = None
         # Now extract the version number
@@ -547,7 +537,7 @@ class FemToolsCcx(QtCore.QRunnable, QtCore.QObject):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=False,
-            startupinfo=startup_info,
+            startupinfo=femutils.startProgramInfo(""),
         )
         ccx_stdout, ccx_stderr = p.communicate()
         ccx_stdout = ccx_stdout.decode()


### PR DESCRIPTION
`femutils.startProgramInfo` returns `None` if the system is not Windows.