### PR TITLE
[TD]do not mark document as changed after print

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -99,8 +99,9 @@ public:
 
     PyObject* getPyObject() override;
     TechDraw::DrawPage * getPage() { return m_vpPage->getDrawPage(); }
-
     ViewProviderPage* getViewProviderPage() {return m_vpPage;}
+    void savePageExportState(ViewProviderPage* page);
+    void resetPageExportState(ViewProviderPage* page) const;
 
     void setTabText(std::string tabText);
 
@@ -160,6 +161,8 @@ private:
 
     void getPaperAttributes();
     PagePrinter* m_pagePrinter;
+
+    bool m_docModStateBeforePrint{false};
 
 };
 


### PR DESCRIPTION
This PR implements a fix of some minor issues raised in issue #17403 - specifically the act of printing marking the document as modified and a missing redraw to the screen after printing.

The main issue raised in #17403 will need changes to QtSvg to support clipping.  It might be possible to use the new pattern support in Qt6.7 as a replacement for the missing clipping support but this has not yet been investigating.