### PR TITLE
[TD]handle cut profiles with only a single edge (fix #17380)

### DIFF
--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -506,13 +506,6 @@ void DrawComplexSection::makeAlignedPieces(const TopoDS_Shape& rawShape)
         return;
     }
 
-    int pieceCount = pieces.size();
-    if (pieceCount < 2) {
-        //no need to space out the pieces
-        m_alignResult = TopoDS::Compound(pieces.front());
-        return;
-    }
-
     //space the pieces "horizontally" or "vertically" in OXYZ
     double movementReverser = isProfileVertical ? verticalReverser : horizReverser;
     gp_Vec movementAxis = gp_Vec(gp::OX().Direction());


### PR DESCRIPTION
This PR implements a fix for issue #17380.   

The complex cut was incorrect if the cutting profile consisted of only a single edge.