### PR TITLE
Help: Fix function return to avoid error when clicking URL on built-in browser

### DIFF
--- a/src/Mod/Help/Help.py
+++ b/src/Mod/Help/Help.py
@@ -183,7 +183,7 @@ def location_url(url_localized: str, url_english: str) -> tuple:
 
 
 def get_location(page) -> tuple:
-    """retrieves the location (online or offline) of a given page"""
+    """retrieves the location (online or offline) of a given page. Returns the location and the page name"""
 
     location = ""
     if page.startswith("http"):

--- a/src/Mod/Help/Help.py
+++ b/src/Mod/Help/Help.py
@@ -160,15 +160,20 @@ def location_url(url_localized: str, url_english: str) -> tuple:
     """
     Returns localized documentation url and page name, if they exist,
     otherwise defaults to english version.
+    Page name is gotten from:
+      a) Name/* metadata tag on raw markdown files from github,
+         Wiki translators should make sure to add it.
+      b) <title> HTML tag
     """
     try:
         req = urllib.request.Request(url_localized)
         with urllib.request.urlopen(req) as response:
             html = response.read().decode("utf-8")
-            if re.search(r"https://wiki.freecad.org", url_localized):
-                pagename_match = re.search(r"<title>(.*?) - .*?</title>", html)
-            else:
+            if re.search(MD_RAW_URL, url_localized):
                 pagename_match = re.search(r"Name/.*?:\s*(.+)", html)
+            else:
+                # Pages from FreeCAD Wiki fall here
+                pagename_match = re.search(r"<title>(.*?) - .*?</title>", html)
             if pagename_match is not None:
                 return (url_localized, pagename_match.group(1))
             else:
@@ -177,17 +182,19 @@ def location_url(url_localized: str, url_english: str) -> tuple:
         return (url_english, "")
 
 
-def get_location(page):
+def get_location(page) -> tuple:
     """retrieves the location (online or offline) of a given page"""
 
     location = ""
     if page.startswith("http"):
-        return page
+        # NOTE: This gets activated when you open a link on the built-in browser, since
+        # we don't know the URL, using location_url() fallback to the HTML <title> tag
+        return location_url(page, page)
     if page.startswith("file://"):
-        return page[7:]
+        return (page[7:], "")
     # offline location
     if os.path.exists(page):
-        return page
+        return (page, "")
     page = page.replace(".md", "")
     page = page.replace(" ", "_")
     page = page.replace("wiki/", "")


### PR DESCRIPTION
Basically surfing across links inside the Wiki was not possible because of the error.

 **Should be backported.**

Is expected that you can navigate freely on the web? The Wiki is fine but you can click links that go outside the Wiki that not always load correctly for example errors like:

```python
14:07:58  (js) Access to font at 'https://forum.freecad.org/assets/fonts/fontawesome-webfont.ttf?v=4.7.0' from origin 'https://forum.freecadweb.org' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

Collateral damage from #16621