### PR TITLE
TopoNaming: Refine - mark joined faces as modified not generated

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4625,7 +4625,7 @@ public:
             if (it.Key().IsNull()) {
                 continue;
             }
-            mapper.populate(MappingStatus::Generated, it.Key(), it.Value());
+            mapper.populate(MappingStatus::Modified, it.Key(), it.Value());
         }
     }
 };

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -621,7 +621,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         self.assertEqual(self.countFacesEdgesVertexes(revolution.Shape.ElementReverseMap),
                          (9, 21, 14))
         self.assertEqual( revolution.Shape.ElementReverseMap["Vertex9"][1].count(";"), 3)
-        self.assertEqual( revolution.Shape.ElementReverseMap["Face9"].count(";"), 16)
+        self.assertEqual( revolution.Shape.ElementReverseMap["Face9"].count(";"), 14)
         # Arrange for an UpToFace mode test
         revolution.Type = 3
         revolution.UpToFace = (pad, ("Face4"))


### PR DESCRIPTION
This is parity change with LS3: https://github.com/realthunder/FreeCAD/blob/a9810d509a6f112b5ac03d4d4831b67e6bffd5b7/src/Mod/Part/App/TopoShapeEx.cpp#L3357

I don't know if this fixes any existing issue, but without it faces joined by refine are wrongly marked as generated. 

Change is extracted from https://github.com/FreeCAD/FreeCAD/pull/17249#issuecomment-2412988261