### PR TITLE
1.0 Hide Classic on linux theme selector too

### DIFF
--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -79,14 +79,9 @@ static bool isSystemInDarkMode()
 
 static bool shouldHideClassicTheme()
 {
-    // Classic on macOS and windows 11 with qt6(.4+?) doesn't work when system
-    // is in dark mode and to make matter worse, on macOS there's a setting that
-    // changes mode depending on time of day.
-#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0) || defined(FC_OS_MACOSX) || defined(FC_OS_WIN32)
+    // Classic has been reported not to work on macOS, windows 11 and linux.
+    // Note, this function had conditionals but was removed when linux workaround was added.
     return true;
-#else
-    return false;
-#endif
 }
 
 


### PR DESCRIPTION
This should fix #17856, but it is untested as only linux behavior changes and I don't have access to a linux machine to test on.

I kept change minimalistic to make it safer to backport it into 1.0