### PR TITLE
Part: OCCWrapper: Fix compound cuts

### DIFF
--- a/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.h
+++ b/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.h
@@ -61,8 +61,7 @@ protected: //! @name Constructors
 
 
 private:
-  TopTools_ListOfShape myOriginalArguments;
   Standard_EXPORT const TopoDS_Shape RecursiveCutCompound(const TopoDS_Shape& theArgument, const Message_ProgressRange& theRange);
-
+  Standard_EXPORT const TopoDS_Shape RecursiveCutByCompound(const TopoDS_Shape& theArgument, const TopoDS_Shape& theTool, const Message_ProgressRange& theRange);
 };
 #endif

--- a/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.h
+++ b/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.h
@@ -49,7 +49,7 @@ public:
     // set fuzzyness based on size
     void setAutoFuzzy();
 
-    Standard_EXPORT virtual void Build(const Message_ProgressRange& theRange = Message_ProgressRange()) Standard_OVERRIDE;
+    Standard_EXPORT virtual void Build(); // not an override - real Build() has optionals, sadly type of those optionals that are differs between OCCT versions
 
 protected: //! @name Constructors
 
@@ -61,7 +61,7 @@ protected: //! @name Constructors
 
 
 private:
-  Standard_EXPORT const TopoDS_Shape RecursiveCutCompound(const TopoDS_Shape& theArgument, const Message_ProgressRange& theRange);
-  Standard_EXPORT const TopoDS_Shape RecursiveCutByCompound(const TopoDS_Shape& theArgument, const TopoDS_Shape& theTool, const Message_ProgressRange& theRange);
+  Standard_EXPORT const TopoDS_Shape RecursiveCutCompound(const TopoDS_Shape& theArgument);
+  Standard_EXPORT void RecursiveAddArguments(const TopoDS_Shape& theArgument);
 };
 #endif

--- a/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.h
+++ b/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.h
@@ -49,6 +49,8 @@ public:
     // set fuzzyness based on size
     void setAutoFuzzy();
 
+    Standard_EXPORT virtual void Build(const Message_ProgressRange& theRange = Message_ProgressRange()) Standard_OVERRIDE;
+
 protected: //! @name Constructors
 
   //! Constructor to perform Boolean operation on only two arguments.
@@ -56,6 +58,11 @@ protected: //! @name Constructors
   Standard_EXPORT FCBRepAlgoAPI_BooleanOperation(const TopoDS_Shape& theS1,
                                                const TopoDS_Shape& theS2,
                                                const BOPAlgo_Operation theOperation);
+
+
+private:
+  TopTools_ListOfShape myOriginalArguments;
+  Standard_EXPORT const TopoDS_Shape RecursiveCutCompound(const TopoDS_Shape& theArgument, const Message_ProgressRange& theRange);
 
 };
 #endif

--- a/src/Mod/Part/parttests/TopoShapeTest.py
+++ b/src/Mod/Part/parttests/TopoShapeTest.py
@@ -73,6 +73,13 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         self.doc.Box2.Length = 2
         self.doc.Box2.Width = 1
         self.doc.Box2.Height = 2
+        self.doc.addObject("Part::Cylinder", "Cylinder1")
+        self.doc.Cylinder1.Radius = 0.5
+        self.doc.Cylinder1.Height = 2
+        self.doc.Cylinder1.Angle = 360
+        self.doc.addObject("Part::Compound", "Compound1")
+        self.doc.Compound1.Links = [ self.doc.Box1, self.doc.Box2 ]
+
         self.doc.recompute()
         self.box = self.doc.Box1.Shape
         self.box2 = self.doc.Box2.Shape
@@ -758,3 +765,32 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
     #     self.assertEqual(result2.ElementMapSize,9)
     #     self.assertEqual(result2.Faces[0].ElementMapSize,0)
 
+    def testPartCompoundCut1(self):
+        # Arrange
+        self.doc.addObject("Part::Cut", "Cut")
+        self.doc.Cut.Base = self.doc.Cylinder1
+        self.doc.Cut.Tool = self.doc.Compound1
+        # Act
+        self.doc.recompute()
+        cut1 = self.doc.Cut.Shape
+        # Assert elementMap
+        refkeys = ['Vertex6', 'Vertex5', 'Edge7', 'Edge8', 'Edge9', 'Edge5', 'Edge6', 'Face4', 'Face2', 'Edge1', 'Vertex4', 'Edge4', 'Vertex3', 'Edge2', 'Edge3', 'Face1', 'Face5', 'Face3', 'Vertex1', 'Vertex2']
+        if cut1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+            self.assertKeysInMap(cut1.ElementReverseMap, refkeys )
+        self.assertEqual(len(cut1.ElementReverseMap.keys()),len(refkeys))
+        # Assert Volume
+        self.assertAlmostEqual(cut1.Volume, self.doc.Cylinder1.Shape.Volume * (3/4))
+
+    def testPartCompoundCut2(self):
+        # Arrange
+        self.doc.addObject("Part::Cut", "Cut")
+        self.doc.Cut.Base = self.doc.Compound1
+        self.doc.Cut.Tool = self.doc.Cylinder1
+        # Act
+        self.doc.recompute()
+        cut1 = self.doc.Cut.Shape
+        # Assert elementMap
+        refkeys = ['Vertex3', 'Vertex4', 'Vertex8', 'Vertex10', 'Vertex7', 'Vertex9', 'Vertex13', 'Vertex14', 'Vertex18', 'Vertex20', 'Vertex17', 'Vertex19', 'Edge3', 'Edge15', 'Edge9', 'Edge12', 'Edge13', 'Edge11', 'Edge8', 'Edge17', 'Edge18', 'Edge19', 'Edge30', 'Edge24', 'Edge27', 'Edge28', 'Edge29', 'Edge25', 'Edge26', 'Edge23', 'Face7', 'Face4', 'Face8', 'Face14', 'Face13', 'Face11', 'Face12', 'Face10', 'Edge22', 'Vertex12', 'Edge20', 'Vertex11', 'Edge21', 'Edge16', 'Face9', 'Vertex15', 'Vertex16']
+        if cut1.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+            self.assertKeysInMap(cut1.ElementReverseMap, refkeys )
+        self.assertEqual(len(cut1.ElementReverseMap.keys()),len(refkeys))


### PR DESCRIPTION
fix #17497

Boolean Cutting compounds or cutting by compounds fails (in some cases miserably) if these compounds have overlapping (intersecting) solids.

Assuming this is an OCCT limitation that will not get fixed, there's two ways to address this.

1. Detect the issue and refuse the cutting operation and throw an exception.
2. Detect the issue and work around it by recursively doing separate cutting operations for each shape in the compounds.

I figured option 2 is better than 1, so this is a proposed fix. Since we already have a wrapper for OCCT Boolean Operations in Part, we can simply use that to fix OCCTs limitation no matter from where in FreeCAD it is used.

The approach is simple:

1. If there is a compound in the tool:
    1. go through every shape in the tool compound and cut the argument by that shape - then make the result the new argument.
    2. return the final argument. (if a tool is a compound, this is done recursively)
2. if there is a compound in the argument(base shape)
    1.go through each shape in the argument compound and cut it by the tool - then add the result to a new compound
    2. return the compound (this too is done recursively if there is a compound in the compound)

this means there total_subshapes_in_arguments times total_subshapes_in_tools cutting operations performed. however the cutting operations are simpler, so the total performance impact is likely marginal



there is one issue, if there are multiple consecutive cutting operations performed on the same shape before it is returns (compound in tools) then I get the following errors:

```
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Vertex1
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Vertex1
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Vertex2
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Vertex6
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Vertex7
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Vertex10
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Edge1
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Edge1
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Edge2
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Edge26
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Edge27
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Edge29
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Edge11
<TopoShape> TopoShapeExpansion.cpp(1887): unnamed lower element Edge14
```

so apparently toponaming can no longer trace element names through the series of boolean operations performed by the wrapper. this only seems to be the case for compound-tools not for compound arguments.

so the question is - what to do

1. somehow find a fix for toponaming or suppress the errors (feedback from toponaming experts welcome)
2. do not cut with compounds in the tools and just throw an error (whether they are intersecting or not)
3. disallow compounds in both arguments and tools and throw an error
4. in case of compounds, try to identify intersections (this might be hard/tricky if there are recursive compounds) and only throw errors if they are intersecting and OCCT fails
5. do nothing and wait for OpenCascade to fix the issue ( (big Spartan "IF" )

Here is a nice test file with multiple recursive compounds in both tools and arguments. 

[OCCTCanCut.zip](https://github.com/user-attachments/files/17535499/OCCTCanCut.zip)
