### PR TITLE
Gui: New transform dialog

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -63,6 +63,7 @@
 #include <Base/BaseClass.h>
 #include <Base/BoundBoxPy.h>
 #include <Base/ConsoleObserver.h>
+#include <Base/ServiceProvider.h>
 #include <Base/CoordinateSystemPy.h>
 #include <Base/Exception.h>
 #include <Base/ExceptionFactory.h>
@@ -89,6 +90,7 @@
 #include "Application.h"
 #include "CleanupProcess.h"
 #include "ComplexGeoData.h"
+#include "Services.h"
 #include "DocumentObjectFileIncluded.h"
 #include "DocumentObjectGroup.h"
 #include "DocumentObjectGroupPy.h"
@@ -2217,6 +2219,8 @@ void Application::initTypes()
     new Base::ExceptionProducer<Base::CADKernelError>;
     new Base::ExceptionProducer<Base::RestoreError>;
     new Base::ExceptionProducer<Base::PropertyError>;
+
+    Base::registerServiceImplementation<CenterOfMassProvider>(new NullCenterOfMass);
 }
 
 namespace {

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -289,6 +289,7 @@ SET(FreeCADApp_CPP_SRCS
     MetadataPyImp.cpp
     ElementNamingUtils.cpp
     SafeMode.cpp
+    Services.cpp
     StringHasher.cpp
     StringHasherPyImp.cpp
     StringIDPyImp.cpp
@@ -313,6 +314,7 @@ SET(FreeCADApp_HPP_SRCS
     MeasureManager.h
     Metadata.h
     ElementNamingUtils.h
+    Services.h
     StringHasher.h
 )
 

--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -184,6 +184,17 @@ bool ComplexGeoData::getCenterOfGravity(Base::Vector3d& unused) const
     return false;
 }
 
+std::optional<Base::Vector3d> ComplexGeoData::centerOfGravity() const
+{
+    Base::Vector3d centerOfGravity;
+
+    if (getCenterOfGravity(centerOfGravity)) {
+        return centerOfGravity;
+    }
+
+    return {};
+}
+
 const std::string& ComplexGeoData::elementMapPrefix()
 {
     static std::string prefix(ELEMENT_MAP_PREFIX);

--- a/src/App/ComplexGeoData.h
+++ b/src/App/ComplexGeoData.h
@@ -28,6 +28,8 @@
 #define APP_COMPLEX_GEO_DATA_H
 
 #include <algorithm>
+#include <optional>
+
 #include <Base/Handle.h>
 #include <Base/Matrix.h>
 #include <Base/Persistence.h>
@@ -200,6 +202,7 @@ public:
      * The default implementation only returns false.
      */
     virtual bool getCenterOfGravity(Base::Vector3d& center) const;
+    virtual std::optional<Base::Vector3d> centerOfGravity() const;
     //@}
 
     static const std::string& elementMapPrefix();

--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -311,6 +311,11 @@ Base::Placement GeoFeature::getGlobalPlacement(App::DocumentObject* targetObj,
         return plc;
     }
 
+    if (rootObj->isLink()) {
+        // Update doc in case its an external link.
+        doc = rootObj->getLinkedObject()->getDocument();
+    }
+
     for (auto& name : names) {
         App::DocumentObject* obj = doc->getObject(name.c_str());
         if (!obj) {

--- a/src/App/GeoFeature.cpp
+++ b/src/App/GeoFeature.cpp
@@ -61,12 +61,7 @@ void GeoFeature::transformPlacement(const Base::Placement& transform)
 
 Base::Placement GeoFeature::globalPlacement() const
 {
-    auto* group = GeoFeatureGroupExtension::getGroupOfObject(this);
-    if (group) {
-        auto ext = group->getExtensionByType<GeoFeatureGroupExtension>();
-        return ext->globalGroupPlacement() * Placement.getValue();
-    }
-    return Placement.getValue();
+    return GeoFeature::getGlobalPlacement(this);
 }
 
 const PropertyComplexGeoData* GeoFeature::getPropertyOfGeometry() const
@@ -350,4 +345,21 @@ Base::Placement GeoFeature::getGlobalPlacement(App::DocumentObject* targetObj,
     }
 
     return getGlobalPlacement(targetObj, prop->getValue(), subs[0]);
+}
+
+Base::Placement GeoFeature::getGlobalPlacement(const DocumentObject* obj)
+{
+    auto placementProperty = obj->getPropertyByName<App::PropertyPlacement>("Placement");
+
+    if (!placementProperty) {
+        return {};
+    }
+
+    auto* group = GeoFeatureGroupExtension::getGroupOfObject(obj);
+    if (group) {
+        auto ext = group->getExtensionByType<GeoFeatureGroupExtension>();
+        return ext->globalGroupPlacement() * placementProperty->getValue();
+    }
+
+    return placementProperty->getValue();
 }

--- a/src/App/GeoFeature.h
+++ b/src/App/GeoFeature.h
@@ -195,6 +195,7 @@ public:
     static Base::Placement
     getGlobalPlacement(DocumentObject* targetObj, DocumentObject* rootObj, const std::string& sub);
     static Base::Placement getGlobalPlacement(DocumentObject* targetObj, PropertyXLinkSub* prop);
+    static Base::Placement getGlobalPlacement(const DocumentObject* obj);
 
 protected:
     void onChanged(const Property* prop) override;

--- a/src/App/Services.cpp
+++ b/src/App/Services.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2024 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "Services.h"
+
+std::optional<Base::Vector3d>
+App::NullCenterOfMass::ofDocumentObject([[maybe_unused]] DocumentObject* object) const
+{
+    return std::nullopt;
+}

--- a/src/App/Services.h
+++ b/src/App/Services.h
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2024 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#ifndef APP_SERVICES_H
+#define APP_SERVICES_H
+
+#include "DocumentObject.h"
+
+#include <optional>
+#include <Base/Placement.h>
+
+namespace App
+{
+
+/**
+* This service should provide placement of given sub object (like for example face).
+* This feature is not implemented in the core and so it must be provided by module.
+*/
+class SubObjectPlacementProvider
+{
+public:
+    virtual ~SubObjectPlacementProvider() = default;
+
+    /**
+    * Returns placement of sub object relative to the base placement.
+    */
+    virtual Base::Placement calculate(SubObjectT object, Base::Placement basePlacement) const = 0;
+};
+
+/**
+* This service should provide center of mass calculation;
+*/
+class CenterOfMassProvider
+{
+public:
+    virtual ~CenterOfMassProvider() = default;
+
+    virtual std::optional<Base::Vector3d> ofDocumentObject(DocumentObject* object) const = 0;
+};
+
+/**
+* Default implementation for the center of mass contract
+* It always returns empty optional
+*/
+class NullCenterOfMass final : public CenterOfMassProvider
+{
+public:
+    std::optional<Base::Vector3d> ofDocumentObject(DocumentObject* object) const override;
+};
+
+}
+
+
+#endif // APP_SERVICES_H

--- a/src/Base/Rotation.cpp
+++ b/src/Base/Rotation.cpp
@@ -87,6 +87,13 @@ Rotation Rotation::fromNormalVector(const Vector3d& normal)
     return Rotation(Vector3d(0, 0, 1), normal);
 }
 
+Rotation Rotation::fromEulerAngles(EulerSequence theOrder, double alpha, double beta, double gamma)
+{
+    Rotation rotation;
+    rotation.setEulerAngles(theOrder, alpha, beta, gamma);
+    return rotation;
+}
+
 const double* Rotation::getValue() const
 {
     return &this->quat[0];

--- a/src/Base/Rotation.cpp
+++ b/src/Base/Rotation.cpp
@@ -81,6 +81,12 @@ Rotation::Rotation(const Vector3d& rotateFrom, const Vector3d& rotateTo)
     this->setValue(rotateFrom, rotateTo);
 }
 
+Rotation Rotation::fromNormalVector(const Vector3d& normal)
+{
+    // We rotate Z axis to be aligned with the supplied normal vector
+    return Rotation(Vector3d(0, 0, 1), normal);
+}
+
 const double* Rotation::getValue() const
 {
     return &this->quat[0];

--- a/src/Base/Rotation.h
+++ b/src/Base/Rotation.h
@@ -50,29 +50,6 @@ public:
     Rotation(Rotation&& rot) = default;
     ~Rotation() = default;
 
-    /// Utility function to create Rotation based on direction / normal vector
-    static Rotation fromNormalVector(const Vector3d& normal);
-    //@}
-
-    /** Methods to get or set rotations. */
-    //@{
-    const double* getValue() const;
-    void getValue(double& q0, double& q1, double& q2, double& q3) const;
-    void setValue(double q0, double q1, double q2, double q3);
-    /// If not a null quaternion then \a axis will be normalized
-    void getValue(Vector3d& axis, double& rfAngle) const;
-    /// Does the same as the method above unless normalizing the axis.
-    void getRawValue(Vector3d& axis, double& rfAngle) const;
-    void getValue(Matrix4D& matrix) const;
-    void setValue(const double q[4]);
-    void setValue(const Matrix4D& matrix);
-    void setValue(const Vector3d& axis, double fAngle);
-    void setValue(const Vector3d& rotateFrom, const Vector3d& rotateTo);
-    /// Euler angles in yaw,pitch,roll notation
-    void setYawPitchRoll(double y, double p, double r);
-    /// Euler angles in yaw,pitch,roll notation
-    void getYawPitchRoll(double& y, double& p, double& r) const;
-
     enum EulerSequence
     {
         Invalid,
@@ -115,6 +92,34 @@ public:
 
         EulerSequenceLast,
     };
+
+    /// Utility function to create Rotation based on direction / normal vector
+    /// Z base vector is assumed to represent the normal vector
+    static Rotation fromNormalVector(const Vector3d& normal);
+    /// Utility function to create Rotation based on euler angles
+    static Rotation
+    fromEulerAngles(EulerSequence theOrder, double alpha, double beta, double gamma);
+    //@}
+
+    /** Methods to get or set rotations. */
+    //@{
+    const double* getValue() const;
+    void getValue(double& q0, double& q1, double& q2, double& q3) const;
+    void setValue(double q0, double q1, double q2, double q3);
+    /// If not a null quaternion then \a axis will be normalized
+    void getValue(Vector3d& axis, double& rfAngle) const;
+    /// Does the same as the method above unless normalizing the axis.
+    void getRawValue(Vector3d& axis, double& rfAngle) const;
+    void getValue(Matrix4D& matrix) const;
+    void setValue(const double q[4]);
+    void setValue(const Matrix4D& matrix);
+    void setValue(const Vector3d& axis, double fAngle);
+    void setValue(const Vector3d& rotateFrom, const Vector3d& rotateTo);
+    /// Euler angles in yaw,pitch,roll notation
+    void setYawPitchRoll(double y, double p, double r);
+    /// Euler angles in yaw,pitch,roll notation
+    void getYawPitchRoll(double& y, double& p, double& r) const;
+
     static const char* eulerSequenceName(EulerSequence seq);
     static EulerSequence eulerSequenceFromName(const char* name);
     void getEulerAngles(EulerSequence theOrder, double& alpha, double& beta, double& gamma) const;

--- a/src/Base/Rotation.h
+++ b/src/Base/Rotation.h
@@ -49,6 +49,9 @@ public:
     Rotation(const Rotation& rot) = default;
     Rotation(Rotation&& rot) = default;
     ~Rotation() = default;
+
+    /// Utility function to create Rotation based on direction / normal vector
+    static Rotation fromNormalVector(const Vector3d& normal);
     //@}
 
     /** Methods to get or set rotations. */

--- a/src/Base/ServiceProvider.cpp
+++ b/src/Base/ServiceProvider.cpp
@@ -26,8 +26,7 @@
 
 #include "ServiceProvider.h"
 
-Base::ServiceProvider& Base::ServiceProvider::get()
+namespace Base
 {
-    static Base::ServiceProvider instance;
-    return instance;
+Base::ServiceProvider globalServiceProvider;
 }

--- a/src/Base/ServiceProvider.h
+++ b/src/Base/ServiceProvider.h
@@ -157,7 +157,7 @@ public:
     }
 
 private:
-    std::map<const char*, std::deque<ServiceDescriptor>> _implementations;
+    std::map<std::string, std::deque<ServiceDescriptor>> _implementations;
 };
 
 BaseExport extern ServiceProvider globalServiceProvider;

--- a/src/Base/ServiceProvider.h
+++ b/src/Base/ServiceProvider.h
@@ -36,6 +36,49 @@
 namespace Base
 {
 
+/**
+ * Class that implements basic service container that can be used to obtain different implementation
+ * of various services.
+ *
+ * Primary use of such container is to provide ability to define global services that can be
+ * implemented within non-core modules. This for example allows to use code that is available only
+ * in Part module from Base with the only requirement being that Part implements specific interface
+ * and registers the service within service provider.
+ *
+ * For ease of use global service provider instance is provided with convenience functions:
+ *  - Base::provideService
+ *  - Base::provideServiceImplementations
+ *  - Base::registerServiceImplementation
+ *
+ * As the example, we can define service that provides placement of sub objects in App:
+ * @code
+ * class SubObjectPlacementProvider
+ * {
+ * public:
+ *     virtual Base::Placement calculate(SubObjectT object, Base::Placement basePlacement) const =
+ * 0;
+ * };
+ * @endcode
+ *
+ * App does not know how to implement this service, but it can be implemented within Part module:
+ * @code
+ * class AttacherSubObjectPlacement final: public App::SubObjectPlacementProvider { ... }
+ *
+ * // later in module initialization method
+ *
+ * Base::registerServiceImplementation<App::SubObjectPlacementProvider>(new
+ * AttacherSubObjectPlacement);
+ * @endcode
+ *
+ * This service can then be obtained inside other modules, without them being aware of the
+ * implementation - only the interface:
+ *
+ * @code
+ * auto subObjectPlacementProvider = Base::provideService<App::SubObjectPlacementProvider>();
+ * @endcode
+ *
+ * This function can (and should) be used as default for constructor injection of services.
+ */
 class BaseExport ServiceProvider
 {
     struct ServiceDescriptor
@@ -106,35 +149,53 @@ public:
      * @tparam T Service interface
      */
     template<typename T>
-    void implement(T* contract)
+    void registerImplementation(T* contract)
     {
         ServiceDescriptor descriptor {typeid(T).name(), contract};
 
         _implementations[typeid(T).name()].push_front(descriptor);
     }
 
-    static ServiceProvider& get();
-
 private:
     std::map<const char*, std::deque<ServiceDescriptor>> _implementations;
 };
 
+BaseExport extern ServiceProvider globalServiceProvider;
+
+/**
+ * Obtains primary implementation of requested service from the global service provider.
+ *
+ * @tparam T Service kind to obtain.
+ * @return Primary implementation of the service or nullptr if there is no implementation available.
+ */
 template<typename T>
-T* provideImplementation()
+T* provideService()
 {
-    return ServiceProvider::get().provide<T>();
+    return globalServiceProvider.provide<T>();
 }
 
+/**
+ * Obtains all available implementations of requested service in the global service provider.
+ *
+ * @tparam T Service kind to obtain.
+ * @return List of available service implementation.
+ */
 template<typename T>
-std::list<T*> provideAllImplementations()
+std::list<T*> provideServiceImplementations()
 {
-    return ServiceProvider::get().all<T>();
+    return globalServiceProvider.all<T>();
 }
 
+/**
+ * Registers implementation of service in the global service provider.
+ *
+ * @tparam T Service kind to obtain.
+ * @return List of available service implementation.
+ */
 template<typename T>
-void implementContract(T* implementation)
+void registerServiceImplementation(T* implementation)
 {
-    ServiceProvider::get().implement<T>(implementation);
+    globalServiceProvider.registerImplementation<T>(implementation);
 }
 
 }  // namespace Base

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -402,6 +402,7 @@ SET(Gui_UIC_SRCS
     SceneInspector.ui
     InputVector.ui
     Placement.ui
+    TaskCSysDragger.ui
     TextureMapping.ui
     TaskView/TaskAppearance.ui
     TaskView/TaskOrientation.ui

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -449,7 +449,7 @@ void QuantitySpinBox::updateEdit(const QString& text)
 
     edit->setText(text);
 
-    cursor = qBound(0, cursor, edit->displayText().size() - d->unitStr.size());
+    cursor = qBound(0, cursor, qMax(0, edit->displayText().size() - d->unitStr.size()));
     if (selsize > 0) {
         edit->setSelection(0, cursor);
     }

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -405,10 +405,18 @@ void QuantitySpinBox::resizeEvent(QResizeEvent * event)
     resizeWidget();
 }
 
-void Gui::QuantitySpinBox::keyPressEvent(QKeyEvent *event)
+void Gui::QuantitySpinBox::keyPressEvent(QKeyEvent* event)
 {
-    if (!handleKeyEvent(event->text()))
+    const auto isEnter = event->key() == Qt::Key_Enter || event->key() == Qt::Key_Return;
+
+    if (isEnter && !isNormalized()) {
+        normalize();
+        return;
+    }
+
+    if (!handleKeyEvent(event->text())) {
         QAbstractSpinBox::keyPressEvent(event);
+    }
 }
 
 void Gui::QuantitySpinBox::paintEvent(QPaintEvent*)
@@ -475,6 +483,24 @@ double QuantitySpinBox::rawValue() const
 {
     Q_D(const QuantitySpinBox);
     return d->quantity.getValue();
+}
+
+void QuantitySpinBox::normalize()
+{
+    // this does not really change the value, only the representation
+    QSignalBlocker blocker(this);
+
+    Q_D(const QuantitySpinBox);
+    return setValue(d->quantity);
+}
+
+bool QuantitySpinBox::isNormalized()
+{
+    static const QRegularExpression operators(QStringLiteral("[+\\-/*]"),
+                                              QRegularExpression::CaseInsensitiveOption);
+
+    Q_D(const QuantitySpinBox);
+    return !d->validStr.contains(operators);
 }
 
 void QuantitySpinBox::setValue(const Base::Quantity& value)
@@ -884,6 +910,7 @@ void QuantitySpinBox::focusInEvent(QFocusEvent * event)
 void QuantitySpinBox::focusOutEvent(QFocusEvent * event)
 {
     validateInput();
+    normalize();
 
     QToolTip::hideText();
     QAbstractSpinBox::focusOutEvent(event);

--- a/src/Gui/QuantitySpinBox.h
+++ b/src/Gui/QuantitySpinBox.h
@@ -57,6 +57,9 @@ public:
     /// Get the current quantity without unit
     double rawValue() const;
 
+    void normalize();
+    bool isNormalized();
+
     /// Gives the current state of the user input, gives true if it is a valid input with correct quantity
     /// or returns false if the input is a unparsable string or has a wrong unit.
     bool hasValidInput() const;

--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -230,15 +230,17 @@ SoSeparator* TDragger::buildLabelGeometry()
     labelSeparator->addChild(labelTranslation);
 
     auto label = new SoFrameLabel();
-    label->justification = SoFrameLabel::CENTER;
     label->string.connectFrom(&this->label);
     label->textColor.setValue(1.0, 1.0, 1.0);
-    label->horAlignment.setValue(SoImage::CENTER);
-    label->vertAlignment.setValue(SoImage::HALF);
+    label->horAlignment = SoImage::CENTER;
+    label->vertAlignment = SoImage::HALF;
+    label->border = false;
+    label->backgroundUseBaseColor = true;
     labelSeparator->addChild(label);
 
     return labelSeparator;
 }
+
 SoBaseColor* TDragger::buildActiveColor()
 {
     auto colorActive = new SoBaseColor();
@@ -1170,7 +1172,6 @@ SoFCCSysDragger::SoFCCSysDragger()
     SO_KIT_ADD_CATALOG_ENTRY(zRotatorDragger, RDragger, TRUE, zRotatorSeparator, "", TRUE);
 
     // Other
-
     SO_KIT_ADD_FIELD(translation, (0.0, 0.0, 0.0));
     SO_KIT_ADD_FIELD(translationIncrement, (1.0));
     SO_KIT_ADD_FIELD(translationIncrementCountX, (0));
@@ -1186,6 +1187,10 @@ SoFCCSysDragger::SoFCCSysDragger()
     SO_KIT_ADD_FIELD(draggerSize, (1.0));
     SO_KIT_ADD_FIELD(autoScaleResult, (1.0));
 
+    SO_KIT_ADD_FIELD(xAxisLabel, ("X"));
+    SO_KIT_ADD_FIELD(yAxisLabel, ("Y"));
+    SO_KIT_ADD_FIELD(zAxisLabel, ("Z"));
+
     SO_KIT_INIT_INSTANCE();
 
     // Colors
@@ -1198,17 +1203,17 @@ SoFCCSysDragger::SoFCCSysDragger()
     tDragger = SO_GET_ANY_PART(this, "xTranslatorDragger", TDragger);
     tDragger->translationIncrement.connectFrom(&this->translationIncrement);
     tDragger->autoScaleResult.connectFrom(&this->autoScaleResult);
-    tDragger->label.setValue("U");
+    tDragger->label.connectFrom(&xAxisLabel);
     translationIncrementCountX.connectFrom(&tDragger->translationIncrementCount);
     tDragger = SO_GET_ANY_PART(this, "yTranslatorDragger", TDragger);
     tDragger->translationIncrement.connectFrom(&this->translationIncrement);
     tDragger->autoScaleResult.connectFrom(&this->autoScaleResult);
-    tDragger->label.setValue("V");
+    tDragger->label.connectFrom(&yAxisLabel);
     translationIncrementCountY.connectFrom(&tDragger->translationIncrementCount);
     tDragger = SO_GET_ANY_PART(this, "zTranslatorDragger", TDragger);
     tDragger->translationIncrement.connectFrom(&this->translationIncrement);
     tDragger->autoScaleResult.connectFrom(&this->autoScaleResult);
-    tDragger->label.setValue("W");
+    tDragger->label.connectFrom(&zAxisLabel);
     translationIncrementCountZ.connectFrom(&tDragger->translationIncrementCount);
     // Planar Translator
     TPlanarDragger* tPlanarDragger;

--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -27,10 +27,8 @@
 #include <Inventor/SbRotation.h>
 #include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/engines/SoComposeVec3f.h>
-#include <Inventor/elements/SoLazyElement.h>
 #include <Inventor/nodes/SoLightModel.h>
 #include <Inventor/nodes/SoDrawStyle.h>
-#include <Inventor/nodes/SoAnnotation.h>
 #include <Inventor/nodes/SoBaseColor.h>
 #include <Inventor/nodes/SoCone.h>
 #include <Inventor/nodes/SoCoordinate3.h>
@@ -46,6 +44,9 @@
 #include <Inventor/nodes/SoSphere.h>
 #include <Inventor/nodes/SoSwitch.h>
 #include <Inventor/nodes/SoTranslation.h>
+#include <Inventor/nodes/SoText2.h>
+#include <Inventor/nodes/SoAnnotation.h>
+#include <Inventor/nodes/SoFontStyle.h>
 #endif
 
 #include <Base/Quantity.h>
@@ -55,6 +56,8 @@
 
 #include "MainWindow.h"
 #include "SoFCDB.h"
+
+#include <SoTextLabel.h>
 
 
 /*
@@ -100,14 +103,20 @@ TDragger::TDragger()
     this->ref();
 #endif
 
-    SO_KIT_ADD_CATALOG_ENTRY(translatorSwitch, SoSwitch, TRUE, geomSeparator, "", TRUE);
-    SO_KIT_ADD_CATALOG_ENTRY(translator, SoSeparator, TRUE, translatorSwitch, "", TRUE);
-    SO_KIT_ADD_CATALOG_ENTRY(translatorActive, SoSeparator, TRUE, translatorSwitch, "", TRUE);
+    SO_KIT_ADD_CATALOG_ENTRY(translator, SoSeparator, TRUE, geomSeparator, "", TRUE);
+    SO_KIT_ADD_CATALOG_ENTRY(activeSwitch, SoSwitch, TRUE, translator, "", TRUE);
+    SO_KIT_ADD_CATALOG_ENTRY(activeColor, SoBaseColor, TRUE, activeSwitch, "", TRUE);
+    SO_KIT_ADD_CATALOG_ENTRY(coneSeparator, SoSeparator, TRUE, translator, "", TRUE);
+    SO_KIT_ADD_CATALOG_ENTRY(cylinderSeparator, SoSeparator, TRUE, translator, "", TRUE);
+    SO_KIT_ADD_CATALOG_ENTRY(labelSeparator, SoSeparator, TRUE, translator, "", TRUE);
 
     if (SO_KIT_IS_FIRST_INSTANCE()) {
         buildFirstInstance();
     }
 
+    SO_KIT_ADD_CATALOG_ENTRY(translator, SoSeparator, TRUE, geomSeparator, "", TRUE);
+
+    SO_KIT_ADD_FIELD(label, (""));
     SO_KIT_ADD_FIELD(translation, (0.0, 0.0, 0.0));
     SO_KIT_ADD_FIELD(translationIncrement, (1.0));
     SO_KIT_ADD_FIELD(translationIncrementCount, (0));
@@ -118,11 +127,15 @@ TDragger::TDragger()
     // initialize default parts.
     // first is from 'SO_KIT_CATALOG_ENTRY_HEADER' macro
     // second is unique name from buildFirstInstance().
-    this->setPartAsDefault("translator", "CSysDynamics_TDragger_Translator");
-    this->setPartAsDefault("translatorActive", "CSysDynamics_TDragger_TranslatorActive");
+    SoInteractionKit::setPartAsDefault("coneSeparator", "CSysDynamics_TDragger_Cone");
+    SoInteractionKit::setPartAsDefault("cylinderSeparator", "CSysDynamics_TDragger_Cylinder");
+    SoInteractionKit::setPartAsDefault("activeColor", "CSysDynamics_TDragger_ActiveColor");
 
-    SoSwitch* sw = SO_GET_ANY_PART(this, "translatorSwitch", SoSwitch);
-    SoInteractionKit::setSwitchValue(sw, 0);
+    SoInteractionKit::setPart("labelSeparator", buildLabelGeometry());
+
+    auto sw = SO_GET_ANY_PART(this, "activeSwitch", SoSwitch);
+    SoInteractionKit::setSwitchValue(sw, SO_SWITCH_NONE);
+
 
     this->addStartCallback(&TDragger::startCB);
     this->addMotionCallback(&TDragger::motionCB);
@@ -150,34 +163,22 @@ TDragger::~TDragger()
 
 void TDragger::buildFirstInstance()
 {
-    SoGroup* geometryGroup = buildGeometry();
+    auto cylinderSeparator = buildCylinderGeometry();
+    auto coneSeparator = buildConeGeometry();
+    auto activeColor = buildActiveColor();
 
-    auto localTranslator = new SoSeparator();
-    localTranslator->setName("CSysDynamics_TDragger_Translator");
-    localTranslator->addChild(geometryGroup);
-    SoFCDB::getStorage()->addChild(localTranslator);
+    cylinderSeparator->setName("CSysDynamics_TDragger_Cylinder");
+    coneSeparator->setName("CSysDynamics_TDragger_Cone");
+    activeColor->setName("CSysDynamics_TDragger_ActiveColor");
 
-    auto localTranslatorActive = new SoSeparator();
-    localTranslatorActive->setName("CSysDynamics_TDragger_TranslatorActive");
-    auto colorActive = new SoBaseColor();
-    colorActive->rgb.setValue(1.0, 1.0, 0.0);
-    localTranslatorActive->addChild(colorActive);
-    localTranslatorActive->addChild(geometryGroup);
-    SoFCDB::getStorage()->addChild(localTranslatorActive);
+    SoFCDB::getStorage()->addChild(cylinderSeparator);
+    SoFCDB::getStorage()->addChild(coneSeparator);
+    SoFCDB::getStorage()->addChild(activeColor);
 }
 
-SoGroup* TDragger::buildGeometry()
+SoSeparator* TDragger::buildCylinderGeometry() const
 {
-    // this builds one leg in the Y+ direction because of default done direction.
-    // the location anchor for shapes is the center of shape.
-
-    auto root = new SoGroup();
-
-    // cylinder
-    float cylinderHeight = 10.0;
-    float cylinderRadius = 0.1f;
     auto cylinderSeparator = new SoSeparator();
-    root->addChild(cylinderSeparator);
 
     auto cylinderLightModel = new SoLightModel();
     cylinderLightModel->model = SoLightModel::BASE_COLOR;
@@ -192,14 +193,15 @@ SoGroup* TDragger::buildGeometry()
     cylinder->height.setValue(cylinderHeight);
     cylinderSeparator->addChild(cylinder);
 
-    // cone
-    float coneBottomRadius = 0.8F;
-    float coneHeight = 2.5;
-    auto coneSeparator = new SoSeparator();
-    root->addChild(coneSeparator);
+    return cylinderSeparator;
+}
 
+SoSeparator* TDragger::buildConeGeometry() const
+{
     auto coneLightModel = new SoLightModel();
     coneLightModel->model = SoLightModel::BASE_COLOR;
+
+    auto coneSeparator = new SoSeparator();
     coneSeparator->addChild(coneLightModel);
 
     auto pickStyle = new SoPickStyle();
@@ -216,7 +218,33 @@ SoGroup* TDragger::buildGeometry()
     cone->height.setValue(coneHeight);
     coneSeparator->addChild(cone);
 
-    return root;
+    return coneSeparator;
+}
+
+SoSeparator* TDragger::buildLabelGeometry()
+{
+    auto labelSeparator = new SoSeparator();
+
+    auto labelTranslation = new SoTranslation();
+    labelTranslation->translation.setValue(0.0, cylinderHeight + coneHeight * 1.5, 0.0);
+    labelSeparator->addChild(labelTranslation);
+
+    auto label = new SoFrameLabel();
+    label->justification = SoFrameLabel::CENTER;
+    label->string.connectFrom(&this->label);
+    label->textColor.setValue(1.0, 1.0, 1.0);
+    label->horAlignment.setValue(SoImage::CENTER);
+    label->vertAlignment.setValue(SoImage::HALF);
+    labelSeparator->addChild(label);
+
+    return labelSeparator;
+}
+SoBaseColor* TDragger::buildActiveColor()
+{
+    auto colorActive = new SoBaseColor();
+    colorActive->rgb.setValue(1.0, 1.0, 0.0);
+
+    return colorActive;
 }
 
 void TDragger::startCB(void*, SoDragger* d)
@@ -274,8 +302,8 @@ void TDragger::valueChangedCB(void*, SoDragger* d)
 void TDragger::dragStart()
 {
     SoSwitch* sw;
-    sw = SO_GET_ANY_PART(this, "translatorSwitch", SoSwitch);
-    SoInteractionKit::setSwitchValue(sw, 1);
+    sw = SO_GET_ANY_PART(this, "activeSwitch", SoSwitch);
+    SoInteractionKit::setSwitchValue(sw, SO_SWITCH_ALL);
 
     // do an initial projection to eliminate discrepancies
     // in arrow head pick. we define the arrow in the y+ direction
@@ -334,8 +362,8 @@ void TDragger::drag()
 void TDragger::dragFinish()
 {
     SoSwitch* sw;
-    sw = SO_GET_ANY_PART(this, "translatorSwitch", SoSwitch);
-    SoInteractionKit::setSwitchValue(sw, 0);
+    sw = SO_GET_ANY_PART(this, "activeSwitch", SoSwitch);
+    SoInteractionKit::setSwitchValue(sw, SO_SWITCH_NONE);
 }
 
 SbBool TDragger::setUpConnections(SbBool onoff, SbBool doitalways)
@@ -1165,21 +1193,22 @@ SoFCCSysDragger::SoFCCSysDragger()
                   SbColor(0, 1.0, 0).getPackedValue(0.0f),
                   SbColor(0, 0, 1.0).getPackedValue(0.0f));
 
-    // Increments
-
     // Translator
     TDragger* tDragger;
     tDragger = SO_GET_ANY_PART(this, "xTranslatorDragger", TDragger);
     tDragger->translationIncrement.connectFrom(&this->translationIncrement);
     tDragger->autoScaleResult.connectFrom(&this->autoScaleResult);
+    tDragger->label.setValue("U");
     translationIncrementCountX.connectFrom(&tDragger->translationIncrementCount);
     tDragger = SO_GET_ANY_PART(this, "yTranslatorDragger", TDragger);
     tDragger->translationIncrement.connectFrom(&this->translationIncrement);
     tDragger->autoScaleResult.connectFrom(&this->autoScaleResult);
+    tDragger->label.setValue("V");
     translationIncrementCountY.connectFrom(&tDragger->translationIncrementCount);
     tDragger = SO_GET_ANY_PART(this, "zTranslatorDragger", TDragger);
     tDragger->translationIncrement.connectFrom(&this->translationIncrement);
     tDragger->autoScaleResult.connectFrom(&this->autoScaleResult);
+    tDragger->label.setValue("W");
     translationIncrementCountZ.connectFrom(&tDragger->translationIncrementCount);
     // Planar Translator
     TPlanarDragger* tPlanarDragger;

--- a/src/Gui/SoFCCSysDragger.cpp
+++ b/src/Gui/SoFCCSysDragger.cpp
@@ -1044,7 +1044,7 @@ SoFCCSysDragger::SoFCCSysDragger()
 
     SO_KIT_ADD_CATALOG_ENTRY(annotation, So3DAnnotation, TRUE, geomSeparator, "", TRUE);
     SO_KIT_ADD_CATALOG_ENTRY(scaleNode, SoScale, TRUE, annotation, "", TRUE);
-
+    SO_KIT_ADD_CATALOG_ENTRY(pickStyle, SoPickStyle, TRUE, annotation, "", TRUE);
     // Translator
 
     SO_KIT_ADD_CATALOG_ENTRY(xTranslatorSwitch, SoSwitch, TRUE, annotation, "", TRUE);
@@ -1308,6 +1308,9 @@ SoFCCSysDragger::SoFCCSysDragger()
     SoScale* localScaleNode = SO_GET_ANY_PART(this, "scaleNode", SoScale);
     localScaleNode->scaleFactor.connectFrom(&scaleEngine->vector);
     autoScaleResult.connectFrom(&draggerSize);
+
+    SoPickStyle* localPickStyle = SO_GET_ANY_PART(this, "pickStyle", SoPickStyle);
+    localPickStyle->style = SoPickStyle::SHAPE_ON_TOP;
 
     addValueChangedCallback(&SoFCCSysDragger::valueChangedCB);
 

--- a/src/Gui/SoFCCSysDragger.h
+++ b/src/Gui/SoFCCSysDragger.h
@@ -282,6 +282,10 @@ public:
     SoSFInt32 rotationIncrementCountY; //!< used from outside for rotation y steps.
     SoSFInt32 rotationIncrementCountZ; //!< used from outside for rotation z steps.
 
+    SoSFString xAxisLabel; //!< label for X axis
+    SoSFString yAxisLabel; //!< label for Y axis
+    SoSFString zAxisLabel; //!< label for Z axis
+
     void clearIncrementCounts(); //!< used to reset after drag update.
 
     /*! @brief Overall scale of dragger node.

--- a/src/Gui/SoFCCSysDragger.h
+++ b/src/Gui/SoFCCSysDragger.h
@@ -217,6 +217,7 @@ class GuiExport SoFCCSysDragger : public SoDragger
     SO_KIT_HEADER(SoFCCSysDragger);
     SO_KIT_CATALOG_ENTRY_HEADER(annotation);
     SO_KIT_CATALOG_ENTRY_HEADER(scaleNode);
+    SO_KIT_CATALOG_ENTRY_HEADER(pickStyle);
     // Translator
     SO_KIT_CATALOG_ENTRY_HEADER(xTranslatorSwitch);
     SO_KIT_CATALOG_ENTRY_HEADER(yTranslatorSwitch);

--- a/src/Gui/SoFCCSysDragger.h
+++ b/src/Gui/SoFCCSysDragger.h
@@ -29,10 +29,12 @@
 #include <Inventor/fields/SoSFFloat.h>
 #include <Inventor/fields/SoSFInt32.h>
 #include <Inventor/fields/SoSFRotation.h>
+#include <Inventor/fields/SoSFString.h>
 #include <Inventor/projectors/SbLineProjector.h>
 #include <Inventor/projectors/SbPlaneProjector.h>
 #include <Inventor/sensors/SoFieldSensor.h>
 #include <Inventor/sensors/SoIdleSensor.h>
+#include <Inventor/nodes/SoBaseColor.h>
 #include <FCGlobal.h>
 
 class SoCamera;
@@ -50,12 +52,23 @@ namespace Gui
 class TDragger : public SoDragger
 {
     SO_KIT_HEADER(TDragger);
-    SO_KIT_CATALOG_ENTRY_HEADER(translatorSwitch);
+    SO_KIT_CATALOG_ENTRY_HEADER(activeSwitch);
+    SO_KIT_CATALOG_ENTRY_HEADER(activeColor);
     SO_KIT_CATALOG_ENTRY_HEADER(translator);
-    SO_KIT_CATALOG_ENTRY_HEADER(translatorActive);
+    SO_KIT_CATALOG_ENTRY_HEADER(cylinderSeparator);
+    SO_KIT_CATALOG_ENTRY_HEADER(coneSeparator);
+    SO_KIT_CATALOG_ENTRY_HEADER(labelSeparator);
+
+    static constexpr float coneBottomRadius { 0.8f };
+    static constexpr float coneHeight { 2.5f };
+
+    static constexpr float cylinderHeight { 10.0f };
+    static constexpr float cylinderRadius { 0.1f };
 public:
     static void initClass();
     TDragger();
+
+    SoSFString label; //!< set from outside and used to label
     SoSFVec3f translation; //!< set from outside and used from outside for single precision.
     SoSFDouble translationIncrement; //!< set from outside and used for rounding.
     SoSFInt32 translationIncrementCount; //!< number of steps. used from outside.
@@ -82,6 +95,12 @@ private:
     void buildFirstInstance();
     SbVec3f roundTranslation(const SbVec3f &vecIn, float incrementIn);
     SoGroup* buildGeometry();
+
+    SoSeparator* buildCylinderGeometry() const;
+    SoSeparator* buildConeGeometry() const;
+    SoSeparator* buildLabelGeometry();
+    SoBaseColor* buildActiveColor();
+
     using inherited = SoDragger;
 };
 

--- a/src/Gui/SoTextLabel.cpp
+++ b/src/Gui/SoTextLabel.cpp
@@ -388,7 +388,6 @@ void SoFrameLabel::setIcon(const QPixmap &pixMap)
     drawImage();
 }
 
-
 void SoFrameLabel::notify(SoNotList * list)
 {
     SoField *f = list->getLastField();
@@ -468,7 +467,6 @@ void SoFrameLabel::drawImage()
 
     if (drawIcon) {
         painter.drawImage(QPoint(padding, paddingIconV), iconImg); 
-        
     }
 
     painter.setPen(front);
@@ -495,6 +493,11 @@ void SoFrameLabel::drawImage()
  */
 void SoFrameLabel::GLRender(SoGLRenderAction *action)
 {
+    SoState * state = action->getState();
+
+    const SbColor& diffuse = SoLazyElement::getDiffuse(state, 0);
+    this->backgroundColor.setValue(diffuse);
+
     inherited::GLRender(action);
 }
 

--- a/src/Gui/SoTextLabel.cpp
+++ b/src/Gui/SoTextLabel.cpp
@@ -379,6 +379,8 @@ SoFrameLabel::SoFrameLabel()
     SO_NODE_ADD_FIELD(name, ("Helvetica"));
     SO_NODE_ADD_FIELD(size, (12));
     SO_NODE_ADD_FIELD(frame, (true));
+    SO_NODE_ADD_FIELD(border, (true));
+    SO_NODE_ADD_FIELD(backgroundUseBaseColor, (false));
   //SO_NODE_ADD_FIELD(image, (SbVec2s(0,0), 0, NULL));
 }
 
@@ -397,9 +399,11 @@ void SoFrameLabel::notify(SoNotList * list)
         f == &this->justification ||
         f == &this->name ||
         f == &this->size ||
-        f == &this->frame) {
+        f == &this->frame ||
+        f == &this->border) {
         drawImage();
     }
+
     inherited::notify(list);
 }
 
@@ -417,11 +421,12 @@ void SoFrameLabel::drawImage()
     int w = 0;
     int h = fm.height() * num;
     const SbColor& b = backgroundColor.getValue();
-    QColor brush;
-    brush.setRgbF(b[0],b[1],b[2]);
+    QColor backgroundBrush;
+    backgroundBrush.setRgbF(b[0],b[1],b[2]);
     const SbColor& t = textColor.getValue();
     QColor front;
     front.setRgbF(t[0],t[1],t[2]);
+    const QPen borderPen(QColor(0,0,127), 2, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
 
     QStringList lines;
     for (int i=0; i<num; i++) {
@@ -431,7 +436,7 @@ void SoFrameLabel::drawImage()
     }
 
     int padding = 5;
-    
+
     bool drawIcon = false;
     QImage iconImg;
     int widthIcon = 0;
@@ -456,14 +461,14 @@ void SoFrameLabel::drawImage()
     painter.setRenderHint(QPainter::Antialiasing);
 
     SbBool drawFrame = frame.getValue();
-    if (drawFrame) {
-        painter.setPen(QPen(QColor(0,0,127), 2, Qt::SolidLine, Qt::RoundCap,
-                            Qt::RoundJoin));
-        painter.setBrush(QBrush(brush, Qt::SolidPattern));
+    SbBool drawBorder = border.getValue();
+    if (drawFrame || drawBorder) {
+        painter.setPen(drawBorder ? borderPen : QPen(Qt::transparent));
+        painter.setBrush(QBrush(drawFrame ? backgroundBrush : Qt::transparent));
+
         QRectF rectangle(0.0, 0.0, widthTotal, heightTotal);
         painter.drawRoundedRect(rectangle, 5, 5);
     }
-
 
     if (drawIcon) {
         painter.drawImage(QPoint(padding, paddingIconV), iconImg); 
@@ -493,10 +498,15 @@ void SoFrameLabel::drawImage()
  */
 void SoFrameLabel::GLRender(SoGLRenderAction *action)
 {
-    SoState * state = action->getState();
 
-    const SbColor& diffuse = SoLazyElement::getDiffuse(state, 0);
-    this->backgroundColor.setValue(diffuse);
+    if (backgroundUseBaseColor.getValue()) {
+        SoState* state = action->getState();
+        const SbColor& diffuse = SoLazyElement::getDiffuse(state, 0);
+
+        if (diffuse != this->backgroundColor.getValue()) {
+            this->backgroundColor.setValue(diffuse);
+        }
+    }
 
     inherited::GLRender(action);
 }

--- a/src/Gui/SoTextLabel.h
+++ b/src/Gui/SoTextLabel.h
@@ -118,6 +118,8 @@ public:
     SoSFName   name;
     SoSFInt32  size;
     SoSFBool   frame;
+    SoSFBool   border;
+    SoSFBool   backgroundUseBaseColor;
   //SoSFImage  image;
     QPixmap    iconPixmap;
 

--- a/src/Gui/TaskCSysDragger.cpp
+++ b/src/Gui/TaskCSysDragger.cpp
@@ -382,6 +382,9 @@ void TaskTransform::setSelectionMode(SelectionMode mode)
             draggerPickStyle->style = SoPickStyle::SHAPE_ON_TOP;
             draggerPickStyle->setOverride(false);
             blockSelection(true);
+
+            vp->setTransformOrigin(vp->getTransformOrigin());
+
             break;
     }
 
@@ -492,6 +495,11 @@ void TaskTransform::onAlignRotationChanged()
 
 void TaskTransform::onAlignToOtherObject()
 {
+    if (selectionMode == SelectionMode::SelectAlignTarget) {
+        setSelectionMode(SelectionMode::None);
+        return;
+    }
+
     setSelectionMode(SelectionMode::SelectAlignTarget);
 }
 

--- a/src/Gui/TaskCSysDragger.cpp
+++ b/src/Gui/TaskCSysDragger.cpp
@@ -406,6 +406,8 @@ void TaskTransform::setSelectionMode(SelectionMode mode)
     }
 
     selectionMode = mode;
+
+    updateSpinBoxesReadOnlyStatus();
 }
 
 TaskTransform::SelectionMode TaskTransform::getSelectionMode() const
@@ -590,6 +592,24 @@ void TaskTransform::updateTransformOrigin()
 
     updatePositionAndRotationUi();
     updateDraggerLabels();
+}
+
+void TaskTransform::updateSpinBoxesReadOnlyStatus() const
+{
+    const bool isReadOnly = selectionMode != SelectionMode::None;
+
+    const auto controls = {
+        ui->xPositionSpinBox,
+        ui->yPositionSpinBox,
+        ui->zPositionSpinBox,
+        ui->xRotationSpinBox,
+        ui->yRotationSpinBox,
+        ui->zRotationSpinBox,
+    };
+
+    for (const auto& control : controls) {
+        control->setReadOnly(isReadOnly);
+    }
 }
 
 void TaskTransform::resetReferencePlacement()

--- a/src/Gui/TaskCSysDragger.cpp
+++ b/src/Gui/TaskCSysDragger.cpp
@@ -25,8 +25,6 @@
 #include <cassert>
 #include <limits>
 #include <QApplication>
-#include <QGridLayout>
-#include <QPushButton>
 #endif
 
 #include <View3DInventorViewer.h>
@@ -102,6 +100,8 @@ TaskTransform::TaskTransform(Gui::ViewProviderDragger* vp,
     vp->resetTransformOrigin();
 
     referencePlacement = vp->getObjectPlacement();
+    referenceRotation = referencePlacement.getRotation();
+
     globalOrigin = vp->getObjectPlacement() * App::GeoFeature::getGlobalPlacement(vp->getObject()).inverse();
 
     setupGui();

--- a/src/Gui/TaskCSysDragger.cpp
+++ b/src/Gui/TaskCSysDragger.cpp
@@ -310,7 +310,7 @@ void TaskTransform::updatePositionAndRotationUi() const
         auto blockers = {QSignalBlocker(x), QSignalBlocker(y), QSignalBlocker(z)};
 
         double alpha, beta, gamma;
-        rot.getEulerAngles(Base::Rotation::Intrinsic_XYZ, alpha, beta, gamma);
+        rot.getEulerAngles(eulerSequence(), alpha, beta, gamma);
 
         x->setValue(fixNegativeZero(alpha));
         y->setValue(fixNegativeZero(beta));
@@ -432,6 +432,12 @@ TaskTransform::CoordinateSystem TaskTransform::currentCoordinateSystem() const
 {
     return ui->positionModeComboBox->currentIndex() == 0 ? localCoordinateSystem()
                                                          : globalCoordinateSystem();
+}
+
+Base::Rotation::EulerSequence TaskTransform::eulerSequence() const
+{
+    return positionMode == PositionMode::Local ? Base::Rotation::Intrinsic_XYZ
+                                               : Base::Rotation::Extrinsic_XYZ;
 }
 
 void TaskTransform::onSelectionChanged(const SelectionChanges& msg)
@@ -676,7 +682,7 @@ void TaskTransform::onRotationChange(QuantitySpinBox* changed)
         }
     }
 
-    const auto uvwRotation = Base::Rotation::fromEulerAngles(Base::Rotation::Intrinsic_XYZ,
+    const auto uvwRotation = Base::Rotation::fromEulerAngles(eulerSequence(),
                                                              ui->xRotationSpinBox->rawValue(),
                                                              ui->yRotationSpinBox->rawValue(),
                                                              ui->zRotationSpinBox->rawValue());

--- a/src/Gui/TaskCSysDragger.h
+++ b/src/Gui/TaskCSysDragger.h
@@ -25,39 +25,138 @@
 #define TASKCSYSDRAGGER_H
 
 #include "TaskView/TaskDialog.h"
-#include <App/DocumentObserver.h>
+#include "TaskView/TaskView.h"
+#include "ViewProviderDragger.h"
+
+#include <Base/ServiceProvider.h>
+#include <App/Services.h>
 
 class SoDragger;
 
-namespace Gui
+namespace Attacher
 {
-  class QuantitySpinBox;
-  class SoFCCSysDragger;
-  class ViewProviderDragger;
-
-  class TaskCSysDragger : public Gui::TaskView::TaskDialog
-  {
-      Q_OBJECT
-    public:
-      TaskCSysDragger(ViewProviderDocumentObject *vpObjectIn, SoFCCSysDragger *draggerIn);
-      ~TaskCSysDragger() override;
-      QDialogButtonBox::StandardButtons getStandardButtons() const override
-        { return QDialogButtonBox::Ok | QDialogButtonBox::Cancel;}
-      void open() override;
-      bool accept() override;
-      bool reject() override;
-    private Q_SLOTS:
-      void onTIncrementSlot(double freshValue);
-      void onRIncrementSlot(double freshValue);
-    private:
-      static inline bool firstDrag = true;
-      static void dragStartCallback(void * data, SoDragger * d);
-      void setupGui();
-      App::DocumentObjectT vpObject;
-      SoFCCSysDragger *dragger;
-      QuantitySpinBox *tSpinBox;
-      QuantitySpinBox *rSpinBox;
-  };
+    class AttachEngine;
 }
 
-#endif // TASKCSYSDRAGGER_H
+namespace Gui
+{
+class QuantitySpinBox;
+class SoFCCSysDragger;
+class ViewProviderDragger;
+class Ui_TaskCSysDragger;
+
+class TaskTransform : public Gui::TaskView::TaskBox, public Gui::SelectionObserver
+{
+    Q_OBJECT
+
+public:
+    enum class SelectionMode { None, SelectTransformOrigin, SelectAlignTarget };
+    enum class PlacementMode { ObjectOrigin, Centroid, Custom };
+    enum class PositionMode { Local, Absolute };
+
+    struct CoordinateSystem
+    {
+        std::array<std::string, 3> labels;
+        Base::Placement origin;
+    };
+
+    Q_ENUM(SelectionMode)
+    Q_ENUM(PlacementMode)
+    Q_ENUM(PositionMode)
+
+    TaskTransform(Gui::ViewProviderDragger* vp,
+                  Gui::SoFCCSysDragger* dragger,
+                  QWidget* parent = nullptr,
+                  App::SubObjectPlacementProvider* subObjectPlacementProvider =
+                      Base::provideService<App::SubObjectPlacementProvider>(),
+                  App::CenterOfMassProvider* centerOfMassProvider =
+                      Base::provideService<App::CenterOfMassProvider>());
+    ~TaskTransform() override;
+
+    void setSelectionMode(SelectionMode mode);
+    SelectionMode getSelectionMode() const;
+
+    CoordinateSystem absoluteCoordinateSystem() const;
+    CoordinateSystem localCoordinateSystem() const;
+    CoordinateSystem currentCoordinateSystem() const;
+
+private:
+    void onSelectionChanged(const SelectionChanges& msg) override;
+
+private Q_SLOTS:
+    void onPlacementModeChange(int index);
+
+    void onPickTransformOrigin();
+    void onTransformOriginReset();
+    void onAlignRotationChanged();
+
+    void onAlignToOtherObject();
+    void onFlip();
+
+    void onCoordinateSystemChange(int mode);
+
+    void onPositionChange();
+    void onRotationChange();
+
+private:
+    static inline bool firstDrag = true;
+    static void dragStartCallback(void* data, SoDragger* d);
+    static void dragMotionCallback(void* data, SoDragger* d);
+
+    void setupGui();
+
+    void loadPreferences();
+    void savePreferences();
+
+    void loadPositionModeItems() const;
+    void loadPlacementModeItems() const;
+
+    void updatePositionAndRotationUi() const;
+    void updateDraggerLabels() const;
+    void updateInputLabels() const;
+    void updateIncrements() const;
+    void updateTransformOrigin();
+
+    bool isDraggerAlignedToCoordinateSystem() const;
+
+    ViewProviderDragger* vp;
+
+    const App::SubObjectPlacementProvider* subObjectPlacementProvider;
+    const App::CenterOfMassProvider *centerOfMassProvider;
+
+    CoinPtr<SoFCCSysDragger> dragger;
+
+    Ui_TaskCSysDragger *ui;
+
+    SelectionMode selectionMode { SelectionMode::None };
+    PlacementMode placementMode { PlacementMode::ObjectOrigin };
+    PositionMode positionMode { PositionMode::Local };
+
+    std::optional<Base::Placement> customTransformOrigin {};
+    Base::Placement originalPlacement {};
+};
+
+class TaskCSysDragger: public Gui::TaskView::TaskDialog
+{
+    Q_OBJECT
+
+public:
+    TaskCSysDragger(ViewProviderDragger* vp, SoFCCSysDragger* dragger);
+    ~TaskCSysDragger() override = default;
+
+    QDialogButtonBox::StandardButtons getStandardButtons() const override
+    {
+        return QDialogButtonBox::Ok | QDialogButtonBox::Cancel;
+    }
+
+    void open() override;
+    bool accept() override;
+    bool reject() override;
+
+private:
+    ViewProviderDragger* vp;
+    TaskTransform* transform;
+};
+}  // namespace Gui
+
+#endif  // TASKCSYSDRAGGER_H

--- a/src/Gui/TaskCSysDragger.h
+++ b/src/Gui/TaskCSysDragger.h
@@ -49,10 +49,12 @@ class TaskTransform : public Gui::TaskView::TaskBox, public Gui::SelectionObserv
 {
     Q_OBJECT
 
+    static constexpr double tolerance = 1e-7;
+
 public:
     enum class SelectionMode { None, SelectTransformOrigin, SelectAlignTarget };
     enum class PlacementMode { ObjectOrigin, Centroid, Custom };
-    enum class PositionMode { Local, Absolute };
+    enum class PositionMode { Local, Global };
 
     struct CoordinateSystem
     {
@@ -76,7 +78,7 @@ public:
     void setSelectionMode(SelectionMode mode);
     SelectionMode getSelectionMode() const;
 
-    CoordinateSystem absoluteCoordinateSystem() const;
+    CoordinateSystem globalCoordinateSystem() const;
     CoordinateSystem localCoordinateSystem() const;
     CoordinateSystem currentCoordinateSystem() const;
 
@@ -96,7 +98,7 @@ private Q_SLOTS:
     void onCoordinateSystemChange(int mode);
 
     void onPositionChange();
-    void onRotationChange();
+    void onRotationChange(QuantitySpinBox* changed);
 
 private:
     static inline bool firstDrag = true;
@@ -117,6 +119,11 @@ private:
     void updateIncrements() const;
     void updateTransformOrigin();
 
+    void resetReferencePlacement();
+    void resetReferenceRotation();
+
+    void moveObjectToDragger();
+
     bool isDraggerAlignedToCoordinateSystem() const;
 
     ViewProviderDragger* vp;
@@ -133,7 +140,9 @@ private:
     PositionMode positionMode { PositionMode::Local };
 
     std::optional<Base::Placement> customTransformOrigin {};
-    Base::Placement originalPlacement {};
+    Base::Placement referencePlacement {};
+    Base::Placement globalOrigin {};
+    Base::Rotation referenceRotation {};
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/History/Dragger");
 };

--- a/src/Gui/TaskCSysDragger.h
+++ b/src/Gui/TaskCSysDragger.h
@@ -134,6 +134,8 @@ private:
 
     std::optional<Base::Placement> customTransformOrigin {};
     Base::Placement originalPlacement {};
+
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/History/Dragger");
 };
 
 class TaskCSysDragger: public Gui::TaskView::TaskDialog

--- a/src/Gui/TaskCSysDragger.h
+++ b/src/Gui/TaskCSysDragger.h
@@ -82,6 +82,8 @@ public:
     CoordinateSystem localCoordinateSystem() const;
     CoordinateSystem currentCoordinateSystem() const;
 
+    Base::Rotation::EulerSequence eulerSequence() const;
+
 private:
     void onSelectionChanged(const SelectionChanges& msg) override;
 

--- a/src/Gui/TaskCSysDragger.h
+++ b/src/Gui/TaskCSysDragger.h
@@ -118,6 +118,7 @@ private:
     void updateInputLabels() const;
     void updateIncrements() const;
     void updateTransformOrigin();
+    void updateSpinBoxesReadOnlyStatus() const;
 
     void resetReferencePlacement();
     void resetReferenceRotation();

--- a/src/Gui/TaskCSysDragger.h
+++ b/src/Gui/TaskCSysDragger.h
@@ -75,15 +75,6 @@ public:
                       Base::provideService<App::CenterOfMassProvider>());
     ~TaskTransform() override;
 
-    void setSelectionMode(SelectionMode mode);
-    SelectionMode getSelectionMode() const;
-
-    CoordinateSystem globalCoordinateSystem() const;
-    CoordinateSystem localCoordinateSystem() const;
-    CoordinateSystem currentCoordinateSystem() const;
-
-    Base::Rotation::EulerSequence eulerSequence() const;
-
 private:
     void onSelectionChanged(const SelectionChanges& msg) override;
 
@@ -106,6 +97,15 @@ private:
     static inline bool firstDrag = true;
     static void dragStartCallback(void* data, SoDragger* d);
     static void dragMotionCallback(void* data, SoDragger* d);
+
+    void setSelectionMode(SelectionMode mode);
+    SelectionMode getSelectionMode() const;
+
+    CoordinateSystem globalCoordinateSystem() const;
+    CoordinateSystem localCoordinateSystem() const;
+    CoordinateSystem currentCoordinateSystem() const;
+
+    Base::Rotation::EulerSequence eulerSequence() const;
 
     void setupGui();
 

--- a/src/Gui/TaskCSysDragger.ui
+++ b/src/Gui/TaskCSysDragger.ui
@@ -126,16 +126,10 @@
          </property>
          <item row="4" column="1">
           <widget class="Gui::QuantitySpinBox" name="zPositionSpinBox">
-           <property name="unit" stdset="0">
-            <string>mm</string>
-           </property>
           </widget>
          </item>
          <item row="2" column="1">
           <widget class="Gui::QuantitySpinBox" name="xPositionSpinBox">
-           <property name="unit" stdset="0">
-            <string>mm</string>
-           </property>
           </widget>
          </item>
          <item row="2" column="0">
@@ -188,9 +182,6 @@
          </item>
          <item row="3" column="1">
           <widget class="Gui::QuantitySpinBox" name="yPositionSpinBox">
-           <property name="unit" stdset="0">
-            <string>mm</string>
-           </property>
           </widget>
          </item>
         </layout>
@@ -370,9 +361,6 @@
       </item>
       <item row="6" column="1">
        <widget class="Gui::QuantitySpinBox" name="translationIncrementSpinBox">
-        <property name="unit" stdset="0">
-         <string>mm</string>
-        </property>
         <property name="minimum">
          <double>0.000000000000000</double>
         </property>

--- a/src/Gui/TaskCSysDragger.ui
+++ b/src/Gui/TaskCSysDragger.ui
@@ -1,0 +1,544 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Gui::TaskCSysDragger</class>
+ <widget class="QWidget" name="Gui::TaskCSysDragger">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>450</width>
+    <height>1012</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Placement</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,1">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Coordinate System</string>
+       </property>
+       <property name="buddy">
+        <cstring>positionModeComboBox</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="positionModeComboBox">
+       <item>
+        <property name="text">
+         <string>Local Coordinate System</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Global Coordinate System</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QCheckBox" name="alignRotationCheckBox">
+       <property name="text">
+        <string>align dragger rotation with selected coordinate system</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="7" column="0">
+    <spacer name="vSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>41</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Policy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>16</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="positionGroupBox">
+     <property name="title">
+      <string>Translation</string>
+     </property>
+     <layout class="QGridLayout" columnminimumwidth="100">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QWidget" name="positionStackWidget" native="true">
+        <layout class="QGridLayout" name="absolutePositionLayout" columnstretch="1,0">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="4" column="1">
+          <widget class="Gui::QuantitySpinBox" name="zPositionSpinBox">
+           <property name="unit" stdset="0">
+            <string>mm</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="Gui::QuantitySpinBox" name="xPositionSpinBox">
+           <property name="unit" stdset="0">
+            <string>mm</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="xPositionLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>X</string>
+           </property>
+           <property name="buddy">
+            <cstring>xPositionSpinBox</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="yPositionLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Y</string>
+           </property>
+           <property name="buddy">
+            <cstring>yPositionSpinBox</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="zPositionLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Z</string>
+           </property>
+           <property name="buddy">
+            <cstring>zPositionSpinBox</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="Gui::QuantitySpinBox" name="yPositionSpinBox">
+           <property name="unit" stdset="0">
+            <string>mm</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Utilities</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QPushButton" name="alignToOtherObjectButton">
+        <property name="text">
+         <string>Move to other object</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QFrame" name="frame">
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Shadow::Raised</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="flipPartButton">
+        <property name="text">
+         <string>Flip</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="transformOriginGroupBox">
+     <property name="title">
+      <string>Dragger</string>
+     </property>
+     <layout class="QGridLayout" name="transformOriginLayout">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="placementComboBox"/>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QLabel" name="snappingLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
+        </property>
+        <property name="text">
+         <string>&lt;b&gt;Snapping&lt;/b&gt;</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="translationIncrementLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Translation</string>
+        </property>
+        <property name="buddy">
+         <cstring>translationIncrementSpinBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="Gui::QuantitySpinBox" name="rotationIncrementSpinBox">
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>360.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>5.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <spacer name="verticalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Orientation::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Policy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QWidget" name="referencePickerWidget" native="true">
+        <layout class="QGridLayout" name="referencePickerLayout" columnstretch="0,1">
+         <property name="sizeConstraint">
+          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="referenceLabel">
+           <property name="minimumSize">
+            <size>
+             <width>68</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Reference</string>
+           </property>
+           <property name="buddy">
+            <cstring>referenceLineEdit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QPushButton" name="pickTransformOriginButton">
+           <property name="text">
+            <string>pick reference</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="referenceLineEdit">
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="Gui::QuantitySpinBox" name="translationIncrementSpinBox">
+        <property name="unit" stdset="0">
+         <string>mm</string>
+        </property>
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>2147483647.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Mode</string>
+        </property>
+        <property name="buddy">
+         <cstring>placementComboBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="rotationIncrementLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Rotation</string>
+        </property>
+        <property name="buddy">
+         <cstring>rotationIncrementSpinBox</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QGroupBox" name="rotationGroupBox">
+     <property name="title">
+      <string>Rotation</string>
+     </property>
+     <layout class="QGridLayout">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <item row="1" column="0" colspan="2">
+       <widget class="QWidget" name="rotationStackWidget" native="true">
+        <layout class="QGridLayout" name="absoluteRotationLayout" columnstretch="1,0">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="2" column="1">
+          <widget class="Gui::QuantitySpinBox" name="zRotationSpinBox"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="yRotationLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Y</string>
+           </property>
+           <property name="buddy">
+            <cstring>yRotationSpinBox</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="zRotationLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Z</string>
+           </property>
+           <property name="buddy">
+            <cstring>zRotationSpinBox</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="Gui::QuantitySpinBox" name="yRotationSpinBox"/>
+         </item>
+         <item row="0" column="1">
+          <widget class="Gui::QuantitySpinBox" name="xRotationSpinBox"/>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="xRotationLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>X</string>
+           </property>
+           <property name="buddy">
+            <cstring>xRotationSpinBox</cstring>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QAbstractSpinBox</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>placementComboBox</tabstop>
+  <tabstop>referenceLineEdit</tabstop>
+  <tabstop>pickTransformOriginButton</tabstop>
+  <tabstop>translationIncrementSpinBox</tabstop>
+  <tabstop>rotationIncrementSpinBox</tabstop>
+  <tabstop>positionModeComboBox</tabstop>
+  <tabstop>alignRotationCheckBox</tabstop>
+  <tabstop>xPositionSpinBox</tabstop>
+  <tabstop>yPositionSpinBox</tabstop>
+  <tabstop>zPositionSpinBox</tabstop>
+  <tabstop>xRotationSpinBox</tabstop>
+  <tabstop>yRotationSpinBox</tabstop>
+  <tabstop>zRotationSpinBox</tabstop>
+  <tabstop>alignToOtherObjectButton</tabstop>
+  <tabstop>flipPartButton</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Gui/Utilities.h
+++ b/src/Gui/Utilities.h
@@ -104,6 +104,28 @@ struct vec_traits<App::Color> {
 private:
     const vec_type& v;
 };
+
+template <>
+inline SbMatrix convertTo<SbMatrix, Base::Matrix4D>(const Base::Matrix4D& vec2)
+{
+    double dMtrx[16];
+    vec2.getGLMatrix(dMtrx);
+    return SbMatrix(dMtrx[0], dMtrx[1], dMtrx[2],  dMtrx[3], // clazy:exclude=rule-of-two-soft
+                    dMtrx[4], dMtrx[5], dMtrx[6],  dMtrx[7],
+                    dMtrx[8], dMtrx[9], dMtrx[10], dMtrx[11],
+                    dMtrx[12],dMtrx[13],dMtrx[14], dMtrx[15]);
+}
+
+template <>
+inline Base::Matrix4D convertTo<Base::Matrix4D, SbMatrix>(const SbMatrix& vec2)
+{
+    Base::Matrix4D mat;
+    for(int i=0;i<4;++i) {
+        for(int j=0;j<4;++j)
+            mat[i][j] = vec2[j][i];
+    }
+    return mat;
+}
 }
 
 namespace App{ class DocumentObject; }

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -56,6 +56,8 @@
 #include "ViewProviderLink.h"
 #include "ViewProviderPy.h"
 
+#include <Utilities.h>
+
 
 FC_LOG_LEVEL_INIT("ViewProvider", true, true)
 
@@ -345,13 +347,7 @@ QIcon ViewProvider::mergeColorfulOverlayIcons (const QIcon & orig) const
 
 void ViewProvider::setTransformation(const Base::Matrix4D &rcMatrix)
 {
-    double dMtrx[16];
-    rcMatrix.getGLMatrix(dMtrx);
-
-    pcTransform->setMatrix(SbMatrix(dMtrx[0], dMtrx[1], dMtrx[2],  dMtrx[3],
-                                    dMtrx[4], dMtrx[5], dMtrx[6],  dMtrx[7],
-                                    dMtrx[8], dMtrx[9], dMtrx[10], dMtrx[11],
-                                    dMtrx[12],dMtrx[13],dMtrx[14], dMtrx[15]));
+    pcTransform->setMatrix(convert(rcMatrix));
 }
 
 void ViewProvider::setTransformation(const SbMatrix &rcMatrix)
@@ -361,24 +357,12 @@ void ViewProvider::setTransformation(const SbMatrix &rcMatrix)
 
 SbMatrix ViewProvider::convert(const Base::Matrix4D &rcMatrix)
 {
-    //NOLINTBEGIN
-    double dMtrx[16];
-    rcMatrix.getGLMatrix(dMtrx);
-    return SbMatrix(dMtrx[0], dMtrx[1], dMtrx[2],  dMtrx[3], // clazy:exclude=rule-of-two-soft
-                    dMtrx[4], dMtrx[5], dMtrx[6],  dMtrx[7],
-                    dMtrx[8], dMtrx[9], dMtrx[10], dMtrx[11],
-                    dMtrx[12],dMtrx[13],dMtrx[14], dMtrx[15]);
-    //NOLINTEND
+    return Base::convertTo<SbMatrix>(rcMatrix);
 }
 
 Base::Matrix4D ViewProvider::convert(const SbMatrix &smat)
 {
-    Base::Matrix4D mat;
-    for(int i=0;i<4;++i) {
-        for(int j=0;j<4;++j)
-            mat[i][j] = smat[j][i];
-    }
-    return mat;
+    return Base::convertTo<Base::Matrix4D>(smat);
 }
 
 void ViewProvider::addDisplayMaskMode(SoNode *node, const char* type)

--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -23,16 +23,19 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <string>
-# include <QAction>
-# include <QMenu>
-# include <Inventor/draggers/SoDragger.h>
-# include <Inventor/nodes/SoPickStyle.h>
-# include <Inventor/nodes/SoTransform.h>
+#include <memory>
+#include <string>
+#include <QAction>
+#include <QMenu>
+#include <Inventor/draggers/SoDragger.h>
+#include <Inventor/nodes/SoPickStyle.h>
+#include <Inventor/nodes/SoTransform.h>
 #endif
 
 #include <App/GeoFeature.h>
 #include <Base/Placement.h>
+#include <Base/Vector3D.h>
+#include <Base/Converter.h>
 #include "Gui/ViewParams.h"
 
 #include "Application.h"
@@ -44,20 +47,25 @@
 #include "TaskCSysDragger.h"
 #include "View3DInventorViewer.h"
 #include "ViewProviderDragger.h"
+#include "Utilities.h"
 
+#include <Base/Tools.h>
 
 using namespace Gui;
 
 PROPERTY_SOURCE(Gui::ViewProviderDragger, Gui::ViewProviderDocumentObject)
 
-ViewProviderDragger::ViewProviderDragger() = default;
+ViewProviderDragger::ViewProviderDragger()
+{
+    ADD_PROPERTY_TYPE(TransformOrigin, ({}), nullptr, App::Prop_Hidden, nullptr);
+};
 
 ViewProviderDragger::~ViewProviderDragger() = default;
 
 void ViewProviderDragger::updateData(const App::Property* prop)
 {
-    if (prop->isDerivedFrom(App::PropertyPlacement::getClassTypeId()) &&
-             strcmp(prop->getName(), "Placement") == 0) {
+    if (prop->isDerivedFrom(App::PropertyPlacement::getClassTypeId())
+        && strcmp(prop->getName(), "Placement") == 0) {
         // Note: If R is the rotation, c the rotation center and t the translation
         // vector then Inventor applies the following transformation: R*(x-c)+c+t
         // In FreeCAD a placement only has a rotation and a translation part but
@@ -73,6 +81,30 @@ void ViewProviderDragger::updateData(const App::Property* prop)
     ViewProviderDocumentObject::updateData(prop);
 }
 
+void ViewProviderDragger::setTransformOrigin(const Base::Placement& placement)
+{
+    TransformOrigin.setValue(placement);
+}
+
+void ViewProviderDragger::resetTransformOrigin()
+{
+    setTransformOrigin({});
+}
+
+void ViewProviderDragger::onChanged(const App::Property* property)
+{
+    if (property == &TransformOrigin) {
+        updateDraggerPosition();
+    }
+
+    ViewProviderDocumentObject::onChanged(property);
+}
+
+TaskView::TaskDialog* ViewProviderDragger::getTransformDialog()
+{
+    return new TaskCSysDragger(this, csysDragger);
+}
+
 bool ViewProviderDragger::doubleClicked()
 {
     Gui::Application::Instance->activeDocument()->setEdit(this, (int)ViewProvider::Default);
@@ -81,249 +113,216 @@ bool ViewProviderDragger::doubleClicked()
 
 void ViewProviderDragger::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {
-    QIcon iconObject = mergeGreyableOverlayIcons(Gui::BitmapFactory().pixmap("Std_TransformManip.svg"));
+    QIcon iconObject =
+        mergeGreyableOverlayIcons(Gui::BitmapFactory().pixmap("Std_TransformManip.svg"));
     QAction* act = menu->addAction(iconObject, QObject::tr("Transform"), receiver, member);
     act->setData(QVariant((int)ViewProvider::Transform));
     ViewProviderDocumentObject::setupContextMenu(menu, receiver, member);
 }
 
-ViewProvider *ViewProviderDragger::startEditing(int mode) {
+ViewProvider* ViewProviderDragger::startEditing(int mode)
+{
     _linkDragger = nullptr;
     auto ret = ViewProviderDocumentObject::startEditing(mode);
-    if(!ret)
+    if (!ret) {
         return ret;
-    return _linkDragger?_linkDragger:ret;
+    }
+    return _linkDragger ? _linkDragger : ret;
 }
 
-bool ViewProviderDragger::checkLink() {
+bool ViewProviderDragger::checkLink()
+{
     // Trying to detect if the editing request is forwarded by a link object,
     // usually by doubleClicked(). If so, we route the request back. There shall
     // be no risk of infinite recursion, as ViewProviderLink handles
     // ViewProvider::Transform request by itself.
-    ViewProviderDocumentObject *vpParent = nullptr;
+    ViewProviderDocumentObject* vpParent = nullptr;
     std::string subname;
+
     auto doc = Application::Instance->editDocument();
-    if(!doc)
+    if (!doc) {
         return false;
-    doc->getInEdit(&vpParent,&subname);
-    if(!vpParent)
+    }
+
+    doc->getInEdit(&vpParent, &subname);
+    if (!vpParent) {
         return false;
+    }
+
     auto sobj = vpParent->getObject()->getSubObject(subname.c_str());
-    if(!sobj || sobj==getObject() || sobj->getLinkedObject(true)!=getObject())
+    if (!sobj || sobj == getObject() || sobj->getLinkedObject(true) != getObject()) {
         return false;
+    }
+
     auto vp = Application::Instance->getViewProvider(sobj);
-    if(!vp)
+    if (!vp) {
         return false;
+    }
+
     _linkDragger = vp->startEditing(ViewProvider::Transform);
-    if(_linkDragger)
-        return true;
-    return false;
+
+    return _linkDragger != nullptr;
 }
 
 bool ViewProviderDragger::setEdit(int ModNum)
 {
-  Q_UNUSED(ModNum);
+    Q_UNUSED(ModNum);
 
-  if (checkLink()) {
-      return true;
-  }
-
-  App::DocumentObject *genericObject = this->getObject();
-
-  if (genericObject->isDerivedFrom(App::GeoFeature::getClassTypeId())) {
-    auto geoFeature = static_cast<App::GeoFeature *>(genericObject);
-    const Base::Placement &placement = geoFeature->Placement.getValue();
-    auto tempTransform = new SoTransform();
-    tempTransform->ref();
-    updateTransform(placement, tempTransform);
+    if (checkLink()) {
+        return true;
+    }
 
     assert(!csysDragger);
+
     csysDragger = new SoFCCSysDragger();
-    csysDragger->setAxisColors(
-      Gui::ViewParams::instance()->getAxisXColor(),
-      Gui::ViewParams::instance()->getAxisYColor(),
-      Gui::ViewParams::instance()->getAxisZColor()
-    );
+    csysDragger->setAxisColors(Gui::ViewParams::instance()->getAxisXColor(),
+                               Gui::ViewParams::instance()->getAxisYColor(),
+                               Gui::ViewParams::instance()->getAxisZColor());
     csysDragger->draggerSize.setValue(ViewParams::instance()->getDraggerScale());
-    csysDragger->translation.setValue(tempTransform->translation.getValue());
-    csysDragger->rotation.setValue(tempTransform->rotation.getValue());
 
-    tempTransform->unref();
-
-    pcTransform->translation.connectFrom(&csysDragger->translation);
-    pcTransform->rotation.connectFrom(&csysDragger->rotation);
-
+    csysDragger->addStartCallback(dragStartCallback, this);
     csysDragger->addFinishCallback(dragFinishCallback, this);
+    csysDragger->addMotionCallback(dragMotionCallback, this);
 
-    // dragger node is added to viewer's editing root in setEditViewer
-    // pcRoot->insertChild(csysDragger, 0);
-    csysDragger->ref();
+    Gui::Control().showDialog(getTransformDialog());
 
-    auto task = new TaskCSysDragger(this, csysDragger);
-    Gui::Control().showDialog(task);
-  }
+    updateDraggerPosition();
 
-  return true;
+    return true;
 }
 
 void ViewProviderDragger::unsetEdit(int ModNum)
 {
-  Q_UNUSED(ModNum);
+    Q_UNUSED(ModNum);
 
-  if(csysDragger)
-  {
-    pcTransform->translation.disconnect(&csysDragger->translation);
-    pcTransform->rotation.disconnect(&csysDragger->rotation);
+    csysDragger.reset();
 
-    // dragger node is added to viewer's editing root in setEditViewer
-    // pcRoot->removeChild(csysDragger); //should delete csysDragger
-    csysDragger->unref();
-    csysDragger = nullptr;
-  }
-  Gui::Control().closeDialog();
+    Gui::Control().closeDialog();
 }
 
 void ViewProviderDragger::setEditViewer(Gui::View3DInventorViewer* viewer, int ModNum)
 {
     Q_UNUSED(ModNum);
 
-    if (csysDragger && viewer)
-    {
-      auto rootPickStyle = new SoPickStyle();
-      rootPickStyle->style = SoPickStyle::UNPICKABLE;
-      auto selection = static_cast<SoGroup*>(viewer->getSceneGraph());
-      selection->insertChild(rootPickStyle, 0);
-      viewer->setSelectionEnabled(false);
-      csysDragger->setUpAutoScale(viewer->getSoRenderManager()->getCamera());
+    if (csysDragger && viewer) {
+        csysDragger->setUpAutoScale(viewer->getSoRenderManager()->getCamera());
 
-      auto mat = viewer->getDocument()->getEditingTransform();
-      viewer->getDocument()->setEditingTransform(mat);
-      auto feat = dynamic_cast<App::GeoFeature *>(getObject());
-      if(feat) {
-          auto matInverse = feat->Placement.getValue().toMatrix();
-          matInverse.inverse();
-          mat *= matInverse;
-      }
-      viewer->setupEditingRoot(csysDragger,&mat);
+        auto mat = viewer->getDocument()->getEditingTransform();
+        if (auto geoFeature = getObject<App::GeoFeature>()) {
+            mat *= geoFeature->Placement.getValue().inverse().toMatrix();
+        }
+
+        viewer->getDocument()->setEditingTransform(mat);
+        viewer->setupEditingRoot(csysDragger, &mat);
     }
 }
 
 void ViewProviderDragger::unsetEditViewer(Gui::View3DInventorViewer* viewer)
-{
-    auto selection = static_cast<SoGroup*>(viewer->getSceneGraph());
-    SoNode *child = selection->getChild(0);
-    if (child && child->isOfType(SoPickStyle::getClassTypeId())) {
-        selection->removeChild(child);
-        viewer->setSelectionEnabled(true);
-    }
-}
+{}
 
-void ViewProviderDragger::dragFinishCallback(void *data, SoDragger *d)
+void ViewProviderDragger::dragStartCallback(void* data, [[maybe_unused]] SoDragger* d)
 {
     // This is called when a manipulator has done manipulating
+    auto vp = static_cast<ViewProviderDragger*>(data);
 
-    auto sudoThis = static_cast<ViewProviderDragger *>(data);
-    auto dragger = static_cast<SoFCCSysDragger *>(d);
-    updatePlacementFromDragger(sudoThis, dragger);
-
-    //Gui::Application::Instance->activeDocument()->commitCommand();
+    vp->draggerPlacement = vp->getDraggerPlacement();
+    vp->csysDragger->clearIncrementCounts();
 }
 
-void ViewProviderDragger::updatePlacementFromDragger(ViewProviderDragger* sudoThis, SoFCCSysDragger* draggerIn)
+void ViewProviderDragger::dragFinishCallback(void* data, SoDragger* d)
 {
-  App::DocumentObject *genericObject = sudoThis->getObject();
-  if (!genericObject->isDerivedFrom(App::GeoFeature::getClassTypeId()))
-    return;
-  auto geoFeature = static_cast<App::GeoFeature *>(genericObject);
-  Base::Placement originalPlacement = geoFeature->Placement.getValue();
-  double pMatrix[16];
-  originalPlacement.toMatrix().getMatrix(pMatrix);
-  Base::Placement freshPlacement = originalPlacement;
+    // This is called when a manipulator has done manipulating
+    auto vp = static_cast<ViewProviderDragger*>(data);
 
-  //local cache for brevity.
-  double translationIncrement = draggerIn->translationIncrement.getValue();
-  double rotationIncrement = draggerIn->rotationIncrement.getValue();
-  int tCountX = draggerIn->translationIncrementCountX.getValue();
-  int tCountY = draggerIn->translationIncrementCountY.getValue();
-  int tCountZ = draggerIn->translationIncrementCountZ.getValue();
-  int rCountX = draggerIn->rotationIncrementCountX.getValue();
-  int rCountY = draggerIn->rotationIncrementCountY.getValue();
-  int rCountZ = draggerIn->rotationIncrementCountZ.getValue();
+    vp->draggerPlacement = vp->getDraggerPlacement();
+    vp->csysDragger->clearIncrementCounts();
 
-  //just as a little sanity check make sure only 1 or 2 fields has changed.
-  int numberOfFieldChanged = 0;
-  if (tCountX) numberOfFieldChanged++;
-  if (tCountY) numberOfFieldChanged++;
-  if (tCountZ) numberOfFieldChanged++;
-  if (rCountX) numberOfFieldChanged++;
-  if (rCountY) numberOfFieldChanged++;
-  if (rCountZ) numberOfFieldChanged++;
-  if (numberOfFieldChanged == 0)
-    return;
-  assert(numberOfFieldChanged == 1 || numberOfFieldChanged == 2);
+    vp->updatePlacementFromDragger();
+}
 
-  //helper lambdas.
-  auto getVectorX = [&pMatrix]() {return Base::Vector3d(pMatrix[0], pMatrix[4], pMatrix[8]);};
-  auto getVectorY = [&pMatrix]() {return Base::Vector3d(pMatrix[1], pMatrix[5], pMatrix[9]);};
-  auto getVectorZ = [&pMatrix]() {return Base::Vector3d(pMatrix[2], pMatrix[6], pMatrix[10]);};
+void ViewProviderDragger::dragMotionCallback(void* data, SoDragger* d)
+{
+    auto vp = static_cast<ViewProviderDragger*>(data);
 
-  if (tCountX)
-  {
-    Base::Vector3d movementVector(getVectorX());
-    movementVector *= (tCountX * translationIncrement);
-    freshPlacement.move(movementVector);
-    geoFeature->Placement.setValue(freshPlacement);
-  }
-  if (tCountY)
-  {
-    Base::Vector3d movementVector(getVectorY());
-    movementVector *= (tCountY * translationIncrement);
-    freshPlacement.move(movementVector);
-    geoFeature->Placement.setValue(freshPlacement);
-  }
-  if (tCountZ)
-  {
-    Base::Vector3d movementVector(getVectorZ());
-    movementVector *= (tCountZ * translationIncrement);
-    freshPlacement.move(movementVector);
-    geoFeature->Placement.setValue(freshPlacement);
-  }
-  if (rCountX)
-  {
-    Base::Vector3d rotationVector(getVectorX());
-    Base::Rotation rotation(rotationVector, rCountX * rotationIncrement);
-    freshPlacement.setRotation(rotation * freshPlacement.getRotation());
-    geoFeature->Placement.setValue(freshPlacement);
-  }
-  if (rCountY)
-  {
-    Base::Vector3d rotationVector(getVectorY());
-    Base::Rotation rotation(rotationVector, rCountY * rotationIncrement);
-    freshPlacement.setRotation(rotation * freshPlacement.getRotation());
-    geoFeature->Placement.setValue(freshPlacement);
-  }
-  if (rCountZ)
-  {
-    Base::Vector3d rotationVector(getVectorZ());
-    Base::Rotation rotation(rotationVector, rCountZ * rotationIncrement);
-    freshPlacement.setRotation(rotation * freshPlacement.getRotation());
-    geoFeature->Placement.setValue(freshPlacement);
-  }
+    vp->updateTransformFromDragger();
+}
 
-  draggerIn->clearIncrementCounts();
+void ViewProviderDragger::updatePlacementFromDragger()
+{
+    const auto geoFeature = getObject<App::GeoFeature>();
+
+    if (!geoFeature) {
+        return;
+    }
+
+    geoFeature->Placement.setValue(getDraggerPlacement() * getTransformOrigin().inverse());
+}
+
+void ViewProviderDragger::updateTransformFromDragger()
+{
+    const auto placement = getDraggerPlacement() * getTransformOrigin().inverse();
+
+    pcTransform->translation.setValue(Base::convertTo<SbVec3f>(placement.getPosition()));
+    pcTransform->rotation.setValue(Base::convertTo<SbRotation>(placement.getRotation()));
+}
+
+Base::Placement ViewProviderDragger::getDraggerPlacement() const
+{
+    const double translationStep = csysDragger->translationIncrement.getValue();
+    const int xSteps = csysDragger->translationIncrementCountX.getValue();
+    const int ySteps = csysDragger->translationIncrementCountY.getValue();
+    const int zSteps = csysDragger->translationIncrementCountZ.getValue();
+
+    const auto rotation = draggerPlacement.getRotation();
+    const auto xBase = rotation.multVec(Base::Vector3d(1, 0, 0));
+    const auto yBase = rotation.multVec(Base::Vector3d(0, 1, 0));
+    const auto zBase = rotation.multVec(Base::Vector3d(0, 0, 1));
+
+    const auto positionIncrement =
+        xBase * (translationStep * xSteps) +
+        yBase * (translationStep * ySteps) +
+        zBase * (translationStep * zSteps);
+
+    const double rotationStep = csysDragger->rotationIncrement.getValue();
+    const int xRotationSteps = csysDragger->rotationIncrementCountX.getValue();
+    const int yRotationSteps = csysDragger->rotationIncrementCountY.getValue();
+    const int zRotationSteps = csysDragger->rotationIncrementCountZ.getValue();
+
+    auto newRotation = rotation;
+    newRotation = newRotation * Base::Rotation(Base::Vector3d(1, 0, 0), xRotationSteps * rotationStep);
+    newRotation = newRotation * Base::Rotation(Base::Vector3d(0, 1, 0), yRotationSteps * rotationStep);
+    newRotation = newRotation * Base::Rotation(Base::Vector3d(0, 0, 1), zRotationSteps * rotationStep);
+
+    return Base::Placement(
+        draggerPlacement.getPosition() + positionIncrement,
+        newRotation
+    );
+}
+
+void ViewProviderDragger::setDraggerPlacement(const Base::Placement& placement)
+{
+    csysDragger->translation.setValue(Base::convertTo<SbVec3f>(placement.getPosition()));
+    csysDragger->rotation.setValue(Base::convertTo<SbRotation>(placement.getRotation()));
+
+    draggerPlacement = placement;
+    csysDragger->clearIncrementCounts();
+}
+
+void ViewProviderDragger::updateDraggerPosition()
+{
+    if (!csysDragger) {
+        return;
+    }
+
+    auto placement = getObject<App::GeoFeature>()->Placement.getValue() * getTransformOrigin();
+
+    setDraggerPlacement(placement);
 }
 
 void ViewProviderDragger::updateTransform(const Base::Placement& from, SoTransform* to)
 {
-    auto q0 = (float)from.getRotation().getValue()[0];
-    auto q1 = (float)from.getRotation().getValue()[1];
-    auto q2 = (float)from.getRotation().getValue()[2];
-    auto q3 = (float)from.getRotation().getValue()[3];
-    auto px = (float)from.getPosition().x;
-    auto py = (float)from.getPosition().y;
-    auto pz = (float)from.getPosition().z;
-  to->rotation.setValue(q0,q1,q2,q3);
-  to->translation.setValue(px,py,pz);
-  to->center.setValue(0.0f,0.0f,0.0f);
-  to->scaleFactor.setValue(1.0f,1.0f,1.0f);
+    to->rotation.setValue(Base::convertTo<SbRotation>(from.getRotation()));
+    to->translation.setValue(Base::convertTo<SbVec3f>(from.getPosition()));
+    to->center.setValue(0.0f, 0.0f, 0.0f);
+    to->scaleFactor.setValue(1.0f, 1.0f, 1.0f);
 }

--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -308,6 +308,11 @@ Base::Placement ViewProviderDragger::getDraggerPlacement() const
     );
 }
 
+Base::Placement ViewProviderDragger::getOriginalDraggerPlacement() const
+{
+    return draggerPlacement;
+}
+
 void ViewProviderDragger::setDraggerPlacement(const Base::Placement& placement)
 {
     csysDragger->translation.setValue(Base::convertTo<SbVec3f>(placement.getPosition()));

--- a/src/Gui/ViewProviderDragger.h
+++ b/src/Gui/ViewProviderDragger.h
@@ -77,6 +77,7 @@ public:
     void updatePlacementFromDragger();
     void updateTransformFromDragger();
 
+    Base::Placement getObjectPlacement() const;
     Base::Placement getDraggerPlacement() const;
     void setDraggerPlacement(const Base::Placement& placement);
 

--- a/src/Gui/ViewProviderDragger.h
+++ b/src/Gui/ViewProviderDragger.h
@@ -90,6 +90,8 @@ protected:
 
     void onChanged(const App::Property* prop) override;
 
+    bool forwardToLink();
+
     /**
      * Returns a newly create dialog for the part to be placed in the task view
      * Must be reimplemented in subclasses.
@@ -97,6 +99,7 @@ protected:
     virtual TaskView::TaskDialog* getTransformDialog();
 
     CoinPtr<SoFCCSysDragger> csysDragger = nullptr;
+    ViewProvider *forwardedViewProvider = nullptr;
 
 private:
     static void dragStartCallback(void *data, SoDragger *d);
@@ -105,9 +108,6 @@ private:
 
     void updateDraggerPosition();
 
-    bool checkLink();
-
-    ViewProvider *_linkDragger = nullptr;
     Base::Placement draggerPlacement { };
 };
 

--- a/src/Gui/ViewProviderDragger.h
+++ b/src/Gui/ViewProviderDragger.h
@@ -56,10 +56,16 @@ public:
     /// destructor.
     ~ViewProviderDragger() override;
 
+    /// Origin used when object is transformed. It temporarily changes the origin of object.
+    /// Dragger is normally placed at the transform origin, unless explicitly overridden via
+    /// ViewProviderDragger#setDraggerPlacement() method.
     App::PropertyPlacement TransformOrigin;
 
+    /// Convenience method to obtain the transform origin
     Base::Placement getTransformOrigin() const { return TransformOrigin.getValue(); }
+    /// Convenience method to set the transform origin
     void setTransformOrigin(const Base::Placement& placement);
+    /// Resets transform origin to the object origin
     void resetTransformOrigin();
 
 public:
@@ -74,11 +80,18 @@ public:
     /*! synchronize From FC placement to Coin placement*/
     static void updateTransform(const Base::Placement &from, SoTransform *to);
 
+    /// updates placement of object based on dragger position
     void updatePlacementFromDragger();
+    /// updates transform of object based on dragger position, can be used to preview movement
     void updateTransformFromDragger();
 
+    /// Gets object placement relative to its coordinate system
     Base::Placement getObjectPlacement() const;
+    /// Gets current dragger placement, including current dragger movement
     Base::Placement getDraggerPlacement() const;
+    /// Gets original dragger placement, without current dragger movement
+    Base::Placement getOriginalDraggerPlacement() const;
+    /// Sets placement of dragger relative to objects origin
     void setDraggerPlacement(const Base::Placement& placement);
 
 protected:

--- a/src/Gui/ViewProviderDragger.h
+++ b/src/Gui/ViewProviderDragger.h
@@ -25,16 +25,20 @@
 #define GUI_VIEWPROVIDER_DRAGGER_H
 
 #include "ViewProviderDocumentObject.h"
+#include "SoFCCSysDragger.h"
+#include <Base/Placement.h>
+#include <App/PropertyGeo.h>
 
 class SoDragger;
 class SoTransform;
 
-namespace Base { class Placement;}
-
 namespace Gui {
 
+namespace TaskView {
+    class TaskDialog;
+}
+
 class View3DInventorViewer;
-class SoFCCSysDragger;
 
 /**
  * The base class for all view providers modifying the placement
@@ -52,6 +56,13 @@ public:
     /// destructor.
     ~ViewProviderDragger() override;
 
+    App::PropertyPlacement TransformOrigin;
+
+    Base::Placement getTransformOrigin() const { return TransformOrigin.getValue(); }
+    void setTransformOrigin(const Base::Placement& placement);
+    void resetTransformOrigin();
+
+public:
     /** @name Edit methods */
     //@{
     bool doubleClicked() override;
@@ -63,21 +74,40 @@ public:
     /*! synchronize From FC placement to Coin placement*/
     static void updateTransform(const Base::Placement &from, SoTransform *to);
 
+    void updatePlacementFromDragger();
+    void updateTransformFromDragger();
+
+    Base::Placement getDraggerPlacement() const;
+    void setDraggerPlacement(const Base::Placement& placement);
+
 protected:
     bool setEdit(int ModNum) override;
     void unsetEdit(int ModNum) override;
     void setEditViewer(View3DInventorViewer*, int ModNum) override;
     void unsetEditViewer(View3DInventorViewer*) override;
     //@}
-    SoFCCSysDragger *csysDragger = nullptr;
+
+    void onChanged(const App::Property* prop) override;
+
+    /**
+     * Returns a newly create dialog for the part to be placed in the task view
+     * Must be reimplemented in subclasses.
+     */
+    virtual TaskView::TaskDialog* getTransformDialog();
+
+    CoinPtr<SoFCCSysDragger> csysDragger = nullptr;
 
 private:
-    static void dragFinishCallback(void * data, SoDragger * d);
-    static void updatePlacementFromDragger(ViewProviderDragger *sudoThis, SoFCCSysDragger *draggerIn);
+    static void dragStartCallback(void *data, SoDragger *d);
+    static void dragFinishCallback(void *data, SoDragger *d);
+    static void dragMotionCallback(void *data, SoDragger *d);
+
+    void updateDraggerPosition();
 
     bool checkLink();
 
     ViewProvider *_linkDragger = nullptr;
+    Base::Placement draggerPlacement { };
 };
 
 } // namespace Gui

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2893,7 +2893,7 @@ void ViewProviderLink::setEditViewer(Gui::View3DInventorViewer* viewer, int ModN
             dragger->setUpAutoScale(viewer->getSoRenderManager()->getCamera());
             viewer->setupEditingRoot(pcDragger,&dragCtx->preTransform);
 
-            auto task = new TaskCSysDragger(this, dragger);
+            auto task = new TaskCSysDragger(nullptr, dragger);
             Gui::Control().showDialog(task);
         }
     }

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -1624,7 +1624,7 @@ static const char *_LinkElementIcon = "LinkElement";
 
 ViewProviderLink::ViewProviderLink()
     :linkType(LinkTypeNone),hasSubName(false),hasSubElement(false)
-    ,useCenterballDragger(false),childVp(nullptr),overlayCacheKey(0)
+    ,childVp(nullptr),overlayCacheKey(0)
 {
     sPixmap = _LinkIcon;
 
@@ -1670,7 +1670,7 @@ ViewProviderLink::~ViewProviderLink()
 }
 
 bool ViewProviderLink::isSelectable() const {
-    return !pcDragger && Selectable.getValue();
+    return Selectable.getValue();
 }
 
 void ViewProviderLink::attach(App::DocumentObject *pcObj) {
@@ -1851,7 +1851,7 @@ void ViewProviderLink::updateDataPrivate(App::LinkBaseExtension *ext, const App:
         auto propLinkPlacement = ext->getLinkPlacementProperty();
         if(!propLinkPlacement || propLinkPlacement == prop) {
             const auto &pla = static_cast<const App::PropertyPlacement*>(prop)->getValue();
-            ViewProviderGeometryObject::updateTransform(pla, pcTransform);
+            // ViewProviderGeometryObject::updateTransform(pla, pcTransform);
             const auto &v = ext->getScaleVector();
             if(canScale(v))
                 pcTransform->scaleFactor.setValue(v.x,v.y,v.z);
@@ -2764,25 +2764,28 @@ ViewProvider *ViewProviderLink::startEditing(int mode) {
     }
 
     static thread_local bool _pendingTransform;
-    static thread_local Base::Matrix4D  _editingTransform;
+    static thread_local Matrix4D _editingTransform;
 
     auto doc = Application::Instance->editDocument();
 
-    if(mode==ViewProvider::Transform) {
-        if(_pendingTransform && doc)
+    if (mode == ViewProvider::Transform) {
+        if (_pendingTransform && doc) {
             doc->setEditingTransform(_editingTransform);
+        }
 
-        if(!initDraggingPlacement())
+        if (!initDraggingPlacement()) {
             return nullptr;
-        if(useCenterballDragger)
-            pcDragger = CoinPtr<SoCenterballDragger>(new SoCenterballDragger);
-        else
-            pcDragger = CoinPtr<SoFCCSysDragger>(new SoFCCSysDragger);
-        updateDraggingPlacement(dragCtx->initialPlacement,true);
-        pcDragger->addStartCallback(dragStartCallback, this);
-        pcDragger->addFinishCallback(dragFinishCallback, this);
-        pcDragger->addMotionCallback(dragMotionCallback, this);
-        return inherited::startEditing(mode);
+        }
+
+        if (auto result = inherited::startEditing(mode)) {
+            csysDragger->addStartCallback(dragStartCallback, this);
+            csysDragger->addFinishCallback(dragFinishCallback, this);
+            csysDragger->addMotionCallback(dragMotionCallback, this);
+
+            setDraggerPlacement(dragCtx->initialPlacement);
+
+            return result;
+        }
     }
 
     if(!linkEdit()) {
@@ -2839,6 +2842,7 @@ bool ViewProviderLink::setEdit(int ModNum)
         Selection().clearSelection();
         return true;
     }
+
     return inherited::setEdit(ModNum);
 }
 
@@ -2849,125 +2853,21 @@ void ViewProviderLink::setEditViewer(Gui::View3DInventorViewer* viewer, int ModN
         return;
     }
 
-    if (pcDragger && viewer)
-    {
-        auto rootPickStyle = new SoPickStyle();
-        rootPickStyle->style = SoPickStyle::UNPICKABLE;
-        static_cast<SoFCUnifiedSelection*>(
-                viewer->getSceneGraph())->insertChild(rootPickStyle, 0);
-
-        if(useCenterballDragger) {
-            auto dragger = static_cast<SoCenterballDragger*>(pcDragger.get());
-            auto group = new SoAnnotation;
-            auto pickStyle = new SoPickStyle;
-            pickStyle->setOverride(true);
-            group->addChild(pickStyle);
-            group->addChild(pcDragger);
-
-            // Because the dragger is not grouped with the actual geometry,
-            // we use an invisible cube sized by the bounding box obtained from
-            // initDraggingPlacement() to scale the centerball dragger properly
-
-            auto * ss = static_cast<SoSurroundScale*>(dragger->getPart("surroundScale", TRUE));
-            ss->numNodesUpToContainer = 3;
-            ss->numNodesUpToReset = 2;
-
-            auto *geoGroup = new SoGroup;
-            group->addChild(geoGroup);
-            auto *style = new SoDrawStyle;
-            style->style.setValue(SoDrawStyle::INVISIBLE);
-            style->setOverride(TRUE);
-            geoGroup->addChild(style);
-            auto *cube = new SoCube;
-            geoGroup->addChild(cube);
-            auto length = std::max(std::max(dragCtx->bbox.LengthX(),
-                        dragCtx->bbox.LengthY()), dragCtx->bbox.LengthZ());
-            cube->width = length;
-            cube->height = length;
-            cube->depth = length;
-
-            viewer->setupEditingRoot(group,&dragCtx->preTransform);
-        } else {
-            auto dragger = static_cast<SoFCCSysDragger*>(pcDragger.get());
-            dragger->draggerSize.setValue(ViewParams::instance()->getDraggerScale());
-            dragger->setUpAutoScale(viewer->getSoRenderManager()->getCamera());
-            viewer->setupEditingRoot(pcDragger,&dragCtx->preTransform);
-
-            auto task = new TaskCSysDragger(nullptr, dragger);
-            Gui::Control().showDialog(task);
-        }
-    }
+    ViewProviderDragger::setEditViewer(viewer, ModNum);
 }
 
 void ViewProviderLink::unsetEditViewer(Gui::View3DInventorViewer* viewer)
 {
-    SoNode *child = static_cast<SoFCUnifiedSelection*>(viewer->getSceneGraph())->getChild(0);
-    if (child && child->isOfType(SoPickStyle::getClassTypeId()))
-        static_cast<SoFCUnifiedSelection*>(viewer->getSceneGraph())->removeChild(child);
-    pcDragger.reset();
     dragCtx.reset();
-    Gui::Control().closeDialog();
+
+    inherited::unsetEditViewer(viewer);
 }
 
-Base::Placement ViewProviderLink::currentDraggingPlacement() const
-{
-    // if there isn't an active dragger return a default placement
-    if (!pcDragger)
-        return Base::Placement();
-
-    SbVec3f v;
-    SbRotation r;
-    if (useCenterballDragger) {
-        auto dragger = static_cast<SoCenterballDragger*>(pcDragger.get());
-        v = dragger->center.getValue();
-        r = dragger->rotation.getValue();
-    }
-    else {
-        auto dragger = static_cast<SoFCCSysDragger*>(pcDragger.get());
-        v = dragger->translation.getValue();
-        r = dragger->rotation.getValue();
-    }
-
-    float q1,q2,q3,q4;
-    r.getValue(q1,q2,q3,q4);
-    return Base::Placement(Base::Vector3d(v[0],v[1],v[2]),Base::Rotation(q1,q2,q3,q4));
-}
-
-void ViewProviderLink::enableCenterballDragger(bool enable) {
-    if(enable == useCenterballDragger)
-        return;
-    if(pcDragger)
-        LINK_THROW(Base::RuntimeError,"Cannot change dragger during dragging");
-    useCenterballDragger = enable;
-}
-
-void ViewProviderLink::updateDraggingPlacement(const Base::Placement &pla, bool force) {
-    if(pcDragger && (force || currentDraggingPlacement()!=pla)) {
-        const auto &pos = pla.getPosition();
-        const auto &rot = pla.getRotation();
-        FC_LOG("updating dragger placement (" << pos.x << ", " << pos.y << ", " << pos.z << ')');
-        if(useCenterballDragger) {
-            auto dragger = static_cast<SoCenterballDragger*>(pcDragger.get());
-            SbBool wasenabled = dragger->enableValueChangedCallbacks(FALSE);
-            SbMatrix matrix;
-            matrix = convert(pla.toMatrix());
-            dragger->center.setValue(SbVec3f(0,0,0));
-            dragger->setMotionMatrix(matrix);
-            if (wasenabled) {
-                dragger->enableValueChangedCallbacks(TRUE);
-                dragger->valueChanged();
-            }
-        }else{
-            auto dragger = static_cast<SoFCCSysDragger*>(pcDragger.get());
-            dragger->translation.setValue(SbVec3f(pos.x,pos.y,pos.z));
-            dragger->rotation.setValue(rot[0],rot[1],rot[2],rot[3]);
-        }
-    }
-}
-
-bool ViewProviderLink::callDraggerProxy(const char *fname, bool update) {
-    if(!pcDragger)
+bool ViewProviderLink::callDraggerProxy(const char* fname) {
+    if (!csysDragger) {
         return false;
+    }
+
     Base::PyGILStateLocker lock;
     try {
         auto* proxy = getPropertyByName("Proxy");
@@ -2986,48 +2886,32 @@ bool ViewProviderLink::callDraggerProxy(const char *fname, bool update) {
         return true;
     }
 
-    if(update) {
-        auto ext = getLinkExtension();
-        if(ext) {
-            const auto &pla = currentDraggingPlacement();
-            auto prop = ext->getLinkPlacementProperty();
-            if(!prop)
-                prop = ext->getPlacementProperty();
-            if(prop) {
-                auto plaNew = pla * Base::Placement(dragCtx->mat);
-                if(prop->getValue()!=plaNew)
-                    prop->setValue(plaNew);
-            }
-            updateDraggingPlacement(pla);
-        }
-    }
     return false;
 }
 
 void ViewProviderLink::dragStartCallback(void *data, SoDragger *) {
     auto me = static_cast<ViewProviderLink*>(data);
-    me->dragCtx->initialPlacement = me->currentDraggingPlacement();
-    if(!me->callDraggerProxy("onDragStart",false)) {
-        me->dragCtx->cmdPending = true;
-        me->getDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Link Transform"));
-    }else
-        me->dragCtx->cmdPending = false;
+
+    me->dragCtx->initialPlacement = me->getDraggerPlacement();
+    me->callDraggerProxy("onDragStart");
 }
 
 void ViewProviderLink::dragFinishCallback(void *data, SoDragger *) {
     auto me = static_cast<ViewProviderLink*>(data);
-    me->callDraggerProxy("onDragEnd",true);
-    if(me->dragCtx->cmdPending) {
-        if(me->currentDraggingPlacement() == me->dragCtx->initialPlacement)
+    me->callDraggerProxy("onDragEnd");
+
+    if (me->dragCtx->cmdPending) {
+        if (me->getDraggerPlacement() == me->dragCtx->initialPlacement) {
             me->getDocument()->abortCommand();
-        else
+        } else {
             me->getDocument()->commitCommand();
+        }
     }
 }
 
 void ViewProviderLink::dragMotionCallback(void *data, SoDragger *) {
     auto me = static_cast<ViewProviderLink*>(data);
-    me->callDraggerProxy("onDragMotion",true);
+    me->callDraggerProxy("onDragMotion");
 }
 
 void ViewProviderLink::updateLinks(ViewProvider *vp) {

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -184,10 +184,10 @@ protected:
     Py::Object PythonObject;
 };
 
-class GuiExport ViewProviderLink : public ViewProviderDocumentObject
+class GuiExport ViewProviderLink : public ViewProviderDragger
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Gui::ViewProviderLink);
-    using inherited = ViewProviderDocumentObject;
+    using inherited = ViewProviderDragger;
 
 public:
     App::PropertyBool OverrideMaterial;
@@ -248,11 +248,6 @@ public:
 
     static void updateLinks(ViewProvider *vp);
 
-    void updateDraggingPlacement(const Base::Placement &pla, bool force=false);
-    Base::Placement currentDraggingPlacement() const;
-    void enableCenterballDragger(bool enable);
-    bool isUsingCenterballDragger() const { return useCenterballDragger; }
-
     std::map<std::string, App::Color> getElementColors(const char *subname=nullptr) const override;
     void setElementColors(const std::map<std::string, App::Color> &colors) override;
 
@@ -311,7 +306,7 @@ protected:
     ViewProvider *getLinkedView(bool real,const App::LinkBaseExtension *ext=nullptr) const;
 
     bool initDraggingPlacement();
-    bool callDraggerProxy(const char *fname, bool update);
+    bool callDraggerProxy(const char* fname);
 
 private:
     static void dragStartCallback(void * data, SoDragger * d);
@@ -323,7 +318,6 @@ protected:
     LinkType linkType;
     bool hasSubName;
     bool hasSubElement;
-    bool useCenterballDragger;
 
     struct DraggerContext{
         Base::Matrix4D preTransform;
@@ -333,7 +327,6 @@ protected:
         bool cmdPending;
     };
     std::unique_ptr<DraggerContext> dragCtx;
-    CoinPtr<SoDragger> pcDragger;
     ViewProviderDocumentObject *childVp;
     LinkInfoPtr childVpLink;
     mutable qint64 overlayCacheKey;

--- a/src/Gui/ViewProviderLinkPy.xml
+++ b/src/Gui/ViewProviderLinkPy.xml
@@ -19,12 +19,6 @@
             </Documentation>
             <Parameter Name="DraggingPlacement" Type="Object" />
         </Attribute>
-        <Attribute Name="UseCenterballDragger">
-            <Documentation>
-                <UserDocu>Get/set dragger type</UserDocu>
-            </Documentation>
-            <Parameter Name="UseCenterballDragger" Type="Boolean" />
-        </Attribute>
         <Attribute Name="LinkView" ReadOnly="true">
             <Documentation>
                 <UserDocu>Get the associated LinkView object</UserDocu>

--- a/src/Gui/ViewProviderLinkPyImp.cpp
+++ b/src/Gui/ViewProviderLinkPyImp.cpp
@@ -46,27 +46,14 @@ std::string ViewProviderLinkPy::representation() const
 
 Py::Object ViewProviderLinkPy::getDraggingPlacement() const {
     return Py::asObject(new Base::PlacementPy(new Base::Placement(
-                    getViewProviderLinkPtr()->currentDraggingPlacement())));
+                    getViewProviderLinkPtr()->getDraggerPlacement())));
 }
 
 void ViewProviderLinkPy::setDraggingPlacement(Py::Object arg) {
     if(!PyObject_TypeCheck(arg.ptr(),&Base::PlacementPy::Type))
         throw Py::TypeError("expects a placement");
-    getViewProviderLinkPtr()->updateDraggingPlacement(
+    getViewProviderLinkPtr()->setDraggerPlacement(
             *static_cast<Base::PlacementPy*>(arg.ptr())->getPlacementPtr());
-}
-
-Py::Boolean ViewProviderLinkPy::getUseCenterballDragger() const {
-    return {getViewProviderLinkPtr()->isUsingCenterballDragger()};
-}
-
-void ViewProviderLinkPy::setUseCenterballDragger(Py::Boolean arg) {
-    try {
-        getViewProviderLinkPtr()->enableCenterballDragger(arg);
-    }catch(const Base::Exception &e){
-        e.setPyException();
-        throw Py::Exception();
-    }
 }
 
 Py::Object ViewProviderLinkPy::getLinkView() const {

--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -34,6 +34,7 @@
 #include <Base/ExceptionFactory.h>
 #include <Base/Interpreter.h>
 #include <Base/Parameter.h>
+#include <Base/ServiceProvider.h>
 #include <Base/PrecisionPy.h>
 
 #include "ArcOfCirclePy.h"
@@ -187,7 +188,11 @@
 
 #include <OCAF/ImportExportSettings.h>
 #include "MeasureClient.h"
+
 #include <FuzzyHelper.h>
+
+#include <App/Services.h>
+#include <Services.h>
 
 namespace Part {
 extern PyObject* initModule();
@@ -572,7 +577,10 @@ PyMOD_INIT_FUNC(Part)
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part/Boolean");
     
     Part::FuzzyHelper::setBooleanFuzzy(hGrp->GetFloat("BooleanFuzzy",10.0));
-    
+
+    Base::registerServiceImplementation<App::SubObjectPlacementProvider>(new AttacherSubObjectPlacement);
+    Base::registerServiceImplementation<App::CenterOfMassProvider>(new PartCenterOfMass);
+
     PyMOD_Return(partModule);
 }
 // clang-format on

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -1901,6 +1901,11 @@ AttachEngine3D::_calculateAttachedPlacement(const std::vector<App::DocumentObjec
         case mmMidpoint: {
             Base::Placement placement;
 
+            // special case for planes
+            if (auto plane = dynamic_cast<App::Plane*>(objs[0])) {
+                return plane->Placement.getValue() * attachmentOffset;
+            }
+
             auto shape = shapes.front();
             auto geom = Geometry::fromShape(shape->getShape());
 
@@ -1929,7 +1934,7 @@ AttachEngine3D::_calculateAttachedPlacement(const std::vector<App::DocumentObjec
                             line->tangent(middle, direction);
                         }
 
-                        placement.setRotation(Base::Rotation::fromNormalVector(-direction));
+                        placement.setRotation(Base::Rotation::fromNormalVector(direction));
                     }
                 }
                 break;
@@ -1941,8 +1946,10 @@ AttachEngine3D::_calculateAttachedPlacement(const std::vector<App::DocumentObjec
                         placement.setPosition(sphere->getLocation());
                     } else if (auto cone = dynamic_cast<GeomCone*>(geom.get())) {
                         placement.setPosition(cone->getApex());
+                    } else if (auto com = shape->centerOfGravity()) {
+                        placement.setPosition(*com);
                     } else {
-                        placement.setPosition(shape->centerOfGravity().value());
+                        placement.setPosition(shape->getBoundBox().GetCenter());
                     }
 
                     if (auto rotation = surface->getRotation()) {

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -438,6 +438,29 @@ protected:
 
     static void throwWrongMode(eMapMode mmode);
 
+    /**
+     * Extracts GeoFeature instance from given DocumentObject.
+     *
+     * In case of object itself being GeoFeature it returns itself, in other cases (like links)
+     * the method should return pointer to associated GeoFeature or nullptr if none is available.
+     *
+     * @param obj The document object to extract the GeoFeature.
+     *
+     * @return App::GeoFeature pointer associated with this document object
+     */
+    static App::GeoFeature* extractGeoFeature(App::DocumentObject* obj);
+
+    /**
+     * Tries to extract sub shape from document object with given subname.
+     *
+     * @param obj       DocumentObject containing the sub shape
+     * @param subname   Name of the sub shape to extract
+     *
+     * @return Extracted sub shape. Can be null.
+     *
+     * @throws AttachEngineException If given sub shape does not exist or is impossible to obtain.
+     */
+    static Part::TopoShape extractSubShape(App::DocumentObject* obj, const std::string& subname);
 };
 
 

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -108,6 +108,7 @@ enum eMapMode {
     mmOYX,
 
     mmParallelPlane,
+    mmMidpoint,
 
     mmDummy_NumberOfModes//a value useful to check the validity of mode value
 };//see also eMapModeStrings[] definition in .cpp

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -363,7 +363,7 @@ public://helper functions that may be useful outside of the class
 
     static eRefType getRefTypeByName(const std::string &typeName);
 
-    static GProp_GProps getInertialPropsOfShape(const std::vector<const TopoDS_Shape*> &shapes);
+    static GProp_GProps getInertialPropsOfShape(const std::vector<const Part::TopoShape*> &shapes);
 
     std::vector<App::DocumentObject*> getRefObjects() const;
     const std::vector<std::string> &getSubValues() const {return subnames;}
@@ -430,7 +430,9 @@ protected:
     }
     static void readLinks(const std::vector<App::DocumentObject*> &objs,
                           const std::vector<std::string> &subs,
-                          std::vector<const TopoDS_Shape*>& shapes, std::vector<TopoDS_Shape> &storage,
+
+                          std::vector<const Part::TopoShape*>& shapes,
+                          std::vector<Part::TopoShape> &storage,
                           std::vector<eRefType> &types);
 
     static void throwWrongMode(eMapMode mmode);

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -553,6 +553,8 @@ SET(Part_SRCS
     PreCompiled.h
     ProgressIndicator.cpp
     ProgressIndicator.h
+    Services.cpp
+    Services.h
     TopoShape.cpp
     TopoShape.h
     TopoShapeCache.cpp

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -58,6 +58,7 @@
 #include <list>
 #include <memory>
 #include <vector>
+#include <optional>
 
 #include <boost/uuid/uuid_generators.hpp>
 
@@ -409,6 +410,7 @@ public:
      */
     Base::Vector3d getCenter() const;
     Base::Vector3d getLocation() const;
+    std::optional<Base::Rotation> getRotation() const;
     void setLocation(const Base::Vector3d& Center);
     /*!
      * \deprecated use setLocation
@@ -882,6 +884,8 @@ public:
 
     GeomPlane *toPlane(bool clone=true, double tol=1e-7) const;
 
+    virtual std::optional<Base::Rotation> getRotation() const;
+
     bool tangentU(double u, double v, gp_Dir& dirU) const;
     bool tangentV(double u, double v, gp_Dir& dirV) const;
     bool normal(double u, double v, gp_Dir& dir) const;
@@ -961,6 +965,7 @@ public:
     ~GeomElementarySurface() override;
 
     Base::Vector3d getLocation() const;
+
     Base::Vector3d getDir() const;
     Base::Vector3d getXDir() const;
     Base::Vector3d getYDir() const;
@@ -1013,6 +1018,8 @@ public:
 
     double getRadius() const;
     double getSemiAngle() const;
+
+    Base::Vector3d getApex() const;
 
     bool isSame(const Geometry &other, double tol, double atol) const override;
 
@@ -1090,6 +1097,8 @@ public:
     explicit GeomPlane(const gp_Pln &pln);
     ~GeomPlane() override;
     Geometry *copy() const override;
+
+    std::optional<Base::Rotation> getRotation() const override;
 
     // Persistence implementer ---------------------
     unsigned int getMemSize() const override;

--- a/src/Mod/Part/App/Services.cpp
+++ b/src/Mod/Part/App/Services.cpp
@@ -33,7 +33,10 @@ Base::Placement AttacherSubObjectPlacement::calculate(App::SubObjectT object,
                                                          Base::Placement basePlacement) const
 {
     attacher->setReferences({object});
-    return basePlacement.inverse() * attacher->calculateAttachedPlacement(basePlacement);
+
+    auto calculatedAttachment = attacher->calculateAttachedPlacement(basePlacement);
+
+    return basePlacement.inverse() * calculatedAttachment;
 }
 
 std::optional<Base::Vector3d> PartCenterOfMass::ofDocumentObject(App::DocumentObject* object) const

--- a/src/Mod/Part/App/Services.cpp
+++ b/src/Mod/Part/App/Services.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2024 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "Services.h"
+
+AttacherSubObjectPlacement::AttacherSubObjectPlacement()
+    : attacher(std::make_unique<Attacher::AttachEngine3D>())
+{
+    attacher->setUp({}, Attacher::mmMidpoint);
+}
+
+Base::Placement AttacherSubObjectPlacement::calculate(App::SubObjectT object,
+                                                         Base::Placement basePlacement) const
+{
+    attacher->setReferences({object});
+    return basePlacement.inverse() * attacher->calculateAttachedPlacement(basePlacement);
+}
+
+std::optional<Base::Vector3d> PartCenterOfMass::ofDocumentObject(App::DocumentObject* object) const
+{
+    if (const auto feature = dynamic_cast<Part::Feature*>(object)) {
+        const auto shape = feature->Shape.getShape();
+
+        if (const auto cog = shape.centerOfGravity()) {
+            const Base::Placement comPlacement { *cog, Base::Rotation { } };
+
+            return (feature->Placement.getValue().inverse() * comPlacement).getPosition();
+        }
+    }
+
+    return {};
+}

--- a/src/Mod/Part/App/Services.h
+++ b/src/Mod/Part/App/Services.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2024 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#ifndef PART_SERVICES_H
+#define PART_SERVICES_H
+
+#include <Attacher.h>
+#include <App/Services.h>
+
+class AttacherSubObjectPlacement final: public App::SubObjectPlacementProvider
+{
+public:
+    AttacherSubObjectPlacement();
+
+    Base::Placement calculate(App::SubObjectT object, Base::Placement basePlacement) const override;
+
+private:
+    std::unique_ptr<Attacher::AttachEngine3D> attacher;
+};
+
+class PartCenterOfMass final: public App::CenterOfMassProvider
+{
+public:
+    std::optional<Base::Vector3d> ofDocumentObject(App::DocumentObject* object) const override;
+};
+
+#endif  // PART_SERVICES_H

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -81,7 +81,16 @@ void ViewProvider::setupContextMenu(QMenu* menu, QObject* receiver, const char* 
 
 bool ViewProvider::setEdit(int ModNum)
 {
-    if (ModNum == ViewProvider::Default ) {
+    if (ModNum == ViewProvider::Transform) {
+        if (forwardToLink()) {
+            return true;
+        }
+
+        // this is feature so we need to forward the transform to the body
+        forwardedViewProvider = getBodyViewProvider();
+        return forwardedViewProvider->startEditing(ModNum);
+    }
+    else if (ModNum == ViewProvider::Default) {
         // When double-clicking on the item for this feature the
         // object unsets and sets its edit mode without closing
         // the task panel
@@ -192,6 +201,22 @@ void ViewProvider::onChanged(const App::Property* prop) {
     }
 
     PartGui::ViewProviderPartExt::onChanged(prop);
+}
+
+Gui::ViewProvider* ViewProvider::startEditing(int ModNum)
+{
+    // in case of transform we forward the request to body
+    if (ModNum == Transform) {
+        forwardedViewProvider = nullptr;
+
+        if (!ViewProviderPart::startEditing(ModNum)) {
+            return nullptr;
+        }
+
+        return forwardedViewProvider;
+    }
+
+    return ViewProviderPart::startEditing(ModNum);
 }
 
 void ViewProvider::setTipIcon(bool onoff) {

--- a/src/Mod/PartDesign/Gui/ViewProvider.h
+++ b/src/Mod/PartDesign/Gui/ViewProvider.h
@@ -55,6 +55,8 @@ public:
     void updateData(const App::Property*) override;
     void onChanged(const App::Property* prop) override;
 
+    Gui::ViewProvider* startEditing(int ModNum) override;
+
     void setTipIcon(bool onoff);
 
     //body mode means that the object is part of a body and that the body is used to set the

--- a/tests/src/Base/ServiceProvider.cpp
+++ b/tests/src/Base/ServiceProvider.cpp
@@ -62,7 +62,7 @@ TEST(ServiceProvider, provideImplementation)
     // Arrange
     Base::ServiceProvider serviceProvider;
 
-    serviceProvider.implement<SimpleService>(new FirstServiceImplementation);
+    serviceProvider.registerImplementation<SimpleService>(new FirstServiceImplementation);
 
     // Act
     auto implementation = serviceProvider.provide<SimpleService>();
@@ -77,8 +77,8 @@ TEST(ServiceProvider, provideLatestImplementation)
     // Arrange
     Base::ServiceProvider serviceProvider;
 
-    serviceProvider.implement<SimpleService>(new FirstServiceImplementation);
-    serviceProvider.implement<SimpleService>(new SecondServiceImplementation);
+    serviceProvider.registerImplementation<SimpleService>(new FirstServiceImplementation);
+    serviceProvider.registerImplementation<SimpleService>(new SecondServiceImplementation);
 
     // Act
     auto implementation = serviceProvider.provide<SimpleService>();
@@ -93,8 +93,8 @@ TEST(ServiceProvider, provideAllImplementations)
     // Arrange
     Base::ServiceProvider serviceProvider;
 
-    serviceProvider.implement<SimpleService>(new FirstServiceImplementation);
-    serviceProvider.implement<SimpleService>(new SecondServiceImplementation);
+    serviceProvider.registerImplementation<SimpleService>(new FirstServiceImplementation);
+    serviceProvider.registerImplementation<SimpleService>(new SecondServiceImplementation);
 
     // Act
     auto implementations = serviceProvider.all<SimpleService>();

--- a/tests/src/Mod/Part/App/Attacher.cpp
+++ b/tests/src/Mod/Part/App/Attacher.cpp
@@ -79,8 +79,8 @@ TEST_F(AttacherTest, TestGetShapeType)
 TEST_F(AttacherTest, TestGetInertialPropsOfShape)
 {
     auto& attacher = _boxes[1]->attacher();
-    std::vector<const TopoDS_Shape*> result;
-    auto faces = _boxes[1]->Shape.getShape().getSubShapes(TopAbs_FACE);
+    std::vector<const TopoShape*> result;
+    auto faces = _boxes[1]->Shape.getShape().getSubTopoShapes(TopAbs_FACE);
     result.emplace_back(&faces[0]);
     auto shapeType = attacher.getInertialPropsOfShape(result);
     EXPECT_EQ(result.size(), 1);


### PR DESCRIPTION
This refactors `ViewProviderDragger` and `TaskCSysDragger` to be more modern and to support selecting Transform Origin. It adds ability to snap transform origin, enter exact coordinates, snap one object to another

> [!CAUTION] 
> **Breaking Changes** 
>
> This removes support for `UseCenterballDragger` from Link view provider. this was obscure feature that was in core basically only because Assembly 3 used it. Keeping it would drastically complicate code and provide yet another place in code where something behaves differently.
>
> As far as I understand, it can be reimplemented inside assembly 3 as addons can create custom nodes and affect the placement from Python. 

**Further work**
- Add preview of moved object - will be done as part of https://github.com/FreeCAD/FPA-grant-proposals/issues/22
- Add preview of transformation path - same as above
- Add more coordinate systems (like Part, Assembly etc)
- Add ability to move multiple objects (requires changes to edit modes)

![image](https://github.com/user-attachments/assets/410f7f27-bc2d-46e0-9f97-aecab4dcb8c2)

https://github.com/user-attachments/assets/c79ca028-616e-4c50-a8a1-c32d57e9c2d7

Fixes #18421
Fixes #13854 
Fixes #12451
Probably fixes #18024
