### PR TITLE
Assembly: fix drag problem with fixed joints

### DIFF
--- a/src/Mod/Assembly/App/AssemblyObject.h
+++ b/src/Mod/Assembly/App/AssemblyObject.h
@@ -250,7 +250,7 @@ private:
 
     std::unordered_map<App::DocumentObject*, MbDPartData> objectPartMap;
     std::vector<std::pair<App::DocumentObject*, double>> objMasses;
-    std::vector<std::shared_ptr<MbD::ASMTPart>> dragMbdParts;
+    std::vector<App::DocumentObject*> draggedParts;
 
     std::vector<std::pair<App::DocumentObject*, Base::Placement>> previousPositions;
 


### PR DESCRIPTION
Store DocumentObject instead of mbdPart for the dragged parts. Fixing the bug where doDragStep was 50% of time failing to find the correct DocumentObject due to bundling.

Fix https://github.com/FreeCAD/FreeCAD/issues/17694