### PR TITLE
BIM: Replace use of ArchWorkbench in ArchSelectionObserver

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -1643,7 +1643,7 @@ class ArchSelectionObserver:
                         self.origin.ViewObject.Transparency = 0
                         self.origin.ViewObject.Selectable = True
                     self.watched.ViewObject.hide()
-                FreeCADGui.activateWorkbench("ArchWorkbench")
+                FreeCADGui.activateWorkbench("BIMWorkbench")
                 if hasattr(FreeCAD,"ArchObserver"):
                     FreeCADGui.Selection.removeObserver(FreeCAD.ArchObserver)
                     del FreeCAD.ArchObserver


### PR DESCRIPTION
I have managed to trigger this a couple of times. Can't work out exactly how but seems clear.

```
Closing Sketch editpyException: Traceback (most recent call last):
  File "/usr/lib64/freecad/Mod/BIM/ArchComponent.py", line 1646, in addSelection
    FreeCADGui.activateWorkbench("ArchWorkbench")
<class 'KeyError'>: "No such workbench 'ArchWorkbench'"
```