### PR TITLE
Fem: Avoid legacy Netgen meshing if there is no referenced shape - fixes #17814

### DIFF
--- a/src/Mod/Fem/App/FemMeshShapeNetgenObject.cpp
+++ b/src/Mod/Fem/App/FemMeshShapeNetgenObject.cpp
@@ -86,7 +86,11 @@ App::DocumentObjectExecReturn* FemMeshShapeNetgenObject::execute()
 
     Fem::FemMesh newMesh;
 
-    Part::Feature* feat = Shape.getValue<Part::Feature*>();
+    const Part::Feature* feat = Shape.getValue<Part::Feature*>();
+    if (!feat) {
+        return App::DocumentObject::StdReturn;
+    }
+
     TopoDS_Shape shape = feat->Shape.getValue();
 
     NETGENPlugin_Mesher myNetGenMesher(newMesh.getSMesh(), shape, true);


### PR DESCRIPTION
Fixes crash reported in #17814