### PR TITLE
[TD]remove spurious mouseReleaseEvent (fix #17519)

### DIFF
--- a/src/Mod/TechDraw/Gui/QGSPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGSPage.cpp
@@ -130,15 +130,6 @@ void QGSPage::mousePressEvent(QGraphicsSceneMouseEvent * event)
     QGraphicsScene::mousePressEvent(event);
 }
 
-void QGSPage::mouseReleaseEvent(QGraphicsSceneMouseEvent * event)
-{
-    Qt::KeyboardModifiers originalModifiers = event->modifiers();
-    if ((event->button() == Qt::LeftButton) && PreferencesGui::multiSelection()) {
-        event->setModifiers(originalModifiers | Qt::ControlModifier);
-    }
-
-    QGraphicsScene::mouseReleaseEvent(event);
-}
 
 //! returns true if clicking on the item should clear the selection
 bool QGSPage::itemClearsSelection(int itemTypeIn)

--- a/src/Mod/TechDraw/Gui/QGSPage.h
+++ b/src/Mod/TechDraw/Gui/QGSPage.h
@@ -152,7 +152,6 @@ public:
 
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
-    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 
     QColor getBackgroundColor();
     bool orphanExists(const char* viewName, const std::vector<App::DocumentObject*>& list);


### PR DESCRIPTION
This PR implements a fix for issue #17519 where items were being "unselected" by the mouseReleaseEvent method. 