### PR TITLE
Fix excessive selection pruning in dae exporter for PartDesign Objects (#17529)

### DIFF
--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -770,6 +770,9 @@ def pruneIncluded(objectslist,strict=False):
                     elif parent.isDerivedFrom("PartDesign::Body") and obj == parent.BaseFeature:
                         # don't consider a PartDesign_Body with a PartDesign_Clone that references obj
                         pass
+                    elif parent.isDerivedFrom("PartDesign::SubShapeBinder") or (hasattr(parent, "TypeId") and parent.TypeId == "PartDesign::ShapeBinder"):
+                        # don't consider a PartDesign_SubShapeBinder or PartDesign_ShapeBinder referncing this object from another object
+                        pass
                     elif hasattr(parent,"Host") and parent.Host == obj:
                         pass
                     elif hasattr(parent,"Hosts") and obj in parent.Hosts:

--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -794,7 +794,7 @@ def pruneIncluded(objectslist,strict=False):
         if toplevel:
             newlist.append(obj)
         else:
-            FreeCAD.Console.PrintLog("pruning "+obj.Label+"\n")
+            FreeCAD.Console.PrintWarning("pruning "+obj.Label+"\n")
     return newlist
 
 def getAllChildren(objectlist):

--- a/src/Mod/BIM/importers/importDAE.py
+++ b/src/Mod/BIM/importers/importDAE.py
@@ -205,7 +205,7 @@ def export(exportList,filename,tessellation=1,colors=None):
     scenenodes = []
     objectslist = Draft.get_group_contents(exportList, walls=True,
                                            addgroups=True)
-    objectslist = Arch.pruneIncluded(objectslist)
+    objectslist = Arch.pruneIncluded(objectslist, strict=True)
     for obj in objectslist:
         findex = numpy.array([])
         m = None
@@ -308,4 +308,4 @@ def export(exportList,filename,tessellation=1,colors=None):
     colmesh.scenes.append(myscene)
     colmesh.scene = myscene
     colmesh.write(filename)
-    FreeCAD.Console.PrintMessage(translate("Arch","file %s successfully created.") % filename)
+    FreeCAD.Console.PrintMessage(translate("Arch","file %s successfully created.") % filename + "\n")

--- a/src/Mod/BIM/importers/importIFClegacy.py
+++ b/src/Mod/BIM/importers/importIFClegacy.py
@@ -956,7 +956,7 @@ def export(exportList,filename):
     # get all children and reorder list to get buildings and floors processed first
     objectslist = Draft.get_group_contents(exportList, walls=True,
                                            addgroups=True)
-    objectslist = Arch.pruneIncluded(objectslist)
+    objectslist = Arch.pruneIncluded(objectslist, strict=True)
 
     sites = []
     buildings = []

--- a/src/Mod/BIM/importers/importOBJ.py
+++ b/src/Mod/BIM/importers/importOBJ.py
@@ -148,7 +148,7 @@ def export(exportList,filename,colors=None):
     offsetvn = 1
     objectslist = Draft.get_group_contents(exportList, walls=True,
                                            addgroups=True)
-    objectslist = Arch.pruneIncluded(objectslist)
+    objectslist = Arch.pruneIncluded(objectslist, strict=True)
     filenamemtl = filename[:-4] + ".mtl"
     materials = []
     outfile.write("mtllib " + os.path.basename(filenamemtl) + "\n")


### PR DESCRIPTION
Fixes the excessive pruning of the export selection inside Arch.PruneIncluded. This was caused by the function not checking correctly for (Sub-)ShapeBinders when determining whether an object was a top level object or not, affecting the DAE exporter, and legacy IFC and OBJ exporters.

The fix includes adding a check for these object types, as well as enabling "strict" mode for PruneIncluded, which makes the pruning only take place if the parent object is also included in the selection. This latter aspect of the fix also makes these exporters able to export non-tip features, which brings it more inline with e.g. the stl exporter.
If pruning does still happen, the log-level for this event has been raised from "Log" (not shown by default) to "Warning" such that the user knows why their object is not included in the exported file.

Also, fixed a missing newline character in the DAE export finished message.

Fixes #17529 