### PR TITLE
Gui: Fix camera behavior when rotation center is far from object

### DIFF
--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -219,6 +219,7 @@ void NavigationStyle::initialize()
     this->spinsamplecounter = 0;
     this->spinincrement = SbRotation::identity();
     this->rotationCenterFound = false;
+    this->rotationCenterIsScenePointAtCursor = false;
 
     // FIXME: use a smaller sphere than the default one to have a larger
     // area close to the borders that gives us "z-axis rotation"?
@@ -868,8 +869,8 @@ void NavigationStyle::spin(const SbVec2f & pointerpos)
 
     float sensitivity = getSensitivity();
 
-    // Adjust the spin projector sphere to the screen position of the rotation center
-    if (rotationCenterFound) {
+    // Adjust the spin projector sphere to the screen position of the rotation center when the mouse intersects an object
+    if (getOrbitStyle() == Trackball && rotationCenterMode & RotationCenterMode::ScenePointAtCursor && rotationCenterFound && rotationCenterIsScenePointAtCursor) {
         const auto pointOnScreen = viewer->getPointOnViewport(rotationCenter);
         const auto sphereCenter = 2 * normalizePixelPos(pointOnScreen) - SbVec2f {1, 1};
 
@@ -1040,6 +1041,7 @@ void NavigationStyle::saveCursorPosition(const SoEvent * const ev)
 {
     this->globalPos.setValue(QCursor::pos().x(), QCursor::pos().y());
     this->localPos = ev->getPosition();
+    rotationCenterIsScenePointAtCursor = false;
 
     // mode is WindowCenter
     if (!this->rotationCenterMode) {
@@ -1058,6 +1060,7 @@ void NavigationStyle::saveCursorPosition(const SoEvent * const ev)
         SoPickedPoint * picked = rpaction.getPickedPoint();
         if (picked) {
             setRotationCenter(picked->getPoint());
+            rotationCenterIsScenePointAtCursor = true;
             return;
         }
     }

--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -284,6 +284,7 @@ private:
 
     SbVec3f rotationCenter;
     SbBool rotationCenterFound;
+    SbBool rotationCenterIsScenePointAtCursor;
     NavigationStyle::RotationCenterModes rotationCenterMode;
     float sensitivity;
     SbBool resetcursorpos;


### PR DESCRIPTION
Fixes #17619 which is a second regression caused by #17341 and also fixes a regression in turntable navigation speed caused by #17466.


This is the behavior after this PR gets merged:

https://github.com/user-attachments/assets/9634e5c4-8aac-4f2d-9dcb-47d314538a6c

The behavior in build 38991 and 39092 can be seen here: https://forum.freecad.org/viewtopic.php?p=789527#p789527.

With this PR the behavior is more like it was in build 38991 but with slightly different behavior when the mouse starts a rotation while above an object. This is to fix the original issue #17246.

