### PR TITLE
Part: bugfix #17468 recursively unpack compounds for boolean fuse

### DIFF
--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -102,12 +102,14 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
     TopoShape compoundOfArguments;
 
     // if only one source shape, and it is a compound - fuse children of the compound
-    if (shapes.size() == 1) {
+    while (shapes.size() == 1) {
         compoundOfArguments = shapes[0];
         if (compoundOfArguments.getShape().ShapeType() == TopAbs_COMPOUND) {
             shapes.clear();
             shapes = compoundOfArguments.getSubTopoShapes();
             argumentsAreInCompound = true;
+        } else {
+            break;
         }
     }
 

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -102,7 +102,8 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
     TopoShape compoundOfArguments;
 
     // if only one source shape, and it is a compound - fuse children of the compound
-    while (shapes.size() == 1) {
+    int naucks_sanity_remaining=1000000; // hard abort after 1 million loops - will trigger "not enough shape objects linked" error below if ever reached
+    while (shapes.size() == 1 && naucks_sanity_remaining-- > 0) {
         compoundOfArguments = shapes[0];
         if (compoundOfArguments.getShape().ShapeType() == TopAbs_COMPOUND) {
             shapes.clear();

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -102,8 +102,8 @@ App::DocumentObjectExecReturn *MultiFuse::execute()
     TopoShape compoundOfArguments;
 
     // if only one source shape, and it is a compound - fuse children of the compound
-    int naucks_sanity_remaining=1000000; // hard abort after 1 million loops - will trigger "not enough shape objects linked" error below if ever reached
-    while (shapes.size() == 1 && naucks_sanity_remaining-- > 0) {
+    const int maxIterations = 1'000'000; // will trigger "not enough shape objects linked" error below if ever reached
+    for (int i = 0; shapes.size() == 1 && i < maxIterations; ++i) {
         compoundOfArguments = shapes[0];
         if (compoundOfArguments.getShape().ShapeType() == TopAbs_COMPOUND) {
             shapes.clear();

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -374,12 +374,15 @@ void CmdPartCommon::activated(int iMsg)
         numShapes = 1; //to be updated later in code, if
         Gui::SelectionObject selobj = Sel[0];
         TopoDS_Shape sh = Part::Feature::getShape(selobj.getObject());
-        if (sh.ShapeType() == TopAbs_COMPOUND) {
+        while (numShapes==1 and sh.ShapeType() == TopAbs_COMPOUND) {
             numShapes = 0;
             TopoDS_Iterator it(sh);
+            TopoDS_Shape last;
             for (; it.More(); it.Next()) {
                 ++numShapes;
+                last = it.Value();
             }
+            sh = last;
         }
     } else {
         numShapes = Sel.size();
@@ -450,12 +453,15 @@ void CmdPartFuse::activated(int iMsg)
         numShapes = 1; //to be updated later in code
         Gui::SelectionObject selobj = Sel[0];
         TopoDS_Shape sh = Part::Feature::getShape(selobj.getObject());
-        if (sh.ShapeType() == TopAbs_COMPOUND) {
+        while (numShapes==1 and sh.ShapeType() == TopAbs_COMPOUND) {
             numShapes = 0;
             TopoDS_Iterator it(sh);
+            TopoDS_Shape last;
             for (; it.More(); it.Next()) {
                 ++numShapes;
+                last = it.Value();
             }
+            sh = last;
         }
     } else {
         numShapes = Sel.size();

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -368,26 +368,7 @@ void CmdPartCommon::activated(int iMsg)
     std::vector<Gui::SelectionObject> Sel =
         getSelection().getSelectionEx(nullptr, App::DocumentObject::getClassTypeId(), Gui::ResolveMode::FollowLink);
 
-    //test if selected object is a compound, and if it is, look how many children it has...
-    std::size_t numShapes = 0;
-    if (Sel.size() == 1){
-        numShapes = 1; //to be updated later in code, if
-        Gui::SelectionObject selobj = Sel[0];
-        TopoDS_Shape sh = Part::Feature::getShape(selobj.getObject());
-        while (numShapes==1 && sh.ShapeType() == TopAbs_COMPOUND) {
-            numShapes = 0;
-            TopoDS_Iterator it(sh);
-            TopoDS_Shape last;
-            for (; it.More(); it.Next()) {
-                ++numShapes;
-                last = it.Value();
-            }
-            sh = last;
-        }
-    } else {
-        numShapes = Sel.size();
-    }
-    if (numShapes < 2) {
+    if (Sel.size() < 1) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
             QObject::tr("Please select two shapes or more. Or, select one compound containing two or more shapes to compute the intersection between."));
         return;

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -374,7 +374,7 @@ void CmdPartCommon::activated(int iMsg)
         numShapes = 1; //to be updated later in code, if
         Gui::SelectionObject selobj = Sel[0];
         TopoDS_Shape sh = Part::Feature::getShape(selobj.getObject());
-        while (numShapes==1 and sh.ShapeType() == TopAbs_COMPOUND) {
+        while (numShapes==1 && sh.ShapeType() == TopAbs_COMPOUND) {
             numShapes = 0;
             TopoDS_Iterator it(sh);
             TopoDS_Shape last;
@@ -453,7 +453,7 @@ void CmdPartFuse::activated(int iMsg)
         numShapes = 1; //to be updated later in code
         Gui::SelectionObject selobj = Sel[0];
         TopoDS_Shape sh = Part::Feature::getShape(selobj.getObject());
-        while (numShapes==1 and sh.ShapeType() == TopAbs_COMPOUND) {
+        while (numShapes==1 && sh.ShapeType() == TopAbs_COMPOUND) {
             numShapes = 0;
             TopoDS_Iterator it(sh);
             TopoDS_Shape last;

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -368,7 +368,7 @@ void CmdPartCommon::activated(int iMsg)
     std::vector<Gui::SelectionObject> Sel =
         getSelection().getSelectionEx(nullptr, App::DocumentObject::getClassTypeId(), Gui::ResolveMode::FollowLink);
 
-    if (Sel.size() < 1) {
+    if (Sel.empty()) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
             QObject::tr("Please select two shapes or more. Or, select one compound containing two or more shapes to compute the intersection between."));
         return;

--- a/tests/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -4,6 +4,7 @@
 
 #include "Mod/Part/App/FeaturePartFuse.h"
 #include <src/App/InitApplication.h>
+#include "Mod/Part/App/FeatureCompound.h"
 
 #include "PartTestHelpers.h"
 
@@ -20,12 +21,14 @@ protected:
     {
         createTestDoc();
         _fuse = dynamic_cast<Part::Fuse*>(_doc->addObject("Part::Fuse"));
+        _multiFuse = dynamic_cast<Part::MultiFuse*>(_doc->addObject("Part::MultiFuse"));
     }
 
     void TearDown() override
     {}
 
     Part::Fuse* _fuse = nullptr;  // NOLINT Can't be private in a test framework
+    Part::MultiFuse* _multiFuse = nullptr;  // NOLINT Can't be private in a test framework
 };
 
 TEST_F(FeaturePartFuseTest, testIntersecting)
@@ -37,6 +40,64 @@ TEST_F(FeaturePartFuseTest, testIntersecting)
     // Act
     _fuse->execute();
     Part::TopoShape ts = _fuse->Shape.getValue();
+    double volume = PartTestHelpers::getVolume(ts.getShape());
+    Base::BoundBox3d bb = ts.getBoundBox();
+
+    // Assert
+    EXPECT_DOUBLE_EQ(volume, 9.0);
+    // double check using bounds:
+    EXPECT_DOUBLE_EQ(bb.MinX, 0.0);
+    EXPECT_DOUBLE_EQ(bb.MinY, 0.0);
+    EXPECT_DOUBLE_EQ(bb.MinZ, 0.0);
+    EXPECT_DOUBLE_EQ(bb.MaxX, 1.0);
+    EXPECT_DOUBLE_EQ(bb.MaxY, 3.0);
+    EXPECT_DOUBLE_EQ(bb.MaxZ, 3.0);
+}
+
+TEST_F(FeaturePartFuseTest, testCompound)
+{
+    // Arrange
+    Part::Compound* _compound = nullptr;
+    _compound = dynamic_cast<Part::Compound*>(_doc->addObject("Part::Compound"));
+    _compound->Links.setValues({_boxes[0], _boxes[1]});
+    _multiFuse->Shapes.setValues({_compound});
+
+    // Act
+    _compound->execute();
+    _multiFuse->execute();
+    Part::TopoShape ts = _multiFuse->Shape.getValue();
+    double volume = PartTestHelpers::getVolume(ts.getShape());
+    Base::BoundBox3d bb = ts.getBoundBox();
+
+    // Assert
+    EXPECT_DOUBLE_EQ(volume, 9.0);
+    // double check using bounds:
+    EXPECT_DOUBLE_EQ(bb.MinX, 0.0);
+    EXPECT_DOUBLE_EQ(bb.MinY, 0.0);
+    EXPECT_DOUBLE_EQ(bb.MinZ, 0.0);
+    EXPECT_DOUBLE_EQ(bb.MaxX, 1.0);
+    EXPECT_DOUBLE_EQ(bb.MaxY, 3.0);
+    EXPECT_DOUBLE_EQ(bb.MaxZ, 3.0);
+}
+TEST_F(FeaturePartFuseTest, testRecursiveCompound)
+{
+    // Arrange
+    Part::Compound* _compound[3] = {nullptr};
+    int t;
+    for (t=0;t<3;t++) {
+        _compound[t] = dynamic_cast<Part::Compound*>(_doc->addObject("Part::Compound"));
+    }
+    _compound[0]->Links.setValues({_boxes[0], _boxes[1]});
+    _compound[1]->Links.setValues({_compound[0]});
+    _compound[2]->Links.setValues({_compound[1]});
+    _multiFuse->Shapes.setValues({_compound[2]});
+
+    // Act
+    for (t=0;t<3;t++) {
+        _compound[t]->execute();
+    }
+    _multiFuse->execute();
+    Part::TopoShape ts = _multiFuse->Shape.getValue();
     double volume = PartTestHelpers::getVolume(ts.getShape());
     Base::BoundBox3d bb = ts.getBoundBox();
 

--- a/tests/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/tests/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -27,7 +27,7 @@ protected:
     void TearDown() override
     {}
 
-    Part::Fuse* _fuse = nullptr;  // NOLINT Can't be private in a test framework
+    Part::Fuse* _fuse = nullptr;            // NOLINT Can't be private in a test framework
     Part::MultiFuse* _multiFuse = nullptr;  // NOLINT Can't be private in a test framework
 };
 
@@ -84,7 +84,7 @@ TEST_F(FeaturePartFuseTest, testRecursiveCompound)
     // Arrange
     Part::Compound* _compound[3] = {nullptr};
     int t;
-    for (t=0;t<3;t++) {
+    for (t = 0; t < 3; t++) {
         _compound[t] = dynamic_cast<Part::Compound*>(_doc->addObject("Part::Compound"));
     }
     _compound[0]->Links.setValues({_boxes[0], _boxes[1]});
@@ -93,7 +93,7 @@ TEST_F(FeaturePartFuseTest, testRecursiveCompound)
     _multiFuse->Shapes.setValues({_compound[2]});
 
     // Act
-    for (t=0;t<3;t++) {
+    for (t = 0; t < 3; t++) {
         _compound[t]->execute();
     }
     _multiFuse->execute();


### PR DESCRIPTION


fix #17468  recursively unpack compounds for boolean fuse


OCCT can boolean fuse multiple shapes in a compound

even if that compound is in another compound
even if that compound is in another compound
even if that compound is in another compound
even if that compound is in another compound
even if that compound is in another compound
even if that compound is in another compound
even if that compound is in another compound
even if that compound is in another compound
even if that compound is in another compound
even if that compound is in another compound
even if that compound is in another compound
even if that compound is in another compound
...

but FreeCAD wouldn't let it because it only checks the topmost layer

sadly multi-recursive compounds can be created from brep export+import (there are scenarios that increase recursion depth by one)  and of course by hand