### PR TITLE
Materials: Selectively apply appearances when changing materials

### DIFF
--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -188,8 +188,19 @@ void ViewProviderGeometryObject::updateData(const App::Property* prop)
         // Set the appearance from the material
         auto geometry = dynamic_cast<App::GeoFeature*>(getObject());
         if (geometry) {
+            /*
+             * Change the appearance only if the appearance hasn't been set explicitly. A cached
+             * material appearance is used to see if the current appearance matches the last
+             * material. It is also compared against an empty material to see if the saved
+             * material value has been initialized.
+             */
+            App::Material defaultMaterial;
             auto material = geometry->getMaterialAppearance();
-            ShapeAppearance.setValue(material);
+            if ((materialAppearance == defaultMaterial)
+                || (ShapeAppearance.getSize() == 1 && ShapeAppearance[0] == materialAppearance)) {
+                ShapeAppearance.setValue(material);
+            }
+            materialAppearance = material;
         }
     }
 

--- a/src/Gui/ViewProviderGeometryObject.h
+++ b/src/Gui/ViewProviderGeometryObject.h
@@ -116,6 +116,8 @@ protected:
     SoFCBoundingBox* pcBoundingBox {nullptr};
     SoSwitch* pcBoundSwitch {nullptr};
     SoBaseColor* pcBoundColor {nullptr};
+
+    App::Material materialAppearance;
 };
 
 }  // namespace Gui


### PR DESCRIPTION
Change the appearance only if the appearance hasn't been set explicitly. A cached material appearance is used to see if the current appearance matches the last material. It is also compared against an empty material to see if the saved material value has been initialized.

This solves the problem of material changes overwriting appearance changes