### PR TITLE
Moved items in the Help menubar

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -758,11 +758,12 @@ MenuItem* StdWorkbench::setupMenuBar() const
     // Help
     auto help = new MenuItem( menuBar );
     help->setCommand("&Help");
-    *help << "Std_OnlineHelp" << "Std_FreeCADWebsite" << "Std_FreeCADDonation"
-          << "Std_FreeCADUserHub" << "Std_FreeCADPowerUserHub"
-          << "Std_PythonHelp" << "Std_FreeCADForum" << "Std_FreeCADFAQ"
-          << "Std_ReportBug" << "Std_About" << "Std_WhatsThis"
-          << "Std_RestartInSafeMode";
+    *help << "Std_OnlineHelp" << "Std_WhatsThis" << "Separator"
+          // Start page and additional separator are dynamically inserted here
+          << "Std_FreeCADUserHub" << "Std_FreeCADForum" << "Std_FreeCADFAQ" << "Std_ReportBug" << "Separator"
+          << "Std_RestartInSafeMode" << "Separator"
+          << "Std_FreeCADPowerUserHub" << "Std_PythonHelp" << "Separator"
+          << "Std_FreeCADWebsite" << "Std_FreeCADDonation" << "Std_About";
 
     return menuBar;
 }

--- a/src/Mod/Start/Gui/Manipulator.cpp
+++ b/src/Mod/Start/Gui/Manipulator.cpp
@@ -75,6 +75,10 @@ void StartGui::Manipulator::modifyMenuBar(Gui::MenuItem* menuBar)
 
     Gui::MenuItem* helpMenu = menuBar->findItem("&Help");
     Gui::MenuItem* loadStart = new Gui::MenuItem();
+    Gui::MenuItem* loadSeparator = new Gui::MenuItem();
     loadStart->setCommand("Start_Start");
-    helpMenu->appendItem(loadStart);
+    loadSeparator->setCommand("Separator");
+    Gui::MenuItem* firstItem = helpMenu->findItem("Std_FreeCADUserHub");
+    helpMenu->insertItem(firstItem, loadStart);
+    helpMenu->insertItem(firstItem, loadSeparator);
 }


### PR DESCRIPTION
Moved items in the Help bar for V1.0. No text changes or translations needed. Based off discussion in DWG channel.

Separate PR for text changes (post V1.0?).

Currently draft status, looking for feedback. See images for comparison.

| Before (V1.0RC2) | After |
---------|-------
| ![Screenshot 2024-10-24 025109](https://github.com/user-attachments/assets/b2d6affe-6001-4222-89d5-d260d243682b) | ![Screenshot 2024-10-24 005817](https://github.com/user-attachments/assets/23256325-f9d4-4b3f-8c99-9621159aeeb0) |


