### PR TITLE
Assembly: Joint: Transparent unconcerned objects

### DIFF
--- a/src/Gui/ViewProviderGeometryObject.h
+++ b/src/Gui/ViewProviderGeometryObject.h
@@ -32,6 +32,7 @@ class SoSwitch;
 class SoSensor;
 class SbVec2s;
 class SoBaseColor;
+class SoPickStyle;
 
 namespace Gui
 {
@@ -116,6 +117,7 @@ protected:
     SoFCBoundingBox* pcBoundingBox {nullptr};
     SoSwitch* pcBoundSwitch {nullptr};
     SoBaseColor* pcBoundColor {nullptr};
+    SoPickStyle* pcPickStyle {nullptr};
 
     App::Material materialAppearance;
 };

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -1188,6 +1188,7 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
         else:
             self.activeType = "Assembly"
             self.assembly.ensureIdentityPlacements()
+            self.transparency_backups = UtilsAssembly.get_transparency_backups(self.assembly)
 
         self.doc = self.assembly.Document
         self.gui_doc = Gui.getDocument(self.doc)
@@ -1334,6 +1335,7 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
             self.assembly.ViewObject.MoveOnlyPreselected = False
             self.assembly.ViewObject.MoveInCommand = True
 
+        UtilsAssembly.restore_transparency_backups(self.transparency_backups)
         Gui.Selection.removeSelectionGate()
         Gui.Selection.removeObserver(self)
         Gui.Selection.setSelectionStyle(Gui.Selection.SelectionStyle.NormalSelection)
@@ -1593,6 +1595,7 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
 
         self.form.jointType.setCurrentIndex(JointTypes.index(self.joint.JointType))
         self.updateJointList()
+        self.updateTransparencies()
 
     def updateJoint(self):
         # First we build the listwidget
@@ -1600,6 +1603,9 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
 
         # Then we pass the new list to the joint object
         self.joint.Proxy.setJointConnectors(self.joint, self.refs)
+
+        # Then we update transparency of components
+        self.updateTransparencies()
 
     def updateJointList(self):
         self.form.featureList.clear()
@@ -1613,6 +1619,25 @@ class TaskAssemblyCreateJoint(QtCore.QObject):
                 sname = sname + "." + element_name
             simplified_names.append(sname)
         self.form.featureList.addItems(simplified_names)
+
+    def updateTransparencies(self):
+        if len(self.refs) != 2:
+            UtilsAssembly.restore_transparency_backups(self.transparency_backups)
+            return
+
+        obj1 = UtilsAssembly.getObject(self.refs[0])
+        obj2 = UtilsAssembly.getObject(self.refs[1])
+
+        for obj, transparency_value in self.transparency_backups.items():
+            vobj = obj.ViewObject
+
+            if hasattr(vobj, "Transparency"):
+                if obj == obj1 or obj == obj2:
+                    vobj.Transparency = 0
+                    vobj.Selectable = True
+                else:
+                    vobj.Transparency = 80
+                    vobj.Selectable = False
 
     def updateLimits(self):
         needLengthLimits = self.jType in JointUsingLimitLength

--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -538,6 +538,37 @@ def findVertexNameInObject(vertex, obj):
     return ""
 
 
+def get_transparency_backups(obj, transparency_backups=None):
+    if transparency_backups is None:
+        transparency_backups = {}
+
+    vobj = obj.ViewObject
+    if hasattr(vobj, "Transparency"):
+        transparency_backups[obj] = vobj.Transparency
+        return transparency_backups
+
+    if obj.isDerivedFrom("App::Part"):
+        for obji in obj.Group:
+            transparency_backups = get_transparency_backups(obji, transparency_backups)
+
+    return transparency_backups
+
+
+def restore_transparency_backups(transparency_backups):
+    """
+    Restores the Transparency attributes of FreeCAD objects from a backup dictionary.
+
+    Args:
+        transparency_backups (dict): A dictionary mapping object identifiers (e.g., objects or names)
+                                     to their Transparency values.
+    """
+    for obj, transparency_value in transparency_backups.items():
+        vobj = obj.ViewObject
+        if hasattr(vobj, "Transparency"):
+            vobj.Transparency = transparency_value
+            vobj.Selectable = True
+
+
 def color_from_unsigned(c):
     return [
         float(int((c >> 24) & 0xFF) / 255),


### PR DESCRIPTION
With this PR, when you edit/create a joint, if your joint is complete, the unconcerned components of the assembly become transparents.

This PR faces 3 bugs that block it : 
- https://github.com/FreeCAD/FreeCAD/issues/14219 : 'Selectable' broken in App::Part
- https://github.com/FreeCAD/FreeCAD/issues/17815 : are 'Selectable' not passthrough.
- link.Transparency changes the original's object transparency. So if you have several links to the same objects, then they all change together. Unless you use copyOnChange.