### PR TITLE
Gui: Make VarSet dialog modal

### DIFF
--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -166,6 +166,7 @@ void StdCmdVarSet::activated(int iMsg)
             group->addObject(doc->getObject(VarSetName.c_str()));
         }
     }
+    commitCommand();
 
     doCommand(Doc, "App.ActiveDocument.getObject('%s').ViewObject.doubleClicked()", VarSetName.c_str());
 }

--- a/src/Gui/DlgAddPropertyVarSet.cpp
+++ b/src/Gui/DlgAddPropertyVarSet.cpp
@@ -47,6 +47,8 @@ using namespace Gui::Dialog;
 const std::string DlgAddPropertyVarSet::GROUP_BASE = "Base";
 
 const bool CLEAR_NAME = true;
+const bool ABORT = true;
+const bool COMMIT = false;
 
 DlgAddPropertyVarSet::DlgAddPropertyVarSet(QWidget* parent,
                                            ViewProviderVarSet* viewProvider)
@@ -55,7 +57,8 @@ DlgAddPropertyVarSet::DlgAddPropertyVarSet(QWidget* parent,
       ui(new Ui_DlgAddPropertyVarSet),
       comboBoxGroup(this),
       completerType(this),
-      editor(nullptr)
+      editor(nullptr),
+      transactionID(0)
 {
     ui->setupUi(this);
 
@@ -329,13 +332,40 @@ void DlgAddPropertyVarSet::changePropertyToAdd() {
 }
 
 
+/* We use these functions rather than the functions provided by App::Document
+ * because this dialog may be opened when another transaction is in progress.
+ * An example is opening a sketch.  If this dialog uses the functions provided
+ * by App::Document, a reject of the dialog would close that transaction.  By
+ * checking whether the transaction ID is "our" transaction ID, we prevent this
+ * behavior.
+ */
+void DlgAddPropertyVarSet::openTransaction()
+{
+    transactionID = App::GetApplication().setActiveTransaction("Add property VarSet");
+}
+
+
+bool DlgAddPropertyVarSet::hasPendingTransaction()
+{
+    return transactionID != 0;
+}
+
+
+void DlgAddPropertyVarSet::closeTransaction(bool abort)
+{
+    if (transactionID != 0) {
+        App::GetApplication().closeActiveTransaction(abort, transactionID);
+        transactionID = 0;
+    }
+}
+
+
 void DlgAddPropertyVarSet::clearCurrentProperty()
 {
     removeEditor();
     varSet->removeDynamicProperty(namePropertyToAdd.c_str());
-    App::Document* doc = varSet->getDocument();
-    if (doc->hasPendingTransaction()) {
-        doc->abortTransaction();
+    if (hasPendingTransaction()) {
+        closeTransaction(ABORT);
     }
     setOkEnabled(false);
     namePropertyToAdd.clear();
@@ -429,8 +459,7 @@ void DlgAddPropertyVarSet::onEditFinished() {
 
     if (namePropertyToAdd.empty()) {
         // we are adding a new property
-        App::Document* doc = varSet->getDocument();
-        doc->openTransaction("Add property VarSet");
+        openTransaction();
         createProperty();
     }
     else {
@@ -487,12 +516,11 @@ void DlgAddPropertyVarSet::addDocumentation() {
 void DlgAddPropertyVarSet::accept()
 {
     addDocumentation();
-    App::Document* doc = varSet->getDocument();
-    doc->commitTransaction();
+    closeTransaction(COMMIT);
 
     if (ui->checkBoxAdd->isChecked()) {
         clearEditors();
-        doc->openTransaction();
+        openTransaction();
         ui->lineEditName->setFocus();
         return;
     }
@@ -520,8 +548,8 @@ void DlgAddPropertyVarSet::reject()
     disconnect(connLineEditNameTextChanged);
 
     // a transaction is not pending if a name has not been determined.
-    if (doc->hasPendingTransaction()) {
-        doc->abortTransaction();
+    if (hasPendingTransaction()) {
+        closeTransaction(ABORT);
     }
     QDialog::reject();
 }

--- a/src/Gui/DlgAddPropertyVarSet.h
+++ b/src/Gui/DlgAddPropertyVarSet.h
@@ -96,6 +96,11 @@ private:
     void createProperty();
     void changePropertyToAdd();
 
+    void openTransaction();
+    bool hasPendingTransaction();
+    void abortTransaction();
+    void closeTransaction(bool abort);
+
     void checkName();
     void checkGroup();
     void checkType();
@@ -127,6 +132,9 @@ private:
     std::string namePropertyToAdd;
     std::unique_ptr<PropertyEditor::PropertyItem> propertyItem;
     std::unique_ptr<App::ObjectIdentifier> objectIdentifier;
+
+    // a transactionID of 0 means that there is no active transaction.
+    int transactionID;
 
     // connections
     QMetaObject::Connection connComboBoxGroup;

--- a/src/Gui/ViewProviderVarSet.cpp
+++ b/src/Gui/ViewProviderVarSet.cpp
@@ -46,6 +46,10 @@ bool ViewProviderVarSet::doubleClicked()
         dialog = std::make_unique<DlgAddPropertyVarSet>(getMainWindow(), this);
     }
 
+    // Do not use exec() here because it blocks and prevents command Std_VarSet
+    // to commit the autotransaction.  This in turn prevents the dialog to
+    // handle transactions well.
+    dialog->setWindowModality(Qt::ApplicationModal);
     dialog->show();
     dialog->raise();
     dialog->activateWindow();


### PR DESCRIPTION
Also tracks its own transactions to prevent interfering with other transactions.

This attempts to fix #17475, but I can't reproduce that anymore, so I'm not sure about that. When I was still on the configuration that triggered the bug, this PR did not show the same behavior.

This fixes #17486.

I see two viable solutions for #17486. One is using a transaction lock, but with a non-modal dialog, this can block other transactions that may lead to unexpected behavior for the user. The other one is making the dialog modal, which is what I chose in the end. The dialog tracks the transaction ID to prevent it to interfere with other transactions. A concrete example is opening a sketch. Using the API in `App::Document` would allow canceling this dialog to close the transaction of the Sketch which is unwanted behavior.

The dialog does not make use of `exec()` because that is a blocking call that interferes with the auto transaction in `Std_VarSet`. When using `exec()` the auto transaction of the `Std_VarSet` does not complete and it results in failing to register the transactions that the dialog makes. 

I find the interaction between the various transactions quite complicated, so it would be good if someone else takes a look at this as well. From my point of view, the dialog with respect to transactions works well in this PR.