### PR TITLE
Core: Generate a static random number in Application::applicationPid()

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -35,6 +35,8 @@
 # endif
 # include <boost/program_options.hpp>
 # include <boost/date_time/posix_time/posix_time.hpp>
+# include <chrono>
+# include <random>
 #endif
 
 #ifdef FC_OS_WIN32
@@ -1117,7 +1119,17 @@ Application::TransactionSignaller::~TransactionSignaller() {
 
 int64_t Application::applicationPid()
 {
-    return QCoreApplication::applicationPid();
+    static int64_t randomNumber = []() {
+        auto tp = std::chrono::high_resolution_clock::now();
+        auto dur = tp.time_since_epoch();
+        auto seed = dur.count();
+        std::mt19937 generator(static_cast<unsigned>(seed));
+        constexpr int64_t minValue {1};
+        constexpr int64_t maxValue {1000000};
+        std::uniform_int_distribution<int64_t> distribution(minValue, maxValue);
+        return distribution(generator);
+    }();
+    return randomNumber;
 }
 
 std::string Application::getHomePath()

--- a/src/App/PreCompiled.h
+++ b/src/App/PreCompiled.h
@@ -69,6 +69,7 @@
 
 // STL
 #include <bitset>
+#include <chrono>
 #include <exception>
 #include <functional>
 #include <iterator>


### PR DESCRIPTION
Using Qt's QCoreApplication::applicationPid() doesn't always give a unique ID so that multiple FreeCAD instances cannot be executed at the same time. This fixes #17678