### PR TITLE
Core: Extend DocumentObjectPy

### DIFF
--- a/src/App/DocumentObjectPy.xml
+++ b/src/App/DocumentObjectPy.xml
@@ -232,6 +232,13 @@ Return tuple(obj,newElementName,oldElementName)
                 </UserDocu>
             </Documentation>
         </Methode>
+        <Methode Name="isAttachedToDocument" Const="true">
+            <Documentation>
+                <UserDocu>
+                    isAttachedToDocument(): return true if the object is part of a document, false otherwise
+                </UserDocu>
+            </Documentation>
+        </Methode>
     <Attribute Name="OutList" ReadOnly="true">
       <Documentation>
         <UserDocu>A list of all objects this object links to.</UserDocu>
@@ -266,7 +273,7 @@ Return tuple(obj,newElementName,oldElementName)
             <Documentation>
                 <UserDocu>Return the internal name of this object</UserDocu>
             </Documentation>
-            <Parameter Name="Name" Type="String"/>
+            <Parameter Name="Name" Type="Object"/>
         </Attribute>
                 <Attribute Name="Document" ReadOnly="true">
                         <Documentation>

--- a/src/App/DocumentObjectPyImp.cpp
+++ b/src/App/DocumentObjectPyImp.cpp
@@ -49,14 +49,14 @@ std::string DocumentObjectPy::representation() const
     return str.str();
 }
 
-Py::String DocumentObjectPy::getName() const
+Py::Object DocumentObjectPy::getName() const
 {
     DocumentObject* object = this->getDocumentObjectPtr();
     const char* internal = object->getNameInDocument();
     if (!internal) {
-        throw Py::RuntimeError(std::string("This object is currently not part of a document"));
+        return Py::None();
     }
-    return {std::string(internal)};
+    return Py::String(internal);
 }
 
 Py::String DocumentObjectPy::getFullName() const
@@ -74,6 +74,17 @@ Py::Object DocumentObjectPy::getDocument() const
     else {
         return Py::Object(doc->getPyObject(), true);
     }
+}
+
+PyObject* DocumentObjectPy::isAttachedToDocument(PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
+    DocumentObject* object = this->getDocumentObjectPtr();
+    bool ok = object->isAttachedToDocument();
+    return Py::new_reference_to(Py::Boolean(ok));
 }
 
 PyObject*  DocumentObjectPy::addProperty(PyObject *args, PyObject *kwd)

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -811,7 +811,7 @@ class Edit(gui_base_original.Modifier):
         """
         for obj in objs:
             obj_gui_tools = self.get_obj_gui_tools(obj)
-            if obj_gui_tools:
+            if obj_gui_tools and obj.isAttachedToDocument():
                 obj_gui_tools.restore_object_style(obj, self.objs_formats[obj.Name])
 
 


### PR DESCRIPTION
* expose isAttachedToDocument to Python
* change DocumentObjectPy::getName() to return None instead of throwing an exception if object is not part of a document