### PR TITLE
PD: Fix default display mode of ViewProviderBoolean

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
@@ -120,11 +120,14 @@ bool ViewProviderBoolean::onDelete(const std::vector<std::string> &s)
     return ViewProvider::onDelete(s);
 }
 
-void ViewProviderBoolean::attach(App::DocumentObject* obj) {
+void ViewProviderBoolean::attach(App::DocumentObject* obj)
+{
     PartGui::ViewProviderPartExt::attach(obj);
+}
 
-    //set default display mode to override the "Group" display mode
-    setDisplayMode("Flat Lines");
+const char* ViewProviderBoolean::getDefaultDisplayMode() const
+{
+    return "Flat Lines";
 }
 
 void ViewProviderBoolean::onChanged(const App::Property* prop) {

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.h
@@ -49,6 +49,7 @@ public:
 
     bool onDelete(const std::vector<std::string> &) override;
     void attach(App::DocumentObject*) override;
+    const char* getDefaultDisplayMode() const override;
     void onChanged(const App::Property* prop) override;
 
 protected:


### PR DESCRIPTION
Make sure that by default display mode is set to 'Flat Lines' instead of 'Group' as otherwise it won't show the result object