### PR TITLE
[TD]handle short&wide hatch area

### DIFF
--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -386,14 +386,14 @@ std::vector<LineSet> DrawGeomHatch::getTrimmedLines(DrawViewPart* source,
 }
 
 /* static */
-std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box b, double scale)
+std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hatchLine, Bnd_Box bBox, double scale)
 {
     constexpr double RightAngleDegrees{90.0};
     constexpr double HalfCircleDegrees{180.0};
     std::vector<TopoDS_Edge> result;
 
     double minX, maxX, minY, maxY, minZ, maxZ;
-    b.Get(minX, minY, minZ, maxX, maxY, maxZ);
+    bBox.Get(minX, minY, minZ, maxX, maxY, maxZ);
     //make the overlay bigger to cover rotations. might need to be bigger than 2x.
     double widthX = maxX - minX;
     double widthY = maxY - minY;
@@ -406,9 +406,9 @@ std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box 
     minY = centerY - width;
     maxY = centerY + width;
 
-    Base::Vector3d origin = hl.getOrigin();
-    double interval = hl.getIntervalX() * scale;
-    double angle = hl.getAngle();
+    Base::Vector3d origin = hatchLine.getOrigin();
+    double interval = hatchLine.getIntervalX() * scale;
+    double angle = hatchLine.getAngle();
 
     //only dealing with angles -180:180 for now
     if (angle > RightAngleDegrees) {
@@ -416,10 +416,10 @@ std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box 
     } else if (angle < -RightAngleDegrees) {
         angle = (HalfCircleDegrees + angle);
     }
-    double slope = hl.getSlope();
+    double slope = hatchLine.getSlope();
 
     if (angle == 0.0) {         //odd case 1: horizontal lines
-        interval = hl.getInterval() * scale;
+        interval = hatchLine.getInterval() * scale;
         double atomY  = origin.y;
         int repeatUp = (int) fabs((maxY - atomY)/interval);
         int repeatDown  = (int) fabs(((atomY - minY)/interval));
@@ -435,7 +435,7 @@ std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box 
         }
     } else if (angle == RightAngleDegrees ||
                angle == -RightAngleDegrees) {         //odd case 2: vertical lines
-        interval = hl.getInterval() * scale;
+        interval = hatchLine.getInterval() * scale;
         double atomX  = origin.x;
         int repeatRight = (int) fabs((maxX - atomX)/interval);
         int repeatLeft  = (int) fabs((atomX - minX)/interval);

--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -232,7 +232,7 @@ std::vector<PATLineSpec> DrawGeomHatch::getDecodedSpecsFromFile(std::string file
     return PATLineSpec::getSpecsForPattern(fileSpec, myPattern);
 }
 
-std::vector<LineSet>  DrawGeomHatch::getTrimmedLines(int i)   //get the trimmed hatch lines for face i
+std::vector<LineSet>  DrawGeomHatch::getTrimmedLines(int iFace)   //get the trimmed hatch lines for face i
 {
     if (m_lineSets.empty()) {
         makeLineSets();
@@ -243,7 +243,7 @@ std::vector<LineSet>  DrawGeomHatch::getTrimmedLines(int i)   //get the trimmed 
         !source->hasGeometry()) {
         return std::vector<LineSet>();
     }
-    return getTrimmedLines(source, m_lineSets, i, ScalePattern.getValue(),
+    return getTrimmedLines(source, m_lineSets, iFace, ScalePattern.getValue(),
                            PatternRotation.getValue(), PatternOffset.getValue());
 }
 
@@ -388,31 +388,33 @@ std::vector<LineSet> DrawGeomHatch::getTrimmedLines(DrawViewPart* source,
 /* static */
 std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box b, double scale)
 {
+    constexpr double RightAngleDegrees{90.0};
+    constexpr double HalfCircleDegrees{180.0};
     std::vector<TopoDS_Edge> result;
 
     double minX, maxX, minY, maxY, minZ, maxZ;
     b.Get(minX, minY, minZ, maxX, maxY, maxZ);
     //make the overlay bigger to cover rotations. might need to be bigger than 2x.
-    double centerX = (minX + maxX) / 2.0;
     double widthX = maxX - minX;
-    minX = centerX - widthX;
-    maxX = centerX + widthX;
-    double centerY = (minY + maxY) / 2.0;
     double widthY = maxY - minY;
-    minY = centerY - widthY;
-    maxY = centerY + widthY;
+    double width = std::max(widthX, widthY);
 
-    Base::Vector3d start;
-    Base::Vector3d end;
+    double centerX = (minX + maxX) / 2;
+    minX = centerX - width;
+    maxX = centerX + width;
+    double centerY = (minY + maxY) / 2;
+    minY = centerY - width;
+    maxY = centerY + width;
+
     Base::Vector3d origin = hl.getOrigin();
     double interval = hl.getIntervalX() * scale;
     double angle = hl.getAngle();
 
     //only dealing with angles -180:180 for now
-    if (angle > 90.0) {
-         angle = -(180.0 - angle);
-    } else if (angle < -90.0) {
-        angle = (180 + angle);
+    if (angle > RightAngleDegrees) {
+         angle = -(HalfCircleDegrees - angle);
+    } else if (angle < -RightAngleDegrees) {
+        angle = (HalfCircleDegrees + angle);
     }
     double slope = hl.getSlope();
 
@@ -431,8 +433,8 @@ std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box 
             TopoDS_Edge newLine = makeLine(newStart, newEnd);
             result.push_back(newLine);
         }
-    } else if (angle == 90.0 ||
-               angle == -90.0) {         //odd case 2: vertical lines
+    } else if (angle == RightAngleDegrees ||
+               angle == -RightAngleDegrees) {         //odd case 2: vertical lines
         interval = hl.getInterval() * scale;
         double atomX  = origin.x;
         int repeatRight = (int) fabs((maxX - atomX)/interval);
@@ -503,9 +505,9 @@ TopoDS_Edge DrawGeomHatch::makeLine(Base::Vector3d s, Base::Vector3d e)
 
 //! get all the untrimmed hatchlines for a face
 //! these will be clipped to shape on the gui side
-std::vector<LineSet> DrawGeomHatch::getFaceOverlay(int fdx)
+std::vector<LineSet> DrawGeomHatch::getFaceOverlay(int iFace)
 {
-//    Base::Console().Message("TRACE - DGH::getFaceOverlay(%d)\n", fdx);
+//    Base::Console().Message("TRACE - DGH::getFaceOverlay(%d)\n", iFace);
     std::vector<LineSet> result;
     DrawViewPart* source = getSourceView();
     if (!source ||
@@ -513,7 +515,7 @@ std::vector<LineSet> DrawGeomHatch::getFaceOverlay(int fdx)
         return result;
     }
 
-    TopoDS_Face face = extractFace(source, fdx);
+    TopoDS_Face face = extractFace(source, iFace);
 
     Bnd_Box bBox;
     BRepBndLib::AddOptimal(face, bBox);

--- a/src/Mod/TechDraw/App/DrawGeomHatch.h
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.h
@@ -64,21 +64,21 @@ public:
     App::PropertyFloat       PatternRotation;
     App::PropertyVector      PatternOffset;
 
-    App::DocumentObjectExecReturn *execute(void) override;
+    App::DocumentObjectExecReturn *execute() override;
     void onChanged(const App::Property* prop) override;
-    const char* getViewProviderName(void) const override {
+    const char* getViewProviderName() const override {
         return "TechDrawGui::ViewProviderGeomHatch";
     }
-    PyObject *getPyObject(void) override;
+    PyObject *getPyObject() override;
     void setupObject() override;
-    void unsetupObject(void) override;
+    void unsetupObject() override;
     void onDocumentRestored() override;
 
 
-    DrawViewPart* getSourceView(void) const;
+    DrawViewPart* getSourceView() const;
 
-    std::vector<LineSet> getFaceOverlay(int i = 0);
-    std::vector<LineSet> getTrimmedLines(int i = 0);
+    std::vector<LineSet> getFaceOverlay(int iFace = 0);
+    std::vector<LineSet> getTrimmedLines(int iFace = 0);
     static std::vector<LineSet> getTrimmedLines(DrawViewPart* dvp, std::vector<LineSet> lineSets, int iface,
                                                 double scale, double hatchRotation = 0.0,
                                                 Base::Vector3d hatchOffset = Base::Vector3d(0.0, 0.0, 0.0));
@@ -89,16 +89,16 @@ public:
                                                 Base::Vector3d hatchOffset = Base::Vector3d(0.0, 0.0, 0.0));
     static std::vector<LineSet> getTrimmedLinesSection(DrawViewSection* source,
                                                                 std::vector<LineSet> lineSets,
-                                                                TopoDS_Face f,
+                                                                TopoDS_Face face,
                                                                 double scale , double hatchRotation = 0.0,
                                                                 Base::Vector3d hatchOffset = Base::Vector3d(0.0, 0.0, 0.0));
 
     static std::vector<TopoDS_Edge> makeEdgeOverlay(PATLineSpec hl, Bnd_Box bBox,
                                     double scale);
-    static TopoDS_Edge makeLine(Base::Vector3d s, Base::Vector3d e);
+    static TopoDS_Edge makeLine(Base::Vector3d start, Base::Vector3d end);
     static std::vector<PATLineSpec> getDecodedSpecsFromFile(std::string fileSpec, std::string myPattern);
     static TopoDS_Face extractFace(DrawViewPart* source, int iface );
-    static std::string prefGeomHatchFile(void);
+    static std::string prefGeomHatchFile();
     static std::string prefGeomHatchName();
     static App::Color prefGeomHatchColor();
     static std::vector<LineSet> makeLineSets(std::string fileSpec, std::string myPattern);
@@ -108,7 +108,7 @@ public:
 protected:
     void replacePatIncluded(std::string newHatchFileName);
 
-    void makeLineSets(void);
+    void makeLineSets();
 
     std::vector<PATLineSpec> getDecodedSpecsFromFile();
 

--- a/src/Mod/TechDraw/App/DrawGeomHatch.h
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.h
@@ -93,7 +93,7 @@ public:
                                                                 double scale , double hatchRotation = 0.0,
                                                                 Base::Vector3d hatchOffset = Base::Vector3d(0.0, 0.0, 0.0));
 
-    static std::vector<TopoDS_Edge> makeEdgeOverlay(PATLineSpec hl, Bnd_Box bBox,
+    static std::vector<TopoDS_Edge> makeEdgeOverlay(PATLineSpec hatchLine, Bnd_Box bBox,
                                     double scale);
     static TopoDS_Edge makeLine(Base::Vector3d start, Base::Vector3d end);
     static std::vector<PATLineSpec> getDecodedSpecsFromFile(std::string fileSpec, std::string myPattern);


### PR DESCRIPTION
This PR implements a fix for a problem with rotated PAT hatch patterns on faces that are significantly wider than they are tall.  The problem was reported here: https://forum.freecad.org/viewtopic.php?t=91600