### PR TITLE
[core] add copy table and paste table context menu items to App::Prop…

### DIFF
--- a/src/Gui/VectorListEditor.h
+++ b/src/Gui/VectorListEditor.h
@@ -27,6 +27,7 @@
 #include <QDialog>
 #include <QItemDelegate>
 #include <QList>
+#include <QMenu>
 
 #include <memory>
 #include <Base/Vector3D.h>
@@ -49,6 +50,8 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QModelIndex parent(const QModelIndex &index) const override;
     void setValues(const QList<Base::Vector3d>& d);
+    void copyToClipboard() const;
+    void pasteFromClipboard();
     const QList<Base::Vector3d>& values() const;
     bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
     bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
@@ -100,6 +103,7 @@ private Q_SLOTS:
     void acceptCurrent();
     void setCurrentRow(int);
     void clickedRow(const QModelIndex&);
+    void showContextMenu(const QPoint&);
 
 private:
     std::unique_ptr<Ui_VectorListEditor> ui;


### PR DESCRIPTION
…ertyVectorList property editor, addresses issue #17804

Editing the table in the property editor is a bit awkward and tedious becuase you have to select the row in the table, edit the values using the spin boxes, then click the button to confirm the changes and commit them to the table.  Large datasets further complicate things.  It could be more convenient to copy the table contents and paste that information into a spreadsheet for easier editing there, and then copy that and paste it back into the property editor table view.  That is what this PR allows to do.

To use: go into Draft workbench and create a polygon.  Select it's Points property, click on the [...] ellipsis button to open the property editor, click the table button to open the table view.  Right click on the table view to find the 2 new context menu items:  Copy table and Paste table.

Select the Copy table option to copy the values from the table to the system clipboard.  The data will be in text format, 3 tab separated values per row.  Create a new spreadsheet object, click on a cell, right click and choose Paste.  The copied table of values will now appear as cells in the spreadsheet.

Edit some of the cells  or select only some cells to retain, right click context menu -> copy, then go back and open the property editor again and paste the contents to the table using Paste table.

Note that pasting replaces the entire table and copying copies the entire table.

Pasting from the clipboard supports the same format that the copy command produces, but it also supports values delimited by tabs, semicolons, or commas.  For locales that use commas as decimals, only tabs and semicolons should be used as the delimiters.

If after pasting the contents into the table the user clicks cancel, then no changes to the table will be made.  It will be as it was before the property editor was opened.

If an error is encountered during the paste operation, then nothing will be pasted to the table, which will remain unchanged.  An error message will be shown in the report view along with the contents of the clipboard for user inspection.