### PR TITLE
Remove octal in expressions when there's a leading zero

### DIFF
--- a/src/App/ExpressionParser.l
+++ b/src/App/ExpressionParser.l
@@ -340,7 +340,7 @@ EXPO     [eE][-+]?[0-9]+
 {DIGIT}*","{DIGIT}+{EXPO}?   COUNTCHARS; yylval.fvalue = num_change(yytext,',','.');       return yylval.fvalue == 1 ? ONE : NUM;
 {DIGIT}+{EXPO}               COUNTCHARS; yylval.fvalue = num_change(yytext,',','.');       return yylval.fvalue == 1 ? ONE : NUM;
 {DIGIT}+                     { COUNTCHARS;
-                               yylval.ivalue = strtoll( yytext, NULL, 0 );
+                               yylval.ivalue = strtoll( yytext, NULL, 10 );
                                if (yylval.ivalue == LLONG_MIN)
                                   throw Base::UnderflowError("Integer underflow");
                                else if (yylval.ivalue == LLONG_MAX)

--- a/src/App/lex.ExpressionParser.c
+++ b/src/App/lex.ExpressionParser.c
@@ -9572,7 +9572,7 @@ case 137:
 YY_RULE_SETUP
 #line 342 "ExpressionParser.l"
 { COUNTCHARS;
-                               yylval.ivalue = strtoll( yytext, NULL, 0 );
+                               yylval.ivalue = strtoll( yytext, NULL, 10 );
                                if (yylval.ivalue == LLONG_MIN)
                                   throw Base::UnderflowError("Integer underflow");
                                else if (yylval.ivalue == LLONG_MAX)


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/17555

For context: hexadecimal, which is more commonly used, is not supported.

Let me know if this is a feature and not a bug (if there's a reason to support octal in expressions)