### PR TITLE
Start: fixes #17857: Icon-files of the startup screen are not removed from /tmp

### DIFF
--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -461,6 +461,13 @@ void ProjectFile::findFiles(XERCES_CPP_NAMESPACE_QUALIFIER DOMNode* node,
     }
 }
 
+bool ProjectFile::containsFile(const std::string& name) const
+{
+    zipios::ZipFile project(stdFile);
+    auto entry = project.getEntry(name);
+    return entry != nullptr;
+}
+
 std::list<std::string> ProjectFile::getInputFiles(const std::string& name) const
 {
     // <ObjectData Count="1">

--- a/src/App/ProjectFile.h
+++ b/src/App/ProjectFile.h
@@ -149,6 +149,11 @@ public:
      */
     std::list<PropertyFile> getPropertyFiles(const std::string& name) const;
     /**
+     * If the project file contains the file \a name true is returned and
+     * false otherwise
+     */
+    bool containsFile(const std::string& name) const;
+    /**
      * Retrieves a list of input file names referenced to the given object name.
      * This method does the same as @ref getPropertyFiles() unless that it only
      * returns the file names.

--- a/src/Mod/Start/App/PreCompiled.h
+++ b/src/Mod/Start/App/PreCompiled.h
@@ -42,7 +42,13 @@
 #include <vector>
 #include <unordered_map>
 
+// boost
+#include <boost/algorithm/string/predicate.hpp>
+
 // Qt (should never include GUI files, only QtCore)
+#include <QByteArray>
+#include <QCryptographicHash>
+#include <QDateTime>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>


### PR DESCRIPTION
It's basically a port of #10951 to the new start page implementation.

Note: Icon files are not removed but re-used instead.

The commit adds some new functions:

* getThumbnailsImage()
  Returns the name of the PNG inside a project file

* getThumbnailsName()
  Returns the directory name containing the image files

* getThumnailsParentDir()
  Returns the parent directory of the directory containing the image files

* getThumbnailsDir()
  Returns the path to the thumbnail directory. There is no need to always create a unique directory
  after each restart because it doesn't harm if the thumbnail directoy contains deprecated files.

* createThumbnailsDir()
  Creates the thumbnail directoy if it doesn't exist yet.

* getSha1Hash
  Helper function to compute a SHA-1 hash of a given path. If the same path is passed
  then the hash value will be the same.
  This way it can be avoided to create a different image file from a project file
  after each restart.

* getUniquePNG
  Computes the path of a PNG image file for a given project file. It's also possible
  to pass an arbitrary string as argument.

* useCachedPNG
  If the PNG image exists and if it's newer than the project file True is returned
  and False otherwise.

For a given project file it is checked if the thumbnail directory already contains
a cached image. If it's newer than the project file it will used, otherwise it will
be re-created.

Fix freecadCanOpen() abd DisplayedFilesModel::addFile() to also check for lower-case
file extensions.
