### PR TITLE
Remove the default channel from conda.

### DIFF
--- a/.github/workflows/sub_buildMacOSCondaApple.yml
+++ b/.github/workflows/sub_buildMacOSCondaApple.yml
@@ -82,6 +82,7 @@ jobs:
           channels: conda-forge
           channel-priority: true
           miniforge-version: latest
+          mamba-version: "*"
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2

--- a/.github/workflows/sub_buildMacOSCondaApple.yml
+++ b/.github/workflows/sub_buildMacOSCondaApple.yml
@@ -83,6 +83,7 @@ jobs:
           channel-priority: true
           miniforge-version: latest
           mamba-version: "*"
+          use-mamba: true
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2

--- a/.github/workflows/sub_buildMacOSCondaApple.yml
+++ b/.github/workflows/sub_buildMacOSCondaApple.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2
+          MAMBA_ROOT_PREFIX: "/home/runner/miniconda3"
         run: |
           ./conda/setup-environment.sh
       - name: Set Environment Variables

--- a/.github/workflows/sub_buildMacOSCondaApple.yml
+++ b/.github/workflows/sub_buildMacOSCondaApple.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           activate-environment: .conda/freecad
           environment-file: conda/conda-env.yaml
+          conda-remove-defaults: true
           channels: conda-forge
           channel-priority: true
           miniforge-version: latest

--- a/.github/workflows/sub_buildMacOSCondaIntel.yml
+++ b/.github/workflows/sub_buildMacOSCondaIntel.yml
@@ -82,6 +82,7 @@ jobs:
           channels: conda-forge
           channel-priority: true
           miniforge-version: latest
+          mamba-version: "*"
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2

--- a/.github/workflows/sub_buildMacOSCondaIntel.yml
+++ b/.github/workflows/sub_buildMacOSCondaIntel.yml
@@ -83,6 +83,7 @@ jobs:
           channel-priority: true
           miniforge-version: latest
           mamba-version: "*"
+          use-mamba: true
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2

--- a/.github/workflows/sub_buildMacOSCondaIntel.yml
+++ b/.github/workflows/sub_buildMacOSCondaIntel.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2
+          MAMBA_ROOT_PREFIX: "/home/runner/miniconda3"
         run: |
           ./conda/setup-environment.sh
       - name: Set Environment Variables

--- a/.github/workflows/sub_buildMacOSCondaIntel.yml
+++ b/.github/workflows/sub_buildMacOSCondaIntel.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           activate-environment: .conda/freecad
           environment-file: conda/conda-env.yaml
+          conda-remove-defaults: true
           channels: conda-forge
           channel-priority: true
           miniforge-version: latest

--- a/.github/workflows/sub_buildUbuntu2204Conda.yml
+++ b/.github/workflows/sub_buildUbuntu2204Conda.yml
@@ -81,6 +81,7 @@ jobs:
           channel-priority: true
           miniforge-version: latest
           mamba-version: "*"
+          use-mamba: true
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2

--- a/.github/workflows/sub_buildUbuntu2204Conda.yml
+++ b/.github/workflows/sub_buildUbuntu2204Conda.yml
@@ -80,6 +80,7 @@ jobs:
           channels: conda-forge
           channel-priority: true
           miniforge-version: latest
+          mamba-version: "*"
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2

--- a/.github/workflows/sub_buildUbuntu2204Conda.yml
+++ b/.github/workflows/sub_buildUbuntu2204Conda.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2
+          MAMBA_ROOT_PREFIX: "/home/runner/miniconda3"
         run: |
           ./conda/setup-environment.sh
       - name: Set Environment Variables

--- a/.github/workflows/sub_buildUbuntu2204Conda.yml
+++ b/.github/workflows/sub_buildUbuntu2204Conda.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           activate-environment: .conda/freecad
           environment-file: conda/conda-env.yaml
+          conda-remove-defaults: true
           channels: conda-forge
           channel-priority: true
           miniforge-version: latest

--- a/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
+++ b/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
@@ -81,6 +81,7 @@ jobs:
           channel-priority: true
           miniforge-version: latest
           mamba-version: "*"
+          use-mamba: true
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2

--- a/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
+++ b/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2
+          MAMBA_ROOT_PREFIX: "/home/runner/miniconda3"
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
+++ b/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
@@ -80,6 +80,7 @@ jobs:
           channels: conda-forge
           channel-priority: true
           miniforge-version: latest
+          mamba-version: "*"
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2

--- a/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
+++ b/.github/workflows/sub_buildUbuntu2204CondaQt6.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           activate-environment: .conda/freecad
           environment-file: conda/conda-env-qt6.yaml
+          conda-remove-defaults: true
           channels: conda-forge
           channel-priority: true
           miniforge-version: latest

--- a/.github/workflows/sub_buildWindowsConda.yml
+++ b/.github/workflows/sub_buildWindowsConda.yml
@@ -76,6 +76,7 @@ jobs:
           channel-priority: true
           miniforge-version: latest
           mamba-version: "*"
+          use-mamba: true
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2

--- a/.github/workflows/sub_buildWindowsConda.yml
+++ b/.github/workflows/sub_buildWindowsConda.yml
@@ -75,6 +75,7 @@ jobs:
           channels: conda-forge
           channel-priority: true
           miniforge-version: latest
+          mamba-version: "*"
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2

--- a/.github/workflows/sub_buildWindowsConda.yml
+++ b/.github/workflows/sub_buildWindowsConda.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Install FreeCAD dependencies
         env:
           CONDA_VERBOSITY: 2
+          MAMBA_ROOT_PREFIX: "/home/runner/miniconda3"
         run: |
           conda config --add envs_dirs $PWD/.conda
           mamba-devenv --no-prune -f conda/environment.devenv.yml

--- a/.github/workflows/sub_buildWindowsConda.yml
+++ b/.github/workflows/sub_buildWindowsConda.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           activate-environment: .conda/freecad
           environment-file: conda/conda-env.yaml
+          conda-remove-defaults: true
           channels: conda-forge
           channel-priority: true
           miniforge-version: latest

--- a/conda/conda-env-qt6.yaml
+++ b/conda/conda-env-qt6.yaml
@@ -2,7 +2,6 @@ name: freecad
 channels:
 - conda-forge
 dependencies:
-- conda-forge/noarch::conda-libmamba-solver==24.7.0
 - conda-devenv
 - mamba
 - python==3.12.*

--- a/conda/conda-env.yaml
+++ b/conda/conda-env.yaml
@@ -2,7 +2,6 @@ name: freecad
 channels:
 - conda-forge
 dependencies:
-- conda-forge/noarch::conda-libmamba-solver==24.7.0
 - conda-devenv
 - mamba
 - python==3.11.*

--- a/conda/environment-qt6.devenv.yml
+++ b/conda/environment-qt6.devenv.yml
@@ -3,7 +3,6 @@ channels:
 - conda-forge
 - conda-forge/label/pivy_rc
 dependencies:
-- conda-forge/noarch::conda-libmamba-solver==24.7.0
 - libspnav                             # [linux]
 - kernel-headers_linux-64              # [linux and x86_64]
 - libdrm-cos7-x86_64                   # [linux and x86_64]

--- a/conda/environment.devenv.yml
+++ b/conda/environment.devenv.yml
@@ -2,7 +2,6 @@ name: freecad
 channels:
 - conda-forge
 dependencies:
-- conda-forge/noarch::conda-libmamba-solver==24.7.0
 - libspnav                             # [linux]
 - kernel-headers_linux-64              # [linux and x86_64]
 - libdrm-cos6-x86_64                   # [linux and x86_64]

--- a/conda/setup-environment.sh
+++ b/conda/setup-environment.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 # create the conda environment as a subdirectory
-if [ ! -d "$DIRECTORY" ]; then
+if [ ! -d ".conda/freecad" ]; then
     mamba env create -p .conda/freecad -f conda/conda-env.yaml
 else
     mamba env update -p .conda/freecad -f conda/conda-env.yaml

--- a/conda/setup-environment.sh
+++ b/conda/setup-environment.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+set -e
+set -x
+
 # create the conda environment as a subdirectory
 mamba env create -p .conda/freecad -f conda/conda-env.yaml
 

--- a/conda/setup-environment.sh
+++ b/conda/setup-environment.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-# create the conda environment as a subdirectory
+# create the conda environment as a subdirectory x
 if [ ! -d ".conda/freecad" ]; then
     mamba env create -p .conda/freecad -f conda/conda-env.yaml
 else

--- a/conda/setup-environment.sh
+++ b/conda/setup-environment.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 # create the conda environment as a subdirectory
-mamba env create --root-prefix .conda/freecad -p .conda/freecad -f conda/conda-env.yaml
+mamba env create -y -p .conda/freecad -f conda/conda-env.yaml
 
 # add the environment subdirectory to the conda configuration
 conda config --add envs_dirs $CONDA_PREFIX/envs
@@ -12,4 +12,4 @@ conda config --add envs_dirs $(pwd)/.conda
 conda config --set env_prompt "({name})"
 
 # install the FreeCAD dependencies into the environment
-mamba run --live-stream -n freecad mamba-devenv --no-prune -f conda/environment.devenv.yml
+mamba run --live-stream -n freecad mamba-devenv -y --no-prune -f conda/environment.devenv.yml

--- a/conda/setup-environment.sh
+++ b/conda/setup-environment.sh
@@ -4,7 +4,11 @@ set -e
 set -x
 
 # create the conda environment as a subdirectory
-mamba env create -y -p .conda/freecad -f conda/conda-env.yaml
+if [ ! -d "$DIRECTORY" ]; then
+    mamba env create -p .conda/freecad -f conda/conda-env.yaml
+else
+    mamba env update -p .conda/freecad -f conda/conda-env.yaml
+fi
 
 # add the environment subdirectory to the conda configuration
 conda config --add envs_dirs $CONDA_PREFIX/envs
@@ -12,4 +16,4 @@ conda config --add envs_dirs $(pwd)/.conda
 conda config --set env_prompt "({name})"
 
 # install the FreeCAD dependencies into the environment
-mamba run --live-stream -n freecad mamba-devenv -y --no-prune -f conda/environment.devenv.yml
+mamba run --live-stream -n freecad mamba-devenv --no-prune -f conda/environment.devenv.yml

--- a/conda/setup-environment.sh
+++ b/conda/setup-environment.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 # create the conda environment as a subdirectory
-mamba env create -p .conda/freecad -f conda/conda-env.yaml
+mamba env create --root-prefix .conda/freecad -p .conda/freecad -f conda/conda-env.yaml
 
 # add the environment subdirectory to the conda configuration
 conda config --add envs_dirs $CONDA_PREFIX/envs


### PR DESCRIPTION
It is now possible to omit the `default` channel from `setup-miniconda`, allowing for unpinning of `conda-libmamba-solver`.