### PR TITLE
[BIM] Fix IFC export elevation with wrong unit

### DIFF
--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -1762,7 +1762,7 @@ def exportIfcAttributes(obj, kwargs, scale=0.001):
             value = obj.getPropertyByName(property)
             if isinstance(value, FreeCAD.Units.Quantity):
                 value = float(value)
-                if property in ["ElevationWithFlooring","Elevation"]:
+                if "Elevation" in property:
                     value = value*scale # some properties must be changed to meters
             if (ifctype == "IfcFurnishingElement") and (property == "PredefinedType"):
                 pass # IFC2x3 Furniture objects get converted to IfcFurnishingElement and have no PredefinedType anymore


### PR DESCRIPTION
Fix #17459 

in origin code
there is only "ElevationWithFlooring"  "Elevation" two attributes will run multiple the scale
however in IFC Schema have other kind of Elevation
eg:  IfcSite has RefElevation
eg: IfcBuilding has ElevationOfTerrain & ElevationOfRefHeight
there might be other else

but I think all of them will including the "Elevation" string in the attributes name
so I think this fix might work