### PR TITLE
Core: Implement SoFCTransform node

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1025,6 +1025,7 @@ SET(Inventor_CPP_SRCS
     Inventor/SoFCBackgroundGradient.cpp
     Inventor/SoFCBoundingBox.cpp
     Inventor/SoMouseWheelEvent.cpp
+    Inventor/SoFCTransform.cpp
     SoFCColorBar.cpp
     SoFCColorBarNotifier.cpp
     SoFCColorGradient.cpp
@@ -1055,6 +1056,7 @@ SET(Inventor_SRCS
     Inventor/SoFCBackgroundGradient.h
     Inventor/SoFCBoundingBox.h
     Inventor/SoMouseWheelEvent.h
+    Inventor/SoFCTransform.h
     SoFCColorBar.h
     SoFCColorBarNotifier.h
     SoFCColorGradient.h

--- a/src/Gui/Inventor/SoFCTransform.cpp
+++ b/src/Gui/Inventor/SoFCTransform.cpp
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2024 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#include <Inventor/actions/SoCallbackAction.h>
+#include <Inventor/actions/SoGetBoundingBoxAction.h>
+#include <Inventor/actions/SoGetPrimitiveCountAction.h>
+#include <Inventor/actions/SoGLRenderAction.h>
+#include <Inventor/actions/SoPickAction.h>
+#include <Inventor/elements/SoModelMatrixElement.h>
+#endif
+
+#include "SoFCTransform.h"
+
+
+using namespace Gui;
+
+SO_NODE_SOURCE(SoFCTransform)
+
+void SoFCTransform::initClass()
+{
+    SO_NODE_INIT_CLASS(SoFCTransform, SoTransform, "Transform");
+}
+
+SoFCTransform::SoFCTransform()
+{
+    SO_NODE_CONSTRUCTOR(SoFCTransform);
+}
+
+void SoFCTransform::GLRender(SoGLRenderAction * action)
+{
+    SoFCTransform::doAction(action);
+}
+
+void SoFCTransform::callback(SoCallbackAction * action)
+{
+    SoFCTransform::doAction(action);
+}
+
+void SoFCTransform::pick(SoPickAction * action)
+{
+    SoFCTransform::doAction(action);
+}
+
+void SoFCTransform::getPrimitiveCount(SoGetPrimitiveCountAction * action)
+{
+    SoFCTransform::doAction(action);
+}
+
+void SoFCTransform::getBoundingBox(SoGetBoundingBoxAction * action)
+{
+    SoFCTransform::doAction(action);
+}
+
+void SoFCTransform::doAction(SoAction * action)
+{
+    SbMatrix matrix;
+    matrix.setTransform(this->translation.getValue(),
+                        this->rotation.getValue(),
+                        this->scaleFactor.getValue(),
+                        this->scaleOrientation.getValue(),
+                        this->center.getValue());
+
+    // This is different to SoTransform::doAction() where model matrix
+    // is always set
+    if (matrix != SbMatrix::identity()) {
+        SoModelMatrixElement::mult(action->getState(), this, matrix);
+    }
+}

--- a/src/Gui/Inventor/SoFCTransform.h
+++ b/src/Gui/Inventor/SoFCTransform.h
@@ -30,6 +30,17 @@
 namespace Gui
 {
 
+/**
+ * @class SoFCTransform
+ * @brief A temporary workaround for coin3d/coin#534.
+ * 
+ * This class is a workaround for a missing feature to reduce the OpenGL stack size.
+ * The issue was reported here: https://github.com/coin3d/coin/issues/534
+ * And was merged here: https://github.com/coin3d/coin/pull/535
+ * 
+ * Once this feature is available in all supported versions of Coin3D, this class should
+ * be removed and all instances should revert to using SoTransform.
+ */
 class GuiExport SoFCTransform : public SoTransform
 {
     using inherited = SoTransform;

--- a/src/Gui/Inventor/SoFCTransform.h
+++ b/src/Gui/Inventor/SoFCTransform.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2024 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#ifndef GUI_INVENTOR_SOFCTRANSFORM_H
+#define GUI_INVENTOR_SOFCTRANSFORM_H
+
+#include <Inventor/nodes/SoTransform.h>
+#include <FCGlobal.h>
+
+namespace Gui
+{
+
+class GuiExport SoFCTransform : public SoTransform
+{
+    using inherited = SoTransform;
+
+    SO_NODE_HEADER(SoFCTransform);
+
+public:
+    static void initClass();
+    SoFCTransform();
+
+protected:
+    void GLRender(SoGLRenderAction * action) override;
+    void callback(SoCallbackAction * action) override;
+    void pick(SoPickAction * action) override;
+    void getPrimitiveCount(SoGetPrimitiveCountAction * action) override;
+    void getBoundingBox(SoGetBoundingBoxAction * action) override;
+    void doAction(SoAction * action) override;
+};
+
+} // namespace Gui
+
+#endif // GUI_INVENTOR_SOFCTRANSFORM_H

--- a/src/Gui/SoFCDB.cpp
+++ b/src/Gui/SoFCDB.cpp
@@ -74,6 +74,7 @@
 #include "Inventor/SoFCBackgroundGradient.h"
 #include "Inventor/SoFCBoundingBox.h"
 #include "Inventor/SoMouseWheelEvent.h"
+#include "Inventor/SoFCTransform.h"
 #include "propertyeditor/PropertyItem.h"
 #include "ArcEngine.h"
 
@@ -134,6 +135,7 @@ void Gui::SoFCDB::init()
     SoAxisCrossKit                  ::initClass();
     SoRegPoint                      ::initClass();
     SoDrawingGrid                   ::initClass();
+    SoFCTransform                   ::initClass();
     SoAutoZoomTranslation           ::initClass();
     MarkerBitmaps                   ::initClass();
     SoFCCSysDragger                 ::initClass();

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -42,6 +42,7 @@
 #include <Base/Matrix.h>
 
 #include "Inventor/SoMouseWheelEvent.h"
+#include "Inventor/SoFCTransform.h"
 #include "ViewProvider.h"
 #include "ActionFunction.h"
 #include "Application.h"
@@ -104,7 +105,7 @@ ViewProvider::ViewProvider()
     pcRoot->ref();
     pcModeSwitch = new SoSwitch();
     pcModeSwitch->ref();
-    pcTransform  = new SoTransform();
+    pcTransform  = new SoFCTransform();
     pcTransform->ref();
     pcRoot->addChild(pcTransform);
     pcRoot->addChild(pcModeSwitch);


### PR DESCRIPTION
In its doAction() method it only sets the model matrix if it's not the identity matrix. This improves the issue #7606