### PR TITLE
Materials: Disable editor right click menu

### DIFF
--- a/src/Mod/Material/Gui/MaterialsEditor.cpp
+++ b/src/Mod/Material/Gui/MaterialsEditor.cpp
@@ -161,11 +161,14 @@ void MaterialsEditor::setup()
             &MaterialsEditor::onSelectMaterial);
     connect(ui->treeMaterials, &QTreeView::doubleClicked, this, &MaterialsEditor::onDoubleClick);
 
+    // Disabled for now. This will be revisited post 1.0
+#if 0
     ui->treeMaterials->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->treeMaterials,
             &QWidget::customContextMenuRequested,
             this,
             &MaterialsEditor::onContextMenu);
+#endif
 }
 
 void MaterialsEditor::getFavorites()


### PR DESCRIPTION
The right click context menu in the materials editor was implemented as a place holder but is currently non-functional. It should be disabled for 1.0. This will be revisited post 1.0 as all editor functionality is reviewed and improved.

Fixes #17110

![Editor Right Click](https://github.com/user-attachments/assets/8fe538fd-ecd3-4f58-9eeb-a887e1164cef)
