### PR TITLE
TopoNaming: Reuse exact sub-shape names whenever possible

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -974,8 +974,7 @@ void TopoShape::mapSubElement(const TopoShape& other, const char* op, bool force
                 }
                 ss.str("");
 
-                ensureElementMap()->encodeElementName(shapetype[0], name, ss, &sids, Tag, op, other.Tag);
-                elementMap()->setElementName(element, name, Tag, &sids);
+                ensureElementMap()->setElementName(element, name, Tag, &sids);
             }
         }
     }
@@ -1464,9 +1463,7 @@ TopoShape& TopoShape::makeShapeWithElementMap(const TopoDS_Shape& shape,
                                                 true,
                                                 &sids));
 
-                int newShapeCounter = 0;
                 for (auto& newShape : mapper.modified(otherElement)) {
-                    ++newShapeCounter;
                     if (newShape.ShapeType() >= TopAbs_SHAPE) {
                         // NOLINTNEXTLINE
                         FC_ERR("unknown modified shape type " << newShape.ShapeType() << " from "
@@ -1506,10 +1503,8 @@ TopoShape& TopoShape::makeShapeWithElementMap(const TopoDS_Shape& shape,
                     }
 
                     key.tag = incomingShape.Tag;
-                    auto& name_info = newNames[element][key];
-                    name_info.sids = sids;
-                    name_info.index = newShapeCounter;
-                    name_info.shapetype = info.shapetype;
+
+                    elementMap()->setElementName(element, key.name, Tag, &sids);
                 }
 
                 int checkParallel = -1;
@@ -1517,7 +1512,7 @@ TopoShape& TopoShape::makeShapeWithElementMap(const TopoDS_Shape& shape,
 
                 // Find all new objects that were generated from an old object
                 // (e.g. a face generated from an edge)
-                newShapeCounter = 0;
+                int newShapeCounter = 0;
                 for (auto& newShape : mapper.generated(otherElement)) {
                     if (newShape.ShapeType() >= TopAbs_SHAPE) {
                         // NOLINTNEXTLINE


### PR DESCRIPTION
This changes toponomaing algorithm so on modification sub elements do not get new names, instead older ones are reused. It fixes issues like chamfers etc, but may introduce others.

This is IMHO the more logical thing to do, for now the code assigned new names to every modified element - in case of chamfers all surrounding faces were trimmed and hence got new names, edges also got new names. This created an issue because `Chamfer001` (second one) was depending not on edge named like `;g2;SKT;:H18c,E;:G;XTR;:H18c:7,F;:U;XTR;:H18c:7,E` but instead on `;g2;SKT;:H18c,E;:G;XTR;:H18c:7,F;:U;XTR;:H18c:7,E;:M;CHF;:H18d:7,E` (notice the additional `:M;CHF;:H18d:7,E` section created by the chamfer) which is not available on previous shape and hence breaks model if the first chamfer is deleted. 

| Original Edge | Current Main | This PR |
|---|---|---|
| ![image](https://github.com/user-attachments/assets/f6373b29-affb-4745-9d83-75f20955b1d8) | ![image](https://github.com/user-attachments/assets/59d64f2e-4972-4499-a304-6fca2acc4047) | ![image](https://github.com/user-attachments/assets/6e7dccc1-51b9-45f2-92df-269db473ae74) |

My idea is to ensure that sub shapes obtain names only on generation and not on modification. As expected this fixes the chamfers (don't mind the message box - I have not bothered to fix that):
https://github.com/user-attachments/assets/261113df-90fd-477e-8072-0c1b2c167b24

Before it complained on missing edge:
https://github.com/user-attachments/assets/4b927839-207c-4a51-a14d-9e0bb2aab81b

This is small change in terms of code but a huge conceptual one and I cannot predict full impact of it. For now I know that it breaks `isElementGenerated` method, all tests as the names are different and probably more. We also loose the history of modifications to the shape as they were stored in the name. 

I don't plan for this PR to be merged in that state - I put it there to start the discussion on how to fix that properly. One solution would be to add additional field to MappedName called `originalName` that would be used for referencing the element and the longer would store all required information on modifications etc.