### PR TITLE
Reword error log to be more verbose

### DIFF
--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -1133,7 +1133,7 @@ def getMovingPart(assembly, ref):
 
     if len(names) < 2:
         App.Console.PrintError(
-            "getMovingPart() in UtilsAssembly.py the object name is too short, at minimum it should be something like ['Box','edge16']. It shouldn't be shorter"
+            f"getMovingPart() in UtilsAssembly.py the object name {names} is too short. It should be at least similar to ['Box','edge16'], not shorter.\n"
         )
         return None
 


### PR DESCRIPTION
As mentioned on https://github.com/FreeCAD/FreeCAD/issues/17198#issuecomment-2408418974

- Print the object name that triggers the error, so that the user can pinpoint the offending object
- Add missing newline character
- Makes the error description more concise