### PR TITLE
Gui: use utf-8 encoding for saving recorded macros

### DIFF
--- a/src/Gui/Macro.cpp
+++ b/src/Gui/Macro.cpp
@@ -80,6 +80,9 @@ bool MacroFile::commit()
 
     // sort import lines and avoid duplicates
     QTextStream str(&file);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+    str.setCodec("UTF-8");
+#endif
     QStringList import;
     import << QString::fromLatin1("import FreeCAD");
     QStringList body;


### PR DESCRIPTION
Recorded FC macros are always saved with the header line `# -*- coding: utf-8 -*`.
But the `QTextStream` class in Qt5 does not always use the utf-8 encoding for saving that macro file.

With this PR, the encoding will be set explicitly.

This explicit setting of the codec is also used in other places in the FreeCAD repo, e.g.:
https://github.com/FreeCAD/FreeCAD/blob/6f8abe880c07ad0d2d39122b7f697f78da60e1d9/src/Gui/AutoSaver.cpp#L152-L155

related discussion and problem description:
https://forum.freecad.org/viewtopic.php?t=92146

