### PR TITLE
Assembly: fixed defect in the migrationScript4 function

### DIFF
--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -28,6 +28,7 @@ import Part
 
 from PySide import QtCore
 from PySide.QtCore import QT_TRANSLATE_NOOP
+from collections.abc import Sequence
 
 if App.GuiUp:
     import FreeCADGui as Gui
@@ -511,7 +512,11 @@ class Joint:
             joint.Offset2 = App.Placement(current_offset, App.Rotation(current_rotation, 0, 0))
 
     def migrationScript4(self, joint):
-        if hasattr(joint, "Reference1") and joint.Reference1[0] is not None:
+        if (
+            hasattr(joint, "Reference1")
+            and isinstance(joint.Reference1, Sequence)
+            and joint.Reference1[0] is not None
+        ):
             doc_name = joint.Reference1[0].Document.Name
             sub1 = joint.Reference1[1][0]
             sub1 = UtilsAssembly.fixBodyExtraFeatureInSub(doc_name, sub1)
@@ -521,7 +526,11 @@ class Joint:
             if sub1 != joint.Reference1[1][0] or sub2 != joint.Reference1[1][1]:
                 joint.Reference1 = (joint.Reference1[0], [sub1, sub2])
 
-        if hasattr(joint, "Reference2") and joint.Reference2[0] is not None:
+        if (
+            hasattr(joint, "Reference2")
+            and isinstance(joint.Reference2, Sequence)
+            and joint.Reference2[0] is not None
+        ):
             doc_name = joint.Reference2[0].Document.Name
             sub1 = joint.Reference2[1][0]
             sub1 = UtilsAssembly.fixBodyExtraFeatureInSub(doc_name, sub1)


### PR DESCRIPTION
The old CAD model created by the development version of FreeCAD (in which the Assembly workbench was used) contained joints that, for some reason, had an empty Joint Connector 1 reference (Reference1).

This was causing an exception and a crash of the Python function called migrationScript4. The FreeCAD Report view contained:

23:28:29  pyException: Traceback (most recent call last):
  File "/FreeCAD/Mod/Assembly/JointObject.py", line 175, in onDocumentRestored
    self.createProperties(joint)
  File "/FreeCAD/Mod/Assembly/JointObject.py", line 181, in createProperties
    self.migrationScript4(joint)
  File "/FreeCAD/Mod/Assembly/JointObject.py", line 514, in migrationScript4
    if hasattr(joint, "Reference1") and joint.Reference1[0] is not None:
                                        ~~~~~~~~~~~~~~~~^^^
<class 'TypeError'>: 'NoneType' object is not subscriptable

This patch attempts to avoid such exceptions by validating the type of the property variable before accessing it.