### PR TITLE
Sketcher: Offset & tranforms: enable external geos input.

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1675,10 +1675,33 @@ int SketchObject::delGeometry(int GeoId, bool deleteinternalgeo)
     return 0;
 }
 
-
 int SketchObject::delGeometries(const std::vector<int>& GeoIds)
 {
-    std::vector<int> sGeoIds(GeoIds);
+    std::vector<int> sGeoIds;
+    std::vector<int> negativeGeoIds;
+
+    // Separate GeoIds into negative (external) and non-negative GeoIds
+    for (int geoId : GeoIds) {
+        if (geoId < 0 && geoId <= GeoEnum::RefExt) {
+            negativeGeoIds.push_back(geoId);
+        }
+        else if (geoId >= 0){
+            sGeoIds.push_back(geoId);
+        }
+    }
+
+    // Handle negative GeoIds by calling delExternal
+    if (!negativeGeoIds.empty()) {
+        int result = delExternal(negativeGeoIds);
+        if (result != 0) {
+            return result; // Return if deletion of external geometries failed
+        }
+    }
+
+    // Proceed with non-negative GeoIds
+    if (sGeoIds.empty()) {
+        return 0; // No positive GeoIds to delete
+    }
 
     // if a GeoId has internal geometry, it must delete internal geometries too
     for (auto c : Constraints.getValues()) {
@@ -7733,7 +7756,7 @@ int SketchObject::delExternal(const std::vector<int>& ExtGeoIds)
 {
     std::set<long> geoIds;
     for (int ExtGeoId : ExtGeoIds) {
-        int GeoId = GeoEnum::RefExt - ExtGeoId;
+        int GeoId = ExtGeoId > 0 ? GeoEnum::RefExt - ExtGeoId : ExtGeoId;
         if (GeoId > GeoEnum::RefExt || -GeoId - 1 >= ExternalGeo.getSize())
             return -1;
 

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -88,12 +88,13 @@ std::vector<int> getListOfSelectedGeoIds(bool forceInternalSelection)
     if (!subNames.empty()) {
 
         for (auto& name : subNames) {
-            // only handle non-external edges
             if (name.size() > 4 && name.substr(0, 4) == "Edge") {
                 int geoId = std::atoi(name.substr(4, 4000).c_str()) - 1;
-                if (geoId >= 0) {
-                    listOfGeoIds.push_back(geoId);
-                }
+                listOfGeoIds.push_back(geoId);
+            }
+            else if (name.size() > 4 && name.substr(0, 12) == "ExternalEdge") {
+                int geoId = -std::atoi(name.substr(12, 4000).c_str()) - 2;
+                listOfGeoIds.push_back(geoId);
             }
             else if (name.size() > 6 && name.substr(0, 6) == "Vertex") {
                 // only if it is a GeomPoint
@@ -2341,23 +2342,28 @@ void CmdSketcherOffset::activated(int iMsg)
     const std::vector<std::string>& subNames = selection[0].getSubNames();
     if (!subNames.empty()) {
         for (auto& name : subNames) {
-            // only handle non-external edges
+            int geoId;
             if (name.size() > 4 && name.substr(0, 4) == "Edge") {
-                int geoId = std::atoi(name.substr(4, 4000).c_str()) - 1;
-                if (geoId >= 0) {
-                    const Part::Geometry* geo = Obj->getGeometry(geoId);
-                    if (!isPoint(*geo)
-                        && !isBSplineCurve(*geo)
-                        && !isEllipse(*geo)
-                        && !isArcOfEllipse(*geo)
-                        && !isArcOfHyperbola(*geo)
-                        && !isArcOfParabola(*geo)
-                        && !GeometryFacade::isInternalAligned(geo)) {
-                        // Currently ellipse/parabola/hyperbola/bspline are not handled correctly.
-                        // Occ engine gives offset of those as set of lines and arcs and does not seem to work consistently.
-                        listOfGeoIds.push_back(geoId);
-                    }
-                }
+                geoId = std::atoi(name.substr(4, 4000).c_str()) - 1;
+            }
+            else if (name.size() > 4 && name.substr(0, 12) == "ExternalEdge") {
+                geoId = -std::atoi(name.substr(12, 4000).c_str()) - 2;
+            }
+            else {
+                continue;
+            }
+
+            const Part::Geometry* geo = Obj->getGeometry(geoId);
+            if (!isPoint(*geo)
+                && !isBSplineCurve(*geo)
+                && !isEllipse(*geo)
+                && !isArcOfEllipse(*geo)
+                && !isArcOfHyperbola(*geo)
+                && !isArcOfParabola(*geo)
+                && !GeometryFacade::isInternalAligned(geo)) {
+                // Currently ellipse/parabola/hyperbola/bspline are not handled correctly.
+                // Occ engine gives offset of those as set of lines and arcs and does not seem to work consistently.
+                listOfGeoIds.push_back(geoId);
             }
         }
     }

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -92,7 +92,7 @@ std::vector<int> getListOfSelectedGeoIds(bool forceInternalSelection)
                 int geoId = std::atoi(name.substr(4, 4000).c_str()) - 1;
                 listOfGeoIds.push_back(geoId);
             }
-            else if (name.size() > 4 && name.substr(0, 12) == "ExternalEdge") {
+            else if (name.size() > 12 && name.substr(0, 12) == "ExternalEdge") {
                 int geoId = -std::atoi(name.substr(12, 4000).c_str()) - 2;
                 listOfGeoIds.push_back(geoId);
             }

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -2346,7 +2346,7 @@ void CmdSketcherOffset::activated(int iMsg)
             if (name.size() > 4 && name.substr(0, 4) == "Edge") {
                 geoId = std::atoi(name.substr(4, 4000).c_str()) - 1;
             }
-            else if (name.size() > 4 && name.substr(0, 12) == "ExternalEdge") {
+            else if (name.size() > 12 && name.substr(0, 12) == "ExternalEdge") {
                 geoId = -std::atoi(name.substr(12, 4000).c_str()) - 2;
             }
             else {


### PR DESCRIPTION
Enable offset tool and transform tools to use external geometries as input

Fix https://github.com/FreeCAD/FreeCAD/issues/12461
Fix https://github.com/FreeCAD/FreeCAD/issues/17616
