### PR TITLE
Gui: Add getObject<T>() helpers to various classes

### DIFF
--- a/src/Gui/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/DlgAddPropertyVarSet.cpp
@@ -53,7 +53,7 @@ const bool COMMIT = false;
 DlgAddPropertyVarSet::DlgAddPropertyVarSet(QWidget* parent,
                                            ViewProviderVarSet* viewProvider)
     : QDialog(parent),
-      varSet(dynamic_cast<App::VarSet*>(viewProvider->getObject())),
+      varSet(viewProvider->getObject<App::VarSet>()),
       ui(new Ui_DlgAddPropertyVarSet),
       comboBoxGroup(this),
       completerType(this),

--- a/src/Gui/ManualAlignment.cpp
+++ b/src/Gui/ManualAlignment.cpp
@@ -240,7 +240,7 @@ Base::BoundBox3d AlignmentGroup::getBoundingBox() const
     std::vector<Gui::ViewProviderDocumentObject*>::const_iterator it;
     for (it = this->_views.begin(); it != this->_views.end(); ++it) {
         if ((*it)->isDerivedFrom(Gui::ViewProviderGeometryObject::getClassTypeId())) {
-            auto geo = static_cast<App::GeoFeature*>((*it)->getObject());
+            auto geo = (*it)->getObject<App::GeoFeature>();
             const App::PropertyComplexGeoData* prop = geo->getPropertyOfGeometry();
             if (prop)
                 box.Add(prop->getBoundingBox());

--- a/src/Gui/SelectionObject.h
+++ b/src/Gui/SelectionObject.h
@@ -71,9 +71,15 @@ public:
     inline const std::vector<Base::Vector3d> getPickedPoints() const { return SelPoses; }
 
     /// returns the selected DocumentObject or NULL if the object is already deleted
-    const App::DocumentObject *getObject() const;
+    const App::DocumentObject* getObject() const;
+    /// returns the selected DocumentObject or NULL if the object is already deleted
+    template <class T>
+    const T* getObject() const { return dynamic_cast<T*>(getObject()); };
     /// returns the selected DocumentObject or NULL if the object is already deleted
     App::DocumentObject *getObject();
+    /// returns the selected DocumentObject if it is of T type or null otherwise
+    template <class T>
+    T* getObject() { return dynamic_cast<T*>(getObject()); }
 
     /// check the selected object is a special type or derived of
     bool isObjectTypeOf(const Base::Type& typeId) const;

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -92,6 +92,9 @@ public:
     void updateView();
     /// Get the object of this ViewProvider object
     App::DocumentObject *getObject() const {return pcObject;}
+    /// Get the object of this ViewProvider object as specified type
+    template <class T>
+    T *getObject() const { return dynamic_cast<T*>(pcObject); }
     /// Asks the view provider if the given object can be deleted.
     bool canDelete(App::DocumentObject* obj) const override;
     /// Ask the view provider if it accepts object deletions while in edit

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -173,7 +173,7 @@ void ViewProviderGeometryObject::updateData(const App::Property* prop)
         pcBoundingBox->maxBounds.setValue(box.MaxX, box.MaxY, box.MaxZ);
     }
     else if (prop->isDerivedFrom(App::PropertyPlacement::getClassTypeId())) {
-        auto geometry = dynamic_cast<App::GeoFeature*>(getObject());
+        auto geometry = getObject<App::GeoFeature>();
         if (geometry && prop == &geometry->Placement) {
             const App::PropertyComplexGeoData* data = geometry->getPropertyOfGeometry();
             if (data) {
@@ -185,8 +185,7 @@ void ViewProviderGeometryObject::updateData(const App::Property* prop)
     }
     else if (std::string(prop->getName()) == "ShapeMaterial") {
         // Set the appearance from the material
-        auto geometry = dynamic_cast<App::GeoFeature*>(getObject());
-        if (geometry) {
+        if (auto geometry = getObject<App::GeoFeature>()) {
             /*
              * Change the appearance only if the appearance hasn't been set explicitly. A cached
              * material appearance is used to see if the current appearance matches the last

--- a/src/Gui/ViewProviderGeometryObjectPyImp.cpp
+++ b/src/Gui/ViewProviderGeometryObjectPyImp.cpp
@@ -58,7 +58,7 @@ PyObject* ViewProviderGeometryObjectPy::getCustomAttributes(const char* attr) co
     }
     if (strcmp(attr, "ShapeMaterial") == 0) {
         // Get material property of ViewProviderGeometryObject
-        auto geometry = dynamic_cast<App::GeoFeature*>(vp->getObject());
+        auto geometry = vp->getObject<App::GeoFeature>();
         if (geometry) {
             auto material = geometry->getMaterialAppearance();
             App::PropertyMaterial prop;
@@ -89,7 +89,7 @@ int ViewProviderGeometryObjectPy::setCustomAttributes(const char* attr, PyObject
     }
     if (strcmp(attr, "ShapeMaterial") == 0) {
         // Get material property of ViewProviderGeometryObject
-        auto geometry = dynamic_cast<App::GeoFeature*>(vp->getObject());
+        auto geometry = vp->getObject<App::GeoFeature>();
         if (geometry) {
             App::PropertyMaterial prop;
             prop.setPyObject(obj);

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -98,7 +98,7 @@ bool ViewProviderGroupExtension::extensionCanDropObject(App::DocumentObject* obj
 
 void ViewProviderGroupExtension::extensionDropObject(App::DocumentObject* obj) {
 
-    auto grp = static_cast<App::DocumentObject*>(getExtendedViewProvider()->getObject());
+    auto grp = getExtendedViewProvider()->getObject();
     App::Document* doc = grp->getDocument();
 
     // build Python command for execution

--- a/src/Gui/ViewProviderImagePlane.cpp
+++ b/src/Gui/ViewProviderImagePlane.cpp
@@ -183,9 +183,7 @@ bool ViewProviderImagePlane::doubleClicked()
 
 void ViewProviderImagePlane::manipulateImage()
 {
-    auto dialog = new TaskImageDialog(
-        dynamic_cast<Image::ImagePlane*>(getObject())
-    );
+    auto dialog = new TaskImageDialog(getObject<Image::ImagePlane>());
 
     Gui::Control().showDialog(dialog);
 }

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2034,7 +2034,7 @@ void ViewProviderLink::checkIcon(const App::LinkBaseExtension *ext) {
             return;
     }
     const char *icon;
-    auto element = freecad_dynamic_cast<App::LinkElement>(getObject());
+    auto element = getObject<App::LinkElement>();
     if(element)
         icon = _LinkElementIcon;
     else if(!ext->getLinkedObjectProperty() && ext->getElementListProperty())
@@ -2380,7 +2380,7 @@ bool ViewProviderLink::getDetailPath(
 }
 
 bool ViewProviderLink::onDelete(const std::vector<std::string> &) {
-    auto element = freecad_dynamic_cast<App::LinkElement>(getObject());
+    auto element = getObject<App::LinkElement>();
     if (element && !element->canDelete())
         return false;
     auto ext = getLinkExtension();

--- a/src/Gui/ViewProviderPart.cpp
+++ b/src/Gui/ViewProviderPart.cpp
@@ -126,7 +126,7 @@ bool ViewProviderPart::doubleClicked()
 QIcon ViewProviderPart::getIcon() const
 {
     // the original Part object for this ViewProviderPart
-    auto part = static_cast<App::Part*>(this->getObject());
+    auto part = this->getObject<App::Part>();
     // the normal case for Std_Part
     const char* pixmap = sPixmap;
     // if it's flagged as an Assembly in its Type, it gets another icon

--- a/src/Gui/ViewProviderTextDocument.cpp
+++ b/src/Gui/ViewProviderTextDocument.cpp
@@ -91,7 +91,7 @@ bool ViewProviderTextDocument::doubleClicked()
 
         getMainWindow()->addWindow(
             new TextDocumentEditorView {
-                static_cast<App::TextDocument*>(getObject()),
+                getObject<App::TextDocument>(),
                 editorWidget, getMainWindow()});
     }
     return true;

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -174,7 +174,7 @@ bool ViewProviderAssembly::canDragObjectToTarget(App::DocumentObject* obj,
 {
     // If a solid is removed from the assembly, its joints need to be removed.
     bool prompted = false;
-    auto* assemblyPart = static_cast<AssemblyObject*>(getObject());
+    auto* assemblyPart = getObject<AssemblyObject>();
 
     // If target is null then it's being dropped on a doc.
     if (target && assemblyPart->hasObject(target)) {
@@ -236,7 +236,7 @@ bool ViewProviderAssembly::setEdit(int mode)
         // When we set edit, we update the grounded joints placements to support :
         // - If user transformed the grounded object
         // - For nested assemblies where the grounded object moves around.
-        auto* assembly = static_cast<AssemblyObject*>(getObject());
+        auto* assembly = getObject<AssemblyObject>();
         assembly->updateGroundedJointsPlacements();
 
         setDragger();
@@ -479,7 +479,7 @@ bool ViewProviderAssembly::tryMouseMove(const SbVec2s& cursorPos, Gui::View3DInv
 
         prevPosition = newPos;
 
-        auto* assemblyPart = static_cast<AssemblyObject*>(getObject());
+        auto* assemblyPart = getObject<AssemblyObject>();
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/Mod/Assembly");
         bool solveOnMove = hGrp->GetBool("SolveOnMove", true);
@@ -575,7 +575,7 @@ bool ViewProviderAssembly::canDragObjectIn3d(App::DocumentObject* obj) const
         return false;
     }
 
-    auto* assemblyPart = static_cast<AssemblyObject*>(getObject());
+    auto* assemblyPart = getObject<AssemblyObject>();
 
     // Check if the selected object is a child of the assembly
     if (!assemblyPart->hasObject(obj, true)) {
@@ -638,7 +638,7 @@ bool ViewProviderAssembly::getSelectedObjectsWithinAssembly(bool addPreselection
     docsToMove.clear();
 
     // Get the assembly object for this ViewProvider
-    auto* assemblyPart = static_cast<AssemblyObject*>(getObject());
+    auto* assemblyPart = getObject<AssemblyObject>();
 
     if (!assemblyPart) {
         return false;
@@ -745,7 +745,7 @@ ViewProviderAssembly::DragMode ViewProviderAssembly::findDragMode()
     };
 
     if (docsToMove.size() == 1) {
-        auto* assemblyPart = static_cast<AssemblyObject*>(getObject());
+        auto* assemblyPart = getObject<AssemblyObject>();
         std::string pName;
         movingJoint = assemblyPart->getJointOfPartConnectingToGround(docsToMove[0].obj, pName);
 
@@ -856,7 +856,7 @@ void ViewProviderAssembly::tryInitMove(const SbVec2s& cursorPos, Gui::View3DInve
         return;
     }
 
-    auto* assemblyPart = static_cast<AssemblyObject*>(getObject());
+    auto* assemblyPart = getObject<AssemblyObject>();
     // When the user drag parts, we switch off all joints visibility and only show the movingjoint
     jointVisibilitiesBackup.clear();
     auto joints = assemblyPart->getJoints();
@@ -945,7 +945,7 @@ void ViewProviderAssembly::endMove()
     partMoving = false;
     canStartDragging = false;
 
-    auto* assemblyPart = static_cast<AssemblyObject*>(getObject());
+    auto* assemblyPart = getObject<AssemblyObject>();
     auto joints = assemblyPart->getJoints();
     for (auto pair : jointVisibilitiesBackup) {
         bool visible = pair.first->Visibility.getValue();
@@ -1077,7 +1077,7 @@ bool ViewProviderAssembly::canDelete(App::DocumentObject* objBeingDeleted) const
     bool res = ViewProviderPart::canDelete(objBeingDeleted);
     if (res) {
         // If a component is deleted, then we delete the joints as well.
-        auto* assemblyPart = static_cast<AssemblyObject*>(getObject());
+        auto* assemblyPart = getObject<AssemblyObject>();
 
         std::vector<App::DocumentObject*> objToDel;
         std::vector<App::DocumentObject*> objsBeingDeleted;

--- a/src/Mod/CAM/Gui/TaskDlgPathCompound.cpp
+++ b/src/Mod/CAM/Gui/TaskDlgPathCompound.cpp
@@ -57,8 +57,7 @@ TaskWidgetPathCompound::TaskWidgetPathCompound(ViewProviderPathCompound* Compoun
 
     this->groupLayout()->addWidget(proxy);
 
-    Path::FeatureCompound* pcCompound =
-        static_cast<Path::FeatureCompound*>(CompoundView->getObject());
+    Path::FeatureCompound* pcCompound = CompoundView->getObject<Path::FeatureCompound>();
     const std::vector<App::DocumentObject*>& Paths = pcCompound->Group.getValues();
     for (std::vector<App::DocumentObject*>::const_iterator it = Paths.begin(); it != Paths.end();
          ++it) {
@@ -128,8 +127,7 @@ void TaskDlgPathCompound::clicked(int button)
 bool TaskDlgPathCompound::accept()
 {
     std::vector<App::DocumentObject*> paths;
-    Path::FeatureCompound* pcCompound =
-        static_cast<Path::FeatureCompound*>(CompoundView->getObject());
+    Path::FeatureCompound* pcCompound = CompoundView->getObject<Path::FeatureCompound>();
     App::Document* pcDoc = static_cast<App::Document*>(pcCompound->getDocument());
     std::vector<std::string> names = parameter->getList();
     for (std::size_t i = 0; i < names.size(); i++) {

--- a/src/Mod/CAM/Gui/ViewProviderArea.cpp
+++ b/src/Mod/CAM/Gui/ViewProviderArea.cpp
@@ -42,8 +42,7 @@ ViewProviderArea::~ViewProviderArea()
 
 std::vector<App::DocumentObject*> ViewProviderArea::claimChildren() const
 {
-    return std::vector<App::DocumentObject*>(
-        static_cast<Path::FeatureArea*>(getObject())->Sources.getValues());
+    return std::vector<App::DocumentObject*>(getObject<Path::FeatureArea>()->Sources.getValues());
 }
 
 bool ViewProviderArea::canDragObjects() const
@@ -58,7 +57,7 @@ bool ViewProviderArea::canDragObject(App::DocumentObject* obj) const
 
 void ViewProviderArea::dragObject(App::DocumentObject* obj)
 {
-    Path::FeatureArea* area = static_cast<Path::FeatureArea*>(getObject());
+    Path::FeatureArea* area = getObject<Path::FeatureArea>();
     std::vector<App::DocumentObject*> sources = area->Sources.getValues();
     for (std::vector<App::DocumentObject*>::iterator it = sources.begin(); it != sources.end();
          ++it) {
@@ -82,7 +81,7 @@ bool ViewProviderArea::canDropObject(App::DocumentObject* obj) const
 
 void ViewProviderArea::dropObject(App::DocumentObject* obj)
 {
-    Path::FeatureArea* area = static_cast<Path::FeatureArea*>(getObject());
+    Path::FeatureArea* area = getObject<Path::FeatureArea>();
     std::vector<App::DocumentObject*> sources = area->Sources.getValues();
     sources.push_back(obj);
     area->Sources.setValues(sources);
@@ -106,7 +105,7 @@ void ViewProviderArea::updateData(const App::Property* prop)
 bool ViewProviderArea::onDelete(const std::vector<std::string>&)
 {
     // get the input shapes
-    Path::FeatureArea* area = static_cast<Path::FeatureArea*>(getObject());
+    Path::FeatureArea* area = getObject<Path::FeatureArea>();
     std::vector<App::DocumentObject*> pShapes = area->Sources.getValues();
     for (std::vector<App::DocumentObject*>::iterator it = pShapes.begin(); it != pShapes.end();
          ++it) {
@@ -132,7 +131,7 @@ ViewProviderAreaView::~ViewProviderAreaView()
 std::vector<App::DocumentObject*> ViewProviderAreaView::claimChildren() const
 {
     std::vector<App::DocumentObject*> ret;
-    Path::FeatureAreaView* feature = static_cast<Path::FeatureAreaView*>(getObject());
+    Path::FeatureAreaView* feature = getObject<Path::FeatureAreaView>();
     if (feature->Source.getValue()) {
         ret.push_back(feature->Source.getValue());
     }
@@ -151,7 +150,7 @@ bool ViewProviderAreaView::canDragObject(App::DocumentObject* obj) const
 
 void ViewProviderAreaView::dragObject(App::DocumentObject*)
 {
-    Path::FeatureAreaView* feature = static_cast<Path::FeatureAreaView*>(getObject());
+    Path::FeatureAreaView* feature = getObject<Path::FeatureAreaView>();
     feature->Source.setValue(nullptr);
 }
 
@@ -167,7 +166,7 @@ bool ViewProviderAreaView::canDropObject(App::DocumentObject* obj) const
 
 void ViewProviderAreaView::dropObject(App::DocumentObject* obj)
 {
-    Path::FeatureAreaView* feature = static_cast<Path::FeatureAreaView*>(getObject());
+    Path::FeatureAreaView* feature = getObject<Path::FeatureAreaView>();
     feature->Source.setValue(obj);
 }
 
@@ -182,7 +181,7 @@ void ViewProviderAreaView::updateData(const App::Property* prop)
 
 bool ViewProviderAreaView::onDelete(const std::vector<std::string>&)
 {
-    Path::FeatureAreaView* feature = static_cast<Path::FeatureAreaView*>(getObject());
+    Path::FeatureAreaView* feature = getObject<Path::FeatureAreaView>();
     Gui::Application::Instance->showViewProvider(feature->Source.getValue());
     return true;
 }

--- a/src/Mod/CAM/Gui/ViewProviderPathCompound.cpp
+++ b/src/Mod/CAM/Gui/ViewProviderPathCompound.cpp
@@ -51,8 +51,7 @@ void ViewProviderPathCompound::unsetEdit(int ModNum)
 
 std::vector<App::DocumentObject*> ViewProviderPathCompound::claimChildren() const
 {
-    return std::vector<App::DocumentObject*>(
-        static_cast<Path::FeatureCompound*>(getObject())->Group.getValues());
+    return std::vector<App::DocumentObject*>(getObject<Path::FeatureCompound>()->Group.getValues());
 }
 
 bool ViewProviderPathCompound::canDragObjects() const
@@ -62,7 +61,7 @@ bool ViewProviderPathCompound::canDragObjects() const
 
 void ViewProviderPathCompound::dragObject(App::DocumentObject* obj)
 {
-    static_cast<Path::FeatureCompound*>(getObject())->removeObject(obj);
+    getObject<Path::FeatureCompound>()->removeObject(obj);
 }
 
 bool ViewProviderPathCompound::canDropObjects() const
@@ -72,7 +71,7 @@ bool ViewProviderPathCompound::canDropObjects() const
 
 void ViewProviderPathCompound::dropObject(App::DocumentObject* obj)
 {
-    static_cast<Path::FeatureCompound*>(getObject())->addObject(obj);
+    getObject<Path::FeatureCompound>()->addObject(obj);
 }
 
 QIcon ViewProviderPathCompound::getIcon() const

--- a/src/Mod/CAM/Gui/ViewProviderPathShape.cpp
+++ b/src/Mod/CAM/Gui/ViewProviderPathShape.cpp
@@ -41,8 +41,7 @@ QIcon ViewProviderPathShape::getIcon() const
 
 std::vector<App::DocumentObject*> ViewProviderPathShape::claimChildren() const
 {
-    return std::vector<App::DocumentObject*>(
-        static_cast<Path::FeatureShape*>(getObject())->Sources.getValues());
+    return std::vector<App::DocumentObject*>(getObject<Path::FeatureShape>()->Sources.getValues());
 }
 
 bool ViewProviderPathShape::canDragObjects() const
@@ -57,7 +56,7 @@ bool ViewProviderPathShape::canDragObject(App::DocumentObject* obj) const
 
 void ViewProviderPathShape::dragObject(App::DocumentObject* obj)
 {
-    Path::FeatureShape* feature = static_cast<Path::FeatureShape*>(getObject());
+    Path::FeatureShape* feature = getObject<Path::FeatureShape>();
     std::vector<App::DocumentObject*> sources = feature->Sources.getValues();
     for (std::vector<App::DocumentObject*>::iterator it = sources.begin(); it != sources.end();
          ++it) {
@@ -81,7 +80,7 @@ bool ViewProviderPathShape::canDropObject(App::DocumentObject* obj) const
 
 void ViewProviderPathShape::dropObject(App::DocumentObject* obj)
 {
-    Path::FeatureShape* feature = static_cast<Path::FeatureShape*>(getObject());
+    Path::FeatureShape* feature = getObject<Path::FeatureShape>();
     std::vector<App::DocumentObject*> sources = feature->Sources.getValues();
     sources.push_back(obj);
     feature->Sources.setValues(sources);
@@ -105,7 +104,7 @@ void ViewProviderPathShape::updateData(const App::Property* prop)
 bool ViewProviderPathShape::onDelete(const std::vector<std::string>&)
 {
     // get the input shapes
-    Path::FeatureShape* feature = static_cast<Path::FeatureShape*>(getObject());
+    Path::FeatureShape* feature = getObject<Path::FeatureShape>();
     std::vector<App::DocumentObject*> pShapes = feature->Sources.getValues();
     for (std::vector<App::DocumentObject*>::iterator it = pShapes.begin(); it != pShapes.end();
          ++it) {

--- a/src/Mod/Fem/Gui/TaskDlgMeshShapeNetgen.cpp
+++ b/src/Mod/Fem/Gui/TaskDlgMeshShapeNetgen.cpp
@@ -52,7 +52,7 @@ TaskDlgMeshShapeNetgen::TaskDlgMeshShapeNetgen(FemGui::ViewProviderFemMeshShapeN
     , param(nullptr)
     , ViewProviderFemMeshShapeNetgen(obj)
 {
-    FemMeshShapeNetgenObject = dynamic_cast<Fem::FemMeshShapeNetgenObject*>(obj->getObject());
+    FemMeshShapeNetgenObject = obj->getObject<Fem::FemMeshShapeNetgenObject>();
     if (FemMeshShapeNetgenObject) {
         param = new TaskTetParameter(FemMeshShapeNetgenObject);
         Content.push_back(param);

--- a/src/Mod/Fem/Gui/TaskFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraint.cpp
@@ -103,7 +103,7 @@ const std::string TaskFemConstraint::getReferences(const std::vector<std::string
 
 const std::string TaskFemConstraint::getScale() const
 {
-    Fem::Constraint* pcConstraint = static_cast<Fem::Constraint*>(ConstraintView->getObject());
+    Fem::Constraint* pcConstraint = ConstraintView->getObject<Fem::Constraint>();
 
     return std::to_string(pcConstraint->Scale.getValue());
 }
@@ -131,7 +131,7 @@ void TaskFemConstraint::setSelection(QListWidgetItem* item)
 
 void TaskFemConstraint::onReferenceDeleted(const int row)
 {
-    Fem::Constraint* pcConstraint = static_cast<Fem::Constraint*>(ConstraintView->getObject());
+    Fem::Constraint* pcConstraint = ConstraintView->getObject<Fem::Constraint>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintBearing.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintBearing.cpp
@@ -80,8 +80,7 @@ TaskFemConstraintBearing::TaskFemConstraintBearing(ViewProviderFemConstraint* Co
     ui->spinDistance->setMaximum(FLOAT_MAX);
 
     // Get the feature data
-    Fem::ConstraintBearing* pcConstraint =
-        static_cast<Fem::ConstraintBearing*>(ConstraintView->getObject());
+    Fem::ConstraintBearing* pcConstraint = ConstraintView->getObject<Fem::ConstraintBearing>();
     double distance = pcConstraint->Dist.getValue();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
@@ -154,8 +153,7 @@ void TaskFemConstraintBearing::onSelectionChanged(const Gui::SelectionChanges& m
             return;
         }
 
-        Fem::ConstraintBearing* pcConstraint =
-            static_cast<Fem::ConstraintBearing*>(ConstraintView->getObject());
+        Fem::ConstraintBearing* pcConstraint = ConstraintView->getObject<Fem::ConstraintBearing>();
         App::DocumentObject* obj =
             ConstraintView->getObject()->getDocument()->getObject(msg.pObjectName);
         Part::Feature* feat = static_cast<Part::Feature*>(obj);
@@ -232,8 +230,7 @@ void TaskFemConstraintBearing::onSelectionChanged(const Gui::SelectionChanges& m
 
 void TaskFemConstraintBearing::onDistanceChanged(double l)
 {
-    Fem::ConstraintBearing* pcConstraint =
-        static_cast<Fem::ConstraintBearing*>(ConstraintView->getObject());
+    Fem::ConstraintBearing* pcConstraint = ConstraintView->getObject<Fem::ConstraintBearing>();
     pcConstraint->Dist.setValue(l);
 }
 
@@ -259,8 +256,7 @@ void TaskFemConstraintBearing::onButtonLocation(const bool pressed)
 
 void TaskFemConstraintBearing::onCheckAxial(const bool pressed)
 {
-    Fem::ConstraintBearing* pcConstraint =
-        static_cast<Fem::ConstraintBearing*>(ConstraintView->getObject());
+    Fem::ConstraintBearing* pcConstraint = ConstraintView->getObject<Fem::ConstraintBearing>();
     pcConstraint->AxialFree.setValue(pressed);
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintContact.cpp
@@ -86,8 +86,7 @@ TaskFemConstraintContact::TaskFemConstraintContact(ViewProviderFemConstraintCont
 
     /* Note: */
     // Get the feature data
-    Fem::ConstraintContact* pcConstraint =
-        static_cast<Fem::ConstraintContact*>(ConstraintView->getObject());
+    Fem::ConstraintContact* pcConstraint = ConstraintView->getObject<Fem::ConstraintContact>();
 
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
@@ -206,8 +205,7 @@ void TaskFemConstraintContact::addToSelectionSlave()
         Gui::Selection().clearSelection();
         return;
     }
-    Fem::ConstraintContact* pcConstraint =
-        static_cast<Fem::ConstraintContact*>(ConstraintView->getObject());
+    Fem::ConstraintContact* pcConstraint = ConstraintView->getObject<Fem::ConstraintContact>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -268,8 +266,7 @@ void TaskFemConstraintContact::removeFromSelectionSlave()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintContact* pcConstraint =
-        static_cast<Fem::ConstraintContact*>(ConstraintView->getObject());
+    Fem::ConstraintContact* pcConstraint = ConstraintView->getObject<Fem::ConstraintContact>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;
@@ -338,8 +335,7 @@ void TaskFemConstraintContact::addToSelectionMaster()
         Gui::Selection().clearSelection();
         return;
     }
-    Fem::ConstraintContact* pcConstraint =
-        static_cast<Fem::ConstraintContact*>(ConstraintView->getObject());
+    Fem::ConstraintContact* pcConstraint = ConstraintView->getObject<Fem::ConstraintContact>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -399,8 +395,7 @@ void TaskFemConstraintContact::removeFromSelectionMaster()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintContact* pcConstraint =
-        static_cast<Fem::ConstraintContact*>(ConstraintView->getObject());
+    Fem::ConstraintContact* pcConstraint = ConstraintView->getObject<Fem::ConstraintContact>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;

--- a/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintDisplacement.cpp
@@ -89,7 +89,7 @@ TaskFemConstraintDisplacement::TaskFemConstraintDisplacement(
 
     // Get the feature data
     Fem::ConstraintDisplacement* pcConstraint =
-        static_cast<Fem::ConstraintDisplacement*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintDisplacement>();
     Base::Quantity fStates[6] {};
     const char* sStates[3] {};
     bool bStates[10] {};
@@ -241,7 +241,7 @@ void TaskFemConstraintDisplacement::addToSelection()
         return;
     }
     Fem::ConstraintDisplacement* pcConstraint =
-        static_cast<Fem::ConstraintDisplacement*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintDisplacement>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -312,7 +312,7 @@ void TaskFemConstraintDisplacement::removeFromSelection()
         return;
     }
     Fem::ConstraintDisplacement* pcConstraint =
-        static_cast<Fem::ConstraintDisplacement*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintDisplacement>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;

--- a/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFixed.cpp
@@ -69,8 +69,7 @@ TaskFemConstraintFixed::TaskFemConstraintFixed(ViewProviderFemConstraintFixed* C
 
     /* Note: */
     // Get the feature data
-    Fem::ConstraintFixed* pcConstraint =
-        static_cast<Fem::ConstraintFixed*>(ConstraintView->getObject());
+    Fem::ConstraintFixed* pcConstraint = ConstraintView->getObject<Fem::ConstraintFixed>();
 
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
@@ -111,8 +110,7 @@ void TaskFemConstraintFixed::addToSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintFixed* pcConstraint =
-        static_cast<Fem::ConstraintFixed*>(ConstraintView->getObject());
+    Fem::ConstraintFixed* pcConstraint = ConstraintView->getObject<Fem::ConstraintFixed>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -183,8 +181,7 @@ void TaskFemConstraintFixed::removeFromSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintFixed* pcConstraint =
-        static_cast<Fem::ConstraintFixed*>(ConstraintView->getObject());
+    Fem::ConstraintFixed* pcConstraint = ConstraintView->getObject<Fem::ConstraintFixed>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;

--- a/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintFluidBoundary.cpp
@@ -208,7 +208,7 @@ TaskFemConstraintFluidBoundary::TaskFemConstraintFluidBoundary(
 
     // Get the feature data
     Fem::ConstraintFluidBoundary* pcConstraint =
-        static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintFluidBoundary>();
 
     Fem::FemAnalysis* pcAnalysis = nullptr;
     if (FemGui::ActiveAnalysisObserver::instance()->hasActiveObject()) {
@@ -381,7 +381,7 @@ const Fem::FemSolverObject* TaskFemConstraintFluidBoundary::getFemSolver() const
 void TaskFemConstraintFluidBoundary::updateBoundaryTypeUI()
 {
     Fem::ConstraintFluidBoundary* pcConstraint =
-        static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintFluidBoundary>();
     std::string boundaryType = ui->comboBoundaryType->currentText().toStdString();
     // std::string boundaryType = pcConstraint->BoundaryType.getValueAsString();
 
@@ -524,7 +524,7 @@ void TaskFemConstraintFluidBoundary::updateTurbulenceUI()
 void TaskFemConstraintFluidBoundary::updateThermalBoundaryUI()
 {
     // Fem::ConstraintFluidBoundary* pcConstraint =
-    // static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject()); std::string
+    // ConstraintView->getObject<Fem::ConstraintFluidBoundary>(); std::string
     // thermalBoundaryType = pcConstraint->ThermalBoundaryType.getValueAsString();
 
     ui->labelHelpText->setText(
@@ -566,7 +566,7 @@ void TaskFemConstraintFluidBoundary::updateThermalBoundaryUI()
 void TaskFemConstraintFluidBoundary::onBoundaryTypeChanged()
 {
     Fem::ConstraintFluidBoundary* pcConstraint =
-        static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintFluidBoundary>();
     // temporarily change BoundaryType property, but command transaction should reset it back if you
     // 'reject' late
     pcConstraint->BoundaryType.setValue(ui->comboBoundaryType->currentIndex());
@@ -597,7 +597,7 @@ void TaskFemConstraintFluidBoundary::onBoundaryValueChanged(double)
 void TaskFemConstraintFluidBoundary::onTurbulenceSpecificationChanged()
 {
     Fem::ConstraintFluidBoundary* pcConstraint =
-        static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintFluidBoundary>();
     pcConstraint->TurbulenceSpecification.setValue(
         ui->comboTurbulenceSpecification->currentIndex());
     updateTurbulenceUI();
@@ -606,7 +606,7 @@ void TaskFemConstraintFluidBoundary::onTurbulenceSpecificationChanged()
 void TaskFemConstraintFluidBoundary::onThermalBoundaryTypeChanged()
 {
     Fem::ConstraintFluidBoundary* pcConstraint =
-        static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintFluidBoundary>();
     pcConstraint->ThermalBoundaryType.setValue(ui->comboThermalBoundaryType->currentIndex());
     updateThermalBoundaryUI();
 }
@@ -632,7 +632,7 @@ void TaskFemConstraintFluidBoundary::onButtonDirection(const bool pressed)
         return;
     }
     Fem::ConstraintFluidBoundary* pcConstraint =
-        static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintFluidBoundary>();
 
     // we only handle the first selected object
     Gui::SelectionObject& selectionElement = selection.at(0);
@@ -696,7 +696,7 @@ void TaskFemConstraintFluidBoundary::onButtonDirection(const bool pressed)
 void TaskFemConstraintFluidBoundary::onCheckReverse(const bool pressed)
 {
     Fem::ConstraintFluidBoundary* pcConstraint =
-        static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintFluidBoundary>();
     pcConstraint->Reversed.setValue(pressed);
 }
 
@@ -820,7 +820,7 @@ void TaskFemConstraintFluidBoundary::addToSelection()
         return;
     }
     Fem::ConstraintFluidBoundary* pcConstraint =
-        static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintFluidBoundary>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -892,7 +892,7 @@ void TaskFemConstraintFluidBoundary::removeFromSelection()
         return;
     }
     Fem::ConstraintFluidBoundary* pcConstraint =
-        static_cast<Fem::ConstraintFluidBoundary*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintFluidBoundary>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;

--- a/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintForce.cpp
@@ -61,8 +61,7 @@ TaskFemConstraintForce::TaskFemConstraintForce(ViewProviderFemConstraintForce* C
     this->groupLayout()->addWidget(proxy);
 
     // Get the feature data
-    Fem::ConstraintForce* pcConstraint =
-        static_cast<Fem::ConstraintForce*>(ConstraintView->getObject());
+    Fem::ConstraintForce* pcConstraint = ConstraintView->getObject<Fem::ConstraintForce>();
     auto force = pcConstraint->Force.getQuantityValue();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
@@ -127,8 +126,7 @@ void TaskFemConstraintForce::addToSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintForce* pcConstraint =
-        static_cast<Fem::ConstraintForce*>(ConstraintView->getObject());
+    Fem::ConstraintForce* pcConstraint = ConstraintView->getObject<Fem::ConstraintForce>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -199,8 +197,7 @@ void TaskFemConstraintForce::removeFromSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintForce* pcConstraint =
-        static_cast<Fem::ConstraintForce*>(ConstraintView->getObject());
+    Fem::ConstraintForce* pcConstraint = ConstraintView->getObject<Fem::ConstraintForce>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;
@@ -320,8 +317,7 @@ void TaskFemConstraintForce::onButtonDirection(const bool pressed)
 
     try {
         std::vector<std::string> direction(1, link.second);
-        Fem::ConstraintForce* pcConstraint =
-            static_cast<Fem::ConstraintForce*>(ConstraintView->getObject());
+        Fem::ConstraintForce* pcConstraint = ConstraintView->getObject<Fem::ConstraintForce>();
 
         // update the direction
         pcConstraint->Direction.setValue(link.first, direction);
@@ -336,8 +332,7 @@ void TaskFemConstraintForce::onButtonDirection(const bool pressed)
 
 void TaskFemConstraintForce::onCheckReverse(const bool pressed)
 {
-    Fem::ConstraintForce* pcConstraint =
-        static_cast<Fem::ConstraintForce*>(ConstraintView->getObject());
+    Fem::ConstraintForce* pcConstraint = ConstraintView->getObject<Fem::ConstraintForce>();
     pcConstraint->Reversed.setValue(pressed);
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintGear.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintGear.cpp
@@ -74,8 +74,7 @@ TaskFemConstraintGear::TaskFemConstraintGear(ViewProviderFemConstraint* Constrai
     ui->checkReversed->blockSignals(true);
 
     // Get the feature data
-    Fem::ConstraintGear* pcConstraint =
-        static_cast<Fem::ConstraintGear*>(ConstraintView->getObject());
+    Fem::ConstraintGear* pcConstraint = ConstraintView->getObject<Fem::ConstraintGear>();
     double dia = pcConstraint->Diameter.getValue();
     double force = pcConstraint->Force.getValue();
     double angle = pcConstraint->ForceAngle.getValue();
@@ -137,8 +136,7 @@ void TaskFemConstraintGear::onSelectionChanged(const Gui::SelectionChanges& msg)
         }
 
         std::vector<std::string> references(1, subName);
-        Fem::ConstraintGear* pcConstraint =
-            static_cast<Fem::ConstraintGear*>(ConstraintView->getObject());
+        Fem::ConstraintGear* pcConstraint = ConstraintView->getObject<Fem::ConstraintGear>();
         App::DocumentObject* obj =
             ConstraintView->getObject()->getDocument()->getObject(msg.pObjectName);
         Part::Feature* feat = static_cast<Part::Feature*>(obj);
@@ -180,22 +178,19 @@ void TaskFemConstraintGear::onSelectionChanged(const Gui::SelectionChanges& msg)
 
 void TaskFemConstraintGear::onDiameterChanged(double l)
 {
-    Fem::ConstraintGear* pcConstraint =
-        static_cast<Fem::ConstraintGear*>(ConstraintView->getObject());
+    Fem::ConstraintGear* pcConstraint = ConstraintView->getObject<Fem::ConstraintGear>();
     pcConstraint->Diameter.setValue(l);
 }
 
 void TaskFemConstraintGear::onForceChanged(double f)
 {
-    Fem::ConstraintGear* pcConstraint =
-        static_cast<Fem::ConstraintGear*>(ConstraintView->getObject());
+    Fem::ConstraintGear* pcConstraint = ConstraintView->getObject<Fem::ConstraintGear>();
     pcConstraint->Force.setValue(f);
 }
 
 void TaskFemConstraintGear::onForceAngleChanged(double a)
 {
-    Fem::ConstraintGear* pcConstraint =
-        static_cast<Fem::ConstraintGear*>(ConstraintView->getObject());
+    Fem::ConstraintGear* pcConstraint = ConstraintView->getObject<Fem::ConstraintGear>();
     pcConstraint->ForceAngle.setValue(a);
 }
 
@@ -213,8 +208,7 @@ void TaskFemConstraintGear::onButtonDirection(const bool pressed)
 
 void TaskFemConstraintGear::onCheckReversed(const bool pressed)
 {
-    Fem::ConstraintGear* pcConstraint =
-        static_cast<Fem::ConstraintGear*>(ConstraintView->getObject());
+    Fem::ConstraintGear* pcConstraint = ConstraintView->getObject<Fem::ConstraintGear>();
     pcConstraint->Reversed.setValue(pressed);
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintHeatflux.cpp
@@ -105,8 +105,7 @@ TaskFemConstraintHeatflux::TaskFemConstraintHeatflux(
     ui->btnRemove->blockSignals(true);
 
     // Get the feature data
-    Fem::ConstraintHeatflux* pcConstraint =
-        static_cast<Fem::ConstraintHeatflux*>(ConstraintView->getObject());
+    Fem::ConstraintHeatflux* pcConstraint = ConstraintView->getObject<Fem::ConstraintHeatflux>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -190,36 +189,31 @@ void TaskFemConstraintHeatflux::updateUI()
 
 void TaskFemConstraintHeatflux::onAmbientTempChanged(double val)
 {
-    Fem::ConstraintHeatflux* pcConstraint =
-        static_cast<Fem::ConstraintHeatflux*>(ConstraintView->getObject());
+    Fem::ConstraintHeatflux* pcConstraint = ConstraintView->getObject<Fem::ConstraintHeatflux>();
     pcConstraint->AmbientTemp.setValue(val);
 }
 
 void TaskFemConstraintHeatflux::onFilmCoefChanged(double val)
 {
-    Fem::ConstraintHeatflux* pcConstraint =
-        static_cast<Fem::ConstraintHeatflux*>(ConstraintView->getObject());
+    Fem::ConstraintHeatflux* pcConstraint = ConstraintView->getObject<Fem::ConstraintHeatflux>();
     pcConstraint->FilmCoef.setValue(val);
 }
 
 void TaskFemConstraintHeatflux::onEmissivityChanged(double val)
 {
-    Fem::ConstraintHeatflux* pcConstraint =
-        static_cast<Fem::ConstraintHeatflux*>(ConstraintView->getObject());
+    Fem::ConstraintHeatflux* pcConstraint = ConstraintView->getObject<Fem::ConstraintHeatflux>();
     pcConstraint->Emissivity.setValue(val);
 }
 
 void TaskFemConstraintHeatflux::onHeatFluxChanged(double val)
 {
-    Fem::ConstraintHeatflux* pcConstraint =
-        static_cast<Fem::ConstraintHeatflux*>(ConstraintView->getObject());
+    Fem::ConstraintHeatflux* pcConstraint = ConstraintView->getObject<Fem::ConstraintHeatflux>();
     pcConstraint->DFlux.setValue(val);
 }
 
 void TaskFemConstraintHeatflux::Conv()
 {
-    Fem::ConstraintHeatflux* pcConstraint =
-        static_cast<Fem::ConstraintHeatflux*>(ConstraintView->getObject());
+    Fem::ConstraintHeatflux* pcConstraint = ConstraintView->getObject<Fem::ConstraintHeatflux>();
     std::string name = ConstraintView->getObject()->getNameInDocument();
     Gui::Command::doCommand(Gui::Command::Doc,
                             "App.ActiveDocument.%s.ConstraintType = %s",
@@ -232,8 +226,7 @@ void TaskFemConstraintHeatflux::Conv()
 
 void TaskFemConstraintHeatflux::Rad()
 {
-    Fem::ConstraintHeatflux* pcConstraint =
-        static_cast<Fem::ConstraintHeatflux*>(ConstraintView->getObject());
+    Fem::ConstraintHeatflux* pcConstraint = ConstraintView->getObject<Fem::ConstraintHeatflux>();
     std::string name = ConstraintView->getObject()->getNameInDocument();
     Gui::Command::doCommand(Gui::Command::Doc,
                             "App.ActiveDocument.%s.ConstraintType = %s",
@@ -246,8 +239,7 @@ void TaskFemConstraintHeatflux::Rad()
 
 void TaskFemConstraintHeatflux::Flux()
 {
-    Fem::ConstraintHeatflux* pcConstraint =
-        static_cast<Fem::ConstraintHeatflux*>(ConstraintView->getObject());
+    Fem::ConstraintHeatflux* pcConstraint = ConstraintView->getObject<Fem::ConstraintHeatflux>();
     std::string name = ConstraintView->getObject()->getNameInDocument();
     Gui::Command::doCommand(Gui::Command::Doc,
                             "App.ActiveDocument.%s.ConstraintType = %s",
@@ -265,8 +257,7 @@ void TaskFemConstraintHeatflux::addToSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintHeatflux* pcConstraint =
-        static_cast<Fem::ConstraintHeatflux*>(ConstraintView->getObject());
+    Fem::ConstraintHeatflux* pcConstraint = ConstraintView->getObject<Fem::ConstraintHeatflux>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -331,8 +322,7 @@ void TaskFemConstraintHeatflux::removeFromSelection()
         return;
     }
 
-    Fem::ConstraintHeatflux* pcConstraint =
-        static_cast<Fem::ConstraintHeatflux*>(ConstraintView->getObject());
+    Fem::ConstraintHeatflux* pcConstraint = ConstraintView->getObject<Fem::ConstraintHeatflux>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;
@@ -419,7 +409,7 @@ std::string TaskFemConstraintHeatflux::getAmbientTemp() const
         temp = ui->qsb_ambienttemp_rad->value().getSafeUserString().toStdString();
     }
     else {
-        auto obj = static_cast<Fem::ConstraintHeatflux*>(ConstraintView->getObject());
+        auto obj = ConstraintView->getObject<Fem::ConstraintHeatflux>();
         temp = obj->AmbientTemp.getQuantityValue().getSafeUserString().toStdString();
     }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintInitialTemperature.cpp
@@ -56,7 +56,7 @@ TaskFemConstraintInitialTemperature::TaskFemConstraintInitialTemperature(
 
     // Get the feature data
     Fem::ConstraintInitialTemperature* pcConstraint =
-        static_cast<Fem::ConstraintInitialTemperature*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintInitialTemperature>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPlaneRotation.cpp
@@ -79,7 +79,7 @@ TaskFemConstraintPlaneRotation::TaskFemConstraintPlaneRotation(
     /* Note: */
     // Get the feature data
     Fem::ConstraintPlaneRotation* pcConstraint =
-        static_cast<Fem::ConstraintPlaneRotation*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintPlaneRotation>();
 
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
@@ -138,7 +138,7 @@ void TaskFemConstraintPlaneRotation::addToSelection()
             return;
         }
         Fem::ConstraintPlaneRotation* pcConstraint =
-            static_cast<Fem::ConstraintPlaneRotation*>(ConstraintView->getObject());
+            ConstraintView->getObject<Fem::ConstraintPlaneRotation>();
         std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
         std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -218,7 +218,7 @@ void TaskFemConstraintPlaneRotation::removeFromSelection()
         return;
     }
     Fem::ConstraintPlaneRotation* pcConstraint =
-        static_cast<Fem::ConstraintPlaneRotation*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintPlaneRotation>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;

--- a/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPressure.cpp
@@ -56,8 +56,7 @@ TaskFemConstraintPressure::TaskFemConstraintPressure(
     this->groupLayout()->addWidget(proxy);
 
     // Get the feature data
-    Fem::ConstraintPressure* pcConstraint =
-        static_cast<Fem::ConstraintPressure*>(ConstraintView->getObject());
+    Fem::ConstraintPressure* pcConstraint = ConstraintView->getObject<Fem::ConstraintPressure>();
 
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
@@ -120,8 +119,7 @@ void TaskFemConstraintPressure::updateUI()
 
 void TaskFemConstraintPressure::onCheckReverse(const bool pressed)
 {
-    Fem::ConstraintPressure* pcConstraint =
-        static_cast<Fem::ConstraintPressure*>(ConstraintView->getObject());
+    Fem::ConstraintPressure* pcConstraint = ConstraintView->getObject<Fem::ConstraintPressure>();
     pcConstraint->Reversed.setValue(pressed);
 }
 
@@ -133,8 +131,7 @@ void TaskFemConstraintPressure::addToSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintPressure* pcConstraint =
-        static_cast<Fem::ConstraintPressure*>(ConstraintView->getObject());
+    Fem::ConstraintPressure* pcConstraint = ConstraintView->getObject<Fem::ConstraintPressure>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -188,8 +185,7 @@ void TaskFemConstraintPressure::removeFromSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintPressure* pcConstraint =
-        static_cast<Fem::ConstraintPressure*>(ConstraintView->getObject());
+    Fem::ConstraintPressure* pcConstraint = ConstraintView->getObject<Fem::ConstraintPressure>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;

--- a/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintPulley.cpp
@@ -68,8 +68,7 @@ TaskFemConstraintPulley::TaskFemConstraintPulley(ViewProviderFemConstraintPulley
     ui->spinTensionForce->blockSignals(true);
 
     // Get the feature data
-    Fem::ConstraintPulley* pcConstraint =
-        static_cast<Fem::ConstraintPulley*>(ConstraintView->getObject());
+    Fem::ConstraintPulley* pcConstraint = ConstraintView->getObject<Fem::ConstraintPulley>();
     double otherdia = pcConstraint->OtherDiameter.getValue();
     double centerdist = pcConstraint->CenterDistance.getValue();
     bool isdriven = pcConstraint->IsDriven.getValue();
@@ -110,29 +109,25 @@ TaskFemConstraintPulley::TaskFemConstraintPulley(ViewProviderFemConstraintPulley
 
 void TaskFemConstraintPulley::onOtherDiameterChanged(double l)
 {
-    Fem::ConstraintPulley* pcConstraint =
-        static_cast<Fem::ConstraintPulley*>(ConstraintView->getObject());
+    Fem::ConstraintPulley* pcConstraint = ConstraintView->getObject<Fem::ConstraintPulley>();
     pcConstraint->OtherDiameter.setValue(l);
 }
 
 void TaskFemConstraintPulley::onCenterDistanceChanged(double l)
 {
-    Fem::ConstraintPulley* pcConstraint =
-        static_cast<Fem::ConstraintPulley*>(ConstraintView->getObject());
+    Fem::ConstraintPulley* pcConstraint = ConstraintView->getObject<Fem::ConstraintPulley>();
     pcConstraint->CenterDistance.setValue(l);
 }
 
 void TaskFemConstraintPulley::onTensionForceChanged(double force)
 {
-    Fem::ConstraintPulley* pcConstraint =
-        static_cast<Fem::ConstraintPulley*>(ConstraintView->getObject());
+    Fem::ConstraintPulley* pcConstraint = ConstraintView->getObject<Fem::ConstraintPulley>();
     pcConstraint->TensionForce.setValue(force);
 }
 
 void TaskFemConstraintPulley::onCheckIsDriven(const bool pressed)
 {
-    Fem::ConstraintPulley* pcConstraint =
-        static_cast<Fem::ConstraintPulley*>(ConstraintView->getObject());
+    Fem::ConstraintPulley* pcConstraint = ConstraintView->getObject<Fem::ConstraintPulley>();
     pcConstraint->IsDriven.setValue(pressed);
 }
 

--- a/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintRigidBody.cpp
@@ -109,7 +109,7 @@ TaskFemConstraintRigidBody::TaskFemConstraintRigidBody(
 
     /* Note: */
     // Get the feature data
-    auto pcConstraint = static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject());
+    auto pcConstraint = ConstraintView->getObject<Fem::ConstraintRigidBody>();
 
     const Base::Vector3d& refNode = pcConstraint->ReferenceNode.getValue();
     const Base::Vector3d& disp = pcConstraint->Displacement.getValue();
@@ -273,8 +273,7 @@ void TaskFemConstraintRigidBody::addToSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintRigidBody* pcConstraint =
-        static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject());
+    Fem::ConstraintRigidBody* pcConstraint = ConstraintView->getObject<Fem::ConstraintRigidBody>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -347,8 +346,7 @@ void TaskFemConstraintRigidBody::removeFromSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintRigidBody* pcConstraint =
-        static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject());
+    Fem::ConstraintRigidBody* pcConstraint = ConstraintView->getObject<Fem::ConstraintRigidBody>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;
@@ -405,7 +403,7 @@ void TaskFemConstraintRigidBody::onReferenceDeleted()
 
 void TaskFemConstraintRigidBody::onRotModeXChanged(int item)
 {
-    const char* val = static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject())
+    const char* val = ConstraintView->getObject<Fem::ConstraintRigidBody>()
                           ->RotationalModeX.getEnumVector()[item]
                           .c_str();
 
@@ -424,7 +422,7 @@ void TaskFemConstraintRigidBody::onRotModeXChanged(int item)
 }
 void TaskFemConstraintRigidBody::onRotModeYChanged(int item)
 {
-    const char* val = static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject())
+    const char* val = ConstraintView->getObject<Fem::ConstraintRigidBody>()
                           ->RotationalModeY.getEnumVector()[item]
                           .c_str();
 
@@ -443,7 +441,7 @@ void TaskFemConstraintRigidBody::onRotModeYChanged(int item)
 }
 void TaskFemConstraintRigidBody::onRotModeZChanged(int item)
 {
-    const char* val = static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject())
+    const char* val = ConstraintView->getObject<Fem::ConstraintRigidBody>()
                           ->RotationalModeZ.getEnumVector()[item]
                           .c_str();
 
@@ -463,7 +461,7 @@ void TaskFemConstraintRigidBody::onRotModeZChanged(int item)
 
 void TaskFemConstraintRigidBody::onTransModeXChanged(int item)
 {
-    const char* val = static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject())
+    const char* val = ConstraintView->getObject<Fem::ConstraintRigidBody>()
                           ->TranslationalModeX.getEnumVector()[item]
                           .c_str();
 
@@ -482,7 +480,7 @@ void TaskFemConstraintRigidBody::onTransModeXChanged(int item)
 }
 void TaskFemConstraintRigidBody::onTransModeYChanged(int item)
 {
-    const char* val = static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject())
+    const char* val = ConstraintView->getObject<Fem::ConstraintRigidBody>()
                           ->TranslationalModeY.getEnumVector()[item]
                           .c_str();
 
@@ -501,7 +499,7 @@ void TaskFemConstraintRigidBody::onTransModeYChanged(int item)
 }
 void TaskFemConstraintRigidBody::onTransModeZChanged(int item)
 {
-    const char* val = static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject())
+    const char* val = ConstraintView->getObject<Fem::ConstraintRigidBody>()
                           ->TranslationalModeZ.getEnumVector()[item]
                           .c_str();
 
@@ -521,7 +519,7 @@ void TaskFemConstraintRigidBody::onTransModeZChanged(int item)
 
 void TaskFemConstraintRigidBody::onRefNodeXChanged(double value)
 {
-    auto obj = static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject());
+    auto obj = ConstraintView->getObject<Fem::ConstraintRigidBody>();
     Base::Vector3d refNode = obj->ReferenceNode.getValue();
     refNode.x = value;
     obj->ReferenceNode.setValue(refNode);
@@ -529,7 +527,7 @@ void TaskFemConstraintRigidBody::onRefNodeXChanged(double value)
 
 void TaskFemConstraintRigidBody::onRefNodeYChanged(double value)
 {
-    auto obj = static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject());
+    auto obj = ConstraintView->getObject<Fem::ConstraintRigidBody>();
     Base::Vector3d refNode = obj->ReferenceNode.getValue();
     refNode.y = value;
     obj->ReferenceNode.setValue(refNode);
@@ -537,7 +535,7 @@ void TaskFemConstraintRigidBody::onRefNodeYChanged(double value)
 
 void TaskFemConstraintRigidBody::onRefNodeZChanged(double value)
 {
-    auto obj = static_cast<Fem::ConstraintRigidBody*>(ConstraintView->getObject());
+    auto obj = ConstraintView->getObject<Fem::ConstraintRigidBody>();
     Base::Vector3d refNode = obj->ReferenceNode.getValue();
     refNode.z = value;
     obj->ReferenceNode.setValue(refNode);

--- a/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintSpring.cpp
@@ -69,8 +69,7 @@ TaskFemConstraintSpring::TaskFemConstraintSpring(ViewProviderFemConstraintSpring
 
     /* Note: */
     // Get the feature data
-    Fem::ConstraintSpring* pcConstraint =
-        static_cast<Fem::ConstraintSpring*>(ConstraintView->getObject());
+    Fem::ConstraintSpring* pcConstraint = ConstraintView->getObject<Fem::ConstraintSpring>();
 
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
@@ -130,8 +129,7 @@ void TaskFemConstraintSpring::addToSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintSpring* pcConstraint =
-        static_cast<Fem::ConstraintSpring*>(ConstraintView->getObject());
+    Fem::ConstraintSpring* pcConstraint = ConstraintView->getObject<Fem::ConstraintSpring>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -185,8 +183,7 @@ void TaskFemConstraintSpring::removeFromSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintSpring* pcConstraint =
-        static_cast<Fem::ConstraintSpring*>(ConstraintView->getObject());
+    Fem::ConstraintSpring* pcConstraint = ConstraintView->getObject<Fem::ConstraintSpring>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;

--- a/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTemperature.cpp
@@ -61,7 +61,7 @@ TaskFemConstraintTemperature::TaskFemConstraintTemperature(
 
     // Get the feature data
     Fem::ConstraintTemperature* pcConstraint =
-        static_cast<Fem::ConstraintTemperature*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintTemperature>();
 
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
@@ -164,7 +164,7 @@ void TaskFemConstraintTemperature::onCFluxChanged(double)
 
 void TaskFemConstraintTemperature::onConstrTypeChanged(int item)
 {
-    auto obj = static_cast<Fem::ConstraintTemperature*>(ConstraintView->getObject());
+    auto obj = ConstraintView->getObject<Fem::ConstraintTemperature>();
     obj->ConstraintType.setValue(item);
     const char* type = obj->ConstraintType.getValueAsString();
     if (strcmp(type, "Temperature") == 0) {
@@ -190,7 +190,7 @@ void TaskFemConstraintTemperature::addToSelection()
         return;
     }
     Fem::ConstraintTemperature* pcConstraint =
-        static_cast<Fem::ConstraintTemperature*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintTemperature>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -241,7 +241,7 @@ void TaskFemConstraintTemperature::removeFromSelection()
         return;
     }
     Fem::ConstraintTemperature* pcConstraint =
-        static_cast<Fem::ConstraintTemperature*>(ConstraintView->getObject());
+        ConstraintView->getObject<Fem::ConstraintTemperature>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;

--- a/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraintTransform.cpp
@@ -106,8 +106,7 @@ TaskFemConstraintTransform::TaskFemConstraintTransform(
             &TaskFemConstraintTransform::angleChanged);
 
     // Get the feature data
-    Fem::ConstraintTransform* pcConstraint =
-        static_cast<Fem::ConstraintTransform*>(ConstraintView->getObject());
+    Fem::ConstraintTransform* pcConstraint = ConstraintView->getObject<Fem::ConstraintTransform>();
 
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
@@ -155,11 +154,10 @@ TaskFemConstraintTransform::TaskFemConstraintTransform(
     ui->lw_Rect->clear();
 
     // Transformable surfaces
-    Gui::Command::doCommand(
-        Gui::Command::Doc,
-        TaskFemConstraintTransform::getSurfaceReferences(
-            (static_cast<Fem::Constraint*>(ConstraintView->getObject()))->getNameInDocument())
-            .c_str());
+    Gui::Command::doCommand(Gui::Command::Doc,
+                            TaskFemConstraintTransform::getSurfaceReferences(
+                                (ConstraintView->getObject<Fem::Constraint>())->getNameInDocument())
+                                .c_str());
     std::vector<App::DocumentObject*> ObjDispl = pcConstraint->RefDispl.getValues();
     std::vector<std::string> SubElemDispl = pcConstraint->RefDispl.getSubValues();
 
@@ -226,8 +224,7 @@ void TaskFemConstraintTransform::xAxisChanged(double x)
 {
     (void)x;
     Base::Rotation rot = getRotation();
-    Fem::ConstraintTransform* pcConstraint =
-        static_cast<Fem::ConstraintTransform*>(ConstraintView->getObject());
+    Fem::ConstraintTransform* pcConstraint = ConstraintView->getObject<Fem::ConstraintTransform>();
     pcConstraint->Rotation.setValue(rot);
 }
 
@@ -235,8 +232,7 @@ void TaskFemConstraintTransform::yAxisChanged(double y)
 {
     (void)y;
     Base::Rotation rot = getRotation();
-    Fem::ConstraintTransform* pcConstraint =
-        static_cast<Fem::ConstraintTransform*>(ConstraintView->getObject());
+    Fem::ConstraintTransform* pcConstraint = ConstraintView->getObject<Fem::ConstraintTransform>();
     pcConstraint->Rotation.setValue(rot);
 }
 
@@ -244,8 +240,7 @@ void TaskFemConstraintTransform::zAxisChanged(double z)
 {
     (void)z;
     Base::Rotation rot = getRotation();
-    Fem::ConstraintTransform* pcConstraint =
-        static_cast<Fem::ConstraintTransform*>(ConstraintView->getObject());
+    Fem::ConstraintTransform* pcConstraint = ConstraintView->getObject<Fem::ConstraintTransform>();
     pcConstraint->Rotation.setValue(rot);
 }
 
@@ -253,8 +248,7 @@ void TaskFemConstraintTransform::angleChanged(double a)
 {
     (void)a;
     Base::Rotation rot = getRotation();
-    Fem::ConstraintTransform* pcConstraint =
-        static_cast<Fem::ConstraintTransform*>(ConstraintView->getObject());
+    Fem::ConstraintTransform* pcConstraint = ConstraintView->getObject<Fem::ConstraintTransform>();
     pcConstraint->Rotation.setValue(rot);
 }
 
@@ -266,8 +260,7 @@ void TaskFemConstraintTransform::Rect()
                             "App.ActiveDocument.%s.TransformType = %s",
                             name.c_str(),
                             get_transform_type().c_str());
-    Fem::ConstraintTransform* pcConstraint =
-        static_cast<Fem::ConstraintTransform*>(ConstraintView->getObject());
+    Fem::ConstraintTransform* pcConstraint = ConstraintView->getObject<Fem::ConstraintTransform>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     if (!Objects.empty()) {
         setSelection(ui->lw_Rect->item(0));
@@ -283,8 +276,7 @@ void TaskFemConstraintTransform::Cyl()
                             "App.ActiveDocument.%s.TransformType = %s",
                             name.c_str(),
                             get_transform_type().c_str());
-    Fem::ConstraintTransform* pcConstraint =
-        static_cast<Fem::ConstraintTransform*>(ConstraintView->getObject());
+    Fem::ConstraintTransform* pcConstraint = ConstraintView->getObject<Fem::ConstraintTransform>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     if (!Objects.empty()) {
         setSelection(ui->lw_Rect->item(0));
@@ -318,8 +310,7 @@ void TaskFemConstraintTransform::addToSelection()
         return;
     }
 
-    Fem::ConstraintTransform* pcConstraint =
-        static_cast<Fem::ConstraintTransform*>(ConstraintView->getObject());
+    Fem::ConstraintTransform* pcConstraint = ConstraintView->getObject<Fem::ConstraintTransform>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
 
@@ -428,8 +419,7 @@ void TaskFemConstraintTransform::removeFromSelection()
         QMessageBox::warning(this, tr("Selection error"), tr("Nothing selected!"));
         return;
     }
-    Fem::ConstraintTransform* pcConstraint =
-        static_cast<Fem::ConstraintTransform*>(ConstraintView->getObject());
+    Fem::ConstraintTransform* pcConstraint = ConstraintView->getObject<Fem::ConstraintTransform>();
     std::vector<App::DocumentObject*> Objects = pcConstraint->References.getValues();
     std::vector<std::string> SubElements = pcConstraint->References.getSubValues();
     std::vector<size_t> itemsToDel;

--- a/src/Mod/Fem/Gui/TaskPostBoxes.cpp
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.cpp
@@ -512,29 +512,26 @@ TaskPostDataAlongLine::TaskPostDataAlongLine(ViewProviderFemPostDataAlongLine* v
     ui->point2Y->setDecimals(UserDecimals);
     ui->point2Z->setDecimals(UserDecimals);
 
-    Base::Unit lengthUnit =
-        static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Point1.getUnit();
+    Base::Unit lengthUnit = getObject<Fem::FemPostDataAlongLineFilter>()->Point1.getUnit();
     ui->point1X->setUnit(lengthUnit);
     ui->point1Y->setUnit(lengthUnit);
     ui->point1Z->setUnit(lengthUnit);
-    lengthUnit = static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Point2.getUnit();
+    lengthUnit = getObject<Fem::FemPostDataAlongLineFilter>()->Point2.getUnit();
     ui->point2X->setUnit(lengthUnit);
     ui->point2Y->setUnit(lengthUnit);
     ui->point2Z->setUnit(lengthUnit);
 
-    const Base::Vector3d& vec1 =
-        static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Point1.getValue();
+    const Base::Vector3d& vec1 = getObject<Fem::FemPostDataAlongLineFilter>()->Point1.getValue();
     ui->point1X->setValue(vec1.x);
     ui->point1Y->setValue(vec1.y);
     ui->point1Z->setValue(vec1.z);
 
-    const Base::Vector3d& vec2 =
-        static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Point2.getValue();
+    const Base::Vector3d& vec2 = getObject<Fem::FemPostDataAlongLineFilter>()->Point2.getValue();
     ui->point2X->setValue(vec2.x);
     ui->point2Y->setValue(vec2.y);
     ui->point2Z->setValue(vec2.z);
 
-    int res = static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Resolution.getValue();
+    int res = getObject<Fem::FemPostDataAlongLineFilter>()->Resolution.getValue();
     ui->resolution->setValue(res);
 
     setupConnectionsStep2();
@@ -649,7 +646,7 @@ void TaskPostDataAlongLine::onSelectPointsClicked()
         if (!marker) {
             // Derives from QObject and we have a parent object, so we don't
             // require a delete.
-            auto obj = static_cast<Fem::FemPostDataAlongLineFilter*>(getObject());
+            auto obj = getObject<Fem::FemPostDataAlongLineFilter>();
             marker = new DataAlongLineMarker(viewer, obj);
             marker->setParent(this);
         }
@@ -755,7 +752,7 @@ void TaskPostDataAlongLine::point1Changed(double)
         auto currentField = getTypedView<ViewProviderFemPostObject>()->Field.getValue();
         getTypedView<ViewProviderFemPostObject>()->Field.setValue(currentField);
         // also the axis data must be refreshed to get correct plots
-        static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->GetAxisData();
+        getObject<Fem::FemPostDataAlongLineFilter>()->GetAxisData();
     }
     catch (const Base::Exception& e) {
         e.ReportException();
@@ -786,7 +783,7 @@ void TaskPostDataAlongLine::point2Changed(double)
         auto currentField = getTypedView<ViewProviderFemPostObject>()->Field.getValue();
         getTypedView<ViewProviderFemPostObject>()->Field.setValue(currentField);
         // also the axis data must be refreshed to get correct plots
-        static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->GetAxisData();
+        getObject<Fem::FemPostDataAlongLineFilter>()->GetAxisData();
     }
     catch (const Base::Exception& e) {
         e.what();
@@ -795,11 +792,11 @@ void TaskPostDataAlongLine::point2Changed(double)
 
 void TaskPostDataAlongLine::resolutionChanged(int val)
 {
-    static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->Resolution.setValue(val);
+    getObject<Fem::FemPostDataAlongLineFilter>()->Resolution.setValue(val);
     // recompute the feature
     getObject()->recomputeFeature();
     // axis data must be refreshed
-    static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->GetAxisData();
+    getObject<Fem::FemPostDataAlongLineFilter>()->GetAxisData();
     // eventually a full recompute is necessary
     getView()->getObject()->getDocument()->recompute();
 }
@@ -853,23 +850,23 @@ void TaskPostDataAlongLine::onFieldActivated(int i)
 {
     getTypedView<ViewProviderFemPostObject>()->Field.setValue(i);
     std::string FieldName = ui->Field->currentText().toStdString();
-    static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->PlotData.setValue(FieldName);
+    getObject<Fem::FemPostDataAlongLineFilter>()->PlotData.setValue(FieldName);
     updateEnumerationList(getTypedView<ViewProviderFemPostObject>()->VectorMode, ui->VectorMode);
 
     auto vecMode = static_cast<ViewProviderFemPostObject*>(getView())->VectorMode.getEnum();
-    static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->PlotDataComponent.setValue(vecMode);
+    getObject<Fem::FemPostDataAlongLineFilter>()->PlotDataComponent.setValue(vecMode);
 }
 
 void TaskPostDataAlongLine::onVectorModeActivated(int i)
 {
     getTypedView<ViewProviderFemPostObject>()->VectorMode.setValue(i);
     int comp = ui->VectorMode->currentIndex();
-    static_cast<Fem::FemPostDataAlongLineFilter*>(getObject())->PlotDataComponent.setValue(comp);
+    getObject<Fem::FemPostDataAlongLineFilter>()->PlotDataComponent.setValue(comp);
 }
 
 std::string TaskPostDataAlongLine::Plot()
 {
-    auto obj = static_cast<Fem::FemPostDataAlongLineFilter*>(getObject());
+    auto obj = getObject<Fem::FemPostDataAlongLineFilter>();
     std::string yLabel;
     // if there is only one component, it is the magnitude
     if (obj->PlotDataComponent.getEnum().maxValue() < 1) {
@@ -932,14 +929,12 @@ TaskPostDataAtPoint::TaskPostDataAtPoint(ViewProviderFemPostDataAtPoint* view, Q
     ui->centerY->setDecimals(UserDecimals);
     ui->centerZ->setDecimals(UserDecimals);
 
-    const Base::Unit lengthUnit =
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Center.getUnit();
+    const Base::Unit lengthUnit = getObject<Fem::FemPostDataAtPointFilter>()->Center.getUnit();
     ui->centerX->setUnit(lengthUnit);
     ui->centerY->setUnit(lengthUnit);
     ui->centerZ->setUnit(lengthUnit);
 
-    const Base::Vector3d& vec =
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Center.getValue();
+    const Base::Vector3d& vec = getObject<Fem::FemPostDataAtPointFilter>()->Center.getValue();
     ui->centerX->setValue(vec.x);
     ui->centerY->setValue(vec.y);
     ui->centerZ->setValue(vec.z);
@@ -948,9 +943,8 @@ TaskPostDataAtPoint::TaskPostDataAtPoint(ViewProviderFemPostDataAtPoint* view, Q
     updateEnumerationList(getTypedView<ViewProviderFemPostObject>()->Field, ui->Field);
 
     // read in point value
-    auto pointValue = static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->PointData[0];
-    showValue(pointValue,
-              static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.getValue());
+    auto pointValue = getObject<Fem::FemPostDataAtPointFilter>()->PointData[0];
+    showValue(pointValue, getObject<Fem::FemPostDataAtPointFilter>()->Unit.getValue());
 
     connect(ui->centerX,
             qOverload<double>(&Gui::QuantitySpinBox::valueChanged),
@@ -1120,11 +1114,11 @@ void TaskPostDataAtPoint::onFieldActivated(int i)
     std::string FieldName = ui->Field->currentText().toStdString();
     // there is no "None" for the FieldName property, thus return here
     if (FieldName == "None") {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("");
         ui->ValueAtPoint->clear();
         return;
     }
-    static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->FieldName.setValue(FieldName);
+    getObject<Fem::FemPostDataAtPointFilter>()->FieldName.setValue(FieldName);
 
     // Set the unit for the different known result types.
 
@@ -1137,51 +1131,51 @@ void TaskPostDataAtPoint::onFieldActivated(int i)
         || (FieldName == "Stress xy component") || (FieldName == "Stress xz component")
         || (FieldName == "Stress yy component") || (FieldName == "Stress yz component")
         || (FieldName == "Stress zz component")) {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("Pa");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("Pa");
     }
     // The Elmer names are different. If there are EigenModes, the names are unique for
     // every mode. Therefore we only check for the beginning of the name.
     else if ((FieldName.find("tresca", 0) == 0) || (FieldName.find("vonmises", 0) == 0)
              || (FieldName.find("stress_", 0) == 0)
              || (FieldName.find("principal stress", 0) == 0)) {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("Pa");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("Pa");
     }
     else if ((FieldName == "current density") || (FieldName == "current density re")
              || (FieldName == "current density im") || (FieldName == "current density abs")) {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("A/m^2");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("A/m^2");
     }
     else if ((FieldName == "Displacement") || (FieldName == "Displacement Magnitude")
              || (FieldName.find("displacement", 0) == 0)) {  // Elmer name
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("m");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("m");
     }
     else if (FieldName == "electric energy density") {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("J/m^3");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("J/m^3");
     }
     else if ((FieldName == "electric field") || (FieldName == "electric field re")
              || (FieldName == "electric field im") || (FieldName == "electric field abs")) {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("V/m");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("V/m");
     }
     else if (FieldName == "electric flux") {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("A*s/m^2");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("A*s/m^2");
     }
     else if (FieldName == "electric force density") {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("N/m^2");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("N/m^2");
     }
     else if ((FieldName == "harmonic loss linear") || (FieldName == "harmonic loss quadratic")) {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("W");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("W");
     }
     else if ((FieldName == "joule heating") || (FieldName == "nodal joule heating")) {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("J");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("J");
     }
     else if ((FieldName == "magnetic field strength") || (FieldName == "magnetic field strength re")
              || (FieldName == "magnetic field strength im")
              || (FieldName == "magnetic field strength abs")) {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("A/m");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("A/m");
     }
     else if ((FieldName == "magnetic flux density") || (FieldName == "magnetic flux density re")
              || (FieldName == "magnetic flux density im")
              || (FieldName == "magnetic flux density abs")) {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("T");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("T");
     }
     else if ((FieldName == "maxwell stress 1") || (FieldName == "maxwell stress 2")
              || (FieldName == "maxwell stress 3") || (FieldName == "maxwell stress 4")
@@ -1192,41 +1186,40 @@ void TaskPostDataAtPoint::onFieldActivated(int i)
              || (FieldName == "maxwell stress im 1") || (FieldName == "maxwell stress im 2")
              || (FieldName == "maxwell stress im 3") || (FieldName == "maxwell stress im 4")
              || (FieldName == "maxwell stress im 5") || (FieldName == "maxwell stress im 6")) {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("As/m^3");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("As/m^3");
     }
     else if (FieldName == "nodal force") {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("N");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("N");
     }
     else if ((FieldName == "potential") || (FieldName == "potential re")
              || (FieldName == "potential im") || (FieldName == "potential abs")
              || (FieldName == "av") || (FieldName == "av re") || (FieldName == "av im")
              || (FieldName == "av abs")) {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("V");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("V");
     }
     else if (FieldName == "potential flux") {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("W/m^2");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("W/m^2");
     }
     // potential loads are in Coulomb: https://www.elmerfem.org/forum/viewtopic.php?t=7780
     else if (FieldName == "potential loads") {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("C");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("C");
     }
     else if (
         // CalculiX name
         FieldName == "Temperature" ||
         // Elmer name
         ((FieldName.find("temperature", 0) == 0) && (FieldName != "temperature flux"))) {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("K");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("K");
     }
     else if (FieldName == "temperature flux") {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("W/m^2");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("W/m^2");
     }
     else {
-        static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.setValue("");
+        getObject<Fem::FemPostDataAtPointFilter>()->Unit.setValue("");
     }
 
-    auto pointValue = static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->PointData[0];
-    showValue(pointValue,
-              static_cast<Fem::FemPostDataAtPointFilter*>(getObject())->Unit.getValue());
+    auto pointValue = getObject<Fem::FemPostDataAtPointFilter>()->PointData[0];
+    showValue(pointValue, getObject<Fem::FemPostDataAtPointFilter>()->Unit.getValue());
 }
 
 void TaskPostDataAtPoint::showValue(double pointValue, const char* unitStr)
@@ -1300,10 +1293,8 @@ TaskPostClip::TaskPostClip(ViewProviderFemPostClip* view,
     ui->CreateButton->setPopupMode(QToolButton::InstantPopup);
 
     // load the default values
-    ui->CutCells->setChecked(
-        static_cast<Fem::FemPostClipFilter*>(getObject())->CutCells.getValue());
-    ui->InsideOut->setChecked(
-        static_cast<Fem::FemPostClipFilter*>(getObject())->InsideOut.getValue());
+    ui->CutCells->setChecked(getObject<Fem::FemPostClipFilter>()->CutCells.getValue());
+    ui->InsideOut->setChecked(getObject<Fem::FemPostClipFilter>()->InsideOut.getValue());
 }
 
 TaskPostClip::~TaskPostClip() = default;
@@ -1338,7 +1329,7 @@ void TaskPostClip::collectImplicitFunctions()
             QStringList items;
             std::size_t currentItem = 0;
             App::DocumentObject* currentFunction =
-                static_cast<Fem::FemPostClipFilter*>(getObject())->Function.getValue();
+                getObject<Fem::FemPostClipFilter>()->Function.getValue();
             const std::vector<App::DocumentObject*>& funcs =
                 static_cast<Fem::FemPostFunctionProvider*>(pipeline->Functions.getValue())
                     ->Functions.getValues();
@@ -1388,17 +1379,17 @@ void TaskPostClip::onFunctionBoxCurrentIndexChanged(int idx)
                 static_cast<Fem::FemPostFunctionProvider*>(pipeline->Functions.getValue())
                     ->Functions.getValues();
             if (idx >= 0) {
-                static_cast<Fem::FemPostClipFilter*>(getObject())->Function.setValue(funcs[idx]);
+                getObject<Fem::FemPostClipFilter>()->Function.setValue(funcs[idx]);
             }
             else {
-                static_cast<Fem::FemPostClipFilter*>(getObject())->Function.setValue(nullptr);
+                getObject<Fem::FemPostClipFilter>()->Function.setValue(nullptr);
             }
         }
     }
 
     // load the correct view
     Fem::FemPostFunction* fobj = static_cast<Fem::FemPostFunction*>(
-        static_cast<Fem::FemPostClipFilter*>(getObject())->Function.getValue());
+        getObject<Fem::FemPostClipFilter>()->Function.getValue());
     Gui::ViewProvider* view = nullptr;
     if (fobj) {
         view = Gui::Application::Instance->getViewProvider(fobj);
@@ -1419,13 +1410,13 @@ void TaskPostClip::onFunctionBoxCurrentIndexChanged(int idx)
 
 void TaskPostClip::onCutCellsToggled(bool val)
 {
-    static_cast<Fem::FemPostClipFilter*>(getObject())->CutCells.setValue(val);
+    getObject<Fem::FemPostClipFilter>()->CutCells.setValue(val);
     recompute();
 }
 
 void TaskPostClip::onInsideOutToggled(bool val)
 {
-    static_cast<Fem::FemPostClipFilter*>(getObject())->InsideOut.setValue(val);
+    getObject<Fem::FemPostClipFilter>()->InsideOut.setValue(val);
     recompute();
 }
 
@@ -1449,13 +1440,13 @@ TaskPostContours::TaskPostContours(ViewProviderFemPostContours* view, QWidget* p
     updateEnumerationList(getTypedObject<Fem::FemPostContoursFilter>()->Field, ui->fieldsCB);
     updateEnumerationList(getTypedObject<Fem::FemPostContoursFilter>()->VectorMode, ui->vectorsCB);
     // for a new filter, initialize the coloring
-    auto colorState = static_cast<Fem::FemPostContoursFilter*>(getObject())->NoColor.getValue();
+    auto colorState = getObject<Fem::FemPostContoursFilter>()->NoColor.getValue();
     if (!colorState && getTypedView<ViewProviderFemPostObject>()->Field.getValue() == 0) {
         getTypedView<ViewProviderFemPostObject>()->Field.setValue(1);
     }
 
     ui->numberContoursSB->setValue(
-        static_cast<Fem::FemPostContoursFilter*>(getObject())->NumberOfContours.getValue());
+        getObject<Fem::FemPostContoursFilter>()->NumberOfContours.getValue());
     ui->noColorCB->setChecked(colorState);
 
     // connect
@@ -1483,7 +1474,7 @@ void TaskPostContours::updateFields()
 {
     // update the ViewProvider Field
     // since the ViewProvider can have another field sorting, we cannot use the same index
-    if (!static_cast<Fem::FemPostContoursFilter*>(getObject())->NoColor.getValue()) {
+    if (!getObject<Fem::FemPostContoursFilter>()->NoColor.getValue()) {
         std::string objectField =
             getTypedObject<Fem::FemPostContoursFilter>()->Field.getValueAsString();
         getTypedView<ViewProviderFemPostObject>()->Field.setValue(objectField.c_str());
@@ -1495,7 +1486,7 @@ void TaskPostContours::updateFields()
 
 void TaskPostContours::onFieldsChanged(int idx)
 {
-    static_cast<Fem::FemPostContoursFilter*>(getObject())->Field.setValue(idx);
+    getObject<Fem::FemPostContoursFilter>()->Field.setValue(idx);
 
     blockVectorUpdate = true;
     updateEnumerationList(getTypedObject<Fem::FemPostContoursFilter>()->VectorMode, ui->vectorsCB);
@@ -1508,7 +1499,7 @@ void TaskPostContours::onFieldsChanged(int idx)
 
     // since a new field can be e.g. no vector while the previous one was,
     // we must also update the VectorMode
-    if (!static_cast<Fem::FemPostContoursFilter*>(getObject())->NoColor.getValue()) {
+    if (!getObject<Fem::FemPostContoursFilter>()->NoColor.getValue()) {
         auto newMode = getTypedObject<Fem::FemPostContoursFilter>()->VectorMode.getValue();
         getTypedView<ViewProviderFemPostObject>()->VectorMode.setValue(newMode);
     }
@@ -1516,7 +1507,7 @@ void TaskPostContours::onFieldsChanged(int idx)
 
 void TaskPostContours::onVectorModeChanged(int idx)
 {
-    static_cast<Fem::FemPostContoursFilter*>(getObject())->VectorMode.setValue(idx);
+    getObject<Fem::FemPostContoursFilter>()->VectorMode.setValue(idx);
     recompute();
     if (!blockVectorUpdate) {
         // we can have the case that the previous field had VectorMode "Z" but
@@ -1525,7 +1516,7 @@ void TaskPostContours::onVectorModeChanged(int idx)
         // first to get the possible VectorModes of that field
         updateFields();
         // now we can set the VectorMode
-        if (!static_cast<Fem::FemPostContoursFilter*>(getObject())->NoColor.getValue()) {
+        if (!getObject<Fem::FemPostContoursFilter>()->NoColor.getValue()) {
             getTypedView<ViewProviderFemPostObject>()->VectorMode.setValue(idx);
         }
     }
@@ -1533,13 +1524,13 @@ void TaskPostContours::onVectorModeChanged(int idx)
 
 void TaskPostContours::onNumberOfContoursChanged(int number)
 {
-    static_cast<Fem::FemPostContoursFilter*>(getObject())->NumberOfContours.setValue(number);
+    getObject<Fem::FemPostContoursFilter>()->NumberOfContours.setValue(number);
     recompute();
 }
 
 void TaskPostContours::onNoColorChanged(bool state)
 {
-    static_cast<Fem::FemPostContoursFilter*>(getObject())->NoColor.setValue(state);
+    getObject<Fem::FemPostContoursFilter>()->NoColor.setValue(state);
     if (state) {
         // no color
         getTypedView<ViewProviderFemPostObject>()->Field.setValue(long(0));
@@ -1621,7 +1612,7 @@ void TaskPostCut::collectImplicitFunctions()
             QStringList items;
             std::size_t currentItem = 0;
             App::DocumentObject* currentFunction =
-                static_cast<Fem::FemPostClipFilter*>(getObject())->Function.getValue();
+                getObject<Fem::FemPostClipFilter>()->Function.getValue();
             const std::vector<App::DocumentObject*>& funcs =
                 static_cast<Fem::FemPostFunctionProvider*>(pipeline->Functions.getValue())
                     ->Functions.getValues();
@@ -1671,17 +1662,17 @@ void TaskPostCut::onFunctionBoxCurrentIndexChanged(int idx)
                 static_cast<Fem::FemPostFunctionProvider*>(pipeline->Functions.getValue())
                     ->Functions.getValues();
             if (idx >= 0) {
-                static_cast<Fem::FemPostCutFilter*>(getObject())->Function.setValue(funcs[idx]);
+                getObject<Fem::FemPostCutFilter>()->Function.setValue(funcs[idx]);
             }
             else {
-                static_cast<Fem::FemPostCutFilter*>(getObject())->Function.setValue(nullptr);
+                getObject<Fem::FemPostCutFilter>()->Function.setValue(nullptr);
             }
         }
     }
 
     // load the correct view
-    Fem::FemPostFunction* fobj = static_cast<Fem::FemPostFunction*>(
-        static_cast<Fem::FemPostCutFilter*>(getObject())->Function.getValue());
+    Fem::FemPostFunction* fobj =
+        static_cast<Fem::FemPostFunction*>(getObject<Fem::FemPostCutFilter>()->Function.getValue());
     Gui::ViewProvider* view = nullptr;
     if (fobj) {
         view = Gui::Application::Instance->getViewProvider(fobj);
@@ -1718,10 +1709,8 @@ TaskPostScalarClip::TaskPostScalarClip(ViewProviderFemPostScalarClip* view, QWid
 
     // load the default values
     updateEnumerationList(getTypedObject<Fem::FemPostScalarClipFilter>()->Scalars, ui->Scalar);
-    ui->InsideOut->setChecked(
-        static_cast<Fem::FemPostScalarClipFilter*>(getObject())->InsideOut.getValue());
-    App::PropertyFloatConstraint& scalar_prop =
-        static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
+    ui->InsideOut->setChecked(getObject<Fem::FemPostScalarClipFilter>()->InsideOut.getValue());
+    App::PropertyFloatConstraint& scalar_prop = getObject<Fem::FemPostScalarClipFilter>()->Value;
     double scalar_factor = scalar_prop.getValue();
 
     // set spinbox scalar_factor, don't forget to sync the slider
@@ -1767,12 +1756,11 @@ void TaskPostScalarClip::applyPythonCode()
 
 void TaskPostScalarClip::onScalarCurrentIndexChanged(int idx)
 {
-    static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Scalars.setValue(idx);
+    getObject<Fem::FemPostScalarClipFilter>()->Scalars.setValue(idx);
     recompute();
 
     // update constraints and values
-    App::PropertyFloatConstraint& scalar_prop =
-        static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
+    App::PropertyFloatConstraint& scalar_prop = getObject<Fem::FemPostScalarClipFilter>()->Value;
     double scalar_factor = scalar_prop.getValue();
     double min = scalar_prop.getConstraints()->LowerBound;
     double max = scalar_prop.getConstraints()->UpperBound;
@@ -1794,8 +1782,7 @@ void TaskPostScalarClip::onScalarCurrentIndexChanged(int idx)
 
 void TaskPostScalarClip::onSliderValueChanged(int v)
 {
-    App::PropertyFloatConstraint& value =
-        static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
+    App::PropertyFloatConstraint& value = getObject<Fem::FemPostScalarClipFilter>()->Value;
     double val = value.getConstraints()->LowerBound * (1 - double(v) / 100.)
         + double(v) / 100. * value.getConstraints()->UpperBound;
 
@@ -1810,8 +1797,7 @@ void TaskPostScalarClip::onSliderValueChanged(int v)
 
 void TaskPostScalarClip::onValueValueChanged(double v)
 {
-    App::PropertyFloatConstraint& value =
-        static_cast<Fem::FemPostScalarClipFilter*>(getObject())->Value;
+    App::PropertyFloatConstraint& value = getObject<Fem::FemPostScalarClipFilter>()->Value;
     value.setValue(v);
     recompute();
 
@@ -1826,7 +1812,7 @@ void TaskPostScalarClip::onValueValueChanged(double v)
 
 void TaskPostScalarClip::onInsideOutToggled(bool val)
 {
-    static_cast<Fem::FemPostScalarClipFilter*>(getObject())->InsideOut.setValue(val);
+    getObject<Fem::FemPostScalarClipFilter>()->InsideOut.setValue(val);
     recompute();
 }
 
@@ -1848,7 +1834,7 @@ TaskPostWarpVector::TaskPostWarpVector(ViewProviderFemPostWarpVector* view, QWid
 
     // load the default values for warp display
     updateEnumerationList(getTypedObject<Fem::FemPostWarpVectorFilter>()->Vector, ui->Vector);
-    double warp_factor = static_cast<Fem::FemPostWarpVectorFilter*>(getObject())
+    double warp_factor = getObject<Fem::FemPostWarpVectorFilter>()
                              ->Factor.getValue();  // get the standard warp factor
 
     // set spinbox warp_factor, don't forget to sync the slider
@@ -1910,7 +1896,7 @@ void TaskPostWarpVector::applyPythonCode()
 void TaskPostWarpVector::onVectorCurrentIndexChanged(int idx)
 {
     // combobox to choose the result to warp
-    static_cast<Fem::FemPostWarpVectorFilter*>(getObject())->Vector.setValue(idx);
+    getObject<Fem::FemPostWarpVectorFilter>()->Vector.setValue(idx);
     recompute();
 }
 
@@ -1925,7 +1911,7 @@ void TaskPostWarpVector::onSliderValueChanged(int slider_value)
     //
     double warp_factor =
         ui->Min->value() + ((ui->Max->value() - ui->Min->value()) / 100.) * slider_value;
-    static_cast<Fem::FemPostWarpVectorFilter*>(getObject())->Factor.setValue(warp_factor);
+    getObject<Fem::FemPostWarpVectorFilter>()->Factor.setValue(warp_factor);
     recompute();
 
     // sync the spinbox
@@ -1941,7 +1927,7 @@ void TaskPostWarpVector::onValueValueChanged(double warp_factor)
 
     // TODO warp factor should not be smaller than min and greater than max,
     // but problems on automate change of warp_factor, see on_Max_valueChanged
-    static_cast<Fem::FemPostWarpVectorFilter*>(getObject())->Factor.setValue(warp_factor);
+    getObject<Fem::FemPostWarpVectorFilter>()->Factor.setValue(warp_factor);
     recompute();
 
     // sync the slider, see above for formula
@@ -1973,7 +1959,7 @@ void TaskPostWarpVector::onMaxValueChanged(double)
     // set warp factor to max, if warp factor > max
     if (ui->Value->value() > ui->Max->value()) {
         double warp_factor = ui->Max->value();
-        static_cast<Fem::FemPostWarpVectorFilter*>(getObject())->Factor.setValue(warp_factor);
+        getObject<Fem::FemPostWarpVectorFilter>()->Factor.setValue(warp_factor);
         recompute();
 
         // sync the slider, see above for formula

--- a/src/Mod/Fem/Gui/TaskPostBoxes.h
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.h
@@ -78,6 +78,11 @@ public:
     void setPoint(int idx, const SbVec3f& pt) const;
     Gui::View3DInventorViewer* getView() const;
     App::DocumentObject* getObject() const;
+    template<class T>
+    T* getObject() const
+    {
+        return Base::freecad_dynamic_cast<T>(getObject());
+    }
     QMetaObject::Connection connSelectPoint;
 
 protected:
@@ -145,6 +150,11 @@ protected:
     App::DocumentObject* getObject() const
     {
         return *m_object;
+    }
+    template<class T>
+    T* getObject() const
+    {
+        return Base::freecad_dynamic_cast<T>(getObject());
     }
     template<typename T>
     T* getTypedObject() const

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -199,7 +199,7 @@ bool ViewProviderFemAnalysis::setEdit(int ModNum)
         //            Gui::Control().showDialog(padDlg);
         //        else
 
-        // Fem::FemAnalysis* pcAna = static_cast<Fem::FemAnalysis*>(this->getObject());
+        // Fem::FemAnalysis* pcAna = this->getObject<Fem::FemAnalysis>();
         // Gui::Control().showDialog(new TaskDlgAnalysis(pcAna));
         // return true;
         return false;

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraint.cpp
@@ -170,7 +170,7 @@ void ViewProviderFemConstraint::onChanged(const App::Property* prop)
 
 void ViewProviderFemConstraint::updateData(const App::Property* prop)
 {
-    auto pcConstraint = static_cast<const Fem::Constraint*>(this->getObject());
+    auto pcConstraint = this->getObject<const Fem::Constraint>();
 
     if (prop == &pcConstraint->Points || prop == &pcConstraint->Normals
         || prop == &pcConstraint->Scale) {
@@ -202,7 +202,7 @@ void ViewProviderFemConstraint::handleChangedPropertyName(Base::XMLReader& reade
 
 void ViewProviderFemConstraint::updateSymbol()
 {
-    auto obj = static_cast<const Fem::Constraint*>(this->getObject());
+    auto obj = this->getObject<const Fem::Constraint>();
     const std::vector<Base::Vector3d>& points = obj->Points.getValue();
     const std::vector<Base::Vector3d>& normals = obj->Normals.getValue();
     if (points.size() != normals.size()) {
@@ -225,7 +225,7 @@ void ViewProviderFemConstraint::transformSymbol(const Base::Vector3d& point,
                                                 const Base::Vector3d& normal,
                                                 SbMatrix& mat) const
 {
-    auto obj = static_cast<const Fem::Constraint*>(this->getObject());
+    auto obj = this->getObject<const Fem::Constraint>();
     SbVec3f axisY(0, 1, 0);
     float s = obj->getScaleFactor();
     SbVec3f scale(s, s, s);
@@ -240,7 +240,7 @@ void ViewProviderFemConstraint::transformSymbol(const Base::Vector3d& point,
 void ViewProviderFemConstraint::transformExtraSymbol() const
 {
     if (pExtraTrans) {
-        auto obj = static_cast<const Fem::Constraint*>(this->getObject());
+        auto obj = this->getObject<const Fem::Constraint>();
         float s = obj->getScaleFactor();
         SbMatrix mat;
         mat.setScale(s);

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintBearing.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintBearing.cpp
@@ -67,7 +67,7 @@ bool ViewProviderFemConstraintBearing::setEdit(int ModNum)
 void ViewProviderFemConstraintBearing::updateData(const App::Property* prop)
 {
     // Gets called whenever a property of the attached object changes
-    Fem::ConstraintBearing* pcConstraint = static_cast<Fem::ConstraintBearing*>(this->getObject());
+    Fem::ConstraintBearing* pcConstraint = this->getObject<Fem::ConstraintBearing>();
 
     if (prop == &pcConstraint->References) {
         Base::Console().Error("\n");  // enable a breakpoint here

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintDisplacement.cpp
@@ -70,8 +70,7 @@ bool ViewProviderFemConstraintDisplacement::setEdit(int ModNum)
 
 void ViewProviderFemConstraintDisplacement::updateData(const App::Property* prop)
 {
-    Fem::ConstraintDisplacement* pcConstraint =
-        static_cast<Fem::ConstraintDisplacement*>(this->getObject());
+    Fem::ConstraintDisplacement* pcConstraint = this->getObject<Fem::ConstraintDisplacement>();
 
     if (prop == &pcConstraint->xFree) {
         auto sw = static_cast<SoSwitch*>(getSymbolSeparator()->getChild(0));

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintFluidBoundary.cpp
@@ -78,8 +78,7 @@ bool ViewProviderFemConstraintFluidBoundary::setEdit(int ModNum)
 void ViewProviderFemConstraintFluidBoundary::updateData(const App::Property* prop)
 {
     // Gets called whenever a property of the attached object changes
-    Fem::ConstraintFluidBoundary* pcConstraint =
-        static_cast<Fem::ConstraintFluidBoundary*>(this->getObject());
+    Fem::ConstraintFluidBoundary* pcConstraint = this->getObject<Fem::ConstraintFluidBoundary>();
     float scaledwidth =
         WIDTH * pcConstraint->Scale.getValue();  // OvG: Calculate scaled values once only
     float scaledheight = HEIGHT * pcConstraint->Scale.getValue();

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintForce.cpp
@@ -66,7 +66,7 @@ bool ViewProviderFemConstraintForce::setEdit(int ModNum)
 
 void ViewProviderFemConstraintForce::updateData(const App::Property* prop)
 {
-    auto pcConstraint = static_cast<Fem::ConstraintForce*>(this->getObject());
+    auto pcConstraint = this->getObject<Fem::ConstraintForce>();
 
     if (prop == &pcConstraint->Reversed || prop == &pcConstraint->DirectionVector) {
         updateSymbol();
@@ -80,7 +80,7 @@ void ViewProviderFemConstraintForce::transformSymbol(const Base::Vector3d& point
                                                      const Base::Vector3d& normal,
                                                      SbMatrix& mat) const
 {
-    auto obj = static_cast<const Fem::ConstraintForce*>(this->getObject());
+    auto obj = this->getObject<const Fem::ConstraintForce>();
     bool rev = obj->Reversed.getValue();
     float s = obj->getScaleFactor();
     // Symbol length from .iv file

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintGear.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintGear.cpp
@@ -69,7 +69,7 @@ bool ViewProviderFemConstraintGear::setEdit(int ModNum)
 
 void ViewProviderFemConstraintGear::updateData(const App::Property* prop)
 {
-    Fem::ConstraintGear* pcConstraint = static_cast<Fem::ConstraintGear*>(this->getObject());
+    Fem::ConstraintGear* pcConstraint = this->getObject<Fem::ConstraintGear>();
 
     // Gets called whenever a property of the attached object changes
     if (prop == &pcConstraint->BasePoint) {

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintOnBoundary.cpp
@@ -43,7 +43,7 @@ ViewProviderFemConstraintOnBoundary::~ViewProviderFemConstraintOnBoundary() = de
 
 void ViewProviderFemConstraintOnBoundary::highlightReferences(const bool on)
 {
-    Fem::Constraint* pcConstraint = static_cast<Fem::Constraint*>(this->getObject());
+    Fem::Constraint* pcConstraint = this->getObject<Fem::Constraint>();
     const auto& subSets = pcConstraint->References.getSubListValues();
 
     for (auto& subSet : subSets) {

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPressure.cpp
@@ -67,7 +67,7 @@ bool ViewProviderFemConstraintPressure::setEdit(int ModNum)
 
 void ViewProviderFemConstraintPressure::updateData(const App::Property* prop)
 {
-    auto pcConstraint = static_cast<Fem::ConstraintPressure*>(this->getObject());
+    auto pcConstraint = this->getObject<Fem::ConstraintPressure>();
 
     if (prop == &pcConstraint->Reversed) {
         updateSymbol();
@@ -81,7 +81,7 @@ void ViewProviderFemConstraintPressure::transformSymbol(const Base::Vector3d& po
                                                         const Base::Vector3d& normal,
                                                         SbMatrix& mat) const
 {
-    auto obj = static_cast<const Fem::ConstraintPressure*>(this->getObject());
+    auto obj = this->getObject<const Fem::ConstraintPressure>();
     float rotAngle = obj->Reversed.getValue() ? F_PI : 0.0f;
     float s = obj->getScaleFactor();
     // Symbol length from .iv file

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintPulley.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintPulley.cpp
@@ -67,7 +67,7 @@ bool ViewProviderFemConstraintPulley::setEdit(int ModNum)
 void ViewProviderFemConstraintPulley::updateData(const App::Property* prop)
 {
     // Gets called whenever a property of the attached object changes
-    Fem::ConstraintPulley* pcConstraint = static_cast<Fem::ConstraintPulley*>(this->getObject());
+    Fem::ConstraintPulley* pcConstraint = this->getObject<Fem::ConstraintPulley>();
 
     if (prop == &pcConstraint->BasePoint) {
         if (pcConstraint->Height.getValue() > Precision::Confusion()) {

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintRigidBody.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintRigidBody.cpp
@@ -65,7 +65,7 @@ bool ViewProviderFemConstraintRigidBody::setEdit(int ModNum)
 
 void ViewProviderFemConstraintRigidBody::updateData(const App::Property* prop)
 {
-    auto obj = static_cast<Fem::ConstraintRigidBody*>(this->getObject());
+    auto obj = this->getObject<Fem::ConstraintRigidBody>();
 
     if (prop == &obj->ReferenceNode) {
         updateSymbol();
@@ -78,7 +78,7 @@ void ViewProviderFemConstraintRigidBody::transformExtraSymbol() const
 {
     SoTransform* symTrans = getExtraSymbolTransform();
     if (symTrans) {
-        auto obj = static_cast<const Fem::ConstraintRigidBody*>(this->getObject());
+        auto obj = this->getObject<const Fem::ConstraintRigidBody>();
         float s = obj->getScaleFactor();
         const Base::Vector3d& refNode = obj->ReferenceNode.getValue();
         SbVec3f tra(refNode.x, refNode.y, refNode.z);

--- a/src/Mod/Fem/Gui/ViewProviderFemConstraintTransform.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemConstraintTransform.cpp
@@ -70,7 +70,7 @@ bool ViewProviderFemConstraintTransform::setEdit(int ModNum)
 
 void ViewProviderFemConstraintTransform::updateData(const App::Property* prop)
 {
-    auto obj = static_cast<Fem::ConstraintTransform*>(this->getObject());
+    auto obj = this->getObject<Fem::ConstraintTransform>();
 
     if (prop == &obj->Rotation) {
         updateSymbol();
@@ -106,7 +106,7 @@ void ViewProviderFemConstraintTransform::transformSymbol(const Base::Vector3d& p
                                                          const Base::Vector3d& normal,
                                                          SbMatrix& mat) const
 {
-    auto obj = static_cast<const Fem::ConstraintTransform*>(this->getObject());
+    auto obj = this->getObject<const Fem::ConstraintTransform>();
 
     std::string transType = obj->TransformType.getValueAsString();
     if (transType == "Rectangular") {
@@ -131,7 +131,7 @@ void ViewProviderFemConstraintTransform::transformSymbol(const Base::Vector3d& p
 
 void ViewProviderFemConstraintTransform::transformExtraSymbol() const
 {
-    auto obj = static_cast<const Fem::ConstraintTransform*>(this->getObject());
+    auto obj = this->getObject<const Fem::ConstraintTransform>();
     std::string transType = obj->TransformType.getValueAsString();
     if (transType == "Cylindrical") {
         SoTransform* trans = getExtraSymbolTransform();

--- a/src/Mod/Fem/Gui/ViewProviderFemMeshPyImp.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemMeshPyImp.cpp
@@ -280,7 +280,7 @@ Py::List ViewProviderFemMeshPy::getHighlightedNodes() const
 void ViewProviderFemMeshPy::setHighlightedNodes(Py::List arg)
 {
     ViewProviderFemMesh* vp = this->getViewProviderFemMeshPtr();
-    const SMESHDS_Mesh* data = static_cast<Fem::FemMeshObject*>(vp->getObject())
+    const SMESHDS_Mesh* data = vp->getObject<Fem::FemMeshObject>()
                                    ->FemMesh.getValue()
                                    .getSMesh()
                                    ->GetMeshDS();

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFilter.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFilter.cpp
@@ -123,9 +123,8 @@ void ViewProviderFemPostClip::setupTaskDialog(TaskDlgPost* dlg)
 
     // add the function box
     assert(dlg->getView() == this);
-    dlg->appendBox(new TaskPostClip(
-        this,
-        &static_cast<Fem::FemPostClipFilter*>(dlg->getView()->getObject())->Function));
+    dlg->appendBox(
+        new TaskPostClip(this, &dlg->getView()->getObject<Fem::FemPostClipFilter>()->Function));
 
     // add the display options
     FemGui::ViewProviderFemPostObject::setupTaskDialog(dlg);
@@ -166,9 +165,8 @@ void ViewProviderFemPostCut::setupTaskDialog(TaskDlgPost* dlg)
 {
     // add the function box
     assert(dlg->getView() == this);
-    dlg->appendBox(new TaskPostCut(
-        this,
-        &static_cast<Fem::FemPostCutFilter*>(dlg->getView()->getObject())->Function));
+    dlg->appendBox(
+        new TaskPostCut(this, &dlg->getView()->getObject<Fem::FemPostCutFilter>()->Function));
 
     // add the display options
     FemGui::ViewProviderFemPostObject::setupTaskDialog(dlg);

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -71,7 +71,7 @@ void FunctionWidget::setViewProvider(ViewProviderFemPostFunction* view)
 {
     // NOLINTBEGIN
     m_view = view;
-    m_object = static_cast<Fem::FemPostFunction*>(view->getObject());
+    m_object = view->getObject<Fem::FemPostFunction>();
     m_connection = m_object->getDocument()->signalChangedObject.connect(
         std::bind(&FunctionWidget::onObjectsChanged, this, sp::_1, sp::_2));
     // NOLINTEND
@@ -94,7 +94,7 @@ ViewProviderFemPostFunctionProvider::~ViewProviderFemPostFunctionProvider() = de
 
 std::vector<App::DocumentObject*> ViewProviderFemPostFunctionProvider::claimChildren() const
 {
-    return static_cast<Fem::FemPostFunctionProvider*>(getObject())->Functions.getValues();
+    return getObject<Fem::FemPostFunctionProvider>()->Functions.getValues();
 }
 
 std::vector<App::DocumentObject*> ViewProviderFemPostFunctionProvider::claimChildren3D() const
@@ -112,7 +112,7 @@ void ViewProviderFemPostFunctionProvider::onChanged(const App::Property* prop)
 void ViewProviderFemPostFunctionProvider::updateData(const App::Property* prop)
 {
     Gui::ViewProviderDocumentObject::updateData(prop);
-    Fem::FemPostFunctionProvider* obj = static_cast<Fem::FemPostFunctionProvider*>(getObject());
+    Fem::FemPostFunctionProvider* obj = getObject<Fem::FemPostFunctionProvider>();
     if (prop == &obj->Functions) {
         updateSize();
     }
@@ -405,7 +405,7 @@ ViewProviderFemPostBoxFunction::~ViewProviderFemPostBoxFunction() = default;
 
 void ViewProviderFemPostBoxFunction::draggerUpdate(SoDragger* m)
 {
-    Fem::FemPostBoxFunction* func = static_cast<Fem::FemPostBoxFunction*>(getObject());
+    Fem::FemPostBoxFunction* func = getObject<Fem::FemPostBoxFunction>();
     SoHandleBoxDragger* dragger = static_cast<SoHandleBoxDragger*>(m);
 
     const SbVec3f& center = dragger->translation.getValue();
@@ -419,7 +419,7 @@ void ViewProviderFemPostBoxFunction::draggerUpdate(SoDragger* m)
 
 void ViewProviderFemPostBoxFunction::updateData(const App::Property* p)
 {
-    Fem::FemPostBoxFunction* func = static_cast<Fem::FemPostBoxFunction*>(getObject());
+    Fem::FemPostBoxFunction* func = getObject<Fem::FemPostBoxFunction>();
     if (!isDragging()
         && (p == &func->Center || p == &func->Length || p == &func->Width || p == &func->Height)) {
         const Base::Vector3d& center = func->Center.getValue();
@@ -502,7 +502,7 @@ void BoxWidget::setViewProvider(ViewProviderFemPostFunction* view)
 {
     FemGui::FunctionWidget::setViewProvider(view);
     setBlockObjectUpdates(true);
-    Fem::FemPostBoxFunction* func = static_cast<Fem::FemPostBoxFunction*>(getObject());
+    Fem::FemPostBoxFunction* func = getObject<Fem::FemPostBoxFunction>();
     Base::Unit unit = func->Center.getUnit();
     ui->centerX->setUnit(unit);
     ui->centerY->setUnit(unit);
@@ -523,7 +523,7 @@ void BoxWidget::setViewProvider(ViewProviderFemPostFunction* view)
 void BoxWidget::onChange(const App::Property& p)
 {
     setBlockObjectUpdates(true);
-    Fem::FemPostBoxFunction* func = static_cast<Fem::FemPostBoxFunction*>(getObject());
+    Fem::FemPostBoxFunction* func = getObject<Fem::FemPostBoxFunction>();
     if (&p == &func->Center) {
         const Base::Vector3d& vec = static_cast<const App::PropertyVector*>(&p)->getValue();
         ui->centerX->setValue(vec.x);
@@ -551,7 +551,7 @@ void BoxWidget::centerChanged(double)
         Base::Vector3d vec(ui->centerX->value().getValue(),
                            ui->centerY->value().getValue(),
                            ui->centerZ->value().getValue());
-        static_cast<Fem::FemPostBoxFunction*>(getObject())->Center.setValue(vec);
+        getObject<Fem::FemPostBoxFunction>()->Center.setValue(vec);
     }
 }
 
@@ -559,7 +559,7 @@ void BoxWidget::lengthChanged(double)
 {
     if (!blockObjectUpdates()) {
         double l = ui->length->value().getValue();
-        static_cast<Fem::FemPostBoxFunction*>(getObject())->Length.setValue(l);
+        getObject<Fem::FemPostBoxFunction>()->Length.setValue(l);
     }
 }
 
@@ -567,7 +567,7 @@ void BoxWidget::widthChanged(double)
 {
     if (!blockObjectUpdates()) {
         double w = ui->width->value().getValue();
-        static_cast<Fem::FemPostBoxFunction*>(getObject())->Width.setValue(w);
+        getObject<Fem::FemPostBoxFunction>()->Width.setValue(w);
     }
 }
 
@@ -575,7 +575,7 @@ void BoxWidget::heightChanged(double)
 {
     if (!blockObjectUpdates()) {
         double h = ui->height->value().getValue();
-        static_cast<Fem::FemPostBoxFunction*>(getObject())->Height.setValue(h);
+        getObject<Fem::FemPostBoxFunction>()->Height.setValue(h);
     }
 }
 
@@ -598,7 +598,7 @@ ViewProviderFemPostCylinderFunction::~ViewProviderFemPostCylinderFunction() = de
 
 void ViewProviderFemPostCylinderFunction::draggerUpdate(SoDragger* m)
 {
-    Fem::FemPostCylinderFunction* func = static_cast<Fem::FemPostCylinderFunction*>(getObject());
+    Fem::FemPostCylinderFunction* func = getObject<Fem::FemPostCylinderFunction>();
     SoJackDragger* dragger = static_cast<SoJackDragger*>(m);
     const SbVec3f& center = dragger->translation.getValue();
     SbVec3f norm(0, 0, 1);
@@ -610,7 +610,7 @@ void ViewProviderFemPostCylinderFunction::draggerUpdate(SoDragger* m)
 
 void ViewProviderFemPostCylinderFunction::updateData(const App::Property* p)
 {
-    Fem::FemPostCylinderFunction* func = static_cast<Fem::FemPostCylinderFunction*>(getObject());
+    Fem::FemPostCylinderFunction* func = getObject<Fem::FemPostCylinderFunction>();
     if (!isDragging() && (p == &func->Center || p == &func->Radius || p == &func->Axis)) {
         Base::Vector3d trans = func->Center.getValue();
         Base::Vector3d axis = func->Axis.getValue();
@@ -698,7 +698,7 @@ void CylinderWidget::setViewProvider(ViewProviderFemPostFunction* view)
 {
     FemGui::FunctionWidget::setViewProvider(view);
     setBlockObjectUpdates(true);
-    Fem::FemPostCylinderFunction* func = static_cast<Fem::FemPostCylinderFunction*>(getObject());
+    Fem::FemPostCylinderFunction* func = getObject<Fem::FemPostCylinderFunction>();
     Base::Unit unit = func->Center.getUnit();
     ui->centerX->setUnit(unit);
     ui->centerY->setUnit(unit);
@@ -714,7 +714,7 @@ void CylinderWidget::setViewProvider(ViewProviderFemPostFunction* view)
 void CylinderWidget::onChange(const App::Property& p)
 {
     setBlockObjectUpdates(true);
-    Fem::FemPostCylinderFunction* func = static_cast<Fem::FemPostCylinderFunction*>(getObject());
+    Fem::FemPostCylinderFunction* func = getObject<Fem::FemPostCylinderFunction>();
     if (&p == &func->Axis) {
         const Base::Vector3d& vec = static_cast<const App::PropertyVector*>(&p)->getValue();
         ui->axisX->setValue(vec.x);
@@ -740,7 +740,7 @@ void CylinderWidget::centerChanged(double)
         Base::Vector3d vec(ui->centerX->value().getValue(),
                            ui->centerY->value().getValue(),
                            ui->centerZ->value().getValue());
-        static_cast<Fem::FemPostCylinderFunction*>(getObject())->Center.setValue(vec);
+        getObject<Fem::FemPostCylinderFunction>()->Center.setValue(vec);
     }
 }
 
@@ -750,15 +750,14 @@ void CylinderWidget::axisChanged(double)
         Base::Vector3d vec(ui->axisX->value().getValue(),
                            ui->axisY->value().getValue(),
                            ui->axisZ->value().getValue());
-        static_cast<Fem::FemPostCylinderFunction*>(getObject())->Axis.setValue(vec);
+        getObject<Fem::FemPostCylinderFunction>()->Axis.setValue(vec);
     }
 }
 
 void CylinderWidget::radiusChanged(double)
 {
     if (!blockObjectUpdates()) {
-        static_cast<Fem::FemPostCylinderFunction*>(getObject())
-            ->Radius.setValue(ui->radius->value().getValue());
+        getObject<Fem::FemPostCylinderFunction>()->Radius.setValue(ui->radius->value().getValue());
     }
 }
 
@@ -790,7 +789,7 @@ ViewProviderFemPostPlaneFunction::~ViewProviderFemPostPlaneFunction() = default;
 
 void ViewProviderFemPostPlaneFunction::draggerUpdate(SoDragger* m)
 {
-    Fem::FemPostPlaneFunction* func = static_cast<Fem::FemPostPlaneFunction*>(getObject());
+    Fem::FemPostPlaneFunction* func = getObject<Fem::FemPostPlaneFunction>();
     SoJackDragger* dragger = static_cast<SoJackDragger*>(m);
 
     // the new axis of the plane
@@ -832,7 +831,7 @@ void ViewProviderFemPostPlaneFunction::onChanged(const App::Property* prop)
 
 void ViewProviderFemPostPlaneFunction::updateData(const App::Property* p)
 {
-    Fem::FemPostPlaneFunction* func = static_cast<Fem::FemPostPlaneFunction*>(getObject());
+    Fem::FemPostPlaneFunction* func = getObject<Fem::FemPostPlaneFunction>();
 
     if (!isDragging() && (p == &func->Origin || p == &func->Normal)) {
         if (!m_detectscale) {
@@ -925,7 +924,7 @@ void PlaneWidget::applyPythonCode()
 void PlaneWidget::setViewProvider(ViewProviderFemPostFunction* view)
 {
     FemGui::FunctionWidget::setViewProvider(view);
-    Fem::FemPostPlaneFunction* func = static_cast<Fem::FemPostPlaneFunction*>(getObject());
+    Fem::FemPostPlaneFunction* func = getObject<Fem::FemPostPlaneFunction>();
     const Base::Unit unit = func->Origin.getUnit();
     setBlockObjectUpdates(true);
     ui->originX->setUnit(unit);
@@ -941,7 +940,7 @@ void PlaneWidget::setViewProvider(ViewProviderFemPostFunction* view)
 void PlaneWidget::onChange(const App::Property& p)
 {
     setBlockObjectUpdates(true);
-    Fem::FemPostPlaneFunction* func = static_cast<Fem::FemPostPlaneFunction*>(getObject());
+    Fem::FemPostPlaneFunction* func = getObject<Fem::FemPostPlaneFunction>();
     if (&p == &func->Normal) {
         const Base::Vector3d& vec = static_cast<const App::PropertyVector*>(&p)->getValue();
         ui->normalX->setValue(vec.x);
@@ -963,7 +962,7 @@ void PlaneWidget::normalChanged(double)
         Base::Vector3d vec(ui->normalX->value().getValue(),
                            ui->normalY->value().getValue(),
                            ui->normalZ->value().getValue());
-        static_cast<Fem::FemPostPlaneFunction*>(getObject())->Normal.setValue(vec);
+        getObject<Fem::FemPostPlaneFunction>()->Normal.setValue(vec);
     }
 }
 
@@ -973,7 +972,7 @@ void PlaneWidget::originChanged(double)
         Base::Vector3d vec(ui->originX->value().getValue(),
                            ui->originY->value().getValue(),
                            ui->originZ->value().getValue());
-        static_cast<Fem::FemPostPlaneFunction*>(getObject())->Origin.setValue(vec);
+        getObject<Fem::FemPostPlaneFunction>()->Origin.setValue(vec);
     }
 }
 
@@ -1015,7 +1014,7 @@ SoTransformManip* ViewProviderFemPostSphereFunction::setupManipulator()
 
 void ViewProviderFemPostSphereFunction::draggerUpdate(SoDragger* m)
 {
-    Fem::FemPostSphereFunction* func = static_cast<Fem::FemPostSphereFunction*>(getObject());
+    Fem::FemPostSphereFunction* func = getObject<Fem::FemPostSphereFunction>();
     SoHandleBoxDragger* dragger = static_cast<SoHandleBoxDragger*>(m);
 
     // the new axis of the plane
@@ -1029,7 +1028,7 @@ void ViewProviderFemPostSphereFunction::draggerUpdate(SoDragger* m)
 
 void ViewProviderFemPostSphereFunction::updateData(const App::Property* p)
 {
-    Fem::FemPostSphereFunction* func = static_cast<Fem::FemPostSphereFunction*>(getObject());
+    Fem::FemPostSphereFunction* func = getObject<Fem::FemPostSphereFunction>();
 
     if (!isDragging() && (p == &func->Center || p == &func->Radius)) {
 
@@ -1093,7 +1092,7 @@ void SphereWidget::setViewProvider(ViewProviderFemPostFunction* view)
 {
     FemGui::FunctionWidget::setViewProvider(view);
     setBlockObjectUpdates(true);
-    Fem::FemPostSphereFunction* func = static_cast<Fem::FemPostSphereFunction*>(getObject());
+    Fem::FemPostSphereFunction* func = getObject<Fem::FemPostSphereFunction>();
     Base::Unit unit = func->Center.getUnit();
     ui->centerX->setUnit(unit);
     ui->centerY->setUnit(unit);
@@ -1108,7 +1107,7 @@ void SphereWidget::setViewProvider(ViewProviderFemPostFunction* view)
 void SphereWidget::onChange(const App::Property& p)
 {
     setBlockObjectUpdates(true);
-    Fem::FemPostSphereFunction* func = static_cast<Fem::FemPostSphereFunction*>(getObject());
+    Fem::FemPostSphereFunction* func = getObject<Fem::FemPostSphereFunction>();
     if (&p == &func->Radius) {
         double val = static_cast<const App::PropertyDistance*>(&p)->getValue();
         ui->radius->setValue(val);
@@ -1128,15 +1127,14 @@ void SphereWidget::centerChanged(double)
         Base::Vector3d vec(ui->centerX->value().getValue(),
                            ui->centerY->value().getValue(),
                            ui->centerZ->value().getValue());
-        static_cast<Fem::FemPostSphereFunction*>(getObject())->Center.setValue(vec);
+        getObject<Fem::FemPostSphereFunction>()->Center.setValue(vec);
     }
 }
 
 void SphereWidget::radiusChanged(double)
 {
     if (!blockObjectUpdates()) {
-        static_cast<Fem::FemPostSphereFunction*>(getObject())
-            ->Radius.setValue(ui->radius->value().getValue());
+        getObject<Fem::FemPostSphereFunction>()->Radius.setValue(ui->radius->value().getValue());
     }
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.h
@@ -65,9 +65,14 @@ protected:
     {
         return m_view;
     }
-    Fem::FemPostFunction* getObject()
+    Fem::FemPostFunction* getObject() const
     {
         return m_object;
+    }
+    template<class T>
+    T* getObject() const
+    {
+        return dynamic_cast<T*>(getObject());
     }
 
     bool blockObjectUpdates()

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -761,7 +761,7 @@ void ViewProviderFemPostObject::WriteTransparency()
 
 void ViewProviderFemPostObject::updateData(const App::Property* p)
 {
-    Fem::FemPostObject* postObject = static_cast<Fem::FemPostObject*>(getObject());
+    Fem::FemPostObject* postObject = getObject<Fem::FemPostObject>();
     if (p == &postObject->Data) {
         updateVtk();
     }
@@ -846,7 +846,7 @@ bool ViewProviderFemPostObject::setupPipeline()
         return false;
     }
 
-    auto postObject = static_cast<Fem::FemPostObject*>(getObject());
+    auto postObject = getObject<Fem::FemPostObject>();
 
     vtkDataObject* data = postObject->Data.getValue();
     if (!data) {
@@ -903,7 +903,7 @@ void ViewProviderFemPostObject::onChanged(const App::Property* prop)
     bool ResetColorBarRange;
 
     // the point filter delivers a single value thus recoloring the bar is senseless
-    if (static_cast<Fem::FemPostObject*>(getObject())->getTypeId()
+    if (getObject<Fem::FemPostObject>()->getTypeId()
         == Base::Type::fromName("Fem::FemPostDataAtPointFilter")) {
         ResetColorBarRange = false;
     }

--- a/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostPipeline.cpp
@@ -53,7 +53,7 @@ ViewProviderFemPostPipeline::~ViewProviderFemPostPipeline() = default;
 std::vector<App::DocumentObject*> ViewProviderFemPostPipeline::claimChildren() const
 {
 
-    Fem::FemPostPipeline* pipeline = static_cast<Fem::FemPostPipeline*>(getObject());
+    Fem::FemPostPipeline* pipeline = getObject<Fem::FemPostPipeline>();
     std::vector<App::DocumentObject*> children;
 
     if (pipeline->Functions.getValue()) {
@@ -75,7 +75,7 @@ std::vector<App::DocumentObject*> ViewProviderFemPostPipeline::claimChildren3D()
 void ViewProviderFemPostPipeline::updateData(const App::Property* prop)
 {
     FemGui::ViewProviderFemPostObject::updateData(prop);
-    Fem::FemPostPipeline* pipeline = static_cast<Fem::FemPostPipeline*>(getObject());
+    Fem::FemPostPipeline* pipeline = getObject<Fem::FemPostPipeline>();
     if (prop == &pipeline->Functions) {
         updateFunctionSize();
     }
@@ -85,7 +85,7 @@ void ViewProviderFemPostPipeline::updateFunctionSize()
 {
 
     // we need to get the bounding box and set the function provider size
-    Fem::FemPostPipeline* obj = static_cast<Fem::FemPostPipeline*>(getObject());
+    Fem::FemPostPipeline* obj = getObject<Fem::FemPostPipeline>();
 
     if (!obj->Functions.getValue()
         || !obj->Functions.getValue()->isDerivedFrom(
@@ -178,7 +178,7 @@ void ViewProviderFemPostPipeline::updateColorBars()
 
 void ViewProviderFemPostPipeline::transformField(char* FieldName, double FieldFactor)
 {
-    Fem::FemPostPipeline* obj = static_cast<Fem::FemPostPipeline*>(getObject());
+    Fem::FemPostPipeline* obj = getObject<Fem::FemPostPipeline>();
 
     vtkSmartPointer<vtkDataObject> data = obj->Data.getValue();
     vtkDataSet* dset = vtkDataSet::SafeDownCast(data);

--- a/src/Mod/Fem/Gui/ViewProviderSetElementNodes.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderSetElementNodes.cpp
@@ -37,7 +37,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderSetElementNodes, Gui::ViewProviderGeometryOb
 bool ViewProviderSetElementNodes::doubleClicked()
 {
     Gui::TaskView::TaskDialog* dlg =
-        new TaskDlgCreateElementSet(static_cast<Fem::FemSetElementNodesObject*>(getObject()));
+        new TaskDlgCreateElementSet(getObject<Fem::FemSetElementNodesObject>());
     Gui::Control().showDialog(dlg);
     return true;
 }

--- a/src/Mod/Fem/Gui/ViewProviderSetElements.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderSetElements.cpp
@@ -31,16 +31,16 @@ PROPERTY_SOURCE(FemGui::ViewProviderSetElements, Gui::ViewProviderGeometryObject
 
 bool ViewProviderSetElements::doubleClicked()
 {
-    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(dynamic_cast<Fem::FemSetNodesObject
-    // *>(getObject())); Gui::Control().showDialog(dlg);
+    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(getObject<Fem::FemSetNodesObject
+    // >()); Gui::Control().showDialog(dlg);
     return true;
 }
 
 
 bool ViewProviderSetElements::setEdit(int)
 {
-    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(dynamic_cast<Fem::FemSetNodesObject
-    // *>(getObject())); Gui::Control().showDialog(dlg);
+    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(getObject<Fem::FemSetNodesObject
+    // >()); Gui::Control().showDialog(dlg);
     return true;
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderSetFaces.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderSetFaces.cpp
@@ -31,16 +31,16 @@ PROPERTY_SOURCE(FemGui::ViewProviderSetFaces, Gui::ViewProviderGeometryObject)
 
 bool ViewProviderSetFaces::doubleClicked()
 {
-    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(dynamic_cast<Fem::FemSetNodesObject
-    // *>(getObject())); Gui::Control().showDialog(dlg);
+    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(getObject<Fem::FemSetNodesObject
+    // >()); Gui::Control().showDialog(dlg);
     return true;
 }
 
 
 bool ViewProviderSetFaces::setEdit(int)
 {
-    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(dynamic_cast<Fem::FemSetNodesObject
-    // *>(getObject())); Gui::Control().showDialog(dlg);
+    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(getObject<Fem::FemSetNodesObject
+    // >()); Gui::Control().showDialog(dlg);
     return true;
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderSetGeometry.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderSetGeometry.cpp
@@ -31,16 +31,16 @@ PROPERTY_SOURCE(FemGui::ViewProviderSetGeometry, Gui::ViewProviderGeometryObject
 
 bool ViewProviderSetGeometry::doubleClicked()
 {
-    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(dynamic_cast<Fem::FemSetNodesObject
-    // *>(getObject())); Gui::Control().showDialog(dlg);
+    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(getObject<Fem::FemSetNodesObject
+    // >()); Gui::Control().showDialog(dlg);
     return true;
 }
 
 
 bool ViewProviderSetGeometry::setEdit(int)
 {
-    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(dynamic_cast<Fem::FemSetNodesObject
-    // *>(getObject())); Gui::Control().showDialog(dlg);
+    // Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(getObject<Fem::FemSetNodesObject
+    // >()); Gui::Control().showDialog(dlg);
     return true;
 }
 

--- a/src/Mod/Fem/Gui/ViewProviderSetNodes.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderSetNodes.cpp
@@ -35,8 +35,7 @@ PROPERTY_SOURCE(FemGui::ViewProviderSetNodes, Gui::ViewProviderGeometryObject)
 
 bool ViewProviderSetNodes::doubleClicked()
 {
-    Gui::TaskView::TaskDialog* dlg =
-        new TaskDlgCreateNodeSet(static_cast<Fem::FemSetNodesObject*>(getObject()));
+    Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(getObject<Fem::FemSetNodesObject>());
     Gui::Control().showDialog(dlg);
     return true;
 }
@@ -44,8 +43,7 @@ bool ViewProviderSetNodes::doubleClicked()
 
 bool ViewProviderSetNodes::setEdit(int)
 {
-    Gui::TaskView::TaskDialog* dlg =
-        new TaskDlgCreateNodeSet(static_cast<Fem::FemSetNodesObject*>(getObject()));
+    Gui::TaskView::TaskDialog* dlg = new TaskDlgCreateNodeSet(getObject<Fem::FemSetNodesObject>());
     Gui::Control().showDialog(dlg);
     return true;
 }

--- a/src/Mod/Mesh/Gui/MeshEditor.cpp
+++ b/src/Mod/Mesh/Gui/MeshEditor.cpp
@@ -230,7 +230,7 @@ void MeshFaceAddition::finishEditing()
 
 void MeshFaceAddition::addFace()
 {
-    Mesh::Feature* mf = static_cast<Mesh::Feature*>(faceView->mesh->getObject());
+    Mesh::Feature* mf = faceView->mesh->getObject<Mesh::Feature>();
     App::Document* doc = mf->getDocument();
     doc->openTransaction("Add triangle");
     Mesh::MeshObject* mesh = mf->Mesh.startEditing();
@@ -290,7 +290,7 @@ void MeshFaceAddition::showMarker(SoPickedPoint* pp)
     if (detail) {
         if (detail->isOfType(SoFaceDetail::getClassTypeId())) {
             const SoFaceDetail* fd = static_cast<const SoFaceDetail*>(detail);
-            Mesh::Feature* mf = static_cast<Mesh::Feature*>(faceView->mesh->getObject());
+            Mesh::Feature* mf = faceView->mesh->getObject<Mesh::Feature>();
             const MeshCore::MeshFacetArray& facets =
                 mf->Mesh.getValuePtr()->getKernel().GetFacets();
             const MeshCore::MeshPointArray& points =
@@ -485,7 +485,7 @@ MeshFillHole::~MeshFillHole()
 
 void MeshFillHole::startEditing(MeshGui::ViewProviderMesh* vp)
 {
-    this->myMesh = static_cast<Mesh::Feature*>(vp->getObject());
+    this->myMesh = vp->getObject<Mesh::Feature>();
 
     Gui::View3DInventor* view = static_cast<Gui::View3DInventor*>(parent());
     Gui::View3DInventorViewer* viewer = view->getViewer();

--- a/src/Mod/Mesh/Gui/MeshSelection.cpp
+++ b/src/Mod/Mesh/Gui/MeshSelection.cpp
@@ -255,7 +255,7 @@ void MeshSelection::fullSelection()
     // select the complete meshes
     std::list<ViewProviderMesh*> views = getViewProviders();
     for (auto view : views) {
-        Mesh::Feature* mf = static_cast<Mesh::Feature*>(view->getObject());
+        Mesh::Feature* mf = view->getObject<Mesh::Feature>();
         const Mesh::MeshObject* mo = mf->Mesh.getValuePtr();
         std::vector<Mesh::FacetIndex> faces(mo->countFacets());
         std::generate(faces.begin(), faces.end(), Base::iotaGen<Mesh::FacetIndex>(0));
@@ -277,7 +277,7 @@ bool MeshSelection::deleteSelection()
     bool selected = false;
     std::list<ViewProviderMesh*> views = getViewProviders();
     for (auto view : views) {
-        Mesh::Feature* mf = static_cast<Mesh::Feature*>(view->getObject());
+        Mesh::Feature* mf = view->getObject<Mesh::Feature>();
         unsigned long ct = MeshCore::MeshAlgorithm(mf->Mesh.getValue().getKernel())
                                .CountFacetFlag(MeshCore::MeshFacet::SELECTED);
         if (ct > 0) {
@@ -302,7 +302,7 @@ bool MeshSelection::deleteSelectionBorder()
     bool deletion = false;
     std::list<ViewProviderMesh*> views = getViewProviders();
     for (auto view : views) {
-        Mesh::Feature* mf = static_cast<Mesh::Feature*>(view->getObject());
+        Mesh::Feature* mf = view->getObject<Mesh::Feature>();
 
         // mark the selected facet as visited
         std::vector<Mesh::FacetIndex> selection;
@@ -361,7 +361,7 @@ void MeshSelection::selectComponent(int size)
 {
     std::list<ViewProviderMesh*> views = getViewProviders();
     for (auto view : views) {
-        Mesh::Feature* mf = static_cast<Mesh::Feature*>(view->getObject());
+        Mesh::Feature* mf = view->getObject<Mesh::Feature>();
         const Mesh::MeshObject* mo = mf->Mesh.getValuePtr();
 
         std::vector<std::vector<Mesh::FacetIndex>> segm;
@@ -383,7 +383,7 @@ void MeshSelection::deselectComponent(int size)
 {
     std::list<ViewProviderMesh*> views = getViewProviders();
     for (auto view : views) {
-        Mesh::Feature* mf = static_cast<Mesh::Feature*>(view->getObject());
+        Mesh::Feature* mf = view->getObject<Mesh::Feature>();
         const Mesh::MeshObject* mo = mf->Mesh.getValuePtr();
 
         std::vector<std::vector<Mesh::FacetIndex>> segm;
@@ -480,8 +480,7 @@ void MeshSelection::selectGLCallback(void* ud, SoEventCallback* n)
     std::list<ViewProviderMesh*> views = self->getViewProviders();
     for (auto vp : views) {
         std::vector<Mesh::FacetIndex> faces;
-        const Mesh::MeshObject& mesh =
-            static_cast<Mesh::Feature*>(vp->getObject())->Mesh.getValue();
+        const Mesh::MeshObject& mesh = vp->getObject<Mesh::Feature>()->Mesh.getValue();
         const MeshCore::MeshKernel& kernel = mesh.getKernel();
 
         // simply get all triangles under the polygon
@@ -489,7 +488,7 @@ void MeshSelection::selectGLCallback(void* ud, SoEventCallback* n)
         SbViewVolume vv = cam->getViewVolume();
         Gui::ViewVolumeProjection proj(vv);
 
-        Base::Placement plm = static_cast<Mesh::Feature*>(vp->getObject())->Placement.getValue();
+        Base::Placement plm = vp->getObject<Mesh::Feature>()->Placement.getValue();
         proj.setTransform(plm.toMatrix());
         vp->getFacetsFromPolygon(polygon, proj, true, faces);
 

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -771,8 +771,8 @@ void ViewProviderMesh::exportMesh(const char* filename, const char* fmt) const
         mat.diffuseColor.emplace_back(c[0], c[1], c[2]);
     }
 
-    Mesh::MeshObject mesh = static_cast<Mesh::Feature*>(getObject())->Mesh.getValue();
-    mesh.setPlacement(static_cast<Mesh::Feature*>(getObject())->globalPlacement());
+    Mesh::MeshObject mesh = getObject<Mesh::Feature>()->Mesh.getValue();
+    mesh.setPlacement(getObject<Mesh::Feature>()->globalPlacement());
     if (mat.diffuseColor.size() == mesh.countPoints()) {
         mat.binding = MeshCore::MeshIO::PER_VERTEX;
     }
@@ -976,7 +976,7 @@ public:
         App::Document* doc = gui->getDocument();
 
         auto cpy = static_cast<Mesh::Feature*>(doc->addObject("Mesh::Feature"));
-        auto org = static_cast<Mesh::Feature*>(mesh->getObject());
+        auto org = mesh->getObject<Mesh::Feature>();
         cpy->Label.setValue(org->Label.getValue());
         cpy->Mesh.setValue(org->Mesh.getValue());
 
@@ -1023,9 +1023,8 @@ void ViewProviderMesh::clipMeshCallback(void* ud, SoEventCallback* cb)
                 SoCamera* cam = view->getSoRenderManager()->getCamera();
                 SbViewVolume vv = cam->getViewVolume();
                 Gui::ViewVolumeProjection proj(vv);
-                proj.setTransform(static_cast<Mesh::Feature*>(self->getObject())
-                                      ->Placement.getValue()
-                                      .toMatrix());
+                proj.setTransform(
+                    self->getObject<Mesh::Feature>()->Placement.getValue().toMatrix());
                 if (role == Gui::SelectionRole::Inner) {
                     self->cutMesh(clPoly, proj, true);
                     commitCommand = true;
@@ -1093,9 +1092,8 @@ void ViewProviderMesh::trimMeshCallback(void* ud, SoEventCallback* cb)
                 SoCamera* cam = view->getSoRenderManager()->getCamera();
                 SbViewVolume vv = cam->getViewVolume();
                 Gui::ViewVolumeProjection proj(vv);
-                proj.setTransform(static_cast<Mesh::Feature*>(self->getObject())
-                                      ->Placement.getValue()
-                                      .toMatrix());
+                proj.setTransform(
+                    self->getObject<Mesh::Feature>()->Placement.getValue().toMatrix());
                 if (role == Gui::SelectionRole::Inner) {
                     self->trimMesh(clPoly, proj, true);
                     commitCommand = true;
@@ -1181,8 +1179,7 @@ void ViewProviderMesh::partMeshCallback(void* ud, SoEventCallback* cb)
             auto that = static_cast<ViewProviderMesh*>(view);
             if (that->getEditingMode() > -1) {
                 that->finishEditing();
-                Base::Placement plm =
-                    static_cast<Mesh::Feature*>(that->getObject())->Placement.getValue();
+                Base::Placement plm = that->getObject<Mesh::Feature>()->Placement.getValue();
                 plm.invert();
                 MeshCore::MeshKernel copyToolMesh(toolMesh);
                 copyToolMesh.Transform(plm.toMatrix());
@@ -1255,8 +1252,7 @@ void ViewProviderMesh::segmMeshCallback(void* ud, SoEventCallback* cb)
             auto that = static_cast<ViewProviderMesh*>(view);
             if (that->getEditingMode() > -1) {
                 that->finishEditing();
-                Base::Placement plm =
-                    static_cast<Mesh::Feature*>(that->getObject())->Placement.getValue();
+                Base::Placement plm = that->getObject<Mesh::Feature>()->Placement.getValue();
                 plm.invert();
                 MeshCore::MeshKernel copyToolMesh(toolMesh);
                 copyToolMesh.Transform(plm.toMatrix());

--- a/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
@@ -315,7 +315,7 @@ void ViewProviderMeshCurvature::updateData(const App::Property* prop)
             if (auto view = dynamic_cast<ViewProviderMesh*>(pDoc->getViewProvider(object))) {
                 this->pcLinkRoot->addChild(view->getHighlightNode());
 
-                auto mesh = dynamic_cast<Mesh::Feature*>(view->getObject());
+                auto mesh = view->getObject<Mesh::Feature>();
                 Base::Placement plm = mesh->Placement.getValue();
                 ViewProviderMesh::updateTransform(plm, pcTransform);
             }

--- a/src/Mod/MeshPart/Gui/CurveOnMesh.cpp
+++ b/src/Mod/MeshPart/Gui/CurveOnMesh.cpp
@@ -263,7 +263,7 @@ public:
     }
     void createGrid()
     {
-        Mesh::Feature* mf = static_cast<Mesh::Feature*>(mesh->getObject());
+        Mesh::Feature* mf = mesh->getObject<Mesh::Feature>();
         const Mesh::MeshObject& meshObject = mf->Mesh.getValue();
         kernel = meshObject.getKernel();
         kernel.Transform(meshObject.getTransform());

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -384,7 +384,7 @@ void Tessellation::setFaceColors(int method, App::Document* doc, App::DocumentOb
                 }
 
                 vpmesh->highlightSegments(diff_col);
-                addFaceColors(dynamic_cast<Mesh::Feature*>(vpmesh->getObject()), diff_col);
+                addFaceColors(vpmesh->getObject<Mesh::Feature>(), diff_col);
             }
         }
     }

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -413,7 +413,7 @@ void PartGui::DlgProjectionOnSurface::store_current_selected_parts(
     std::vector<Gui::SelectionObject> selObj = Gui::Selection().getSelectionEx();
     if (!selObj.empty()) {
         for (auto it = selObj.begin(); it != selObj.end(); ++it) {
-            auto aPart = dynamic_cast<Part::Feature*>(it->getObject());
+            auto aPart = it->getObject<Part::Feature>();
             if (!aPart) {
                 continue;
             }

--- a/src/Mod/Part/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/Part/Gui/ViewProviderBoolean.cpp
@@ -46,8 +46,8 @@ ViewProviderBoolean::~ViewProviderBoolean() = default;
 std::vector<App::DocumentObject*> ViewProviderBoolean::claimChildren()const
 {
     std::vector<App::DocumentObject*> temp;
-    temp.push_back(static_cast<Part::Boolean*>(getObject())->Base.getValue());
-    temp.push_back(static_cast<Part::Boolean*>(getObject())->Tool.getValue());
+    temp.push_back(getObject<Part::Boolean>()->Base.getValue());
+    temp.push_back(getObject<Part::Boolean>()->Tool.getValue());
 
     return temp;
 }
@@ -78,7 +78,7 @@ void ViewProviderBoolean::updateData(const App::Property* prop)
             (prop)->getValues();
         if (hist.size() != 2)
             return;
-        Part::Boolean* objBool = dynamic_cast<Part::Boolean*>(getObject());
+        Part::Boolean* objBool = getObject<Part::Boolean>();
         if (!objBool)
             return;
         Part::Feature* objBase = dynamic_cast<Part::Feature*>(
@@ -143,7 +143,7 @@ void ViewProviderBoolean::updateData(const App::Property* prop)
 bool ViewProviderBoolean::onDelete(const std::vector<std::string> &)
 {
     // get the input shapes
-    Part::Boolean* pBool = static_cast<Part::Boolean*>(getObject());
+    Part::Boolean* pBool = getObject<Part::Boolean>();
     App::DocumentObject *pBase = pBool->Base.getValue();
     App::DocumentObject *pTool = pBool->Tool.getValue();
 
@@ -163,7 +163,7 @@ ViewProviderMultiFuse::~ViewProviderMultiFuse() = default;
 
 std::vector<App::DocumentObject*> ViewProviderMultiFuse::claimChildren()const
 {
-    return static_cast<Part::MultiFuse*>(getObject())->Shapes.getValues();
+    return getObject<Part::MultiFuse>()->Shapes.getValues();
 }
 
 QIcon ViewProviderMultiFuse::getIcon() const
@@ -177,7 +177,7 @@ void ViewProviderMultiFuse::updateData(const App::Property* prop)
     if (prop->is<Part::PropertyShapeHistory>()) {
         const std::vector<Part::ShapeHistory>& hist = static_cast<const Part::PropertyShapeHistory*>
             (prop)->getValues();
-        Part::MultiFuse* objBool = static_cast<Part::MultiFuse*>(getObject());
+        Part::MultiFuse* objBool = getObject<Part::MultiFuse>();
         std::vector<App::DocumentObject*> sources = objBool->Shapes.getValues();
         if (hist.size() != sources.size())
             return;
@@ -234,7 +234,7 @@ void ViewProviderMultiFuse::updateData(const App::Property* prop)
 bool ViewProviderMultiFuse::onDelete(const std::vector<std::string> &)
 {
     // get the input shapes
-    Part::MultiFuse* pBool = static_cast<Part::MultiFuse*>(getObject());
+    Part::MultiFuse* pBool = getObject<Part::MultiFuse>();
     std::vector<App::DocumentObject*> pShapes = pBool->Shapes.getValues();
     for (auto it : pShapes) {
         if (it) {
@@ -259,7 +259,7 @@ bool ViewProviderMultiFuse::canDragObject(App::DocumentObject* obj) const
 
 void ViewProviderMultiFuse::dragObject(App::DocumentObject* obj)
 {
-    Part::MultiFuse* pBool = static_cast<Part::MultiFuse*>(getObject());
+    Part::MultiFuse* pBool = getObject<Part::MultiFuse>();
     std::vector<App::DocumentObject*> pShapes = pBool->Shapes.getValues();
     for (std::vector<App::DocumentObject*>::iterator it = pShapes.begin(); it != pShapes.end(); ++it) {
         if (*it == obj) {
@@ -284,7 +284,7 @@ bool ViewProviderMultiFuse::canDropObject(App::DocumentObject* obj) const
 
 void ViewProviderMultiFuse::dropObject(App::DocumentObject* obj)
 {
-    Part::MultiFuse* pBool = static_cast<Part::MultiFuse*>(getObject());
+    Part::MultiFuse* pBool = getObject<Part::MultiFuse>();
     std::vector<App::DocumentObject*> pShapes = pBool->Shapes.getValues();
     pShapes.push_back(obj);
     pBool->Shapes.setValues(pShapes);
@@ -298,7 +298,7 @@ ViewProviderMultiCommon::~ViewProviderMultiCommon() = default;
 
 std::vector<App::DocumentObject*> ViewProviderMultiCommon::claimChildren()const
 {
-    return static_cast<Part::MultiCommon*>(getObject())->Shapes.getValues();
+    return getObject<Part::MultiCommon>()->Shapes.getValues();
 }
 
 QIcon ViewProviderMultiCommon::getIcon() const
@@ -312,7 +312,7 @@ void ViewProviderMultiCommon::updateData(const App::Property* prop)
     if (prop->is<Part::PropertyShapeHistory>()) {
         const std::vector<Part::ShapeHistory>& hist = static_cast<const Part::PropertyShapeHistory*>
             (prop)->getValues();
-        Part::MultiCommon* objBool = static_cast<Part::MultiCommon*>(getObject());
+        Part::MultiCommon* objBool = getObject<Part::MultiCommon>();
         std::vector<App::DocumentObject*> sources = objBool->Shapes.getValues();
         if (hist.size() != sources.size())
             return;
@@ -369,7 +369,7 @@ void ViewProviderMultiCommon::updateData(const App::Property* prop)
 bool ViewProviderMultiCommon::onDelete(const std::vector<std::string> &)
 {
     // get the input shapes
-    Part::MultiCommon* pBool = static_cast<Part::MultiCommon*>(getObject());
+    Part::MultiCommon* pBool = getObject<Part::MultiCommon>();
     std::vector<App::DocumentObject*> pShapes = pBool->Shapes.getValues();
     for (auto it : pShapes) {
         if (it) {
@@ -394,7 +394,7 @@ bool ViewProviderMultiCommon::canDragObject(App::DocumentObject* obj) const
 
 void ViewProviderMultiCommon::dragObject(App::DocumentObject* obj)
 {
-    Part::MultiCommon* pBool = static_cast<Part::MultiCommon*>(getObject());
+    Part::MultiCommon* pBool = getObject<Part::MultiCommon>();
     std::vector<App::DocumentObject*> pShapes = pBool->Shapes.getValues();
     for (std::vector<App::DocumentObject*>::iterator it = pShapes.begin(); it != pShapes.end(); ++it) {
         if (*it == obj) {
@@ -419,7 +419,7 @@ bool ViewProviderMultiCommon::canDropObject(App::DocumentObject* obj) const
 
 void ViewProviderMultiCommon::dropObject(App::DocumentObject* obj)
 {
-    Part::MultiCommon* pBool = static_cast<Part::MultiCommon*>(getObject());
+    Part::MultiCommon* pBool = getObject<Part::MultiCommon>();
     std::vector<App::DocumentObject*> pShapes = pBool->Shapes.getValues();
     pShapes.push_back(obj);
     pBool->Shapes.setValues(pShapes);

--- a/src/Mod/Part/Gui/ViewProviderCompound.cpp
+++ b/src/Mod/Part/Gui/ViewProviderCompound.cpp
@@ -46,13 +46,13 @@ ViewProviderCompound::~ViewProviderCompound() = default;
 
 std::vector<App::DocumentObject*> ViewProviderCompound::claimChildren() const
 {
-    return static_cast<Part::Compound*>(getObject())->Links.getValues();
+    return getObject<Part::Compound>()->Links.getValues();
 }
 
 bool ViewProviderCompound::onDelete(const std::vector<std::string> &)
 {
     // get the input shapes
-    Part::Compound* pComp = static_cast<Part::Compound*>(getObject());
+    Part::Compound* pComp = getObject<Part::Compound>();
     std::vector<App::DocumentObject*> pLinks = pComp->Links.getValues();
     for (auto pLink : pLinks) {
         if (pLink)
@@ -68,7 +68,7 @@ void ViewProviderCompound::updateData(const App::Property* prop)
     if (prop->is<Part::PropertyShapeHistory>()) {
         const std::vector<Part::ShapeHistory>& hist = static_cast<const Part::PropertyShapeHistory*>
             (prop)->getValues();
-        Part::Compound* objComp = static_cast<Part::Compound*>(getObject());
+        Part::Compound* objComp = getObject<Part::Compound>();
         std::vector<App::DocumentObject*> sources = objComp->Links.getValues();
 
         if (hist.size() != sources.size()) {
@@ -151,7 +151,7 @@ bool ViewProviderCompound::canDragObject(App::DocumentObject* obj) const
 
 void ViewProviderCompound::dragObject(App::DocumentObject* obj)
 {
-    Part::Compound* pComp = static_cast<Part::Compound*>(getObject());
+    Part::Compound* pComp = getObject<Part::Compound>();
     std::vector<App::DocumentObject*> pShapes = pComp->Links.getValues();
     for (std::vector<App::DocumentObject*>::iterator it = pShapes.begin(); it != pShapes.end(); ++it) {
         if (*it == obj) {
@@ -174,7 +174,7 @@ bool ViewProviderCompound::canDropObject(App::DocumentObject* obj) const
 
 void ViewProviderCompound::dropObject(App::DocumentObject* obj)
 {
-    Part::Compound* pComp = static_cast<Part::Compound*>(getObject());
+    Part::Compound* pComp = getObject<Part::Compound>();
     std::vector<App::DocumentObject*> pShapes = pComp->Links.getValues();
     pShapes.push_back(obj);
     pComp->Links.setValues(pShapes);

--- a/src/Mod/Part/Gui/ViewProviderExtrusion.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExtrusion.cpp
@@ -41,7 +41,7 @@ ViewProviderExtrusion::~ViewProviderExtrusion() = default;
 std::vector<App::DocumentObject*> ViewProviderExtrusion::claimChildren()const
 {
     std::vector<App::DocumentObject*> temp;
-    temp.push_back(static_cast<Part::Extrusion*>(getObject())->Base.getValue());
+    temp.push_back(getObject<Part::Extrusion>()->Base.getValue());
 
     return temp;
 }

--- a/src/Mod/Part/Gui/ViewProviderMirror.cpp
+++ b/src/Mod/Part/Gui/ViewProviderMirror.cpp
@@ -74,7 +74,7 @@ ViewProviderMirror::~ViewProviderMirror()
 void ViewProviderMirror::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {
     // don't add plane editor to context menu if MirrorPlane is set because it would override any changes, anyway
-    Part::Mirroring* mf = static_cast<Part::Mirroring*>(getObject());
+    Part::Mirroring* mf = getObject<Part::Mirroring>();
     Part::Feature* ref = static_cast<Part::Feature*>(mf->MirrorPlane.getValue());
     bool enabled = true;
     if (ref){
@@ -92,7 +92,7 @@ bool ViewProviderMirror::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default) {
         // get the properties from the mirror feature
-        Part::Mirroring* mf = static_cast<Part::Mirroring*>(getObject());
+        Part::Mirroring* mf = getObject<Part::Mirroring>();
         Part::Feature* ref = static_cast<Part::Feature*>(mf->MirrorPlane.getValue());
         if (ref) { //skip this editor if MirrorPlane property is set
             return false;
@@ -173,7 +173,7 @@ void ViewProviderMirror::unsetEdit(int ModNum)
         rot.multVec(norm,norm);
 
         // apply the new values
-        Part::Mirroring* mf = static_cast<Part::Mirroring*>(getObject());
+        Part::Mirroring* mf = getObject<Part::Mirroring>();
         mf->Base.setValue(move[0],move[1],move[2]);
         mf->Normal.setValue(norm[0],norm[1],norm[2]);
 
@@ -189,14 +189,14 @@ std::vector<App::DocumentObject*> ViewProviderMirror::claimChildren() const
 {
     // Make the input object a child (see also #0001482)
     std::vector<App::DocumentObject*> temp;
-    temp.push_back(static_cast<Part::Mirroring*>(getObject())->Source.getValue());
+    temp.push_back(getObject<Part::Mirroring>()->Source.getValue());
     return temp;
 }
 
 bool ViewProviderMirror::onDelete(const std::vector<std::string> &)
 {
     // get the input shape
-    Part::Mirroring* pMirroring = static_cast<Part::Mirroring*>(getObject());
+    Part::Mirroring* pMirroring = getObject<Part::Mirroring>();
     App::DocumentObject *pSource = pMirroring->Source.getValue();
     if (pSource)
         Gui::Application::Instance->showViewProvider(pSource);
@@ -224,7 +224,7 @@ void ViewProviderMirror::dragMotionCallback(void *data, SoDragger *drag)
     SbRotation rot(mat);
     SbVec3f norm(0,0,1);
     rot.multVec(norm,norm);
-    Part::Mirroring* mf = static_cast<Part::Mirroring*>(that->getObject());
+    Part::Mirroring* mf = that->getObject<Part::Mirroring>();
     mf->Base.setValue(mat[3][0],mat[3][1],mat[3][2]);
     mf->Normal.setValue(norm[0],norm[1],norm[2]);
 }
@@ -248,7 +248,7 @@ void ViewProviderFillet::updateData(const App::Property* prop)
             (prop)->getValues();
         if (hist.size() != 1)
             return;
-        Part::Fillet* objFill = dynamic_cast<Part::Fillet*>(getObject());
+        Part::Fillet* objFill = getObject<Part::Fillet>();
         if (!objFill)
             return;
         Part::Feature* objBase = dynamic_cast<Part::Feature*>(
@@ -301,7 +301,7 @@ bool ViewProviderFillet::setEdit(int ModNum)
     if (ModNum == ViewProvider::Default ) {
         if (Gui::Control().activeDialog())
             return false;
-        Part::Fillet* fillet = static_cast<Part::Fillet*>(getObject());
+        Part::Fillet* fillet = getObject<Part::Fillet>();
         Gui::Control().showDialog(new PartGui::TaskFilletEdges(fillet));
         return true;
     }
@@ -324,14 +324,14 @@ void ViewProviderFillet::unsetEdit(int ModNum)
 std::vector<App::DocumentObject*> ViewProviderFillet::claimChildren() const
 {
     std::vector<App::DocumentObject*> temp;
-    temp.push_back(static_cast<Part::Fillet*>(getObject())->Base.getValue());
+    temp.push_back(getObject<Part::Fillet>()->Base.getValue());
     return temp;
 }
 
 bool ViewProviderFillet::onDelete(const std::vector<std::string> &)
 {
     // get the input shape
-    Part::Fillet* pFillet = static_cast<Part::Fillet*>(getObject());
+    Part::Fillet* pFillet = getObject<Part::Fillet>();
     App::DocumentObject *pBase = pFillet->Base.getValue();
     if (pBase)
         Gui::Application::Instance->showViewProvider(pBase);
@@ -358,7 +358,7 @@ void ViewProviderChamfer::updateData(const App::Property* prop)
             (prop)->getValues();
         if (hist.size() != 1)
             return;
-        Part::Chamfer* objCham = dynamic_cast<Part::Chamfer*>(getObject());
+        Part::Chamfer* objCham = getObject<Part::Chamfer>();
         if (!objCham)
             return;
         Part::Feature* objBase = dynamic_cast<Part::Feature*>(
@@ -411,7 +411,7 @@ bool ViewProviderChamfer::setEdit(int ModNum)
     if (ModNum == ViewProvider::Default ) {
         if (Gui::Control().activeDialog())
             return false;
-        Part::Chamfer* chamfer = static_cast<Part::Chamfer*>(getObject());
+        Part::Chamfer* chamfer = getObject<Part::Chamfer>();
         Gui::Control().showDialog(new PartGui::TaskChamferEdges(chamfer));
         return true;
     }
@@ -434,14 +434,14 @@ void ViewProviderChamfer::unsetEdit(int ModNum)
 std::vector<App::DocumentObject*> ViewProviderChamfer::claimChildren() const
 {
     std::vector<App::DocumentObject*> temp;
-    temp.push_back(static_cast<Part::Chamfer*>(getObject())->Base.getValue());
+    temp.push_back(getObject<Part::Chamfer>()->Base.getValue());
     return temp;
 }
 
 bool ViewProviderChamfer::onDelete(const std::vector<std::string> &)
 {
     // get the input shape
-    Part::Chamfer* pChamfer = static_cast<Part::Chamfer*>(getObject());
+    Part::Chamfer* pChamfer = getObject<Part::Chamfer>();
     App::DocumentObject *pBase = pChamfer->Base.getValue();
     if (pBase)
         Gui::Application::Instance->showViewProvider(pBase);
@@ -463,14 +463,14 @@ ViewProviderRevolution::~ViewProviderRevolution() = default;
 std::vector<App::DocumentObject*> ViewProviderRevolution::claimChildren() const
 {
     std::vector<App::DocumentObject*> temp;
-    temp.push_back(static_cast<Part::Revolution*>(getObject())->Source.getValue());
+    temp.push_back(getObject<Part::Revolution>()->Source.getValue());
     return temp;
 }
 
 bool ViewProviderRevolution::onDelete(const std::vector<std::string> &)
 {
     // get the input shape
-    Part::Revolution* pRevolve = static_cast<Part::Revolution*>(getObject());
+    Part::Revolution* pRevolve = getObject<Part::Revolution>();
     App::DocumentObject *pBase = pRevolve->Source.getValue();
     if (pBase)
         Gui::Application::Instance->showViewProvider(pBase);
@@ -491,7 +491,7 @@ ViewProviderLoft::~ViewProviderLoft() = default;
 
 std::vector<App::DocumentObject*> ViewProviderLoft::claimChildren() const
 {
-    return static_cast<Part::Loft*>(getObject())->Sections.getValues();
+    return getObject<Part::Loft>()->Sections.getValues();
 }
 
 bool ViewProviderLoft::onDelete(const std::vector<std::string> &)
@@ -512,7 +512,7 @@ ViewProviderSweep::~ViewProviderSweep() = default;
 
 std::vector<App::DocumentObject*> ViewProviderSweep::claimChildren() const
 {
-    auto obj = static_cast<Part::Sweep*>(getObject());
+    auto obj = getObject<Part::Sweep>();
     auto children = obj->Sections.getValues();
     if(obj->Spine.getValue())
         children.push_back(obj->Spine.getValue());
@@ -562,7 +562,7 @@ bool ViewProviderOffset::setEdit(int ModNum)
         if (offsetDlg)
             Gui::Control().showDialog(offsetDlg);
         else
-            Gui::Control().showDialog(new TaskOffset(static_cast<Part::Offset*>(getObject())));
+            Gui::Control().showDialog(new TaskOffset(getObject<Part::Offset>()));
 
         return true;
     }
@@ -585,14 +585,14 @@ void ViewProviderOffset::unsetEdit(int ModNum)
 std::vector<App::DocumentObject*> ViewProviderOffset::claimChildren() const
 {
     std::vector<App::DocumentObject*> child;
-    child.push_back(static_cast<Part::Offset*>(getObject())->Source.getValue());
+    child.push_back(getObject<Part::Offset>()->Source.getValue());
     return child;
 }
 
 bool ViewProviderOffset::onDelete(const std::vector<std::string> &)
 {
     // get the support and Sketch
-    Part::Offset* offset = static_cast<Part::Offset*>(getObject());
+    Part::Offset* offset = getObject<Part::Offset>();
     App::DocumentObject* source = offset->Source.getValue();
     if (source){
         Gui::Application::Instance->getViewProvider(source)->show();
@@ -644,7 +644,7 @@ bool ViewProviderThickness::setEdit(int ModNum)
         if (thicknessDlg)
             Gui::Control().showDialog(thicknessDlg);
         else
-            Gui::Control().showDialog(new TaskThickness(static_cast<Part::Thickness*>(getObject())));
+            Gui::Control().showDialog(new TaskThickness(getObject<Part::Thickness>()));
 
         return true;
     }
@@ -667,14 +667,14 @@ void ViewProviderThickness::unsetEdit(int ModNum)
 std::vector<App::DocumentObject*> ViewProviderThickness::claimChildren() const
 {
     std::vector<App::DocumentObject*> child;
-    child.push_back(static_cast<Part::Thickness*>(getObject())->Faces.getValue());
+    child.push_back(getObject<Part::Thickness>()->Faces.getValue());
     return child;
 }
 
 bool ViewProviderThickness::onDelete(const std::vector<std::string> &)
 {
     // get the support and Sketch
-    Part::Thickness* thickness = static_cast<Part::Thickness*>(getObject());
+    Part::Thickness* thickness = getObject<Part::Thickness>();
     App::DocumentObject* source = thickness->Faces.getValue();
     if (source){
         Gui::Application::Instance->getViewProvider(source)->show();

--- a/src/Mod/Part/Gui/ViewProviderPlaneParametric.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPlaneParametric.cpp
@@ -67,7 +67,7 @@ ViewProviderFace::~ViewProviderFace() = default;
 
 std::vector<App::DocumentObject*> ViewProviderFace::claimChildren() const
 {
-    return static_cast<Part::Face*>(getObject())->Sources.getValues();
+    return getObject<Part::Face>()->Sources.getValues();
 }
 
 bool ViewProviderFace::canDragObjects() const
@@ -84,7 +84,7 @@ bool ViewProviderFace::canDragObject(App::DocumentObject* obj) const
 
 void ViewProviderFace::dragObject(App::DocumentObject* obj)
 {
-    Part::Face* face = static_cast<Part::Face*>(getObject());
+    Part::Face* face = getObject<Part::Face>();
     std::vector<App::DocumentObject*> sources = face->Sources.getValues();
     for (std::vector<App::DocumentObject*>::iterator it = sources.begin(); it != sources.end(); ++it) {
         if (*it == obj) {
@@ -107,7 +107,7 @@ bool ViewProviderFace::canDropObject(App::DocumentObject* obj) const
 
 void ViewProviderFace::dropObject(App::DocumentObject* obj)
 {
-    Part::Face* face = static_cast<Part::Face*>(getObject());
+    Part::Face* face = getObject<Part::Face>();
     std::vector<App::DocumentObject*> sources = face->Sources.getValues();
     sources.push_back(obj);
     face->Sources.setValues(sources);

--- a/src/Mod/Part/Gui/ViewProviderPrimitive.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPrimitive.cpp
@@ -65,7 +65,7 @@ bool ViewProviderPrimitive::setEdit(int ModNum)
         if (Gui::Control().activeDialog())
             return false;
         PartGui::TaskPrimitivesEdit* dlg
-            = new PartGui::TaskPrimitivesEdit(dynamic_cast<Part::Primitive*>(getObject()));
+            = new PartGui::TaskPrimitivesEdit(getObject<Part::Primitive>());
         Gui::Control().showDialog(dlg);
         return true;
     }

--- a/src/Mod/Part/Gui/ViewProviderProjectOnSurface.cpp
+++ b/src/Mod/Part/Gui/ViewProviderProjectOnSurface.cpp
@@ -64,7 +64,7 @@ bool ViewProviderProjectOnSurface::setEdit(int ModNum)
             return false;
         }
 
-        if (auto feature = dynamic_cast<Part::ProjectOnSurface*>(getObject())) {
+        if (auto feature = getObject<Part::ProjectOnSurface>()) {
             Gui::Control().showDialog(new TaskProjectOnSurface(feature));
             return true;
         }

--- a/src/Mod/Part/Gui/ViewProviderRuledSurface.cpp
+++ b/src/Mod/Part/Gui/ViewProviderRuledSurface.cpp
@@ -48,8 +48,8 @@ std::vector<App::DocumentObject*> ViewProviderRuledSurface::claimChildren() cons
 {
     // in a set each element is unique
     std::set<App::DocumentObject*> temp;
-    temp.insert(static_cast<Part::RuledSurface*>(getObject())->Curve1.getValue());
-    temp.insert(static_cast<Part::RuledSurface*>(getObject())->Curve2.getValue());
+    temp.insert(getObject<Part::RuledSurface>()->Curve1.getValue());
+    temp.insert(getObject<Part::RuledSurface>()->Curve2.getValue());
 
     std::vector<App::DocumentObject*> array;
     array.insert(array.begin(), temp.begin(), temp.end());
@@ -66,7 +66,7 @@ void ViewProviderRuledSurface::updateData(const App::Property* prop)
     /*  //The following hides the Children shapes. If the edges from which the Ruled Surface was created
      * were selected from the subshapes of another shape, it is likely that one would not want to hide the shape
      * hence this section is commented out
-    Part::RuledSurface* pRuledSurface = static_cast<Part::RuledSurface*>(getObject());
+    Part::RuledSurface* pRuledSurface = getObject<Part::RuledSurface>();
     App::DocumentObject *pCurve1 = pRuledSurface->Curve1.getValue();
     App::DocumentObject *pCurve2 = pRuledSurface->Curve2.getValue();
     if (pCurve1)
@@ -79,7 +79,7 @@ void ViewProviderRuledSurface::updateData(const App::Property* prop)
 bool ViewProviderRuledSurface::onDelete(const std::vector<std::string> &)
 {
     // get the input shape
-    Part::RuledSurface* pRuledSurface = static_cast<Part::RuledSurface*>(getObject());
+    Part::RuledSurface* pRuledSurface = getObject<Part::RuledSurface>();
     App::DocumentObject *pCurve1 = pRuledSurface->Curve1.getValue();
     App::DocumentObject *pCurve2 = pRuledSurface->Curve2.getValue();
     if (pCurve1)

--- a/src/Mod/Part/Gui/ViewProviderScale.cpp
+++ b/src/Mod/Part/Gui/ViewProviderScale.cpp
@@ -41,7 +41,7 @@ ViewProviderScale::~ViewProviderScale() = default;
 std::vector<App::DocumentObject*> ViewProviderScale::claimChildren()const
 {
     std::vector<App::DocumentObject*> temp;
-    temp.push_back(static_cast<Part::Scale*>(getObject())->Base.getValue());
+    temp.push_back(getObject<Part::Scale>()->Base.getValue());
 
     return temp;
 }

--- a/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
@@ -74,7 +74,7 @@ TaskBooleanParameters::TaskBooleanParameters(ViewProviderBoolean* BooleanView, Q
 
     this->groupLayout()->addWidget(proxy);
 
-    PartDesign::Boolean* pcBoolean = static_cast<PartDesign::Boolean*>(BooleanView->getObject());
+    PartDesign::Boolean* pcBoolean = BooleanView->getObject<PartDesign::Boolean>();
     std::vector<App::DocumentObject*> bodies = pcBoolean->Group.getValues();
     for (auto body : bodies) {
         QListWidgetItem* item = new QListWidgetItem(ui->listWidgetBodies);
@@ -114,7 +114,7 @@ void TaskBooleanParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
 
         // get the selected object
         PartDesign::Boolean* pcBoolean =
-            static_cast<PartDesign::Boolean*>(BooleanView->getObject());
+            BooleanView->getObject<PartDesign::Boolean>();
         std::string body(msg.pObjectName);
         if (body.empty()) {
             return;
@@ -225,7 +225,7 @@ void TaskBooleanParameters::onButtonBodyAdd(bool checked)
 {
     if (checked) {
         PartDesign::Boolean* pcBoolean =
-            static_cast<PartDesign::Boolean*>(BooleanView->getObject());
+            BooleanView->getObject<PartDesign::Boolean>();
         Gui::Document* doc = BooleanView->getDocument();
         BooleanView->hide();
         if (pcBoolean->Group.getValues().empty() && pcBoolean->BaseFeature.getValue()) {
@@ -256,7 +256,7 @@ void TaskBooleanParameters::onButtonBodyRemove(bool checked)
 
 void TaskBooleanParameters::onTypeChanged(int index)
 {
-    PartDesign::Boolean* pcBoolean = static_cast<PartDesign::Boolean*>(BooleanView->getObject());
+    PartDesign::Boolean* pcBoolean = BooleanView->getObject<PartDesign::Boolean>();
 
     switch (index) {
         case 0:
@@ -292,7 +292,7 @@ int TaskBooleanParameters::getType() const
 
 void TaskBooleanParameters::onBodyDeleted()
 {
-    PartDesign::Boolean* pcBoolean = static_cast<PartDesign::Boolean*>(BooleanView->getObject());
+    PartDesign::Boolean* pcBoolean = BooleanView->getObject<PartDesign::Boolean>();
     std::vector<App::DocumentObject*> bodies = pcBoolean->Group.getValues();
     int index = ui->listWidgetBodies->currentRow();
     if (index < 0 && (size_t)index > bodies.size()) {
@@ -420,7 +420,7 @@ bool TaskDlgBooleanParameters::accept()
 bool TaskDlgBooleanParameters::reject()
 {
     // Show the bodies again
-    PartDesign::Boolean* obj = static_cast<PartDesign::Boolean*>(BooleanView->getObject());
+    PartDesign::Boolean* obj = BooleanView->getObject<PartDesign::Boolean>();
     Gui::Document* doc = Gui::Application::Instance->activeDocument();
     if (doc) {
         if (obj->BaseFeature.getValue()) {

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -56,7 +56,7 @@ TaskChamferParameters::TaskChamferParameters(ViewProviderDressUp* DressUpView, Q
     ui->setupUi(proxy);
     this->groupLayout()->addWidget(proxy);
 
-    PartDesign::Chamfer* pcChamfer = static_cast<PartDesign::Chamfer*>(DressUpView->getObject());
+    PartDesign::Chamfer* pcChamfer = DressUpView->getObject<PartDesign::Chamfer>();
 
     setUpUI(pcChamfer);
 

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -90,7 +90,7 @@ bool TaskDlgDatumParameters::reject() {
 
 bool TaskDlgDatumParameters::accept() {
 
-    Part::Datum* pcDatum = static_cast<Part::Datum*>(ViewProvider->getObject());
+    Part::Datum* pcDatum = ViewProvider->getObject<Part::Datum>();
     auto pcActiveBody = PartDesignGui::getBodyFor(pcDatum, false);
     auto pcActivePart = PartDesignGui::getPartFor(pcActiveBody, false);
     std::vector<App::DocumentObject*> copies;

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.cpp
@@ -58,7 +58,7 @@ TaskDraftParameters::TaskDraftParameters(ViewProviderDressUp* DressUpView, QWidg
 
     this->groupLayout()->addWidget(proxy);
 
-    PartDesign::Draft* pcDraft = static_cast<PartDesign::Draft*>(DressUpView->getObject());
+    PartDesign::Draft* pcDraft = DressUpView->getObject<PartDesign::Draft>();
     double a = pcDraft->Angle.getValue();
 
     ui->draftAngle->setMinimum(pcDraft->Angle.getMinimum());

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -114,7 +114,7 @@ void TaskDressUpParameters::referenceSelected(const Gui::SelectionChanges& msg, 
 
     Gui::Selection().clearSelection();
 
-    PartDesign::DressUp* pcDressUp = static_cast<PartDesign::DressUp*>(DressUpView->getObject());
+    PartDesign::DressUp* pcDressUp = DressUpView->getObject<PartDesign::DressUp>();
     App::DocumentObject* base = this->getBase();
 
     // TODO: Must we make a copy here instead of assigning to const char* ?
@@ -146,7 +146,7 @@ void TaskDressUpParameters::addAllEdges(QListWidget* widget)
         return;
     }
 
-    PartDesign::DressUp* pcDressUp = static_cast<PartDesign::DressUp*>(DressUpView->getObject());
+    PartDesign::DressUp* pcDressUp = DressUpView->getObject<PartDesign::DressUp>();
     App::DocumentObject* base = pcDressUp->Base.getValue();
     if (!base) {
         return;
@@ -181,7 +181,7 @@ void TaskDressUpParameters::deleteRef(QListWidget* widget)
     // get the list of items to be deleted
     QList<QListWidgetItem*> selectedList = widget->selectedItems();
 
-    PartDesign::DressUp* pcDressUp = static_cast<PartDesign::DressUp*>(DressUpView->getObject());
+    PartDesign::DressUp* pcDressUp = DressUpView->getObject<PartDesign::DressUp>();
     std::vector<std::string> refs = pcDressUp->Base.getSubValues();
 
     // delete the selection backwards to assure the list index keeps valid for the deletion
@@ -354,7 +354,7 @@ void TaskDressUpParameters::keyPressEvent(QKeyEvent* ke)
 
 const std::vector<std::string> TaskDressUpParameters::getReferences() const
 {
-    PartDesign::DressUp* pcDressUp = static_cast<PartDesign::DressUp*>(DressUpView->getObject());
+    PartDesign::DressUp* pcDressUp = DressUpView->getObject<PartDesign::DressUp>();
     std::vector<std::string> result = pcDressUp->Base.getSubValues();
     return result;
 }
@@ -412,7 +412,7 @@ ViewProviderDressUp* TaskDressUpParameters::getDressUpView() const
 Part::Feature* TaskDressUpParameters::getBase() const
 {
     if (ViewProviderDressUp* vp = getDressUpView()) {
-        auto dressUp = dynamic_cast<PartDesign::DressUp*>(vp->getObject());
+        auto dressUp = vp->getObject<PartDesign::DressUp>();
         // Unlikely but this may throw an exception in case we are started to edit an object which
         // base feature was deleted. This exception will be likely unhandled inside the dialog and
         // pass upper. But an error message inside the report view is better than a SEGFAULT.
@@ -464,7 +464,7 @@ TaskDlgDressUpParameters::TaskDlgDressUpParameters(ViewProviderDressUp *DressUpV
     , parameter(nullptr)
 {
     assert(DressUpView);
-    auto pcDressUp = dynamic_cast<PartDesign::DressUp*>(DressUpView->getObject());
+    auto pcDressUp = DressUpView->getObject<PartDesign::DressUp>();
     auto base = pcDressUp->Base.getValue();
     std::vector<std::string> newSubList;
     bool changed = false;

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
@@ -95,8 +95,9 @@ protected:
     template<typename T = App::DocumentObject> T* getObject() const
     {
         static_assert(std::is_base_of<App::DocumentObject, T>::value, "Wrong template argument");
+
         if (!DressUpView.expired()) {
-            return dynamic_cast<T*>(DressUpView->getObject());
+            return DressUpView->getObject<T>();
         }
 
         return nullptr;

--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.h
@@ -75,8 +75,9 @@ protected:
     template<typename T = App::DocumentObject> T* getObject() const
     {
         static_assert(std::is_base_of<App::DocumentObject, T>::value, "Wrong template argument");
+
         if (vp) {
-            return dynamic_cast<T*>(vp->getObject());
+            return vp->getObject<T>();
         }
 
         return nullptr;
@@ -134,7 +135,7 @@ public:
     {
         static_assert(std::is_base_of<App::DocumentObject, T>::value, "Wrong template argument");
         if (vp) {
-            return dynamic_cast<T*>(vp->getObject());
+            return vp->getObject<T>();
         }
 
         return nullptr;

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.cpp
@@ -54,7 +54,7 @@ TaskFilletParameters::TaskFilletParameters(ViewProviderDressUp* DressUpView, QWi
     ui->setupUi(proxy);
     this->groupLayout()->addWidget(proxy);
 
-    PartDesign::Fillet* pcFillet = static_cast<PartDesign::Fillet*>(DressUpView->getObject());
+    PartDesign::Fillet* pcFillet = DressUpView->getObject<PartDesign::Fillet>();
     bool useAllEdges = pcFillet->UseAllEdges.getValue();
     ui->checkBoxUseAllEdges->setChecked(useAllEdges);
     ui->buttonRefSel->setEnabled(!useAllEdges);

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.cpp
@@ -74,7 +74,7 @@ void TaskLinearPatternParameters::setupParameterUI(QWidget* widget)
     QMetaObject::connectSlotsByName(this);
 
     // Get the feature data
-    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = getObject<PartDesign::LinearPattern>();
 
     ui->spinLength->bind(pcLinearPattern->Length);
     ui->spinOffset->bind(pcLinearPattern->Offset);
@@ -166,7 +166,7 @@ void TaskLinearPatternParameters::updateUI()
     }
     blockUpdate = true;
 
-    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = getObject<PartDesign::LinearPattern>();
     auto mode = static_cast<PartDesign::LinearPatternMode>(pcLinearPattern->Mode.getValue());
 
     bool reverse = pcLinearPattern->Reversed.getValue();
@@ -195,7 +195,7 @@ void TaskLinearPatternParameters::updateUI()
 
 void TaskLinearPatternParameters::adaptVisibilityToMode()
 {
-    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = getObject<PartDesign::LinearPattern>();
     auto mode = static_cast<PartDesign::LinearPatternMode>(pcLinearPattern->Mode.getValue());
 
     ui->lengthWrapper->setVisible(mode == PartDesign::LinearPatternMode::length);
@@ -222,7 +222,7 @@ void TaskLinearPatternParameters::onSelectionChanged(const Gui::SelectionChanges
             exitSelectionMode();
         }
         else {
-            auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+            auto pcLinearPattern = getObject<PartDesign::LinearPattern>();
 
             std::vector<std::string> directions;
             App::DocumentObject* selObj = nullptr;
@@ -248,7 +248,7 @@ void TaskLinearPatternParameters::onCheckReverse(const bool on)
     if (blockUpdate) {
         return;
     }
-    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = getObject<PartDesign::LinearPattern>();
     pcLinearPattern->Reversed.setValue(on);
 
     exitSelectionMode();
@@ -260,7 +260,7 @@ void TaskLinearPatternParameters::onModeChanged(const int mode)
     if (blockUpdate) {
         return;
     }
-    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = getObject<PartDesign::LinearPattern>();
     pcLinearPattern->Mode.setValue(mode);
 
     adaptVisibilityToMode();
@@ -274,7 +274,7 @@ void TaskLinearPatternParameters::onLength(const double length)
     if (blockUpdate) {
         return;
     }
-    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = getObject<PartDesign::LinearPattern>();
     pcLinearPattern->Length.setValue(length);
 
     exitSelectionMode();
@@ -286,7 +286,7 @@ void TaskLinearPatternParameters::onOffset(const double offset)
     if (blockUpdate) {
         return;
     }
-    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = getObject<PartDesign::LinearPattern>();
     pcLinearPattern->Offset.setValue(offset);
 
     exitSelectionMode();
@@ -298,7 +298,7 @@ void TaskLinearPatternParameters::onOccurrences(const uint number)
     if (blockUpdate) {
         return;
     }
-    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = getObject<PartDesign::LinearPattern>();
     pcLinearPattern->Occurrences.setValue(number);
 
     exitSelectionMode();
@@ -310,7 +310,7 @@ void TaskLinearPatternParameters::onDirectionChanged(int /*num*/)
     if (blockUpdate) {
         return;
     }
-    auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+    auto pcLinearPattern = getObject<PartDesign::LinearPattern>();
     try {
         if (!dirLinks.getCurrentLink().getValue()) {
             // enter reference selection mode
@@ -338,7 +338,7 @@ void TaskLinearPatternParameters::onUpdateView(bool on)
     blockUpdate = !on;
     if (on) {
         // Do the same like in TaskDlgLinearPatternParameters::accept() but without doCommand
-        auto pcLinearPattern = static_cast<PartDesign::LinearPattern*>(getObject());
+        auto pcLinearPattern = getObject<PartDesign::LinearPattern>();
         std::vector<std::string> directions;
         App::DocumentObject* obj = nullptr;
 

--- a/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskLoftParameters.cpp
@@ -99,7 +99,7 @@ TaskLoftParameters::TaskLoftParameters(ViewProviderLoft* LoftView, bool /*newObj
     }
 
     // add the profiles
-    PartDesign::Loft* loft = static_cast<PartDesign::Loft*>(LoftView->getObject());
+    PartDesign::Loft* loft = LoftView->getObject<PartDesign::Loft>();
     App::DocumentObject* profile = loft->Profile.getValue();
     if (profile) {
         Gui::Application::Instance->showViewProvider(profile);

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.cpp
@@ -114,7 +114,7 @@ void TaskMirroredParameters::updateUI()
     }
     blockUpdate = true;
 
-    auto pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
+    auto pcMirrored = getObject<PartDesign::Mirrored>();
 
     if (planeLinks.setCurrentLink(pcMirrored->MirrorPlane) == -1) {
         // failed to set current, because the link isn't in the list yet
@@ -135,7 +135,7 @@ void TaskMirroredParameters::onSelectionChanged(const Gui::SelectionChanges& msg
             exitSelectionMode();
         }
         else {
-            auto pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
+            auto pcMirrored = getObject<PartDesign::Mirrored>();
 
             std::vector<std::string> mirrorPlanes;
             App::DocumentObject* selObj = nullptr;
@@ -161,7 +161,7 @@ void TaskMirroredParameters::onPlaneChanged(int /*num*/)
         return;
     }
     setupTransaction();
-    auto pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
+    auto pcMirrored = getObject<PartDesign::Mirrored>();
     try {
         if (!planeLinks.getCurrentLink().getValue()) {
             // enter reference selection mode
@@ -189,7 +189,7 @@ void TaskMirroredParameters::onUpdateView(bool on)
     if (on) {
         setupTransaction();
         // Do the same like in TaskDlgMirroredParameters::accept() but without doCommand
-        auto pcMirrored = static_cast<PartDesign::Mirrored*>(getObject());
+        auto pcMirrored = getObject<PartDesign::Mirrored>();
         std::vector<std::string> mirrorPlanes;
         App::DocumentObject* obj = nullptr;
 

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.cpp
@@ -124,7 +124,7 @@ void TaskMultiTransformParameters::setupParameterUI(QWidget* widget)
     ui->buttonOK->hide();
 
     // Get the transformFeatures data
-    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    auto pcMultiTransform = TransformedView->getObject<PartDesign::MultiTransform>();
     std::vector<App::DocumentObject*> transformFeatures =
         pcMultiTransform->Transformations.getValues();
 
@@ -190,7 +190,7 @@ void TaskMultiTransformParameters::onTransformDelete()
         return;  // Can't delete the hint...
     }
     int row = ui->listTransformFeatures->currentIndex().row();
-    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    auto pcMultiTransform = TransformedView->getObject<PartDesign::MultiTransform>();
     std::vector<App::DocumentObject*> transformFeatures =
         pcMultiTransform->Transformations.getValues();
 
@@ -222,7 +222,7 @@ void TaskMultiTransformParameters::onTransformEdit()
                      // without OK'ing first
     ui->listTransformFeatures->currentItem()->setSelected(true);
     int row = ui->listTransformFeatures->currentIndex().row();
-    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    auto pcMultiTransform = TransformedView->getObject<PartDesign::MultiTransform>();
     std::vector<App::DocumentObject*> transformFeatures =
         pcMultiTransform->Transformations.getValues();
 
@@ -410,7 +410,7 @@ void TaskMultiTransformParameters::finishAdd(std::string& newFeatName)
     // getOriginals().front()->getNameInDocument().c_str());
 
     setupTransaction();
-    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    auto pcMultiTransform = TransformedView->getObject<PartDesign::MultiTransform>();
     if (editHint) {
         // Remove hint, first feature is being added
         ui->listTransformFeatures->model()->removeRow(0);
@@ -459,7 +459,7 @@ void TaskMultiTransformParameters::moveTransformFeature(const int increment)
 {
     setupTransaction();
     int row = ui->listTransformFeatures->currentIndex().row();
-    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(TransformedView->getObject());
+    auto pcMultiTransform = TransformedView->getObject<PartDesign::MultiTransform>();
     std::vector<App::DocumentObject*> transformFeatures =
         pcMultiTransform->Transformations.getValues();
 
@@ -521,7 +521,7 @@ void TaskMultiTransformParameters::onUpdateView(bool on)
 
 void TaskMultiTransformParameters::apply()
 {
-    auto pcMultiTransform = static_cast<PartDesign::MultiTransform*>(getObject());
+    auto pcMultiTransform = getObject<PartDesign::MultiTransform>();
     std::vector<App::DocumentObject*> transformFeatures =
         pcMultiTransform->Transformations.getValues();
     std::stringstream str;

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -102,7 +102,7 @@ TaskPipeParameters::TaskPipeParameters(ViewProviderPipe* PipeView, bool /*newObj
 
     this->groupLayout()->addWidget(proxy);
 
-    PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(PipeView->getObject());
+    PartDesign::Pipe* pipe = PipeView->getObject<PartDesign::Pipe>();
     Gui::Document* doc = PipeView->getDocument();
 
     // make sure the user sees all important things and load the values
@@ -625,7 +625,7 @@ TaskPipeOrientation::TaskPipeOrientation(ViewProviderPipe* PipeView,
 
     this->groupLayout()->addWidget(proxy);
 
-    PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(PipeView->getObject());
+    PartDesign::Pipe* pipe = PipeView->getObject<PartDesign::Pipe>();
 
     // add initial values
     if (pipe->AuxillerySpine.getValue()) {
@@ -923,7 +923,7 @@ TaskPipeScaling::TaskPipeScaling(ViewProviderPipe* PipeView, bool /*newObj*/, QW
 
     this->groupLayout()->addWidget(proxy);
 
-    PartDesign::Pipe* pipe = static_cast<PartDesign::Pipe*>(PipeView->getObject());
+    PartDesign::Pipe* pipe = PipeView->getObject<PartDesign::Pipe>();
     for (auto& subSet : pipe->Sections.getSubListValues()) {
         Gui::Application::Instance->showViewProvider(subSet.first);
         QString label = make2DLabel(subSet.first, subSet.second);

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.cpp
@@ -81,7 +81,7 @@ void TaskPolarPatternParameters::setupParameterUI(QWidget* widget)
     QMetaObject::connectSlotsByName(this);
 
     // Get the feature data
-    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = getObject<PartDesign::PolarPattern>();
 
     ui->polarAngle->bind(pcPolarPattern->Angle);
     ui->angleOffset->bind(pcPolarPattern->Offset);
@@ -168,7 +168,7 @@ void TaskPolarPatternParameters::updateUI()
     }
     blockUpdate = true;
 
-    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = getObject<PartDesign::PolarPattern>();
 
     auto mode = static_cast<PartDesign::PolarPatternMode>(pcPolarPattern->Mode.getValue());
     bool reverse = pcPolarPattern->Reversed.getValue();
@@ -208,7 +208,7 @@ void TaskPolarPatternParameters::kickUpdateViewTimer() const
 
 void TaskPolarPatternParameters::adaptVisibilityToMode()
 {
-    auto pcLinearPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcLinearPattern = getObject<PartDesign::PolarPattern>();
     auto mode = static_cast<PartDesign::PolarPatternMode>(pcLinearPattern->Mode.getValue());
 
     ui->polarAngleWrapper->setVisible(mode == PartDesign::PolarPatternMode::angle);
@@ -222,7 +222,7 @@ void TaskPolarPatternParameters::onSelectionChanged(const Gui::SelectionChanges&
             exitSelectionMode();
         }
         else {
-            auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+            auto pcPolarPattern = getObject<PartDesign::PolarPattern>();
 
             std::vector<std::string> axes;
             App::DocumentObject* selObj = nullptr;
@@ -247,7 +247,7 @@ void TaskPolarPatternParameters::onCheckReverse(const bool on)
     if (blockUpdate) {
         return;
     }
-    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = getObject<PartDesign::PolarPattern>();
     pcPolarPattern->Reversed.setValue(on);
 
     exitSelectionMode();
@@ -259,7 +259,7 @@ void TaskPolarPatternParameters::onModeChanged(const int mode)
     if (blockUpdate) {
         return;
     }
-    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = getObject<PartDesign::PolarPattern>();
     pcPolarPattern->Mode.setValue(mode);
 
     adaptVisibilityToMode();
@@ -273,7 +273,7 @@ void TaskPolarPatternParameters::onAngle(const double angle)
     if (blockUpdate) {
         return;
     }
-    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = getObject<PartDesign::PolarPattern>();
     pcPolarPattern->Angle.setValue(angle);
 
     exitSelectionMode();
@@ -285,7 +285,7 @@ void TaskPolarPatternParameters::onOffset(const double offset)
     if (blockUpdate) {
         return;
     }
-    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = getObject<PartDesign::PolarPattern>();
     pcPolarPattern->Offset.setValue(offset);
 
     exitSelectionMode();
@@ -297,7 +297,7 @@ void TaskPolarPatternParameters::onOccurrences(const uint n)
     if (blockUpdate) {
         return;
     }
-    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = getObject<PartDesign::PolarPattern>();
     pcPolarPattern->Occurrences.setValue(n);
 
     exitSelectionMode();
@@ -309,7 +309,7 @@ void TaskPolarPatternParameters::onAxisChanged(int /*num*/)
     if (blockUpdate) {
         return;
     }
-    auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+    auto pcPolarPattern = getObject<PartDesign::PolarPattern>();
 
     try {
         if (!axesLinks.getCurrentLink().getValue()) {
@@ -337,7 +337,7 @@ void TaskPolarPatternParameters::onUpdateView(bool on)
     blockUpdate = !on;
     if (on) {
         // Do the same like in TaskDlgPolarPatternParameters::accept() but without doCommand
-        auto pcPolarPattern = static_cast<PartDesign::PolarPattern*>(getObject());
+        auto pcPolarPattern = getObject<PartDesign::PolarPattern>();
         std::vector<std::string> axes;
         App::DocumentObject* obj = nullptr;
 

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.h
@@ -105,7 +105,7 @@ private:
     {
         static_assert(std::is_base_of<App::DocumentObject, T>::value, "Wrong template argument");
         if (vp) {
-            return dynamic_cast<T*>(vp->getObject());
+            return vp->getObject<T>();
         }
 
         return nullptr;

--- a/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskScaledParameters.cpp
@@ -75,7 +75,7 @@ void TaskScaledParameters::setupParameterUI(QWidget* widget)
             &TaskScaledParameters::onOccurrences);
 
     // Get the feature data
-    auto pcScaled = static_cast<PartDesign::Scaled*>(getObject());
+    auto pcScaled = getObject<PartDesign::Scaled>();
 
     ui->spinFactor->bind(pcScaled->Factor);
     ui->spinOccurrences->setMaximum(INT_MAX);
@@ -99,7 +99,7 @@ void TaskScaledParameters::updateUI()
     }
     blockUpdate = true;
 
-    auto pcScaled = static_cast<PartDesign::Scaled*>(getObject());
+    auto pcScaled = getObject<PartDesign::Scaled>();
 
     double factor = pcScaled->Factor.getValue();
     unsigned occurrences = pcScaled->Occurrences.getValue();
@@ -115,7 +115,7 @@ void TaskScaledParameters::onFactor(const double factor)
     if (blockUpdate) {
         return;
     }
-    auto pcScaled = static_cast<PartDesign::Scaled*>(getObject());
+    auto pcScaled = getObject<PartDesign::Scaled>();
     pcScaled->Factor.setValue(factor);
     recomputeFeature();
 }
@@ -125,7 +125,7 @@ void TaskScaledParameters::onOccurrences(const uint number)
     if (blockUpdate) {
         return;
     }
-    auto pcScaled = static_cast<PartDesign::Scaled*>(getObject());
+    auto pcScaled = getObject<PartDesign::Scaled>();
     pcScaled->Occurrences.setValue(number);
     recomputeFeature();
 }
@@ -135,7 +135,7 @@ void TaskScaledParameters::onUpdateView(bool on)
     blockUpdate = !on;
     if (on) {
         // Do the same like in TaskDlgScaledParameters::accept() but without doCommand
-        auto pcScaled = static_cast<PartDesign::Scaled*>(getObject());
+        auto pcScaled = getObject<PartDesign::Scaled>();
         pcScaled->Factor.setValue(getFactor());
         pcScaled->Occurrences.setValue(getOccurrences());
         recomputeFeature();

--- a/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
@@ -86,7 +86,7 @@ void TaskShapeBinder::updateUI()
     App::GeoFeature* obj = nullptr;
     std::vector<std::string> subs;
 
-    PartDesign::ShapeBinder::getFilteredReferences(&static_cast<PartDesign::ShapeBinder*>(vp->getObject())->Support, obj, subs);
+    PartDesign::ShapeBinder::getFilteredReferences(&vp->getObject<PartDesign::ShapeBinder>()->Support, obj, subs);
 
     if (obj) {
         ui->baseEdit->setText(QString::fromStdString(obj->Label.getStrValue()));
@@ -146,7 +146,7 @@ void TaskShapeBinder::setupContextMenu()
 void TaskShapeBinder::supportChanged(const QString& text)
 {
     if (!vp.expired() && text.isEmpty()) {
-        PartDesign::ShapeBinder* binder = static_cast<PartDesign::ShapeBinder*>(vp->getObject());
+        PartDesign::ShapeBinder* binder = vp->getObject<PartDesign::ShapeBinder>();
         binder->Support.setValue(nullptr, nullptr);
         vp->highlightReferences(false);
         vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
@@ -201,7 +201,7 @@ void TaskShapeBinder::deleteItem()
         App::GeoFeature* obj = nullptr;
         std::vector<std::string> subs;
 
-        PartDesign::ShapeBinder* binder = static_cast<PartDesign::ShapeBinder*>(vp->getObject());
+        PartDesign::ShapeBinder* binder = vp->getObject<PartDesign::ShapeBinder>();
         PartDesign::ShapeBinder::getFilteredReferences(&binder->Support, obj, subs);
 
         std::string subname = data.constData();
@@ -298,7 +298,7 @@ bool TaskShapeBinder::referenceSelected(const SelectionChanges& msg) const
         App::GeoFeature* obj = nullptr;
         std::vector<std::string> refs;
 
-        PartDesign::ShapeBinder::getFilteredReferences(&static_cast<PartDesign::ShapeBinder*>(vp->getObject())->Support, obj, refs);
+        PartDesign::ShapeBinder::getFilteredReferences(&vp->getObject<PartDesign::ShapeBinder>()->Support, obj, refs);
 
         // get selected object
         auto docObj = vp->getObject()->getDocument()->getObject(msg.pObjectName);
@@ -341,7 +341,7 @@ bool TaskShapeBinder::referenceSelected(const SelectionChanges& msg) const
             obj = selectedObj;
         }
 
-        static_cast<PartDesign::ShapeBinder*>(vp->getObject())->Support.setValue(obj, refs);
+        vp->getObject<PartDesign::ShapeBinder>()->Support.setValue(obj, refs);
 
         return true;
     }
@@ -368,7 +368,7 @@ void TaskShapeBinder::accept()
         return;
 
     std::string label = ui->baseEdit->text().toStdString();
-    PartDesign::ShapeBinder* binder = static_cast<PartDesign::ShapeBinder*>(vp->getObject());
+    PartDesign::ShapeBinder* binder = vp->getObject<PartDesign::ShapeBinder>();
     if (!binder->Support.getValue() && !label.empty()) {
         auto mode = selectionMode;
         selectionMode = refObjAdd;

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.cpp
@@ -123,7 +123,7 @@ void TaskTransformedParameters::setupUI()
             &TaskTransformedParameters::onUpdateView);
 
     // Get the feature data
-    auto pcTransformed = static_cast<PartDesign::Transformed*>(getObject());
+    auto pcTransformed = getObject<PartDesign::Transformed>();
 
     using Mode = PartDesign::Transformed::Mode;
 
@@ -307,7 +307,7 @@ void TaskTransformedParameters::onModeChanged(int mode_id)
         return;
     }
 
-    auto pcTransformed = static_cast<PartDesign::Transformed*>(getObject());
+    auto pcTransformed = getObject<PartDesign::Transformed>();
     pcTransformed->TransformMode.setValue(mode_id);
 
     using Mode = PartDesign::Transformed::Mode;
@@ -500,7 +500,7 @@ PartDesign::Transformed* TaskTransformedParameters::getObject() const
         return parentTask->getSubFeature();
     }
     if (TransformedView) {
-        return static_cast<PartDesign::Transformed*>(TransformedView->getObject());
+        return TransformedView->getObject<PartDesign::Transformed>();
     }
     return nullptr;
 }

--- a/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskTransformedParameters.h
@@ -178,6 +178,9 @@ protected:
      */
     PartDesign::Transformed* getObject() const;
 
+    template <class T>
+    T* getObject() const { return dynamic_cast<T*>(getObject()); }
+
     /// Get the sketch object of the first original either of the object associated with this
     /// feature or with the parent feature (MultiTransform mode)
     App::DocumentObject* getSketchObject() const;

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -214,7 +214,7 @@ QIcon ViewProvider::mergeColorfulOverlayIcons (const QIcon & orig) const
 
 bool ViewProvider::onDelete(const std::vector<std::string> &)
 {
-    PartDesign::Feature* feature = static_cast<PartDesign::Feature*>(getObject());
+    PartDesign::Feature* feature = getObject<PartDesign::Feature>();
 
     App::DocumentObject* previousfeat = feature->BaseFeature.getValue();
 

--- a/src/Mod/PartDesign/Gui/ViewProviderAddSub.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderAddSub.cpp
@@ -102,7 +102,7 @@ void ViewProviderAddSub::attach(App::DocumentObject* obj) {
 
 void ViewProviderAddSub::updateAddSubShapeIndicator() {
 
-    TopoDS_Shape cShape(static_cast<PartDesign::FeatureAddSub*>(getObject())->AddSubShape.getValue());
+    TopoDS_Shape cShape(getObject<PartDesign::FeatureAddSub>()->AddSubShape.getValue());
     if (cShape.IsNull()) {
         previewCoords  ->point      .setNum(0);
         previewNorm    ->vector     .setNum(0);
@@ -254,7 +254,7 @@ void ViewProviderAddSub::setPreviewDisplayMode(bool onoff) {
         pcModeSwitch->whichChild.setValue(whichChild);
     }
 
-    App::DocumentObject* obj = static_cast<PartDesign::Feature*>(getObject())->BaseFeature.getValue();
+    App::DocumentObject* obj = getObject<PartDesign::Feature>()->BaseFeature.getValue();
     if (obj)
         static_cast<PartDesignGui::ViewProvider*>(Gui::Application::Instance->getViewProvider(obj))->makeTemporaryVisible(onoff);
 }

--- a/src/Mod/PartDesign/Gui/ViewProviderBase.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBase.cpp
@@ -45,7 +45,7 @@ bool ViewProviderBase::doubleClicked()
 {
     // If the Placement is mutable then open the transform panel.
     // If the Placement can't be modified then just do nothing on double-click.
-    PartDesign::FeatureBase* base = static_cast<PartDesign::FeatureBase*>(getObject());
+    PartDesign::FeatureBase* base = getObject<PartDesign::FeatureBase>();
     if (!base->Placement.testStatus(App::Property::Immutable) &&
         !base->Placement.testStatus(App::Property::ReadOnly) &&
         !base->Placement.testStatus(App::Property::Hidden)) {
@@ -68,7 +68,7 @@ bool ViewProviderBase::doubleClicked()
 void ViewProviderBase::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {
     // If the Placement is mutable then show the context-menu of the base class.
-    PartDesign::FeatureBase* base = static_cast<PartDesign::FeatureBase*>(getObject());
+    PartDesign::FeatureBase* base = getObject<PartDesign::FeatureBase>();
     if (!base->Placement.testStatus(App::Property::Immutable) &&
         !base->Placement.testStatus(App::Property::ReadOnly) &&
         !base->Placement.testStatus(App::Property::Hidden)) {
@@ -78,7 +78,7 @@ void ViewProviderBase::setupContextMenu(QMenu* menu, QObject* receiver, const ch
 
 bool ViewProviderBase::setEdit(int ModNum)
 {
-    PartDesign::FeatureBase* base = static_cast<PartDesign::FeatureBase*>(getObject());
+    PartDesign::FeatureBase* base = getObject<PartDesign::FeatureBase>();
     if (!base->Placement.testStatus(App::Property::Immutable) &&
         !base->Placement.testStatus(App::Property::ReadOnly) &&
         !base->Placement.testStatus(App::Property::Hidden)) {

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -184,7 +184,7 @@ bool ViewProviderBody::doubleClicked()
 //
 //    // Highlight active body and all its features
 //    //Base::Console().Error("ViewProviderBody::updateTree()\n");
-//    PartDesign::Body* body = static_cast<PartDesign::Body*>(getObject());
+//    PartDesign::Body* body = getObject<PartDesign::Body>();
 //    bool active = body->IsActive.getValue();
 //    //Base::Console().Error("Body is %s\n", active ? "active" : "inactive");
 //    ActiveGuiDoc->signalHighlightObject(*this, Gui::Blue, active);
@@ -209,7 +209,7 @@ bool ViewProviderBody::onDelete ( const std::vector<std::string> &) {
 
 void ViewProviderBody::updateData(const App::Property* prop)
 {
-    PartDesign::Body* body = static_cast<PartDesign::Body*>(getObject());
+    PartDesign::Body* body = getObject<PartDesign::Body>();
 
     if (prop == &body->Group || prop == &body->BaseFeature) {
         //ensure all model features are in visual body mode
@@ -237,7 +237,7 @@ void ViewProviderBody::updateData(const App::Property* prop)
 void ViewProviderBody::onChanged(const App::Property* prop) {
 
     if(prop == &DisplayModeBody) {
-        auto body = dynamic_cast<PartDesign::Body*>(getObject());
+        auto body = getObject<PartDesign::Body>();
 
         if ( DisplayModeBody.getValue() == 0 )  {
             //if we are in an override mode we need to make sure to come out, because
@@ -342,7 +342,7 @@ bool ViewProviderBody::canDropObjects() const
 {
     // if the BaseFeature property is marked as hidden or read-only then
     // it's not allowed to modify it.
-    PartDesign::Body* body = static_cast<PartDesign::Body*>(getObject());
+    PartDesign::Body* body = getObject<PartDesign::Body>();
     if (body->BaseFeature.testStatus(App::Property::Status::Hidden))
         return false;
     if (body->BaseFeature.testStatus(App::Property::Status::ReadOnly))
@@ -375,7 +375,7 @@ bool ViewProviderBody::canDropObject(App::DocumentObject* obj) const
 
 void ViewProviderBody::dropObject(App::DocumentObject* obj)
 {
-    PartDesign::Body* body = static_cast<PartDesign::Body*>(getObject());
+    PartDesign::Body* body = getObject<PartDesign::Body>();
     if (obj->isDerivedFrom<Part::Part2DObject>()) {
         body->addObject(obj);
     }

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
@@ -107,7 +107,7 @@ bool ViewProviderBoolean::setEdit(int ModNum)
 
 bool ViewProviderBoolean::onDelete(const std::vector<std::string> &s)
 {
-    PartDesign::Boolean* pcBoolean = static_cast<PartDesign::Boolean*>(getObject());
+    PartDesign::Boolean* pcBoolean = getObject<PartDesign::Boolean>();
 
     // if abort command deleted the object the bodies are visible again
     std::vector<App::DocumentObject*> bodies = pcBoolean->Group.getValues();

--- a/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
@@ -289,7 +289,7 @@ bool ViewProviderDatum::doubleClicked()
     Msg += this->pcObject->Label.getValue();
     Gui::Command::openCommand(Msg.c_str());
 
-    Part::Datum* pcDatum = static_cast<Part::Datum*>(getObject());
+    Part::Datum* pcDatum = getObject<Part::Datum>();
     PartDesign::Body* activeBody = activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY);
     auto datumBody = PartDesignGui::getBodyFor(pcDatum, false);
 

--- a/src/Mod/PartDesign/Gui/ViewProviderDatumLine.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatumLine.cpp
@@ -72,7 +72,7 @@ void ViewProviderDatumLine::updateData(const App::Property* prop)
         updateExtents ();
     }
     else if (strcmp(prop->getName(),"Length") == 0) {
-        PartDesign::Line* pcDatum = static_cast<PartDesign::Line*>(this->getObject());
+        PartDesign::Line* pcDatum = this->getObject<PartDesign::Line>();
         if (pcDatum->ResizeMode.getValue() != 0)
             setExtents(pcDatum->Length.getValue());
     }
@@ -82,7 +82,7 @@ void ViewProviderDatumLine::updateData(const App::Property* prop)
 
 
 void ViewProviderDatumLine::setExtents (Base::BoundBox3d bbox) {
-    PartDesign::Line* pcDatum = static_cast<PartDesign::Line*>(this->getObject());
+    PartDesign::Line* pcDatum = this->getObject<PartDesign::Line>();
     // set manual size
     if (pcDatum->ResizeMode.getValue() != 0) {
         setExtents(pcDatum->Length.getValue());

--- a/src/Mod/PartDesign/Gui/ViewProviderDatumPlane.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatumPlane.cpp
@@ -95,7 +95,7 @@ void ViewProviderDatumPlane::updateData(const App::Property* prop)
     }
     else if (strcmp(prop->getName(),"Length") == 0 ||
              strcmp(prop->getName(),"Width") == 0) {
-        PartDesign::Plane* pcDatum = static_cast<PartDesign::Plane*>(this->getObject());
+        PartDesign::Plane* pcDatum = this->getObject<PartDesign::Plane>();
         if (pcDatum->ResizeMode.getValue() != 0)
             setExtents(pcDatum->Length.getValue(), pcDatum->Width.getValue());
     }
@@ -105,7 +105,7 @@ void ViewProviderDatumPlane::updateData(const App::Property* prop)
 
 
 void ViewProviderDatumPlane::setExtents (Base::BoundBox3d bbox) {
-    PartDesign::Plane* pcDatum = static_cast<PartDesign::Plane*>(this->getObject());
+    PartDesign::Plane* pcDatum = this->getObject<PartDesign::Plane>();
     if (pcDatum->ResizeMode.getValue() != 0) {
         setExtents(pcDatum->Length.getValue(), pcDatum->Width.getValue());
         return;

--- a/src/Mod/PartDesign/Gui/ViewProviderDressUp.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDressUp.cpp
@@ -66,7 +66,7 @@ bool ViewProviderDressUp::setEdit(int ModNum) {
     if (ModNum == ViewProvider::Default) {
         // Here we should prevent edit of a Feature with missing base
         // Otherwise it could call unhandled exception.
-        PartDesign::DressUp* dressUp = static_cast<PartDesign::DressUp*>(getObject());
+        PartDesign::DressUp* dressUp = getObject<PartDesign::DressUp>();
         assert (dressUp);
         if (dressUp->getBaseObject (/*silent =*/ true)) {
             return ViewProvider::setEdit(ModNum);
@@ -86,7 +86,7 @@ bool ViewProviderDressUp::setEdit(int ModNum) {
 
 void ViewProviderDressUp::highlightReferences(const bool on)
 {
-    PartDesign::DressUp* pcDressUp = static_cast<PartDesign::DressUp*>(getObject());
+    PartDesign::DressUp* pcDressUp = getObject<PartDesign::DressUp>();
     Part::Feature* base = pcDressUp->getBaseObject (/*silent =*/ true);
     if (!base)
         return;

--- a/src/Mod/PartDesign/Gui/ViewProviderExtrude.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderExtrude.cpp
@@ -42,7 +42,7 @@ PROPERTY_SOURCE(PartDesignGui::ViewProviderExtrude, PartDesignGui::ViewProviderS
 
 void PartDesignGui::ViewProviderExtrude::highlightShapeFaces(const std::vector<std::string>& faces)
 {
-    auto extrude = static_cast<PartDesign::FeatureExtrude*>(getObject());
+    auto extrude = getObject<PartDesign::FeatureExtrude>();
     auto base = static_cast<Part::Feature*>(extrude->UpToShape.getValue());
 
     auto baseViewProvider =

--- a/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHelix.cpp
@@ -59,7 +59,7 @@ TaskDlgFeatureParameters *ViewProviderHelix::getEditDialog()
 
 QIcon ViewProviderHelix::getIcon() const {
     QString str = QString::fromLatin1("PartDesign_");
-    auto* prim = static_cast<PartDesign::Helix*>(getObject());
+    auto* prim = getObject<PartDesign::Helix>();
     if(prim->getAddSubType() == PartDesign::FeatureAddSub::Additive)
         str += QString::fromLatin1("Additive");
     else
@@ -72,7 +72,7 @@ QIcon ViewProviderHelix::getIcon() const {
 bool ViewProviderHelix::setEdit(int ModNum)
 {
     if (ModNum == ViewProvider::Default ) {
-        auto* prim = static_cast<PartDesign::Helix*>(getObject());
+        auto* prim = getObject<PartDesign::Helix>();
         setPreviewDisplayMode(TaskHelixParameters::showPreview(prim));
     }
     return ViewProviderAddSub::setEdit(ModNum);
@@ -88,7 +88,7 @@ void ViewProviderHelix::unsetEdit(int ModNum)
 
 std::vector<App::DocumentObject*> ViewProviderHelix::claimChildren() const {
     std::vector<App::DocumentObject*> temp;
-    App::DocumentObject* sketch = static_cast<PartDesign::ProfileBased*>(getObject())->Profile.getValue();
+    App::DocumentObject* sketch = getObject<PartDesign::ProfileBased>()->Profile.getValue();
     if (sketch && sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
         temp.push_back(sketch);
 
@@ -96,7 +96,7 @@ std::vector<App::DocumentObject*> ViewProviderHelix::claimChildren() const {
 }
 
 bool ViewProviderHelix::onDelete(const std::vector<std::string> &s) {
-    PartDesign::ProfileBased* feature = static_cast<PartDesign::ProfileBased*>(getObject());
+    PartDesign::ProfileBased* feature = getObject<PartDesign::ProfileBased>();
 
     // get the Sketch
     Sketcher::SketchObject *pcSketch = nullptr;

--- a/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
@@ -51,7 +51,7 @@ ViewProviderHole::~ViewProviderHole() = default;
 std::vector<App::DocumentObject*> ViewProviderHole::claimChildren()const
 {
     std::vector<App::DocumentObject*> temp;
-    temp.push_back(static_cast<PartDesign::Hole*>(getObject())->Profile.getValue());
+    temp.push_back(getObject<PartDesign::Hole>()->Profile.getValue());
 
     return temp;
 }
@@ -107,7 +107,7 @@ bool ViewProviderHole::setEdit(int ModNum)
 bool ViewProviderHole::onDelete(const std::vector<std::string> &s)
 {
     // get the Sketch
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(getObject());
+    PartDesign::Hole* pcHole = getObject<PartDesign::Hole>();
     Sketcher::SketchObject *pcSketch = nullptr;
     if (pcHole->Profile.getValue())
         pcSketch = static_cast<Sketcher::SketchObject*>(pcHole->Profile.getValue());

--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
@@ -47,7 +47,7 @@ std::vector<App::DocumentObject*> ViewProviderLoft::claimChildren()const
 {
     std::vector<App::DocumentObject*> temp;
 
-    PartDesign::Loft* pcLoft = static_cast<PartDesign::Loft*>(getObject());
+    PartDesign::Loft* pcLoft = getObject<PartDesign::Loft>();
 
     App::DocumentObject* sketch = pcLoft->getVerifiedSketch(true);
     if (sketch)
@@ -88,7 +88,7 @@ void ViewProviderLoft::unsetEdit(int ModNum) {
 
 bool ViewProviderLoft::onDelete(const std::vector<std::string> & /*s*/)
 {/*
-    PartDesign::Loft* pcLoft = static_cast<PartDesign::Loft*>(getObject());
+    PartDesign::Loft* pcLoft = getObject<PartDesign::Loft>();
 
     // get the Sketch
     Sketcher::SketchObject *pcSketch = 0;
@@ -105,14 +105,14 @@ bool ViewProviderLoft::onDelete(const std::vector<std::string> & /*s*/)
 
 void ViewProviderLoft::highlightProfile(bool on)
 {
-    PartDesign::Loft* pcLoft = static_cast<PartDesign::Loft*>(getObject());
+    PartDesign::Loft* pcLoft = getObject<PartDesign::Loft>();
     highlightReferences(dynamic_cast<Part::Feature*>(pcLoft->Profile.getValue()),
                         pcLoft->Profile.getSubValues(), on);
 }
 
 void ViewProviderLoft::highlightSection(bool on)
 {
-    PartDesign::Loft* pcLoft = static_cast<PartDesign::Loft*>(getObject());
+    PartDesign::Loft* pcLoft = getObject<PartDesign::Loft>();
     auto sections = pcLoft->Sections.getSubListValues();
     for (auto& it : sections) {
         // only take the entire shape when we have a sketch selected, but
@@ -171,7 +171,7 @@ void ViewProviderLoft::highlightReferences(Part::Feature* base, const std::vecto
 
 QIcon ViewProviderLoft::getIcon() const {
     QString str = QString::fromLatin1("PartDesign_");
-    auto* prim = static_cast<PartDesign::Loft*>(getObject());
+    auto* prim = getObject<PartDesign::Loft>();
     if(prim->getAddSubType() == PartDesign::FeatureAddSub::Additive)
         str += QString::fromLatin1("Additive");
     else

--- a/src/Mod/PartDesign/Gui/ViewProviderMainPart.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderMainPart.cpp
@@ -41,7 +41,7 @@ ViewProviderMainPart::~ViewProviderMainPart()
 std::vector<App::DocumentObject*> ViewProviderMainPart::claimChildren(void)const
 {
     std::vector<App::DocumentObject*> temp;
-    temp.push_back(static_cast<PartDesign::MainPart*>(getObject())->Sketch.getValue());
+    temp.push_back(getObject<PartDesign::MainPart>()->Sketch.getValue());
 
     return temp;
 }

--- a/src/Mod/PartDesign/Gui/ViewProviderMultiTransform.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderMultiTransform.cpp
@@ -51,7 +51,7 @@ void ViewProviderMultiTransform::setupContextMenu(QMenu* menu, QObject* receiver
 
 std::vector<App::DocumentObject*> ViewProviderMultiTransform::claimChildren() const
 {
-    PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(getObject());
+    PartDesign::MultiTransform* pcMultiTransform = getObject<PartDesign::MultiTransform>();
     if (!pcMultiTransform)
         return {}; // TODO: Show error?
 
@@ -61,7 +61,7 @@ std::vector<App::DocumentObject*> ViewProviderMultiTransform::claimChildren() co
 
 bool ViewProviderMultiTransform::onDelete(const std::vector<std::string> &svec) {
     // Delete the transformation features
-    PartDesign::MultiTransform* pcMultiTransform = static_cast<PartDesign::MultiTransform*>(getObject());
+    PartDesign::MultiTransform* pcMultiTransform = getObject<PartDesign::MultiTransform>();
     std::vector<App::DocumentObject*> transformFeatures = pcMultiTransform->Transformations.getValues();
 
     // if the multitransform object was deleted the transformed features must be deleted, too

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
@@ -47,7 +47,7 @@ std::vector<App::DocumentObject*> ViewProviderPipe::claimChildren()const
 {
     std::vector<App::DocumentObject*> temp;
 
-    PartDesign::Pipe* pcPipe = static_cast<PartDesign::Pipe*>(getObject());
+    PartDesign::Pipe* pcPipe = getObject<PartDesign::Pipe>();
 
     App::DocumentObject* sketch = pcPipe->getVerifiedSketch(true);
     if (sketch)
@@ -94,7 +94,7 @@ TaskDlgFeatureParameters* ViewProviderPipe::getEditDialog() {
 
 bool ViewProviderPipe::onDelete(const std::vector<std::string> &s)
 {/*
-    PartDesign::Pipe* pcPipe = static_cast<PartDesign::Pipe*>(getObject());
+    PartDesign::Pipe* pcPipe = getObject<PartDesign::Pipe>();
 
     // get the Sketch
     Sketcher::SketchObject *pcSketch = 0;
@@ -112,7 +112,7 @@ bool ViewProviderPipe::onDelete(const std::vector<std::string> &s)
 
 void ViewProviderPipe::highlightReferences(ViewProviderPipe::Reference mode, bool on)
 {
-    PartDesign::Pipe* pcPipe = static_cast<PartDesign::Pipe*>(getObject());
+    PartDesign::Pipe* pcPipe = getObject<PartDesign::Pipe>();
 
     switch (mode) {
     case Spine:
@@ -172,7 +172,7 @@ void ViewProviderPipe::highlightReferences(Part::Feature* base, const std::vecto
 
 QIcon ViewProviderPipe::getIcon() const {
     QString str = QString::fromLatin1("PartDesign_");
-    auto* prim = static_cast<PartDesign::Pipe*>(getObject());
+    auto* prim = getObject<PartDesign::Pipe>();
     if(prim->getAddSubType() == PartDesign::FeatureAddSub::Additive)
         str += QString::fromLatin1("Additive");
     else

--- a/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
@@ -115,7 +115,7 @@ void ViewProviderPrimitive::updateData(const App::Property* p) {
 QIcon ViewProviderPrimitive::getIcon() const {
 
     QString str = QString::fromLatin1("PartDesign_");
-    auto* prim = static_cast<PartDesign::FeaturePrimitive*>(getObject());
+    auto* prim = getObject<PartDesign::FeaturePrimitive>();
     if(prim->getAddSubType() == PartDesign::FeatureAddSub::Additive)
         str += QString::fromLatin1("Additive");
     else

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -139,7 +139,7 @@ void ViewProviderShapeBinder::highlightReferences(bool on)
     std::vector<std::string> subs;
 
     if (getObject()->isDerivedFrom(PartDesign::ShapeBinder::getClassTypeId()))
-        PartDesign::ShapeBinder::getFilteredReferences(&static_cast<PartDesign::ShapeBinder*>(getObject())->Support, obj, subs);
+        PartDesign::ShapeBinder::getFilteredReferences(&getObject<PartDesign::ShapeBinder>()->Support, obj, subs);
     else
         return;
 
@@ -278,7 +278,7 @@ bool ViewProviderSubShapeBinder::canDropObjectEx(App::DocumentObject*,
 std::string ViewProviderSubShapeBinder::dropObjectEx(App::DocumentObject* obj, App::DocumentObject* owner,
     const char* subname, const std::vector<std::string>& elements)
 {
-    auto self = dynamic_cast<PartDesign::SubShapeBinder*>(getObject());
+    auto self = getObject<PartDesign::SubShapeBinder>();
     if (!self)
         return {};
     std::map<App::DocumentObject*, std::vector<std::string> > values;
@@ -327,7 +327,7 @@ bool ViewProviderSubShapeBinder::setEdit(int ModNum) {
         updatePlacement(true);
         break;
     case SelectObject: {
-        auto self = dynamic_cast<PartDesign::SubShapeBinder*>(getObject());
+        auto self = getObject<PartDesign::SubShapeBinder>();
         if (!self || !self->Support.getValue())
             break;
 
@@ -355,7 +355,7 @@ bool ViewProviderSubShapeBinder::setEdit(int ModNum) {
 }
 
 void ViewProviderSubShapeBinder::updatePlacement(bool transaction) {
-    auto self = dynamic_cast<PartDesign::SubShapeBinder*>(getObject());
+    auto self = getObject<PartDesign::SubShapeBinder>();
     if (!self || !self->Support.getValue())
         return;
 

--- a/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderSketchBased.cpp
@@ -42,7 +42,7 @@ ViewProviderSketchBased::~ViewProviderSketchBased() = default;
 
 std::vector<App::DocumentObject*> ViewProviderSketchBased::claimChildren() const {
     std::vector<App::DocumentObject*> temp;
-    App::DocumentObject* sketch = static_cast<PartDesign::ProfileBased*>(getObject())->Profile.getValue();
+    App::DocumentObject* sketch = getObject<PartDesign::ProfileBased>()->Profile.getValue();
     if (sketch && !sketch->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
         temp.push_back(sketch);
 
@@ -51,7 +51,7 @@ std::vector<App::DocumentObject*> ViewProviderSketchBased::claimChildren() const
 
 
 bool ViewProviderSketchBased::onDelete(const std::vector<std::string> &s) {
-    PartDesign::ProfileBased* feature = static_cast<PartDesign::ProfileBased*>(getObject());
+    PartDesign::ProfileBased* feature = getObject<PartDesign::ProfileBased>();
 
     // get the Sketch
     Sketcher::SketchObject *pcSketch = nullptr;

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -78,7 +78,7 @@ void ViewProviderTransformed::setupContextMenu(QMenu* menu, QObject* receiver, c
 }
 
 Gui::ViewProvider *ViewProviderTransformed::startEditing(int ModNum) {
-    PartDesign::Transformed* pcTransformed = static_cast<PartDesign::Transformed*>(getObject());
+    PartDesign::Transformed* pcTransformed = getObject<PartDesign::Transformed>();
     if(!pcTransformed->Originals.getSize()) {
         for(auto obj : pcTransformed->getInList()) {
             if(obj->isDerivedFrom(PartDesign::MultiTransform::getClassTypeId())) {
@@ -160,7 +160,7 @@ bool ViewProviderTransformed::onDelete(const std::vector<std::string> &s)
 
 void ViewProviderTransformed::recomputeFeature(bool recompute)
 {
-    PartDesign::Transformed* pcTransformed = static_cast<PartDesign::Transformed*>(getObject());
+    PartDesign::Transformed* pcTransformed = getObject<PartDesign::Transformed>();
     if(recompute || (pcTransformed->isError() || pcTransformed->mustExecute()))
         pcTransformed->recomputeFeature(true);
 

--- a/src/Mod/Robot/Gui/ViewProviderEdge2TracObject.cpp
+++ b/src/Mod/Robot/Gui/ViewProviderEdge2TracObject.cpp
@@ -35,8 +35,7 @@ PROPERTY_SOURCE(RobotGui::ViewProviderEdge2TracObject, RobotGui::ViewProviderTra
 
 bool ViewProviderEdge2TracObject::doubleClicked()
 {
-    Gui::TaskView::TaskDialog* dlg =
-        new TaskDlgEdge2Trac(static_cast<Robot::Edge2TracObject*>(getObject()));
+    Gui::TaskView::TaskDialog* dlg = new TaskDlgEdge2Trac(getObject<Robot::Edge2TracObject>());
     Gui::Control().showDialog(dlg);
     return true;
 }
@@ -44,8 +43,7 @@ bool ViewProviderEdge2TracObject::doubleClicked()
 
 bool ViewProviderEdge2TracObject::setEdit(int)
 {
-    Gui::TaskView::TaskDialog* dlg =
-        new TaskDlgEdge2Trac(static_cast<Robot::Edge2TracObject*>(getObject()));
+    Gui::TaskView::TaskDialog* dlg = new TaskDlgEdge2Trac(getObject<Robot::Edge2TracObject>());
     Gui::Control().showDialog(dlg);
     return true;
 }

--- a/src/Mod/Robot/Gui/ViewProviderTrajectoryCompound.cpp
+++ b/src/Mod/Robot/Gui/ViewProviderTrajectoryCompound.cpp
@@ -37,7 +37,7 @@ PROPERTY_SOURCE(RobotGui::ViewProviderTrajectoryCompound, RobotGui::ViewProvider
 // bool ViewProviderTrajectoryCompound::doubleClicked(void)
 //{
 //     Gui::TaskView::TaskDialog* dlg = new
-//     TaskDlgTrajectoryCompound(dynamic_cast<Robot::TrajectoryCompound *>(getObject()));
+//     TaskDlgTrajectoryCompound(getObject<Robot::TrajectoryCompound >());
 //     Gui::Control().showDialog(dlg);
 //     return true;
 // }
@@ -46,7 +46,7 @@ PROPERTY_SOURCE(RobotGui::ViewProviderTrajectoryCompound, RobotGui::ViewProvider
 bool ViewProviderTrajectoryCompound::setEdit(int)
 {
     Gui::TaskView::TaskDialog* dlg =
-        new TaskDlgTrajectoryCompound(dynamic_cast<Robot::TrajectoryCompound*>(getObject()));
+        new TaskDlgTrajectoryCompound(getObject<Robot::TrajectoryCompound>());
     Gui::Control().showDialog(dlg);
     return true;
 }
@@ -59,5 +59,5 @@ void ViewProviderTrajectoryCompound::unsetEdit(int)
 
 std::vector<App::DocumentObject*> ViewProviderTrajectoryCompound::claimChildren() const
 {
-    return static_cast<Robot::TrajectoryCompound*>(getObject())->Source.getValues();
+    return getObject<Robot::TrajectoryCompound>()->Source.getValues();
 }

--- a/src/Mod/Robot/Gui/ViewProviderTrajectoryDressUp.cpp
+++ b/src/Mod/Robot/Gui/ViewProviderTrajectoryDressUp.cpp
@@ -36,7 +36,7 @@ PROPERTY_SOURCE(RobotGui::ViewProviderTrajectoryDressUp, RobotGui::ViewProviderT
 // bool ViewProviderTrajectoryDressUp::doubleClicked(void)
 //{
 //     Gui::TaskView::TaskDialog* dlg = new
-//     TaskDlgTrajectoryDressUp(dynamic_cast<Robot::TrajectoryDressUpObject *>(getObject()));
+//     TaskDlgTrajectoryDressUp(getObject<Robot::TrajectoryDressUpObject >());
 //     Gui::Control().showDialog(dlg);
 //     return true;
 // }
@@ -45,7 +45,7 @@ PROPERTY_SOURCE(RobotGui::ViewProviderTrajectoryDressUp, RobotGui::ViewProviderT
 bool ViewProviderTrajectoryDressUp::setEdit(int)
 {
     Gui::TaskView::TaskDialog* dlg =
-        new TaskDlgTrajectoryDressUp(static_cast<Robot::TrajectoryDressUpObject*>(getObject()));
+        new TaskDlgTrajectoryDressUp(getObject<Robot::TrajectoryDressUpObject>());
     Gui::Control().showDialog(dlg);
     return true;
 }
@@ -59,7 +59,7 @@ void ViewProviderTrajectoryDressUp::unsetEdit(int)
 std::vector<App::DocumentObject*> ViewProviderTrajectoryDressUp::claimChildren() const
 {
     std::vector<App::DocumentObject*> temp;
-    temp.push_back(static_cast<Robot::TrajectoryDressUpObject*>(getObject())->Source.getValue());
+    temp.push_back(getObject<Robot::TrajectoryDressUpObject>()->Source.getValue());
 
     return temp;
 }

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -3691,7 +3691,7 @@ void CmdSketcherConstrainBlock::applyConstraint(std::vector<SelIdPair>& selSeq, 
             SketcherGui::ViewProviderSketch* sketchgui =
                 static_cast<SketcherGui::ViewProviderSketch*>(getActiveGuiDocument()->getInEdit());
 
-            auto Obj = static_cast<Sketcher::SketchObject*>(sketchgui->getObject());
+            auto Obj = sketchgui->getObject<Sketcher::SketchObject>();
 
             // check if the edge already has a Block constraint
             const std::vector<Sketcher::Constraint*>& vals = Obj->Constraints.getValues();

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -1280,7 +1280,7 @@ public:
             }
 
             tryAutoRecomputeIfNotSolve(
-                static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                sketchgui->getObject<Sketcher::SketchObject>());
             EditCurve.clear();
             drawEdit(EditCurve);
 
@@ -1294,7 +1294,7 @@ private:
     void activated() override
     {
         setCursor(QPixmap(cursor_createcopy), 7, 7);
-        Origin = static_cast<Sketcher::SketchObject*>(sketchgui->getObject())
+        Origin = sketchgui->getObject<Sketcher::SketchObject>()
                      ->getPoint(OriginGeoId, OriginPos);
         EditCurve[0] = Base::Vector2d(Origin.x, Origin.y);
     }
@@ -1862,7 +1862,7 @@ public:
                 sugConstr1.clear();
             }
             tryAutoRecomputeIfNotSolve(
-                static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                sketchgui->getObject<Sketcher::SketchObject>());
 
             EditCurve.clear();
             drawEdit(EditCurve);
@@ -1877,7 +1877,7 @@ private:
     void activated() override
     {
         setCursor(QPixmap(cursor_createrectangulararray), 7, 7);
-        Origin = static_cast<Sketcher::SketchObject*>(sketchgui->getObject())
+        Origin = sketchgui->getObject<Sketcher::SketchObject>()
                      ->getPoint(OriginGeoId, OriginPos);
         EditCurve[0] = Base::Vector2d(Origin.x, Origin.y);
     }

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -776,7 +776,7 @@ protected:
                     } break;
                     case Sketcher::Tangent: {
                         Sketcher::SketchObject* Obj =
-                            static_cast<Sketcher::SketchObject*>(sketchgui->getObject());
+                            sketchgui->getObject<Sketcher::SketchObject>();
 
                         const Part::Geometry* geom1 = Obj->getGeometry(geoId1);
                         const Part::Geometry* geom2 = Obj->getGeometry(ac.GeoId);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -318,8 +318,7 @@ public:
                     QT_TRANSLATE_NOOP("Notifications", "Failed to add arc of ellipse"));
                 Gui::Command::abortCommand();
 
-                tryAutoRecomputeIfNotSolve(
-                    static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
 
                 return false;
             }
@@ -356,8 +355,7 @@ public:
                 sugConstr4.clear();
             }
 
-            tryAutoRecomputeIfNotSolve(
-                static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+            tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
 
             ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
                 "User parameter:BaseApp/Preferences/Mod/Sketcher");

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -331,8 +331,7 @@ public:
                     QT_TRANSLATE_NOOP("Notifications", "Cannot create arc of hyperbola"));
                 Gui::Command::abortCommand();
 
-                tryAutoRecomputeIfNotSolve(
-                    static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
 
                 return false;
             }
@@ -369,8 +368,7 @@ public:
                 sugConstr4.clear();
             }
 
-            tryAutoRecomputeIfNotSolve(
-                static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+            tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
 
             ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
                 "User parameter:BaseApp/Preferences/Mod/Sketcher");

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -254,8 +254,7 @@ public:
                     QT_TRANSLATE_NOOP("Notifications", "Cannot create arc of parabola"));
                 Gui::Command::abortCommand();
 
-                tryAutoRecomputeIfNotSolve(
-                    static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
 
                 return false;
             }
@@ -292,8 +291,7 @@ public:
                 sugConstr4.clear();
             }
 
-            tryAutoRecomputeIfNotSolve(
-                static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+            tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
 
             ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
                 "User parameter:BaseApp/Preferences/Mod/Sketcher");

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -171,8 +171,7 @@ public:
 
                     Gui::Command::commitCommand();
 
-                    tryAutoRecomputeIfNotSolve(
-                        static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                    tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
 
                     Gui::Selection().clearSelection();
                     /* this is ok not to call to purgeHandler

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -178,8 +178,7 @@ public:
                     // because we only redraw a changed Sketch if the solver geometry amount is the
                     // same as the SkethObject geometry amount (as this avoids other issues). This
                     // solver is a very low cost one anyway (there is actually nothing to solve).
-                    tryAutoRecomputeIfNotSolve(
-                        static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                    tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
 
                     Gui::Selection().clearSelection();
                     /* this is ok not to call to purgeHandler

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -557,8 +557,7 @@ public:
                 }
                 Gui::Command::commitCommand();
 
-                tryAutoRecomputeIfNotSolve(
-                    static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
             }
 
             ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
@@ -572,13 +571,13 @@ public:
                     if (SegmentMode == SEGMENT_MODE_Line) {  // avoid redundant constraints.
                         if (sugConstr1.size() > 0) {
                             removeRedundantHorizontalVertical(
-                                static_cast<Sketcher::SketchObject*>(sketchgui->getObject()),
+                                sketchgui->getObject<Sketcher::SketchObject>(),
                                 sugConstr1,
                                 sugConstr2);
                         }
                         else {
                             removeRedundantHorizontalVertical(
-                                static_cast<Sketcher::SketchObject*>(sketchgui->getObject()),
+                                sketchgui->getObject<Sketcher::SketchObject>(),
                                 virtualsugConstr1,
                                 sugConstr2);
                         }
@@ -599,8 +598,7 @@ public:
                     sugConstr2.clear();
                 }
 
-                tryAutoRecomputeIfNotSolve(
-                    static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
 
                 unsetCursor();
 
@@ -653,13 +651,13 @@ public:
                     if (SegmentMode == SEGMENT_MODE_Line) {  // avoid redundant constraints.
                         if (sugConstr1.size() > 0) {
                             removeRedundantHorizontalVertical(
-                                static_cast<Sketcher::SketchObject*>(sketchgui->getObject()),
+                                sketchgui->getObject<Sketcher::SketchObject>(),
                                 sugConstr1,
                                 sugConstr2);
                         }
                         else {
                             removeRedundantHorizontalVertical(
-                                static_cast<Sketcher::SketchObject*>(sketchgui->getObject()),
+                                sketchgui->getObject<Sketcher::SketchObject>(),
                                 virtualsugConstr1,
                                 sugConstr2);
                         }
@@ -678,8 +676,7 @@ public:
                     sugConstr2.clear();
                 }
 
-                tryAutoRecomputeIfNotSolve(
-                    static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
 
                 // remember the vertex for the next rounds constraint..
                 previousCurve = getHighestCurveIndex();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerPolygon.h
@@ -124,8 +124,7 @@ private:
 
             Gui::Command::commitCommand();
 
-            tryAutoRecomputeIfNotSolve(
-                static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+            tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
         }
         catch (const Base::Exception&) {
             Gui::NotifyError(sketchgui,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -151,7 +151,7 @@ public:
                                       onSketchPos.x,
                                       onSketchPos.y);
                 Gui::Command::commitCommand();
-                tryAutoRecompute(static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                tryAutoRecompute(sketchgui->getObject<Sketcher::SketchObject>());
             }
             catch (const Base::Exception&) {
                 Gui::NotifyError(sketchgui,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTrimming.h
@@ -98,7 +98,7 @@ public:
             int GeoId = getPreselectCurve();
 
             if (GeoId > -1) {
-                auto sk = static_cast<Sketcher::SketchObject*>(sketchgui->getObject());
+                auto sk = sketchgui->getObject<Sketcher::SketchObject>();
                 int GeoId1, GeoId2;
                 Base::Vector3d intersect1, intersect2;
                 if (sk->seekTrimPoints(GeoId,
@@ -175,7 +175,7 @@ public:
                                       onSketchPos.x,
                                       onSketchPos.y);
                 Gui::Command::commitCommand();
-                tryAutoRecompute(static_cast<Sketcher::SketchObject*>(sketchgui->getObject()));
+                tryAutoRecompute(sketchgui->getObject<Sketcher::SketchObject>());
             }
             catch (const Base::Exception&) {
                 Gui::NotifyError(sketchgui,

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -578,7 +578,7 @@ void ElementView::changeLayer(int layer)
     doc->openTransaction("Geometry Layer Change");
     std::vector<Gui::SelectionObject> sel = Gui::Selection().getSelectionEx(doc->getName());
     for (std::vector<Gui::SelectionObject>::iterator ft = sel.begin(); ft != sel.end(); ++ft) {
-        auto sketchobject = dynamic_cast<Sketcher::SketchObject*>(ft->getObject());
+        auto sketchobject = ft->getObject<Sketcher::SketchObject>();
 
         auto geoids = getGeoIdsOfEdgesFromNames(sketchobject, ft->getSubNames());
 

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -111,7 +111,7 @@ void ViewProviderSheet::showSheetMdi()
 
 void ViewProviderSheet::exportAsFile()
 {
-    auto* sheet = static_cast<Spreadsheet::Sheet*>(getObject());
+    auto* sheet = getObject<Spreadsheet::Sheet>();
     QString selectedFilter;
     QString formatList = QObject::tr("CSV (*.csv *.CSV);;All (*)");
     QString fileName = Gui::FileDialog::getSaveFileName(Gui::getMainWindow(),

--- a/src/Mod/Surface/Gui/TaskFilling.cpp
+++ b/src/Mod/Surface/Gui/TaskFilling.cpp
@@ -72,7 +72,7 @@ bool ViewProviderFilling::setEdit(int ModNum)
         // object unsets and sets its edit mode without closing
         // the task panel
 
-        Surface::Filling* obj = static_cast<Surface::Filling*>(this->getObject());
+        Surface::Filling* obj = this->getObject<Surface::Filling>();
 
         Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
 

--- a/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
+++ b/src/Mod/Surface/Gui/TaskGeomFillSurface.cpp
@@ -70,7 +70,7 @@ bool ViewProviderGeomFillSurface::setEdit(int ModNum)
         // object unsets and sets its edit mode without closing
         // the task panel
 
-        Surface::GeomFillSurface* obj = static_cast<Surface::GeomFillSurface*>(this->getObject());
+        Surface::GeomFillSurface* obj = this->getObject<Surface::GeomFillSurface>();
 
         Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
 
@@ -110,7 +110,7 @@ QIcon ViewProviderGeomFillSurface::getIcon() const
 
 void ViewProviderGeomFillSurface::highlightReferences(bool on)
 {
-    Surface::GeomFillSurface* surface = static_cast<Surface::GeomFillSurface*>(getObject());
+    Surface::GeomFillSurface* surface = getObject<Surface::GeomFillSurface>();
     auto bounds = surface->BoundaryList.getSubListValues();
     for (const auto& it : bounds) {
         Part::Feature* base = dynamic_cast<Part::Feature*>(it.first);

--- a/src/Mod/Surface/Gui/TaskSections.cpp
+++ b/src/Mod/Surface/Gui/TaskSections.cpp
@@ -66,7 +66,7 @@ bool ViewProviderSections::setEdit(int ModNum)
         // object unsets and sets its edit mode without closing
         // the task panel
 
-        Surface::Sections* obj = static_cast<Surface::Sections*>(this->getObject());
+        Surface::Sections* obj = this->getObject<Surface::Sections>();
 
         Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
 

--- a/src/Mod/TechDraw/App/DimensionReferences.cpp
+++ b/src/Mod/TechDraw/App/DimensionReferences.cpp
@@ -113,7 +113,7 @@ TopoDS_Shape ReferenceEntry::getGeometry() const
 
     // 3d geometry
     Part::TopoShape shape = Part::Feature::getTopoShape(getObject());
-    auto geoFeat = dynamic_cast<App::GeoFeature*>(getObject());
+    auto geoFeat = getObject<App::GeoFeature>();
     if (geoFeat) {
         shape.setPlacement(geoFeat->globalPlacement());
     }
@@ -132,7 +132,7 @@ TopoDS_Shape ReferenceEntry::getGeometry2d() const
     // Base::Console().Message("RE::getGeometry2d()\n");
     std::string gType;
     try {
-        auto dvp = static_cast<TechDraw::DrawViewPart*>(getObject());   //NOLINT cppcoreguidelines-pro-type-static-cast-downcast
+        auto dvp = getObject<TechDraw::DrawViewPart>();   //NOLINT cppcoreguidelines-pro-type-static-cast-downcast
         gType = geomType();
         if (gType == "Vertex") {
             // getVertex throws on not found, but we want to return null
@@ -228,7 +228,7 @@ Part::TopoShape ReferenceEntry::asCanonicalTopoShape() const
     }
 
     // this is a 2d reference
-    auto dvp = static_cast<DrawViewPart*>(getObject()); //NOLINT cppcoreguidelines-pro-type-static-cast-downcast
+    auto dvp = getObject<DrawViewPart>(); //NOLINT cppcoreguidelines-pro-type-static-cast-downcast
     auto rawTopoShape = asTopoShape();
     return ReferenceEntry::asCanonicalTopoShape(rawTopoShape, *dvp);
 }
@@ -277,7 +277,7 @@ std::string ReferenceEntry::geomType() const
 GeomType ReferenceEntry::geomEdgeType() const
 {
     int geoId = TechDraw::DrawUtil::getIndexFromName(getSubName());
-    auto dvp = static_cast<TechDraw::DrawViewPart*>(getObject());
+    auto dvp = getObject<TechDraw::DrawViewPart>();
     BaseGeomPtr geom = dvp->getGeomByIndex(geoId);
 
     if (geomType() == "Edge" && geom) {
@@ -331,7 +331,7 @@ bool ReferenceEntry::hasGeometry() const
 //! check if this 2d reference has valid geometry in the model
 bool ReferenceEntry::hasGeometry2d() const
 {
-    auto dvp = static_cast<TechDraw::DrawViewPart*>(getObject());   //NOLINT cppcoreguidelines-pro-type-static-cast-downcast
+    auto dvp = getObject<TechDraw::DrawViewPart>();   //NOLINT cppcoreguidelines-pro-type-static-cast-downcast
     if (getSubName().empty()) {
         return false;
     }

--- a/src/Mod/TechDraw/App/DimensionReferences.h
+++ b/src/Mod/TechDraw/App/DimensionReferences.h
@@ -63,6 +63,7 @@ public:
     bool operator== (const ReferenceEntry& otherRef) const;
 
     App::DocumentObject* getObject() const;
+    template <class T> T* getObject() const { return dynamic_cast<T*>(getObject()); }
     void setObject(App::DocumentObject* docObj) { m_object = docObj; }
     std::string getSubName(bool longForm = false) const;
     void setSubName(const std::string& subName) { m_subName = subName; }

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -299,7 +299,7 @@ bool ViewProviderViewPart::setEdit(int ModNum)
                                         dvd->getNameInDocument());
     }
     else {
-        auto* view = dynamic_cast<TechDraw::DrawView*>(getObject());
+        auto* view = getObject<TechDraw::DrawView>();
         Gui::Control().showDialog(new TaskDlgProjGroup(view, false));
     }
 


### PR DESCRIPTION
Obtaining specific kind of document object is very common task. This commit introduces handy helper which makes that a lot easier.

```diff
-        auto geometry = dynamic_cast<App::GeoFeature*>(getObject());
-        if (geometry) {
+        if (auto geometry = getObject<App::GeoFeature>()) {
```

First commit introduces the required methods, second commit replaces all trivial casts with uses of introduced methods. It can be regenerated if needed with simple regex based find and replace.