### PR TITLE
Sketcher: Rotate : Fix exploding sketches when rotating.

### DIFF
--- a/src/Mod/Sketcher/App/PythonConverter.cpp
+++ b/src/Mod/Sketcher/App/PythonConverter.cpp
@@ -211,6 +211,8 @@ PythonConverter::SingleGeometry PythonConverter::process(const Part::Geometry* g
             {Part::GeomArcOfCircle::getClassTypeId(),
              [](const Part::Geometry* geo) {
                  auto arc = static_cast<const Part::GeomArcOfCircle*>(geo);
+                 double startAngle, endAngle;
+                 arc->getRange(startAngle, endAngle, /*emulateCCWXY=*/true);
                  SingleGeometry sg;
                  sg.creation =
                      boost::str(boost::format("Part.ArcOfCircle(Part.Circle(App.Vector(%f, %f, "
@@ -218,7 +220,7 @@ PythonConverter::SingleGeometry PythonConverter::process(const Part::Geometry* g
                                 % arc->getCenter().x % arc->getCenter().y % arc->getCenter().z
                                 % arc->getAxisDirection().x % arc->getAxisDirection().y
                                 % arc->getAxisDirection().z % arc->getRadius()
-                                % arc->getFirstParameter() % arc->getLastParameter());
+                                % startAngle % endAngle);
                  sg.construction = Sketcher::GeometryFacade::getConstruction(geo);
                  return sg;
              }},
@@ -250,6 +252,8 @@ PythonConverter::SingleGeometry PythonConverter::process(const Part::Geometry* g
             {Part::GeomArcOfEllipse::getClassTypeId(),
              [](const Part::Geometry* geo) {
                  auto aoe = static_cast<const Part::GeomArcOfEllipse*>(geo);
+                 double startAngle, endAngle;
+                 aoe->getRange(startAngle, endAngle, /*emulateCCWXY=*/true);
                  SingleGeometry sg;
                  auto center = aoe->getCenter();
                  auto periapsis = center + aoe->getMajorAxisDir() * aoe->getMajorRadius();
@@ -259,14 +263,16 @@ PythonConverter::SingleGeometry PythonConverter::process(const Part::Geometry* g
                          "Part.ArcOfEllipse(Part.Ellipse(App.Vector(%f, %f, %f), App.Vector(%f, "
                          "%f, %f), App.Vector(%f, %f, %f)), %f, %f)")
                      % periapsis.x % periapsis.y % periapsis.z % positiveB.x % positiveB.y
-                     % positiveB.z % center.x % center.y % center.z % aoe->getFirstParameter()
-                     % aoe->getLastParameter());
+                     % positiveB.z % center.x % center.y % center.z % startAngle
+                     % endAngle);
                  sg.construction = Sketcher::GeometryFacade::getConstruction(geo);
                  return sg;
              }},
             {Part::GeomArcOfHyperbola::getClassTypeId(),
              [](const Part::Geometry* geo) {
                  auto aoh = static_cast<const Part::GeomArcOfHyperbola*>(geo);
+                 double startAngle, endAngle;
+                 aoh->getRange(startAngle, endAngle, /*emulateCCWXY=*/true);
                  SingleGeometry sg;
                  auto center = aoh->getCenter();
                  auto majAxisPoint = center + aoh->getMajorAxisDir() * aoh->getMajorRadius();
@@ -276,13 +282,15 @@ PythonConverter::SingleGeometry PythonConverter::process(const Part::Geometry* g
                                    "App.Vector(%f, %f, %f), App.Vector(%f, %f, %f)), %f, %f)")
                      % majAxisPoint.x % majAxisPoint.y % majAxisPoint.z % minAxisPoint.x
                      % minAxisPoint.y % minAxisPoint.z % center.x % center.y % center.z
-                     % aoh->getFirstParameter() % aoh->getLastParameter());
+                     % startAngle % endAngle);
                  sg.construction = Sketcher::GeometryFacade::getConstruction(geo);
                  return sg;
              }},
             {Part::GeomArcOfParabola::getClassTypeId(),
              [](const Part::Geometry* geo) {
                  auto aop = static_cast<const Part::GeomArcOfParabola*>(geo);
+                 double startAngle, endAngle;
+                 aop->getRange(startAngle, endAngle, /*emulateCCWXY=*/true);
                  SingleGeometry sg;
                  auto focus = aop->getFocus();
                  auto axisPoint = aop->getCenter();
@@ -290,7 +298,7 @@ PythonConverter::SingleGeometry PythonConverter::process(const Part::Geometry* g
                      boost::format("Part.ArcOfParabola(Part.Parabola(App.Vector(%f, %f, %f), "
                                    "App.Vector(%f, %f, %f), App.Vector(0, 0, 1)), %f, %f)")
                      % focus.x % focus.y % focus.z % axisPoint.x % axisPoint.y % axisPoint.z
-                     % aop->getFirstParameter() % aop->getLastParameter());
+                     % startAngle % endAngle);
                  sg.construction = Sketcher::GeometryFacade::getConstruction(geo);
                  return sg;
              }},

--- a/src/Mod/Sketcher/App/PythonConverter.cpp
+++ b/src/Mod/Sketcher/App/PythonConverter.cpp
@@ -214,13 +214,12 @@ PythonConverter::SingleGeometry PythonConverter::process(const Part::Geometry* g
                  double startAngle, endAngle;
                  arc->getRange(startAngle, endAngle, /*emulateCCWXY=*/true);
                  SingleGeometry sg;
-                 sg.creation =
-                     boost::str(boost::format("Part.ArcOfCircle(Part.Circle(App.Vector(%f, %f, "
-                                              "%f), App.Vector(%f, %f, %f), %f), %f, %f)")
-                                % arc->getCenter().x % arc->getCenter().y % arc->getCenter().z
-                                % arc->getAxisDirection().x % arc->getAxisDirection().y
-                                % arc->getAxisDirection().z % arc->getRadius()
-                                % startAngle % endAngle);
+                 sg.creation = boost::str(
+                     boost::format("Part.ArcOfCircle(Part.Circle(App.Vector(%f, %f, "
+                                   "%f), App.Vector(%f, %f, %f), %f), %f, %f)")
+                     % arc->getCenter().x % arc->getCenter().y % arc->getCenter().z
+                     % arc->getAxisDirection().x % arc->getAxisDirection().y
+                     % arc->getAxisDirection().z % arc->getRadius() % startAngle % endAngle);
                  sg.construction = Sketcher::GeometryFacade::getConstruction(geo);
                  return sg;
              }},
@@ -263,8 +262,7 @@ PythonConverter::SingleGeometry PythonConverter::process(const Part::Geometry* g
                          "Part.ArcOfEllipse(Part.Ellipse(App.Vector(%f, %f, %f), App.Vector(%f, "
                          "%f, %f), App.Vector(%f, %f, %f)), %f, %f)")
                      % periapsis.x % periapsis.y % periapsis.z % positiveB.x % positiveB.y
-                     % positiveB.z % center.x % center.y % center.z % startAngle
-                     % endAngle);
+                     % positiveB.z % center.x % center.y % center.z % startAngle % endAngle);
                  sg.construction = Sketcher::GeometryFacade::getConstruction(geo);
                  return sg;
              }},
@@ -281,8 +279,8 @@ PythonConverter::SingleGeometry PythonConverter::process(const Part::Geometry* g
                      boost::format("Part.ArcOfHyperbola(Part.Hyperbola(App.Vector(%f, %f, %f), "
                                    "App.Vector(%f, %f, %f), App.Vector(%f, %f, %f)), %f, %f)")
                      % majAxisPoint.x % majAxisPoint.y % majAxisPoint.z % minAxisPoint.x
-                     % minAxisPoint.y % minAxisPoint.z % center.x % center.y % center.z
-                     % startAngle % endAngle);
+                     % minAxisPoint.y % minAxisPoint.z % center.x % center.y % center.z % startAngle
+                     % endAngle);
                  sg.construction = Sketcher::GeometryFacade::getConstruction(geo);
                  return sg;
              }},

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -397,8 +397,31 @@ private:
                             newConstr->Second = secondIndexi;
                             geoIdsWhoAlreadyHasEqual.push_back(secondIndexi);
                         }
-                        else {
+                        else if (cstr->Type == Distance) {
                             newConstr->Second = secondIndexi;
+                        }
+                        else {
+                            // We should be able to handle cases where rotation is 90 or 180, but
+                            // this is segfaulting. The same is reported in
+                            // SketchObject::addSymmetric. There's apparantly a problem with
+                            // creation of DistanceX/Y. On top of the segfault the DistanceX/Y flips
+                            // the new geometry.
+                            /*if (cstr->Type == DistanceX || cstr->Type == DistanceY) {
+                                //DistanceX/Y can be applied only if the rotation if 90 or 180.
+                                if (fabs(fmod(individualAngle, M_PI)) < Precision::Confusion()) {
+                                    // ok and nothing to do actually
+                                }
+                                else if (fabs(fmod(individualAngle, M_PI * 0.5)) <
+                            Precision::Confusion()) { cstr->Type = cstr->Type == DistanceX ?
+                            DistanceY : DistanceX;
+                                }
+                                else {
+                                    // cannot apply for random angles
+                                    continue;
+                                }
+                            }*/
+                            // So for now we just ignore all DistanceX/Y
+                            continue;
                         }
                     }
                     else if ((cstr->Type == Block) && firstIndex >= 0) {


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/14769
Fix https://github.com/FreeCAD/FreeCAD/issues/15547

There were 2 issues actually : 
- "bad" arcs would be added by the python converter without fixing the CCW. Exploding the sketch
- The distance X and Y were being copied. And if you rotate a sketch that's obviously bad.

We could actually handle DistanceX/Y when rotating 90 or 180, but it appears that DistanceX/Y are finicky so that's another project. I left a comment with the necessary code for when DistanceX/Y's issues are fixed.