### PR TITLE
Measure: Fix quickmeasure problem with Part::Line objects

### DIFF
--- a/src/Mod/Measure/App/Measurement.cpp
+++ b/src/Mod/Measure/App/Measurement.cpp
@@ -122,68 +122,63 @@ MeasureType Measurement::findType()
     int other = 0;
 
     for (; obj != objects.end(); ++obj, ++subEl) {
-
-        // Check if solid object
-        if (strcmp((*subEl).c_str(), "") == 0) {
-            vols++;
+        TopoDS_Shape refSubShape;
+        try {
+            refSubShape = Part::Feature::getShape(*obj, (*subEl).c_str(), true);
+            if (refSubShape.IsNull()) {
+                return MeasureType::Invalid;
+            }
         }
-        else {
+        catch (Standard_Failure& e) {
+            std::stringstream errorMsg;
 
-            TopoDS_Shape refSubShape;
-            try {
-                refSubShape = Part::Feature::getShape(*obj, (*subEl).c_str(), true);
-                if (refSubShape.IsNull()) {
-                    return MeasureType::Invalid;
+            errorMsg << "Measurement - getType - " << e.GetMessageString() << std::endl;
+            throw Base::CADKernelError(e.GetMessageString());
+        }
+
+        switch (refSubShape.ShapeType()) {
+            case TopAbs_VERTEX: {
+                verts++;
+            } break;
+            case TopAbs_EDGE: {
+                edges++;
+                TopoDS_Edge edge = TopoDS::Edge(refSubShape);
+                BRepAdaptor_Curve sf(edge);
+
+                if (sf.GetType() == GeomAbs_Line) {
+                    lines++;
                 }
-            }
-            catch (Standard_Failure& e) {
-                std::stringstream errorMsg;
+                else if (sf.GetType() == GeomAbs_Circle) {
+                    circles++;
+                }
+            } break;
+            case TopAbs_FACE: {
+                faces++;
+                TopoDS_Face face = TopoDS::Face(refSubShape);
+                BRepAdaptor_Surface sf(face);
 
-                errorMsg << "Measurement - getType - " << e.GetMessageString() << std::endl;
-                throw Base::CADKernelError(e.GetMessageString());
-            }
-
-            switch (refSubShape.ShapeType()) {
-                case TopAbs_VERTEX: {
-                    verts++;
-                } break;
-                case TopAbs_EDGE: {
-                    edges++;
-                    TopoDS_Edge edge = TopoDS::Edge(refSubShape);
-                    BRepAdaptor_Curve sf(edge);
-
-                    if (sf.GetType() == GeomAbs_Line) {
-                        lines++;
-                    }
-                    else if (sf.GetType() == GeomAbs_Circle) {
-                        circles++;
-                    }
-                } break;
-                case TopAbs_FACE: {
-                    faces++;
-                    TopoDS_Face face = TopoDS::Face(refSubShape);
-                    BRepAdaptor_Surface sf(face);
-
-                    if (sf.GetType() == GeomAbs_Plane) {
-                        planes++;
-                    }
-                    else if (sf.GetType() == GeomAbs_Cylinder) {
-                        cylinders++;
-                    }
-                    else if (sf.GetType() == GeomAbs_Sphere) {
-                        spheres++;
-                    }
-                    else if (sf.GetType() == GeomAbs_Cone) {
-                        cones++;
-                    }
-                    else if (sf.GetType() == GeomAbs_Torus) {
-                        torus++;
-                    }
-                } break;
-                default:
-                    other++;
-                    break;
-            }
+                if (sf.GetType() == GeomAbs_Plane) {
+                    planes++;
+                }
+                else if (sf.GetType() == GeomAbs_Cylinder) {
+                    cylinders++;
+                }
+                else if (sf.GetType() == GeomAbs_Sphere) {
+                    spheres++;
+                }
+                else if (sf.GetType() == GeomAbs_Cone) {
+                    cones++;
+                }
+                else if (sf.GetType() == GeomAbs_Torus) {
+                    torus++;
+                }
+            } break;
+            case TopAbs_SOLID: {
+                vols++;
+            } break;
+            default:
+                other++;
+                break;
         }
     }
 
@@ -287,7 +282,7 @@ TopoDS_Shape Measurement::getShape(App::DocumentObject* rootObj, const char* sub
 {
     std::vector<std::string> names = Base::Tools::splitSubName(subName);
 
-    if (names.empty() || names.back() == "") {
+    if (names.empty()) {
         TopoDS_Shape shape = Part::Feature::getShape(rootObj);
         if (shape.IsNull()) {
             throw Part::NullShapeException("null shape in measurement");


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/17624
This is actually a small PR, appears big because it changed indentation of a large section.

Code explanation : 
Replace the way we find solid which was : 
```
         if (strcmp((*subEl).c_str(), "") == 0) {
            vols++;
         }
```
Because empty subname is in fact not necessarily a solid (example Part::Line).
Instead we add a case for vols : 
```
            case TopAbs_SOLID: {
                vols++;
            } break;
```
This enables stand-alone Part::Line to be detected correctly (which was why the bug happened only when the Part::Line was in a App::Part).

Remove  `|| names.back() == ""` from the if  in getShape which was wrong since it was forcing the shape to be the rootObj even if there was a subobject.