### PR TITLE
[TD]fix PrintAll fail on hidden Page tab

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -492,7 +492,6 @@ void MDIViewPage::print(QPrinter* printer)
 //static routine to print all pages in a document
 void MDIViewPage::printAll(QPrinter* printer, App::Document* doc)
 {
-    // Base::Console().Message("MDIVP::printAll()\n");
     PagePrinter::printAll(printer, doc);
 }
 

--- a/src/Mod/TechDraw/Gui/PagePrinter.h
+++ b/src/Mod/TechDraw/Gui/PagePrinter.h
@@ -96,7 +96,6 @@ public:
     void setOwner(MDIViewPage* owner) { m_owner = owner; }
     void setScene(QGSPage* scene);
 
-
     TechDraw::DrawPage * getPage() { return m_vpPage->getDrawPage(); }
 
     ViewProviderPage* getViewProviderPage() {return m_vpPage;}
@@ -107,6 +106,8 @@ public:
     QPageSize::PageSizeId getPaperSize() const { return m_paperSize; }
     double getPageWidth() const { return m_pagewidth; }
     double getPageHeight() const { return m_pageheight; }
+
+    static void resetPageState(ViewProviderPage* vpPage, bool savedState);
 
 private:
     std::string m_objectName;


### PR DESCRIPTION
This PR implements a fix to a problem introduced by PR #17488.

- if the MdiViewPage associated with a Page (ie a tab) is closed, PrintAll fails due to a null pointer.
- fix is to remove the dependency on the Page's MdiView from the PrintAll logic by using  ViewProviderPage and a local variable.