### PR TITLE
Draft: avoid race condition in todo code

### DIFF
--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -151,7 +151,9 @@ class ToDo:
         ToDo.itinerary = []
 
         if ToDo.commitlist:
-            for name, func in ToDo.commitlist:
+            commit_list = ToDo.commitlist
+            ToDo.commitlist = []  # Reset immediately to avoid race condition.
+            for name, func in commit_list:
                 if _DEBUG_inner:
                     _msg("Debug: committing.\n"
                          "name: {}\n".format(name))
@@ -174,7 +176,7 @@ class ToDo:
             # Restack Draft screen widgets after creation
             if hasattr(Gui, "Snapper"):
                 Gui.Snapper.restack()
-        ToDo.commitlist = []
+
 
         for f, arg in ToDo.afteritinerary:
             try:


### PR DESCRIPTION
The doTasks function is called multiple times when using Draft tools. In some cases the ToDo.commitlist belonging to a previous call was not fuly processed, resulting in the same list being processed twice. To avoid this the list is stored as a local variable and then immediately reset.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=91832
