### PR TITLE
BIM: Fix Ifc Spatial Element Default Composition Type should be 'Element'

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -125,6 +125,7 @@ def makeFloor(objectslist=None,baseobj=None,name=None):
     obj = makeBuildingPart(objectslist)
     obj.Label = name if name else translate("Arch","Level")
     obj.IfcType = "Building Storey"
+    obj.CompositionType = "ELEMENT"
     return obj
 
 
@@ -136,6 +137,7 @@ def makeBuilding(objectslist=None,baseobj=None,name=None):
     obj = makeBuildingPart(objectslist)
     obj.Label = name if name else translate("Arch","Building")
     obj.IfcType = "Building"
+    obj.CompositionType = "ELEMENT"
     t = QT_TRANSLATE_NOOP("App::Property","The type of this building")
     obj.addProperty("App::PropertyEnumeration","BuildingType","Building",t)
     obj.BuildingType = ArchBuildingPart.BuildingTypes
@@ -162,8 +164,10 @@ def convertFloors(floor=None):
             nobj = makeBuildingPart(obj.Group)
             if Draft.getType(obj) == "Floor":
                 nobj.IfcType = "Building Storey"
+                nobj.CompositionType = "ELEMENT"
             else:
                 nobj.IfcType = "Building"
+                nobj.CompositionType = "ELEMENT"
                 t = QT_TRANSLATE_NOOP("App::Property","The type of this building")
                 nobj.addProperty("App::PropertyEnumeration","BuildingType","Building",t)
                 nobj.BuildingType = ArchBuildingPart.BuildingTypes

--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -503,6 +503,8 @@ class _Site(ArchIFC.IfcProduct):
         obj.Proxy = self
         self.setProperties(obj)
         obj.IfcType = "Site"
+        obj.CompositionType = "ELEMENT"
+
 
     def setProperties(self,obj):
         """Gives the object properties unique to sites.

--- a/src/Mod/BIM/ArchSpace.py
+++ b/src/Mod/BIM/ArchSpace.py
@@ -212,6 +212,7 @@ class _Space(ArchComponent.Component):
         ArchComponent.Component.__init__(self,obj)
         self.setProperties(obj)
         obj.IfcType = "Space"
+        obj.CompositionType = "ELEMENT"
 
     def setProperties(self,obj):
 


### PR DESCRIPTION
When creating [IfcSpatialStructureElement](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcSpatialStructureElement.htm) objects such as Site, Building, Storey, and Space, their CompositionType attribute, which is of type [IfcElementCompositionEnum](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcElementCompositionEnum.htm), defaults to the first alphabetic option, `COMPLEX`. However, according to IFC standards, the intended default value should be `ELEMENT`.

![image](https://github.com/user-attachments/assets/7cf954ed-cd9c-4919-bad2-85db6d7972e7)

Most of the time, we should be using ELEMENT for CompositionType. Only in specific cases, like creating split-level houses, would we use a combination of COMPLEX and PARTIAL.