### PR TITLE
Gui: take in account module-path argument

### DIFF
--- a/src/Gui/DlgPreferencePackManagementImp.cpp
+++ b/src/Gui/DlgPreferencePackManagementImp.cpp
@@ -54,7 +54,7 @@ void DlgPreferencePackManagementImp::showEvent(QShowEvent* event)
     // but can only disable individual installed packs (though we can completely uninstall the pack's
     // containing Addon by redirecting to the Addon Manager).
     auto savedPreferencePacksDirectory = fs::path(App::Application::getUserAppDataDir()) / "SavedPreferencePacks";
-    auto modDirectory = fs::path(App::Application::getUserAppDataDir()) / "Mod";
+    auto modDirectories = Application::Instance->prefPackManager()->modPaths();
     auto resourcePath = fs::path(App::Application::getResourceDir()) / "Gui" / "PreferencePacks";
 
     // The displayed tree has two levels: at the toplevel is either "User-Saved Packs" or the name
@@ -66,12 +66,14 @@ void DlgPreferencePackManagementImp::showEvent(QShowEvent* event)
     auto builtinPacks = getPacksFromDirectory(resourcePath);
 
     std::map<std::string, std::vector<std::string>> installedPacks;
-    if (fs::exists(modDirectory) && fs::is_directory(modDirectory)) {
-        for (const auto& mod : fs::directory_iterator(modDirectory)) {
-            auto packs = getPacksFromDirectory(mod);
-            if (!packs.empty()) {
-                auto modName = mod.path().filename().string();
-                installedPacks.emplace(modName, packs);
+    for (const auto& modDirectory : modDirectories) {
+        if (fs::exists(modDirectory) && fs::is_directory(modDirectory)) {
+            for (const auto& mod : fs::directory_iterator(modDirectory)) {
+                auto packs = getPacksFromDirectory(mod);
+                if (!packs.empty()) {
+                    auto modName = mod.path().filename().string();
+                    installedPacks.emplace(modName, packs);
+                }
             }
         }
     }

--- a/src/Gui/PreferencePackManager.h
+++ b/src/Gui/PreferencePackManager.h
@@ -191,6 +191,11 @@ namespace Gui {
          */
         void importConfig(const std::string &packName, const boost::filesystem::path &path);
 
+        /**
+         * Get a list of all mod directories.
+         */
+        std::vector<boost::filesystem::path> modPaths() const;
+
     private:
 
         void FindPreferencePacksInPackage(const boost::filesystem::path& mod);


### PR DESCRIPTION
Use paths passed with `--module-path` argument to search for preference packs

I'am [working](https://github.com/NixOS/nixpkgs/pull/347776) on process of introducing the "NIX-way" of configuration of freecad. I'am trying to introduce the `modules` configuration option which allows to pass the downloaded by nix modules to freecad in nix pure way. I'am using the `--module-path` argument for that. It works ok with python modules with `Init.py` fine out the box, but does not work with Preferences Packs, like OpenTheme. 

This patch adds loading Preferences Packs and temlates from paths passed by `--module-path` arguments.