### PR TITLE
[ArchCurtainWall]  Bug-fix Sketch as Base

### DIFF
--- a/src/Mod/BIM/ArchCurtainWall.py
+++ b/src/Mod/BIM/ArchCurtainWall.py
@@ -221,7 +221,6 @@ class CurtainWall(ArchComponent.Component):
                 return
 
         facets = []
-
         faces = []
 
         curtainWallBaseShapeEdges = None
@@ -240,24 +239,25 @@ class CurtainWall(ArchComponent.Component):
             if curtainWallBaseShapeEdges:  # would be false (none) if SketchArch Add-on is not installed, or base ArchSketch does not have the edges stored / input by user
                 curtainWallEdges = curtainWallBaseShapeEdges.get('curtainWallEdges')
             elif obj.Base.isDerivedFrom("Sketcher::SketchObject"):
+                skGeom = obj.Base.GeometryFacadeList
                 skGeomEdges = []
-                skPlacement = obj.Placement  # Get Sketch's placement to restore later
-                if obj.OverrideEdges:
-                    for i in obj.OverrideEdges:
-                        skGeomI = fp.Geometry[i]
-                        # support Line, Arc, Circle at the moment
-                        if isinstance(skGeomI, (Part.LineSegment, Part.Circle, Part.ArcOfCircle)):
-                            skGeomEdgesI = skGeomI.toShape()
+                skPlacement = obj.Base.Placement  # Get Sketch's placement to restore later
+                for ig, geom  in enumerate(skGeom):
+                    if (not obj.OverrideEdges and not geom.Construction) or str(ig) in obj.OverrideEdges:
+                        # support Line, Arc, Circle, Ellipse for Sketch
+                        # as Base at the moment
+                        if isinstance(geom.Geometry, (Part.LineSegment,
+                                      Part.Circle, Part.ArcOfCircle)):
+                            skGeomEdgesI = geom.Geometry.toShape()
                             skGeomEdges.append(skGeomEdgesI)
-                    for edge in skGeomEdges:
-                        edge.Placement = edge.Placement.multiply(skPlacement)
-                        curtainWallEdges.append(edge)
-            #if not curtainWallEdges:
-            else:
+                curtainWallEdges = []
+                for edge in skGeomEdges:
+                    edge.Placement = edge.Placement.multiply(skPlacement)
+                    curtainWallEdges.append(edge)
+            if not curtainWallEdges:
                 curtainWallEdges = obj.Base.Shape.Edges
             if curtainWallEdges:
                 faces = [edge.extrude(ext) for edge in curtainWallEdges]
-
         if not faces:
             FreeCAD.Console.PrintLog(obj.Label+": unable to build base faces\n")
             return


### PR DESCRIPTION
Found regression when Sketch is used as Base and OverrideEdges is specified.